### PR TITLE
Spec: fix a few builtin type arguments

### DIFF
--- a/plutus-core-spec/figures/PlutusCoreBuiltins.tex
+++ b/plutus-core-spec/figures/PlutusCoreBuiltins.tex
@@ -99,7 +99,7 @@
         \texttt{sizeOfInteger}   &  \sig{s :: size}{integer_{s}}{size_{s}}                                   &   s          & s!i        & s\\
         %&&\\
 
-        \texttt{intToByteString}  &   \sig{s_0 :: size, s_1 :: size}{size_{s_1},integer_{s_0}}{str_{s_1}}  &  s & z, s_0!i           & \text{the binary representation of $i$} &-2^{8s_1-1} \leq i < 2^{8s_1-1}\\
+        \texttt{intToByteString}  &   \sig{s_0 :: size, s_1 :: size}{size_{s_1},integer_{s_0}}{str_{s_1}}  &  s_0, s_1  & z, s_0!i           & \text{the binary representation of $i$} &-2^{8s_1-1} \leq i < 2^{8s_1-1}\\
             &&&&\quad\text{$0$ padded to a}\\
             &&&&\quad\text{most-significant-bit-first}\\
             &&&&\quad\text{$s_1$-byte bytestring}\\

--- a/plutus-core-spec/figures/PlutusCoreBuiltins.tex
+++ b/plutus-core-spec/figures/PlutusCoreBuiltins.tex
@@ -95,8 +95,8 @@
         \texttt{equalsInteger}              &  \sig{s :: size}{integer_s, integer_s}{boolean}  &  s & s!i_0 , s!i_1   &   i_0 == i_1\\
         %&&\\
 
-        \texttt{resizeInteger}   &  \sig{s_0 :: size, s_1 :: size}{size_{s_1},integer_{s_0}}{integer_{s_1}}  &   z, s_0!i   & s_1!i & -2^{8s_1-1} \leq i < 2^{8s_1-1}\\
-        \texttt{sizeOfInteger}   &  \sig{s :: size}{integer_{s}}{size_{s}}                                   &   s          & s!i   & s\\
+        \texttt{resizeInteger}   &  \sig{s_0 :: size, s_1 :: size}{size_{s_1},integer_{s_0}}{integer_{s_1}}  &   s_0, s_1   & z, s_0!i   & s_1!i & -2^{8s_1-1} \leq i < 2^{8s_1-1}\\
+        \texttt{sizeOfInteger}   &  \sig{s :: size}{integer_{s}}{size_{s}}                                   &   s          & s!i        & s\\
         %&&\\
 
         \texttt{intToByteString}  &   \sig{s_0 :: size, s_1 :: size}{size_{s_1},integer_{s_0}}{str_{s_1}}  &  s & z, s_0!i           & \text{the binary representation of $i$} &-2^{8s_1-1} \leq i < 2^{8s_1-1}\\

--- a/plutus-core-spec/figures/PlutusCoreBuiltins.tex
+++ b/plutus-core-spec/figures/PlutusCoreBuiltins.tex
@@ -126,7 +126,7 @@
         \texttt{resizeByteString}   &   \sig{s_0 :: size, s_1 :: size}{size_{s_1},str_{s_0}}{str_{s_1}}   &   s _0, s_1 & z, s_0!b   &   s_1!b & |b| \leq s_1\\
         %&&\\
 
-        \texttt{equalsByteString}  &   \sig{s :: size}{str_s,str_s}{boolean}   &   s_0 & b_0 , b_1   & b_0 == b_1\\
+        \texttt{equalsByteString}  &   \sig{s :: size}{str_s,str_s}{boolean}   &   s & b_0 , b_1   & b_0 == b_1\\
         %&&\\
 
         \texttt{txhash}^{\dagger}   &   \sig{}{}{str_{256}}   &   & \textrm{---}  & 256!txh\\


### PR DESCRIPTION
This fixes a few bugs in the spec relating to builtin type arguments. Mostly these are cosmetic, but the first one makes it look like `resizeInteger` doesn't have failure conditions, which it certainly does.