### PR TITLE
[CGP-387] Rewrote the renamer

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -109,7 +109,6 @@ module Language.PlutusCore
     ) where
 
 import           Control.Monad.Except
-import           Control.Monad.State
 import qualified Data.ByteString.Lazy                     as BSL
 import qualified Data.Text                                as T
 import           Data.Text.Prettyprint.Doc
@@ -162,7 +161,7 @@ printNormalizeType norm bs = runQuoteT $ prettyPlcDefText <$> do
 -- | Parse and rewrite so that names are globally unique, not just unique within
 -- their scope.
 parseScoped :: (MonadError (Error AlexPosn) m) => BSL.ByteString -> m (Program TyName Name AlexPosn)
-parseScoped str = liftEither $ convertError $ fmap (\(p, s) -> rename s p) $ runExcept $ runStateT (parseST str) emptyIdentifierState
+parseScoped str = runQuoteT $ parseProgram str >>= rename
 
 -- | Parse a program and typecheck it.
 parseTypecheck :: (MonadError (Error AlexPosn) m, MonadQuote m) => Natural -> BSL.ByteString -> m (NormalizedType TyNameWithKind ())


### PR DESCRIPTION
I need the renamer to run in `Quote` rather than the custom monad it's currently running in. But once I started to change things, I realized there is a nicer way the renamer can be defined.