### PR TITLE
CBOR: use Serialise throughout

### DIFF
--- a/language-plutus-core/bench/Bench.hs
+++ b/language-plutus-core/bench/Bench.hs
@@ -1,5 +1,7 @@
 module Main (main) where
 
+import           Codec.Serialise
+import           Control.Monad
 import           Criterion.Main
 import qualified Data.ByteString.Lazy       as BSL
 import qualified Data.Text                  as T
@@ -33,7 +35,7 @@ main =
                       ]
                 , env largeTypeFile $ \ g ->
                   bgroup "CBOR"
-                    [ bench "writeProgram" $ nf (fmap writeProgram) (parse g)
+                    [ bench "writeProgram" $ nf (fmap (serialise . void)) $ parse g
                     ]
                 ]
     where envFile = BSL.readFile "test/data/addInteger.plc"

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -114,6 +114,7 @@ library
         th-lift-instances -any,
         mmorph -any,
         cborg -any,
+        serialise -any,
         safe-exceptions -any,
         dependent-sum -any,
         dependent-map -any,
@@ -139,6 +140,7 @@ executable language-plutus-core-generate-evaluation-test
         base -any,
         language-plutus-core -any,
         bytestring -any,
+        serialise -any,
         text -any,
         prettyprinter -any,
         mmorph -any,
@@ -179,6 +181,7 @@ test-suite language-plutus-core-test
         tasty-hedgehog -any,
         transformers -any,
         bytestring -any,
+        serialise -any,
         filepath -any,
         tasty-golden -any,
         text -any,
@@ -209,6 +212,7 @@ benchmark language-plutus-core-bench
         language-plutus-core -any,
         criterion -any,
         bytestring -any,
+        serialise -any,
         text -any
 
     if flag(eventlog)

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -73,11 +73,6 @@ module Language.PlutusCore
     , runTypeCheckM
     , typecheckPipeline
     , defaultTypecheckerGas
-    -- * Serialization
-    , encodeProgram
-    , decodeProgram
-    , readProgram
-    , writeProgram
     -- * Errors
     , Error (..)
     , IsError (..)
@@ -111,7 +106,7 @@ import           Control.Monad.State
 import qualified Data.ByteString.Lazy                     as BSL
 import qualified Data.Text                                as T
 import           Data.Text.Prettyprint.Doc
-import           Language.PlutusCore.CBOR
+import           Language.PlutusCore.CBOR                 ()
 import           Language.PlutusCore.Clone
 import           Language.PlutusCore.Error
 import           Language.PlutusCore.Evaluation.CkMachine

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -1,13 +1,11 @@
-module Language.PlutusCore.CBOR ( encodeProgram
-                                , decodeProgram
-                                , readProgram
-                                , writeProgram
-                                ) where
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Language.PlutusCore.CBOR () where
 
 import           Codec.CBOR.Decoding
 import           Codec.CBOR.Encoding
-import           Codec.CBOR.Read
-import           Codec.CBOR.Write
+import           Codec.Serialise
 import qualified Data.ByteString.Lazy           as BSL
 import           Data.Functor.Foldable          hiding (fold)
 import           Language.PlutusCore.Lexer.Type
@@ -15,192 +13,160 @@ import           Language.PlutusCore.Name
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
-encodeTyBuiltin :: TypeBuiltin -> Encoding
-encodeTyBuiltin bi =
-    let i = case bi of
-            TyByteString -> 0
-            TyInteger    -> 1
-            TySize       -> 2
-    in encodeTag i
+instance Serialise TypeBuiltin where
+    encode bi =
+        let i = case bi of
+                TyByteString -> 0
+                TyInteger    -> 1
+                TySize       -> 2
+        in encodeTag i
 
-decodeTyBuiltin :: Decoder s TypeBuiltin
-decodeTyBuiltin = go =<< decodeTag
-    where go 0 = pure TyByteString
-          go 1 = pure TyInteger
-          go 2 = pure TySize
-          go _ = fail "Failed to decode TypeBuiltin"
+    decode = go =<< decodeTag
+        where go 0 = pure TyByteString
+              go 1 = pure TyInteger
+              go 2 = pure TySize
+              go _ = fail "Failed to decode TypeBuiltin"
 
