### PR TITLE
core-to-plc: allow passing locations as type lits

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -20,6 +20,7 @@
 
 - ignore: {name: Reduce duplication, within: [Language.PlutusCore.Renamer, Language.PlutusCore.Constant.Prelude, Language.PlutusCore.StdLib.Data.Bool, Language.PlutusCore.StdLib.Data.ChurchNat, Language.PlutusCore.StdLib.Data.Function, Language.PlutusCore.StdLib.Data.List, Language.PlutusCore.StdLib.Data.Nat, Language.PlutusCore.Pretty.Readable, Language.Plutus.CoreToPLC, Evaluation.CkMachine, Spec.Crowdfunding, Spec.Vesting, Language.Plutus.Lift]}
 - ignore: {name: Redundant $, within: [Evaluation.Constant.Success, Language.PlutusCore.Generators.Internal.TypedBuiltinGen]}
+- ignore: {name: Redundant bracket, within: [Language.Plutus.TH]}
 # this is rarely an improvement, also ignored in cardano
 - ignore: {name: Move brackets to avoid $}
 # this aids clarity since you can name the parameters

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
@@ -171,7 +171,7 @@ convertMarkedExprs opts markerName =
         convB = convertMarkedExprsBind opts markerName
     in \case
       -- the ignored argument is the type for the polymorphic 'plc'
-      e@(GHC.App(GHC.App (GHC.App (GHC.Var fid) (GHC.Type (GHC.isStrLitTy -> Just (fs_locStr)))) (GHC.Type _)) inner) | markerName == GHC.idName fid ->
+      e@(GHC.App(GHC.App (GHC.App (GHC.Var fid) (GHC.Type (GHC.isStrLitTy -> Just fs_locStr))) (GHC.Type _)) inner) | markerName == GHC.idName fid ->
           let
               vtype = GHC.varType fid
               locStr = show fs_locStr

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
@@ -226,13 +226,6 @@ convertExpr opts locStr origE resType = do
             then pure $ GHC.mkRuntimeErrorApp GHC.rUNTIME_ERROR_ID resType shown -- this will blow up at runtime
             else liftIO $ GHC.throwGhcExceptionIO (GHC.ProgramError shown) -- this will actually terminate compilation
         Right term -> do
-            let termRep = T.unpack $ PLC.docText $ PLC.prettyPlcClassicDebug term
-            -- Note: tests run with --verbose, so these will appear
-            GHC.debugTraceMsg $
-                "Successfully converted GHC core expression:" GHC.$+$
-                GHC.ppr origE GHC.$+$
-                "Resulting PLC term is:" GHC.$+$
-                GHC.text termRep
             let program = PLC.Program () (PLC.defaultVersion ()) term
             let serialized = serialise program
             -- The GHC api only exposes a way to make literals for Words, not Word8s, so we need to convert them

