### PR TITLE
Share the VarDecl types across language-plutus-core and dependents

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Binders.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Binders.hs
@@ -12,6 +12,7 @@ import           Language.Plutus.CoreToPLC.PLCTypes
 import qualified GhcPlugins                                          as GHC
 
 import qualified Language.PlutusCore                                 as PLC
+import qualified Language.PlutusCore.MkPlc                           as PLC
 
 import           Control.Monad.Reader
 
@@ -32,7 +33,7 @@ variable *last* (so it is on the outside, so will be first when applying).
 mkLamAbsScoped :: Converting m => GHC.Var -> m PLCTerm -> m PLCTerm
 mkLamAbsScoped v body = do
     let ghcName = GHC.getName v
-    var@(PLCVar n' t') <- convVarFresh v
+    var@(PLC.VarDecl _ n' t') <- convVarFresh v
     body' <- local (\c -> c {ccScopes=pushName ghcName var (ccScopes c)}) body
     pure $ PLC.LamAbs () n' t' body'
 
@@ -44,7 +45,7 @@ mkIterLamAbsScoped vars body = foldr (\v acc -> mkLamAbsScoped v acc) body vars
 mkTyAbsScoped :: Converting m => GHC.Var -> m PLCTerm -> m PLCTerm
 mkTyAbsScoped v body = do
     let ghcName = GHC.getName v
-    var@(PLCTyVar t' k') <- convTyVarFresh v
+    var@(PLC.TyVarDecl _ t' k') <- convTyVarFresh v
     body' <- local (\c -> c {ccScopes=pushTyName ghcName var (ccScopes c)}) body
     checkTyAbsBody body'
     pure $ PLC.TyAbs () t' k' body'
@@ -57,7 +58,7 @@ mkIterTyAbsScoped vars body = foldr (\v acc -> mkTyAbsScoped v acc) body vars
 mkTyForallScoped :: Converting m => GHC.Var -> m PLCType -> m PLCType
 mkTyForallScoped v body = do
     let ghcName = GHC.getName v
-    var@(PLCTyVar t' k') <- convTyVarFresh v
+    var@(PLC.TyVarDecl _ t' k') <- convTyVarFresh v
     body' <- local (\c -> c {ccScopes=pushTyName ghcName var (ccScopes c)}) body
     pure $ PLC.TyForall () t' k' body'
 
@@ -69,7 +70,7 @@ mkIterTyForallScoped vars body = foldr (\v acc -> mkTyForallScoped v acc) body v
 mkTyLamScoped :: Converting m => GHC.Var -> m PLCType -> m PLCType
 mkTyLamScoped v body = do
     let ghcName = GHC.getName v
-    var@(PLCTyVar t' k') <- convTyVarFresh v
+    var@(PLC.TyVarDecl _ t' k') <- convTyVarFresh v
     body' <- local (\c -> c {ccScopes=pushTyName ghcName var (ccScopes c)}) body
     pure $ PLC.TyLam () t' k' body'
 

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
@@ -26,7 +26,7 @@ import qualified MkId                                           as GHC
 import qualified PrelNames                                      as GHC
 
 import qualified Language.PlutusCore                            as PLC
-import           Language.PlutusCore.MkPlc
+import qualified Language.PlutusCore.MkPlc                      as PLC
 import           Language.PlutusCore.Quote
 import qualified Language.PlutusCore.StdLib.Data.Function       as Function
 
@@ -145,7 +145,7 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
         -- void# - values of type void get represented as error, since they should be unreachable
         GHC.Var n | n == GHC.voidPrimId || n == GHC.voidArgId -> liftQuote errorFunc
         -- locally bound vars
-        GHC.Var (lookupName top . GHC.getName -> Just (PLCVar name _)) -> pure $ PLC.Var () name
+        GHC.Var (lookupName top . GHC.getName -> Just (PLC.VarDecl _ name _)) -> pure $ PLC.Var () name
         -- Special kinds of id
         GHC.Var (GHC.idDetails -> GHC.PrimOpId po) -> convPrimitiveOp po
         GHC.Var (GHC.idDetails -> GHC.DataConWorkId dc) ->
