### PR TITLE
HTTP MockChain Part 2

### DIFF
--- a/wallet-api/emulator/Main.hs
+++ b/wallet-api/emulator/Main.hs
@@ -1,13 +1,10 @@
 module Main where
 
-import           Control.Concurrent.STM   (atomically, newTVar)
-import qualified Data.HashMap.Strict      as HM
 import           Network.Wai.Handler.Warp (run)
-import           Wallet.Emulator.Http     (State (State), app)
+import           Wallet.Emulator.Http     (app, initialState)
 
 main :: IO ()
 main = do
   putStrLn "start emulator"
-  initialState <- atomically $ newTVar HM.empty
-  let state = State initialState
+  state <- initialState
   run 8080 $ app state

--- a/wallet-api/src/Wallet/Emulator/Http.hs
+++ b/wallet-api/src/Wallet/Emulator/Http.hs
@@ -6,9 +6,13 @@
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE TypeOperators              #-}
 
-module Wallet.Emulator.Http where
+module Wallet.Emulator.Http
+  ( app
+  , initialState
+  ) where
 
-import           Control.Concurrent.STM     (STM, TVar, atomically, modifyTVar, readTVar, readTVarIO)
+import           Control.Concurrent.STM     (STM, TVar, atomically, modifyTVar, newTVar, readTVar, readTVarIO,
+                                             writeTVar)
 import           Control.Monad.Error.Class  (MonadError)
 import           Control.Monad.Except       (ExceptT, liftEither, runExceptT)
 import           Control.Monad.IO.Class     (MonadIO, liftIO)
@@ -17,19 +21,25 @@ import           Control.Monad.State        (runStateT)
 import           Control.Monad.Writer       (runWriter)
 import           Control.Natural            (type (~>))
 import qualified Data.ByteString.Lazy.Char8 as BSL
-import           Data.HashMap.Strict        (HashMap)
-import qualified Data.HashMap.Strict        as HM
+import qualified Data.Map                   as Map
+import           Data.Maybe                 (catMaybes)
+import           Data.Monoid                ((<>))
 import           Data.Proxy                 (Proxy (Proxy))
 import           Data.Set                   (Set)
 import qualified Data.Set                   as Set
-import           Servant                    (Application, Handler, ServantErr (errBody), Server, err404, err500, err501,
+import           Lens.Micro                 (over, set, to)
+import           Lens.Micro.Extras          (view)
+import           Servant                    (Application, Handler, ServantErr (errBody), Server, err404, err500,
                                              hoistServer, serve, throwError)
 import           Servant.API                ((:<|>) ((:<|>)), (:>), Capture, Get, JSON, NoContent (NoContent), Post,
-                                             ReqBody)
+                                             Put, ReqBody)
 import qualified Wallet.API                 as WAPI
-import           Wallet.Emulator.Types      (EmulatedWalletApi, Wallet, WalletState, emptyWalletState,
-                                             runEmulatedWalletApi)
-import           Wallet.UTXO                (Tx, TxIn', TxOut', Value)
+import           Wallet.Emulator.Types      (EmulatedWalletApi, EmulatorState (emWalletState),
+                                             Notification (BlockHeight, BlockValidated), Wallet, WalletState, chain,
+                                             emTxPool, emptyEmulatorState, emptyWalletState, runEmulatedWalletApi,
+                                             txPool, validateEm, validationData, walletStates)
+import qualified Wallet.Emulator.Types      as Types
+import           Wallet.UTXO                (Block, Height, Tx, TxIn', TxOut', ValidationData, Value)
 
 type WalletAPI
    = "wallets" :> Get '[ JSON] [Wallet]
@@ -41,8 +51,18 @@ type WalletAPI
      :<|> "wallets" :> Capture "walletid" Wallet :> "transactions" :> ReqBody '[ JSON] Tx :> Post '[ JSON] ()
      :<|> "wallets" :> "transactions" :> Get '[ JSON] [Tx]
 
