### PR TITLE
core-to-plc: fix a couple of bugs

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Definitions.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Definitions.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleInstances #-}
 
 module Language.Plutus.CoreToPLC.Compiler.Definitions where
 

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Definitions.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Definitions.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module Language.Plutus.CoreToPLC.Compiler.Definitions where
 
@@ -39,6 +40,9 @@ trTy = \case
 
 type TypeDef = Def PLCTyVar TypeRep
 
+instance Show (Def PLCTyVar TypeRep) where
+    show Def{dVar=v} = show (PLC.tyVarDeclName v)
+
 tydTy :: TypeDef -> PLCType
 tydTy = \case
     Def Abstract (PLC.TyVarDecl _ n _) _ -> PLC.TyVar () n
@@ -55,6 +59,9 @@ tydMatch = \case
     _ -> Nothing
 
 type TermDef = Def PLCVar PLCTerm
+
+instance Show (Def PLCVar PLCTerm) where
+    show Def{dVar=v} = show (PLC.varDeclName v)
 
 tdTerm :: TermDef -> PLCTerm
 tdTerm = \case
@@ -74,8 +81,7 @@ defSccs typeDefs termDefs =
         typeInputs = fmap (\(ghcName, (d, deps)) -> (TypeDef d, ghcName, deps)) (Map.assocs typeDefs)
         termInputs = fmap (\(ghcName, (d, deps)) -> (TermDef d, ghcName, deps)) (Map.assocs termDefs)
     in
-        -- weirdly this produces them in reverse topological order
-        reverse $ Graph.stronglyConnComp (typeInputs ++ termInputs)
+        Graph.stronglyConnComp (typeInputs ++ termInputs)
 
 wrapWithDefs
     :: (MonadError ConvError m)

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Names.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Names.hs
@@ -36,6 +36,7 @@ safeFreshName s
     -- some special cases
     | s == ":" = safeFreshName "cons"
     | s == "[]" = safeFreshName "list"
+    | s == "()" = safeFreshName "unit"
     | otherwise =
           let
               -- See Note [PLC names]

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Type.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Type.hs
@@ -122,8 +122,8 @@ convTyCon tc = do
                     match <- mkMatch tc
                     pure (constrs, match)
 
-                -- See Note [Booleans and abstraction]
-                let finalVisibility = if tc == GHC.boolTyCon then Visible else Abstract
+                -- See Note [Booleans, unit and abstraction]
+                let finalVisibility = if tc == GHC.boolTyCon || tc == GHC.unitTyCon then Visible else Abstract
                 (constrDefs, matchDef) <- do
                     -- make the constructor *types* with the type abstract
                     let abstractDef = Def finalVisibility (PLC.TyVarDecl () finalName k) (PlainType ty)
@@ -318,15 +318,18 @@ When constructing a datatype we therefore carefully construct its pieces in seve
   and with all the constructors and destructors attached.
 -}
 
-{- Note [Booleans and abstraction]
+{- Note [Booleans, unit and abstraction]
 While we convert most datatypes as abstract (see Note [Abstract data types]), we do *not*
-do so for Booleans. This is because the booleans produced by builtins will be non-abstract
+do so for Booleans and Unit.
+
+This is because the Booleans and Unit appear in our builtins. Booleans are in the spec, and Unit
+appears because we need to expose error as `\_ -> error`. But these types will be non-abstract
 (i.e. will actually be the Scott-encoded values), and so in order for user code to interoperate
 with that we would have to either:
-1. Wrap all builtins that return booleans to convert them into abstract booleans.
-2. Leave booleans as visible throughout.
+1. Wrap all builtins that use such types to convert them into the abstract types.
+2. Leave the types as visible throughout.
 
-At the moment we take option 2 since Bool is a fairly small type, but possibly we should
+At the moment we take option 2 since Bool and Unit are fairly small types, but possibly we should
 consider option 1 later.
 -}
 

--- a/core-to-plc/test/IllTyped.hs
+++ b/core-to-plc/test/IllTyped.hs
@@ -56,11 +56,3 @@ sumViaFold = plc (let fold :: (a -> b -> a) -> a -> [b] -> a
                       sum = fold (+) 0
                   in sum)
 -}
