### PR TITLE
[CGP-398] [Test] Added a way to conveniently export interesting test files

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,7 +1,7 @@
 ---
 - functions:
   - {name: unsafePerformIO, within: [PlutusPrelude, Language.PlutusCore.Generators.Internal.Entity]}
-  - {name: error, within: [Main, PlutusPrelude, Language.PlutusCore.StdLib.Meta, Evaluation.Constant.Success, Language.PlutusCore.Constant.Apply, Language.PlutusCore.Constant.Typed, Language.PlutusCore.Evaluation.CkMachine, Language.PlutusCore.TypeSynthesis, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Constant.Make, Language.PlutusCore.TH, Language.Plutus.CoreToPLC.Error]}
+  - {name: error, within: [Main, PlutusPrelude, Language.PlutusCore.StdLib.Meta, Evaluation.Constant.Success, Language.PlutusCore.Constant.Apply, Language.PlutusCore.Constant.Typed, Language.PlutusCore.Evaluation.CkMachine, Language.PlutusCore.TypeSynthesis, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Generators.Test, Language.PlutusCore.Constant.Make, Language.PlutusCore.TH, Language.Plutus.CoreToPLC.Error]}
   - {name: undefined, within: [Language.PlutusCore.Constant.Apply, Language.Plutus.Lift]}
   - {name: fromJust, within: [Language.Plutus.Lift]}
   - {name: foldl, within: []}

--- a/language-plutus-core/generate-evaluation-test/Main.hs
+++ b/language-plutus-core/generate-evaluation-test/Main.hs
@@ -2,39 +2,19 @@
 module Main (main) where
 
 import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Evaluation.CkMachine
-import           Language.PlutusCore.Evaluation.Result
 import           Language.PlutusCore.Generators
+import           Language.PlutusCore.Generators.Test
 import           Language.PlutusCore.Pretty
-import           PlutusPrelude                            hiding (hoist)
 
-import           Control.Monad
-import           Control.Monad.Morph
 import           Data.Foldable
-import           Data.Text                                (Text)
-import qualified Data.Text                                as Text
-import qualified Data.Text.IO                             as Text
-import qualified Hedgehog.Gen                             as Gen
+import           Data.Text                           (Text)
+import qualified Data.Text                           as Text
+import qualified Data.Text.IO                        as Text
 
 -- | Generate a test sample: a term of arbitrary type and what it computes to.
 -- Uses 'genTermLoose' under the hood.
 generateTerm :: IO (TermOf (Value TyName Name ()))
