### PR TITLE
Use fd instead of find to speedup fixStylishHaskell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -24,10 +24,10 @@ let
   ]);
   fixStylishHaskell = pkgs.stdenv.mkDerivation {
     name = "fix-stylish-haskell";
-    buildInputs = with pkgs; [ plutusPkgs.stylish-haskell git ];
+    buildInputs = with pkgs; [ plutusPkgs.stylish-haskell git fd ];
     shellHook = ''
       git diff > pre-stylish.diff
-      find . -type f -name "*hs" -not -path '.git' -not -path '*.stack-work*' -not -path '*/dist/*' -not -path '*/docs/*' -not -name 'HLint.hs' -exec stylish-haskell -i {} \;
+      fd --extension hs --exclude '*/dist/*' --exclude '*/docs/*' --exec stylish-haskell -i {}
       git diff > post-stylish.diff
       diff pre-stylish.diff post-stylish.diff > /dev/null
       if [ $? != 0 ]


### PR DESCRIPTION
fd is parallel, this gives a nice 4x speedup on my machine.

`stylish-haskell` itself seems to take almost 5 times longer to start in the nix shell than in my shell, but I leave that mystery for another time.