### PR TITLE
MkPlc: take annotation for new constructs

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Definitions.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Definitions.hs
@@ -116,5 +116,5 @@ wrapDef term def = case def of
             vars = fmap dVar abstractTerms
             vals = fmap dVal abstractTerms
         in
-            PLC.mkIterApp (PLC.mkIterInst (PLC.mkIterTyAbs tyVars (PLC.mkIterLamAbs vars term)) tys) vals
-    TermDef (Def _ d rhs) -> PLC.mkTermLet (PLC.Def d rhs) term
+            PLC.mkIterApp () (PLC.mkIterInst () (PLC.mkIterTyAbs () tyVars (PLC.mkIterLamAbs () vars term)) tys) vals
+    TermDef (Def _ d rhs) -> PLC.mkTermLet () (PLC.Def d rhs) term

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
@@ -195,12 +195,12 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
 
             q <- safeFreshTyName "Q"
             choose <- safeFreshName "choose"
-            let chooseTy = PLC.mkIterTyFun tys (PLC.TyVar () q)
+            let chooseTy = PLC.mkIterTyFun () tys (PLC.TyVar () q)
 
             -- \f1 ... fn -> choose b1 ... bn
             bsLam <- mkIterLamAbsScoped (fmap fst bs) $ do
                 rhss <- mapM convExpr (fmap snd bs)
-                pure $ PLC.mkIterApp (PLC.Var() choose) rhss
+                pure $ PLC.mkIterApp () (PLC.Var() choose) rhss
 
             -- abstract out Q and choose
             let cLam = PLC.TyAbs () q (PLC.Type ()) $ PLC.LamAbs () choose chooseTy bsLam
@@ -208,7 +208,7 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
             -- fixN {A1 B1 ... An Bn}
             instantiatedFix <- do
                 fixN <- liftQuote $ Function.getBuiltinFixN (length bs)
-                pure $ PLC.mkIterInst fixN $ foldMap (\(a, b) -> [a, b]) asbs
+                pure $ PLC.mkIterInst () fixN $ foldMap (\(a, b) -> [a, b]) asbs
 
             let fixed = PLC.Apply () instantiatedFix cLam
 
@@ -240,7 +240,7 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
                 Just alt -> convAlt lazyCase dc alt
                 Nothing  -> throwPlain $ ConversionError "No case matched and no default case"
 
-            let applied = PLC.mkIterApp instantiated branches
+            let applied = PLC.mkIterApp () instantiated branches
             -- See Note [Case expressions and laziness]
             maybeForce lazyCase applied
         -- ignore annotation

--- a/core-to-plc/src/Language/Plutus/Lift.hs
+++ b/core-to-plc/src/Language/Plutus/Lift.hs
@@ -83,7 +83,7 @@ instance (TypeablePlc a, LiftPlc a) => LiftPlc [a] where
         argType <- typeRep @a
         h <- lift x
         t <- lift xs
-        pure $ mkIterApp (TyInst () cons argType) [h, t]
+        pure $ mkIterApp () (TyInst () cons argType) [h, t]
 
 -- Tweaked copies of the stdlib functions, see note [Stdlib lists].
 
@@ -146,7 +146,7 @@ getBuiltinCons = do
         . TyAbs () r (Type ())
         . LamAbs () z (TyVar () r)
         . LamAbs () f (TyFun () (TyVar () a) . TyFun () (TyApp () (TyVar () list) (TyVar () a)) $ TyVar () r)
-        $ mkIterApp (Var () f)
+        $ mkIterApp () (Var () f)
           [ Var () x
           , Var () xs
           ]
@@ -193,8 +193,8 @@ instance (GGetConstructorTypes f, Datatype d)  => GTypeablePlc (M1 D d f) where
         -- See note [Ordering of constructors]
         constrs <- sortConstructors (packageName @d undefined) (datatypeName @d undefined) <$> gGetConstructorTypes @f
         r <- liftQuote $ freshTyName () "r"