-
-evenMutual :: PlcCode
-evenMutual = plc @"evenMutual" (
-    let even :: Int -> Bool
-        even n = if n == 0 then True else odd (n-1)
-        odd :: Int -> Bool
-        odd n = if n == 0 then False else even (n-1)
-    in even)

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -163,8 +163,7 @@ monoData = testNested "monomorphic" [
   , goldenPlc "defaultCase" defaultCase
   , goldenEval "monoConstDestDefault" [ monoCase, monoConstructed ]
   , goldenPlc "monoRecord" monoRecord
-   -- FIXME: this should *not* fail
-  , goldenPlcCatch "nonValueCase" nonValueCase
+  , goldenPlc "nonValueCase" nonValueCase
   , goldenPlc "synonym" synonym
   ]
 

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -280,6 +280,14 @@ fib = plc @"fib" (
         fib n = if n == 0 then 0 else if n == 1 then 1 else fib(n-1) + fib(n-2)
     in fib)
 
+evenMutual :: PlcCode
+evenMutual = plc @"evenMutual" (
+    let even :: Int -> Bool
+        even n = if n == 0 then True else odd (n-1)
+        odd :: Int -> Bool
+        odd n = if n == 0 then False else even (n-1)
+    in even)
+
 errors :: TestNested
 errors = testNested "errors" [
     goldenPlcCatch "integer" integer

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -224,8 +224,7 @@ newtypes = testNested "newtypes" [
    , goldenPlc "newtypeMatch" newtypeMatch
    , goldenPlc "newtypeCreate" newtypeCreate
    , goldenPlc "newtypeCreate2" newtypeCreate2
-   -- FIXME: this should *not* fail
-   , goldenPlcCatch "nestedNewtypeMatch" nestedNewtypeMatch
+   , goldenPlc "nestedNewtypeMatch" nestedNewtypeMatch
    , goldenEval "newtypeCreatDest" [ newtypeMatch, newtypeCreate2 ]
    ]
 

--- a/core-to-plc/test/data/monomorphic/nonValueCase.plc.golden
+++ b/core-to-plc/test/data/monomorphic/nonValueCase.plc.golden
@@ -1,7 +1,88 @@
-Error: Type mismatch at () in term
-         'bad_name_25'.
-       Expected type
-         'bad_name_21',
-       found type
-         '(all a_36 (type) (fun a_36 a_36))'
-Context: Converting expr at "nonValueCase"
+(program 1.0.0
+  [
+    [
+      [
+        {
+          (abs
+            MyEnum_2
+            (type)
+            (lam
+              Enum1_10
+              MyEnum_2
+              (lam
+                Enum2_11
+                MyEnum_2
+                (lam
+                  MyEnum_match_12
+                  (fun MyEnum_2 (all MyEnum_matchOut_13 (type) (fun MyEnum_matchOut_13 (fun MyEnum_matchOut_13 MyEnum_matchOut_13))))
+                  (lam
+                    ds_14
+                    MyEnum_2
+                    [
+                      [
+                        [
+                          {
+                            [
+                              MyEnum_match_12 ds_14
+                            ]
+                            (fun (all a_29 (type) (fun a_29 a_29)) [(con integer) (con 64)])
+                          }
+                          (lam
+                            thunk_30
+                            (all a_32 (type) (fun a_32 a_32))
+                            (con 64 ! 1)
+                          )
+                        ]
+                        (lam
+                          thunk_37
+                          (all a_39 (type) (fun a_39 a_39))
+                          [
+                            {
+                              (abs
+                                e_33
+                                (type)
+                                (lam
+                                  thunk_34
+                                  (all a_36 (type) (fun a_36 a_36))
+                                  (error e_33)
+                                )
+                              )
+                              [(con integer) (con 64)]
+                            }
+                            (abs
+                              p_matchOut_22
+                              (type)
+                              (lam unit_23 p_matchOut_22 unit_23)
+                            )
+                          ]
+                        )
+                      ]
+                      (abs a_42 (type) (lam x_43 a_42 x_43))
+                    ]
+                  )
+                )
+              )
+            )
+          )
+          (all MyEnum_matchOut_1 (type) (fun MyEnum_matchOut_1 (fun MyEnum_matchOut_1 MyEnum_matchOut_1)))
+        }
+        (abs
+          MyEnum_matchOut_3
+          (type)
+          (lam Enum1_4 MyEnum_matchOut_3 (lam Enum2_5 MyEnum_matchOut_3 Enum1_4)
+          )
+        )
+      ]
+      (abs
+        MyEnum_matchOut_6
+        (type)
+        (lam Enum1_7 MyEnum_matchOut_6 (lam Enum2_8 MyEnum_matchOut_6 Enum2_8))
+      )
+    ]
+    (lam
+      x_9
+      (all MyEnum_matchOut_1 (type) (fun MyEnum_matchOut_1 (fun MyEnum_matchOut_1 MyEnum_matchOut_1)))
+      x_9
+    )
+  ]
+)

--- a/core-to-plc/test/data/newtypes/nestedNewtypeMatch.plc.golden
+++ b/core-to-plc/test/data/newtypes/nestedNewtypeMatch.plc.golden
@@ -1,2 +1,95 @@
-Error: Error at (). Type variable MyNewtype_4 is not in scope.
-Context: Converting expr at "nestedNewtypeMatch"
+(program 1.0.0
+  [
+    [
+      {
+        (abs
+          MyNewtype_4
+          (type)
+          (lam
+            MyNewtype_9
+            (fun [(con integer) (con 64)] MyNewtype_4)
+            (lam
+              MyNewtype_match_10
+              (fun MyNewtype_4 (all MyNewtype_matchOut_11 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_11) MyNewtype_matchOut_11)))
+              [
+                [
+                  {
+                    (abs
+                      MyNewtype2_12
+                      (type)
+                      (lam
+                        MyNewtype2_17
+                        (fun MyNewtype_4 MyNewtype2_12)
+                        (lam
+                          MyNewtype2_match_18
+                          (fun MyNewtype2_12 (all MyNewtype2_matchOut_19 (type) (fun (fun MyNewtype_4 MyNewtype2_matchOut_19) MyNewtype2_matchOut_19)))
+                          (lam
+                            ds_20
+                            MyNewtype2_12
+                            [
+                              {
+                                [
+                                  MyNewtype_match_10
+                                  [
+                                    {
+                                      [ MyNewtype2_match_18 ds_20 ] MyNewtype_4
+                                    }
+                                    (lam inner_21 MyNewtype_4 inner_21)
+                                  ]
+                                ]
+                                [(con integer) (con 64)]
+                              }
+                              (lam inner_22 [(con integer) (con 64)] inner_22)
+                            ]
+                          )
+                        )
+                      )
+                    )
+                    (all MyNewtype2_matchOut_1 (type) (fun (fun MyNewtype_4 MyNewtype2_matchOut_1) MyNewtype2_matchOut_1))
+                  }
+                  (lam
+                    MyNewtype2_arg0_15
+                    MyNewtype_4
+                    (abs
+                      MyNewtype2_matchOut_13
+                      (type)
+                      (lam
+                        MyNewtype2_14
+                        (fun MyNewtype_4 MyNewtype2_matchOut_13)
+                        [ MyNewtype2_14 MyNewtype2_arg0_15 ]
+                      )
+                    )
+                  )
+                ]
+                (lam
+                  x_16
+                  (all MyNewtype2_matchOut_1 (type) (fun (fun MyNewtype_4 MyNewtype2_matchOut_1) MyNewtype2_matchOut_1))
+                  x_16
+                )
+              ]
+            )
+          )
+        )
+        (all MyNewtype_matchOut_3 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_3) MyNewtype_matchOut_3))
+      }
+      (lam
+        MyNewtype_arg0_7
+        [(con integer) (con 64)]
+        (abs
+          MyNewtype_matchOut_5
+          (type)
+          (lam
+            MyNewtype_6
+            (fun [(con integer) (con 64)] MyNewtype_matchOut_5)
+            [ MyNewtype_6 MyNewtype_arg0_7 ]
+          )
+        )
+      )
+    ]
+    (lam
+      x_8
+      (all MyNewtype_matchOut_3 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_3) MyNewtype_matchOut_3))
+      x_8
+    )
+  ]
+)

