### PR TITLE
Generify convertErrors a bit

### DIFF
--- a/language-plutus-core/prelude/PlutusPrelude.hs
+++ b/language-plutus-core/prelude/PlutusPrelude.hs
@@ -1,6 +1,11 @@
+-- this is needed so that mapErrors can have its type argument provided later
+{-# LANGUAGE AllowAmbiguousTypes   #-}
+{-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes            #-}
 
 module PlutusPrelude ( -- * Reëxports from base
                        (&&&)
@@ -71,6 +76,8 @@ module PlutusPrelude ( -- * Reëxports from base
                      , iasqrt
                      , ilogFloor
                      , ilogRound
+                     -- * Error conversion
+                     , mapErrors
                      ) where
 
 import           Control.Applicative                     (Alternative (..))
@@ -79,6 +86,7 @@ import           Control.Composition                     ((.*))
 import           Control.DeepSeq                         (NFData)
 import           Control.Exception                       (Exception, throw)
 import           Control.Monad                           (guard, join, (<=<))
+import           Control.Monad.Except
 import           Data.Bifunctor                          (first, second)
 import           Data.Bool                               (bool)
 import qualified Data.ByteString.Lazy                    as BSL
@@ -100,6 +108,7 @@ import           Data.Text.Prettyprint.Doc.Render.Text   (renderStrict)
 import           Data.Typeable                           (Typeable)
 import           Data.Word                               (Word8)
 import           Debug.Trace
+import           GHC.Exts                                (Constraint)
 import           GHC.Generics                            (Generic)
 import           GHC.Natural                             (Natural)
 
@@ -255,3 +264,27 @@ ilogRound b x
     | b ^ p == x = p
     | otherwise  = p + 1
     where p = ilogFloor b x
+
+-- | Map the given function over the errors in a monad with a 'MonadError' constraint. The
+-- constraint type parameter represents additional constraints that are preserved - this cannot
+-- be inferred and must be passed explicitly with @-XTypeApplications@.
+mapErrors :: forall (c :: (* -> *) -> Constraint) (m :: * -> *) e e' a .
+  -- We need the Constraint to apply both to m, and to m wrapped in ExceptT. This constrains
+  -- what Constraints we can use in the way we'd expect
+  (MonadError e' m, c (ExceptT e m))
+  => (e -> e')
+  -> (forall n . (MonadError e n, c n) => n a)
+  -> m a
+mapErrors convert act =
+    let
+        -- We instantiate n to ExceptT with *m* on the inside. This gives us the ability to
+        -- throw errors of type e' in m, although none will have been thrown yet since we
+        -- just made up the fact that it's m rather than something else on the inside.
+        (instantiated :: ExceptT e m a) = act
+        -- Map the errors into e'
+        (mapped :: ExceptT e' m a) = withExceptT convert instantiated
+        -- Unwrap the ExceptT into a form we can lift
+        (unwrapped :: m (Either e' a)) = runExceptT mapped
+        -- Lift into new context now we have the right types
+        (lifted :: m a) = unwrapped >>= liftEither
+    in lifted

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -97,7 +97,6 @@ module Language.PlutusCore
     , runQuoteT
     , MonadQuote
     , liftQuote
-    , convertErrors
     -- * Name generation
     , freshUnique
     , freshName

--- a/language-plutus-core/src/Language/PlutusCore/Parser.y
+++ b/language-plutus-core/src/Language/PlutusCore/Parser.y
@@ -1,5 +1,6 @@
 {
     {-# LANGUAGE OverloadedStrings  #-}
+    {-# LANGUAGE TypeApplications   #-}
     module Language.PlutusCore.Parser ( parse
                                       , parseST
                                       , parseTermST
@@ -162,7 +163,7 @@ parseTypeST str = runAlexST' str (runExceptT parsePlutusCoreType) >>= liftEither
 mapParseRun :: (MonadError (Error a) m, MonadQuote m) => StateT IdentifierState (Except (ParseError a)) b -> m b
 -- we need to run the parser starting from our current next unique, then throw away the rest of the
 -- parser state and get back the new next unique
-mapParseRun run = convertErrors asError $ do
+mapParseRun run = mapErrors @MonadQuote asError $ do
     nextU <- liftQuote get
     (p, (_, _, u)) <- liftEither $ runExcept $ runStateT run (identifierStateFrom nextU)
     liftQuote $ put u

--- a/language-plutus-core/src/Language/PlutusCore/Quote.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Quote.hs
@@ -17,7 +17,6 @@ module Language.PlutusCore.Quote (
             , MonadQuote
             , FreshState
             , liftQuote
-            , convertErrors
             ) where
 
 import           Control.Monad.Except
@@ -58,15 +57,6 @@ instance MonadQuote m => MonadQuote (StateT s m)
 instance MonadQuote m => MonadQuote (ExceptT e m)
 instance MonadQuote m => MonadQuote (ReaderT r m)
 instance MonadQuote m => MonadQuote (GenT m)
-
--- | Map the errors in a 'MonadError' and 'MonadQuote' context according to the given function.
--- This can be used on the functions exported from this module to change the error type.
-convertErrors :: forall a b m o .
-  (MonadError b m, MonadQuote m)
-  => (a -> b)
-  -> ExceptT a Quote o
-  -> m o
-convertErrors convert act = (liftEither . first convert) =<< (liftQuote $ runExceptT act)
 
 -- | Run a quote from an empty identifier state. Note that the resulting term cannot necessarily
 -- be safely combined with other terms - that should happen inside 'QuoteT'.

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Main (main) where
 
@@ -11,6 +12,8 @@ import           Language.PlutusCore.Quote
 
 import           Language.PlutusIR
 import           Language.PlutusIR.Compiler
+
+import           PlutusPrelude                        (mapErrors)
 
 import qualified Language.PlutusCore                  as PLC
 import qualified Language.PlutusCore.MkPlc            as PLC
@@ -42,7 +45,7 @@ compileAndMaybeTypecheck doTypecheck pir = either (error . show . PLC.prettyPlcC
     -- names during compilation that are not fresh
     compiled <- compileTerm =<< liftQuote pir
     when doTypecheck $ void $
-        convertErrors PLCError $ do
+        mapErrors @MonadQuote PLCError $ do
             annotated <- PLC.annotateTerm compiled
             -- need our own typechecker pipeline to allow normalized types
             PLC.typecheckTerm (PLC.TypeCheckCfg PLC.defaultTypecheckerGas $ PLC.TypeConfig True mempty) annotated


### PR DESCRIPTION
I'm not saying this came to me in a dream... but that's awfully close to what happened ;)

I think this is better than the previous version: it uses a little dash of `Constraint` magic to avoid coupling things to `Quote`, which is nice. The cost is that we can't infer the `Constraint` (I'm not entirely sure why not) so we have to pass it explicitly with `TypeApplications`.