### PR TITLE
add Semigroup instances

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -96,7 +96,8 @@ library
                       ExistentialQuantification
     ghc-options: -Wall -Wnoncanonical-monad-instances
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
-                 -Wredundant-constraints -Widentities -Wcompat
+                 -Wredundant-constraints -Widentities
+                 -Wnoncanonical-monoid-instances
     build-depends:
         base >=4.9 && <5,
         bytestring -any,

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -85,8 +85,8 @@ library
         Data.Functor.Foldable.Monadic
         Data.Text.Prettyprint.Doc.Custom
     default-language: Haskell2010
-    default-extensions: ScopedTypeVariables
-                        FlexibleContexts DeriveGeneric StandaloneDeriving DeriveLift
+    default-extensions: ScopedTypeVariables FlexibleContexts
+                        DeriveGeneric StandaloneDeriving DeriveLift
                         GeneralizedNewtypeDeriving DeriveFunctor DeriveFoldable
                         DeriveTraversable
     other-extensions: DeriveAnyClass FlexibleInstances
@@ -96,7 +96,7 @@ library
                       ExistentialQuantification
     ghc-options: -Wall -Wnoncanonical-monad-instances
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
-                 -Wredundant-constraints -Widentities
+                 -Wredundant-constraints -Widentities -Wcompat
     build-depends:
         base >=4.9 && <5,
         bytestring -any,

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Typed.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Typed.hs
@@ -156,7 +156,7 @@ data DynamicBuiltinNameDefinition =
 -- | Mapping from 'DynamicBuiltinName's to their 'DynamicBuiltinNameMeaning's.
 newtype DynamicBuiltinNameMeanings = DynamicBuiltinNameMeanings
     { unDynamicBuiltinNameMeanings :: Map DynamicBuiltinName DynamicBuiltinNameMeaning
-    } deriving (Monoid)
+    } deriving (Semigroup, Monoid)
 
 instance Pretty BuiltinSized where
     pretty BuiltinSizedInt  = "integer"

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -36,7 +36,7 @@ import           PlutusPrelude
 -- | Mapping from 'DynamicBuiltinName's to their 'Type's.
 newtype DynamicBuiltinNameTypes = DynamicBuiltinNameTypes
     { unDynamicBuiltinNameTypes :: Map DynamicBuiltinName (Quote (Type TyName ()))
-    } deriving (Monoid)
+    } deriving (Semigroup, Monoid)
 
 -- | Configuration of the type checker.
 data TypeConfig = TypeConfig


### PR DESCRIPTION
This adds `Semigroup` instances so that, among other things, this builds with GHC 8.6.1.

I also added `-Wnoncanonical-monoid-instances` so that noncanonical monoid instances don't pass CI in the future. 