### PR TITLE
plutus-ir: init (CGP-395)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -60,6 +60,7 @@ let
       plutus-core-interpreter = addWerror (doHaddockHydra (addRealTimeTestLogs (filterSource super.plutus-core-interpreter)));
       plutus-exe = addWerror (addRealTimeTestLogs (filterSource super.plutus-exe));
       core-to-plc = addWerror (doHaddockHydra (addRealTimeTestLogs (filterSource super.core-to-plc)));
+      plutus-ir = addWerror (doHaddockHydra (addRealTimeTestLogs (filterSource super.plutus-ir)));
       plutus-th = addWerror (doHaddockHydra (addRealTimeTestLogs (filterSource super.plutus-th)));
       plutus-use-cases = addWerror (addRealTimeTestLogs (filterSource super.plutus-use-cases));
       wallet-api = addWerror (doHaddockHydra (addRealTimeTestLogs (filterSource super.wallet-api)));

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55631,6 +55631,55 @@ description = "Executable for Plutus Core tools";
 license = stdenv.lib.licenses.bsd3;
 
 }) {};
+"plutus-ir" = callPackage
+({
+  mkDerivation
+, base
+, bytestring
+, containers
+, language-plutus-core
+, microlens
+, mtl
+, prettyprinter
+, stdenv
+, tasty
+, tasty-golden
+, tasty-hunit
+, text
+, transformers
+}:
+mkDerivation {
+
+pname = "plutus-ir";
+version = "0.1.0.0";
+src = ./../plutus-ir;
+libraryHaskellDepends = [
+base
+bytestring
+containers
+language-plutus-core
+microlens
+mtl
+prettyprinter
+text
+transformers
+];
+testHaskellDepends = [
+base
+bytestring
+language-plutus-core
+mtl
+prettyprinter
+tasty
+tasty-golden
+tasty-hunit
+text
+];
+doHaddock = false;
+description = "Plutus IR language";
+license = stdenv.lib.licenses.bsd3;
+
+}) {};
 "plutus-prototype" = callPackage
 ({
   mkDerivation

--- a/plutus-ir/LICENSE
+++ b/plutus-ir/LICENSE
@@ -1,0 +1,11 @@
+Copyright Input Output (c) 2018
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/plutus-ir/README.md
+++ b/plutus-ir/README.md
@@ -1,0 +1,3 @@
+# Plutus IR
+
+This package is a library for working with the Plutus IR language, as well as the compiler from Plutus IR to Plutus Core.

--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -1,0 +1,74 @@
+cabal-version: 1.18
+name: plutus-ir
+version: 0.1.0.0
+license: BSD3
+license-file: LICENSE
+copyright: Copyright: (c) 2018 Input Output
+maintainer: michael.peyton-jones@iohk.io
+author: Michael Peyton Jones
+synopsis: Plutus IR language
+description:
+    Plutus IR language library and compiler to Plutus Core.
+category: Language
+build-type: Simple
+extra-doc-files: README.md
+
+source-repository head
+    type: git
+    location: https://github.com/input-output-hk/plutus
+
+flag development
+    description:
+        Enable `-Werror`
+    default: False
+    manual: True
+
+library
+    exposed-modules:
+        Language.PlutusIR
+    hs-source-dirs: src
+    other-modules:
+    default-language: Haskell2010
+    default-extensions: ExplicitForAll ScopedTypeVariables
+                        DeriveGeneric StandaloneDeriving DeriveLift
+                        GeneralizedNewtypeDeriving DeriveFunctor DeriveFoldable
+                        DeriveTraversable
+    other-extensions: DeriveAnyClass FlexibleContexts FlexibleInstances
+                      MultiParamTypeClasses TypeFamilies OverloadedStrings
+                      MonadComprehensions ConstrainedClassMethods TupleSections GADTs
+                      RankNTypes TemplateHaskell QuasiQuotes TypeApplications
+                      ExistentialQuantification
+    ghc-options: -Wall -Wnoncanonical-monad-instances
+                 -Wincomplete-uni-patterns -Wincomplete-record-updates
+                 -Wredundant-constraints -Widentities
+    build-depends:
+        base >=4.9 && <5,
+        bytestring -any,
+        containers -any,
+        language-plutus-core -any,
+        microlens -any,
+        mtl -any,
+        prettyprinter -any,
+        text -any,
+        transformers -any
+
+    if (flag(development) && impl(ghc <8.4))
+        ghc-options: -Werror
+
+test-suite plutus-ir-test
+    type: exitcode-stdio-1.0
+    main-is: Spec.hs
+    hs-source-dirs: test
+    other-modules:
+    default-language: Haskell2010
+    build-depends:
+        base >=4.9 && <5,
+        plutus-ir -any,
+        language-plutus-core -any,
+        bytestring -any,
+        mtl -any,
+        text -any,
+        prettyprinter -any,
+        tasty -any,
+        tasty-hunit -any,
+        tasty-golden -any

--- a/plutus-ir/shell.nix
+++ b/plutus-ir/shell.nix
@@ -1,0 +1,1 @@
+(import ../. {}).plutus-ir.env

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+module Language.PlutusIR (
+    TyName (..),
+    Name (..),
+    Kind (..),
+    Type (..),
+    VarDecl (..),
+    TyVarDecl (..),
+    Datatype (..),
+    Recursivity (..),
+    Binding (..),
+    Term (..),
+    prettyDef,
+    embedIntoIR
+    ) where
+
+import           PlutusPrelude
+
+import           Language.PlutusCore        (Kind, Name, TyName, Type)
+import qualified Language.PlutusCore        as PLC
+import qualified Language.PlutusCore.Pretty as PLC
+
+import           GHC.Generics               (Generic)
+
+-- Variable declarations
+
+data VarDecl tyname name a = VarDecl a (name a) (Type tyname a)
+    deriving (Functor, Show, Eq, Generic)
+data TyVarDecl tyname a = TyVarDecl a (tyname a) (Kind a)
+    deriving (Functor, Show, Eq, Generic)
+
+-- Datatypes
+
+data Datatype tyname name a = Datatype a (TyVarDecl tyname a) [TyVarDecl tyname a] (name a) [VarDecl tyname name a]
+    deriving (Functor, Show, Eq, Generic)
+
+-- Bindings
+
+data Recursivity = NonRec | Rec
+    deriving (Show, Eq, Generic)
+data Binding tyname name a = TermBind a (VarDecl tyname name a) (Term tyname name a)
+                           | TypeBind a (TyVarDecl tyname a) (Type tyname a)
+                           | DatatypeBind a (Datatype tyname name a)
+    deriving (Functor, Show, Eq, Generic)
+
+-- Terms
+
+{- Note [PIR as a PLC extension]
+PIR is designed to be an extension of PLC, which means that we try and be strict superset of it.
+
+The main benefit of this is simplicity, but we hope that in future it will make sharing of
+theoretical and practical material easier. In the long run it would be nice if PIR was a "true"
+extension of PLC (perhaps in the sense of "Trees that Grow"), and then we could potentially
+even share most of the typechecker.
+-}
+
+{- Note [Declarations in Plutus Core]
+In Plutus Core declarations are usually *flattened*, i.e. `(lam x ty t)`, whereas
+in Plutus IR they are *reified*, i.e. `(termBind (vardecl x ty) t)`.
+
+Plutus IR needs reified declarations to make it easier to parse *lists* of declarations,
+which occur in a few places.
+
+However, we also include all of Plutus Core's term syntax in our term syntax (and we also use
+its types). We therefore have somewhat inconsistent syntax since declarations in Plutus
+Core terms will be flattened. This makes the embedding obvious and makes life easier
+if we were ever to use the Plutus Core AST "for real".
+
+It would be nice to resolve the inconsistency, but this would probably require changing
+Plutus Core to use reified declarations.
+-}
+
+-- See note [PIR as a PLC extension]
+data Term tyname name a = Let a Recursivity [Binding tyname name a] (Term tyname name a)
+                        -- Plutus Core (ish) forms, see note [Declarations in Plutus Core]
+                        | Var a (name a)
+                        | TyAbs a (tyname a) (Kind a) (Term tyname name a)
+                        | LamAbs a (name a) (Type tyname a) (Term tyname name a)
+                        | Apply a (Term tyname name a) (Term tyname name a)
+                        | Constant a (PLC.Constant a)
+                        | TyInst a (Term tyname name a) (Type tyname a)
+                        | Error a (Type tyname a)
+                        | Wrap a (tyname a) (Type tyname a) (Term tyname name a)
+                        | Unwrap a (Term tyname name a)
+                        deriving (Functor, Show, Eq, Generic)
+
+embedIntoIR :: PLC.Term tyname name a -> Term tyname name a
+embedIntoIR = \case
+    PLC.Var a n -> Var a n
+    PLC.TyAbs a tn k t -> TyAbs a tn k (embedIntoIR t)
+    PLC.LamAbs a n ty t -> LamAbs a n ty (embedIntoIR t)
+    PLC.Apply a t1 t2 -> Apply a (embedIntoIR t1) (embedIntoIR t2)
+    PLC.Constant a c ->  Constant a c
+    PLC.TyInst a t ty -> TyInst a (embedIntoIR t) ty
+    PLC.Error a ty -> Error a ty
+    PLC.Unwrap a t -> Unwrap a (embedIntoIR t)
+    PLC.Wrap a tn ty t -> Wrap a tn ty (embedIntoIR t)
+
+-- Pretty-printing
+
+instance (PLC.PrettyClassicBy configName (tyname a), PLC.PrettyClassicBy configName (name a)) =>
+        PrettyBy (PLC.PrettyConfigClassic configName) (VarDecl tyname name a) where
+    prettyBy config (VarDecl _ n ty) = parens' ("vardecl" </> vsep' [prettyBy config n, prettyBy config ty])
+
+instance (PLC.PrettyClassicBy configName (tyname a)) =>
+        PrettyBy (PLC.PrettyConfigClassic configName) (TyVarDecl tyname a) where
+    prettyBy config (TyVarDecl _ n ty) = parens' ("tyvardecl" </> vsep' [prettyBy config n, prettyBy config ty])
+
+instance PrettyBy (PLC.PrettyConfigClassic configName) Recursivity where
+    prettyBy _ = \case
+        NonRec -> parens' "nonrec"
+        Rec -> parens' "rec"
+
+instance (PLC.PrettyClassicBy configName (tyname a), PLC.PrettyClassicBy configName (name a)) =>
+        PrettyBy (PLC.PrettyConfigClassic configName) (Datatype tyname name a) where
+    prettyBy config (Datatype _ ty tyvars destr constrs) = parens' ("datatype" </> vsep' [
+                                                                         prettyBy config ty,
+                                                                         vsep' $ fmap (prettyBy config) tyvars,
+                                                                         prettyBy config destr,
+                                                                         vsep' $ fmap (prettyBy config) constrs])
+
+instance (PLC.PrettyClassicBy configName (tyname a), PLC.PrettyClassicBy configName (name a)) =>
+        PrettyBy (PLC.PrettyConfigClassic configName) (Binding tyname name a) where
+    prettyBy config = \case
+        TermBind _ d t -> parens' ("termbind" </> vsep' [prettyBy config d, prettyBy config t])
+        TypeBind _ d ty -> parens' ("typebind" </> vsep' [prettyBy config d, prettyBy config ty])
+        DatatypeBind _ d -> parens' ("datatypebind" </> prettyBy config d)
+
+instance (PLC.PrettyClassicBy configName (tyname a), PLC.PrettyClassicBy configName (name a)) =>
+        PrettyBy (PLC.PrettyConfigClassic configName) (Term tyname name a) where
+    prettyBy config = \case
+        Let _ r bs t -> parens' ("let" </> vsep' [prettyBy config r, vsep' $ fmap (prettyBy config) bs, prettyBy config t])
+        Var _ n -> prettyBy config n
+        TyAbs _ tn k t -> parens' ("abs" </> vsep' [prettyBy config tn, prettyBy config k, prettyBy config t])
+        LamAbs _ n ty t -> parens' ("lam" </> vsep' [prettyBy config n, prettyBy config ty, prettyBy config t])
+        Apply _ t1 t2 -> brackets' (vsep' [prettyBy config t1, prettyBy config t2])
+        Constant _ c -> parens' ("con" </> prettyBy config c)
+        TyInst _ t ty -> braces' (vsep' [prettyBy config t, prettyBy config ty])
+        Error _ ty -> parens' ("error" </> prettyBy config ty)
+        Wrap _ n ty t -> parens' ("wrap" </> vsep' [ prettyBy config n, prettyBy config ty, prettyBy config t ])
+        Unwrap _ t -> parens' ("unwrap" </> prettyBy config t)
+
+prettyDef :: Term TyName Name a -> Doc ann
+prettyDef = prettyBy $ PLC.PrettyConfigClassic PLC.defPrettyConfigName

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import           Common
+
+import           Language.PlutusCore.Quote
+import           Language.PlutusIR
+
+import           Language.PlutusCore.StdLib.Data.Unit as Unit
+
+import           Test.Tasty
+
+main :: IO ()
+main = defaultMain $ runTestNestedIn ["test"] tests
+
+golden :: String -> Term TyName Name () -> TestNested
+golden name value = nestedGoldenVsDoc name $ prettyDef value
+
+tests :: TestNested
+tests = testGroup "plutus-ir" <$> sequence [
+    basicTests
+    ]
+
+basicTests :: TestNested
+basicTests = testNested "prettyprinting" [
+    golden "basic" basic
+    , golden "datatype" datatype
+    ]
+
+basic :: Term TyName Name ()
+basic = runQuote $ do
+    a <- freshTyName () "a"
+    x <- freshName () "x"
+    pure $
+        TyAbs () a (Type ()) $
+        LamAbs () x (TyVar () a) $
+        Var () x
+
+datatype :: Term TyName Name ()
+datatype = runQuote $ do
+    m <- freshTyName () "Maybe"
+    a <- freshTyName () "a"
+    match <- freshName () "match_Maybe"
+    nothing <- freshName () "Nothing"
+    just <- freshName () "Just"
+    unit <- getBuiltinUnit
+    unitval <- embedIntoIR <$> getBuiltinUnitval
+    pure $
+        Let ()
+            NonRec
+            [
+                DatatypeBind () $
+                Datatype ()
+                    (TyVarDecl () m (KindArrow () (Type ()) (Type ())))
+                    [
+                        TyVarDecl () a (Type ())
+                    ]
+                match
+                [
+                    VarDecl () nothing (TyApp () (TyVar () m) (TyVar () a)),
+                    VarDecl () just (TyFun () (TyVar () a) (TyApp () (TyVar () m) (TyVar () a)))
+                ]
+            ] $
+        Apply () (TyInst () (Var () just) unit) unitval

