### PR TITLE
plutus-ir: typecheck test output and fix many bugs

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -42,6 +42,7 @@ library
         Language.PlutusCore.Constant
         Language.PlutusCore.Pretty
         Language.PlutusCore.View
+        Language.PlutusCore.Subst
         Language.PlutusCore.StdLib.Data.Bool
         Language.PlutusCore.StdLib.Data.ChurchNat
         Language.PlutusCore.StdLib.Data.Function
@@ -79,7 +80,6 @@ library
         Language.PlutusCore.TypeSynthesis
         Language.PlutusCore.Normalize
         Language.PlutusCore.CBOR
-        Language.PlutusCore.Subst
         Language.PlutusCore.Generators.Internal.Denotation
         Language.PlutusCore.Generators.Internal.Entity
         Language.PlutusCore.Generators.Internal.TypedBuiltinGen

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -111,9 +111,6 @@ module Language.PlutusCore
     , EvaluationResult
     -- * Combining programs
     , applyProgram
-    -- * Substitution
-    , substTy
-    , substTerm
     ) where
 
 import           Control.Monad.Except
@@ -132,7 +129,6 @@ import           Language.PlutusCore.Parser
 import           Language.PlutusCore.Pretty
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Renamer
-import           Language.PlutusCore.Subst
 import           Language.PlutusCore.TH
 import           Language.PlutusCore.Type
 import           Language.PlutusCore.TypeSynthesis

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -50,6 +50,7 @@ module Language.PlutusCore
     , TypeState (..)
     , RenamedType
     , RenamedTerm
+    , rename
     , alphaRename
     , globalRename
     -- * Normalization

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -111,6 +111,9 @@ module Language.PlutusCore
     , EvaluationResult
     -- * Combining programs
     , applyProgram
+    -- * Substitution
+    , substTy
+    , substTerm
     ) where
 
 import           Control.Monad.Except
@@ -129,6 +132,7 @@ import           Language.PlutusCore.Parser
 import           Language.PlutusCore.Pretty
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Renamer
+import           Language.PlutusCore.Subst
 import           Language.PlutusCore.TH
 import           Language.PlutusCore.Type
 import           Language.PlutusCore.TypeSynthesis

