### PR TITLE
Spec typo in context definition

### DIFF
--- a/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
+++ b/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
@@ -31,7 +31,7 @@
     
      \begin{prooftree}
         \AxiomC{\(\ctxni{\Gamma}{\typeJ{\alpha}{K}}\)}
-        \UnaryInfC{\(\ctxni{\Gamma, \termJ{y}{B}}{\typeJ{\alpha}{B}}\)}
+        \UnaryInfC{\(\ctxni{\Gamma, \termJ{y}{B}}{\typeJ{\alpha}{K}}\)}
     \end{prooftree}
     
     \begin{prooftree}


### PR DESCRIPTION
Too small of a typo to get lost in spec-typos branch.