### PR TITLE
nix build: set -Werror

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,6 +55,7 @@ let
     overrides = self: super: {
       plutus-prototype = addRealTimeTestLogs (filterSource super.plutus-prototype);
       # we want to enable benchmarking, which also means we have criterion in the corresponding env
+      # we need to enable benchmarks as a flag too, until we are on a newer nixpkgs where this is implied by doBenchmark
       language-plutus-core = addWerror (appendConfigureFlag (doBenchmark (doHaddockHydra (addRealTimeTestLogs (filterSource super.language-plutus-core)))) "--enable-benchmarks");
       plutus-core-interpreter = addWerror (doHaddockHydra (addRealTimeTestLogs (filterSource super.plutus-core-interpreter)));
       plutus-exe = addWerror (addRealTimeTestLogs (filterSource super.plutus-exe));

--- a/default.nix
+++ b/default.nix
@@ -31,6 +31,8 @@ let
   addRealTimeTestLogs = drv: overrideCabal drv (attrs: {
     testTarget = "--show-details=streaming";
   });
+  # probably replace with failOnAllWarnings from the haskell lib once we're on a newer nixpkgs
+  addWerror = drv: appendConfigureFlag drv "--ghc-option=-Werror";
   filterSource = drv: drv.overrideAttrs (attrs : {
     src = builtins.filterSource cleanSourceFilter attrs.src;
   });
@@ -53,13 +55,13 @@ let
     overrides = self: super: {
       plutus-prototype = addRealTimeTestLogs (filterSource super.plutus-prototype);
       # we want to enable benchmarking, which also means we have criterion in the corresponding env
-      language-plutus-core = appendConfigureFlag (doBenchmark (doHaddockHydra (addRealTimeTestLogs (filterSource super.language-plutus-core)))) "--enable-benchmarks";
-      plutus-core-interpreter = doHaddockHydra (addRealTimeTestLogs (filterSource super.plutus-core-interpreter));
-      plutus-exe = addRealTimeTestLogs (filterSource super.plutus-exe);
-      core-to-plc = doHaddockHydra (addRealTimeTestLogs (filterSource super.core-to-plc));
-      plutus-th = doHaddockHydra (addRealTimeTestLogs (filterSource super.plutus-th));
-      plutus-use-cases = addRealTimeTestLogs (filterSource super.plutus-use-cases);
-      wallet-api = doHaddockHydra (addRealTimeTestLogs (filterSource super.wallet-api));
+      language-plutus-core = addWerror (appendConfigureFlag (doBenchmark (doHaddockHydra (addRealTimeTestLogs (filterSource super.language-plutus-core)))) "--enable-benchmarks");
+      plutus-core-interpreter = addWerror (doHaddockHydra (addRealTimeTestLogs (filterSource super.plutus-core-interpreter)));
+      plutus-exe = addWerror (addRealTimeTestLogs (filterSource super.plutus-exe));
+      core-to-plc = addWerror (doHaddockHydra (addRealTimeTestLogs (filterSource super.core-to-plc)));
+      plutus-th = addWerror (doHaddockHydra (addRealTimeTestLogs (filterSource super.plutus-th)));
+      plutus-use-cases = addWerror (addRealTimeTestLogs (filterSource super.plutus-use-cases));
+      wallet-api = addWerror (doHaddockHydra (addRealTimeTestLogs (filterSource super.wallet-api)));
     };
   };
   other = rec {

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -9,9 +9,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE ViewPatterns        #-}
 {-# OPTIONS -fplugin=Language.Plutus.CoreToPLC.Plugin -fplugin-opt Language.Plutus.CoreToPLC.Plugin:dont-typecheck #-}
-{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
 module Language.Plutus.Coordination.Contracts.CrowdFunding (
     -- * Campaign parameters
     Campaign(..)
@@ -137,7 +135,6 @@ contributionScript (CampaignPLC c)  = Validator val where
                         -- In case of a refund, we can only collect the funds that
                         -- were committed by this contributor
                     in refundable
-                _ -> False
         in
         if isValid then () else Builtins.error ()) |])
 

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE ViewPatterns        #-}
 {-# OPTIONS -fplugin=Language.Plutus.CoreToPLC.Plugin -fplugin-opt Language.Plutus.CoreToPLC.Plugin:dont-typecheck #-}
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
 module Language.Plutus.Coordination.Contracts.CrowdFunding (
     -- * Campaign parameters
     Campaign(..)

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 -- Disabled until we can use the Num.(*) for `Ratio Int`
 -- {-# OPTIONS -fplugin=Language.Plutus.CoreToPLC.Plugin #-}
 module Language.Plutus.Coordination.Contracts.Swap(


### PR DESCRIPTION
It seems like most people run with `-Werror` locally, so we should do it on CI too.

Why not do this in the cabal file? I think (like most people) that I often have warnings while I'm developing, and it would be annoying if it failed to compile at that point. So I think having it only turned on for CI is good behaviour.