--- a/core-to-plc/test/IllTyped.hs
+++ b/core-to-plc/test/IllTyped.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS -fplugin Language.Plutus.CoreToPLC.Plugin -fplugin-opt Language.Plutus.CoreToPLC.Plugin:dont-typecheck #-}
 -- the simplfiier messes with things otherwise
 {-# OPTIONS_GHC   -O0 #-}
@@ -8,36 +10,35 @@
 module IllTyped where
 
 import           Language.Plutus.CoreToPLC.Plugin
-import           Language.Plutus.CoreToPLC.Primitives as Prims
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module "HLint: ignore" #-}
 
 listConstruct :: PlcCode
-listConstruct = plc ([]::[Int])
+listConstruct = plc @"listConstruct" ([]::[Int])
 
 listConstruct2 :: PlcCode
-listConstruct2 = plc ([1]::[Int])
+listConstruct2 = plc @"listConstruct2" ([1]::[Int])
 
 -- It is very difficult to get GHC to make a non-polymorphic redex if you use
 -- list literal syntax with integers. But this works.
 listConstruct3 :: PlcCode
-listConstruct3 = plc ((1::Int):(2::Int):(3::Int):[])
+listConstruct3 = plc @"listConstruct3" ((1::Int):(2::Int):(3::Int):[])
 
 listMatch :: PlcCode
-listMatch = plc (\(l::[Int]) -> case l of { (x:_) -> x ; [] -> 0; })
+listMatch = plc @"listMatch" (\(l::[Int]) -> case l of { (x:_) -> x ; [] -> 0; })
 
 data B a = One a | Two (B (a, a))
 
 ptreeConstruct :: PlcCode
-ptreeConstruct = plc (Two (Two (One ((1,2),(3,4)))) :: B Int)
+ptreeConstruct = plc @"ptreeConstruct" (Two (Two (One ((1,2),(3,4)))) :: B Int)
 
 -- TODO: replace this with 'first' when we have working recursive functions
 ptreeMatch :: PlcCode
-ptreeMatch = plc (\(t::B Int) -> case t of { One a -> a; Two _ -> 2; })
+ptreeMatch = plc @"ptreeMatch" (\(t::B Int) -> case t of { One a -> a; Two _ -> 2; })
 
 sumDirect :: PlcCode
-sumDirect = plc (
+sumDirect = plc @"sumDirect" (
     let sum :: [Int] -> Int
         sum []     = 0
         sum (x:xs) = x + sum xs
@@ -57,7 +58,7 @@ sumViaFold = plc (let fold :: (a -> b -> a) -> a -> [b] -> a
 -}
 
 evenMutual :: PlcCode
-evenMutual = plc (
+evenMutual = plc @"evenMutual" (
     let even :: Int -> Bool
         even n = if n == 0 then True else odd (n-1)
         odd :: Int -> Bool

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
@@ -83,10 +84,10 @@ basic = testNested "basic" [
   ]
 
 monoId :: PlcCode
-monoId = plc (\(x :: Int) -> x)
+monoId = plc @"monoId" (\(x :: Int) -> x)
 
 monoK :: PlcCode
-monoK = plc (\(i :: Int) -> \(j :: Int) -> i)
+monoK = plc @"monoK" (\(i :: Int) -> \(j :: Int) -> i)
 
 primitives :: TestNested
 primitives = testNested "primitives" [
@@ -95,7 +96,7 @@ primitives = testNested "primitives" [
   , golden "int2" int
   , golden "bool" bool
   , golden "and" andPlc
-  , goldenEval "andApply" [ andPlc, plc True, plc False ]
+  , goldenEval "andApply" [ andPlc, plc @"T" True, plc @"F" False ]
   , golden "tuple" tuple
   , golden "tupleMatch" tupleMatch
   , goldenEval "tupleConstDest" [ tupleMatch, tuple ]
@@ -114,53 +115,53 @@ primitives = testNested "primitives" [
   ]
 
 string :: PlcCode
-string = plc "test"
+string = plc @"string" "test"
 
 int :: PlcCode
-int = plc (1::Int)
+int = plc @"int" (1::Int)
 
 int2 :: PlcCode
-int2 = plc (2::Int)
+int2 = plc @"int2" (2::Int)
 
 bool :: PlcCode
-bool = plc True
+bool = plc @"bool" True
 
 andPlc :: PlcCode
-andPlc = plc (\(x::Bool) (y::Bool) -> if x then (if y then True else False) else False)
+andPlc = plc @"andPlc" (\(x::Bool) (y::Bool) -> if x then (if y then True else False) else False)
 
 tuple :: PlcCode
-tuple = plc ((1::Int), (2::Int))
+tuple = plc @"tuple" ((1::Int), (2::Int))
 
 tupleMatch :: PlcCode
-tupleMatch = plc (\(x:: (Int, Int)) -> let (a, b) = x in a)
+tupleMatch = plc @"tupleMatch" (\(x:: (Int, Int)) -> let (a, b) = x in a)
 
 intCompare :: PlcCode
-intCompare = plc (\(x::Int) (y::Int) -> x < y)
+intCompare = plc @"intCompare" (\(x::Int) (y::Int) -> x < y)
 
 intEq :: PlcCode
-intEq = plc (\(x::Int) (y::Int) -> x == y)
+intEq = plc @"intEq" (\(x::Int) (y::Int) -> x == y)
 
 -- Has a Void in it
 void :: PlcCode
-void = plc (\(x::Int) (y::Int) -> let a x' y' = case (x', y') of { (True, True) -> True; _ -> False; } in (x == y) `a` (y == x))
+void = plc @"void" (\(x::Int) (y::Int) -> let a x' y' = case (x', y') of { (True, True) -> True; _ -> False; } in (x == y) `a` (y == x))
 
 intPlus :: PlcCode
-intPlus = plc (\(x::Int) (y::Int) -> x + y)
+intPlus = plc @"intPlus" (\(x::Int) (y::Int) -> x + y)
 
 errorPlc :: PlcCode
-errorPlc = plc (Prims.error @Int)
+errorPlc = plc @"errorPlc" (Prims.error @Int)
 
 ifThenElse :: PlcCode
-ifThenElse = plc (\(x::Int) (y::Int) -> if x == y then x else y)
+ifThenElse = plc @"ifThenElse" (\(x::Int) (y::Int) -> if x == y then x else y)
 
 blocknumPlc :: PlcCode
-blocknumPlc = plc Prims.blocknum
+blocknumPlc = plc @"blocknumPlc" Prims.blocknum
 
 bytestring :: PlcCode
-bytestring = plc (\(x::Prims.ByteString) -> x)
+bytestring = plc @"bytestring" (\(x::Prims.ByteString) -> x)
 
 verify :: PlcCode
-verify = plc (\(x::Prims.ByteString) (y::Prims.ByteString) (z::Prims.ByteString) -> Prims.verifySignature x y z)
+verify = plc @"verify" (\(x::Prims.ByteString) (y::Prims.ByteString) (z::Prims.ByteString) -> Prims.verifySignature x y z)
 
 structure :: TestNested
 structure = testNested "structure" [
@@ -169,7 +170,7 @@ structure = testNested "structure" [
 
 -- GHC acutually turns this into a lambda for us, try and make one that stays a let
 letFun :: PlcCode
-letFun = plc (\(x::Int) (y::Int) -> let f z = x == z in f y)
+letFun = plc @"lefFun" (\(x::Int) (y::Int) -> let f z = x == z in f y)
 
 datat :: TestNested
 datat = testNested "data" [
@@ -196,38 +197,38 @@ monoData = testNested "monomorphic" [
 data MyEnum = Enum1 | Enum2
 
 basicEnum :: PlcCode
-basicEnum = plc (Enum1)
+basicEnum = plc @"basicEnum" (Enum1)
 
 data MyMonoData = Mono1 Int Int | Mono2 Int | Mono3 Int deriving (Generic)
 
 monoDataType :: PlcCode
-monoDataType = plc (\(x :: MyMonoData) -> x)
+monoDataType = plc @"monoDataType" (\(x :: MyMonoData) -> x)
 
 monoConstructor :: PlcCode
-monoConstructor = plc (Mono1)
+monoConstructor = plc @"monConstructor" (Mono1)
 
 monoConstructed :: PlcCode
-monoConstructed = plc (Mono2 1)
+monoConstructed = plc @"monoConstructed" (Mono2 1)
 
 monoCase :: PlcCode
-monoCase = plc (\(x :: MyMonoData) -> case x of { Mono1 a b -> b;  Mono2 a -> a; Mono3 a -> a })
+monoCase = plc @"monoCase" (\(x :: MyMonoData) -> case x of { Mono1 a b -> b;  Mono2 a -> a; Mono3 a -> a })
 
 defaultCase :: PlcCode
-defaultCase = plc (\(x :: MyMonoData) -> case x of { Mono3 a -> a ; _ -> 2; })
+defaultCase = plc @"defaultCase" (\(x :: MyMonoData) -> case x of { Mono3 a -> a ; _ -> 2; })
 
 data MyMonoRecord = MyMonoRecord { a :: Int , b :: Int} deriving Generic
 
 monoRecord :: PlcCode
-monoRecord = plc (\(x :: MyMonoRecord) -> x)
+monoRecord = plc @"monoRecord" (\(x :: MyMonoRecord) -> x)
 
 -- must be compiled with a lazy case
 nonValueCase :: PlcCode
-nonValueCase = plc (\(x :: MyEnum) -> case x of { Enum1 -> 1::Int ; Enum2 -> Prims.error (); })
+nonValueCase = plc @"nonValueCase" (\(x :: MyEnum) -> case x of { Enum1 -> 1::Int ; Enum2 -> Prims.error (); })
 
 type Synonym = Int
 
 synonym :: PlcCode
-synonym = plc (1::Synonym)
+synonym = plc @"synonym" (1::Synonym)
 
 polyData :: TestNested
 polyData = testNested "polymorphic" [
@@ -238,10 +239,10 @@ polyData = testNested "polymorphic" [
 data MyPolyData a b = Poly1 a b | Poly2 a
 
 polyDataType :: PlcCode
-polyDataType = plc (\(x:: MyPolyData Int Int) -> x)
+polyDataType = plc @"polyDataType" (\(x:: MyPolyData Int Int) -> x)
 
 polyConstructed :: PlcCode
-polyConstructed = plc (Poly1 (1::Int) (2::Int))
+polyConstructed = plc @"polyConstructed" (Poly1 (1::Int) (2::Int))
 
 newtypes :: TestNested
 newtypes = testNested "newtypes" [
@@ -258,19 +259,19 @@ newtype MyNewtype = MyNewtype Int
 newtype MyNewtype2 = MyNewtype2 MyNewtype
 
 basicNewtype :: PlcCode
-basicNewtype = plc (\(x::MyNewtype) -> x)
+basicNewtype = plc @"basicNewtype" (\(x::MyNewtype) -> x)
 
 newtypeMatch :: PlcCode
-newtypeMatch = plc (\(MyNewtype x) -> x)
+newtypeMatch = plc @"newtypeMatch" (\(MyNewtype x) -> x)
 
 newtypeCreate :: PlcCode
-newtypeCreate = plc (\(x::Int) -> MyNewtype x)
+newtypeCreate = plc @"newtypeCreate" (\(x::Int) -> MyNewtype x)
 
 newtypeCreate2 :: PlcCode
-newtypeCreate2 = plc (MyNewtype 1)
+newtypeCreate2 = plc @"newtypeCreate2" (MyNewtype 1)
 
 nestedNewtypeMatch :: PlcCode
-nestedNewtypeMatch = plc (\(MyNewtype2 (MyNewtype x)) -> x)
+nestedNewtypeMatch = plc @"nestedNewtypeMatch" (\(MyNewtype2 (MyNewtype x)) -> x)
 
 recursiveTypes :: TestNested
 recursiveTypes = testNested "recursiveTypes" [
@@ -289,19 +290,19 @@ recursion :: TestNested
 recursion = testNested "recursiveFunctions" [
     -- currently broken, will come back to this later
     golden "fib" fib
-    , goldenEval "fib4" [ fib, plc (4::Int) ]
+    , goldenEval "fib4" [ fib, plc @"4" (4::Int) ]
     , golden "sum" sumDirect
     , goldenEval "sumList" [ sumDirect, listConstruct3 ]
     --, golden "sumFold" sumViaFold
     --, goldenEval "sumFoldList" [ sumViaFold, listConstruct3 ]
     , golden "even" evenMutual
-    , goldenEval "even3" [ evenMutual, plc (3::Int) ]
-    , goldenEval "even4" [ evenMutual, plc (4::Int) ]
+    , goldenEval "even3" [ evenMutual, plc @"3" (3::Int) ]
+    , goldenEval "even4" [ evenMutual, plc @"4" (4::Int) ]
   ]
 
 fib :: PlcCode
 -- not using case to avoid literal cases
-fib = plc (
+fib = plc @"fib" (
     let fib :: Int -> Int
         fib n = if n == 0 then 0 else if n == 1 then 1 else fib(n-1) + fib(n-2)
     in fib)
@@ -314,15 +315,15 @@ errors = testNested "errors" [
   ]
 
 integer :: PlcCode
-integer = plc (1::Integer)
+integer = plc @"integer" (1::Integer)
 
 free :: PlcCode
-free = plc (True && False)
+free = plc @"free" (True && False)
 
 -- It's little tricky to get something that GHC actually turns into a polymorphic computation! We use our value twice
 -- at different types to prevent the obvious specialization.
 valueRestriction :: PlcCode
-valueRestriction = plc (let { f :: forall a . a; f = Prims.error (); } in (f @Bool, f @Int))
+valueRestriction = plc @"valueRestriction" (let { f :: forall a . a; f = Prims.error (); } in (f @Bool, f @Int))
 
 instance LiftPlc (MyMonoData)
 instance LiftPlc (MyMonoRecord)

--- a/core-to-plc/test/data/monomorphic/nonValueCase.plc.golden
+++ b/core-to-plc/test/data/monomorphic/nonValueCase.plc.golden
@@ -4,3 +4,4 @@ Error: Type mismatch at () in term
          'bad_name_20',
        found type
          '(all a_32 (type) (fun a_32 a_32))'
+Context: Converting expr at "nonValueCase"

--- a/core-to-plc/test/data/newtypes/nestedNewtypeMatch.plc.golden
+++ b/core-to-plc/test/data/newtypes/nestedNewtypeMatch.plc.golden
@@ -1,1 +1,2 @@
 Error: Error at (). Type variable MyNewtype_4 is not in scope.
+Context: Converting expr at "nestedNewtypeMatch"

--- a/core-to-plc/test/errors/free.plc.golden
+++ b/core-to-plc/test/errors/free.plc.golden
@@ -2,3 +2,4 @@ Error: Used but not defined in the current conversion: Variable: &&
 Context: Converting expr: &&
 Context: Converting expr: && True
 Context: Converting expr: && True False
+Context: Converting expr at "free"

--- a/core-to-plc/test/errors/integer.plc.golden
+++ b/core-to-plc/test/errors/integer.plc.golden
@@ -1,2 +1,3 @@
 Error: Unsupported: Literal (unbounded) integer
 Context: Converting expr: 1
+Context: Converting expr at "integer"

--- a/core-to-plc/test/errors/valueRestriction.plc.golden
+++ b/core-to-plc/test/errors/valueRestriction.plc.golden
@@ -5,3 +5,4 @@ Context: Converting expr: let {
                             [LclId]
                             f = \ (@ a) -> error @ a () } in
                           (f @ Bool, f @ Int)
+Context: Converting expr at "valueRestriction"

--- a/plutus-th/src/Language/Plutus/TH.hs
+++ b/plutus-th/src/Language/Plutus/TH.hs
@@ -1,19 +1,18 @@
-{-# LANGUAGE TemplateHaskell #-}
-module Language.Plutus.TH (plutus, plutusT, PlcCode, getSerializedCode, getAst, applyPlc) where
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TypeApplications #-}
+module Language.Plutus.TH (plutus, PlcCode, getSerializedCode, getAst, applyPlc) where
 
 import           Language.Plutus.CoreToPLC.Plugin
 
-import           Language.Haskell.TH
+import qualified Language.Haskell.TH              as TH
 
 -- | Covert a quoted Haskell expression into a corresponding Plutus Core program. Produces an expression of type
 -- 'PlcCode'.
-plutus :: Q Exp -> Q Exp
+plutus :: TH.Q TH.Exp -> TH.Q TH.Exp
 -- We would like to do `addCorePlugin "Language.Plutus.CoreToPLC.Plugin"``, but this needs template-haskell-2.13.0.0,
 -- which is in the next LTS snapshot.
-plutus e = [| plc $(e) |]
-
--- | Covert a (typed) quoted Haskell expression into a corresponding Plutus Core program.
-plutusT :: Q (TExp a) -> Q (TExp PlcCode)
--- We would like to do `addCorePlugin "Language.Plutus.CoreToPLC.Plugin"``, but this needs template-haskell-2.13.0.0,
--- which is in the next LTS snapshot.
-plutusT e = [||plc $$(e)||]
+plutus e = do
+    loc <- TH.location
+    let locStr = TH.pprint loc
+    [| plc @($(TH.litT $ TH.strTyLit locStr)) $(e) |]

--- a/plutus-th/src/Language/Plutus/TH.hs
+++ b/plutus-th/src/Language/Plutus/TH.hs
@@ -16,3 +16,10 @@ plutus e = do
     loc <- TH.location
     let locStr = TH.pprint loc
     [| plc @($(TH.litT $ TH.strTyLit locStr)) $(e) |]
+
+{- Note [Typed TH]
+It would be nice to have a typed TH version of `plutus`. However, this is hard to do because the singleton type
+is not known until TH runtime.
+
+We could cheat and use `unsafeTExpCoerce`, but I'd prefer not to do that unless we have to.
+-}

--- a/plutus-th/test/Spec.hs
+++ b/plutus-th/test/Spec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 -- remove when we can use addCorePlugin
@@ -31,11 +32,11 @@ tests = testGroup "plutus-th" <$> sequence [
   ]
 
 simple :: PlcCode
-simple = $$(plutusT [|| \(x::Bool) -> if x then (1::Int) else (2::Int) ||])
+simple = $(plutus [| \(x::Bool) -> if x then (1::Int) else (2::Int) |])
 
 -- similar to the power example for Feldspar - should be completely unrolled at compile time
 powerPlc :: PlcCode
-powerPlc = $$(plutusT [|| $$(power (4::Int)) ||])
+powerPlc = $(plutus [| $(power (4::Int)) |])
 
 andPlc :: PlcCode
-andPlc = $$(plutusT [|| $$(andTH) True False ||])
+andPlc = $(plutus [| $(andTH) True False |])

--- a/plutus-th/test/Spec.hs
+++ b/plutus-th/test/Spec.hs
@@ -22,7 +22,7 @@ main :: IO ()
 main = defaultMain $ runTestNestedIn ["test"] tests
 
 golden :: String -> PlcCode -> TestNested
-golden name value = (nestedGoldenVsDoc name . PLC.prettyPlcClassicDebug . getAst) value
+golden name = nestedGoldenVsDoc name . PLC.prettyPlcClassicDebug . getAst
 
 tests :: TestNested
 tests = testGroup "plutus-th" <$> sequence [

--- a/plutus-th/test/TestTH.hs
+++ b/plutus-th/test/TestTH.hs
@@ -4,6 +4,8 @@ module TestTH where
 
 import           Language.Haskell.TH
 
+{-# ANN module "HLint: ignore" #-}
+
 power :: Int -> Q Exp
 power n =
     if n <= 0 then

--- a/plutus-th/test/TestTH.hs
+++ b/plutus-th/test/TestTH.hs
@@ -3,16 +3,15 @@
 module TestTH where
 
 import           Language.Haskell.TH
-import           Language.Haskell.TH.Syntax
 
-power :: Int -> Q (TExp (Int -> Int))
+power :: Int -> Q Exp
 power n =
     if n <= 0 then
-        [|| \ _ -> (1::Int) ||]
+        [| \ _ -> (1::Int) |]
     else if even n then
-        [|| \(x::Int) -> let y = $$(power (n `div` (2::Int))) x in y * y ||]
+        [| \(x::Int) -> let y = $(power (n `div` (2::Int))) x in y * y |]
     else
-        [|| \(x::Int) -> x * ($$(power (n - (1::Int))) x) ||]
+        [| \(x::Int) -> x * ($(power (n - (1::Int))) x) |]
 
-andTH :: Q (TExp (Bool -> Bool -> Bool))
-andTH = [||\(a :: Bool) -> \(b::Bool) -> if a then if b then True else False else False||]
+andTH :: Q Exp
+andTH = [|\(a :: Bool) -> \(b::Bool) -> if a then if b then True else False else False|]

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -2,6 +2,7 @@
 -- This is the fully parallel version that collects all contributions
 -- in a single transaction. This is, of course, limited by the maximum
 -- number of inputs a transaction can have.
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE OverloadedStrings   #-}

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
@@ -1,4 +1,5 @@
 -- | Vesting scheme as a PLC contract
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}

--- a/wallet-api/src/Wallet/UTXO/Types.hs
+++ b/wallet-api/src/Wallet/UTXO/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DefaultSignatures  #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}


### PR DESCRIPTION
This allows us to pass the location of the overall splice in to the plugin from TH as a type level literal (trick once again stolen from `inline-java`, but we do it better with `TypeApplications` rather than `Proxy`s). Unfortunately this does require `DataKinds` (ping @mchakravarty for the UI issue).

You would think that we could get this information from Core, but apparently not. Only names have locations, and those often aren't where you'd expect, since things can have been lifted etc. The TH locations are reliably where the user put them.

There's a bunch of noise for `core-to-plc`'s tests since they don't use the TH stuff so have to pass something themselves.

I also removed some unnecessary debug printing that might have been part of why `plutus-use-cases` has been slow, since it'll be printing out very big terms unconditionally.