--- a/plutus-ir/src/Language/PlutusIR/Compiler.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler.hs
@@ -1,9 +1,19 @@
+{-# LANGUAGE FlexibleContexts #-}
 module Language.PlutusIR.Compiler (
     compileTerm,
     Compiling,
     CompError (..),
     runCompiling) where
 
+import           Language.PlutusIR
 import           Language.PlutusIR.Compiler.Error
-import           Language.PlutusIR.Compiler.Term
+import qualified Language.PlutusIR.Compiler.Term  as Term
 import           Language.PlutusIR.Compiler.Types
+
+import qualified Language.PlutusCore              as PLC
+
+import           Control.Monad
+
+-- | Compile a 'Term' into a PLC Term. Note: the result *does* have globally unique names.
+compileTerm :: Compiling m => Term TyName Name () -> m (PLC.Term TyName Name ())
+compileTerm = PLC.rename <=< Term.compileTerm

--- a/plutus-ir/src/Language/PlutusIR/Compiler.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler.hs
@@ -1,11 +1,9 @@
 module Language.PlutusIR.Compiler (
     compileTerm,
-    compileDatatype,
     Compiling,
     CompError (..),
     runCompiling) where
 
-import           Language.PlutusIR.Compiler.Datatype
 import           Language.PlutusIR.Compiler.Error
 import           Language.PlutusIR.Compiler.Term
 import           Language.PlutusIR.Compiler.Types

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
@@ -10,6 +10,7 @@ import           PlutusPrelude             (strToBs)
 import qualified Language.PlutusCore       as PLC
 import qualified Language.PlutusCore.MkPlc as PLC
 import           Language.PlutusCore.Quote
+import qualified Language.PlutusCore.Subst as PLC
 
 import           Data.List
 import           Data.Maybe

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
@@ -227,9 +227,9 @@ mkDatatypePatternFunctor d@(Datatype _ _ tvs _ _) = PLC.mkIterTyLam tvs <$> mkSc
 
 -- | Make the real PLC type corresponding to a 'Datatype' with the given pattern functor.
 -- @
---     mkDatatypeType List <pattern functor of List> =
---         fix list . <pattern functor of List> =
---         fix list . \(a :: *) -> forall (r :: *) . r -> (a -> List a -> r) -> r =
+--     mkDatatypeType List <pattern functor of List>
+--         = fix list . <pattern functor of List>
+--         = fix list . \(a :: *) -> forall (r :: *) . r -> (a -> List a -> r) -> r
 -- @
 mkDatatypeType :: MonadQuote m => Recursivity -> Type TyName () -> Datatype TyName Name () -> m (PLC.Type TyName ())
 mkDatatypeType r pf (Datatype _ tn _ _ _) = pure $ case r of
@@ -256,8 +256,8 @@ mkConstructorType (Datatype _ _ tvs _ _) constr = pure $ PLC.mkIterTyForall tvs 
 -- | Make a constructor of a 'Datatype' with the given pattern functor. The constructor argument mostly serves to identify the constructor
 -- that we are interested in in the list of constructors.
 -- @
---     mkConstructor <definition of List> <pattern functor of List> List Cons =
---         /\(a :: *) . \(arg1 : a) (arg2 : <definition of List> a) .
+--     mkConstructor <definition of List> <pattern functor of List> List Cons
+--         = /\(a :: *) . \(arg1 : a) (arg2 : <definition of List> a) .
 --             wrap <pattern functor of List> /\(out_List :: *) .
 --                 \(case_Nil : out_List) (case_Cons : a -> List a -> out_List) . case_Cons arg1 arg2
 -- @
@@ -313,9 +313,9 @@ mkConstructor r dty pf d@(Datatype _ tn tvs _ constrs) constr = do
 -- See note [Scott encoding of datatypes]
 -- | Make the destructor for a 'Datatype'.
 -- @
---     mkDestructor <definition of List> List =
---        /\(a :: *) -> \(x : (<definition of List> a)) -> unwrap x =
---        /\(a :: *) -> \(x : (fix list . \(a :: *) -> forall (r :: *) . r -> (a -> List a -> r) -> r) a) -> unwrap x
+--     mkDestructor <definition of List> List
+--        = /\(a :: *) -> \(x : (<definition of List> a)) -> unwrap x
+--        = /\(a :: *) -> \(x : (fix List . \(a :: *) -> forall (r :: *) . r -> (a -> List a -> r) -> r) a) -> unwrap x
 -- @
 mkDestructor :: MonadQuote m => Recursivity -> Type TyName () -> Datatype TyName Name () -> m (PLC.Term TyName Name ())
 mkDestructor r dty (Datatype _ _ tvs _ _) = do
@@ -342,9 +342,9 @@ mkDestructor r dty (Datatype _ _ tvs _ _) = do
 -- See note [Scott encoding of datatypes]
 -- | Make the type of a destructor for a 'Datatype'.
 -- @
---     mkDestructorTy <pattern functor of List> List =
---         forall (a :: *) . (List a) -> ((<pattern functor of List>) a) =
---         forall (a :: *) . (List a) -> ((\(a :: *) -> forall (out_List :: *) . (out_List -> (a -> List a -> out_List) -> out_List)) a)
+--     mkDestructorTy <pattern functor of List> List
+--         = forall (a :: *) . (List a) -> ((<pattern functor of List>) a)
+--         = forall (a :: *) . (List a) -> ((\(a :: *) -> forall (out_List :: *) . (out_List -> (a -> List a -> out_List) -> out_List)) a)
 -- @
 mkDestructorTy :: MonadQuote m => PLC.Type TyName () -> Datatype TyName Name () -> m (PLC.Type TyName ())
 mkDestructorTy pf (Datatype _ tn tvs _ _) =

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
@@ -1,14 +1,20 @@
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
 module Language.PlutusIR.Compiler.Error (CompError (..)) where
 
-import qualified Data.Text                 as T
-import qualified Data.Text.Prettyprint.Doc as PP
+import qualified Language.PlutusCore        as PLC
+import qualified Language.PlutusCore.Pretty as PLC
 
-data CompError = CompilationError T.Text
-               | UnsupportedError T.Text
+import qualified Data.Text                  as T
+import qualified Data.Text.Prettyprint.Doc  as PP
 
-instance PP.Pretty CompError where
-    pretty = \case
+data CompError a = CompilationError T.Text -- ^ A generic compilation error.
+                 | UnsupportedError T.Text -- ^ An error relating specifically to an unsupported feature.
+                 | PLCError (PLC.Error a) -- ^ An error from running some PLC function, lifted into this error type for convenience.
+
+instance PP.Pretty a => PLC.PrettyBy PLC.PrettyConfigPlc (CompError a) where
+    prettyBy config = \case
         CompilationError e -> "Error during compilation:" PP.<+> PP.pretty e
         UnsupportedError e -> "Unsupported:" PP.<+> PP.pretty e
+        PLCError e -> PLC.prettyBy config e

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Term.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Term.hs
@@ -18,7 +18,7 @@ import qualified Language.PlutusCore.MkPlc            as PLC
 
 import           Data.List
 
--- | Compile a 'Term' into a PLC Term.
+-- | Compile a 'Term' into a PLC Term. Note: the result does *not* have globally unique names.
 compileTerm :: Compiling m => Term TyName Name () -> m (PLC.Term TyName Name ())
 compileTerm = \case
     Let _ r bs body -> do

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
@@ -10,9 +10,9 @@ import           Control.Monad.Except
 import qualified Language.PlutusCore.MkPlc        as PLC
 import           Language.PlutusCore.Quote
 
-type Compiling m = (Monad m, MonadError CompError m, MonadQuote m)
+type Compiling m = (Monad m, MonadError (CompError ()) m, MonadQuote m)
 
-runCompiling :: QuoteT (Except CompError) a -> Either CompError a
+runCompiling :: QuoteT (Except (CompError())) a -> Either (CompError ()) a
 runCompiling = runExcept . runQuoteT
 
 type TermDef tyname name a = PLC.Def (PLC.VarDecl tyname name a) (Term tyname name a)

--- a/plutus-ir/test/datatypes/listMatch.plc.golden
+++ b/plutus-ir/test/datatypes/listMatch.plc.golden
@@ -4,35 +4,35 @@
       [
         {
           (abs
-            List_0
+            List_23
             (fun (type) (type))
             (lam
-              Nil_1
-              (all a_2 (type) [List_0 a_2])
+              Nil_24
+              (all a_25 (type) [List_23 a_25])
               (lam
-                Cons_3
-                (all a_4 (type) (fun a_4 (fun [List_0 a_4] [List_0 a_4])))
+                Cons_26
+                (all a_27 (type) (fun a_27 (fun [List_23 a_27] [List_23 a_27])))
                 (lam
-                  match_List_5
-                  (all a_6 (type) (fun [List_0 a_6] [(lam a_7 (type) (all out_List_8 (type) (fun out_List_8 (fun (fun a_7 (fun [List_0 a_7] out_List_8)) out_List_8)))) a_6]))
+                  match_List_28
+                  (all a_29 (type) (fun [List_23 a_29] [(lam a_30 (type) (all out_List_31 (type) (fun out_List_31 (fun (fun a_30 (fun [List_23 a_30] out_List_31)) out_List_31)))) a_29]))
                   [
                     [
                       {
                         [
-                          { match_List_5 (all a_9 (type) (fun a_9 a_9)) }
-                          { Nil_1 (all a_10 (type) (fun a_10 a_10)) }
+                          { match_List_28 (all a_32 (type) (fun a_32 a_32)) }
+                          { Nil_24 (all a_33 (type) (fun a_33 a_33)) }
                         ]
-                        (all a_11 (type) (fun a_11 a_11))
+                        (all a_34 (type) (fun a_34 a_34))
                       }
-                      (abs a_12 (type) (lam x_13 a_12 x_13))
+                      (abs a_35 (type) (lam x_36 a_35 x_36))
                     ]
                     (lam
-                      head_14
-                      (all a_15 (type) (fun a_15 a_15))
+                      head_37
+                      (all a_38 (type) (fun a_38 a_38))
                       (lam
-                        tail_16
-                        [List_0 (all a_17 (type) (fun a_17 a_17))]
-                        head_14
+                        tail_39
+                        [List_23 (all a_40 (type) (fun a_40 a_40))]
+                        head_37
                       )
                     )
                   ]
@@ -40,24 +40,24 @@
               )
             )
           )
-          (fix List_18 (lam a_19 (type) (all out_List_20 (type) (fun out_List_20 (fun (fun a_19 (fun [List_18 a_19] out_List_20)) out_List_20)))))
+          (fix List_41 (lam a_42 (type) (all out_List_43 (type) (fun out_List_43 (fun (fun a_42 (fun [List_41 a_42] out_List_43)) out_List_43)))))
         }
         (abs
-          a_21
+          a_44
           (type)
           (wrap
-            List_22
-            (lam a_23 (type) (all out_List_24 (type) (fun out_List_24 (fun (fun a_23 (fun [List_22 a_23] out_List_24)) out_List_24))))
+            List_45
+            (lam a_46 (type) (all out_List_47 (type) (fun out_List_47 (fun (fun a_46 (fun [List_45 a_46] out_List_47)) out_List_47))))
             (abs
-              out_List_25
+              out_List_48
               (type)
               (lam
-                case_Nil_26
-                out_List_25
+                case_Nil_49
+                out_List_48
                 (lam
-                  case_Cons_27
-                  (fun a_21 (fun [List_22 a_21] out_List_25))
-                  case_Nil_26
+                  case_Cons_50
+                  (fun a_44 (fun [List_45 a_44] out_List_48))
+                  case_Nil_49
                 )
               )
             )
@@ -65,27 +65,27 @@
         )
       ]
       (abs
-        a_28
+        a_51
         (type)
         (lam
-          arg_0_29
-          a_28
+          arg_0_52
+          a_51
           (lam
-            arg_1_30
-            [(fix List_31 (lam a_32 (type) (all out_List_33 (type) (fun out_List_33 (fun (fun a_32 (fun [List_31 a_32] out_List_33)) out_List_33))))) a_28]
+            arg_1_53
+            [(fix List_54 (lam a_55 (type) (all out_List_56 (type) (fun out_List_56 (fun (fun a_55 (fun [List_54 a_55] out_List_56)) out_List_56))))) a_51]
             (wrap
-              List_34
-              (lam a_35 (type) (all out_List_36 (type) (fun out_List_36 (fun (fun a_35 (fun [List_34 a_35] out_List_36)) out_List_36))))
+              List_57
+              (lam a_58 (type) (all out_List_59 (type) (fun out_List_59 (fun (fun a_58 (fun [List_57 a_58] out_List_59)) out_List_59))))
               (abs
-                out_List_37
+                out_List_60
                 (type)
                 (lam
-                  case_Nil_38
-                  out_List_37
+                  case_Nil_61
+                  out_List_60
                   (lam
-                    case_Cons_39
-                    (fun a_28 (fun [List_34 a_28] out_List_37))
-                    [ [ case_Cons_39 arg_0_29 ] arg_1_30 ]
+                    case_Cons_62
+                    (fun a_51 (fun [List_57 a_51] out_List_60))
+                    [ [ case_Cons_62 arg_0_52 ] arg_1_53 ]
                   )
                 )
               )
@@ -95,12 +95,12 @@
       )
     ]
     (abs
-      a_40
+      a_63
       (type)
       (lam
-        x_41
-        [(fix List_42 (lam a_43 (type) (all out_List_44 (type) (fun out_List_44 (fun (fun a_43 (fun [List_42 a_43] out_List_44)) out_List_44))))) a_40]
-        (unwrap x_41)
+        x_64
+        [(fix List_65 (lam a_66 (type) (all out_List_67 (type) (fun out_List_67 (fun (fun a_66 (fun [List_65 a_66] out_List_67)) out_List_67))))) a_63]
+        (unwrap x_64)
       )
     )
   ]

--- a/plutus-ir/test/datatypes/listMatch.plc.golden
+++ b/plutus-ir/test/datatypes/listMatch.plc.golden
@@ -7,30 +7,32 @@
             List_0
             (fun (type) (type))
             (lam
-              Nil_3
-              [List_0 a_1]
+              Nil_1
+              (all a_2 (type) [List_0 a_2])
               (lam
-                Cons_4
-                (fun a_1 (fun [List_0 a_1] [List_0 a_1]))
+                Cons_3
+                (all a_4 (type) (fun a_4 (fun [List_0 a_4] [List_0 a_4])))
                 (lam
-                  match_List_2
-                  (all a_1 (type) (fun [List_0 a_1] [(lam a_1 (type) (all r_0 (type) (fun r_0 (fun (fun a_1 (fun [List_0 a_1] r_0)) r_0)))) a_1]))
+                  match_List_5
+                  (all a_6 (type) (fun [List_0 a_6] [(lam a_7 (type) (all out_List_8 (type) (fun out_List_8 (fun (fun a_7 (fun [List_0 a_7] out_List_8)) out_List_8)))) a_6]))
                   [
                     [
                       {
                         [
-                          { match_List_2 (all a_6 (type) (fun a_6 a_6)) }
-                          { Nil_3 (all a_6 (type) (fun a_6 a_6)) }
+                          { match_List_5 (all a_9 (type) (fun a_9 a_9)) }
+                          { Nil_1 (all a_10 (type) (fun a_10 a_10)) }
                         ]
-                        (all a_6 (type) (fun a_6 a_6))
+                        (all a_11 (type) (fun a_11 a_11))
                       }
-                      (abs a_9 (type) (lam x_10 a_9 x_10))
+                      (abs a_12 (type) (lam x_13 a_12 x_13))
                     ]
                     (lam
-                      head_11
-                      (all a_6 (type) (fun a_6 a_6))
+                      head_14
+                      (all a_15 (type) (fun a_15 a_15))
                       (lam
-                        tail_12 [List_0 (all a_6 (type) (fun a_6 a_6))] head_11
+                        tail_16
+                        [List_0 (all a_17 (type) (fun a_17 a_17))]
+                        head_14
                       )
                     )
                   ]
@@ -38,22 +40,24 @@
               )
             )
           )
-          (fix List_0 (lam a_1 (type) (all r_0 (type) (fun r_0 (fun (fun a_1 (fun [List_0 a_1] r_0)) r_0)))))
+          (fix List_18 (lam a_19 (type) (all out_List_20 (type) (fun out_List_20 (fun (fun a_19 (fun [List_18 a_19] out_List_20)) out_List_20)))))
         }
         (abs
-          a_1
+          a_21
           (type)
           (wrap
-            List_0
-            (lam a_1 (type) (all r_0 (type) (fun r_0 (fun (fun a_1 (fun [List_0 a_1] r_0)) r_0))))
+            List_22
+            (lam a_23 (type) (all out_List_24 (type) (fun out_List_24 (fun (fun a_23 (fun [List_22 a_23] out_List_24)) out_List_24))))
             (abs
-              out_List_1
+              out_List_25
               (type)
               (lam
-                case_Nil_2
-                out_List_1
+                case_Nil_26
+                out_List_25
                 (lam
-                  case_Cons_3 (fun a_1 (fun [List_0 a_1] out_List_1)) case_Nil_2
+                  case_Cons_27
+                  (fun a_21 (fun [List_22 a_21] out_List_25))
+                  case_Nil_26
                 )
               )
             )
@@ -61,27 +65,27 @@
         )
       ]
       (abs
-        a_1
+        a_28
         (type)
         (lam
-          arg_0_7
-          a_1
+          arg_0_29
+          a_28
           (lam
-            arg_1_8
-            [List_0 a_1]
+            arg_1_30
+            [(fix List_31 (lam a_32 (type) (all out_List_33 (type) (fun out_List_33 (fun (fun a_32 (fun [List_31 a_32] out_List_33)) out_List_33))))) a_28]
             (wrap
-              List_0
-              (lam a_1 (type) (all r_0 (type) (fun r_0 (fun (fun a_1 (fun [List_0 a_1] r_0)) r_0))))
+              List_34
+              (lam a_35 (type) (all out_List_36 (type) (fun out_List_36 (fun (fun a_35 (fun [List_34 a_35] out_List_36)) out_List_36))))
               (abs
-                out_List_4
+                out_List_37
                 (type)
                 (lam
-                  case_Nil_5
-                  out_List_4
+                  case_Nil_38
+                  out_List_37
                   (lam
-                    case_Cons_6
-                    (fun a_1 (fun [List_0 a_1] out_List_4))
-                    [ [ case_Cons_6 arg_0_7 ] arg_1_8 ]
+                    case_Cons_39
+                    (fun a_28 (fun [List_34 a_28] out_List_37))
+                    [ [ case_Cons_39 arg_0_29 ] arg_1_30 ]
                   )
                 )
               )
@@ -90,6 +94,14 @@
         )
       )
     ]
-    (abs a_1 (type) (lam x_9 [List_0 a_1] (unwrap x_9)))
+    (abs
+      a_40
+      (type)
+      (lam
+        x_41
+        [(fix List_42 (lam a_43 (type) (all out_List_44 (type) (fun out_List_44 (fun (fun a_43 (fun [List_42 a_43] out_List_44)) out_List_44))))) a_40]
+        (unwrap x_41)
+      )
+    )
   ]
 )

--- a/plutus-ir/test/datatypes/listMatchEval.plc.golden
+++ b/plutus-ir/test/datatypes/listMatchEval.plc.golden
@@ -1,1 +1,1 @@
-(abs a_9 (type) (lam x_10 a_9 x_10))
+(abs a_12 (type) (lam x_13 a_12 x_13))

--- a/plutus-ir/test/datatypes/listMatchEval.plc.golden
+++ b/plutus-ir/test/datatypes/listMatchEval.plc.golden
@@ -1,1 +1,1 @@
-(abs a_12 (type) (lam x_13 a_12 x_13))
+(abs a_35 (type) (lam x_36 a_35 x_36))

--- a/plutus-ir/test/datatypes/maybe.plc.golden
+++ b/plutus-ir/test/datatypes/maybe.plc.golden
@@ -7,56 +7,66 @@
             Maybe_0
             (fun (type) (type))
             (lam
-              Nothing_3
-              [Maybe_0 a_1]
+              Nothing_1
+              (all a_2 (type) [Maybe_0 a_2])
               (lam
-                Just_4
-                (fun a_1 [Maybe_0 a_1])
+                Just_3
+                (all a_4 (type) (fun a_4 [Maybe_0 a_4]))
                 (lam
-                  match_Maybe_2
-                  (all a_1 (type) (fun [Maybe_0 a_1] [(lam a_1 (type) (all r_0 (type) (fun r_0 (fun (fun a_1 r_0) r_0)))) a_1]))
+                  match_Maybe_5
+                  (all a_6 (type) (fun [Maybe_0 a_6] [(lam a_7 (type) (all out_Maybe_8 (type) (fun out_Maybe_8 (fun (fun a_7 out_Maybe_8) out_Maybe_8)))) a_6]))
                   [
-                    { Just_4 (all a_6 (type) (fun a_6 a_6)) }
-                    (abs a_9 (type) (lam x_10 a_9 x_10))
+                    { Just_3 (all a_9 (type) (fun a_9 a_9)) }
+                    (abs a_10 (type) (lam x_11 a_10 x_11))
                   ]
                 )
               )
             )
           )
-          (lam a_1 (type) (all r_0 (type) (fun r_0 (fun (fun a_1 r_0) r_0))))
+          (lam a_12 (type) (all out_Maybe_13 (type) (fun out_Maybe_13 (fun (fun a_12 out_Maybe_13) out_Maybe_13))))
         }
         (abs
-          a_1
+          a_14
           (type)
           (abs
-            out_Maybe_1
+            out_Maybe_15
             (type)
             (lam
-              case_Nothing_2
-              out_Maybe_1
-              (lam case_Just_3 (fun a_1 out_Maybe_1) case_Nothing_2)
+              case_Nothing_16
+              out_Maybe_15
+              (lam case_Just_17 (fun a_14 out_Maybe_15) case_Nothing_16)
             )
           )
         )
       ]
       (abs
-        a_1
+        a_18
         (type)
         (lam
-          arg_0_7
-          a_1
+          arg_0_19
+          a_18
           (abs
-            out_Maybe_4
+            out_Maybe_20
             (type)
             (lam
-              case_Nothing_5
-              out_Maybe_4
-              (lam case_Just_6 (fun a_1 out_Maybe_4) [ case_Just_6 arg_0_7 ])
+              case_Nothing_21
+              out_Maybe_20
+              (lam
+                case_Just_22 (fun a_18 out_Maybe_20) [ case_Just_22 arg_0_19 ]
+              )
             )
           )
         )
       )
     ]
