### PR TITLE
[CGP-362] [Type checker] Remove 'BuiltinTable' in favor of 'typeOfBuiltinName'

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,7 +1,7 @@
 ---
 - functions:
   - {name: unsafePerformIO, within: [PlutusPrelude, Language.PlutusCore.Generators.Internal.Entity]}
-  - {name: error, within: [Main, Language.PlutusCore.StdLib.Meta, Evaluation.Constant.Success, Language.PlutusCore.Constant.Apply, Language.PlutusCore.Constant.Typed, Language.PlutusCore.Evaluation.CkMachine, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Constant.Make, Language.PlutusCore.Generators.Internal.TypedBuiltinGen, Language.PlutusCore.TH, Language.Plutus.CoreToPLC.Error]}
+  - {name: error, within: [Main, Language.PlutusCore.StdLib.Meta, Evaluation.Constant.Success, Language.PlutusCore.Constant.Apply, Language.PlutusCore.Constant.Typed, Language.PlutusCore.Evaluation.CkMachine, Language.PlutusCore.TypeSynthesis, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Constant.Make, Language.PlutusCore.Generators.Internal.TypedBuiltinGen, Language.PlutusCore.TH, Language.Plutus.CoreToPLC.Error]}
   - {name: undefined, within: [Language.PlutusCore.Constant.Apply]}
   - {name: fromJust, within: []}
   - {name: foldl, within: []}

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -64,7 +64,6 @@ module Language.PlutusCore
     , TypeError (..)
     , TypeCheckCfg (..)
     , TypeCheckM
-    , BuiltinTable (..)
     , parseTypecheck
     -- for testing
     , normalizeType

--- a/language-plutus-core/src/Language/PlutusCore/Error.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Error.hs
@@ -43,8 +43,7 @@ data RenameError a
     deriving (Show, Eq, Generic, NFData)
 
 data TypeError a
-    = InternalError -- ^ This is thrown if builtin lookup fails
-    | KindMismatch a (Type TyNameWithKind ()) (Kind ()) (Kind ())
+    = KindMismatch a (Type TyNameWithKind ()) (Kind ()) (Kind ())
     | TypeMismatch a (Term TyNameWithKind NameWithType ())
                      (Type TyNameWithKind ())
                      (NormalizedType TyNameWithKind ())
