### PR TITLE
Fixed the wrap case in the type checker

### DIFF
--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -21,7 +21,7 @@ import           Test.Tasty
 import           Test.Tasty.Golden
 import           Test.Tasty.Hedgehog
 import           Test.Tasty.HUnit
--- import           TypeSynthesis.Spec         (test_typecheck)
+import           TypeSynthesis.Spec         (test_typecheck)
 
 main :: IO ()
 main = do
@@ -93,7 +93,7 @@ allTests plcFiles rwFiles typeFiles typeNormalizeFiles typeErrorFiles = testGrou
     , testsNormalizeType typeNormalizeFiles
     , testsType typeErrorFiles
     , test_PrettyReadable
---     , test_typecheck
+    , test_typecheck
     , test_constantApplication
     , test_evaluateCk
     , Quotation.tests


### PR DESCRIPTION
This fixes another bunch of bugs in the type checker which finally allows us to type check the standard library.

It also showcases how we should comment each of the cases:

```
    -- G |- term : nTermTy, ty ~>* nTy, [fix n nTy / n] nTy ~>* nTermTy', nTermTy ~ nTermTy'
    -- -------------------------------------------------------------------------------------
    -- G |- wrap n ty term : fix n nTy
```

I'll write more on that on the mailing list, but hey, we can type check the standard library.