--- a/core-to-plc/test/recursiveTypes/ptreeConstruct.plc.golden
+++ b/core-to-plc/test/recursiveTypes/ptreeConstruct.plc.golden
@@ -1,32 +1,32 @@
 (program 1.0.0
   [
     [
-      [
-        {
-          (abs
-            B_24
-            (fun (type) (type))
+      {
+        (abs
+          bad_name_7
+          (fun (type) (fun (type) (type)))
+          (lam
+            bad_name_17
+            (all a_18 (type) (all b_19 (type) (fun a_18 (fun b_19 [[bad_name_7 a_18] b_19]))))
             (lam
-              One_37
-              (all a_38 (type) (fun a_38 [B_24 a_38]))
-              (lam
-                Two_39
-                (all a_40 (type) (fun [B_24 [[bad_name_7 a_40] a_40]] [B_24 a_40]))
-                (lam
-                  B_match_41
-                  (all a_42 (type) (fun [B_24 a_42] (all B_matchOut_43 (type) (fun (fun a_42 B_matchOut_43) (fun (fun [B_24 [[bad_name_7 a_42] a_42]] B_matchOut_43) B_matchOut_43)))))
+              p_match_20
+              (all a_21 (type) (all b_22 (type) (fun [[bad_name_7 a_21] b_22] (all p_matchOut_23 (type) (fun (fun a_21 (fun b_22 p_matchOut_23)) p_matchOut_23)))))
+              [
+                [
                   [
-                    [
-                      {
-                        (abs
-                          bad_name_7
-                          (fun (type) (fun (type) (type)))
+                    {
+                      (abs
+                        B_24
+                        (fun (type) (type))
+                        (lam
+                          One_37
+                          (all a_38 (type) (fun a_38 [B_24 a_38]))
                           (lam
-                            bad_name_17
-                            (all a_18 (type) (all b_19 (type) (fun a_18 (fun b_19 [[bad_name_7 a_18] b_19]))))
+                            Two_39
+                            (all a_40 (type) (fun [B_24 [[bad_name_7 a_40] a_40]] [B_24 a_40]))
                             (lam
-                              p_match_20
-                              (all a_21 (type) (all b_22 (type) (fun [[bad_name_7 a_21] b_22] (all p_matchOut_23 (type) (fun (fun a_21 (fun b_22 p_matchOut_23)) p_matchOut_23)))))
+                              B_match_41
+                              (all a_42 (type) (fun [B_24 a_42] (all B_matchOut_43 (type) (fun (fun a_42 B_matchOut_43) (fun (fun [B_24 [[bad_name_7 a_42] a_42]] B_matchOut_43) B_matchOut_43)))))
                               [
                                 {
                                   Two_39 [(con integer) (con 64)]
@@ -84,99 +84,95 @@
                             )
                           )
                         )
-                        (lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6))))
-                      }
-                      (abs
-                        a_8
-                        (type)
-                        (abs
-                          b_9
-                          (type)
-                          (lam
-                            p_arg0_12
-                            a_8
+                      )
+                      (fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2)))))
+                    }
+                    (abs
+                      a_25
+                      (type)
+                      (lam
+                        One_arg0_29
+                        a_25
+                        (wrap
+                          B_0
+                          (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
+                          (abs
+                            B_matchOut_26
+                            (type)
                             (lam
-                              p_arg1_13
-                              b_9
-                              (abs
-                                p_matchOut_10
-                                (type)
-                                (lam
-                                  bad_name_11
-                                  (fun a_8 (fun b_9 p_matchOut_10))
-                                  [ [ bad_name_11 p_arg0_12 ] p_arg1_13 ]
-                                )
+                              One_27
+                              (fun a_25 B_matchOut_26)
+                              (lam
+                                Two_28
+                                (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_25] a_25]] B_matchOut_26)
+                                [ One_27 One_arg0_29 ]
                               )
                             )
                           )
                         )
                       )
-                    ]
-                    (abs
-                      a_14
-                      (type)
-                      (abs
-                        b_15
-                        (type)
-                        (lam
-                          x_16
-                          [[(lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6)))) a_14] b_15]
-                          x_16
+                    )
+                  ]
+                  (abs
+                    a_30
+                    (type)
+                    (lam
+                      Two_arg0_34
+                      [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]]
+                      (wrap
+                        B_0
+                        (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
+                        (abs
+                          B_matchOut_31
+                          (type)
+                          (lam
+                            One_32
+                            (fun a_30 B_matchOut_31)
+                            (lam
+                              Two_33
+                              (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]] B_matchOut_31)
+                              [ Two_33 Two_arg0_34 ]
+                            )
+                          )
                         )
                       )
                     )
-                  ]
-                )
-              )
-            )
-          )
-          (fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2)))))
-        }
-        (abs
-          a_25
-          (type)
-          (lam
-            One_arg0_29
-            a_25
-            (wrap
-              B_0
-              (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
-              (abs
-                B_matchOut_26
-                (type)
-                (lam
-                  One_27
-                  (fun a_25 B_matchOut_26)
+                  )
+                ]
+                (abs
+                  a_35
+                  (type)
                   (lam
-                    Two_28
-                    (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_25] a_25]] B_matchOut_26)
-                    [ One_27 One_arg0_29 ]
+                    x_36
+                    [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) a_35]
+                    (unwrap x_36)
                   )
                 )
-              )
+              ]
             )
           )
         )
