### PR TITLE
[CGP-405] Separated type normalization from type checking

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -72,6 +72,7 @@ library
         Language.PlutusCore.Constant.Apply
         Language.PlutusCore.Constant.Make
         Language.PlutusCore.Constant.Typed
+        Language.PlutusCore.Check.Normal
         Language.PlutusCore.Pretty.Classic
         Language.PlutusCore.Pretty.Plc
         Language.PlutusCore.Pretty.Readable

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -118,13 +118,13 @@ import qualified Data.ByteString.Lazy                     as BSL
 import qualified Data.Text                                as T
 import           Data.Text.Prettyprint.Doc
 import           Language.PlutusCore.CBOR                 ()
+import           Language.PlutusCore.Check.Normal
 import           Language.PlutusCore.Clone
 import           Language.PlutusCore.Error
 import           Language.PlutusCore.Evaluation.CkMachine
 import           Language.PlutusCore.Lexer
 import           Language.PlutusCore.Lexer.Type
 import           Language.PlutusCore.Name
-import           Language.PlutusCore.Normalize
 import           Language.PlutusCore.Parser
 import           Language.PlutusCore.Pretty
 import           Language.PlutusCore.Quote

--- a/language-plutus-core/src/Language/PlutusCore/Check/Normal.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Normal.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
+
+-- | This module makes sure terms and types are well-formed according to Fig. 2
+module Language.PlutusCore.Check.Normal ( check
+                                        , checkProgram
+                                        , checkTerm
+                                        , NormalizationError
+                                        , isTypeValue
+                                        , isTermValue
+                                        ) where
+
+import           Control.Monad.Except
+
+import           Data.Functor.Foldable
+import           Data.Functor.Foldable.Monadic
+
+import           Language.PlutusCore.Error
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Type
+import           PlutusPrelude
+
+-- | Ensure that all terms and types are well-formed accoring to Fig. 2
+checkProgram :: (MonadError (Error a) m) => Program TyName Name a -> m ()
+checkProgram p = void $ liftEither $ convertError $ preCheck p
+
+-- | Ensure that all terms and types are well-formed accoring to Fig. 2
+checkTerm :: (MonadError (Error a) m) => Term TyName Name a -> m ()
+checkTerm p = void $ liftEither $ convertError $ checkTerm p
+
+check :: Program tyname name a -> Maybe (NormalizationError tyname name a)
+check = go . preCheck where
+    go Right{}  = Nothing
+    go (Left x) = Just x
+
+-- | Ensure that all terms and types are well-formed accoring to Fig. 2
+preCheck :: Program tyname name a -> Either (NormalizationError tyname name a) (Program tyname name a)
+preCheck (Program l v t) = Program l v <$> checkT t
+
+-- this basically ensures all type instatiations, etc. occur only with type *values*
+checkT :: Term tyname name a -> Either (NormalizationError tyname name a) (Term tyname name a)
+checkT (Error l ty)      = Error l <$> typeValue ty
+checkT (TyInst l t ty)   = TyInst l <$> checkT t <*> typeValue ty
+checkT (Wrap l tn ty t)  = Wrap l tn <$> typeValue ty <*> checkT t
+checkT (Unwrap l t)      = Unwrap l <$> checkT t
+checkT (LamAbs l n ty t) = LamAbs l n <$> typeValue ty <*> checkT t
+checkT (Apply l t t')    = Apply l <$> checkT t <*> checkT t'
+checkT (TyAbs l tn k t)  = TyAbs l tn k <$> termValue t
+checkT t@Var{}           = pure t
+checkT t@Constant{}      = pure t
+
+isTermValue :: Term tyname name a -> Bool
+isTermValue = isRight . termValue
+
+-- ensure a term is a value
+termValue :: Term tyname name a -> Either (NormalizationError tyname name a) (Term tyname name a)
+termValue (LamAbs l n ty t) = LamAbs l n ty <$> checkT t
+termValue (Wrap l tn ty t)  = Wrap l tn ty <$> termValue t
+termValue (TyAbs l tn k t)  = TyAbs l tn k <$> termValue t
+termValue t                 = builtinValue t
+
+builtinValue :: Term tyname name a -> Either (NormalizationError tyname name a) (Term tyname name a)
+builtinValue t@Constant{}    = pure t
+builtinValue (TyInst l t ty) = TyInst l <$> builtinValue t <*> pure ty
+builtinValue (Apply l t t')  = Apply l <$> builtinValue t <*> termValue t'
+builtinValue t               = Left $ BadTerm (termLoc t) t "builtin value"
+
+isTypeValue :: Type tyname a -> Bool
+isTypeValue = isRight . typeValue
+
+-- ensure that a type is a type value
+typeValue :: Type tyname a -> Either (NormalizationError tyname name a) (Type tyname a)
+typeValue = cataM aM where
+
+    aM ty | isTyValue ty = pure (embed ty)
+          | otherwise    = neutralType (embed ty)
+
+    isTyValue TyFunF{}     = True
+    isTyValue TyForallF{}  = True
+    isTyValue TyFixF{}     = True
+    isTyValue TyLamF{}     = True
+    isTyValue TyBuiltinF{} = True
+    isTyValue TyIntF{}     = True
+    isTyValue _            = False
+
+-- ensure a type is a neutral type
+neutralType :: Type tyname a -> Either (NormalizationError tyname name a) (Type tyname a)
+neutralType = cataM aM where
+
+    aM ty | isNeutralType ty = pure (embed ty)
+          | otherwise        = Left (BadType (tyLocF ty) (embed ty) "neutral type")
+
+    isNeutralType TyVarF{} = True
+    isNeutralType TyAppF{} = True
+    isNeutralType _        = False
+
+    tyLocF = tyLoc . embed

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -14,24 +14,23 @@ module Language.PlutusCore.TypeSynthesis ( typecheckProgram
                                          , TypeCheckCfg (..)
                                          ) where
 
+import           Language.PlutusCore.Constant.Typed
+import           Language.PlutusCore.Error
+import           Language.PlutusCore.Lexer.Type     hiding (name)
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Normalize
+import           Language.PlutusCore.Quote
+import           Language.PlutusCore.Renamer        (annotateType)
+import           Language.PlutusCore.Type
+import           PlutusPrelude
+
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Control.Monad.State.Class
 import           Control.Monad.Trans.State          hiding (get, modify)
-import qualified Data.IntMap                        as IM
 import           Data.Map                           (Map)
 import qualified Data.Map                           as Map
-import           Language.PlutusCore.Clone
-import           Language.PlutusCore.Constant.Typed (DynamicBuiltinNameMeanings (..), dynamicBuiltinNameMeaningToType,
-                                                     typeOfBuiltinName)
-import           Language.PlutusCore.Error
-import           Language.PlutusCore.Lexer.Type     hiding (name)
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Renamer        (annotateType)
-import           Language.PlutusCore.Type
 import           Lens.Micro
-import           PlutusPrelude
 
 -- | Mapping from 'DynamicBuiltinName's to their 'Type's.
 newtype DynamicBuiltinNameTypes = DynamicBuiltinNameTypes
@@ -40,15 +39,13 @@ newtype DynamicBuiltinNameTypes = DynamicBuiltinNameTypes
 
 -- | Configuration of the type checker.
 data TypeConfig = TypeConfig
-    { _typeConfigNormalize           :: Bool                 -- ^ Whether to normalize type annotations
+    { _typeConfigNormalize           :: Bool
+      -- ^ Whether to normalize type annotations
     , _typeConfigDynBuiltinNameTypes :: DynamicBuiltinNameTypes
     }
 
-type TypeSt = IM.IntMap (NormalizedType TyNameWithKind ())
-
-data TypeCheckSt = TypeCheckSt
-    { _uniqueLookup :: TypeSt
-    , _gas          :: Natural
+newtype TypeCheckSt = TypeCheckSt
+    { _gas :: Natural
     }
 
 data TypeCheckCfg = TypeCheckCfg
@@ -59,9 +56,6 @@ data TypeCheckCfg = TypeCheckCfg
 -- | The type checking monad contains the 'BuiltinTable' and it lets us throw
 -- 'TypeError's.
 type TypeCheckM a = StateT TypeCheckSt (ReaderT TypeConfig (ExceptT (TypeError a) Quote))
-
-uniqueLookup :: Lens' TypeCheckSt TypeSt
-uniqueLookup f s = fmap (\x -> s { _uniqueLookup = x }) (f (_uniqueLookup s))
 
 gas :: Lens' TypeCheckSt Natural
 gas f s = fmap (\x -> s { _gas = x }) (f (_gas s))
@@ -125,11 +119,11 @@ runTypeCheckM :: TypeCheckCfg
               -> TypeCheckM a b
               -> ExceptT (TypeError a) Quote b
 runTypeCheckM (TypeCheckCfg i typeConfig) tc =
-    runReaderT (evalStateT tc (TypeCheckSt mempty i)) typeConfig
+    runReaderT (evalStateT tc (TypeCheckSt i)) typeConfig
 
 typeCheckStep :: TypeCheckM a ()
 typeCheckStep = do
-    (TypeCheckSt _ i) <- get
+    (TypeCheckSt i) <- get
     if i == 0
         then throwError OutOfGas
         else modify (over gas (subtract 1))
@@ -289,7 +283,7 @@ typeOf (TyInst x body ty) = do
             kindCheckM x ty nK
             vTy <- normalizeTypeOpt $ void ty
             typeCheckStep
-            normalizeTypeBinder n vTy vCod
+            substituteNormalizeType vTy n vCod
         _ -> throwError (TypeMismatch x (void body) (TyForall () dummyTyName dummyKind dummyType) vBodyTy)
 
 -- [infer| term : fix n vPat]    [fix n vPat / n] vPat ~> vRes
@@ -298,7 +292,7 @@ typeOf (TyInst x body ty) = do
 typeOf (Unwrap x term) = do
     vTermTy <- typeOf term
     case getNormalizedType vTermTy of
-        TyFix _ n vPat -> normalizeTypeBinder n vTermTy vPat
+        TyFix _ n vPat -> substituteNormalizeType vTermTy n vPat
         _              -> throwError (TypeMismatch x (void term) (TyFix () dummyTyName dummyType) vTermTy)
 
 -- [check| pat :: *]    pat ~>? vPat    [fix n vPat / n] vPat ~> vTermTy'    [check| term : vTermTy]
@@ -307,7 +301,7 @@ typeOf (Unwrap x term) = do
 typeOf (Wrap x n pat term) = do
     kindCheckM x pat $ Type ()
     vPat <- normalizeTypeOpt $ void pat
-    vTermTy <- normalizeTypeBinder (void n) (TyFix () (void n) <$> vPat) $ getNormalizedType vPat
+    vTermTy <- substituteNormalizeType (TyFix () (void n) <$> vPat) (void n) $ getNormalizedType vPat
     typeCheckStep
     typeCheckM x term vTermTy
     pure $ TyFix () (void n) <$> vPat
@@ -325,38 +319,6 @@ typeCheckM x term vTy = do
     vTermTy <- typeOf term
     when (vTermTy /= vTy) $ throwError (TypeMismatch x (void term) (getNormalizedType vTermTy) vTy)
 
-{- Note [NormalizedTypeBinder]
-'normalizeTypeBinder' is only ever used as normalizing substitution (we should probably change the name)
-that receives two already normalized types. However we do not enforce this in the type signature, because
-1) it's perfectly correct for the last argument to be non-normalized
-2) it would be annoying to wrap 'Type's into 'NormalizedType's
--}
-
-normalizeTypeBinder
-    :: TyNameWithKind ()
-    -> NormalizedType TyNameWithKind ()
-    -> Type TyNameWithKind ()
-    -> TypeCheckM a (NormalizedType TyNameWithKind ())
-normalizeTypeBinder n ty ty' = do
-    let u = extractUnique n
-    tyEnvAssign u ty
-    normalizeType ty' <* tyEnvDelete u
-
-extractUnique :: TyNameWithKind a -> Unique
-extractUnique = nameUnique . unTyName . unTyNameWithKind
-
--- This works because names are globally unique
-tyEnvDelete :: MonadState TypeCheckSt m
-            => Unique
-            -> m ()
-tyEnvDelete (Unique i) = modify (over uniqueLookup (IM.delete i))
-
-tyEnvAssign :: MonadState TypeCheckSt m
-            => Unique
-            -> NormalizedType TyNameWithKind ()
-            -> m ()
-tyEnvAssign (Unique i) ty = modify (over uniqueLookup (IM.insert i ty))
-
 -- this will reduce a type, or simply wrap it in a 'NormalizedType' constructor
 -- if we are working with normalized type annotations
 normalizeTypeOpt :: Type TyNameWithKind () -> TypeCheckM a (NormalizedType TyNameWithKind ())
@@ -365,29 +327,3 @@ normalizeTypeOpt ty = do
     if _typeConfigNormalize typeConfig
         then normalizeType ty
         else pure $ NormalizedType ty
-
--- | Normalize a 'Type'.
-normalizeType :: Type TyNameWithKind () -> TypeCheckM a (NormalizedType TyNameWithKind ())
-normalizeType (TyForall x tn k ty) = TyForall x tn k <<$>> normalizeType ty
-normalizeType (TyFix x tn ty)      = TyFix x tn <<$>> normalizeType ty
-normalizeType (TyFun x ty ty')     = TyFun x <<$>> normalizeType ty <<*>> normalizeType ty'
-normalizeType (TyLam x tn k ty)    = TyLam x tn k <<$>> normalizeType ty
-normalizeType (TyApp x fun arg)    = do
-    nFun <- normalizeType fun
-    nArg <- normalizeType arg
-    case getNormalizedType nFun of
-        TyLam _ name _ body -> normalizeTypeBinder name nArg body
-        _                   -> pure $ TyApp x <$> nFun <*> nArg
-normalizeType ty@(TyVar _ (TyNameWithKind (TyName (Name _ _ u)))) = do
-    (TypeCheckSt st _) <- get
-    case IM.lookup (unUnique u) st of
-
-        -- we must use recursive lookups because we can have an assignment
-        -- a -> b and an assignment b -> c which is locally valid but in
-        -- a smaller scope than a -> b.
-        Just ty'@(NormalizedType TyVar{}) -> pure ty'
-        Just ty'                          -> traverse alphaRename ty'
-        Nothing                           -> pure $ NormalizedType ty
-
-normalizeType ty@TyInt{}     = pure $ NormalizedType ty
-normalizeType ty@TyBuiltin{} = pure $ NormalizedType ty


### PR DESCRIPTION
This

1. moves `Language.PlutusCore.Normalize` to `Language.PlutusCore.Check.Normal`. We will have more checks (at least three more), so I made a folder for that
2. Unties type normalization from type checking
3. Sprinkles `rename` on term generators, because I was too lazy to prepare a separate pull request

I'll add some more docs, so do not merge yet.