### PR TITLE
wallet-api: Better validation errors

### DIFF
--- a/wallet-api/src/Wallet/Emulator/Types.hs
+++ b/wallet-api/src/Wallet/Emulator/Types.hs
@@ -269,8 +269,8 @@ type MonadEmulator m = (MonadState EmulatorState m, MonadError AssertionError m)
 -- | Validate a transaction in the current emulator state
 validateEm :: EmulatorState -> Tx -> Maybe Tx
 validateEm EmulatorState{emIndex=idx, emValidationData = vd} txn =
-    let result = Index.runLookup (Index.validTxIndexed vd txn) idx in
-    either (const Nothing) (\r -> if r then Just txn else Nothing) result
+    let result = Index.runValidation (Index.validateTransaction vd txn) idx in
+    either (const Nothing) (const $ Just txn) result
 
 liftEmulatedWallet :: (MonadEmulator m) => Wallet -> EmulatedWalletApi a -> m ([Tx], Either WalletAPIError a)
 liftEmulatedWallet wallet act = do

--- a/wallet-api/src/Wallet/UTXO/Index.hs
+++ b/wallet-api/src/Wallet/UTXO/Index.hs
@@ -1,33 +1,38 @@
 {-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE DeriveGeneric    #-}
 {-# LANGUAGE FlexibleContexts #-}
--- | A map of transaction hashes to transactions for efficient lookups of
---   values on the mockchain.
+-- | An index of unspent transaction outputs, and some functions for validating
+--   transactions using the UTXO index.
 module Wallet.UTXO.Index(
-    UtxoLookup,
+    ValidationMonad,
     UtxoIndex(..),
     empty,
     insert,
     insertBlock,
     initialise,
-    Lookup,
-    runLookup,
+    Validation,
+    runValidation,
     lookupRef,
-    LookupError(..),
-    validTxIndexed
+    ValidationError(..),
+    validateTransaction
     ) where
 
-import           Control.Applicative  (liftA2)
 import           Control.Monad.Except (MonadError (..), liftEither)
 import           Control.Monad.Reader (MonadReader (..), ReaderT (..), ask)
-import           Data.Foldable        (foldl')
+import           Data.Foldable        (foldl', traverse_)
 import qualified Data.Map             as Map
 import           Data.Semigroup       (Semigroup, Sum (..))
 import qualified Data.Set             as Set
+import           GHC.Generics         (Generic)
 import           Prelude              hiding (lookup)
-import           Wallet.UTXO.Types    (Blockchain, Tx (..), TxIn (..), TxOut (..), TxOut', TxOutRef', ValidationData,
-                                       Value, unspentOutputs, updateUtxo, validValuesTx, validate)
+import           Wallet.UTXO.Types    (Blockchain, DataScript, PubKey, Signature, Tx (..), TxIn (..), TxIn', TxOut (..),
+                                       TxOut', TxOutRef', ValidationData, Value, unspentOutputs, updateUtxo,
+                                       validValuesTx)
+import qualified Wallet.UTXO.Types    as UTXO
 
-type UtxoLookup m = (MonadReader UtxoIndex m, MonadError LookupError m)
+-- | Context for validating transactions. We need access to the unspent
+--   transaction outputs of the blockchain, and we can throw `ValidationError`s
+type ValidationMonad m = (MonadReader UtxoIndex m, MonadError ValidationError m)
 
 -- | The transactions of a blockchain indexed by hash
 newtype UtxoIndex = UtxoIndex { getIndex :: Map.Map TxOutRef' TxOut' }
@@ -50,55 +55,98 @@ insertBlock :: [Tx] -> UtxoIndex -> UtxoIndex
 insertBlock blck i = foldl' (flip insert) i blck
 
 -- | Find an unspent transaction output by the `TxOutRef'` that spends it.
-lookup :: TxOutRef' -> UtxoIndex -> Either LookupError TxOut'
+lookup :: TxOutRef' -> UtxoIndex -> Either ValidationError TxOut'
 lookup i =
     maybe (Left $ TxOutRefNotFound i) Right . Map.lookup i . getIndex
 
-newtype LookupError = TxOutRefNotFound TxOutRef'
-    deriving (Eq)
+-- | Reason why a transaction is invalid
+data ValidationError =
+    InOutTypeMismatch TxIn' TxOut'
+    -- ^ A pay-to-pubkey output was consumed by a pay-to-script input or vice versa
+    | TxOutRefNotFound TxOutRef'
+    -- ^ The unspent transaction output consumed by a transaction input could not be found (either because it was already spent, or because there was no transaction with the given hash on the blockchain)
+    | InvalidScriptHash DataScript
+    -- ^ (for pay-to-script outputs) The validator script provided in the transaction input does not match the hash specified in the transaction output
+    | InvalidSignature PubKey Signature
+    -- ^ (for pay-to-pubkey outputs) The signature of the transaction input does not match the public key of the transaction output
+    | ValueNotPreserved Value Value
+    -- ^ The amount spent by the transaction differs from the amount consumed by it
+    | NegativeValue Tx
+    -- ^ The transaction produces an output with a negative value
+    | ScriptFailure
+    -- ^ Evaluation of the validator script failed
+    deriving (Eq, Show, Generic)
 
-newtype Lookup a = Lookup { _runLookup :: (ReaderT UtxoIndex (Either LookupError)) a }
-    deriving (Functor, Applicative, Monad, MonadReader UtxoIndex, MonadError LookupError)
+newtype Validation a = Validation { _runValidation :: (ReaderT UtxoIndex (Either ValidationError)) a }
+    deriving (Functor, Applicative, Monad, MonadReader UtxoIndex, MonadError ValidationError)
 
 -- | Find an unspent transaction output by its reference. Assumes that the
 --   output for this reference exists. If you want to handle the lookup error
 --   you can use `runLookup`.
-lookupRef :: UtxoLookup m => TxOutRef' -> m TxOut'
+lookupRef :: ValidationMonad m => TxOutRef' -> m TxOut'
 lookupRef t = liftEither  . lookup t =<< ask
 
--- | Run a `Lookup` on a `UtxoIndex`
-runLookup :: Lookup a -> UtxoIndex -> Either LookupError a
-runLookup l = runReaderT (_runLookup l)
+-- | Run a `Validation` on a `UtxoIndex`
+runValidation :: Validation a -> UtxoIndex -> Either ValidationError a
+runValidation l = runReaderT (_runValidation l)
 
 -- | Determine the unspent value that an input refers to
-value :: UtxoLookup m => TxOutRef' -> m Value
+value :: ValidationMonad m => TxOutRef' -> m Value
 value o = txOutValue <$> lookupRef o
 
-infixr 3 <&&>
-
--- | Lifted `(&&)`
-(<&&>) :: Applicative f => f Bool -> f Bool -> f Bool
-(<&&>) = liftA2 (&&)
-
 -- | Validate a transaction in a `UtxoLookup` context.
+--
 --   This does the same as `Wallet.UTXO.Types.validTx`, but more efficiently as
 --   it doesn't compute the UTXO of a blockchain from scratch.
---   It also gives a more precise error: A return value of `False` indicates
---   that one of the value preservation conditions is false, or that the script
---   failed. Failing with `LookupError` means that the outputs spent by the
---   transaction are not part of the UTxO set of the blockchain. In
---   `Wallet.UTXO.Types.validTx` this failure condition would also result in
---   `False`.
-validTxIndexed :: UtxoLookup m => ValidationData -> Tx -> m Bool
-validTxIndexed v t = valueIsPreserved t <&&> pure (validValuesTx t) <&&> inputsAreValid  where
-    inputsAreValid = and <$> traverse validates (Set.toList $ txInputs t)
-    validates txIn = validate v txIn <$> lookupRef (txInRef txIn)
+--   It also gives a more precise error: `ValidationError` instead of `False`.
+validateTransaction :: ValidationMonad m
+    => ValidationData
+    -> Tx
+    -> m ()
+validateTransaction v t =
+    checkValuePreserved t >> checkPositiveValues t >> checkValidInputs v t
+
+-- | Check if the inputs of the transaction consume outputs that
+--   (a) exist and
+--   (b) can be unlocked by the signatures or validator scripts of the inputs
+checkValidInputs :: ValidationMonad m => ValidationData -> Tx -> m ()
+checkValidInputs v = traverse_ (checkValidInput v) . Set.toList . txInputs
+
+-- | Validate a single transaction input
+checkValidInput :: ValidationMonad m => ValidationData -> TxIn' -> m ()
+checkValidInput v i = (lookupRef $ txInRef i) >>= checkInputOutput v i
+
+-- | Check that a transaction output can be spent by a transaction input
+checkInputOutput :: ValidationMonad m => ValidationData -> TxIn' -> TxOut' -> m ()
+checkInputOutput bs i txo =
+    case (txInType i, txOutType txo) of
+        (UTXO.ConsumeScriptAddress v r, UTXO.PayToScript d)
+            | txOutAddress txo /= UTXO.scriptAddress (txOutValue txo) v d ->
+                throwError $ InvalidScriptHash d
+            | otherwise ->
+                if UTXO.runScript bs v r d
+                then pure ()
+                else throwError ScriptFailure
+        (UTXO.ConsumePublicKeyAddress sig, UTXO.PayToPubKey pk) ->
+            if sig `UTXO.signedBy` pk
+            then pure ()
+            else throwError $ InvalidSignature pk sig
+        _ -> throwError $ InOutTypeMismatch i txo
 
 -- | Check if the value produced by a transaction equals the value consumed by
 --   it.
-valueIsPreserved :: UtxoLookup m => Tx -> m Bool
-valueIsPreserved t = (== outVal) <$> inVal where
-    inVal =
-        (txForge t +) <$> fmap (getSum . foldMap Sum) (traverse (value . txInRef) (Set.toList $ txInputs t))
-    outVal =
-        txFee t + sum (map txOutValue (txOutputs t))
+checkValuePreserved :: ValidationMonad m => Tx -> m ()
+checkValuePreserved t = do
+    inVal <- (txForge t +) <$> fmap (getSum . foldMap Sum) (traverse (value . txInRef) (Set.toList $ txInputs t))
+    let outVal = txFee t + sum (map txOutValue (txOutputs t))
+    if outVal == inVal
+    then pure ()
+    else throwError $ ValueNotPreserved inVal outVal
+
+-- | Check if all values produced and consumed by a transaction are
+--   non-negative.
+checkPositiveValues :: ValidationMonad m => Tx -> m ()
+checkPositiveValues t =
+    if validValuesTx t
+    then pure ()
+    else throwError $ NegativeValue t

--- a/wallet-api/src/Wallet/UTXO/Types.hs
+++ b/wallet-api/src/Wallet/UTXO/Types.hs
@@ -78,6 +78,7 @@ module Wallet.UTXO.Types(
     unitRedeemer,
     unitData,
     unitValidationData,
+    runScript,
     -- * Lenses
     inputs,
     outputs,

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -68,7 +68,7 @@ txnIndexValid = property $ do
     (m, txn) <- forAll genChainTxn
     let (result, st) = Gen.runTrace m blockchainActions
         idx = emIndex st
-    Hedgehog.assert (Right True == Index.runLookup (Index.validTxIndexed unitValidationData txn) idx)
+    Hedgehog.assert (Right () == Index.runValidation (Index.validateTransaction unitValidationData txn) idx)
 
 -- | Submit a transaction to the blockchain and assert that it has been
 --   validated


### PR DESCRIPTION
* Extend the `LookupError` type to cover all possible validation errors
* Add `validateTransaction` which produces much more detailed errors
  than `validate`
* Change the `BlockchainLookup` type to `ValidationMonad`

After I started building the new runtime validation stuff I realised that the `LookupError` is only relevant when validating a transaction, and decided to add a more detailed error type that covers all failure conditions. Even if we don't get such precise errors from the real blockchain it is useful to have them in the emulator for writing plutus contracts.