### PR TITLE
Add two missing golden files

### DIFF
--- a/language-plutus-core/test/TypeSynthesis/Golden/ModInteger.plc.golden
+++ b/language-plutus-core/test/TypeSynthesis/Golden/ModInteger.plc.golden
@@ -1,0 +1,1 @@
+(all s0 (size) (fun [(con integer) s0] (fun [(con integer) s0] [(con integer) s0])))

--- a/language-plutus-core/test/TypeSynthesis/Golden/QuotientInteger.plc.golden
+++ b/language-plutus-core/test/TypeSynthesis/Golden/QuotientInteger.plc.golden
@@ -1,0 +1,1 @@
+(all s0 (size) (fun [(con integer) s0] (fun [(con integer) s0] [(con integer) s0])))


### PR DESCRIPTION
These just needed to be committed - `cabal test` just generates them and succeeds otherwise.

I noticed they also popped up in https://github.com/input-output-hk/plutus/pull/236, presumably for a similar reason.