@@ -195,12 +195,12 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
 
             q <- safeFreshTyName "Q"
             choose <- safeFreshName "choose"
-            let chooseTy = mkIterTyFun tys (PLC.TyVar () q)
+            let chooseTy = PLC.mkIterTyFun tys (PLC.TyVar () q)
 
             -- \f1 ... fn -> choose b1 ... bn
             bsLam <- mkIterLamAbsScoped (fmap fst bs) $ do
                 rhss <- mapM convExpr (fmap snd bs)
-                pure $ mkIterApp (PLC.Var() choose) rhss
+                pure $ PLC.mkIterApp (PLC.Var() choose) rhss
 
             -- abstract out Q and choose
             let cLam = PLC.TyAbs () q (PLC.Type ()) $ PLC.LamAbs () choose chooseTy bsLam
@@ -208,7 +208,7 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
             -- fixN {A1 B1 ... An Bn}
             instantiatedFix <- do
                 fixN <- liftQuote $ Function.getBuiltinFixN (length bs)
-                pure $ mkIterInst fixN $ foldMap (\(a, b) -> [a, b]) asbs
+                pure $ PLC.mkIterInst fixN $ foldMap (\(a, b) -> [a, b]) asbs
 
             let fixed = PLC.Apply () instantiatedFix cLam
 
@@ -240,7 +240,7 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
                 Just alt -> convAlt lazyCase dc alt
                 Nothing  -> throwPlain $ ConversionError "No case matched and no default case"
 
-            let applied = mkIterApp instantiated branches
+            let applied = PLC.mkIterApp instantiated branches
             -- See Note [Case expressions and laziness]
             maybeForce lazyCase applied
         -- ignore annotation

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Names.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Names.hs
@@ -14,6 +14,7 @@ import           Language.Plutus.CoreToPLC.Utils
 import qualified GhcPlugins                               as GHC
 
 import qualified Language.PlutusCore                      as PLC
+import qualified Language.PlutusCore.MkPlc                as PLC
 import           Language.PlutusCore.Quote
 
 import           Data.Char
@@ -57,7 +58,7 @@ convVarFresh :: Converting m => GHC.Var -> m PLCVar
 convVarFresh v = do
     t' <- convType $ GHC.varType v
     n' <- convNameFresh $ GHC.getName v
-    pure $ PLCVar n' t'
+    pure $ PLC.VarDecl () n' t'
 
 lookupTyName :: Scope -> GHC.Name -> Maybe PLCTyVar
 lookupTyName (Scope _ tyns) n = Map.lookup n tyns
@@ -72,7 +73,7 @@ convTyVarFresh :: Converting m => GHC.TyVar -> m PLCTyVar
 convTyVarFresh v = do
     k' <- convKind $ GHC.tyVarKind v
     t' <- convTyNameFresh $ GHC.getName v
-    pure $ PLCTyVar t' k'
+    pure $ PLC.TyVarDecl () t' k'
 
 pushName :: GHC.Name -> PLCVar-> ScopeStack -> ScopeStack
 pushName ghcName n stack = let Scope ns tyns = NE.head stack in Scope (Map.insert ghcName n ns) tyns NE.<| stack

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/PLCTypes.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/PLCTypes.hs
@@ -1,17 +1,11 @@
 module Language.Plutus.CoreToPLC.PLCTypes where
 
-import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore       as PLC
+import qualified Language.PlutusCore.MkPlc as PLC
 
 type PLCKind = PLC.Kind ()
 type PLCType = PLC.Type PLC.TyName ()
 type PLCTerm = PLC.Term PLC.TyName PLC.Name ()
 
-data PLCTyVar = PLCTyVar (PLC.TyName ()) PLCKind
-
-splitTyVar :: PLCTyVar -> (PLC.TyName (), PLCKind)
-splitTyVar (PLCTyVar n k) = (n, k)
-
-data PLCVar = PLCVar (PLC.Name ()) PLCType
-
-splitVar :: PLCVar -> (PLC.Name (), PLCType)
-splitVar (PLCVar n ty) = (n, ty)
+type PLCVar = PLC.VarDecl PLC.TyName PLC.Name ()
+type PLCTyVar = PLC.TyVarDecl PLC.TyName ()

