### PR TITLE
README: add instructions for adding binary caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ nix build -f default.nix language-plutus-core
 
 The Plutus Core specification is also built this way, as the attribute `plutus-core-spec`.
 
+### Binary caches
+
+You may wish to add the IOHK binary cache to your Nix configuration. This will speed up builds a lot, since many things will have
+been built already by our CI.
+
+Put the following in `/etc/nix/nix.conf`, or `~/.config/nix/nix.conf` if you are a trusted user (if you don't know what that means, just use `/etc/nix/nix.conf`):
+```
+substituters        = https://hydra.iohk.io https://cache.nixos.org/
+trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+```
+
 ## Docs
 
 Docs are built by hydra. The latest docs for plutus core master branch can be found at


### PR DESCRIPTION
You can find these if you poke around `cardano-sl`, but better to have them in our README, since it's very useful.