### PR TITLE
wallet-api: gain own abstract Script type

### DIFF
--- a/core-to-plc/core-to-plc.cabal
+++ b/core-to-plc/core-to-plc.cabal
@@ -60,8 +60,6 @@ library
                  -Wredundant-constraints -Widentities
     build-depends:
         base >=4.9 && <5,
-        aeson -any,
-        base64-bytestring -any,
         bytestring -any,
         cborg -any,
         containers -any,

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15645,9 +15645,7 @@ license = stdenv.lib.licenses.mit;
 "core-to-plc" = callPackage
 ({
   mkDerivation
-, aeson
 , base
-, base64-bytestring
 , bytestring
 , cborg
 , containers
@@ -15672,9 +15670,7 @@ pname = "core-to-plc";
 version = "0.1.0.0";
 src = ./../core-to-plc;
 libraryHaskellDepends = [
-aeson
 base
-base64-bytestring
 bytestring
 cborg
 containers

--- a/plutus-th/src/Language/Plutus/TH.hs
+++ b/plutus-th/src/Language/Plutus/TH.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE TemplateHaskell  #-}
 {-# LANGUAGE TypeApplications #-}
-module Language.Plutus.TH (plutus, PlcCode, getSerializedCode, getAst, applyPlc) where
+module Language.Plutus.TH (plutus, PlcCode, getSerializedCode, getAst) where
 
 import           Language.Plutus.CoreToPLC.Plugin
 

--- a/plutus-th/src/Language/Plutus/TH.hs
+++ b/plutus-th/src/Language/Plutus/TH.hs
@@ -1,11 +1,17 @@
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE TemplateHaskell  #-}
 {-# LANGUAGE TypeApplications #-}
-module Language.Plutus.TH (plutus, PlcCode, getSerializedCode, getAst) where
+module Language.Plutus.TH (
+    module Builtins,
+    plutus,
+    PlcCode,
+    getSerializedCode,
+    getAst) where
 
+import           Language.Plutus.CoreToPLC.Builtins as Builtins
 import           Language.Plutus.CoreToPLC.Plugin
 
-import qualified Language.Haskell.TH              as TH
+import qualified Language.Haskell.TH                as TH
 
 -- | Covert a quoted Haskell expression into a corresponding Plutus Core program. Produces an expression of type
 -- 'PlcCode'.

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -34,10 +34,9 @@ import qualified Data.Set                           as Set
 import           GHC.Generics                       (Generic)
 
 import qualified Language.Plutus.CoreToPLC.Builtins as Builtins
-import           Language.Plutus.CoreToPLC.Plugin   (lifted)
 import           Language.Plutus.Lift               (LiftPlc (..), TypeablePlc (..))
 import           Language.Plutus.Runtime            (Height, PendingTx (..), PendingTxIn (..), PubKey (..), Value)
-import           Language.Plutus.TH                 (applyPlc, plutus)
+import           Language.Plutus.TH                 (plutus)
 import           Wallet.API                         (EventTrigger (..), Range (..), WalletAPI (..), WalletAPIError,
                                                      otherError, pubKey, signAndSubmit)
 import           Wallet.UTXO                        (Address', DataScript (..), TxOutRef', Validator (..), scriptTxIn,
@@ -71,7 +70,7 @@ contribute :: (
     -> m ()
 contribute cmp value = do
     _ <- if value <= 0 then otherError "Must contribute a positive value" else pure ()
-    ds <- DataScript . lifted . pubKey <$> myKeyPair
+    ds <- DataScript . UTXO.lifted . pubKey <$> myKeyPair
 
     -- TODO: Remove duplicate definition of Value
     --       (Value = Integer in Haskell land but Value = Int in PLC land)
@@ -100,11 +99,11 @@ contribute cmp value = do
 --      covered by the `refundable` branch.
 contributionScript :: Campaign -> Validator
 contributionScript cmp  = Validator val where
-    val = applyPlc inner (lifted cmp)
+    val = UTXO.applyScript inner (UTXO.lifted cmp)
 
     --   See note [Contracts and Validator Scripts] in
     --       Language.Plutus.Coordination.Contracts
-    inner = $(plutus [| (\Campaign{..} () (a :: CampaignActor) (p :: PendingTx) ->
+    inner = UTXO.fromPlcCode $(plutus [| (\Campaign{..} () (a :: CampaignActor) (p :: PendingTx) ->
         let
             -- | Check that a transaction input is signed by the private key of the given
             --   public key.

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -25,27 +25,26 @@ module Language.Plutus.Coordination.Contracts.CrowdFunding (
     , collectFundsTrigger
     ) where
 
-import           Control.Applicative                (Applicative (..))
-import           Control.Monad                      (Monad (..))
-import           Control.Monad.Error.Class          (MonadError (..))
-import           Data.Foldable                      (foldMap)
-import           Data.Monoid                        (Sum (..))
-import qualified Data.Set                           as Set
-import           GHC.Generics                       (Generic)
+import           Control.Applicative        (Applicative (..))
+import           Control.Monad              (Monad (..))
+import           Control.Monad.Error.Class  (MonadError (..))
+import           Data.Foldable              (foldMap)
+import           Data.Monoid                (Sum (..))
+import qualified Data.Set                   as Set
+import           GHC.Generics               (Generic)
 
-import qualified Language.Plutus.CoreToPLC.Builtins as Builtins
-import           Language.Plutus.Lift               (LiftPlc (..), TypeablePlc (..))
-import           Language.Plutus.Runtime            (Height, PendingTx (..), PendingTxIn (..), PubKey (..), Value)
-import           Language.Plutus.TH                 (plutus)
-import           Wallet.API                         (EventTrigger (..), Range (..), WalletAPI (..), WalletAPIError,
-                                                     otherError, pubKey, signAndSubmit)
-import           Wallet.UTXO                        (Address', DataScript (..), TxOutRef', Validator (..), scriptTxIn,
-                                                     scriptTxOut)
-import qualified Wallet.UTXO                        as UTXO
+import           Language.Plutus.Lift       (LiftPlc (..), TypeablePlc (..))
+import           Language.Plutus.Runtime    (Height, PendingTx (..), PendingTxIn (..), PubKey (..), Value)
+import           Language.Plutus.TH         (plutus)
+import qualified Language.Plutus.TH         as Builtins
+import           Wallet.API                 (EventTrigger (..), Range (..), WalletAPI (..), WalletAPIError, otherError,
+                                             pubKey, signAndSubmit)
+import           Wallet.UTXO                (Address', DataScript (..), TxOutRef', Validator (..), scriptTxIn,
+                                             scriptTxOut)
+import qualified Wallet.UTXO                as UTXO
 
-import qualified Language.Plutus.Runtime.TH         as TH
-import           Prelude                            (Bool (..), Num (..), Ord (..), fromIntegral, snd, succ, ($), (.),
-                                                     (<$>))
+import qualified Language.Plutus.Runtime.TH as TH
+import           Prelude                    (Bool (..), Num (..), Ord (..), fromIntegral, snd, succ, ($), (.), (<$>))
 
 -- | A crowdfunding campaign.
 data Campaign = Campaign

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
@@ -16,6 +16,7 @@ import           Language.Plutus.Runtime            (OracleValue (..), PendingTx
 import qualified Language.Plutus.Runtime.TH         as TH
 import           Language.Plutus.TH                 (plutus)
 import           Wallet.UTXO                        (Height, Validator (..))
+import qualified Wallet.UTXO                        as UTXO
 
 import           Data.Ratio                         (Ratio)
 import           Prelude                            (Bool (..), Eq (..), Int, Num (..), Ord (..))
@@ -58,7 +59,7 @@ type SwapOracle = OracleValue (Ratio Int)
 --       Language.Plutus.Coordination.Contracts
 swapValidator :: Swap -> Validator
 swapValidator _ = Validator result where
-    result = $(plutus [| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx) Swap{..} ->
+    result = UTXO.fromPlcCode $(plutus [| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx) Swap{..} ->
         let
             infixr 3 &&
             (&&) :: Bool -> Bool -> Bool

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
@@ -10,16 +10,16 @@ module Language.Plutus.Coordination.Contracts.Swap(
     swapValidator
     ) where
 
-import qualified Language.Plutus.CoreToPLC.Builtins as Builtins
-import           Language.Plutus.Runtime            (OracleValue (..), PendingTx (..), PendingTxIn (..),
-                                                     PendingTxOut (..), PubKey, Value)
-import qualified Language.Plutus.Runtime.TH         as TH
-import           Language.Plutus.TH                 (plutus)
-import           Wallet.UTXO                        (Height, Validator (..))
-import qualified Wallet.UTXO                        as UTXO
+import           Language.Plutus.Runtime    (OracleValue (..), PendingTx (..), PendingTxIn (..), PendingTxOut (..),
+                                             PubKey, Value)
+import qualified Language.Plutus.Runtime.TH as TH
+import           Language.Plutus.TH         (plutus)
+import qualified Language.Plutus.TH         as Builtins
+import           Wallet.UTXO                (Height, Validator (..))
+import qualified Wallet.UTXO                as UTXO
 
-import           Data.Ratio                         (Ratio)
-import           Prelude                            (Bool (..), Eq (..), Int, Num (..), Ord (..))
+import           Data.Ratio                 (Ratio)
+import           Prelude                    (Bool (..), Eq (..), Int, Num (..), Ord (..))
 
 -- | A swap is an agreement to exchange cashflows at future dates. To keep
 --  things simple, this is an interest rate swap (meaning that the cashflows are

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
@@ -16,20 +16,19 @@ module Language.Plutus.Coordination.Contracts.Vesting (
     totalAmount
     ) where
 
-import           Control.Monad.Error.Class          (MonadError (..))
-import qualified Data.Set                           as Set
-import           GHC.Generics                       (Generic)
-import qualified Language.Plutus.CoreToPLC.Builtins as Builtins
-import           Language.Plutus.Lift               (LiftPlc (..), TypeablePlc (..))
-import           Language.Plutus.Runtime            (Hash, Height, PendingTx (..), PendingTxOut (..),
-                                                     PendingTxOutType (..), PubKey (..), Value)
-import qualified Language.Plutus.Runtime.TH         as TH
-import           Language.Plutus.TH                 (plutus)
-import           Prelude                            hiding ((&&))
-import           Wallet.API                         (WalletAPI (..), WalletAPIError, otherError, signAndSubmit)
-import           Wallet.UTXO                        (DataScript (..), TxOutRef', Validator (..), scriptTxIn,
-                                                     scriptTxOut)
-import qualified Wallet.UTXO                        as UTXO
+import           Control.Monad.Error.Class  (MonadError (..))
+import qualified Data.Set                   as Set
+import           GHC.Generics               (Generic)
+import           Language.Plutus.Lift       (LiftPlc (..), TypeablePlc (..))
+import           Language.Plutus.Runtime    (Hash, Height, PendingTx (..), PendingTxOut (..), PendingTxOutType (..),
+                                             PubKey (..), Value)
+import qualified Language.Plutus.Runtime.TH as TH
+import           Language.Plutus.TH         (plutus)
+import qualified Language.Plutus.TH         as Builtins
+import           Prelude                    hiding ((&&))
+import           Wallet.API                 (WalletAPI (..), WalletAPIError, otherError, signAndSubmit)
+import           Wallet.UTXO                (DataScript (..), TxOutRef', Validator (..), scriptTxIn, scriptTxOut)
+import qualified Wallet.UTXO                as UTXO
 
 -- | Tranche of a vesting scheme.
 data VestingTranche = VestingTranche {

--- a/wallet-api/src/Wallet/UTXO/Index.hs
+++ b/wallet-api/src/Wallet/UTXO/Index.hs
@@ -25,22 +25,20 @@ module Wallet.UTXO.Index(
     validateTransaction
     ) where
 
-import           Control.Monad.Except             (MonadError (..), liftEither)
-import           Control.Monad.Reader             (MonadReader (..), ReaderT (..), ask)
-import           Crypto.Hash                      (Digest, SHA256)
-import           Data.Foldable                    (foldl', traverse_)
-import qualified Data.Map                         as Map
-import           Data.Semigroup                   (Semigroup, Sum (..))
-import qualified Data.Set                         as Set
-import           GHC.Generics                     (Generic)
-import           Language.Plutus.CoreToPLC.Plugin (lifted)
-import           Prelude                          hiding (lookup)
-import           Wallet.UTXO.Runtime              (PendingTx (..))
-import qualified Wallet.UTXO.Runtime              as Runtime
-import           Wallet.UTXO.Types                (Blockchain, DataScript, PubKey, Signature, Tx (..), TxIn (..), TxIn',
-                                                   TxOut (..), TxOut', TxOutRef', ValidationData (..), Value,
-                                                   updateUtxo, validValuesTx)
-import qualified Wallet.UTXO.Types                as UTXO
+import           Control.Monad.Except (MonadError (..), liftEither)
+import           Control.Monad.Reader (MonadReader (..), ReaderT (..), ask)
+import           Crypto.Hash          (Digest, SHA256)
+import           Data.Foldable        (foldl', traverse_)
+import qualified Data.Map             as Map
+import           Data.Semigroup       (Semigroup, Sum (..))
+import qualified Data.Set             as Set
+import           GHC.Generics         (Generic)
+import           Prelude              hiding (lookup)
+import           Wallet.UTXO.Runtime  (PendingTx (..))
+import qualified Wallet.UTXO.Runtime  as Runtime
+import           Wallet.UTXO.Types    (Blockchain, DataScript, PubKey, Signature, Tx (..), TxIn (..), TxIn', TxOut (..),
+                                       TxOut', TxOutRef', ValidationData (..), Value, lifted, updateUtxo, validValuesTx)
+import qualified Wallet.UTXO.Types    as UTXO
 
 -- | Context for validating transactions. We need access to the unspent
 --   transaction outputs of the blockchain, and we can throw `ValidationError`s


### PR DESCRIPTION
This makes `PlcCode` something that's only used by the plugin, which is good, because then we can change its internal representation without affecting anything else (and that internal representation is largely determined by what is convenient for the plugin).

Therefore `wallet-api` gains a new `Script` type, along with functions for interacting with it. This is also nice because it makes our implementation closer to the original model, where `Script` was opaque.

I also did another quick change which I've meant to do for a while, which is to make `plutus-th` re-export the builtin names from `core-to-plc`. That way you can reference them without explicitly using the `core-to-plc` package. Eventually users shouldn't use that at all, once we can finally use `addCorePlugin`.