### PR TITLE
[CGP-351] Added a minilib for golden testing

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -150,6 +150,7 @@ test-suite language-plutus-core-test
     main-is: Spec.hs
     hs-source-dirs: test
     other-modules:
+        Common
         Evaluation.CkMachine
         Evaluation.Constant.All
         Evaluation.Constant.Apply

--- a/language-plutus-core/src/Language/PlutusCore/Pretty.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty.hs
@@ -1,7 +1,8 @@
 module Language.PlutusCore.Pretty
     (
     -- * Basic types and functions
-      Pretty (..)
+      Doc
+    , Pretty (..)
     , PrettyBy (..)
     , PrettyConfigIgnore (..)
     , PrettyConfigAttach (..)

--- a/language-plutus-core/test/Common.hs
+++ b/language-plutus-core/test/Common.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DerivingStrategies #-}
+module Common
+    ( TestNestedGolden
+    , runTestNestedGoldenIn
+    , testNestedGolden
+    , goldenVsText
+    , goldenVsDoc
+    , nestedGoldenVsText
+    , nestedGoldenVsDoc
+    ) where
+
+import           Language.PlutusCore.Pretty
+
+import           Control.Monad.Reader       (Reader)
+import qualified Control.Monad.Reader       as Reader
+import qualified Data.ByteString.Lazy       as BSL
+import           Data.Text                  (Text)
+import           Data.Text.Encoding         (encodeUtf8)
+import           System.FilePath            ((</>))
+import           Test.Tasty
+import           Test.Tasty.Golden
+
+-- | A 'TestTree' of golden tests stored in some folder.
+type TestNestedGolden = Reader (String -> FilePath) TestTree
+
+-- | Run a 'TestTree' of golden tests against a folder.
+runTestNestedGoldenIn :: FilePath -> TestNestedGolden -> TestTree
+runTestNestedGoldenIn folder test = Reader.runReader test (</> folder)
+
+-- | Descend into a folder of golden tests.
+testNestedGolden :: String -> [TestNestedGolden] -> TestNestedGolden
+testNestedGolden folderName =
+    Reader.local ((</> folderName ) .) . fmap (testGroup folderName) . sequence
+
+-- | Check the contents of a file against a 'Text'.
+goldenVsText :: TestName -> FilePath -> Text -> TestTree
+goldenVsText name ref = goldenVsString name ref . pure . BSL.fromStrict . encodeUtf8
+
+-- | Check the contents of a file against a 'Doc'.
+goldenVsDoc :: TestName -> FilePath -> Doc ann -> TestTree
+goldenVsDoc name ref = goldenVsText name ref . docText
+
+-- | Check the contents of a file nested in some folder against a 'Text'.
+nestedGoldenVsText :: TestName -> Text -> TestNestedGolden
+nestedGoldenVsText name text = do
+    toFolder <- Reader.ask
+    return $ goldenVsText name (toFolder "" </> name ++ ".plc.golden") text
+
+-- | Check the contents of a file nested in some folder against a 'Text'.
+nestedGoldenVsDoc :: TestName -> Doc ann -> TestNestedGolden
+nestedGoldenVsDoc name = nestedGoldenVsText name . docText


### PR DESCRIPTION
This adds a nice way to do testing with nested folders of golden tests. See [test/Pretty/Golden/Readable/StdLib](https://github.com/input-output-hk/plutus/tree/master/language-plutus-core/test/Pretty/Golden/Readable/StdLib) for an example of tests structured this way.

Please let's not put golden files together with `*.hs` files which run tests, because this makes it hard to read our tests and annoying to navigate.

Besides this adds a `Common` module where common stuff for tests can be put. We have a lot of repetition in tests, so make sure it doesn't grow at least. Right now I expect at least this:

```haskell
goldenVsDoc :: TestName -> FilePath -> Doc ann -> TestTree
```

to be useful.

CC'ing @michaelpj just to make sure he'll see this.