### PR TITLE
[CGP-358] Treat 'integer' as a type constructor

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -101,8 +101,8 @@ defaultTable :: (MonadQuote m) => m BuiltinTable
 defaultTable = do
 
     let tyTable = M.fromList [ (TyByteString, KindArrow () (Size ()) (Type ()))
-                             , (TySize, Size ())
-                             , (TyInteger, KindArrow () (Size ()) (Type ()))
+                             , (TySize      , KindArrow () (Size ()) (Type ()))
+                             , (TyInteger   , KindArrow () (Size ()) (Type ()))
                              ]
         intTypes = [ AddInteger, SubtractInteger, MultiplyInteger, DivideInteger, RemainderInteger ]
         intRelTypes = [ LessThanInteger, LessThanEqInteger, GreaterThanInteger, GreaterThanEqInteger, EqInteger ]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
@@ -169,7 +169,7 @@ getBuiltinFoldList = do
 getBuiltinSum :: Natural -> Quote (Term TyName Name ())
 getBuiltinSum s = do
     foldList <- getBuiltinFoldList
-    let int = TyBuiltin () TyInteger
+    let int = TyApp () (TyBuiltin () TyInteger) $ TyInt () s
     return
         . mkIterApp (mkIterInst foldList [int, int])
         $ [ TyInst () (Constant () (BuiltinName () AddInteger)) $ TyInt () s

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
@@ -140,8 +140,8 @@ getBuiltinNatToInteger s = do
     RecursiveType _ nat <- holedToRecursive <$> getBuiltinNat
     return
         . LamAbs () n nat
-        $ mkIterApp (TyInst () builtinFoldNat $ TyBuiltin () TyInteger)
-          [ Apply () (Constant () $ BuiltinName () AddInteger) $ int 1
+        $ mkIterApp (TyInst () builtinFoldNat $ TyApp () (TyBuiltin () TyInteger) (TyInt () s))
+          [ Apply () (TyInst () (Constant () $ BuiltinName () AddInteger) (TyInt () s)) $ int 1
           , int 0
           , Var () n
           ]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta.hs
@@ -25,11 +25,11 @@ getBuiltinIntegerToNat n
           go 0 = getBuiltinZero
           go m = Apply () <$> getBuiltinSucc <*> go (m - 1)
 
--- |  'sumNat' as a PLC term.
+-- | @sumNat@ as a PLC term.
 getBuiltinNatSum :: Natural -> Quote (Term TyName Name ())
 getBuiltinNatSum s = do
     foldList <- getBuiltinFoldList
-    let int = TyBuiltin () TyInteger
+    let int = TyApp () (TyBuiltin () TyInteger) $ TyInt () s
     let add = TyInst () (Constant () (BuiltinName () AddInteger)) $ TyInt () s
     RecursiveType _ nat1 <- holedToRecursive <$> getBuiltinNat
     nti <- getBuiltinNatToInteger s


### PR DESCRIPTION
This fixes a bunch of bugs where `integer` is treated as it has the `*` kind instead of `size -> *`.

Tests are disabled still, because there is a "not implemented" error (confusingly spelled as "Internal error") and also at least one more serious error.