### PR TITLE
Http client

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -16773,6 +16773,7 @@ license = stdenv.lib.licenses.bsd3;
 ({
   mkDerivation
 , base
+, basement
 , bytestring
 , deepseq
 , ghc-prim
@@ -16783,10 +16784,11 @@ license = stdenv.lib.licenses.bsd3;
 mkDerivation {
 
 pname = "cryptonite";
-version = "0.22";
-sha256 = "4be312a42a12ccd2ca60272ef485664f242c7ed89fa1909ba36a54c5fb6ff5f0";
+version = "0.25";
+sha256 = "89be1a18af8730a7bfe4d718d7d5f6ce858e9df93a411566d15bf992db5a3c8c";
 libraryHaskellDepends = [
 base
+basement
 bytestring
 deepseq
 ghc-prim
@@ -55553,6 +55555,7 @@ license = stdenv.lib.licenses.bsd3;
 , hedgehog
 , language-plutus-core
 , mmorph
+, mtl
 , prettyprinter
 , stdenv
 , tasty
@@ -55571,6 +55574,7 @@ base
 bytestring
 containers
 language-plutus-core
+mtl
 prettyprinter
 text
 ];
@@ -55581,6 +55585,7 @@ containers
 hedgehog
 language-plutus-core
 mmorph
+mtl
 prettyprinter
 tasty
 tasty-golden
@@ -78418,6 +78423,7 @@ license = stdenv.lib.licenses.mit;
 , prettyprinter
 , serialise
 , servant
+, servant-client
 , servant-server
 , stdenv
 , stm
@@ -78464,6 +78470,7 @@ plutus-th
 prettyprinter
 serialise
 servant
+servant-client
 servant-server
 stm
 template-haskell

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ packages:
   extra-dep: true
 
 extra-deps:
-- cryptonite-0.22
+- cryptonite-0.25
 - cborg-0.2.0.0
 - serialise-0.2.0.0
 - monad-stm-0.1.0.2

--- a/wallet-api/src/Wallet/Emulator/Client.hs
+++ b/wallet-api/src/Wallet/Emulator/Client.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DataKinds #-}
+
+module Wallet.Emulator.Client where
+
+import           Data.Proxy            (Proxy (Proxy))
+import           Data.Set              (Set)
+import           Servant.API           ((:<|>) ((:<|>)), NoContent)
+import           Servant.Client        (ClientM, client)
+import           Wallet.Emulator.Http  (API)
+import           Wallet.Emulator.Types (Wallet)
+import           Wallet.UTXO           (Block, Height, Tx, TxIn', TxOut', ValidationData, Value)
+
+api :: Proxy API
+api = Proxy
+
+wallets :: ClientM [Wallet]
+fetchWallet :: Wallet -> ClientM Wallet
+createWallet :: Wallet -> ClientM NoContent
+createPaymentWithChange :: Wallet -> Value -> ClientM (Set TxIn', TxOut')
+payToPublicKey :: Wallet -> Value -> ClientM TxOut'
+submitTxn :: Wallet -> Tx -> ClientM ()
+getTransactions :: ClientM [Tx]
+blockchainActions :: ClientM [Tx]
+setValidationData :: ValidationData -> ClientM ()
+blockValidated :: Wallet -> Block -> ClientM ()
+blockHeight :: Wallet -> Height -> ClientM ()
+assertOwnFundsEq :: Wallet -> Value -> ClientM NoContent
+assertIsValidated :: Tx -> ClientM NoContent
+(wallets :<|> fetchWallet :<|> createWallet :<|> createPaymentWithChange :<|> payToPublicKey :<|> submitTxn :<|> getTransactions) :<|> (blockValidated :<|> blockHeight) :<|> (blockchainActions :<|> setValidationData) :<|> (assertOwnFundsEq :<|> assertIsValidated) =
+  client api

--- a/wallet-api/src/Wallet/UTXO/Types.hs
+++ b/wallet-api/src/Wallet/UTXO/Types.hs
@@ -280,7 +280,7 @@ instance Ord Redeemer where
 newtype Height = Height { getHeight :: Integer }
     deriving (Eq, Ord, Show, Enum)
     deriving stock (Generic)
-    deriving newtype (Num, Real, Integral, Serialise, FromJSON)
+    deriving newtype (Num, Real, Integral, Serialise, FromJSON, ToJSON)
 
 -- | The height of a blockchain
 height :: Blockchain -> Height

--- a/wallet-api/wallet-api.cabal
+++ b/wallet-api/wallet-api.cabal
@@ -43,6 +43,7 @@ library
     exposed-modules:
         Wallet.API
         Wallet.Emulator
+        Wallet.Emulator.Client
         Wallet.Emulator.Http
         Wallet.Emulator.Types
         Wallet.Generators
@@ -72,7 +73,7 @@ library
         cborg -any,
         containers -any,
         core-to-plc -any,
-        cryptonite -any,
+        cryptonite >=0.25,
         errors -any,
         free -any,
         ghc -any,
@@ -90,6 +91,7 @@ library
         prettyprinter -any,
         serialise -any,
         servant -any,
+        servant-client -any,
         servant-server -any,
         stm -any,
         template-haskell -any,


### PR DESCRIPTION
There are 2 parts to this PR (in 2 commits)

1. Clean up the HTTP server so that it reuses the existing machinery from `Trace`
2. Create an HTTP client for all the endpoints

I am actually unsure where to go from here. The client can't fit into `Trace` since that contains `EmulatedWalletApi` which is a wrapper around `StateT WalletState`. Basically I'm unsure how or where we now use this client?

Anyway, that would be the remit of another PR, I don't think it should stop this PR being merged.