-        let caseTys = fmap (\(_, tys) -> mkIterTyFun tys (TyVar () r)) constrs
-        pure $ TyForall () r (Type ()) $ mkIterTyFun caseTys (TyVar () r)
+        let caseTys = fmap (\(_, tys) -> mkIterTyFun () tys (TyVar () r)) constrs
+        pure $ TyForall () r (Type ()) $ mkIterTyFun () caseTys (TyVar () r)
 
 -- See Note [Specific generic functions]
 instance (GGetConstructorTypes f, GGetConstructorArgs f, Datatype d)  => GLiftPlc (M1 D d f) where
@@ -207,10 +207,10 @@ instance (GGetConstructorTypes f, GGetConstructorArgs f, Datatype d)  => GLiftPl
         r <- liftQuote $ freshTyName () "r"
         cases <- forM constrs $ \(n, tys) -> do
                 arg <- liftQuote $ freshName () (strToBs n)
-                let ty = mkIterTyFun tys (TyVar () r)
+                let ty = mkIterTyFun () tys (TyVar () r)
                 pure $ VarDecl () arg ty
 
-        pure $ TyAbs () r (Type ()) $ mkIterLamAbs cases $ mkIterApp (mkVar $ cases !! index) (snd constr)
+        pure $ TyAbs () r (Type ()) $ mkIterLamAbs () cases $ mkIterApp () (mkVar $ cases !! index) (snd constr)
 
 -- Auxiliary generic functions
 

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Interesting.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Interesting.hs
@@ -49,9 +49,9 @@ getBuiltinFactorial = do
     return
         . TyAbs () s (Size ())
         . LamAbs () i int