-      ]
+        (lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6))))
+      }
       (abs
-        a_30
+        a_8
         (type)
-        (lam
-          Two_arg0_34
-          [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]]
-          (wrap
-            B_0
-            (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
-            (abs
-              B_matchOut_31
-              (type)
-              (lam
-                One_32
-                (fun a_30 B_matchOut_31)
+        (abs
+          b_9
+          (type)
+          (lam
+            p_arg0_12
+            a_8
+            (lam
+              p_arg1_13
+              b_9
+              (abs
+                p_matchOut_10
+                (type)
                 (lam
-                  Two_33
-                  (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]] B_matchOut_31)
-                  [ Two_33 Two_arg0_34 ]
+                  bad_name_11
+                  (fun a_8 (fun b_9 p_matchOut_10))
+                  [ [ bad_name_11 p_arg0_12 ] p_arg1_13 ]
                 )
               )
             )
@@ -185,12 +181,16 @@
       )
     ]
     (abs
-      a_35
+      a_14
       (type)
-      (lam
-        x_36
-        [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) a_35]
-        (unwrap x_36)
+      (abs
+        b_15
+        (type)
+        (lam
+          x_16
+          [[(lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6)))) a_14] b_15]
+          x_16
+        )
       )
     )
   ]

--- a/core-to-plc/test/recursiveTypes/ptreeMatch.plc.golden
+++ b/core-to-plc/test/recursiveTypes/ptreeMatch.plc.golden
@@ -1,32 +1,32 @@
 (program 1.0.0
   [
     [
-      [
-        {
-          (abs
-            B_24
-            (fun (type) (type))
+      {
+        (abs
+          bad_name_7
+          (fun (type) (fun (type) (type)))
+          (lam
+            bad_name_17
+            (all a_18 (type) (all b_19 (type) (fun a_18 (fun b_19 [[bad_name_7 a_18] b_19]))))
             (lam
-              One_37
-              (all a_38 (type) (fun a_38 [B_24 a_38]))
-              (lam
-                Two_39
-                (all a_40 (type) (fun [B_24 [[bad_name_7 a_40] a_40]] [B_24 a_40]))
-                (lam
-                  B_match_41
-                  (all a_42 (type) (fun [B_24 a_42] (all B_matchOut_43 (type) (fun (fun a_42 B_matchOut_43) (fun (fun [B_24 [[bad_name_7 a_42] a_42]] B_matchOut_43) B_matchOut_43)))))
+              p_match_20
+              (all a_21 (type) (all b_22 (type) (fun [[bad_name_7 a_21] b_22] (all p_matchOut_23 (type) (fun (fun a_21 (fun b_22 p_matchOut_23)) p_matchOut_23)))))
+              [
+                [
                   [
-                    [
-                      {
-                        (abs
-                          bad_name_7
-                          (fun (type) (fun (type) (type)))
+                    {
+                      (abs
+                        B_24
+                        (fun (type) (type))
+                        (lam
+                          One_37
+                          (all a_38 (type) (fun a_38 [B_24 a_38]))
                           (lam
-                            bad_name_17
-                            (all a_18 (type) (all b_19 (type) (fun a_18 (fun b_19 [[bad_name_7 a_18] b_19]))))
+                            Two_39
+                            (all a_40 (type) (fun [B_24 [[bad_name_7 a_40] a_40]] [B_24 a_40]))
                             (lam
-                              p_match_20
-                              (all a_21 (type) (all b_22 (type) (fun [[bad_name_7 a_21] b_22] (all p_matchOut_23 (type) (fun (fun a_21 (fun b_22 p_matchOut_23)) p_matchOut_23)))))
+                              B_match_41
+                              (all a_42 (type) (fun [B_24 a_42] (all B_matchOut_43 (type) (fun (fun a_42 B_matchOut_43) (fun (fun [B_24 [[bad_name_7 a_42] a_42]] B_matchOut_43) B_matchOut_43)))))
                               (lam
                                 ds_44
                                 [B_24 [(con integer) (con 64)]]
@@ -51,99 +51,95 @@
                             )
                           )
                         )
-                        (lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6))))
-                      }
-                      (abs
-                        a_8
-                        (type)
-                        (abs
-                          b_9
-                          (type)
-                          (lam
-                            p_arg0_12
-                            a_8
+                      )
+                      (fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2)))))
+                    }
+                    (abs
+                      a_25
+                      (type)
+                      (lam
+                        One_arg0_29
+                        a_25
+                        (wrap
+                          B_0
+                          (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
+                          (abs
+                            B_matchOut_26
+                            (type)
                             (lam
-                              p_arg1_13
-                              b_9
-                              (abs
-                                p_matchOut_10
-                                (type)
-                                (lam
-                                  bad_name_11
-                                  (fun a_8 (fun b_9 p_matchOut_10))
-                                  [ [ bad_name_11 p_arg0_12 ] p_arg1_13 ]
-                                )
+                              One_27
+                              (fun a_25 B_matchOut_26)
+                              (lam
+                                Two_28
+                                (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_25] a_25]] B_matchOut_26)
+                                [ One_27 One_arg0_29 ]
                               )
                             )
                           )
                         )
                       )
-                    ]
-                    (abs
-                      a_14
-                      (type)
-                      (abs
-                        b_15
-                        (type)
-                        (lam
-                          x_16
-                          [[(lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6)))) a_14] b_15]
-                          x_16
+                    )
+                  ]
+                  (abs
+                    a_30
+                    (type)
+                    (lam
+                      Two_arg0_34
+                      [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]]
+                      (wrap
+                        B_0
+                        (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
+                        (abs
+                          B_matchOut_31
+                          (type)
+                          (lam
+                            One_32
+                            (fun a_30 B_matchOut_31)
+                            (lam
+                              Two_33
+                              (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]] B_matchOut_31)
+                              [ Two_33 Two_arg0_34 ]
+                            )
+                          )
                         )
                       )
                     )
-                  ]
-                )
-              )
-            )
-          )
-          (fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2)))))
-        }
-        (abs
-          a_25
-          (type)
-          (lam
-            One_arg0_29
-            a_25
-            (wrap
-              B_0
-              (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
-              (abs
-                B_matchOut_26
-                (type)
-                (lam
-                  One_27
-                  (fun a_25 B_matchOut_26)
+                  )
+                ]
+                (abs
+                  a_35
+                  (type)
                   (lam
-                    Two_28
-                    (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_25] a_25]] B_matchOut_26)
-                    [ One_27 One_arg0_29 ]
+                    x_36
+                    [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) a_35]
+                    (unwrap x_36)
                   )
                 )