-encodeBuiltinName :: BuiltinName -> Encoding
-encodeBuiltinName bi =
-    let i = case bi of
-            AddInteger           -> 0
-            SubtractInteger      -> 1
-            MultiplyInteger      -> 2
-            DivideInteger        -> 3
-            RemainderInteger     -> 4
-            LessThanInteger      -> 5
-            LessThanEqInteger    -> 6
-            GreaterThanInteger   -> 7
-            GreaterThanEqInteger -> 8
-            EqInteger            -> 9
-            ResizeInteger        -> 10
-            IntToByteString      -> 11
-            Concatenate          -> 12
-            TakeByteString       -> 13
-            DropByteString       -> 14
-            ResizeByteString     -> 15
-            SHA2                 -> 16
-            SHA3                 -> 17
-            VerifySignature      -> 18
-            EqByteString         -> 19
-            TxHash               -> 20
-            BlockNum             -> 21
-    in encodeTag i
+instance Serialise BuiltinName where
+    encode bi =
+        let i = case bi of
+                AddInteger           -> 0
+                SubtractInteger      -> 1
+                MultiplyInteger      -> 2
+                DivideInteger        -> 3
+                RemainderInteger     -> 4
+                LessThanInteger      -> 5
+                LessThanEqInteger    -> 6
+                GreaterThanInteger   -> 7
+                GreaterThanEqInteger -> 8
+                EqInteger            -> 9
+                ResizeInteger        -> 10
+                IntToByteString      -> 11
+                Concatenate          -> 12
+                TakeByteString       -> 13
+                DropByteString       -> 14
+                ResizeByteString     -> 15
+                SHA2                 -> 16
+                SHA3                 -> 17
+                VerifySignature      -> 18
+                EqByteString         -> 19
+                TxHash               -> 20
+                BlockNum             -> 21
+        in encodeTag i
 
-decodeBuiltinName :: Decoder s BuiltinName
-decodeBuiltinName = go =<< decodeTag
-    where go 0  = pure AddInteger
-          go 1  = pure SubtractInteger
-          go 2  = pure MultiplyInteger
-          go 3  = pure DivideInteger
-          go 4  = pure RemainderInteger
-          go 5  = pure LessThanInteger
-          go 6  = pure LessThanEqInteger
-          go 7  = pure GreaterThanInteger
-          go 8  = pure GreaterThanEqInteger
-          go 9  = pure EqInteger
-          go 10 = pure ResizeInteger
-          go 11 = pure IntToByteString
-          go 12 = pure Concatenate
-          go 13 = pure TakeByteString
-          go 14 = pure DropByteString
-          go 15 = pure ResizeByteString
-          go 16 = pure SHA2
-          go 17 = pure SHA3
-          go 18 = pure VerifySignature
-          go 19 = pure EqByteString
-          go 20 = pure TxHash
-          go 21 = pure BlockNum
-          go _  = fail "Failed to decode BuiltinName"
+    decode = go =<< decodeTag
+        where go 0  = pure AddInteger
+              go 1  = pure SubtractInteger
+              go 2  = pure MultiplyInteger
+              go 3  = pure DivideInteger
+              go 4  = pure RemainderInteger
+              go 5  = pure LessThanInteger
+              go 6  = pure LessThanEqInteger
+              go 7  = pure GreaterThanInteger
+              go 8  = pure GreaterThanEqInteger
+              go 9  = pure EqInteger
+              go 10 = pure ResizeInteger
+              go 11 = pure IntToByteString
+              go 12 = pure Concatenate
+              go 13 = pure TakeByteString
+              go 14 = pure DropByteString
+              go 15 = pure ResizeByteString
+              go 16 = pure SHA2
+              go 17 = pure SHA3
+              go 18 = pure VerifySignature
+              go 19 = pure EqByteString
+              go 20 = pure TxHash
+              go 21 = pure BlockNum
+              go _  = fail "Failed to decode BuiltinName"
 
-encodeNatural :: Natural -> Encoding
-encodeNatural = encodeInteger . fromIntegral
+instance Serialise Unique where
+    encode (Unique i) = encodeInt i
+    decode = Unique <$> decodeInt
 
-decodeNatural :: Decoder s Natural
-decodeNatural = fromIntegral <$> decodeInteger
+instance Serialise (Name ()) where
+    -- TODO: should we encode the name or not?
+    encode (Name _ bs u) = encodeBytes (BSL.toStrict bs) <> encode u
+    decode = Name () <$> fmap BSL.fromStrict decodeBytes <*> decode
 
-encodeUnique :: Unique -> Encoding
-encodeUnique (Unique i) = encodeInt i
+instance Serialise (TyName ()) where
+    encode (TyName n) = encode n
+    decode = TyName <$> decode
 