@@ -106,7 +105,6 @@ instance (Pretty a, HasPrettyConfigName config) => PrettyBy config (RenameError 
         "is not in scope."
 
 instance Pretty a => PrettyBy PrettyConfigPlc (TypeError a) where
-    prettyBy _      InternalError             = "Internal error."
     prettyBy config (KindMismatch x ty k k')  =
         "Kind mismatch at" <+> pretty x <+>
         "in type" <+> squotes (prettyBy config ty) <>

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -7,7 +7,6 @@ module Language.PlutusCore.TypeSynthesis ( typecheckProgram
                                          , normalizeType
                                          , runTypeCheckM
                                          , TypeCheckM
-                                         , BuiltinTable (..)
                                          , TypeError (..)
                                          , TypeCheckCfg (..)
                                          ) where
@@ -15,35 +14,39 @@ module Language.PlutusCore.TypeSynthesis ( typecheckProgram
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Control.Monad.State.Class
-import           Control.Monad.Trans.State      hiding (get, modify)
-import qualified Data.IntMap                    as IM
-import qualified Data.Map                       as M
+import           Control.Monad.Trans.State          hiding (get, modify)
+import qualified Data.IntMap                        as IM
 import           Language.PlutusCore.Clone
+import           Language.PlutusCore.Constant.Typed (typeOfBuiltinName)
 import           Language.PlutusCore.Error
-import           Language.PlutusCore.Lexer.Type hiding (name)
+import           Language.PlutusCore.Lexer.Type     hiding (name)
 import           Language.PlutusCore.Name
+import           Language.PlutusCore.Pretty         (prettyPlcDefString)
 import           Language.PlutusCore.Quote
+import           Language.PlutusCore.Renamer        (annotateType)
 import           Language.PlutusCore.Type
 import           Lens.Micro
 import           PlutusPrelude
 
--- | A builtin table contains the kinds of builtin types and the types of
--- builtin names.
-data BuiltinTable = BuiltinTable (M.Map TypeBuiltin (Kind ())) (M.Map BuiltinName (NormalizedType TyNameWithKind ()))
+newtype TypeConfig = TypeConfig
+    { _typeConfigNormalize :: Bool  -- ^ Whether we normalize type annotations
+    }
 
 type TypeSt = IM.IntMap (NormalizedType TyNameWithKind ())
 
-data TypeConfig = TypeConfig { _reduce   :: Bool -- ^ Whether we reduce type annotations
-                             , _builtins :: BuiltinTable -- ^ Builtin types
-                             }
+data TypeCheckSt = TypeCheckSt
+    { _uniqueLookup :: TypeSt
+    , _gas          :: Natural
+    }
 
-data TypeCheckSt = TypeCheckSt { _uniqueLookup :: TypeSt
-                               , _gas          :: Natural
-                               }
+data TypeCheckCfg = TypeCheckCfg
+    { _cfgGas       :: Natural  -- ^ Gas to be provided to the typechecker
+    , _cfgNormalize :: Bool     -- ^ Whether we should normalize type annotations
+    }
 
-data TypeCheckCfg = TypeCheckCfg { _cfgGas       :: Natural -- ^ Gas to be provided to the typechecker
-                                 , _cfgNormalize :: Bool -- ^ Whether we should reduce type annotations
-                                 }
+-- | The type checking monad contains the 'BuiltinTable' and it lets us throw
+-- 'TypeError's.
+type TypeCheckM a = StateT TypeCheckSt (ReaderT TypeConfig (ExceptT (TypeError a) Quote))
 
 uniqueLookup :: Lens' TypeCheckSt TypeSt
 uniqueLookup f s = fmap (\x -> s { _uniqueLookup = x }) (f (_uniqueLookup s))
@@ -51,70 +54,17 @@ uniqueLookup f s = fmap (\x -> s { _uniqueLookup = x }) (f (_uniqueLookup s))
 gas :: Lens' TypeCheckSt Natural
 gas f s = fmap (\x -> s { _gas = x }) (f (_gas s))
 
--- | The type checking monad contains the 'BuiltinTable' and it lets us throw
--- 'TypeError's.
-type TypeCheckM a = StateT TypeCheckSt (ReaderT TypeConfig (ExceptT (TypeError a) Quote))
+sizeToType :: Kind ()
+sizeToType = KindArrow () (Size ()) (Type ())
+
+kindOfBuiltinType :: TypeBuiltin -> Kind ()
+kindOfBuiltinType TyInteger    = sizeToType
+kindOfBuiltinType TyByteString = sizeToType
+kindOfBuiltinType TySize       = sizeToType
 
 isType :: Kind a -> Bool
 isType Type{} = True
 isType _      = False
-
--- | Create a new 'Type' for an integer operation.
-intop :: (MonadQuote m) => m (NormalizedType TyNameWithKind ())
-intop = do
-    nam <- newTyName (Size ())
-    let ity = TyApp () (TyBuiltin () TyInteger) (TyVar () nam)
-        fty = TyFun () ity (TyFun () ity ity)
-    pure $ NormalizedType $ TyForall () nam (Size ()) fty
-
--- | Create a new 'Type' for an integer relation
-intRel :: (MonadQuote m)  => m (NormalizedType TyNameWithKind ())
-intRel = NormalizedType <$> builtinRel TyInteger
-
-bsRel :: (MonadQuote m) => m (NormalizedType TyNameWithKind ())
-bsRel = NormalizedType <$> builtinRel TyByteString
-
--- | Create a dummy 'TyName'
-newTyName :: (MonadQuote m) => Kind () -> m (TyNameWithKind ())
-newTyName k = do
-    u <- nameUnique . unTyName <$> liftQuote (freshTyName () "a")
-    pure $ TyNameWithKind (TyName (Name ((), k) "a" u))
-
-boolean :: MonadQuote m => m (Type TyNameWithKind ())
-boolean = do
-    nam <- newTyName (Type ())
-    let var = TyVar () nam
-    pure $ TyForall () nam (Type ()) (TyFun () var (TyFun () var var))
-
-builtinRel :: (MonadQuote m) => TypeBuiltin -> m (Type TyNameWithKind ())
-builtinRel bi = do
-    nam <- newTyName (Size ())
-    b <- boolean
-    let ity = TyApp () (TyBuiltin () bi) (TyVar () nam)
-        fty = TyFun () ity (TyFun () ity b)
-    pure $ TyForall () nam (Size ()) fty
-
-txHash :: NormalizedType TyNameWithKind ()
-txHash = NormalizedType $ TyApp () (TyBuiltin () TyByteString) (TyInt () 256)
-
-defaultTable :: (MonadQuote m) => m BuiltinTable
-defaultTable = do
-
-    let tyTable = M.fromList [ (TyByteString, KindArrow () (Size ()) (Type ()))
-                             , (TySize      , KindArrow () (Size ()) (Type ()))
-                             , (TyInteger   , KindArrow () (Size ()) (Type ()))
-                             ]
-        intTypes = [ AddInteger, SubtractInteger, MultiplyInteger, DivideInteger, RemainderInteger ]
-        intRelTypes = [ LessThanInteger, LessThanEqInteger, GreaterThanInteger, GreaterThanEqInteger, EqInteger ]
-
-    is <- repeatM (length intTypes) intop
-    irs <- repeatM (length intRelTypes) intRel
-    bsRelType <- bsRel
-
-    let f = M.fromList .* zip
-        termTable = f intTypes is <> f intRelTypes irs <> f [TxHash, EqByteString] [txHash, bsRelType]
-
-    pure $ BuiltinTable tyTable termTable
 
 -- | Type-check a program, returning a normalized type.
 typecheckProgram :: (MonadError (Error a) m, MonadQuote m)
@@ -141,9 +91,8 @@ kindCheck cfg t = convertErrors asError $ runTypeCheckM cfg (kindOf t)
 runTypeCheckM :: TypeCheckCfg
               -> TypeCheckM a b
               -> ExceptT (TypeError a) Quote b
-runTypeCheckM (TypeCheckCfg i n) tc = do
-    table <- defaultTable
-    runReaderT (evalStateT tc (TypeCheckSt mempty i)) (TypeConfig n table)
+runTypeCheckM (TypeCheckCfg i n) tc =
+    runReaderT (evalStateT tc (TypeCheckSt mempty i)) (TypeConfig n)
 
 typeCheckStep :: TypeCheckM a ()
 typeCheckStep = do
@@ -172,11 +121,7 @@ kindOf (TyForall x _ _ ty) = do
 kindOf (TyLam _ _ k ty) =
     [ KindArrow () (void k) k' | k' <- kindOf ty ]
 kindOf (TyVar _ (TyNameWithKind (TyName (Name (_, k) _ _)))) = pure (void k)
-kindOf (TyBuiltin _ b) = do
-    (TypeConfig _ (BuiltinTable tyst _)) <- ask
-    case M.lookup b tyst of
-        Just k -> pure k
-        _      -> throwError InternalError
+kindOf (TyBuiltin _ b) = pure $ kindOfBuiltinType b
 kindOf (TyFix x _ ty) = do
     k <- kindOf ty
     if isType k
@@ -236,11 +181,11 @@ typeOf (Error x ty)                              = do
         Type{} -> normalizeType (void ty)
         _      -> throwError (KindMismatch x (void ty) (Type ()) k)
 typeOf (TyAbs _ n k t)                           = TyForall () (void n) (void k) <<$>> typeOf t
-typeOf (Constant _ (BuiltinName _ n)) = do
-    (TypeConfig _ (BuiltinTable _ st)) <- ask
-    case M.lookup n st of
-        Just k -> pure k
-        _      -> throwError InternalError
+typeOf (Constant _ (BuiltinName _ name))         = do
+    tyOfName <- liftQuote $ typeOfBuiltinName name
+    case annotateType tyOfName of
+        Left  err         -> error $ "Internal error: " ++ prettyPlcDefString err
+        Right annTyOfName -> pure $ NormalizedType annTyOfName
 typeOf (Constant _ (BuiltinInt _ n _))           = pure (integerType n)
 typeOf (Constant _ (BuiltinBS _ n _))            = pure (bsType n)
 typeOf (Constant _ (BuiltinSize _ n))            = pure (sizeType n)
@@ -313,8 +258,8 @@ tyEnvAssign (Unique i) ty = modify (over uniqueLookup (IM.insert i ty))
 -- if we are working with normalized type annotations
 normalizeTypeOpt :: Type TyNameWithKind () -> TypeCheckM a (NormalizedType TyNameWithKind ())
 normalizeTypeOpt ty = do
-    TypeConfig norm _ <- ask
-    if norm
+    typeConfig <- ask
+    if _typeConfigNormalize typeConfig
         then normalizeType ty
         else pure $ NormalizedType ty
 


### PR DESCRIPTION
This removes `BuiltinTable` and all associated machinery (including `InternalError`) in favor of `typeOfBuiltinName`.