+type ControlAPI
+   = "emulator" :> ("blockchain-actions" :> Get '[ JSON] [Tx]
+                    :<|> "validation-data" :> ReqBody '[ JSON] ValidationData :> Put '[ JSON] ()
+                    :<|> "wallets" :> Capture "walletid" Wallet :> "notifications" :> "block-validation" :> ReqBody '[ JSON] Block :> Post '[ JSON] ()
+                    :<|> "wallets" :> Capture "walletid" Wallet :> "notifications" :> "block-height" :> ReqBody '[ JSON] Height :> Post '[ JSON] ())
+
+type API
+   = WalletAPI
+     :<|> ControlAPI
+
 newtype State = State
-  { getWallets :: TVar (HashMap Wallet WalletState)
+  { getState :: TVar EmulatorState
   }
 
 data AppError
@@ -52,26 +72,26 @@ data AppError
 wallets ::
      (MonadError ServantErr m, MonadReader State m, MonadIO m) => m [Wallet]
 wallets = do
-  var <- asks getWallets
+  var <- asks getState
   ws <- liftIO $ readTVarIO var
-  pure $ HM.keys ws
+  pure . Map.keys . emWalletState $ ws
 
 fetchWallet ::
      (MonadError ServantErr m, MonadReader State m, MonadIO m)
   => Wallet
   -> m Wallet
 fetchWallet wallet = do
-  var <- asks getWallets
+  var <- asks getState
   ws <- liftIO $ readTVarIO var
-  if HM.member wallet ws
+  if Map.member wallet . emWalletState $ ws
     then pure wallet
     else throwError err404
 
 createWallet :: (MonadReader State m, MonadIO m) => Wallet -> m NoContent
 createWallet wallet = do
-  var <- asks getWallets
+  var <- asks getState
   let walletState = emptyWalletState wallet
-  liftIO . atomically $ modifyTVar var (HM.insert wallet walletState)
+  liftIO . atomically $ modifyTVar var (insertWallet wallet walletState)
   pure NoContent
 
 createPaymentWithChange ::
@@ -102,7 +122,7 @@ runWalletApiAction ::
   -> a
   -> m b
 runWalletApiAction action wallet a = do
-  var <- asks getWallets
+  var <- asks getState
   result <- liftIO . atomically $ runWalletApiActionSTM var wallet action a
   case result of
     Left (HttpError e) -> throwError e
@@ -111,30 +131,39 @@ runWalletApiAction action wallet a = do
     Right res -> pure res
 
 runWalletApiActionSTM ::
-     TVar (HashMap Wallet WalletState)
+     TVar EmulatorState
   -> Wallet
   -> (a -> EmulatedWalletApi b)
   -> a
   -> STM (Either AppError b)
 runWalletApiActionSTM var wallet action a = do
   states <- readTVar var
-  let mState = HM.lookup wallet states
+  let mState = Map.lookup wallet . emWalletState $ states
   case mState of
     Nothing -> pure . Left . HttpError $ err404
     Just oldState -> do
-      let (res, _) =
+      let (res, txs) =
             runWriter .
             flip runStateT oldState . runExceptT . runEmulatedWalletApi $
             action a
+      modifyTVar var (addTransactions txs)
       case res of
         (Left e, _) -> pure . Left . WalletAPIError $ e
         (Right v, newState) -> do
-          modifyTVar var (HM.insert wallet newState)
+          modifyTVar var (insertWallet wallet newState)
           pure $ Right v
 
--- TODO: This will be part of the transactions API
-getTransactions :: (MonadError ServantErr m) => m [Tx]
-getTransactions = throwError err501
+insertWallet :: Wallet -> WalletState -> EmulatorState -> EmulatorState
+insertWallet w ws = over walletStates (Map.insert w ws)
+
+addTransactions :: [Tx] -> EmulatorState -> EmulatorState
+addTransactions txs = over txPool (<> txs)
+
+getTransactions :: (MonadReader State m, MonadIO m) => m [Tx]
+getTransactions = do
+  var <- asks getState
+  states <- liftIO $ readTVarIO var
+  view (txPool . to pure) states
 
 -- | Concrete monad stack for server server
 newtype AppM a = AppM
@@ -152,16 +181,67 @@ runM state r = do
   res <- liftIO . runExceptT . flip runReaderT state . unM $ r
   liftEither res
 
-walletHandlers :: State -> Server WalletAPI
-walletHandlers state =
-  hoistServer walletApi (runM state) $
-  wallets :<|> fetchWallet :<|> createWallet :<|> createPaymentWithChange :<|>
-  payToPublicKey :<|>
-  submitTxn :<|>
-  getTransactions
+walletHandlers :: State -> Server API
+walletHandlers state = hoistServer api (runM state) $ walletApi :<|> controlApi
+  where
+    walletApi =
+      wallets :<|> fetchWallet :<|> createWallet :<|> createPaymentWithChange :<|>
+      payToPublicKey :<|>
+      submitTxn :<|>
+      getTransactions
+    controlApi =
+      blockchainActions :<|> setValidationData :<|> blockValidated :<|>
+      blockHeight
 
-walletApi :: Proxy WalletAPI
-walletApi = Proxy
+handleNotifications ::
+     (MonadReader State m, MonadIO m, MonadError ServantErr m)
+  => Wallet
+  -> [Notification]
+  -> m ()
+handleNotifications = runWalletApiAction Types.handleNotifications
+
+blockValidated ::
+     (MonadReader State m, MonadIO m, MonadError ServantErr m)
+  => Wallet
+  -> Block
+  -> m ()
+blockValidated wallet block = handleNotifications wallet [BlockValidated block]
+
+blockHeight ::
+     (MonadReader State m, MonadIO m, MonadError ServantErr m)
+  => Wallet
+  -> Height
+  -> m ()
+blockHeight wallet height = handleNotifications wallet [BlockHeight height]
+
+setValidationData :: (MonadReader State m, MonadIO m) => ValidationData -> m ()
+setValidationData vd = do
+  var <- asks getState
+  liftIO . atomically $ modifyTVar var (set validationData vd)
+
+blockchainActions :: (MonadReader State m, MonadIO m) => m [Tx]
+blockchainActions = do
+  var <- asks getState
+  liftIO . atomically $ blockchainActionsSTM var
+
+blockchainActionsSTM :: TVar EmulatorState -> STM [Tx]
+blockchainActionsSTM var = do
+  es <- readTVar var
+  let processed = validateEm es <$> emTxPool es
+      validated = catMaybes processed
+      block = validated
+      newState = addBlock block . emptyPool $ es
+  writeTVar var newState
+  pure block
+  where
+    addBlock block = over chain ((:) block)
+    emptyPool = set txPool []
+
+api :: Proxy API
+api = Proxy
 
 app :: State -> Application
-app state = serve walletApi $ walletHandlers state
+app state = serve api $ walletHandlers state
+
+initialState :: IO State
+initialState = atomically $ State <$> newTVar emptyEmulatorState

--- a/wallet-api/src/Wallet/UTXO.hs
+++ b/wallet-api/src/Wallet/UTXO.hs
@@ -268,7 +268,7 @@ instance Ord Redeemer where
 newtype Height = Height { getHeight :: Integer }
     deriving (Eq, Ord, Show, Enum)
     deriving stock (Generic)
-    deriving newtype (Num, Real, Integral, Serialise)
+    deriving newtype (Num, Real, Integral, Serialise, FromJSON)
 
 -- | The height of a blockchain
 height :: Blockchain -> Height
@@ -549,6 +549,7 @@ data BlockchainState = BlockchainState {
 --   for now we have to construct it at compilation time (in the test suite)
 --   and pass it to the validator.
 newtype ValidationData = ValidationData PlcCode
+  deriving newtype (ToJSON, FromJSON)
 
 instance Show ValidationData where
     show = const "ValidationData { <script> }"


### PR DESCRIPTION
This commit adds new endpoints to trigger validation
and notifications.

The next stage is to create a client and try to fit
it into the Trace api. The only issue I see is assertions.
Since these are Haskell functions, we cannot serialize
them. It may be that we can remove them from the Trace API
and run them separately. We may need more endpoints for
this in order to see more state within the emulator.