-    (abs a_1 (type) (lam x_8 [Maybe_0 a_1] x_8))
+    (abs
+      a_23
+      (type)
+      (lam
+        x_24
+        [(lam a_25 (type) (all out_Maybe_26 (type) (fun out_Maybe_26 (fun (fun a_25 out_Maybe_26) out_Maybe_26)))) a_23]
+        x_24
+      )
+    )
   ]
 )

--- a/plutus-ir/test/datatypes/maybe.plc.golden
+++ b/plutus-ir/test/datatypes/maybe.plc.golden
@@ -4,55 +4,55 @@
       [
         {
           (abs
-            Maybe_0
+            Maybe_20
             (fun (type) (type))
             (lam
-              Nothing_1
-              (all a_2 (type) [Maybe_0 a_2])
+              Nothing_21
+              (all a_22 (type) [Maybe_20 a_22])
               (lam
-                Just_3
-                (all a_4 (type) (fun a_4 [Maybe_0 a_4]))
+                Just_23
+                (all a_24 (type) (fun a_24 [Maybe_20 a_24]))
                 (lam
-                  match_Maybe_5
-                  (all a_6 (type) (fun [Maybe_0 a_6] [(lam a_7 (type) (all out_Maybe_8 (type) (fun out_Maybe_8 (fun (fun a_7 out_Maybe_8) out_Maybe_8)))) a_6]))
+                  match_Maybe_25
+                  (all a_26 (type) (fun [Maybe_20 a_26] [(lam a_27 (type) (all out_Maybe_28 (type) (fun out_Maybe_28 (fun (fun a_27 out_Maybe_28) out_Maybe_28)))) a_26]))
                   [
-                    { Just_3 (all a_9 (type) (fun a_9 a_9)) }
-                    (abs a_10 (type) (lam x_11 a_10 x_11))
+                    { Just_23 (all a_29 (type) (fun a_29 a_29)) }
+                    (abs a_30 (type) (lam x_31 a_30 x_31))
                   ]
                 )
               )
             )
           )
-          (lam a_12 (type) (all out_Maybe_13 (type) (fun out_Maybe_13 (fun (fun a_12 out_Maybe_13) out_Maybe_13))))
+          (lam a_32 (type) (all out_Maybe_33 (type) (fun out_Maybe_33 (fun (fun a_32 out_Maybe_33) out_Maybe_33))))
         }
         (abs
-          a_14
+          a_34
           (type)
           (abs
-            out_Maybe_15
+            out_Maybe_35
             (type)
             (lam
-              case_Nothing_16
-              out_Maybe_15
-              (lam case_Just_17 (fun a_14 out_Maybe_15) case_Nothing_16)
+              case_Nothing_36
+              out_Maybe_35
+              (lam case_Just_37 (fun a_34 out_Maybe_35) case_Nothing_36)
             )
           )
         )
       ]
       (abs
-        a_18
+        a_38
         (type)
         (lam
-          arg_0_19
-          a_18
+          arg_0_39
+          a_38
           (abs
-            out_Maybe_20
+            out_Maybe_40
             (type)
             (lam
-              case_Nothing_21
-              out_Maybe_20
+              case_Nothing_41
+              out_Maybe_40
               (lam
-                case_Just_22 (fun a_18 out_Maybe_20) [ case_Just_22 arg_0_19 ]
+                case_Just_42 (fun a_38 out_Maybe_40) [ case_Just_42 arg_0_39 ]
               )
             )
           )
@@ -60,12 +60,12 @@
       )
     ]
     (abs
-      a_23
+      a_43
       (type)
       (lam
-        x_24
-        [(lam a_25 (type) (all out_Maybe_26 (type) (fun out_Maybe_26 (fun (fun a_25 out_Maybe_26) out_Maybe_26)))) a_23]
-        x_24
+        x_44
+        [(lam a_45 (type) (all out_Maybe_46 (type) (fun out_Maybe_46 (fun (fun a_45 out_Maybe_46) out_Maybe_46)))) a_43]
+        x_44
       )
     )
   ]

