### PR TITLE
Fix cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,9 +1,15 @@
-packages: ./
+packages: language-plutus-core
+          plutus-core-interpreter
+          plutus-exe
+          core-to-plc
 optimization: 2
 constraints: language-plutus-core +development
 tests: true
 benchmarks: true
 documentation: true
+
+allow-newer:
+    cborg:containers
 
 program-options
   alex-options: -g


### PR DESCRIPTION
I'm pretty sure I'm the only one who uses this, but it will be good to be able to use `cabal` when we upload this Hackage.