### PR TITLE
pir: add an isTermValue function

### DIFF
--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -29,6 +29,7 @@ library
         Language.PlutusIR.Compiler
     hs-source-dirs: src
     other-modules:
+        Language.PlutusIR.Value
         Language.PlutusIR.Compiler.Error
         Language.PlutusIR.Compiler.Term
         Language.PlutusIR.Compiler.Datatype

--- a/plutus-ir/src/Language/PlutusIR/Value.hs
+++ b/plutus-ir/src/Language/PlutusIR/Value.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE LambdaCase #-}
+module Language.PlutusIR.Value (isTermValue) where
+
+import           Language.PlutusIR
+
+-- | Whether the given PIR term is (will compile to) a PLC term value.
+isTermValue :: Term tyname name a -> Bool
+isTermValue = \case
+    -- Let is not a value (will compile into applications and/or type instantiations)
+    Let {} -> False
+    -- Lambdas and constants are always values
+    LamAbs {} -> True
+    Constant {} -> True
+    -- Type abstractions and wraps are values if their bodies are
+    TyAbs _ _ _ t -> isTermValue t
+    Wrap _ _ _ t -> isTermValue t
+    -- All other PLC terms are not values
+    Var {} -> False
+    Apply {} -> False
+    TyInst {} -> False
+    Error {} -> False
+    Unwrap {} -> False


### PR DESCRIPTION
This is based on whether the compiled PIR term will be a PLC value. Fortunately, we can determine this statically without compiling the term: the only interesting case is `let`, which will always not be a value, since it compiles into applications/type instantiations.

This is used `core-to-plc`, so we need a PIR version.