--- a/plutus-ir/test/recursion/even3.plc.golden
+++ b/plutus-ir/test/recursion/even3.plc.golden
@@ -1,46 +1,46 @@
 (program 1.0.0
   [
     (lam
-      arg_32
-      (fix nat_33 (all r_34 (type) (fun r_34 (fun (fun nat_33 r_34) r_34))))
+      arg_0
+      (fix nat_1 (all r_2 (type) (fun r_2 (fun (fun nat_1 r_2) r_2))))
       [
         (lam
           tuple_3
-          [[(lam t_0_0 (type) (lam t_1_1 (type) (all r_2 (type) (fun (fun t_0_0 (fun t_1_1 r_2)) r_2)))) (fun (fix nat_13 (all r_14 (type) (fun r_14 (fun (fun nat_13 r_14) r_14)))) (all a_16 (type) (fun a_16 (fun a_16 a_16))))] (fun (fix nat_18 (all r_19 (type) (fun r_19 (fun (fun nat_18 r_19) r_19)))) (all a_21 (type) (fun a_21 (fun a_21 a_21))))]
+          [[(lam t_0_4 (type) (lam t_1_5 (type) (all r_6 (type) (fun (fun t_0_4 (fun t_1_5 r_6)) r_6)))) (fun (fix nat_7 (all r_8 (type) (fun r_8 (fun (fun nat_7 r_8) r_8)))) (all a_9 (type) (fun a_9 (fun a_9 a_9))))] (fun (fix nat_10 (all r_11 (type) (fun r_11 (fun (fun nat_10 r_11) r_11)))) (all a_12 (type) (fun a_12 (fun a_12 a_12))))]
           [
             (lam
-              even_12
-              (fun (fix nat_13 (all r_14 (type) (fun r_14 (fun (fun nat_13 r_14) r_14)))) (all a_16 (type) (fun a_16 (fun a_16 a_16))))
+              even_13
+              (fun (fix nat_14 (all r_15 (type) (fun r_15 (fun (fun nat_14 r_15) r_15)))) (all a_16 (type) (fun a_16 (fun a_16 a_16))))
               [
                 (lam
                   odd_17
-                  (fun (fix nat_18 (all r_19 (type) (fun r_19 (fun (fun nat_18 r_19) r_19)))) (all a_21 (type) (fun a_21 (fun a_21 a_21))))
-                  [ even_12 arg_32 ]
+                  (fun (fix nat_18 (all r_19 (type) (fun r_19 (fun (fun nat_18 r_19) r_19)))) (all a_20 (type) (fun a_20 (fun a_20 a_20))))
+                  [ even_13 arg_0 ]
                 )
                 [
                   {
                     {
                       (abs
-                        t_0_28
+                        t_0_21
                         (type)
                         (abs
-                          t_1_29
+                          t_1_22
                           (type)
                           (lam
-                            tuple_30
-                            [[(lam t_0_31 (type) (lam t_1_32 (type) (all r_33 (type) (fun (fun t_0_31 (fun t_1_32 r_33)) r_33)))) t_0_28] t_1_29]
+                            tuple_23
+                            [[(lam t_0_24 (type) (lam t_1_25 (type) (all r_26 (type) (fun (fun t_0_24 (fun t_1_25 r_26)) r_26)))) t_0_21] t_1_22]
                             [
-                              { tuple_30 t_1_29 }
+                              { tuple_23 t_1_22 }
                               (lam
-                                arg_0_34 t_0_28 (lam arg_1_35 t_1_29 arg_1_35)
+                                arg_0_27 t_0_21 (lam arg_1_28 t_1_22 arg_1_28)
                               )
                             ]
                           )
                         )
                       )
-                      (fun (fix nat_13 (all r_14 (type) (fun r_14 (fun (fun nat_13 r_14) r_14)))) (all a_16 (type) (fun a_16 (fun a_16 a_16))))
+                      (fun (fix nat_29 (all r_30 (type) (fun r_30 (fun (fun nat_29 r_30) r_30)))) (all a_31 (type) (fun a_31 (fun a_31 a_31))))
                     }
-                    (fun (fix nat_18 (all r_19 (type) (fun r_19 (fun (fun nat_18 r_19) r_19)))) (all a_21 (type) (fun a_21 (fun a_21 a_21))))
+                    (fun (fix nat_32 (all r_33 (type) (fun r_33 (fun (fun nat_32 r_33) r_33)))) (all a_34 (type) (fun a_34 (fun a_34 a_34))))
                   }
                   tuple_3
                 ]
@@ -50,24 +50,24 @@
               {
                 {
                   (abs
-                    t_0_12
+                    t_0_35
                     (type)
                     (abs
-                      t_1_13
+                      t_1_36
                       (type)
                       (lam
-                        tuple_14
-                        [[(lam t_0_15 (type) (lam t_1_16 (type) (all r_17 (type) (fun (fun t_0_15 (fun t_1_16 r_17)) r_17)))) t_0_12] t_1_13]
+                        tuple_37
+                        [[(lam t_0_38 (type) (lam t_1_39 (type) (all r_40 (type) (fun (fun t_0_38 (fun t_1_39 r_40)) r_40)))) t_0_35] t_1_36]
                         [
-                          { tuple_14 t_0_12 }
-                          (lam arg_0_18 t_0_12 (lam arg_1_19 t_1_13 arg_0_18))
+                          { tuple_37 t_0_35 }
+                          (lam arg_0_41 t_0_35 (lam arg_1_42 t_1_36 arg_0_41))
                         ]
                       )
                     )
                   )
-                  (fun (fix nat_13 (all r_14 (type) (fun r_14 (fun (fun nat_13 r_14) r_14)))) (all a_16 (type) (fun a_16 (fun a_16 a_16))))
+                  (fun (fix nat_43 (all r_44 (type) (fun r_44 (fun (fun nat_43 r_44) r_44)))) (all a_45 (type) (fun a_45 (fun a_45 a_45))))
                 }
-                (fun (fix nat_18 (all r_19 (type) (fun r_19 (fun (fun nat_18 r_19) r_19)))) (all a_21 (type) (fun a_21 (fun a_21 a_21))))
+                (fun (fix nat_46 (all r_47 (type) (fun r_47 (fun (fun nat_46 r_47) r_47)))) (all a_48 (type) (fun a_48 (fun a_48 a_48))))
               }
               tuple_3
             ]
@@ -79,25 +79,25 @@
               {
                 {
                   (abs
-                    a_38
+                    a_49
                     (type)
                     (abs
-                      b_39
+                      b_50
                       (type)
                       (abs
-                        a_40
+                        a_51
                         (type)
                         (abs
-                          b_41
+                          b_52
                           (type)
                           [
                             {
                               (abs
-                                F_42
+                                F_53
                                 (fun (type) (type))
                                 (lam
-                                  by_43
-                                  (fun (all Q_44 (type) (fun [F_42 Q_44] Q_44)) (all Q_45 (type) (fun [F_42 Q_45] Q_45)))
+                                  by_54
+                                  (fun (all Q_55 (type) (fun [F_53 Q_55] Q_55)) (all Q_56 (type) (fun [F_53 Q_56] Q_56)))
                                   [
                                     {
                                       {
@@ -164,32 +164,32 @@
                                             )
                                           )
                                         )
-                                        (all Q_74 (type) (fun [F_42 Q_74] [F_42 Q_74]))
+                                        (all Q_74 (type) (fun [F_53 Q_74] [F_53 Q_74]))
                                       }
-                                      (all Q_75 (type) (fun [F_42 Q_75] Q_75))
+                                      (all Q_75 (type) (fun [F_53 Q_75] Q_75))
                                     }
                                     (lam
                                       rec_76
-                                      (fun (all Q_77 (type) (fun [F_42 Q_77] [F_42 Q_77])) (all Q_78 (type) (fun [F_42 Q_78] Q_78)))
+                                      (fun (all Q_77 (type) (fun [F_53 Q_77] [F_53 Q_77])) (all Q_78 (type) (fun [F_53 Q_78] Q_78)))
                                       (lam
                                         h_79
-                                        (all Q_80 (type) (fun [F_42 Q_80] [F_42 Q_80]))
+                                        (all Q_80 (type) (fun [F_53 Q_80] [F_53 Q_80]))
                                         (abs
                                           R_81
                                           (type)
                                           (lam
                                             fr_82
-                                            [F_42 R_81]
+                                            [F_53 R_81]
                                             [
                                               {
                                                 [
-                                                  by_43
+                                                  by_54
                                                   (abs
                                                     Q_83
                                                     (type)
                                                     (lam
                                                       fq_84
-                                                      [F_42 Q_83]
+                                                      [F_53 Q_83]
                                                       [
                                                         { [ rec_76 h_79 ] Q_83 }
                                                         [ { h_79 Q_83 } fq_84 ]
@@ -208,45 +208,45 @@
                                   ]
                                 )
                               )
-                              (lam X_85 (type) (fun (fun a_38 b_39) (fun (fun a_40 b_41) X_85)))
+                              (lam X_85 (type) (fun (fun a_49 b_50) (fun (fun a_51 b_52) X_85)))
                             }
                             (lam
-                              k_87
-                              (all Q_88 (type) (fun (fun (fun a_38 b_39) (fun (fun a_40 b_41) Q_88)) Q_88))
+                              k_86
+                              (all Q_87 (type) (fun (fun (fun a_49 b_50) (fun (fun a_51 b_52) Q_87)) Q_87))
                               (abs
-                                S_86
+                                S_88
                                 (type)
                                 (lam
                                   h_89
-                                  (fun (fun a_38 b_39) (fun (fun a_40 b_41) S_86))
+                                  (fun (fun a_49 b_50) (fun (fun a_51 b_52) S_88))
                                   [
                                     [
                                       h_89
                                       (lam
-                                        x_92
-                                        a_38
+                                        x_90
+                                        a_49
                                         [
-                                          { k_87 b_39 }
+                                          { k_86 b_50 }
                                           (lam
-                                            f_90
-                                            (fun a_38 b_39)
+                                            f_91
+                                            (fun a_49 b_50)
                                             (lam
-                                              f_91 (fun a_40 b_41) [ f_90 x_92 ]
+                                              f_92 (fun a_51 b_52) [ f_91 x_90 ]
                                             )
                                           )
                                         ]
                                       )
                                     ]
                                     (lam
-                                      x_95
-                                      a_40
+                                      x_93
+                                      a_51
                                       [
-                                        { k_87 b_41 }
+                                        { k_86 b_52 }
                                         (lam
-                                          f_93
-                                          (fun a_38 b_39)
+                                          f_94
+                                          (fun a_49 b_50)
                                           (lam
-                                            f_94 (fun a_40 b_41) [ f_94 x_95 ]
+                                            f_95 (fun a_51 b_52) [ f_95 x_93 ]
                                           )
                                         )
                                       ]
@@ -260,56 +260,64 @@
                       )
                     )
                   )
-                  (fix nat_13 (all r_14 (type) (fun r_14 (fun (fun nat_13 r_14) r_14))))
+                  (fix nat_96 (all r_97 (type) (fun r_97 (fun (fun nat_96 r_97) r_97))))
                 }
-                (all a_16 (type) (fun a_16 (fun a_16 a_16)))
+                (all a_98 (type) (fun a_98 (fun a_98 a_98)))
               }
-              (fix nat_18 (all r_19 (type) (fun r_19 (fun (fun nat_18 r_19) r_19))))
+              (fix nat_99 (all r_100 (type) (fun r_100 (fun (fun nat_99 r_100) r_100))))
             }
-            (all a_21 (type) (fun a_21 (fun a_21 a_21)))
+            (all a_101 (type) (fun a_101 (fun a_101 a_101)))
           }
           (abs
-            Q_36
+            Q_102
             (type)
             (lam
-              choose_37
-              (fun (fun (fix nat_13 (all r_14 (type) (fun r_14 (fun (fun nat_13 r_14) r_14)))) (all a_16 (type) (fun a_16 (fun a_16 a_16)))) (fun (fun (fix nat_18 (all r_19 (type) (fun r_19 (fun (fun nat_18 r_19) r_19)))) (all a_21 (type) (fun a_21 (fun a_21 a_21)))) Q_36))
+              choose_103
+              (fun (fun (fix nat_104 (all r_105 (type) (fun r_105 (fun (fun nat_104 r_105) r_105)))) (all a_106 (type) (fun a_106 (fun a_106 a_106)))) (fun (fun (fix nat_107 (all r_108 (type) (fun r_108 (fun (fun nat_107 r_108) r_108)))) (all a_109 (type) (fun a_109 (fun a_109 a_109)))) Q_102))
               (lam
-                even_12
-                (fun (fix nat_13 (all r_14 (type) (fun r_14 (fun (fun nat_13 r_14) r_14)))) (all a_16 (type) (fun a_16 (fun a_16 a_16))))
+                even_110
+                (fun (fix nat_111 (all r_112 (type) (fun r_112 (fun (fun nat_111 r_112) r_112)))) (all a_113 (type) (fun a_113 (fun a_113 a_113))))
                 (lam
-                  odd_17
-                  (fun (fix nat_18 (all r_19 (type) (fun r_19 (fun (fun nat_18 r_19) r_19)))) (all a_21 (type) (fun a_21 (fun a_21 a_21))))
+                  odd_114
+                  (fun (fix nat_115 (all r_116 (type) (fun r_116 (fun (fun nat_115 r_116) r_116)))) (all a_117 (type) (fun a_117 (fun a_117 a_117))))
                   [
                     [
-                      choose_37
+                      choose_103
                       (lam
-                        n_22
-                        (fix nat_23 (all r_24 (type) (fun r_24 (fun (fun nat_23 r_24) r_24))))
+                        n_118
+                        (fix nat_119 (all r_120 (type) (fun r_120 (fun (fun nat_119 r_120) r_120))))
                         [
                           [
                             {
-                              (unwrap n_22)
-                              (all a_26 (type) (fun a_26 (fun a_26 a_26)))
+                              (unwrap n_118)
+                              (all a_121 (type) (fun a_121 (fun a_121 a_121)))
                             }
-                            (abs a_3 (type) (lam x_4 a_3 (lam y_5 a_3 x_4)))
+                            (abs
+                              a_122
+                              (type)
+                              (lam x_123 a_122 (lam y_124 a_122 x_123))
+                            )
                           ]
-                          odd_17
+                          odd_114
                         ]
                       )
                     ]
                     (lam
-                      n_27
-                      (fix nat_28 (all r_29 (type) (fun r_29 (fun (fun nat_28 r_29) r_29))))
+                      n_125
+                      (fix nat_126 (all r_127 (type) (fun r_127 (fun (fun nat_126 r_127) r_127))))
                       [
                         [
                           {
-                            (unwrap n_27)
-                            (all a_31 (type) (fun a_31 (fun a_31 a_31)))
+                            (unwrap n_125)
+                            (all a_128 (type) (fun a_128 (fun a_128 a_128)))
                           }
-                          (abs a_9 (type) (lam x_10 a_9 (lam y_11 a_9 y_11)))
+                          (abs
+                            a_129
+                            (type)
+                            (lam x_130 a_129 (lam y_131 a_129 y_131))
+                          )
                         ]
-                        even_12
+                        even_110
                       ]
                     )
                   ]
@@ -322,21 +330,21 @@
     )
     [
       (lam
-        n_41
-        (fix nat_42 (all r_43 (type) (fun r_43 (fun (fun nat_42 r_43) r_43))))
+        n_132
+        (fix nat_133 (all r_134 (type) (fun r_134 (fun (fun nat_133 r_134) r_134))))
         (wrap
-          nat_44
-          (all r_45 (type) (fun r_45 (fun (fun nat_44 r_45) r_45)))
+          nat_135
+          (all r_136 (type) (fun r_136 (fun (fun nat_135 r_136) r_136)))
           (abs
-            r_46
+            r_137
             (type)
             (lam
-              z_47
-              r_46
+              z_138
+              r_137
               (lam
-                f_48
-                (fun (fix nat_49 (all r_50 (type) (fun r_50 (fun (fun nat_49 r_50) r_50)))) r_46)
-                [ f_48 n_41 ]
+                f_139
+                (fun (fix nat_140 (all r_141 (type) (fun r_141 (fun (fun nat_140 r_141) r_141)))) r_137)
+                [ f_139 n_132 ]
               )
             )
           )
@@ -344,21 +352,21 @@
       )
       [
         (lam
-          n_57
-          (fix nat_58 (all r_59 (type) (fun r_59 (fun (fun nat_58 r_59) r_59))))
+          n_142
+          (fix nat_143 (all r_144 (type) (fun r_144 (fun (fun nat_143 r_144) r_144))))
           (wrap
-            nat_60
-            (all r_61 (type) (fun r_61 (fun (fun nat_60 r_61) r_61)))
+            nat_145
+            (all r_146 (type) (fun r_146 (fun (fun nat_145 r_146) r_146)))
             (abs
-              r_62
+              r_147
               (type)
               (lam
-                z_63
-                r_62
+                z_148
+                r_147
                 (lam
-                  f_64
-                  (fun (fix nat_65 (all r_66 (type) (fun r_66 (fun (fun nat_65 r_66) r_66)))) r_62)
-                  [ f_64 n_57 ]
+                  f_149
+                  (fun (fix nat_150 (all r_151 (type) (fun r_151 (fun (fun nat_150 r_151) r_151)))) r_147)
+                  [ f_149 n_142 ]
                 )
               )
             )
@@ -366,39 +374,39 @@
         )
         [
           (lam
-            n_73
-            (fix nat_74 (all r_75 (type) (fun r_75 (fun (fun nat_74 r_75) r_75))))
+            n_152
+            (fix nat_153 (all r_154 (type) (fun r_154 (fun (fun nat_153 r_154) r_154))))
             (wrap
-              nat_76
-              (all r_77 (type) (fun r_77 (fun (fun nat_76 r_77) r_77)))
+              nat_155
+              (all r_156 (type) (fun r_156 (fun (fun nat_155 r_156) r_156)))
               (abs
-                r_78
+                r_157
                 (type)
                 (lam
-                  z_79
-                  r_78
+                  z_158
+                  r_157
                   (lam
-                    f_80
-                    (fun (fix nat_81 (all r_82 (type) (fun r_82 (fun (fun nat_81 r_82) r_82)))) r_78)
-                    [ f_80 n_73 ]
+                    f_159
+                    (fun (fix nat_160 (all r_161 (type) (fun r_161 (fun (fun nat_160 r_161) r_161)))) r_157)
+                    [ f_159 n_152 ]
                   )
                 )
               )
             )
           )
           (wrap
-            nat_88
-            (all r_89 (type) (fun r_89 (fun (fun nat_88 r_89) r_89)))
+            nat_162
+            (all r_163 (type) (fun r_163 (fun (fun nat_162 r_163) r_163)))
             (abs
-              r_90
+              r_164
               (type)
               (lam
-                z_91
-                r_90
+                z_165
+                r_164
                 (lam
-                  f_92
-                  (fun (fix nat_93 (all r_94 (type) (fun r_94 (fun (fun nat_93 r_94) r_94)))) r_90)
-                  z_91
+                  f_166
+                  (fun (fix nat_167 (all r_168 (type) (fun r_168 (fun (fun nat_167 r_168) r_168)))) r_164)
+                  z_165
                 )
               )
             )

--- a/plutus-ir/test/recursion/even3.plc.golden
+++ b/plutus-ir/test/recursion/even3.plc.golden
@@ -1,48 +1,50 @@
 (program 1.0.0
   [
     (lam
-      arg_0
-      (fix nat_1 (all r_2 (type) (fun r_2 (fun (fun nat_1 r_2) r_2))))
+      arg_191
+      (fix nat_192 (all r_193 (type) (fun r_193 (fun (fun nat_192 r_193) r_193))))
       [
         (lam
-          tuple_3
-          [[(lam t_0_4 (type) (lam t_1_5 (type) (all r_6 (type) (fun (fun t_0_4 (fun t_1_5 r_6)) r_6)))) (fun (fix nat_7 (all r_8 (type) (fun r_8 (fun (fun nat_7 r_8) r_8)))) (all a_9 (type) (fun a_9 (fun a_9 a_9))))] (fun (fix nat_10 (all r_11 (type) (fun r_11 (fun (fun nat_10 r_11) r_11)))) (all a_12 (type) (fun a_12 (fun a_12 a_12))))]
+          tuple_194
+          [[(lam t_0_195 (type) (lam t_1_196 (type) (all r_197 (type) (fun (fun t_0_195 (fun t_1_196 r_197)) r_197)))) (fun (fix nat_198 (all r_199 (type) (fun r_199 (fun (fun nat_198 r_199) r_199)))) (all a_200 (type) (fun a_200 (fun a_200 a_200))))] (fun (fix nat_201 (all r_202 (type) (fun r_202 (fun (fun nat_201 r_202) r_202)))) (all a_203 (type) (fun a_203 (fun a_203 a_203))))]
           [
             (lam
-              even_13
-              (fun (fix nat_14 (all r_15 (type) (fun r_15 (fun (fun nat_14 r_15) r_15)))) (all a_16 (type) (fun a_16 (fun a_16 a_16))))
+              even_204
+              (fun (fix nat_205 (all r_206 (type) (fun r_206 (fun (fun nat_205 r_206) r_206)))) (all a_207 (type) (fun a_207 (fun a_207 a_207))))
               [
                 (lam
-                  odd_17
-                  (fun (fix nat_18 (all r_19 (type) (fun r_19 (fun (fun nat_18 r_19) r_19)))) (all a_20 (type) (fun a_20 (fun a_20 a_20))))
-                  [ even_13 arg_0 ]
+                  odd_208
+                  (fun (fix nat_209 (all r_210 (type) (fun r_210 (fun (fun nat_209 r_210) r_210)))) (all a_211 (type) (fun a_211 (fun a_211 a_211))))
+                  [ even_204 arg_191 ]
                 )
                 [
                   {
                     {
                       (abs
-                        t_0_21
+                        t_0_212
                         (type)
                         (abs
-                          t_1_22
+                          t_1_213
                           (type)
                           (lam
-                            tuple_23
-                            [[(lam t_0_24 (type) (lam t_1_25 (type) (all r_26 (type) (fun (fun t_0_24 (fun t_1_25 r_26)) r_26)))) t_0_21] t_1_22]
+                            tuple_214
+                            [[(lam t_0_215 (type) (lam t_1_216 (type) (all r_217 (type) (fun (fun t_0_215 (fun t_1_216 r_217)) r_217)))) t_0_212] t_1_213]
                             [
-                              { tuple_23 t_1_22 }
+                              { tuple_214 t_1_213 }
                               (lam
-                                arg_0_27 t_0_21 (lam arg_1_28 t_1_22 arg_1_28)
+                                arg_0_218
+                                t_0_212
+                                (lam arg_1_219 t_1_213 arg_1_219)
                               )
                             ]
                           )
                         )
                       )
-                      (fun (fix nat_29 (all r_30 (type) (fun r_30 (fun (fun nat_29 r_30) r_30)))) (all a_31 (type) (fun a_31 (fun a_31 a_31))))
+                      (fun (fix nat_220 (all r_221 (type) (fun r_221 (fun (fun nat_220 r_221) r_221)))) (all a_222 (type) (fun a_222 (fun a_222 a_222))))
                     }
-                    (fun (fix nat_32 (all r_33 (type) (fun r_33 (fun (fun nat_32 r_33) r_33)))) (all a_34 (type) (fun a_34 (fun a_34 a_34))))
+                    (fun (fix nat_223 (all r_224 (type) (fun r_224 (fun (fun nat_223 r_224) r_224)))) (all a_225 (type) (fun a_225 (fun a_225 a_225))))
                   }
-                  tuple_3
+                  tuple_194
                 ]
               ]
             )
@@ -50,26 +52,28 @@
               {
                 {
                   (abs
-                    t_0_35
+                    t_0_226
                     (type)
                     (abs
-                      t_1_36
+                      t_1_227
                       (type)
                       (lam
-                        tuple_37
-                        [[(lam t_0_38 (type) (lam t_1_39 (type) (all r_40 (type) (fun (fun t_0_38 (fun t_1_39 r_40)) r_40)))) t_0_35] t_1_36]
+                        tuple_228
+                        [[(lam t_0_229 (type) (lam t_1_230 (type) (all r_231 (type) (fun (fun t_0_229 (fun t_1_230 r_231)) r_231)))) t_0_226] t_1_227]
                         [
-                          { tuple_37 t_0_35 }
-                          (lam arg_0_41 t_0_35 (lam arg_1_42 t_1_36 arg_0_41))
+                          { tuple_228 t_0_226 }
+                          (lam
+                            arg_0_232 t_0_226 (lam arg_1_233 t_1_227 arg_0_232)
+                          )
                         ]
                       )
                     )
                   )
-                  (fun (fix nat_43 (all r_44 (type) (fun r_44 (fun (fun nat_43 r_44) r_44)))) (all a_45 (type) (fun a_45 (fun a_45 a_45))))
+                  (fun (fix nat_234 (all r_235 (type) (fun r_235 (fun (fun nat_234 r_235) r_235)))) (all a_236 (type) (fun a_236 (fun a_236 a_236))))
                 }
-                (fun (fix nat_46 (all r_47 (type) (fun r_47 (fun (fun nat_46 r_47) r_47)))) (all a_48 (type) (fun a_48 (fun a_48 a_48))))
+                (fun (fix nat_237 (all r_238 (type) (fun r_238 (fun (fun nat_237 r_238) r_238)))) (all a_239 (type) (fun a_239 (fun a_239 a_239))))
               }
-              tuple_3
+              tuple_194
             ]
           ]
         )
@@ -79,83 +83,84 @@
               {
                 {
                   (abs
-                    a_49
+                    a_240
                     (type)
                     (abs
-                      b_50
+                      b_241
                       (type)
                       (abs
-                        a_51
+                        a_242
                         (type)
                         (abs
-                          b_52
+                          b_243
                           (type)
                           [
                             {
                               (abs
-                                F_53
+                                F_244
                                 (fun (type) (type))
                                 (lam
-                                  by_54
-                                  (fun (all Q_55 (type) (fun [F_53 Q_55] Q_55)) (all Q_56 (type) (fun [F_53 Q_56] Q_56)))
+                                  by_245
+                                  (fun (all Q_246 (type) (fun [F_244 Q_246] Q_246)) (all Q_247 (type) (fun [F_244 Q_247] Q_247)))
                                   [
                                     {
                                       {
                                         (abs
-                                          a_57
+                                          a_248
                                           (type)
                                           (abs
-                                            b_58
+                                            b_249
                                             (type)
                                             (lam
-                                              f_59
-                                              (fun (fun a_57 b_58) (fun a_57 b_58))
+                                              f_250
+                                              (fun (fun a_248 b_249) (fun a_248 b_249))
                                               [
                                                 {
                                                   (abs
-                                                    a_60
+                                                    a_251
                                                     (type)
                                                     (lam
-                                                      s_61
-                                                      [(lam a_62 (type) (fix self_63 (fun self_63 a_62))) a_60]
-                                                      [ (unwrap s_61) s_61 ]
+                                                      s_252
+                                                      [(lam a_253 (type) (fix self_254 (fun self_254 a_253))) a_251]
+                                                      [ (unwrap s_252) s_252 ]
                                                     )
                                                   )
-                                                  (fun a_57 b_58)
+                                                  (fun a_248 b_249)
                                                 }
                                                 (wrap
-                                                  self_64
-                                                  [(lam a_65 (type) (fun self_64 a_65)) (fun a_57 b_58)]
+                                                  self_255
+                                                  [(lam a_256 (type) (fun self_255 a_256)) (fun a_248 b_249)]
                                                   (lam
-                                                    s_66
-                                                    [(lam a_67 (type) (fix self_68 (fun self_68 a_67))) (fun a_57 b_58)]
+                                                    s_257
+                                                    [(lam a_258 (type) (fix self_259 (fun self_259 a_258))) (fun a_248 b_249)]
                                                     (lam
-                                                      x_69
-                                                      a_57
+                                                      x_260
+                                                      a_248
                                                       [
                                                         [
-                                                          f_59
+                                                          f_250
                                                           [
                                                             {
                                                               (abs
-                                                                a_70
+                                                                a_261
                                                                 (type)
                                                                 (lam
-                                                                  s_71
-                                                                  [(lam a_72 (type) (fix self_73 (fun self_73 a_72))) a_70]
+                                                                  s_262
+                                                                  [(lam a_263 (type) (fix self_264 (fun self_264 a_263))) a_261]
                                                                   [
-                                                                    (unwrap s_71
+                                                                    (unwrap
+                                                                      s_262
                                                                     )
-                                                                    s_71
+                                                                    s_262
                                                                   ]
                                                                 )
                                                               )
-                                                              (fun a_57 b_58)
+                                                              (fun a_248 b_249)
                                                             }
-                                                            s_66
+                                                            s_257
                                                           ]
                                                         ]
-                                                        x_69
+                                                        x_260
                                                       ]
                                                     )
                                                   )
@@ -164,42 +169,47 @@
                                             )
                                           )
                                         )
-                                        (all Q_74 (type) (fun [F_53 Q_74] [F_53 Q_74]))
+                                        (all Q_265 (type) (fun [F_244 Q_265] [F_244 Q_265]))
                                       }
-                                      (all Q_75 (type) (fun [F_53 Q_75] Q_75))
+                                      (all Q_266 (type) (fun [F_244 Q_266] Q_266))
                                     }
                                     (lam
-                                      rec_76
-                                      (fun (all Q_77 (type) (fun [F_53 Q_77] [F_53 Q_77])) (all Q_78 (type) (fun [F_53 Q_78] Q_78)))
+                                      rec_267
+                                      (fun (all Q_268 (type) (fun [F_244 Q_268] [F_244 Q_268])) (all Q_269 (type) (fun [F_244 Q_269] Q_269)))
                                       (lam
-                                        h_79
-                                        (all Q_80 (type) (fun [F_53 Q_80] [F_53 Q_80]))
+                                        h_270
+                                        (all Q_271 (type) (fun [F_244 Q_271] [F_244 Q_271]))
                                         (abs
-                                          R_81
+                                          R_272
                                           (type)
                                           (lam
-                                            fr_82
-                                            [F_53 R_81]
+                                            fr_273
+                                            [F_244 R_272]
                                             [
                                               {
                                                 [
-                                                  by_54
+                                                  by_245
                                                   (abs
-                                                    Q_83
+                                                    Q_274
                                                     (type)
                                                     (lam
-                                                      fq_84
-                                                      [F_53 Q_83]
+                                                      fq_275
+                                                      [F_244 Q_274]
                                                       [
-                                                        { [ rec_76 h_79 ] Q_83 }
-                                                        [ { h_79 Q_83 } fq_84 ]
+                                                        {
+                                                          [ rec_267 h_270 ]
+                                                          Q_274
+                                                        }
+                                                        [
+                                                          { h_270 Q_274 } fq_275
+                                                        ]
                                                       ]
                                                     )
                                                   )
                                                 ]
-                                                R_81
+                                                R_272
                                               }
-                                              fr_82
+                                              fr_273
                                             ]
                                           )
                                         )
@@ -208,45 +218,49 @@
                                   ]
                                 )
                               )
-                              (lam X_85 (type) (fun (fun a_49 b_50) (fun (fun a_51 b_52) X_85)))
+                              (lam X_276 (type) (fun (fun a_240 b_241) (fun (fun a_242 b_243) X_276)))
                             }
                             (lam
-                              k_86
-                              (all Q_87 (type) (fun (fun (fun a_49 b_50) (fun (fun a_51 b_52) Q_87)) Q_87))
+                              k_277
+                              (all Q_278 (type) (fun (fun (fun a_240 b_241) (fun (fun a_242 b_243) Q_278)) Q_278))
                               (abs
-                                S_88
+                                S_279
                                 (type)
                                 (lam
-                                  h_89
-                                  (fun (fun a_49 b_50) (fun (fun a_51 b_52) S_88))
+                                  h_280
+                                  (fun (fun a_240 b_241) (fun (fun a_242 b_243) S_279))
                                   [
                                     [
-                                      h_89
+                                      h_280
                                       (lam
-                                        x_90
-                                        a_49
+                                        x_281
+                                        a_240
                                         [
-                                          { k_86 b_50 }
+                                          { k_277 b_241 }
                                           (lam
-                                            f_91
-                                            (fun a_49 b_50)
+                                            f_282
+                                            (fun a_240 b_241)
                                             (lam
-                                              f_92 (fun a_51 b_52) [ f_91 x_90 ]
+                                              f_283
+                                              (fun a_242 b_243)
+                                              [ f_282 x_281 ]
                                             )
                                           )
                                         ]
                                       )
                                     ]
                                     (lam
-                                      x_93
-                                      a_51
+                                      x_284
+                                      a_242
                                       [
-                                        { k_86 b_52 }
+                                        { k_277 b_243 }
                                         (lam
-                                          f_94
-                                          (fun a_49 b_50)
+                                          f_285
+                                          (fun a_240 b_241)
                                           (lam
-                                            f_95 (fun a_51 b_52) [ f_95 x_93 ]
+                                            f_286
+                                            (fun a_242 b_243)
+                                            [ f_286 x_284 ]
                                           )
                                         )
                                       ]
@@ -260,64 +274,64 @@
                       )
                     )
                   )
-                  (fix nat_96 (all r_97 (type) (fun r_97 (fun (fun nat_96 r_97) r_97))))
+                  (fix nat_287 (all r_288 (type) (fun r_288 (fun (fun nat_287 r_288) r_288))))
                 }
-                (all a_98 (type) (fun a_98 (fun a_98 a_98)))
+                (all a_289 (type) (fun a_289 (fun a_289 a_289)))
               }
-              (fix nat_99 (all r_100 (type) (fun r_100 (fun (fun nat_99 r_100) r_100))))
+              (fix nat_290 (all r_291 (type) (fun r_291 (fun (fun nat_290 r_291) r_291))))
             }
-            (all a_101 (type) (fun a_101 (fun a_101 a_101)))
+            (all a_292 (type) (fun a_292 (fun a_292 a_292)))
           }
           (abs
-            Q_102
+            Q_293
             (type)
             (lam
-              choose_103
-              (fun (fun (fix nat_104 (all r_105 (type) (fun r_105 (fun (fun nat_104 r_105) r_105)))) (all a_106 (type) (fun a_106 (fun a_106 a_106)))) (fun (fun (fix nat_107 (all r_108 (type) (fun r_108 (fun (fun nat_107 r_108) r_108)))) (all a_109 (type) (fun a_109 (fun a_109 a_109)))) Q_102))
+              choose_294
+              (fun (fun (fix nat_295 (all r_296 (type) (fun r_296 (fun (fun nat_295 r_296) r_296)))) (all a_297 (type) (fun a_297 (fun a_297 a_297)))) (fun (fun (fix nat_298 (all r_299 (type) (fun r_299 (fun (fun nat_298 r_299) r_299)))) (all a_300 (type) (fun a_300 (fun a_300 a_300)))) Q_293))
               (lam
-                even_110
-                (fun (fix nat_111 (all r_112 (type) (fun r_112 (fun (fun nat_111 r_112) r_112)))) (all a_113 (type) (fun a_113 (fun a_113 a_113))))
+                even_301
+                (fun (fix nat_302 (all r_303 (type) (fun r_303 (fun (fun nat_302 r_303) r_303)))) (all a_304 (type) (fun a_304 (fun a_304 a_304))))
                 (lam
-                  odd_114
-                  (fun (fix nat_115 (all r_116 (type) (fun r_116 (fun (fun nat_115 r_116) r_116)))) (all a_117 (type) (fun a_117 (fun a_117 a_117))))
+                  odd_305
+                  (fun (fix nat_306 (all r_307 (type) (fun r_307 (fun (fun nat_306 r_307) r_307)))) (all a_308 (type) (fun a_308 (fun a_308 a_308))))
                   [
                     [
-                      choose_103
+                      choose_294
                       (lam
-                        n_118
-                        (fix nat_119 (all r_120 (type) (fun r_120 (fun (fun nat_119 r_120) r_120))))
+                        n_309
+                        (fix nat_310 (all r_311 (type) (fun r_311 (fun (fun nat_310 r_311) r_311))))
                         [
                           [
                             {
-                              (unwrap n_118)
-                              (all a_121 (type) (fun a_121 (fun a_121 a_121)))
+                              (unwrap n_309)
+                              (all a_312 (type) (fun a_312 (fun a_312 a_312)))
                             }
                             (abs
-                              a_122
+                              a_313
                               (type)
-                              (lam x_123 a_122 (lam y_124 a_122 x_123))
+                              (lam x_314 a_313 (lam y_315 a_313 x_314))
                             )
                           ]
-                          odd_114
+                          odd_305
                         ]
                       )
                     ]
                     (lam
-                      n_125
-                      (fix nat_126 (all r_127 (type) (fun r_127 (fun (fun nat_126 r_127) r_127))))
+                      n_316
+                      (fix nat_317 (all r_318 (type) (fun r_318 (fun (fun nat_317 r_318) r_318))))
                       [
                         [
                           {
-                            (unwrap n_125)
-                            (all a_128 (type) (fun a_128 (fun a_128 a_128)))
+                            (unwrap n_316)
+                            (all a_319 (type) (fun a_319 (fun a_319 a_319)))
                           }
                           (abs
-                            a_129
+                            a_320
                             (type)
-                            (lam x_130 a_129 (lam y_131 a_129 y_131))
+                            (lam x_321 a_320 (lam y_322 a_320 y_322))
                           )
                         ]
-                        even_110
+                        even_301
                       ]
                     )
                   ]
@@ -330,21 +344,21 @@
     )
     [
       (lam
-        n_132
-        (fix nat_133 (all r_134 (type) (fun r_134 (fun (fun nat_133 r_134) r_134))))
+        n_323
+        (fix nat_324 (all r_325 (type) (fun r_325 (fun (fun nat_324 r_325) r_325))))
         (wrap
-          nat_135
-          (all r_136 (type) (fun r_136 (fun (fun nat_135 r_136) r_136)))
+          nat_326
+          (all r_327 (type) (fun r_327 (fun (fun nat_326 r_327) r_327)))
           (abs
-            r_137
+            r_328
             (type)
             (lam
-              z_138
-              r_137
+              z_329
+              r_328
               (lam
-                f_139
-                (fun (fix nat_140 (all r_141 (type) (fun r_141 (fun (fun nat_140 r_141) r_141)))) r_137)
-                [ f_139 n_132 ]
+                f_330
+                (fun (fix nat_331 (all r_332 (type) (fun r_332 (fun (fun nat_331 r_332) r_332)))) r_328)
+                [ f_330 n_323 ]
               )
             )
           )
@@ -352,21 +366,21 @@
       )
       [
         (lam
-          n_142
-          (fix nat_143 (all r_144 (type) (fun r_144 (fun (fun nat_143 r_144) r_144))))
+          n_333
+          (fix nat_334 (all r_335 (type) (fun r_335 (fun (fun nat_334 r_335) r_335))))
           (wrap
-            nat_145
-            (all r_146 (type) (fun r_146 (fun (fun nat_145 r_146) r_146)))
+            nat_336
+            (all r_337 (type) (fun r_337 (fun (fun nat_336 r_337) r_337)))
             (abs
-              r_147
+              r_338
               (type)
               (lam
-                z_148
-                r_147
+                z_339
+                r_338
                 (lam
-                  f_149
-                  (fun (fix nat_150 (all r_151 (type) (fun r_151 (fun (fun nat_150 r_151) r_151)))) r_147)
-                  [ f_149 n_142 ]
+                  f_340
+                  (fun (fix nat_341 (all r_342 (type) (fun r_342 (fun (fun nat_341 r_342) r_342)))) r_338)
+                  [ f_340 n_333 ]
                 )
               )
             )
@@ -374,39 +388,39 @@
         )
         [
           (lam
-            n_152
-            (fix nat_153 (all r_154 (type) (fun r_154 (fun (fun nat_153 r_154) r_154))))
+            n_343
+            (fix nat_344 (all r_345 (type) (fun r_345 (fun (fun nat_344 r_345) r_345))))
             (wrap
-              nat_155
-              (all r_156 (type) (fun r_156 (fun (fun nat_155 r_156) r_156)))
+              nat_346
+              (all r_347 (type) (fun r_347 (fun (fun nat_346 r_347) r_347)))
               (abs
-                r_157
+                r_348
                 (type)
                 (lam
-                  z_158
-                  r_157
+                  z_349
+                  r_348
                   (lam
-                    f_159
-                    (fun (fix nat_160 (all r_161 (type) (fun r_161 (fun (fun nat_160 r_161) r_161)))) r_157)
-                    [ f_159 n_152 ]
+                    f_350
+                    (fun (fix nat_351 (all r_352 (type) (fun r_352 (fun (fun nat_351 r_352) r_352)))) r_348)
+                    [ f_350 n_343 ]
                   )
                 )
               )
             )
           )
           (wrap
-            nat_162
-            (all r_163 (type) (fun r_163 (fun (fun nat_162 r_163) r_163)))
+            nat_353
+            (all r_354 (type) (fun r_354 (fun (fun nat_353 r_354) r_354)))
             (abs
-              r_164
+              r_355
               (type)
               (lam
-                z_165
-                r_164
+                z_356
+                r_355
                 (lam
-                  f_166
-                  (fun (fix nat_167 (all r_168 (type) (fun r_168 (fun (fun nat_167 r_168) r_168)))) r_164)
-                  z_165
+                  f_357
+                  (fun (fix nat_358 (all r_359 (type) (fun r_359 (fun (fun nat_358 r_359) r_359)))) r_355)
+                  z_356
                 )
               )
             )

--- a/plutus-ir/test/recursion/even3Eval.plc.golden
+++ b/plutus-ir/test/recursion/even3Eval.plc.golden
@@ -1,1 +1,1 @@
-(abs a_129 (type) (lam x_130 a_129 (lam y_131 a_129 y_131)))
+(abs a_320 (type) (lam x_321 a_320 (lam y_322 a_320 y_322)))

--- a/plutus-ir/test/recursion/even3Eval.plc.golden
+++ b/plutus-ir/test/recursion/even3Eval.plc.golden
@@ -1,1 +1,1 @@
-(abs a_9 (type) (lam x_10 a_9 (lam y_11 a_9 y_11)))
+(abs a_129 (type) (lam x_130 a_129 (lam y_131 a_129 y_131)))


### PR DESCRIPTION
Non-exhaustive list:
- Need to run PIR term generation and compilation in the same `Quote`
  monad to avoid compilation introducing names that are not fresh.
- The types of constructors weren't quantifying out the type variables.
- Various subtleties about making sure that we use the abstract/concrete
  version of types where we need to.

List-based examples don't work, of course, since we still can't
typecheck that stuff.