-decodeUnique :: Decoder s Unique
-decodeUnique = Unique <$> decodeInt
+instance Serialise (Version ()) where
+    encode (Version _ n n' n'') = fold [ encode n, encode n', encode n'' ]
+    decode = Version () <$> decode <*> decode <*> decode
 
--- TODO: should we encode the name or not?
-encodeName :: Name a -> Encoding
-encodeName (Name _ bs u) = encodeBytes (BSL.toStrict bs) <> encodeUnique u
+instance Serialise (Kind ()) where
+    encode = cata a where
+        a TypeF{}             = encodeTag 0
+        a (KindArrowF _ k k') = fold [ encodeTag 1, k , k' ]
+        a SizeF{}             = encodeTag 2
 
-decodeName :: Decoder s (Name ())
-decodeName = Name () <$> fmap BSL.fromStrict decodeBytes <*> decodeUnique
+    decode = go =<< decodeTag
+        where go 0 = pure (Type ())
+              go 1 = KindArrow () <$> decode <*> decode
+              go 2 = pure (Size ())
+              go _ = fail "Failed to decode Kind ()"
 
-encodeTyName :: TyName a -> Encoding
-encodeTyName (TyName n) = encodeName n
+instance Serialise (tyname ()) => Serialise (Type tyname ()) where
+    encode = cata a where
+        a (TyVarF _ tn)        = encodeTag 0 <> encode tn
+        a (TyFunF _ t t')      = encodeTag 1 <> t <> t'
+        a (TyFixF _ tn t)      = encodeTag 2 <> encode tn <> t
+        a (TyForallF _ tn k t) = encodeTag 3 <> encode tn <> encode k <> t
+        a (TyBuiltinF _ bi)    = encodeTag 4 <> encode bi
+        a (TyIntF _ n)         = encodeTag 5 <> encode n
+        a (TyLamF _ n k t)     = encodeTag 6 <> encode n <> encode k <> t
+        a (TyAppF _ t t')      = encodeTag 7 <> t <> t'
 
-decodeTyName :: Decoder s (TyName ())
-decodeTyName = TyName <$> decodeName
+    decode = go =<< decodeTag
+        where go 0 = TyVar () <$> decode
+              go 1 = TyFun () <$> decode <*> decode
+              go 2 = TyFix () <$> decode <*> decode
+              go 3 = TyForall () <$> decode <*> decode <*> decode
+              go 4 = TyBuiltin () <$> decode
+              go 5 = TyInt () <$> decode
+              go 6 = TyLam () <$> decode <*> decode <*> decode
+              go 7 = TyApp () <$> decode <*> decode
+              go _ = fail "Failed to decode Type TyName ()"
 
-encodeVersion :: Version a -> Encoding
-encodeVersion (Version _ n n' n'') = fold [ encodeNatural n, encodeNatural n', encodeNatural n'' ]
+instance Serialise (Constant ()) where
+    encode (BuiltinInt _ n i) = fold [ encodeTag 0, encode n, encodeInteger i ]
+    encode (BuiltinBS _ n bs) = fold [ encodeTag 1, encode n, encodeBytes (BSL.toStrict bs) ]
+    encode (BuiltinSize _ n)  = encodeTag 2 <> encode n
+    encode (BuiltinName _ bn) = encodeTag 3 <> encode bn
 
-decodeVersion :: Decoder s (Version ())
-decodeVersion = Version () <$> decodeNatural <*> decodeNatural <*> decodeNatural
+    decode = go =<< decodeTag
+        where go 0 = BuiltinInt () <$> decode <*> decodeInteger
+              go 1 = BuiltinBS () <$> decode <*> fmap BSL.fromStrict decodeBytes
+              go 2 = BuiltinSize () <$> decode
+              go 3 = BuiltinName () <$> decode
+              go _ = fail "Failed to decode Constant ()"
 
-encodeKind :: Kind a -> Encoding
-encodeKind = cata a where
-    a TypeF{}             = encodeTag 0
-    a (KindArrowF _ k k') = fold [ encodeTag 1, k , k' ]
-    a SizeF{}             = encodeTag 2
+instance (Serialise (tyname ()), Serialise (name ())) => Serialise (Term tyname name ()) where
+    encode = cata a where
+        a (VarF _ n)         = encodeTag 0 <> encode n
+        a (TyAbsF _ tn k t)  = encodeTag 1 <> encode tn <> encode k <> t
+        a (LamAbsF _ n ty t) = encodeTag 2 <> encode n <> encode ty <> t
+        a (ApplyF _ t t')    = encodeTag 3 <> t <> t'
+        a (ConstantF _ c)    = encodeTag 4 <> encode c
+        a (TyInstF _ t ty)   = encodeTag 5 <> t <> encode ty
+        a (UnwrapF _ t)      = encodeTag 6 <> t
+        a (WrapF _ tn ty t)  = encodeTag 7 <> encode tn <> encode ty <> t
+        a (ErrorF _ ty)      = encodeTag 8 <> encode ty
 
-decodeKind :: Decoder s (Kind ())
-decodeKind = go =<< decodeTag
-    where go 0 = pure (Type ())
-          go 1 = KindArrow () <$> decodeKind <*> decodeKind
-          go 2 = pure (Size ())
-          go _ = fail "Failed to decode Kind ()"
+    decode = go =<< decodeTag
+        where go 0 = Var () <$> decode
+              go 1 = TyAbs () <$> decode <*> decode <*> decode
+              go 2 = LamAbs () <$> decode <*> decode <*> decode
+              go 3 = Apply () <$> decode <*> decode
+              go 4 = Constant () <$> decode
+              go 5 = TyInst () <$> decode <*> decode
+              go 6 = Unwrap () <$> decode
+              go 7 = Wrap () <$> decode <*> decode <*> decode
+              go 8 = Error () <$> decode
+              go _ = fail "Failed to decode Term TyName Name ()"
 
-encodeType :: Type TyName a -> Encoding
-encodeType = cata a where
-    a (TyVarF _ tn)        = encodeTag 0 <> encodeTyName tn
-    a (TyFunF _ t t')      = encodeTag 1 <> t <> t'
-    a (TyFixF _ tn t)      = encodeTag 2 <> encodeTyName tn <> t
-    a (TyForallF _ tn k t) = encodeTag 3 <> encodeTyName tn <> encodeKind k <> t
-    a (TyBuiltinF _ bi)    = encodeTag 4 <> encodeTyBuiltin bi
-    a (TyIntF _ n)         = encodeTag 5 <> encodeNatural n
-    a (TyLamF _ n k t)     = encodeTag 6 <> encodeTyName n <> encodeKind k <> t
-    a (TyAppF _ t t')      = encodeTag 7 <> t <> t'
-
-decodeType :: Decoder a (Type TyName ())
-decodeType = go =<< decodeTag
-    where go 0 = TyVar () <$> decodeTyName
-          go 1 = TyFun () <$> decodeType <*> decodeType
-          go 2 = TyFix () <$> decodeTyName <*> decodeType
-          go 3 = TyForall () <$> decodeTyName <*> decodeKind <*> decodeType
-          go 4 = TyBuiltin () <$> decodeTyBuiltin
-          go 5 = TyInt () <$> decodeNatural
-          go 6 = TyLam () <$> decodeTyName <*> decodeKind <*> decodeType
-          go 7 = TyApp () <$> decodeType <*> decodeType
-          go _ = fail "Failed to decode Type TyName ()"
-
-encodeConstant :: Constant a -> Encoding
-encodeConstant (BuiltinInt _ n i) = fold [ encodeTag 0, encodeNatural n, encodeInteger i ]
-encodeConstant (BuiltinBS _ n bs) = fold [ encodeTag 1, encodeNatural n, encodeBytes (BSL.toStrict bs) ]
-encodeConstant (BuiltinSize _ n)  = encodeTag 2 <> encodeNatural n
-encodeConstant (BuiltinName _ bn) = encodeTag 3 <> encodeBuiltinName bn
-
-decodeConstant :: Decoder s (Constant ())
-decodeConstant = go =<< decodeTag
-    where go 0 = BuiltinInt () <$> decodeNatural <*> decodeInteger
-          go 1 = BuiltinBS () <$> decodeNatural <*> fmap BSL.fromStrict decodeBytes
-          go 2 = BuiltinSize () <$> decodeNatural
-          go 3 = BuiltinName () <$> decodeBuiltinName
-          go _ = fail "Failed to decode Constant ()"
-
-encodeTerm :: Term TyName Name a -> Encoding
-encodeTerm = cata a where
-    a (VarF _ n)         = encodeTag 0 <> encodeName n
-    a (TyAbsF _ tn k t)  = encodeTag 1 <> encodeTyName tn <> encodeKind k <> t
-    a (LamAbsF _ n ty t) = encodeTag 2 <> encodeName n <> encodeType ty <> t
-    a (ApplyF _ t t')    = encodeTag 3 <> t <> t'
-    a (ConstantF _ c)    = encodeTag 4 <> encodeConstant c
-    a (TyInstF _ t ty)   = encodeTag 5 <> t <> encodeType ty
-    a (UnwrapF _ t)      = encodeTag 6 <> t
-    a (WrapF _ tn ty t)  = encodeTag 7 <> encodeTyName tn <> encodeType ty <> t
-    a (ErrorF _ ty)      = encodeTag 8 <> encodeType ty
-
-decodeTerm :: Decoder s (Term TyName Name ())
-decodeTerm = go =<< decodeTag
-    where go 0 = Var () <$> decodeName
-          go 1 = TyAbs () <$> decodeTyName <*> decodeKind <*> decodeTerm
-          go 2 = LamAbs () <$> decodeName <*> decodeType <*> decodeTerm
-          go 3 = Apply () <$> decodeTerm <*> decodeTerm
-          go 4 = Constant () <$> decodeConstant
-          go 5 = TyInst () <$> decodeTerm <*> decodeType
-          go 6 = Unwrap () <$> decodeTerm
-          go 7 = Wrap () <$> decodeTyName <*> decodeType <*> decodeTerm
-          go 8 = Error () <$> decodeType
-          go _ = fail "Failed to decode Term TyName Name ()"
-
--- | Encode a program. For use with the @cborg@ library.
-encodeProgram :: Program TyName Name a -> Encoding
-encodeProgram (Program _ v t) = encodeVersion v <> encodeTerm t
-
--- | 'Decoder' for a 'Program'
-decodeProgram :: Decoder s (Program TyName Name ())
-decodeProgram = Program () <$> decodeVersion <*> decodeTerm
-
--- | Encode a program as a 'ByteString'
-writeProgram :: Program TyName Name a -> BSL.ByteString
-writeProgram = toLazyByteString . encodeProgram
-
--- | Attempt to deserialize a 'Program' form a 'ByteString'
-readProgram :: BSL.ByteString -> Either DeserialiseFailure (Program TyName Name ())
-readProgram = fmap snd . deserialiseFromBytes decodeProgram
+instance (Serialise (tyname ()), Serialise (name ())) => Serialise (Program tyname name ()) where
+    encode (Program _ v t) = encode v <> encode t
+    decode = Program () <$> decode <*> decode

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -3,6 +3,7 @@
 module Main ( main
             ) where
 
+import           Codec.Serialise
 import           Control.Monad
 import           Control.Monad.Trans.Except   (runExceptT)
 import qualified Data.ByteString.Lazy         as BSL
@@ -70,7 +71,8 @@ compareProgram (Program _ v t) (Program _ v' t') = v == v' && compareTerm t t'
 propCBOR :: Property
 propCBOR = property $ do
     prog <- forAll genProgram
-    let trip = readProgram . writeProgram
+    let
+        trip = deserialiseOrFail . serialise
         compared = (==) <$> trip (void prog) <*> pure (void prog)
     Hedgehog.assert (fromRight False compared)
 

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -42147,6 +42147,7 @@ license = stdenv.lib.licenses.bsd3;
 , prettyprinter
 , recursion-schemes
 , safe-exceptions
+, serialise
 , stdenv
 , tasty
 , tasty-golden
@@ -42182,6 +42183,7 @@ mtl
 prettyprinter
 recursion-schemes
 safe-exceptions
+serialise
 tasty
 tasty-golden
 template-haskell
@@ -42199,6 +42201,7 @@ bytestring
 hedgehog
 mmorph
 prettyprinter
+serialise
 text
 ];
 testHaskellDepends = [
@@ -42210,6 +42213,7 @@ hedgehog
 mmorph
 mtl
 prettyprinter
+serialise
 tasty
 tasty-golden
 tasty-hedgehog
@@ -78397,6 +78401,7 @@ license = stdenv.lib.licenses.mit;
 , errors
 , free
 , ghc
+, hashable
 , hedgehog
 , language-plutus-core
 , memory
@@ -78442,6 +78447,7 @@ cryptonite
 errors
 free
 ghc
+hashable
 hedgehog
 language-plutus-core
 memory


### PR DESCRIPTION
This has a number of benefits:
- Avoid proliferation of functions, and redefinition of functions
already provided by `serialise` (`serialise`, `deserialiseOrFail`, etc.)
- Simplify clients of serialisation (e.g. the plugin)
- Open a natural avenue for serializing dynamic builtins by requiring
something like `Serialize dyn => Serialize (Term TyName Name dyn ())`

I didn't change anything in the serialization scheme itself, although it
occurs to me that it would now be quite easy to make it serialise the
annotations if they are serialisable. This would have some advantages:
for example, it would allow us to give better diagnostics when running
things on the mockchain if we serialized positions too.