### PR TITLE
Use PLCVar and PLCTyVar in a few more places

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Binders.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Binders.hs
@@ -32,8 +32,8 @@ variable *last* (so it is on the outside, so will be first when applying).
 mkLamAbsScoped :: Converting m => GHC.Var -> m PLCTerm -> m PLCTerm
 mkLamAbsScoped v body = do
     let ghcName = GHC.getName v
-    (t', n') <- convVarFresh v
-    body' <- local (\c -> c {ccScopes=pushName ghcName n' (ccScopes c)}) body
+    var@(PLCVar n' t') <- convVarFresh v
+    body' <- local (\c -> c {ccScopes=pushName ghcName var (ccScopes c)}) body
     pure $ PLC.LamAbs () n' t' body'
 
 mkIterLamAbsScoped :: Converting m => [GHC.Var] -> m PLCTerm -> m PLCTerm
@@ -44,8 +44,8 @@ mkIterLamAbsScoped vars body = foldr (\v acc -> mkLamAbsScoped v acc) body vars
 mkTyAbsScoped :: Converting m => GHC.Var -> m PLCTerm -> m PLCTerm
 mkTyAbsScoped v body = do
     let ghcName = GHC.getName v
-    (t', k') <- convTyVarFresh v
-    body' <- local (\c -> c {ccScopes=pushTyName ghcName t' (ccScopes c)}) body
+    var@(PLCTyVar t' k') <- convTyVarFresh v
+    body' <- local (\c -> c {ccScopes=pushTyName ghcName var (ccScopes c)}) body
     checkTyAbsBody body'
     pure $ PLC.TyAbs () t' k' body'
 
@@ -57,8 +57,8 @@ mkIterTyAbsScoped vars body = foldr (\v acc -> mkTyAbsScoped v acc) body vars
 mkTyForallScoped :: Converting m => GHC.Var -> m PLCType -> m PLCType
 mkTyForallScoped v body = do
     let ghcName = GHC.getName v
-    (t', k') <- convTyVarFresh v
-    body' <- local (\c -> c {ccScopes=pushTyName ghcName t' (ccScopes c)}) body
+    var@(PLCTyVar t' k') <- convTyVarFresh v
+    body' <- local (\c -> c {ccScopes=pushTyName ghcName var (ccScopes c)}) body
     pure $ PLC.TyForall () t' k' body'
 
 mkIterTyForallScoped :: Converting m => [GHC.Var] -> m PLCType -> m PLCType
@@ -69,8 +69,8 @@ mkIterTyForallScoped vars body = foldr (\v acc -> mkTyForallScoped v acc) body v
 mkTyLamScoped :: Converting m => GHC.Var -> m PLCType -> m PLCType
 mkTyLamScoped v body = do
     let ghcName = GHC.getName v
-    (t', k') <- convTyVarFresh v
-    body' <- local (\c -> c {ccScopes=pushTyName ghcName t' (ccScopes c)}) body
+    var@(PLCTyVar t' k') <- convTyVarFresh v
+    body' <- local (\c -> c {ccScopes=pushTyName ghcName var (ccScopes c)}) body
     pure $ PLC.TyLam () t' k' body'
 
 mkIterTyLamScoped :: Converting m => [GHC.Var] -> m PLCType -> m PLCType

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
@@ -145,7 +145,7 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
         -- void# - values of type void get represented as error, since they should be unreachable
         GHC.Var n | n == GHC.voidPrimId || n == GHC.voidArgId -> liftQuote errorFunc
         -- locally bound vars
-        GHC.Var (lookupName top . GHC.getName -> Just name) -> pure $ PLC.Var () name
+        GHC.Var (lookupName top . GHC.getName -> Just (PLCVar name _)) -> pure $ PLC.Var () name
         -- Special kinds of id
         GHC.Var (GHC.idDetails -> GHC.PrimOpId po) -> convPrimitiveOp po
         GHC.Var (GHC.idDetails -> GHC.DataConWorkId dc) ->

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Type.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Type.hs
@@ -58,7 +58,7 @@ convType t = withContextM (sdToTxt $ "Converting type:" GHC.<+> GHC.ppr t) $ do
     let top = NE.head stack
     case t of
         -- in scope type name
-        (GHC.getTyVar_maybe -> Just (lookupTyName top . GHC.getName -> Just name)) -> pure $ PLC.TyVar () name
+        (GHC.getTyVar_maybe -> Just (lookupTyName top . GHC.getName -> Just (PLCTyVar name _))) -> pure $ PLC.TyVar () name
         (GHC.getTyVar_maybe -> Just v) -> throwSd FreeVariableError $ "Type variable:" GHC.<+> GHC.ppr v
         (GHC.splitFunTy_maybe -> Just (i, o)) -> PLC.TyFun () <$> convType i <*> convType o
         (GHC.splitTyConApp_maybe -> Just (tc, ts)) -> convTyConApp tc ts

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Types.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Types.hs
@@ -8,7 +8,6 @@ import           Language.Plutus.CoreToPLC.Compiler.Definitions
 import           Language.Plutus.CoreToPLC.Error
 import           Language.Plutus.CoreToPLC.PLCTypes
 
-import qualified Language.PlutusCore                            as PLC
 import           Language.PlutusCore.Quote
 
 import qualified GhcPlugins                                     as GHC
@@ -64,7 +63,7 @@ appropriately.
 So we have the usual mechanism of carrying around a stack of scopes.
 -}
 
-data Scope = Scope (Map.Map GHC.Name (PLC.Name ())) (Map.Map GHC.Name (PLC.TyName ()))
+data Scope = Scope (Map.Map GHC.Name PLCVar) (Map.Map GHC.Name PLCTyVar)
 type ScopeStack = NE.NonEmpty Scope
 
 initialScopeStack :: ScopeStack


### PR DESCRIPTION
Just a little refactoring - it makes sense for things in the scope envs to be vars rather than just names.