--- a/core-to-plc/src/Language/Plutus/Lift.hs
+++ b/core-to-plc/src/Language/Plutus/Lift.hs
@@ -208,9 +208,9 @@ instance (GGetConstructorTypes f, GGetConstructorArgs f, Datatype d)  => GLiftPl
         cases <- forM constrs $ \(n, tys) -> do
                 arg <- liftQuote $ freshName () (strToBs n)
                 let ty = mkIterTyFun tys (TyVar () r)
-                pure (arg, ty)
+                pure $ VarDecl () arg ty
 
-        pure $ TyAbs () r (Type ()) $ mkIterLamAbs cases $ mkIterApp (Var () $ fst $ cases !! index) (snd constr)
+        pure $ TyAbs () r (Type ()) $ mkIterLamAbs cases $ mkIterApp (mkVar $ cases !! index) (snd constr)
 
 -- Auxiliary generic functions
 

--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -1,5 +1,12 @@
 
-module Language.PlutusCore.MkPlc ( mkTermLet
+module Language.PlutusCore.MkPlc ( VarDecl (..)
+                                 , TyVarDecl (..)
+                                 , mkVar
+                                 , mkTyVar
+                                 , Def (..)
+                                 , TermDef
+                                 , TypeDef
+                                 , mkTermLet
                                  , mkTypeLet
                                  , mkIterTyForall
                                  , mkIterTyLam
@@ -14,24 +21,45 @@ module Language.PlutusCore.MkPlc ( mkTermLet
 import           Language.PlutusCore.Type
 
 import           Data.List                (foldl')
+import           GHC.Generics             (Generic)
+
+-- | A "variable declaration", i.e. a name and a type for a variable.
+data VarDecl tyname name a = VarDecl {varDeclAnn::a, varDeclName::name a, varDeclType::Type tyname a}
+    deriving (Functor, Show, Eq, Generic)
+
+-- | Make a 'Var' referencing the given 'VarDecl'.
+mkVar :: VarDecl tyname name () -> Term tyname name ()
+mkVar = Var () . varDeclName
+
+-- | A "type variable declaration", i.e. a name and a kind for a type variable.
+data TyVarDecl tyname a = TyVarDecl {tyVarDeclAnn::a, tyVarDeclName::tyname a, tyVarDeclKind::Kind a}
+    deriving (Functor, Show, Eq, Generic)
+
+-- | Make a 'TyVar' referencing the given 'TyVarDecl'.
+mkTyVar :: TyVarDecl tyname () -> Type tyname ()
+mkTyVar = TyVar () . tyVarDeclName
+
+-- | A definition. Pretty much just a pair with more descriptive names.
+data Def var val = Def { defVar::var, defVal::val}
+
+-- | A term definition as a variable.
+type TermDef tyname name a = Def (VarDecl tyname name ()) (Term tyname name ())
+-- | A type definition as a type variable.
+type TypeDef tyname a = Def (TyVarDecl tyname ()) (Type tyname ())
 
 -- | Make a "let-binding" for a term.
 mkTermLet
-    :: name () -- ^ The name for the binding
-    -> Term tyname name () -- ^ The term to be bound
-    -> Type tyname () -- ^ The type of the term
+    :: TermDef tyname name ()
     -> Term tyname name () -- ^ The body of the let, possibly referencing the name.
     -> Term tyname name ()
-mkTermLet name bind ty body = Apply () (LamAbs () name ty body) bind
+mkTermLet (Def (VarDecl _ name ty) bind) body = Apply () (LamAbs () name ty body) bind
 
 -- | Make a "let-binding" for a type. Note: the body must be a value.
 mkTypeLet
-    :: tyname () -- ^ The name for the binding
-    -> Type tyname () -- ^ The type to be bound
-    -> Kind () -- ^ The kind of the type
+    :: TypeDef tyname ()
     -> Term tyname name () -- ^ The body of the let, possibly referencing the name.
     -> Term tyname name ()
-mkTypeLet name bind ty body = TyInst () (TyAbs () name ty body) bind
+mkTypeLet (Def (TyVarDecl _ name k) bind) body = TyInst () (TyAbs () name k body) bind
 
 -- | Make an iterated application.
 mkIterApp
@@ -49,17 +77,17 @@ mkIterInst = foldl' (TyInst ())
 
 -- | Lambda abstract a list of names.
 mkIterLamAbs
-    :: [(name (), Type tyname ())]
+    :: [VarDecl tyname name ()]
     -> Term tyname name ()
     -> Term tyname name ()
-mkIterLamAbs args body = foldr (\(n, ty) acc -> LamAbs () n ty acc) body args
+mkIterLamAbs args body = foldr (\(VarDecl _ n ty) acc -> LamAbs () n ty acc) body args
 
 -- | Type abstract a list of names.
 mkIterTyAbs
-    :: [(tyname (), Kind ())]
+    :: [TyVarDecl tyname ()]
     -> Term tyname name ()
     -> Term tyname name ()
-mkIterTyAbs args body = foldr (\(n, ty) acc -> TyAbs () n ty acc) body args
+mkIterTyAbs args body = foldr (\(TyVarDecl _ n k) acc -> TyAbs () n k acc) body args
 
 -- | Make an iterated type application.
 mkIterTyApp
@@ -77,14 +105,14 @@ mkIterTyFun tys target = foldr (\ty acc -> TyFun () ty acc) target tys
 
 -- | Universally quantify a list of names.
 mkIterTyForall
-    :: [(tyname (), Kind ())]
+    :: [TyVarDecl tyname ()]
     -> Type tyname ()
     -> Type tyname ()
-mkIterTyForall args body = foldr (\(n, k) acc -> TyForall () n k acc) body args
+mkIterTyForall args body = foldr (\(TyVarDecl _ n k) acc -> TyForall () n k acc) body args
 
 -- | Lambda abstract a list of names.
 mkIterTyLam
-    :: [(tyname (), Kind ())]
+    :: [TyVarDecl tyname ()]
     -> Type tyname ()
     -> Type tyname ()
-mkIterTyLam args body = foldr (\(n, k) acc -> TyLam () n k acc) body args
+mkIterTyLam args body = foldr (\(TyVarDecl _ n k) acc -> TyLam () n k acc) body args

--- a/language-plutus-core/src/Language/PlutusCore/Quote.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Quote.hs
@@ -12,8 +12,6 @@ module Language.PlutusCore.Quote (
             , freshTyName
             , freshenName
             , freshenTyName
-            , withTerm
-            , withType
             , QuoteT
             , Quote
             , MonadQuote
@@ -23,17 +21,15 @@ module Language.PlutusCore.Quote (
             ) where
 
 import           Control.Monad.Except
-import           Control.Monad.Morph       as MM
+import           Control.Monad.Morph      as MM
 import           Control.Monad.Reader
 import           Control.Monad.State
 
-import qualified Data.ByteString.Lazy      as BSL
+import qualified Data.ByteString.Lazy     as BSL
 import           Data.Functor.Identity
-import           Hedgehog                  (GenT)
+import           Hedgehog                 (GenT)
 
-import           Language.PlutusCore.MkPlc
 import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
 import           PlutusPrelude
 
 -- | The state contains the "next" 'Unique' that should be used for a name
@@ -106,15 +102,3 @@ freshTyName = fmap TyName .* freshName
 -- | Make a copy of the given 'TyName' that is distinct from the old one.
 freshenTyName :: (Monad m) =>  TyName a -> QuoteT m (TyName a)
 freshenTyName (TyName name) = TyName <$> freshenName name
-
--- | Make a term available under a given name inside a computation.
-withTerm :: (MonadQuote m) => m (Term TyName Name ()) -> m (Type TyName ()) -> m (Name ()) -> (Name () -> m (Term TyName Name ())) -> m (Term TyName Name ())
-withTerm bindM tyM n f = do
-    name <- n
-    mkTermLet name <$> bindM <*> tyM <*> f name
-
--- | Make a type available under a given name inside a computation. Note: the result of the computation must be a value.
-withType :: (MonadQuote m) => m (Type TyName ()) -> m (Kind ()) -> m (TyName ()) -> (TyName () -> m (Term TyName Name ())) -> m (Term TyName Name ())
-withType bindM kM n f = do
-    name <- n
-    mkTypeLet name <$> bindM <*> kM <*> f name

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Bool.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Bool.hs
@@ -39,8 +39,8 @@ getBuiltinTrue = rename =<< do
     return
        . TyAbs () a (Type ())
        $ mkIterLamAbs [
-          (x, TyVar () a),
-          (y, TyVar () a)
+          VarDecl () x (TyVar () a),
+          VarDecl () y (TyVar () a)
           ]
        $ Var () x
 
@@ -55,8 +55,8 @@ getBuiltinFalse = rename =<< do
     return
        . TyAbs () a (Type ())
        $ mkIterLamAbs [
-          (x, TyVar () a),
-          (y, TyVar () a)
+          VarDecl () x (TyVar () a),
+          VarDecl () y (TyVar () a)
           ]
        $ Var () y
 
@@ -76,9 +76,9 @@ getBuiltinIf = rename =<< do
     return
        . TyAbs () a (Type ())
       $ mkIterLamAbs [
-          (b, builtinBool),
-          (x, unitFunA),
-          (y, unitFunA)
+          VarDecl () b builtinBool,
+          VarDecl () x unitFunA,
+          VarDecl () y unitFunA
           ]
       $ mkIterApp
           (TyInst () (Var () b) unitFunA)

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
@@ -229,7 +229,7 @@ getBuiltinFixN n = do
             -- names and types for the f arguments
             fs <- forM asbs $ \(a',b') -> do
                 f <- freshName () "f"
-                pure (f, TyFun () (TyVar () a') (TyVar () b'))
+                pure $ VarDecl () f (TyFun () (TyVar () a') (TyVar () b'))
 
             x <- freshName () "x"
 
@@ -238,7 +238,7 @@ getBuiltinFixN n = do
                 Apply () (TyInst () (Var () k) (TyVar () b)) $
                 mkIterLamAbs fs $
                 -- this is an ugly but straightforward way of getting the right fi
-                Apply() (Var () (fst (fs !! i))) (Var () x)
+                Apply() (mkVar (fs !! i)) (Var () x)
 
     -- a list of all the branches
     branches <- forM (zip asbs [0..]) $ uncurry branch
@@ -247,7 +247,7 @@ getBuiltinFixN n = do
     let allAsBs = foldMap (\(a, b) -> [a, b]) asbs
     pure $
         -- abstract out all the As and Bs
-        mkIterTyAbs (zip allAsBs (repeat (Type ()))) $
+        mkIterTyAbs (fmap (\tn -> TyVarDecl () tn (Type ())) allAsBs) $
         Apply () instantiatedFix $
         LamAbs () k kTy $
         TyAbs () s (Type ()) $

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -3,19 +3,14 @@
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# OPTIONS_GHC -Wno-orphans       #-}
 module Language.PlutusIR (
     TyName (..),
     Name (..),
+    VarDecl (..),
+    TyVarDecl (..),
     Kind (..),
     Type (..),
-    VarDecl (..),
-    varDeclName,
-    varDeclTy,
-    splitVarDecl,
-    TyVarDecl (..),
-    tyVarDeclName,
-    tyVarDeclKind,
-    splitTyVarDecl,
     Datatype (..),
     Recursivity (..),
     Binding (..),
@@ -28,35 +23,10 @@ import           PlutusPrelude
 
 import           Language.PlutusCore        (Kind, Name, TyName, Type)
 import qualified Language.PlutusCore        as PLC
+import           Language.PlutusCore.MkPlc  (TyVarDecl (..), VarDecl (..))
 import qualified Language.PlutusCore.Pretty as PLC
 
 import           GHC.Generics               (Generic)
-
--- Variable declarations
-
-data VarDecl tyname name a = VarDecl a (name a) (Type tyname a)
-    deriving (Functor, Show, Eq, Generic)
-
-varDeclName :: VarDecl tyname name a -> name a
-varDeclName (VarDecl _ n _) = n
-
-varDeclTy :: VarDecl tyname name a -> Type tyname a
-varDeclTy (VarDecl _ _ ty) = ty
-
-splitVarDecl :: VarDecl tyname name a -> (name a, Type tyname a)
-splitVarDecl (VarDecl _ n ty) = (n, ty)
-
-data TyVarDecl tyname a = TyVarDecl a (tyname a) (Kind a)
-    deriving (Functor, Show, Eq, Generic)
-
-tyVarDeclName :: TyVarDecl tyname a -> tyname a
-tyVarDeclName (TyVarDecl _ n _) = n
-
-tyVarDeclKind :: TyVarDecl name a -> Kind a
-tyVarDeclKind (TyVarDecl _ _ k) = k
-
-splitTyVarDecl :: TyVarDecl tyname a -> (tyname a, Kind a)
-splitTyVarDecl (TyVarDecl _ n k) = (n, k)
 
 -- Datatypes
 

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
@@ -2,10 +2,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Language.PlutusIR.Compiler.Types where
 
+import           Language.PlutusIR
 import           Language.PlutusIR.Compiler.Error
 
 import           Control.Monad.Except
 
+import qualified Language.PlutusCore.MkPlc        as PLC
 import           Language.PlutusCore.Quote
 
 type Compiling m = (Monad m, MonadError CompError m, MonadQuote m)
@@ -13,5 +15,4 @@ type Compiling m = (Monad m, MonadError CompError m, MonadQuote m)
 runCompiling :: QuoteT (Except CompError) a -> Either CompError a
 runCompiling = runExcept . runQuoteT
 
--- | A definition. Pretty much just a pair with more descriptive names.
-data Def var val = Def { defVar::var, defVal::val}
+type TermDef tyname name a = PLC.Def (PLC.VarDecl tyname name a) (Term tyname name a)

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -92,7 +92,7 @@ listMatch :: Term TyName Name ()
 listMatch = runQuote $ do
     m <- freshTyName () "List"
     a <- freshTyName () "a"
-    let ma = (TyApp () (TyVar () m) (TyVar () a))
+    let ma = TyApp () (TyVar () m) (TyVar () a)
     match <- freshName () "match_List"
     nil <- freshName () "Nil"
     cons <- freshName () "Cons"
@@ -102,8 +102,8 @@ listMatch = runQuote $ do
     h <- freshName () "head"
     t <- freshName () "tail"
 
-    let unitMatch = (PLC.TyInst () (PLC.Var () match) unit)
-    let unitNil = (PLC.TyInst () (PLC.Var () nil) unit)
+    let unitMatch = PLC.TyInst () (PLC.Var () match) unit
+    let unitNil = PLC.TyInst () (PLC.Var () nil) unit
     pure $
         Let ()
             Rec
@@ -121,12 +121,12 @@ listMatch = runQuote $ do
                 ]
             ] $
             -- embed so we can use PLC construction functions
-            embedIntoIR $ PLC.mkIterApp (PLC.TyInst () (PLC.Apply () unitMatch unitNil) unit) $
+            embedIntoIR $ PLC.mkIterApp (PLC.TyInst () (PLC.Apply () unitMatch unitNil) unit)
                 [
                     -- nil case
                     unitval,
                     -- cons case
-                    PLC.mkIterLamAbs [(h, unit), (t, PLC.TyApp () (PLC.TyVar () m) unit) ] $ PLC.Var () h
+                    PLC.mkIterLamAbs [PLC.VarDecl () h unit, PLC.VarDecl () t (PLC.TyApp () (PLC.TyVar () m) unit)] $ PLC.Var () h
                 ]
 
 datatypes :: TestNested


### PR DESCRIPTION
Share the VarDecl types across language-plutus-core and dependents
    
This makes the interface to `MkPlc` a bit more expressively typed,
namely we add
- `VarDecl` and `TyVarDecl` representing "declarations" of variables,
i.e. pais of names and types/kinds.
- `Def` (and applied synonyms `TermDef` and `TypeDef`) representing a
pair of a variable declaration and a value.
    
We then use these in the `MkPlc` functions.
   
We can furthermore use them in both `core-to-plc` and `plutus-ir`, which
both have similar notions. In `plutus-ir` we actually use them as part
of the AST, which saves us a great deal of shuffling back and forth when
using the `MkPlc` functions.
