### PR TITLE
plutus-use-cases: reduce test limit

### DIFF
--- a/plutus-use-cases/test/Spec.hs
+++ b/plutus-use-cases/test/Spec.hs
@@ -4,12 +4,20 @@ module Main(main) where
 import qualified Spec.Crowdfunding
 import qualified Spec.Vesting
 import           Test.Tasty
+import           Test.Tasty.Hedgehog (HedgehogTestLimit (..))
 
 main :: IO ()
 main = defaultMain tests
 
+-- | Number of successful tests for each hedgehog property.
+--   The default is 100 but we use a smaller number here in order to speed up
+--   the test suite.
+--
+limit :: HedgehogTestLimit
+limit = HedgehogTestLimit 30
+
 tests :: TestTree
-tests = testGroup "use cases" [
+tests = localOption limit $ testGroup "use cases" [
     Spec.Crowdfunding.tests,
     Spec.Vesting.tests
     ]


### PR DESCRIPTION
This reduces the time of the test suite from 8.5s to 3.4s on my machine.

I don't think we should go below 5 successful tests. The most important parameter that varies in the generated chains is the distribution of coins to transaction outputs in the initial transaction, which in turn has an impact on coin selection. And we should at least cover a small number of different distributions here.