-generateTerm
-    = Gen.sample
-    . Gen.just
-    . hoist (pure . runQuote)
-    $ withAnyTermLoose
-    $ \(TermOf term tbv) -> pure $ do
-          let expected = runQuote $ unsafeMakeBuiltin tbv
-          actual <- evaluationResultToMaybe $ evaluateCk term
-          when (actual /= expected) . error $ fold
-              [ "An internal error in 'generateTerm' occured while computing "
-              , prettyPlcDefString term, "\n"
-              , "Expected result: ", prettyPlcDefString expected , "\n"
-              , "Actual result: ", prettyPlcDefString actual, "\n"
-              ]
-          Just $ TermOf term actual
+generateTerm = runQuoteSampleSucceed $ withAnyTermLoose $ liftQuote . unsafeTypeEvalCheck
 
 oneline :: Text -> Text
 oneline = Text.unwords . Text.words

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypedBuiltinGen.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypedBuiltinGen.hs
@@ -43,7 +43,7 @@ genLowerBytes range = BSL.fromStrict <$> Gen.utf8 range Gen.lower
 data TermOf a = TermOf
     { _termOfTerm  :: Term TyName Name ()  -- ^ The PLC term
     , _termOfValue :: a                    -- ^ The Haskell value.
-    } deriving (Functor)
+    } deriving (Functor, Foldable, Traversable)
 -- This has an interesting @Apply@ instance (no pun intended).
 
 -- | A function of this type generates values of built-in typed (see 'TypedBuiltin' for

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Utils.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Utils.hs
@@ -2,6 +2,7 @@
 
 {-# LANGUAGE GADTs      #-}
 {-# LANGUAGE RankNTypes #-}
+
 module Language.PlutusCore.Generators.Internal.Utils
     ( liftT
     , hoistSupply
@@ -12,9 +13,11 @@ module Language.PlutusCore.Generators.Internal.Utils
     , forAllPrettyT
     , forAllPrettyPlc
     , forAllPrettyPlcT
+    , runQuoteSampleSucceed
     ) where
 
 import           Language.PlutusCore.Pretty (PrettyPlc, prettyPlcDefString)
+import           Language.PlutusCore.Quote  (Quote, runQuote)
 import           PlutusPrelude              hiding (hoist)
 
 import           Control.Monad.Morph
@@ -63,3 +66,7 @@ forAllPrettyPlc = forAllWith prettyPlcDefString
 -- A supplied generator has access to the 'Monad' the whole property has access to.
 forAllPrettyPlcT :: (Monad m, PrettyPlc a) => GenT m a -> PropertyT m a
 forAllPrettyPlcT = forAllWithT prettyPlcDefString
+
+-- | Run a generator until it succeeds with a 'Just'.
+runQuoteSampleSucceed :: GenT Quote (Maybe a) -> IO a
+runQuoteSampleSucceed = Gen.sample . Gen.just . hoist (pure . runQuote)

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -26,6 +26,9 @@ module Language.PlutusCore
     , DynamicBuiltinName (..)
     , StagedBuiltinName (..)
     , TypeBuiltin (..)
+    , Normalized (..)
+    , NormalizedType
+    , getNormalizedType
     , defaultVersion
     , allBuiltinNames
     -- * Lexer
@@ -103,7 +106,8 @@ module Language.PlutusCore
     , plcTerm
     , plcProgram
     -- * Evaluation
-    , EvaluationResult (..)
+    , EvaluationResultF (EvaluationSuccess, EvaluationFailure)
+    , EvaluationResult
     -- * Combining programs
     , applyProgram
     ) where

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/CkMachine.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/CkMachine.hs
@@ -4,7 +4,8 @@
 
 module Language.PlutusCore.Evaluation.CkMachine
     ( CkMachineException
-    , EvaluationResult(..)
+    , EvaluationResultF (EvaluationSuccess, EvaluationFailure)
+    , EvaluationResult
     , evaluateCk
     , runCk
     ) where

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/Result.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/Result.hs
@@ -6,7 +6,8 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 module Language.PlutusCore.Evaluation.Result
-    ( EvaluationResult(..)
+    ( EvaluationResultF (EvaluationSuccess, EvaluationFailure)
+    , EvaluationResult
     , evaluationResultToMaybe
     , maybeToEvaluationResult
     ) where
@@ -15,11 +16,14 @@ import           Language.PlutusCore.Name
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
--- | The type of results various evaluation engines return.
-data EvaluationResult
-    = EvaluationSuccess (Value TyName Name ())
+-- | The parameterized type of results various evaluation engines return.
+data EvaluationResultF a
+    = EvaluationSuccess a
     | EvaluationFailure
-    deriving (Show, Eq)
+    deriving (Show, Eq, Functor, Foldable, Traversable)
+
+-- | The type of results various evaluation engines return.
+type EvaluationResult = EvaluationResultF (Value TyName Name ())
 
 instance PrettyBy config (Value TyName Name ()) => PrettyBy config EvaluationResult where
     prettyBy config (EvaluationSuccess value) = prettyBy config value

--- a/language-plutus-core/test/Evaluation/CkMachine.hs
+++ b/language-plutus-core/test/Evaluation/CkMachine.hs
@@ -185,7 +185,7 @@ goldenVsPretty name value = goldenVsString name ("test/Evaluation/" ++ name ++ "
 
 test_evaluateCk :: TestTree
 test_evaluateCk = testGroup "evaluateCk"
-    [ testGroup "props" $ fromInteretingGens (\name -> testProperty name . propEvaluate evaluateCk)
+    [ testGroup "props" $ fromInterestingTermGens (\name -> testProperty name . propEvaluate evaluateCk)
     , goldenVsPretty "even2" (pure $ evaluateCk (runQuote $
                                                  Apply () <$> getEven <*> getBuiltinIntegerToNat 2))
     , goldenVsPretty "even3" (pure $ evaluateCk (runQuote $

--- a/plutus-core-interpreter/src/Language/PlutusCore/Interpreter/CekMachine.hs
+++ b/plutus-core-interpreter/src/Language/PlutusCore/Interpreter/CekMachine.hs
@@ -13,7 +13,8 @@
 
 module Language.PlutusCore.Interpreter.CekMachine
     ( CekMachineException
-    , EvaluationResult (..)
+    , EvaluationResultF (EvaluationSuccess, EvaluationFailure)
+    , EvaluationResult
     , evaluateCekCatch
     , evaluateCek
     , runCek

--- a/plutus-core-interpreter/test/CekMachine.hs
+++ b/plutus-core-interpreter/test/CekMachine.hs
@@ -15,6 +15,6 @@ import           Test.Tasty.Hedgehog
 test_evaluateCek :: TestTree
 test_evaluateCek =
     testGroup "evaluateCek"
-        [ testGroup "props" $ fromInteretingGens $ \name ->
+        [ testGroup "props" $ fromInterestingTermGens $ \name ->
             testProperty name . propEvaluate (evaluateCek mempty)
         ]


### PR DESCRIPTION
The main thing here is

```haskell
-- | Generate a pair of files: @<folder>.<name>.plc@ and @<folder>.<name>.plc.golden@.
-- The first file contains a term generated by a term generator (wrapped in 'Program'),
-- the second file contains the result of evaluation of the term.
sampleProgramValueGolden
```

I need this in order to pass tests to the RV team.

Others are just refactoring and reduced code duplication.