-        . mkIterApp (TyInst () product' $ TyVar () s)
+        . mkIterApp () (TyInst () product' $ TyVar () s)
         $ [ ss
-          , mkIterApp (TyInst () enumFromTo' $ TyVar () s)
+          , mkIterApp () (TyInst () enumFromTo' $ TyVar () s)
                 [ makeDynBuiltinInt (TyVar () s) ss 1
                 , Var () i
                 ]
@@ -92,7 +92,7 @@ genNatRoundtrip = do
     term <- lift $ do
         n <- getBuiltinIntegerToNat iv
         natToInteger <- getBuiltinNatToInteger
-        return $ mkIterApp (TyInst () natToInteger size) [ssize, n]
+        return $ mkIterApp () (TyInst () natToInteger size) [ssize, n]
     return . TermOf term $ TypedBuiltinValue typedIntSized iv
 
 -- | Generate a list of 'Integer's, turn it into a Scott-encoded PLC @List@ (see 'getBuiltinList'),
@@ -107,7 +107,7 @@ genListSum = do
         builtinSum <- getBuiltinSum
         list <- getListToBuiltinList intSized $ map _termOfTerm ps
         return
-            $ mkIterApp (TyInst () builtinSum $ TyInt () size)
+            $ mkIterApp () (TyInst () builtinSum $ TyInt () size)
             [ Constant () $ BuiltinSize () size
             , list
             ]
@@ -128,8 +128,8 @@ genIfIntegers = do
     builtinUnit  <- lift getBuiltinUnit
     builtinIf    <- lift getBuiltinIf
     let builtinConstSpec =
-            Apply () $ mkIterInst builtinConst [intSized, builtinUnit]
-        term = mkIterApp
+            Apply () $ mkIterInst () builtinConst [intSized, builtinUnit]
+        term = mkIterApp ()
             (TyInst () builtinIf intSized)
             [b, builtinConstSpec i, builtinConstSpec j]
         value = if bv then iv else jv

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Make.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Make.hs
@@ -87,7 +87,7 @@ makeDynBuiltinInt
     -> Integer              -- ^ An 'Integer' to lift.
     -> Term tyname name ()
 makeDynBuiltinInt sTy sTerm intVal =
-    mkIterApp (mkIterInst resizeInteger [TyInt () sizeOfIntVal, sTy]) [sTerm, intTerm] where
+    mkIterApp () (mkIterInst () resizeInteger [TyInt () sizeOfIntVal, sTy]) [sTerm, intTerm] where
         sizeOfIntVal = sizeOfInteger intVal
         resizeInteger = builtinNameAsTerm ResizeInteger
         intTerm = Constant () $ BuiltinInt () sizeOfIntVal intVal

--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -43,76 +43,86 @@ mkTyVar = TyVar () . tyVarDeclName
 data Def var val = Def { defVar::var, defVal::val}
 
 -- | A term definition as a variable.
-type TermDef tyname name a = Def (VarDecl tyname name ()) (Term tyname name ())
+type TermDef tyname name a = Def (VarDecl tyname name a) (Term tyname name a)
 -- | A type definition as a type variable.
-type TypeDef tyname a = Def (TyVarDecl tyname ()) (Type tyname ())
+type TypeDef tyname a = Def (TyVarDecl tyname a) (Type tyname a)
 
 -- | Make a "let-binding" for a term.
 mkTermLet
-    :: TermDef tyname name ()
-    -> Term tyname name () -- ^ The body of the let, possibly referencing the name.
-    -> Term tyname name ()
-mkTermLet (Def (VarDecl _ name ty) bind) body = Apply () (LamAbs () name ty body) bind
+    :: a
+    -> TermDef tyname name a
+    -> Term tyname name a -- ^ The body of the let, possibly referencing the name.
+    -> Term tyname name a
+mkTermLet x (Def (VarDecl _ name ty) bind) body = Apply x (LamAbs x name ty body) bind
 
 -- | Make a "let-binding" for a type. Note: the body must be a value.
 mkTypeLet
-    :: TypeDef tyname ()
-    -> Term tyname name () -- ^ The body of the let, possibly referencing the name.
-    -> Term tyname name ()
-mkTypeLet (Def (TyVarDecl _ name k) bind) body = TyInst () (TyAbs () name k body) bind
+    :: a
+    -> TypeDef tyname a
+    -> Term tyname name a -- ^ The body of the let, possibly referencing the name.
+    -> Term tyname name a
+mkTypeLet x (Def (TyVarDecl _ name k) bind) body = TyInst x (TyAbs x name k body) bind
 
 -- | Make an iterated application.
 mkIterApp
-    :: Term tyname name () -- ^ @f@
-    -> [Term tyname name ()] -- ^@[ x0 ... xn ]@
-    -> Term tyname name () -- ^ @[f x0 ... xn ]@
-mkIterApp = foldl' (Apply ())
+    :: a
+    -> Term tyname name a -- ^ @f@
+    -> [Term tyname name a] -- ^@[ x0 ... xn ]@
+    -> Term tyname name a -- ^ @[f x0 ... xn ]@
+mkIterApp x = foldl' (Apply x)
 
 -- | Make an iterated instantiation.
 mkIterInst
-    :: Term tyname name () -- ^ @a@
-    -> [Type tyname ()] -- ^ @ [ x0 ... xn ] @
-    -> Term tyname name () -- ^ @{ a x0 ... xn }@
-mkIterInst = foldl' (TyInst ())
+    :: a
+    -> Term tyname name a -- ^ @a@
+    -> [Type tyname a] -- ^ @ [ x0 ... xn ] @
+    -> Term tyname name a -- ^ @{ a x0 ... xn }@
+mkIterInst x = foldl' (TyInst x)
 
 -- | Lambda abstract a list of names.
 mkIterLamAbs
-    :: [VarDecl tyname name ()]
-    -> Term tyname name ()
-    -> Term tyname name ()
-mkIterLamAbs args body = foldr (\(VarDecl _ n ty) acc -> LamAbs () n ty acc) body args
+    :: a
+    -> [VarDecl tyname name a]
+    -> Term tyname name a
+    -> Term tyname name a
+mkIterLamAbs x args body = foldr (\(VarDecl _ n ty) acc -> LamAbs x n ty acc) body args
 
 -- | Type abstract a list of names.
 mkIterTyAbs
-    :: [TyVarDecl tyname ()]
-    -> Term tyname name ()
-    -> Term tyname name ()
-mkIterTyAbs args body = foldr (\(TyVarDecl _ n k) acc -> TyAbs () n k acc) body args
+    :: a
+    -> [TyVarDecl tyname a]
+    -> Term tyname name a
+    -> Term tyname name a
+mkIterTyAbs x args body = foldr (\(TyVarDecl _ n k) acc -> TyAbs x n k acc) body args
 
 -- | Make an iterated type application.
 mkIterTyApp
-    :: Type tyname () -- ^ @f@
-    -> [Type tyname ()] -- ^ @[ x0 ... xn ]@
-    -> Type tyname () -- ^ @[ f x0 ... xn ]@
-mkIterTyApp = foldl' (TyApp ())
+    :: a
+    -> Type tyname a -- ^ @f@
+    -> [Type tyname a] -- ^ @[ x0 ... xn ]@
+    -> Type tyname a -- ^ @[ f x0 ... xn ]@
+mkIterTyApp x = foldl' (TyApp x)
 
 -- | Make an iterated function type.
 mkIterTyFun
-    :: [Type tyname ()]
-    -> Type tyname ()
-    -> Type tyname ()
-mkIterTyFun tys target = foldr (\ty acc -> TyFun () ty acc) target tys
+    :: a
+    -> [Type tyname a]
+    -> Type tyname a
+    -> Type tyname a
+mkIterTyFun x tys target = foldr (\ty acc -> TyFun x ty acc) target tys
 
 -- | Universally quantify a list of names.
 mkIterTyForall
-    :: [TyVarDecl tyname ()]
-    -> Type tyname ()
-    -> Type tyname ()
-mkIterTyForall args body = foldr (\(TyVarDecl _ n k) acc -> TyForall () n k acc) body args
+    :: a
+    -> [TyVarDecl tyname a]
+    -> Type tyname a
+    -> Type tyname a
+mkIterTyForall x args body = foldr (\(TyVarDecl _ n k) acc -> TyForall x n k acc) body args
 
 -- | Lambda abstract a list of names.
 mkIterTyLam
-    :: [TyVarDecl tyname ()]
-    -> Type tyname ()
-    -> Type tyname ()
-mkIterTyLam args body = foldr (\(TyVarDecl _ n k) acc -> TyLam () n k acc) body args
+    :: a
+    -> [TyVarDecl tyname a]
+    -> Type tyname a
+    -> Type tyname a
+mkIterTyLam x args body = foldr (\(TyVarDecl _ n k) acc -> TyLam x n k acc) body args

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Bool.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Bool.hs
@@ -25,7 +25,7 @@ getBuiltinBool = rename =<< do
     a <- freshTyName () "a"
     return
         . TyForall () a (Type ())
-        $ mkIterTyFun [ TyVar () a, TyVar () a ]
+        $ mkIterTyFun () [ TyVar () a, TyVar () a ]
         $ TyVar () a
 
 -- | 'True' as a PLC term.
@@ -38,7 +38,7 @@ getBuiltinTrue = rename =<< do
     y <- freshName () "y"
     return
        . TyAbs () a (Type ())
-       $ mkIterLamAbs [
+       $ mkIterLamAbs () [
           VarDecl () x (TyVar () a),
           VarDecl () y (TyVar () a)
           ]
@@ -54,7 +54,7 @@ getBuiltinFalse = rename =<< do
     y <- freshName () "y"
     return
        . TyAbs () a (Type ())
-       $ mkIterLamAbs [
+       $ mkIterLamAbs () [
           VarDecl () x (TyVar () a),
           VarDecl () y (TyVar () a)
           ]
@@ -75,11 +75,11 @@ getBuiltinIf = rename =<< do
     let unitFunA = TyFun () unit (TyVar () a)
     return
        . TyAbs () a (Type ())
-      $ mkIterLamAbs [
+      $ mkIterLamAbs () [
           VarDecl () b builtinBool,
           VarDecl () x unitFunA,
           VarDecl () y unitFunA
           ]
-      $ mkIterApp
+      $ mkIterApp ()
           (TyInst () (Var () b) unitFunA)
           [Var () x, Var () y, unitval]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/ChurchNat.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/ChurchNat.hs
@@ -56,7 +56,7 @@ getBuiltinChurchSucc = rename =<< do
         . LamAbs () z (TyVar () r)
         . LamAbs () f (TyFun () (TyVar () r) $ TyVar () r)
         . Apply () (Var () f)
-        $ mkIterApp (TyInst () (Var () n) $ TyVar () r)
+        $ mkIterApp () (TyInst () (Var () n) $ TyVar () r)
           [ Var () z
           , Var () f
           ]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
@@ -93,7 +93,7 @@ getBuiltinFix = rename =<< do
         . wrapSelfFunAB
         . LamAbs () s selfFunAB
         . LamAbs () x (TyVar () a)
-        $ mkIterApp (Var () f)
+        $ mkIterApp () (Var () f)
           [ Apply () unrollFunAB $ Var () s
           , Var () x
           ]
@@ -204,7 +204,7 @@ getBuiltinFixN n = do
     let abFuns = fmap (\(a, b) -> TyFun () (TyVar () a) (TyVar () b)) asbs
 
     -- funTysTo X = (A1 -> B1) -> ... -> (An -> Bn) -> X
-    let funTysTo = mkIterTyFun abFuns
+    let funTysTo = mkIterTyFun () abFuns
 
     -- instantiatedFix = fixBy { \X :: * -> (A1 -> B1) -> ... -> (An -> Bn) -> X }
     instantiatedFix <- do
@@ -236,9 +236,9 @@ getBuiltinFixN n = do
             pure $
                 LamAbs () x (TyVar () a) $
                 Apply () (TyInst () (Var () k) (TyVar () b)) $
-                mkIterLamAbs fs $
+                mkIterLamAbs () fs $
                 -- this is an ugly but straightforward way of getting the right fi
-                Apply() (mkVar (fs !! i)) (Var () x)
+                Apply () (mkVar (fs !! i)) (Var () x)
 
     -- a list of all the branches
     branches <- forM (zip asbs [0..]) $ uncurry branch
@@ -247,9 +247,9 @@ getBuiltinFixN n = do
     let allAsBs = foldMap (\(a, b) -> [a, b]) asbs
     pure $
         -- abstract out all the As and Bs
-        mkIterTyAbs (fmap (\tn -> TyVarDecl () tn (Type ())) allAsBs) $
+        mkIterTyAbs () (fmap (\tn -> TyVarDecl () tn (Type ())) allAsBs) $
         Apply () instantiatedFix $
         LamAbs () k kTy $
         TyAbs () s (Type ()) $
         LamAbs () h hTy $
-        mkIterApp (Var () h) branches
+        mkIterApp () (Var () h) branches

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Integer.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Integer.hs
@@ -24,7 +24,7 @@ getBuiltinSuccInteger = rename =<< do
     return
         . TyAbs () s (Size ())
         . LamAbs () i (TyApp () (TyBuiltin () TyInteger) $ TyVar () s)
-        . mkIterApp (TyInst () (Constant () $ BuiltinName () AddInteger) $ TyVar () s)
+        . mkIterApp () (TyInst () (Constant () $ BuiltinName () AddInteger) $ TyVar () s)
         $ [ Var () i
           , makeDynBuiltinIntSizedAs (TyVar () s) (Var () i) 1
           ]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
@@ -86,7 +86,7 @@ getBuiltinCons = rename =<< do
         . TyAbs () r (Type ())
         . LamAbs () z (TyVar () r)
         . LamAbs () f (TyFun () (TyVar () a) . TyFun () listA $ TyVar () r)
-        $ mkIterApp (Var () f)
+        $ mkIterApp () (Var () f)
           [ Var () x
           , Var () xs
           ]
@@ -115,13 +115,13 @@ getBuiltinFoldrList = rename =<< do
         . TyAbs () r (Type ())
         . LamAbs () f (TyFun () (TyVar () r) . TyFun () (TyVar () a) $ TyVar () r)
         . LamAbs () z (TyVar () r)
-        . Apply () (mkIterInst fix [listA, TyVar () r])
+        . Apply () (mkIterInst () fix [listA, TyVar () r])
         . LamAbs () rec (TyFun () listA $ TyVar () r)
         . LamAbs () xs listA
         . Apply () (Apply () (TyInst () (Unwrap () (Var () xs)) $ TyVar () r) $ Var () z)
         . LamAbs () x (TyVar () a)
         . LamAbs () xs' listA
-        $ mkIterApp (Var () f)
+        $ mkIterApp () (Var () f)
           [ Apply () (Var () rec) $ Var () xs'
           , Var () x
           ]
@@ -149,15 +149,15 @@ getBuiltinFoldList = rename =<< do
         . TyAbs () a (Type ())
         . TyAbs () r (Type ())
         . LamAbs () f (TyFun () (TyVar () r) . TyFun () (TyVar () a) $ TyVar () r)
-        . Apply () (mkIterInst fix [TyVar () r, TyFun () listA $ TyVar () r])
+        . Apply () (mkIterInst () fix [TyVar () r, TyFun () listA $ TyVar () r])
         . LamAbs () rec (TyFun () (TyVar () r) . TyFun () listA $ TyVar () r)
         . LamAbs () z (TyVar () r)
         . LamAbs () xs listA
         . Apply () (Apply () (TyInst () (Unwrap () (Var () xs)) $ TyVar () r) $ Var () z)
         . LamAbs () x (TyVar () a)
         . LamAbs () xs' listA
-        . mkIterApp (Var () rec)
-        $ [ mkIterApp (Var () f) [Var () z, Var () x]
+        . mkIterApp () (Var () rec)
+        $ [ mkIterApp () (Var () f) [Var () z, Var () x]
           , Var () xs'
           ]
 
@@ -194,16 +194,16 @@ getBuiltinEnumFromTo = rename =<< do
         . TyAbs () s (Size ())
         . LamAbs () n int
         . LamAbs () m int
-        . mkIterApp (mkIterInst fix [int, listInt])
+        . mkIterApp () (mkIterInst () fix [int, listInt])
         $ [   LamAbs () rec (TyFun () int listInt)
             . LamAbs () n' int
-            . mkIterApp (TyInst () ifThenElse listInt)
-            $ [ mkIterApp (TyInst () gtInteger $ TyVar () s)
+            . mkIterApp () (TyInst () ifThenElse listInt)
+            $ [ mkIterApp () (TyInst () gtInteger $ TyVar () s)
                     [ Var () n'
                     , Var () m
                     ]
               , LamAbs () u unit $ TyInst () nil int
-              , LamAbs () u unit $ mkIterApp (TyInst () cons int)
+              , LamAbs () u unit $ mkIterApp () (TyInst () cons int)
                     [ Var () n'
                     ,    Apply () (Var () rec)
                        . Apply () (TyInst () succInteger (TyVar () s))
@@ -228,7 +228,7 @@ getBuiltinSum = rename =<< do
     return
         . TyAbs () s (Size ())
         . LamAbs () ss (TyApp () (TyBuiltin () TySize) sv)
-        . mkIterApp (mkIterInst foldList [int, int])
+        . mkIterApp () (mkIterInst () foldList [int, int])
         $ [ add
           , makeDynBuiltinInt sv (Var () ss) 0
           ]
@@ -248,7 +248,7 @@ getBuiltinProduct = rename =<< do
     return
         . TyAbs () s (Size ())
         . LamAbs () ss (TyApp () (TyBuiltin () TySize) sv)
-        . mkIterApp (mkIterInst foldList [int, int])
+        . mkIterApp () (mkIterInst () foldList [int, int])
         $ [ mul
           , makeDynBuiltinInt sv (Var () ss) 1
           ]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
@@ -89,7 +89,7 @@ getBuiltinFoldrNat = rename =<< do
         . TyAbs () r (Type ())
         . LamAbs () f (TyFun () (TyVar () r) (TyVar () r))
         . LamAbs () z (TyVar () r)
-        . Apply () (mkIterInst fix [nat, TyVar () r])
+        . Apply () (mkIterInst () fix [nat, TyVar () r])
         . LamAbs () rec (TyFun () nat $ TyVar () r)
         . LamAbs () n nat
         . Apply () (Apply () (TyInst () (Unwrap () (Var () n)) $ TyVar () r) $ Var () z)
@@ -116,13 +116,13 @@ getBuiltinFoldNat = rename =<< do
     return
         . TyAbs () r (Type ())
         . LamAbs () f (TyFun () (TyVar () r) (TyVar () r))
-        . Apply () (mkIterInst fix [TyVar () r, TyFun () nat $ TyVar () r])
+        . Apply () (mkIterInst () fix [TyVar () r, TyFun () nat $ TyVar () r])
         . LamAbs () rec (TyFun () (TyVar () r) . TyFun () nat $ TyVar () r)
         . LamAbs () z (TyVar () r)
         . LamAbs () n nat
         . Apply () (Apply () (TyInst () (Unwrap () (Var () n)) $ TyVar () r) $ Var () z)
         . LamAbs () n' nat
-        . mkIterApp (Var () rec)
+        . mkIterApp () (Var () rec)
         $ [ Apply () (Var () f) $ Var () z
           , Var () n'
           ]
@@ -144,7 +144,7 @@ getBuiltinNatToInteger = rename =<< do
     return
         . TyAbs ()  s  (Size ())
         . LamAbs () ss (TyApp () (TyBuiltin () TySize) sv)
-        $ mkIterApp (TyInst () foldNat $ TyApp () (TyBuiltin () TyInteger) sv)
+        $ mkIterApp () (TyInst () foldNat $ TyApp () (TyBuiltin () TyInteger) sv)
           [ Apply ()
               (TyInst () addInteger (TyVar () s))
               (makeDynBuiltinInt sv ssv 1)

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta.hs
@@ -37,12 +37,12 @@ getBuiltinNatSum s = do
     n <- freshName () "n"
     RecursiveType _ nat2 <- holedToRecursive <$> getBuiltinNat
     return
-        $ mkIterApp (mkIterInst foldList [nat1, int])
+        $ mkIterApp () (mkIterInst () foldList [nat1, int])
           [   LamAbs () acc int
             . LamAbs () n nat2
-            . mkIterApp add
+            . mkIterApp () add
             $ [ Var () acc
-              , mkIterApp (TyInst () nti (TyInt () s))
+              , mkIterApp () (TyInst () nti (TyInt () s))
                   [ Constant () $ BuiltinSize () s
                   , Var () n
                   ]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Tuple.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Tuple.hs
@@ -28,10 +28,10 @@ getBuiltinTuple arity = do
         pure $ TyVarDecl () tn $ Type ()
 
     resultType <- liftQuote $ freshTyName () "r"
-    let caseType = mkIterTyFun (fmap mkTyVar tyVars) (TyVar () resultType)
+    let caseType = mkIterTyFun () (fmap mkTyVar tyVars) (TyVar () resultType)
     pure $
         -- \T_1 .. T_n
-        mkIterTyLam tyVars $
+        mkIterTyLam () tyVars $
         -- all R
         TyForall () resultType (Type ()) $
         -- (T_1 -> .. -> T_n -> r) -> r
@@ -58,18 +58,18 @@ getBuiltinTupleConstructor arity = do
         pure $ VarDecl () n $ mkTyVar $ tyVars !! i
 
     caseArg <- liftQuote $ freshName () "case"
-    let caseTy = mkIterTyFun (fmap mkTyVar tyVars) (TyVar () resultType)
+    let caseTy = mkIterTyFun () (fmap mkTyVar tyVars) (TyVar () resultType)
     pure $
         -- /\T_1 .. T_n
-        mkIterTyAbs tyVars $
+        mkIterTyAbs () tyVars $
         -- \arg_1 .. arg_n
-        mkIterLamAbs args $
+        mkIterLamAbs () args $
         -- /\R
         TyAbs () resultType (Type ()) $
         -- \case
         LamAbs () caseArg caseTy $
         -- case arg_1 .. arg_n
-        mkIterApp (Var() caseArg) $ fmap mkVar args
+        mkIterApp () (Var () caseArg) $ fmap mkVar args
 
 -- | Given an arity @n@ and an index @i@, create a function for accessing the i'th component of a n-tuple.
 --
@@ -86,7 +86,7 @@ getBuiltinTupleAccessor arity index = rename =<< do
 
     tupleTy <- do
         genericTuple <- getBuiltinTuple arity
-        pure $ mkIterTyApp genericTuple (fmap mkTyVar tyVars)
+        pure $ mkIterTyApp () genericTuple (fmap mkTyVar tyVars)
     let selectedTy = mkTyVar $ tyVars !! index
 
     args <- for [0..(arity -1)] $ \i -> do
@@ -97,10 +97,10 @@ getBuiltinTupleAccessor arity index = rename =<< do
     tupleArg <- liftQuote $ freshName () "tuple"
     pure $
         -- /\T_1 .. T_n
-        mkIterTyAbs tyVars $
+        mkIterTyAbs () tyVars $
         -- \tuple :: (tupleN T_1 .. T_n)
         LamAbs () tupleArg tupleTy $
         -- tuple {T_i}
         Apply () (TyInst () (Var () tupleArg) selectedTy) $
         -- \arg_1 .. arg_n . arg_i
-        mkIterLamAbs args selectedArg
+        mkIterLamAbs () args selectedArg

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Term.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Term.hs
@@ -69,8 +69,8 @@ compileSingleBinding r body b = case b of
         Rec -> compileRecTerms body [PLC.Def d rhs]
         NonRec -> do
             def <- PLC.Def d <$> compileTerm rhs
-            pure $ PLC.mkTermLet def body
+            pure $ PLC.mkTermLet () def body
     TypeBind () d rhs -> do
         let def = PLC.Def d rhs
-        pure $ PLC.mkTypeLet def body
+        pure $ PLC.mkTypeLet () def body
     DatatypeBind () d -> compileDatatype r body d

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -133,12 +133,12 @@ listMatch = do
                 ]
             ] $
             -- embed so we can use PLC construction functions
-            embedIntoIR $ PLC.mkIterApp (PLC.TyInst () (PLC.Apply () unitMatch unitNil) unit)
+            embedIntoIR $ PLC.mkIterApp () (PLC.TyInst () (PLC.Apply () unitMatch unitNil) unit)
                 [
                     -- nil case
                     unitval,
                     -- cons case
-                    PLC.mkIterLamAbs [PLC.VarDecl () h unit, PLC.VarDecl () t (PLC.TyApp () (PLC.TyVar () m) unit)] $ PLC.Var () h
+                    PLC.mkIterLamAbs () [PLC.VarDecl () h unit, PLC.VarDecl () t (PLC.TyApp () (PLC.TyVar () m) unit)] $ PLC.Var () h
                 ]
 
 datatypes :: TestNested


### PR DESCRIPTION
I would like to give proper annotations to some of the PLC and PIR that
I'm generating, with at least some kind of identifying information.
So I need the `MkPlc` functions to take an annotation for the new terms.

I think this is not *too* bad - we have to scatter some more `()`s
around, but we already have to do this for more-or-less every term
construction.