-              )
+              ]
             )
           )
         )
-      ]
+        (lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6))))
+      }
       (abs
-        a_30
+        a_8
         (type)
-        (lam
-          Two_arg0_34
-          [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]]
-          (wrap
-            B_0
-            (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
-            (abs
-              B_matchOut_31
-              (type)
-              (lam
-                One_32
-                (fun a_30 B_matchOut_31)
+        (abs
+          b_9
+          (type)
+          (lam
+            p_arg0_12
+            a_8
+            (lam
+              p_arg1_13
+              b_9
+              (abs
+                p_matchOut_10
+                (type)
                 (lam
-                  Two_33
-                  (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]] B_matchOut_31)
-                  [ Two_33 Two_arg0_34 ]
+                  bad_name_11
+                  (fun a_8 (fun b_9 p_matchOut_10))
+                  [ [ bad_name_11 p_arg0_12 ] p_arg1_13 ]
                 )
               )
             )
@@ -152,12 +148,16 @@
       )
     ]
     (abs
-      a_35
+      a_14
       (type)
-      (lam
-        x_36
-        [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) a_35]
-        (unwrap x_36)
+      (abs
+        b_15
+        (type)
+        (lam
+          x_16
+          [[(lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6)))) a_14] b_15]
+          x_16
+        )
       )
     )
   ]


### PR DESCRIPTION
These had crept in as testing the error message when they shouldn't be failing at all. Two bugs (see commit messages for details):
- Dependencies were the wrong way around (not sure how that happened
- Unit needs to be non-abstract (*shakes fist at value restriction*)
- Move a test that does in fact typecheck