### PR TITLE
[CGP-360] [Type checker] Reduced 'NormalizedType' clutter

### DIFF
--- a/language-plutus-core/prelude/PlutusPrelude.hs
+++ b/language-plutus-core/prelude/PlutusPrelude.hs
@@ -35,6 +35,8 @@ module PlutusPrelude ( -- * Reëxports from base
                      -- * Reëxports from "Control.Composition"
                      , (.*)
                      -- * Custom functions
+                     , (<<$>>)
+                     , (<<*>>)
                      , foldMapM
                      , repeatM
                      , (?)
@@ -96,7 +98,10 @@ import           Debug.Trace
 import           GHC.Generics                            (Generic)
 import           GHC.Natural                             (Natural)
 
+import           Data.Functor.Compose
+
 infixr 2 ?
+infixl 4 <<$>>, <<*>>
 
 -- | This class is used in order to provide default implementations of 'PrettyBy' for
 -- particular @config@s. Whenever a @Config@ is a sum type of @Subconfig1@, @Subconfig2@, etc,
@@ -170,6 +175,12 @@ prettyStringBy = docString .* prettyBy
 -- | Render a value as strict 'Text'.
 prettyTextBy :: PrettyBy config a => config -> a -> T.Text
 prettyTextBy = docText .* prettyBy
+
+(<<$>>) :: (Functor f1, Functor f2) => (a -> b) -> f1 (f2 a) -> f1 (f2 b)
+(<<$>>) f = getCompose . fmap f . Compose
+
+(<<*>>) :: (Applicative f1, Applicative f2) => f1 (f2 (a -> b)) -> f1 (f2 a) -> f1 (f2 b)
+f <<*>> a = getCompose $ Compose f <*> Compose a
 
 -- | Fold a monadic function over a 'Foldable'. The monadic version of 'foldMap'.
 foldMapM :: (Foldable f, Monad m, Monoid b) => (a -> m b) -> f a -> m b

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -67,7 +67,7 @@ module Language.PlutusCore
     , BuiltinTable (..)
     , parseTypecheck
     -- for testing
-    , tyReduce
+    , normalizeType
     , runTypeCheckM
     , typecheckPipeline
     , defaultTypecheckerGas

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -4,7 +4,7 @@
 module Language.PlutusCore.TypeSynthesis ( typecheckProgram
                                          , typecheckTerm
                                          , kindCheck
-                                         , tyReduce
+                                         , normalizeType
                                          , runTypeCheckM
                                          , TypeCheckM
                                          , BuiltinTable (..)
@@ -20,7 +20,7 @@ import qualified Data.IntMap                    as IM
 import qualified Data.Map                       as M
 import           Language.PlutusCore.Clone
 import           Language.PlutusCore.Error
-import           Language.PlutusCore.Lexer.Type
+import           Language.PlutusCore.Lexer.Type hiding (name)
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Type
@@ -227,19 +227,15 @@ dummyType = TyVar () dummyTyName
 -- unique and so we will not delete the wrong thing.
 -- | Synthesize the type of a term, returning a normalized type.
 typeOf :: Term TyNameWithKind NameWithType a -> TypeCheckM a (NormalizedType TyNameWithKind ())
-typeOf (Var _ (NameWithType (Name (_, ty) _ _))) = do
-    (TypeConfig norm _) <- ask
-    maybeRed norm (void ty)
-typeOf (LamAbs _ _ ty t)                         = do
-    (TypeConfig norm _) <- ask
-    (NormalizedType ty') <- maybeRed norm (void ty)
-    NormalizedType <$> (TyFun () ty' <$> (getNormalizedType <$> typeOf t))
+typeOf (Var _ (NameWithType (Name (_, ty) _ _))) = normalizeTypeOpt $ void ty
+typeOf (LamAbs _ _ ty t)                         =
+    TyFun () <<$>> normalizeTypeOpt (void ty) <<*>> typeOf t
 typeOf (Error x ty)                              = do
     k <- kindOf ty
     case k of
-        Type{} -> tyReduce (void ty)
+        Type{} -> normalizeType (void ty)
         _      -> throwError (KindMismatch x (void ty) (Type ()) k)
-typeOf (TyAbs _ n k t)                           = NormalizedType <$> (TyForall () (void n) (void k) <$> (getNormalizedType <$> typeOf t))
+typeOf (TyAbs _ n k t)                           = TyForall () (void n) (void k) <<$>> typeOf t
 typeOf (Constant _ (BuiltinName _ n)) = do
     (TypeConfig _ (BuiltinTable _ st)) <- ask
     case M.lookup n st of
@@ -249,50 +245,54 @@ typeOf (Constant _ (BuiltinInt _ n _))           = pure (integerType n)
 typeOf (Constant _ (BuiltinBS _ n _))            = pure (bsType n)
 typeOf (Constant _ (BuiltinSize _ n))            = pure (sizeType n)
 typeOf (Apply x fun arg) = do
-    nFunTy@(NormalizedType funTy) <- typeOf fun
-    case funTy of
+    nFunTy <- typeOf fun
+    case getNormalizedType nFunTy of
         TyFun _ inTy outTy -> do
-            nArgTy@(NormalizedType argTy) <- typeOf arg
+            nArgTy <- typeOf arg
             typeCheckStep
-            if inTy == argTy
+            if inTy == getNormalizedType nArgTy
                 then pure $ NormalizedType outTy -- subpart of a normalized type, so normalized
                 else throwError (TypeMismatch x (void arg) inTy nArgTy)
         _ -> throwError (TypeMismatch x (void fun) (TyFun () dummyType dummyType) nFunTy)
 typeOf (TyInst x body ty) = do
-    nBodyTy@(NormalizedType bodyTy) <- typeOf body
-    case bodyTy of
+    nBodyTy <- typeOf body
+    case getNormalizedType nBodyTy of
         TyForall _ n k absTy -> do
-            nTy <- tyReduce $ void ty
+            nTy <- normalizeTypeOpt $ void ty
             k' <- kindOf ty
             typeCheckStep
             if k == k'
-                then tyReduceBinder n nTy absTy
+                then normalizeTypeBinder n nTy absTy
                 else throwError (KindMismatch x (void ty) k k')
         _ -> throwError (TypeMismatch x (void body) (TyForall () dummyTyName dummyKind dummyType) nBodyTy)
 typeOf (Unwrap x body) = do
-    nBodyTy@(NormalizedType bodyTy) <- typeOf body
-    case bodyTy of
+    nBodyTy <- typeOf body
+    case getNormalizedType nBodyTy of
         TyFix _ n fixTy ->
-            tyReduceBinder n nBodyTy fixTy
+            normalizeTypeBinder n nBodyTy fixTy
         _             -> throwError (TypeMismatch x (void body) (TyFix () dummyTyName dummyType) nBodyTy)
 typeOf (Wrap x n ty term) = do
     -- G |- term : nTermTy, ty ~>* nTy, [fix n nTy / n] nTy ~>* nTermTy', nTermTy ~ nTermTy'
     -- -------------------------------------------------------------------------------------
     -- G |- wrap n ty term : fix n nTy
 
-    NormalizedType nTy <- tyReduce $ void ty
+    nTy <- normalizeType $ void ty
     nTermTy <- typeOf term
     typeCheckStep
-    nTermTy' <- tyReduceBinder (void n) (NormalizedType $ TyFix () (void n) nTy) nTy
+    nTermTy' <- normalizeTypeBinder (void n) (TyFix () (void n) <$> nTy) $ getNormalizedType nTy
     if nTermTy == nTermTy'
-        then pure $ NormalizedType (TyFix () (void n) nTy)
+        then pure $ TyFix () (void n) <$> nTy
         else throwError (TypeMismatch x (void term) (getNormalizedType nTermTy') nTermTy)
 
-tyReduceBinder :: TyNameWithKind () -> NormalizedType TyNameWithKind () -> Type TyNameWithKind () -> TypeCheckM a (NormalizedType TyNameWithKind ())
-tyReduceBinder n ty ty' = do
+normalizeTypeBinder
+    :: TyNameWithKind ()
+    -> NormalizedType TyNameWithKind ()
+    -> Type TyNameWithKind ()
+    -> TypeCheckM err (NormalizedType TyNameWithKind ())
+normalizeTypeBinder n ty ty' = do
     let u = extractUnique n
     tyEnvAssign u ty
-    tyReduce ty' <* tyEnvDelete u
+    normalizeType ty' <* tyEnvDelete u
 
 extractUnique :: TyNameWithKind a -> Unique
 extractUnique = nameUnique . unTyName . unTyNameWithKind
@@ -311,30 +311,26 @@ tyEnvAssign (Unique i) ty = modify (over uniqueLookup (IM.insert i ty))
 
 -- this will reduce a type, or simply wrap it in a 'NormalizedType' constructor
 -- if we are working with normalized type annotations
-maybeRed :: Bool -> Type TyNameWithKind () -> TypeCheckM a (NormalizedType TyNameWithKind ())
-maybeRed True  = tyReduce
-maybeRed False = pure . NormalizedType
+normalizeTypeOpt :: Type TyNameWithKind () -> TypeCheckM a (NormalizedType TyNameWithKind ())
+normalizeTypeOpt ty = do
+    TypeConfig norm _ <- ask
+    if norm
+        then normalizeType ty
+        else pure $ NormalizedType ty
 
--- | Reduce any redexes inside a type.
-tyReduce :: Type TyNameWithKind () -> TypeCheckM a (NormalizedType TyNameWithKind ())
-tyReduce (TyForall x tn k ty) = NormalizedType <$> (TyForall x tn k <$> (getNormalizedType <$> tyReduce ty))
-tyReduce (TyFix x tn ty) = NormalizedType <$> (TyFix x tn <$> (getNormalizedType <$> tyReduce ty))
-tyReduce (TyFun x ty ty') = NormalizedType <$> (TyFun x <$> (getNormalizedType <$> tyReduce ty) <*> (getNormalizedType <$> tyReduce ty'))
-tyReduce (TyLam x tn k ty) = NormalizedType <$> (TyLam x tn k <$> (getNormalizedType <$> tyReduce ty))
-
-tyReduce (TyApp x ty ty') = do
-
-    -- Once again, @fun@ will always be a type value once reduced so we can do
-    -- reduction here
-    arg <- tyReduce ty'
-    fun <- getNormalizedType <$> tyReduce ty
-    case fun of
-        (TyLam _ (TyNameWithKind (TyName (Name _ _ u))) _ ty'') -> do
-            tyEnvAssign u (void arg)
-            tyReduce ty'' <* tyEnvDelete u
-        _ -> pure $ NormalizedType $ TyApp x fun (getNormalizedType arg)
-
-tyReduce ty@(TyVar _ (TyNameWithKind (TyName (Name _ _ u)))) = do
+-- | Normalize a 'Type'.
+normalizeType :: Type TyNameWithKind () -> TypeCheckM err (NormalizedType TyNameWithKind ())
+normalizeType (TyForall x tn k ty) = TyForall x tn k <<$>> normalizeType ty
+normalizeType (TyFix x tn ty)      = TyFix x tn <<$>> normalizeType ty
+normalizeType (TyFun x ty ty')     = TyFun x <<$>> normalizeType ty <<*>> normalizeType ty'
+normalizeType (TyLam x tn k ty)    = TyLam x tn k <<$>> normalizeType ty
+normalizeType (TyApp x fun arg)    = do
+    nFun <- normalizeType fun
+    nArg <- normalizeType arg
+    case getNormalizedType nFun of
+        TyLam _ name _ body -> normalizeTypeBinder name nArg body
+        _                   -> pure $ TyApp x <$> nFun <*> nArg
+normalizeType ty@(TyVar _ (TyNameWithKind (TyName (Name _ _ u)))) = do
     (TypeCheckSt st _) <- get
     case IM.lookup (unUnique u) st of
 
@@ -342,8 +338,8 @@ tyReduce ty@(TyVar _ (TyNameWithKind (TyName (Name _ _ u)))) = do
         -- a -> b and an assignment b -> c which is locally valid but in
         -- a smaller scope than a -> b.
         Just ty'@(NormalizedType TyVar{}) -> pure ty'
-        Just ty'                          -> NormalizedType <$> cloneType (getNormalizedType ty')
+        Just ty'                          -> traverse cloneType ty'
         Nothing                           -> pure $ NormalizedType ty
 
-tyReduce x@TyInt{} = pure $ NormalizedType x
-tyReduce x@TyBuiltin{} = pure $ NormalizedType x
+normalizeType ty@TyInt{}     = pure $ NormalizedType ty
+normalizeType ty@TyBuiltin{} = pure $ NormalizedType ty

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -139,7 +139,7 @@ appAppLamLam = do
 
 testLam :: Either (TypeError ()) String
 testLam = fmap prettyPlcDefString . runQuote . runExceptT $ runTypeCheckM (TypeCheckCfg 100 False) $
-    tyReduce =<< appAppLamLam
+    normalizeType =<< appAppLamLam
 
 tests :: TestTree
 tests = testCase "example programs" $ fold


### PR DESCRIPTION
This introduces

```haskell
newtype Normalized a = Normalized { getNormalized :: a }
```

and uses its `Functor`, `Applicative`, `Traversable` instances in order to reduce clutter. Backwards compatibility is preserved via

```haskell
type NormalizedType tyname a = Normalized (Type tyname a)

pattern NormalizedType :: Type tyname a -> NormalizedType tyname a
pattern NormalizedType ty = Normalized ty

getNormalizedType :: NormalizedType tyname a -> Type tyname a
getNormalizedType (Normalized ty) = ty
```

which can be kept or removed in another PR.

I also removed several uses of the `NormalizedType`, because there was at least one bug previously related to inaccurate use of `NormalizedType`.

I also renamed `tyReduce` to `normalizeType` and simplified it (as per the latest call). Replaced `maybeRed` by `normalizeTypeOpt` which now doesn't receive the redundant `Bool` argument, because it can be just looked up in the environment.