--- a/plutus-ir/test/prettyprinting/basic.plc.golden
+++ b/plutus-ir/test/prettyprinting/basic.plc.golden
@@ -1,0 +1,1 @@
+(abs a (type) (lam x a x))

--- a/plutus-ir/test/prettyprinting/datatype.plc.golden
+++ b/plutus-ir/test/prettyprinting/datatype.plc.golden
@@ -1,0 +1,12 @@
+(let
+  (nonrec)
+  (datatypebind
+    (datatype
+      (tyvardecl Maybe (fun (type) (type)))
+      (tyvardecl a (type))
+      match_Maybe
+      (vardecl Nothing [Maybe a]) (vardecl Just (fun a [Maybe a]))
+    )
+  )
+  [ { Just (all a (type) (fun a a)) } (abs a (type) (lam x a x)) ]
+)

--- a/release.nix
+++ b/release.nix
@@ -19,6 +19,7 @@ let
     plutus-core-interpreter = supportedSystems;
     plutus-exe = supportedSystems;
     core-to-plc = supportedSystems;
+    plutus-ir = supportedSystems;
     plutus-th = supportedSystems;
     plutus-use-cases = supportedSystems;
     wallet-api = supportedSystems;

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ packages:
 - plutus-core-interpreter
 - plutus-exe
 - core-to-plc
+- plutus-ir
 - plutus-th
 - plutus-use-cases
 - wallet-api


### PR DESCRIPTION
This adds the AST and some basic support functions for Plutus IR, following the design doc.

I've made the whole thing completely separate from `language-plutus-core` at the minute, which I think is the right thing to do. The `Term` AST is completely reproduced, since I don't think there's a clean way to reuse the PLC `Term` AST without using a "Trees that Grow"-style approach which I don't think we want to do yet, if ever. We do use the `Type` AST from PLC as-is, however.