### PR TITLE
[CGP-400] Use bytestrings and proper hashes

### DIFF
--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
@@ -13,7 +13,8 @@ module Language.Plutus.Coordination.Contracts.Vesting (
     vestFunds,
     retrieveFunds,
     validatorScript,
-    totalAmount
+    totalAmount,
+    validatorScriptHash
     ) where
 
 import           Control.Monad.Error.Class  (MonadError (..))
@@ -29,6 +30,7 @@ import           Prelude                    hiding ((&&))
 import           Wallet.API                 (WalletAPI (..), WalletAPIError, otherError, signAndSubmit)
 import           Wallet.UTXO                (DataScript (..), TxOutRef', Validator (..), scriptTxIn, scriptTxOut)
 import qualified Wallet.UTXO                as UTXO
+import qualified Wallet.UTXO.Runtime        as Runtime
 
 -- | Tranche of a vesting scheme.
 data VestingTranche = VestingTranche {
@@ -78,7 +80,7 @@ vestFunds vst value = do
     (payment, change) <- createPaymentWithChange v'
     let vs = validatorScript vst
         o = scriptTxOut v' vs (DataScript $ UTXO.lifted vd)
-        vd =  VestingData 1123 0 -- [CGP-400]
+        vd =  VestingData (validatorScriptHash vst) 0
     signAndSubmit payment [o, change]
     pure vd
 
@@ -101,11 +103,17 @@ retrieveFunds vs vd r vnow = do
     signAndSubmit (Set.singleton inp) [oo, o]
     pure vd'
 
+validatorScriptHash :: Vesting -> Runtime.Hash
+validatorScriptHash = Runtime.plcHash . validatorScript
+
 validatorScript :: Vesting -> Validator
 validatorScript v = Validator val where
     val = UTXO.applyScript inner (UTXO.lifted v)
     inner = UTXO.fromPlcCode $(plutus [| \Vesting{..} () VestingData{..} (p :: PendingTx) ->
         let
+
+            eqBs :: Hash -> Hash -> Bool
+            eqBs = Builtins.equalsByteString
 
             eqPk :: PubKey -> PubKey -> Bool
             eqPk = $(TH.eqPubKey)
@@ -147,8 +155,8 @@ validatorScript v = Validator val where
             -- Check that the remaining output is locked by the same validation
             -- script
             txnOutputsValid = case os of
-                (_::PendingTxOut):(PendingTxOut _ (Just d') DataTxOut::PendingTxOut):(_::[PendingTxOut]) ->
-                    d' == vestingDataHash
+                (_::PendingTxOut):(PendingTxOut _ (Just (vl', _))  DataTxOut::PendingTxOut):(_::[PendingTxOut]) ->
+                    vl' `eqBs` vestingDataHash
                 (_::[PendingTxOut]) -> Builtins.error ()
 
             isValid = amountsValid && txnOutputsValid

--- a/plutus-use-cases/src/Language/Plutus/Runtime/TH.hs
+++ b/plutus-use-cases/src/Language/Plutus/Runtime/TH.hs
@@ -20,10 +20,15 @@ module Language.Plutus.Runtime.TH(
     -- * Transactions
     pubKeyOutput,
     scriptOutput,
-    eqPubKey
+    eqPubKey,
+    eqDataScript,
+    eqRedeemer,
+    eqValidator,
+    eqTx
     ) where
 
 import           Language.Haskell.TH (Exp, Q)
+import qualified Language.Plutus.TH  as Builtins
 import           Wallet.UTXO.Runtime
 
 import           Prelude             (Bool (..), Eq (..), Int, Maybe (..))
@@ -113,3 +118,18 @@ scriptOutput = [| \(o:: PendingTxOut) -> case o of
 -- | Equality of public keys
 eqPubKey :: Q Exp
 eqPubKey = [| \(PubKey l) (PubKey r) -> l == r |]
+
+-- | Equality of data scripts
+eqDataScript :: Q Exp
+eqDataScript = [| \(DataScriptHash l) (DataScriptHash r) -> Builtins.equalsByteString l r |]
+
+-- | Equality of validator scripts
+eqValidator :: Q Exp
+eqValidator = [| \(ValidatorHash l) (ValidatorHash r) -> Builtins.equalsByteString l r |]
+
+-- | Equality of redeemer scripts
+eqRedeemer :: Q Exp
+eqRedeemer = [| \(RedeemerHash l) (RedeemerHash r) -> Builtins.equalsByteString l r |]
+
+eqTx :: Q Exp
+eqTx = [| \(TxHash l) (TxHash r) -> Builtins.equalsByteString l r |]

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -17,13 +17,13 @@ import           Test.Tasty
 import           Test.Tasty.Hedgehog                            (testProperty)
 
 import           Language.Plutus.Coordination.Contracts.Vesting (Vesting (..), VestingData (..), VestingTranche (..),
-                                                                 retrieveFunds, totalAmount, vestFunds)
+                                                                 retrieveFunds, totalAmount, validatorScriptHash,
+                                                                 vestFunds)
 import qualified Language.Plutus.Runtime                        as Runtime
 import           Wallet.API                                     (PubKey (..))
 import           Wallet.Emulator                                hiding (Value)
 import qualified Wallet.Generators                              as Gen
 import qualified Wallet.UTXO                                    as UTXO
-
 
 tests :: TestTree
 tests = testGroup "vesting" [
@@ -46,7 +46,7 @@ scen1 = VestingScenario{..} where
     vsInitialBalances = Map.fromList [
         (PubKey 1, startingBalance),
         (PubKey 2, startingBalance)]
-    vsScriptHash = 1123
+    vsScriptHash = validatorScriptHash vsVestingScheme
 
 -- | Commit some funds from a wallet to a vesting scheme. Returns the reference
 --   to the transaction output that is locked by the schemes's validator
@@ -125,7 +125,7 @@ data VestingScenario = VestingScenario {
     vsVestingScheme   :: Vesting,
     vsWallets         :: [Wallet],
     vsInitialBalances :: Map.Map PubKey UTXO.Value,
-    vsScriptHash      :: Runtime.Hash -- Hash of validator script for this scenario [CGP-400]
+    vsScriptHash      :: Runtime.Hash -- Hash of validator script for this scenario
     }
 
 -- | Funds available to each wallet after the initial transaction on the

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -125,7 +125,7 @@ data VestingScenario = VestingScenario {
     vsVestingScheme   :: Vesting,
     vsWallets         :: [Wallet],
     vsInitialBalances :: Map.Map PubKey UTXO.Value,
-    vsScriptHash      :: Runtime.Hash -- Hash of validator script for this scenario
+    vsScriptHash      :: Runtime.ValidatorHash -- Hash of validator script for this scenario
     }
 
 -- | Funds available to each wallet after the initial transaction on the

--- a/wallet-api/src/Wallet/UTXO/Runtime.hs
+++ b/wallet-api/src/Wallet/UTXO/Runtime.hs
@@ -7,10 +7,17 @@ module Wallet.UTXO.Runtime (-- * Transactions and related types
               , Value
               , Height
               , PendingTxOutRef(..)
-              , Hash
-              , plcHash
-              , plcDigest
               , Signature(..)
+              -- ** Hashes (see note [Hashes in validator scripts])
+              , DataScriptHash(..)
+              , RedeemerHash(..)
+              , ValidatorHash(..)
+              , TxHash(..)
+              , plcDataScriptHash
+              , plcValidatorHash
+              , plcValidatorDigest
+              , plcRedeemerHash
+              , plcTxHash
               -- * Pending transactions
               , PendingTx(..)
               , PendingTxOut(..)
@@ -28,6 +35,7 @@ import qualified Data.ByteString.Lazy as BSL
 import           GHC.Generics         (Generic)
 import           Language.Plutus.Lift (LiftPlc (..), TypeablePlc (..))
 import           Wallet.UTXO.Types    (PubKey (..), Signature (..))
+import qualified Wallet.UTXO.Types    as UTXO
 
 data PendingTxOutType =
     PubKeyTxOut PubKey -- ^ Pub key address
@@ -40,7 +48,7 @@ instance LiftPlc PendingTxOutType
 -- | Output of a pending transaction.
 data PendingTxOut = PendingTxOut {
     pendingTxOutValue  :: Value,
-    pendingTxOutHashes :: Maybe (Hash, Hash), -- ^ Hashes of validator script and data script
+    pendingTxOutHashes :: Maybe (ValidatorHash, DataScriptHash), -- ^ Hashes of validator script and data script
     pendingTxOutData   :: PendingTxOutType
     } deriving Generic
 
@@ -48,7 +56,7 @@ instance TypeablePlc PendingTxOut
 instance LiftPlc PendingTxOut
 
 data PendingTxOutRef = PendingTxOutRef {
-    pendingTxOutRefId  :: Hash, -- ^ Transaction whose outputs are consumed
+    pendingTxOutRefId  :: TxHash, -- ^ Transaction whose outputs are consumed
     pendingTxOutRefIdx :: Int, -- ^ Index into the referenced transaction's list of outputs
     pendingTxOutSigs   :: [Signature]
     } deriving Generic
@@ -59,7 +67,7 @@ instance LiftPlc PendingTxOutRef
 -- | Input of a pending transaction.
 data PendingTxIn = PendingTxIn {
     pendingTxInRef       :: PendingTxOutRef,
-    pendingTxInRefHashes :: Maybe (Hash, Hash), -- ^ Hashes of validator and redeemer scripts
+    pendingTxInRefHashes :: Maybe (ValidatorHash, RedeemerHash), -- ^ Hashes of validator and redeemer scripts
     pendingTxInValue     :: Value -- ^ Value consumed by this txn input
     } deriving Generic
 
@@ -98,14 +106,76 @@ instance (TypeablePlc a, LiftPlc a) => LiftPlc (Signed a)
 -- TODO: Use [[Wallet.UTXO.Types.Value]] when Integer is supported
 type Value = Int
 
-type Hash = BSL.ByteString
+{- Note [Hashes in validator scripts]
+
+We need to deal with hashes of four different things in a validator script:
+
+1. Transactions
+2. Validator scripts
+3. Data scripts
+4. Redeemer scripts
+
+The mockchain code in [[Wallet.UTXO.Types]] only deals with the hashes of(1)
+and (2), and uses the [[Wallet.UTXO.Types.TxId']] and `Digest SHA256` types for
+them.
+
+In PLC validator scripts the situation is different: First, they need to work
+with hashes of (1-4). Second, the `Digest SHA256` type is not available in PLC
+- we have to represent all hashes as `ByteStrings`.
+
+To ensure that we only compare hashes of the correct type inside a validator
+script, we define a newtype for each of them, as well as functions for creating
+them from the correct types in Haskell, and for comparing them (in
+`Language.Plutus.Runtime.TH`).
+
+-}
+
+-- | PLC runtime representation of a `Digest SHA256`
+newtype ValidatorHash = ValidatorHash BSL.ByteString
+    deriving (Eq, Generic)
+
+instance TypeablePlc ValidatorHash
+instance LiftPlc ValidatorHash
+
+newtype DataScriptHash = DataScriptHash BSL.ByteString
+    deriving (Eq, Generic)
+
+instance TypeablePlc DataScriptHash
+instance LiftPlc DataScriptHash
+
+newtype RedeemerHash = RedeemerHash BSL.ByteString
+    deriving (Eq, Generic)
+
+instance TypeablePlc RedeemerHash
+instance LiftPlc RedeemerHash
+
+newtype TxHash = TxHash BSL.ByteString
+    deriving (Eq, Generic)
+
+instance TypeablePlc TxHash
+instance LiftPlc TxHash
+
+plcDataScriptHash :: UTXO.DataScript -> DataScriptHash
+plcDataScriptHash = DataScriptHash . plcHash
+
+plcValidatorHash :: UTXO.Validator -> ValidatorHash
+plcValidatorHash = ValidatorHash . plcHash
+
+plcValidatorDigest :: Digest SHA256 -> ValidatorHash
+plcValidatorDigest = ValidatorHash . plcDigest
+
+plcRedeemerHash :: UTXO.Redeemer -> RedeemerHash
+plcRedeemerHash = RedeemerHash . plcHash
+
+plcTxHash :: UTXO.TxId' -> TxHash
+plcTxHash = TxHash . plcDigest . UTXO.getTxId
 
 -- | PLC-compatible hash of a hashable value
-plcHash :: BA.ByteArrayAccess a => a -> Hash
+plcHash :: BA.ByteArrayAccess a => a -> BSL.ByteString
 plcHash = plcDigest . hash
 
 -- | Convert a `Digest SHA256` to a PLC `Hash`
-plcDigest :: Digest SHA256 -> Hash
+plcDigest :: Digest SHA256 -> BSL.ByteString
 plcDigest = serialise
 
 -- | Blockchain height


### PR DESCRIPTION
* Previously the `PendingTx` type (representing the transaction that is
  being validated in a PLC validator script) used `Int`s instead of
  `ByteString`s for hashes
* With this commit we use the correct `ByteString` type and get all
  hashes from the mockchain, instead of having to use stand-in values
* Note that this also changes the UTXO model in `Wallet.UTXO.Types`:
  The `PayToScript` constructor of `TxOutType` now contains the hash of
  the validator script as a field, where previously that hash was included
  implicitly, in the address generated by `scriptTxOut` in the same
  module.
  The address is a combined hash of value, validator and data script.
  However, if we want to ensure that transaction outputs are locked by a
  specific validator script, we need to look at the hash of that script
  on its own.
  (see plutus-use-cases/Language/Plutus/Coordination/Contracts/Vesting.hs,
  l. 158 for an example)