### PR TITLE
core-to-plc: move some tests that now typecheck

### DIFF
--- a/core-to-plc/test/IllTyped.hs
+++ b/core-to-plc/test/IllTyped.hs
@@ -13,18 +13,6 @@ import           Language.Plutus.CoreToPLC.Primitives as Prims
 -- this module does lots of weird stuff deliberately
 {-# ANN module "HLint: ignore" #-}
 
-blocknumPlc :: PlcCode
-blocknumPlc = plc Prims.blocknum
-
-bytestring :: PlcCode
-bytestring = plc (\(x::Prims.ByteString) -> x)
-
-verify :: PlcCode
-verify = plc (\(x::Prims.ByteString) (y::Prims.ByteString) (z::Prims.ByteString) -> Prims.verifySignature x y z)
-
-tupleMatch :: PlcCode
-tupleMatch = plc (\(x:: (Int, Int)) -> let (a, b) = x in a)
-
 listConstruct :: PlcCode
 listConstruct = plc ([]::[Int])
 
@@ -47,13 +35,6 @@ ptreeConstruct = plc (Two (Two (One ((1,2),(3,4)))) :: B Int)
 -- TODO: replace this with 'first' when we have working recursive functions
 ptreeMatch :: PlcCode
 ptreeMatch = plc (\(t::B Int) -> case t of { One a -> a; Two _ -> 2; })
-
-fib :: PlcCode
--- not using case to avoid literal cases
-fib = plc (
-    let fib :: Int -> Int
-        fib n = if n == 0 then 0 else if n == 1 then 1 else fib(n-1) + fib(n-2)
-    in fib)
 
 sumDirect :: PlcCode
 sumDirect = plc (

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -118,6 +118,9 @@ andPlc = plc (\(x::Bool) (y::Bool) -> if x then (if y then True else False) else
 tuple :: PlcCode
 tuple = plc ((1::Int), (2::Int))
 
+tupleMatch :: PlcCode
+tupleMatch = plc (\(x:: (Int, Int)) -> let (a, b) = x in a)
+
 intCompare :: PlcCode
 intCompare = plc (\(x::Int) (y::Int) -> x < y)
 
@@ -136,6 +139,15 @@ errorPlc = plc (Prims.error @Int)
 
 ifThenElse :: PlcCode
 ifThenElse = plc (\(x::Int) (y::Int) -> if x == y then x else y)
+
+blocknumPlc :: PlcCode
+blocknumPlc = plc Prims.blocknum
+
+bytestring :: PlcCode
+bytestring = plc (\(x::Prims.ByteString) -> x)
+
+verify :: PlcCode
+verify = plc (\(x::Prims.ByteString) (y::Prims.ByteString) (z::Prims.ByteString) -> Prims.verifySignature x y z)
 
 structure :: TestTree
 structure = testGroup "Structures" [
@@ -267,6 +279,13 @@ recursion = testGroup "Recursive functions" [
     , goldenEvalApp "even3" [ evenMutual, plc (3::Int) ]
     , goldenEvalApp "even4" [ evenMutual, plc (4::Int) ]
   ]
+
+fib :: PlcCode
+-- not using case to avoid literal cases
+fib = plc (
+    let fib :: Int -> Int
+        fib n = if n == 0 then 0 else if n == 1 then 1 else fib(n-1) + fib(n-2)
+    in fib)
 
 errors :: TestTree
 errors = testGroup "Errors" [


### PR DESCRIPTION
The remainder are waiting on CGP-324 so we can fix on types of arbitrary kind.