### PR TITLE
use-cases: Add futures contract

### DIFF
--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -40,6 +40,7 @@ library
   exposed-modules:
     Language.Plutus.Coordination.Contracts
     Language.Plutus.Coordination.Contracts.CrowdFunding
+    Language.Plutus.Coordination.Contracts.Future
     Language.Plutus.Coordination.Contracts.Vesting
     Language.Plutus.Coordination.Contracts.Swap
     Language.Plutus.Runtime
@@ -56,6 +57,7 @@ test-suite plutus-use-cases-test
     main-is: Spec.hs
     other-modules:
       Spec.Crowdfunding
+      Spec.Future
       Spec.Vesting
     build-depends:
         base >=4.9 && <5,

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Future.hs
@@ -1,0 +1,308 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# OPTIONS -fplugin=Language.Plutus.CoreToPLC.Plugin -fplugin-opt Language.Plutus.CoreToPLC.Plugin:dont-typecheck #-}
+{-# OPTIONS_GHC -fno-warn-unused-matches #-}
+-- | A futures contract in Plutus. This example illustrates three concepts.
+--   1. Maintaining a margin (a kind of deposit) during the duration of the contract to protect against breach of contract (see note [Futures in Plutus])
+--   2. Using oracle values to obtain current pricing information (see note [Oracles] in Language.Plutus.Runtime)
+--   3. Using the redeemer script to model actions that the participants in the contract may take.
+module Language.Plutus.Coordination.Contracts.Future(
+    -- * Data types
+    Future(..),
+    FutureData(..),
+    FutureRedeemer(..),
+    -- * Actions
+    initialise,
+    settle,
+    settleEarly,
+    adjustMargin,
+    -- * Script
+    validatorScript
+    ) where
+
+import           Control.Monad.Error.Class  (MonadError (..))
+import qualified Data.Set                   as Set
+import           GHC.Generics               (Generic)
+import           Language.Plutus.Lift       (LiftPlc (..), TypeablePlc (..))
+import qualified Language.Plutus.Runtime.TH as TH
+import           Language.Plutus.TH         (plutus)
+import qualified Language.Plutus.TH         as Builtins
+import           Wallet.API                 (WalletAPI (..), WalletAPIError, otherError, pubKey, signAndSubmit)
+import           Wallet.UTXO                (DataScript (..), TxOutRef', Validator (..), scriptTxIn, scriptTxOut)
+import qualified Wallet.UTXO                as UTXO
+
+import           Language.Plutus.Runtime    (Height, OracleValue (..), PendingTx (..), PendingTxOut (..),
+                                             PendingTxOutType (..), PubKey, Signed (..), ValidatorHash, Value)
+
+import           Prelude                    hiding ((&&), (||))
+
+{- note [Futures in Plutus]
+
+A futures contract ("future") is an agreement to change ownership of an
+asset at a certain time (the delivery time) for an agreed price (the forward
+price). The time of the transfer, and the price, are fixed at the beginning of the contract.
+
+On the mockchain we only have one type of asset (namely, Ada coin value),
+so we simply exchange the difference in price between the forward price and the
+actual price. This is called a "cash settlement".
+
+The agreement involves two parties, a buyer (long position) and a seller (short
+position). At the delivery time the actual price of the asset (spot price) is
+quite likely different from the forward price. If the spot price is higher than
+the forward price, then the seller transfers the difference to the buyer. If
+the spot price is lower than the forward price, then the buyer transfers money
+to the seller. In either case there is a risk that the payer does not meet their
+obligation (by simply not paying). To protect against this risk, the contract
+includes a kind of deposit called "margin".
+
+Each party deposits an initial margin. If the price moves against the seller,
+then the seller has to top up their margin periodically (in our case, once each
+block). Likewise, if it moves against the buyer then the buyer has to top up
+their margin. If either party fails to make a margin payment then the contract
+will be settled early.
+
+The current value of the underlying asset is determined by an oracle. See note
+[Oracles] in Language.Plutus.Runtime.
+
+-}
+
+-- | Initialise the futures contract by paying the initial margin.
+--
+initialise :: (
+    MonadError WalletAPIError m,
+    WalletAPI m)
+    => PubKey
+    -- ^ Identity of the holder of the long position
+    -> PubKey
+    -- ^ Identity of the holder of the short position
+    -> Future
+    -> m ()
+initialise long short f = do
+    let
+        im = futureInitialMargin f
+        vl = fromIntegral im
+        o = scriptTxOut vl (validatorScript f) ds
+        ds = DataScript $ UTXO.lifted $ FutureData long short im im
+
+    (payment, change) <- createPaymentWithChange vl
+    signAndSubmit payment [o, change]
+
+-- | Close the position by extracting the payment
+settle :: (
+    MonadError WalletAPIError m,
+    WalletAPI m)
+    => [TxOutRef']
+    -> Future
+    -> FutureData
+    -> OracleValue Value
+    -> m ()
+settle refs ft fd ov = do
+    let
+        forwardPrice = futureUnitPrice ft
+        OracleValue (Signed (_, (_, spotPrice))) = ov
+        delta = futureUnits ft * (spotPrice - forwardPrice)
+        longOut = fromIntegral $ futureDataMarginLong fd + delta
+        shortOut = fromIntegral $ futureDataMarginShort fd - delta
+        red = UTXO.Redeemer $ UTXO.lifted $ Settle ov
+        outs = [
+            UTXO.pubKeyTxOut longOut (futureDataLong fd),
+            UTXO.pubKeyTxOut shortOut (futureDataShort fd)
+            ]
+        inp = (\r -> scriptTxIn r (validatorScript ft) red) <$> refs
+    signAndSubmit (Set.fromList inp) outs
+
+-- | Settle the position early if a margin payment has been missed.
+settleEarly :: (
+    MonadError WalletAPIError m,
+    WalletAPI m)
+    => [TxOutRef']
+    -> Future
+    -> FutureData
+    -> OracleValue Value
+    -> m ()
+settleEarly refs ft fd ov = do
+    let totalVal = fromIntegral $ futureDataMarginLong fd + futureDataMarginShort fd
+        outs = [UTXO.pubKeyTxOut totalVal (futureDataLong fd)]
+        inp = (\r -> scriptTxIn r (validatorScript ft) red) <$> refs
+        red = UTXO.Redeemer $ UTXO.lifted $ Settle ov
+    signAndSubmit (Set.fromList inp) outs
+
+adjustMargin :: (
+    MonadError WalletAPIError m,
+    WalletAPI m)
+    => [TxOutRef']
+    -> Future
+    -> FutureData
+    -> UTXO.Value
+    -> m ()
+adjustMargin refs ft fd vl = do
+    pk <- pubKey <$> myKeyPair
+    (payment, change) <- createPaymentWithChange vl
+    fd' <- let fd''
+                | pk == futureDataLong fd = pure $ fd { futureDataMarginLong  = fromIntegral vl + futureDataMarginLong fd  }
+                | pk == futureDataShort fd = pure $ fd { futureDataMarginShort = fromIntegral vl + futureDataMarginShort fd }
+                | otherwise = otherError "Private key is not part of futures contrat"
+            in fd''
+    let
+        red = UTXO.Redeemer $ UTXO.lifted AdjustMargin
+        ds  = DataScript $ UTXO.lifted fd'
+        o = scriptTxOut outVal (validatorScript ft) ds
+        outVal = vl + fromIntegral (futureDataMarginLong fd + futureDataMarginShort fd)
+        inp = Set.fromList $ (\r -> scriptTxIn r (validatorScript ft) red) <$> refs
+    signAndSubmit (Set.union payment inp) [o, change]
+
+
+-- | Basic data of a futures contract. `Future` contains all values that do not
+--   change during the lifetime of the contract.
+--
+data Future = Future {
+    futureDeliveryDate  :: Height,
+    futureUnits         :: Int,
+    futureUnitPrice     :: Value,
+    futureInitialMargin :: Value,
+    futurePriceOracle   :: PubKey,
+    futureMarginPenalty :: Value
+    -- ^ How much a participant loses if they fail to make the required margin
+    --   payments.
+    } deriving Generic
+
+instance LiftPlc Future
+instance TypeablePlc Future
+
+-- | The current "state" of the futures contract. `FutureData` contains values
+--   that may change during the lifetime of the contract. This is the data
+--   script.
+--
+data FutureData = FutureData {
+    futureDataLong        :: PubKey,
+    -- ^ Holder of the long position (buyer)
+    futureDataShort       :: PubKey,
+    -- ^ Holder of the short position (seller)
+    futureDataMarginLong  :: Value,
+    -- ^ Current balance of the margin account of the long position
+    futureDataMarginShort :: Value
+    -- ^ Current balance of the margin account of the short position
+    } deriving Generic
+
+instance LiftPlc FutureData
+instance TypeablePlc FutureData
+
+-- | Actions that either participant may take. This is the redeemer script.
+data FutureRedeemer =
+      AdjustMargin
+    -- ^ Make a margin payment
+    | Settle (OracleValue Value)
+    -- ^ Settle the contract
+    deriving Generic
+
+instance LiftPlc FutureRedeemer
+instance TypeablePlc FutureRedeemer
+
+validatorScript :: Future -> Validator
+validatorScript ft = Validator val where
+    val = UTXO.applyScript inner (UTXO.lifted ft)
+    inner = UTXO.fromPlcCode $(plutus [|
+        \Future{..} (r :: FutureRedeemer) FutureData{..} (p :: (PendingTx ValidatorHash)) ->
+
+            let
+                PendingTx _ outs _ _ height _ ownHash = p
+
+                eqPk :: PubKey -> PubKey -> Bool
+                eqPk = $(TH.eqPubKey)
+
+                infixr 3 &&
+                (&&) :: Bool -> Bool -> Bool
+                (&&) = $(TH.and)
+
+                infixr 3 ||
+                (||) :: Bool -> Bool -> Bool
+                (||) = $(TH.or)
+
+                -- Compute the required margin from the current price of the
+                -- underlying asset.
+                requiredMargin :: Value -> Value
+                requiredMargin spotPrice =
+                    let
+                        delta  = futureUnits * (spotPrice - futureUnitPrice)
+                    in
+                        futureMarginPenalty + delta
+
+                isPubKeyOutput :: PendingTxOut -> PubKey -> Bool
+                isPubKeyOutput o k = $(TH.maybe) False ($(TH.eqPubKey) k) ($(TH.pubKeyOutput) o)
+
+                --  | Check if a `PendingTxOut` is a public key output for the given pub. key and value
+                paidOutTo :: Value -> PubKey -> PendingTxOut -> Bool
+                paidOutTo vl pk txo =
+                    let PendingTxOut vl' _ _ = txo in
+                    isPubKeyOutput txo pk && vl == vl'
+
+                verifyOracle :: OracleValue a -> (Height, a)
+                verifyOracle (OracleValue (Signed (pk, t))) =
+                    if pk `eqPk` futurePriceOracle then t else Builtins.error ()
+
+                isValid =
+                    case r of
+
+                        -- Settling the contract is allowed if any of three conditions hold:
+                        --
+                        -- 1. The `futureDeliveryDate` has been reached. In this case both parties get what is left of their margin
+                        -- plus/minus the difference between spot and forward price.
+                        -- 2. The owner of the long position has failed to make a margin payment. In this case the owner of the short position gets both margins.
+                        -- 3. The owner of the short position has failed to make a margin payment. In this case the owner of the long position gets both margins.
+                        --
+                        -- In case (1) there are two payments (1 to each of the participants). In cases (2) and (3) there is only one payment.
+
+                        Settle ov ->
+                            let
+                                (_, spotPrice) = verifyOracle ov
+                                delta  = futureUnits *  (spotPrice - futureUnitPrice)
+                                expShort = futureDataMarginShort - delta
+                                expLong  = futureDataMarginLong + delta
+                                heightvalid = height >= futureDeliveryDate
+
+                                canSettle =
+                                    case outs of
+                                        (o1 :: PendingTxOut):(os::[PendingTxOut]) ->
+                                            case os of
+                                                (o2 :: PendingTxOut):(_::[PendingTxOut]) ->
+                                                    let paymentsValid =
+                                                            (paidOutTo expShort futureDataShort o1 && paidOutTo expLong futureDataLong o2)
+                                                            || (paidOutTo expShort futureDataShort o2 && paidOutTo expLong futureDataLong o1)
+                                                    in
+                                                        heightvalid && paymentsValid
+                                                (_::[PendingTxOut]) ->
+                                                    let
+                                                        totalMargin = futureDataMarginShort + futureDataMarginLong
+                                                        case2 = futureDataMarginLong < requiredMargin spotPrice
+                                                                && paidOutTo totalMargin futureDataShort o1
+
+                                                        case3 = futureDataMarginShort < requiredMargin spotPrice
+                                                                && paidOutTo totalMargin futureDataLong o1
+
+                                                    in
+                                                        case2 || case3
+                                        (_::[PendingTxOut]) -> False
+
+                            in
+                               canSettle
+
+                        -- For adjusting the margin we simply check that the amount locked in the contract
+                        -- is larger than it was before.
+                        --
+                        AdjustMargin ->
+                            case outs of
+                                (ot :: PendingTxOut):(_::[PendingTxOut]) ->
+                                    case ot of
+                                        PendingTxOut v (Just (vh, _)) DataTxOut ->
+                                            v > futureDataMarginShort + futureDataMarginLong
+                                            && $(TH.eqValidator) vh ownHash
+                                        _ -> True
+
+                                (_::[PendingTxOut]) -> False
+            in
+                if isValid then () else Builtins.error ()
+            |])

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
@@ -11,7 +11,7 @@ module Language.Plutus.Coordination.Contracts.Swap(
     ) where
 
 import           Language.Plutus.Runtime    (OracleValue (..), PendingTx (..), PendingTxIn (..), PendingTxOut (..),
-                                             PubKey, Value)
+                                             PubKey, ValidatorHash, Value)
 import qualified Language.Plutus.Runtime.TH as TH
 import           Language.Plutus.TH         (plutus)
 import qualified Language.Plutus.TH         as Builtins
@@ -59,7 +59,7 @@ type SwapOracle = OracleValue (Ratio Int)
 --       Language.Plutus.Coordination.Contracts
 swapValidator :: Swap -> Validator
 swapValidator _ = Validator result where
-    result = UTXO.fromPlcCode $(plutus [| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx) Swap{..} ->
+    result = UTXO.fromPlcCode $(plutus [| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx ValidatorHash) Swap{..} ->
         let
             infixr 3 &&
             (&&) :: Bool -> Bool -> Bool
@@ -124,7 +124,7 @@ swapValidator _ = Validator result where
             -- NOTE: Partial match is OK because if it fails then the PLC script
             --       terminates with `error` and the validation fails (which is
             --       what we want when the number of inputs and outputs is /= 2)
-            PendingTx [t1, t2] [o1, o2] _ _ _ _ = p
+            PendingTx [t1, t2] [o1, o2] _ _ _ _ _ = p
 
             -- Each participant must deposit the margin. But we don't know
             -- which of the two participant's deposit we are currently

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
@@ -109,7 +109,7 @@ validatorScriptHash = Runtime.plcValidatorHash . validatorScript
 validatorScript :: Vesting -> Validator
 validatorScript v = Validator val where
     val = UTXO.applyScript inner (UTXO.lifted v)
-    inner = UTXO.fromPlcCode $(plutus [| \Vesting{..} () VestingData{..} (p :: PendingTx) ->
+    inner = UTXO.fromPlcCode $(plutus [| \Vesting{..} () VestingData{..} (p :: PendingTx ValidatorHash) ->
         let
 
             eqBs :: ValidatorHash -> ValidatorHash -> Bool
@@ -122,7 +122,7 @@ validatorScript v = Validator val where
             (&&) :: Bool -> Bool -> Bool
             (&&) = $( TH.and )
 
-            PendingTx _ os _ _ h _ = p
+            PendingTx _ os _ _ h _ _ = p
             VestingTranche d1 a1 = vestingTranche1
             VestingTranche d2 a2 = vestingTranche2
 

--- a/plutus-use-cases/src/Language/Plutus/Runtime.hs
+++ b/plutus-use-cases/src/Language/Plutus/Runtime.hs
@@ -39,14 +39,24 @@ I'm not sure how oracles are going to work eventually, so I'm going to use this
 definition for now:
 
 * Oracles are identified by their public key
+
 * An oracle can produce "observations", which are values annotated with time
-  (block height). These observations are signed by the oracle.
+  (block height). These observations are signed by the oracle. This means we are
+  assume a _trusted_ oracle (as opposed to services such as
+  http://www.oraclize.it/ who provide untrusted oracles). Trusting the oracle
+  makes sense when dealing with financial data: Current prices etc. are usually
+  provided by companies such as Bloomberg or Yahoo Finance, who are
+  necessarily trusted by the consumers of their data. It seems reasonable to
+  assume that similar providers will exist for Plutus, who simply sign the
+  data with a known key in the way we implemented it here.
+
 * To use an oracle value inside a validator script, it has to be provided as the
-  data script of the transaction that consumes the output locked by the
+  redeemer script of the transaction that consumes the output locked by the
   validator script.
 
-An example of this can be found in the
-Language.Plutus.Coordination.Contracts.Swap.swapValidator script.
+Examples of this can be found in the
+Language.Plutus.Coordination.Contracts.Swap.swapValidator and
+Language.Plutus.Coordination.Contracts.Future.validatorScript scripts.
 
 -}
 

--- a/plutus-use-cases/src/Language/Plutus/Runtime/TH.hs
+++ b/plutus-use-cases/src/Language/Plutus/Runtime/TH.hs
@@ -56,9 +56,9 @@ max = [| \(a :: Int) (b :: Int) -> if a > b then a else b |]
 -- | Check if a transaction was signed by a public key
 txSignedBy :: Q Exp
 txSignedBy = [|
-    \(p :: PendingTx) (PubKey k) ->
+    \(p :: PendingTx ValidatorHash) (PubKey k) ->
         let
-            PendingTx _ _ _ _ _ sigs = p
+            PendingTx _ _ _ _ _ sigs _ = p
 
             signedBy :: Signature -> Bool
             signedBy (Signature s) = s == k

--- a/plutus-use-cases/test/Spec.hs
+++ b/plutus-use-cases/test/Spec.hs
@@ -2,6 +2,7 @@
 module Main(main) where
 
 import qualified Spec.Crowdfunding
+import qualified Spec.Future
 import qualified Spec.Vesting
 import           Test.Tasty
 import           Test.Tasty.Hedgehog (HedgehogTestLimit (..))
@@ -19,5 +20,6 @@ limit = HedgehogTestLimit (Just 30)
 tests :: TestTree
 tests = localOption limit $ testGroup "use cases" [
     Spec.Crowdfunding.tests,
-    Spec.Vesting.tests
+    Spec.Vesting.tests,
+    Spec.Future.tests
     ]

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+module Spec.Future(tests) where
+
+import           Control.Monad                                 (void)
+import           Data.Either                                   (isRight)
+import           Data.Foldable                                 (traverse_)
+import qualified Data.Map                                      as Map
+import           Hedgehog                                      (Property, forAll, property)
+import qualified Hedgehog
+import           Test.Tasty
+import           Test.Tasty.Hedgehog                           (testProperty)
+
+import           Prelude                                       hiding (init)
+import           Wallet.API                                    (PubKey (..))
+import           Wallet.Emulator                               hiding (Value)
+import qualified Wallet.Generators                             as Gen
+import qualified Wallet.UTXO                                   as UTXO
+import           Wallet.UTXO.Runtime                           (OracleValue (..), Signed (..))
+import qualified Wallet.UTXO.Runtime                           as Runtime
+
+import           Language.Plutus.Coordination.Contracts.Future (Future (..), FutureData (..))
+import qualified Language.Plutus.Coordination.Contracts.Future as F
+
+tests :: TestTree
+tests = testGroup "futures" [
+    testProperty "commit initial margin" initialiseFuture,
+    testProperty "close the position" settle,
+    testProperty "close early if margin payment was missed" settleEarly,
+    testProperty "increase the margin" increaseMargin
+    ]
+
+init :: Wallet -> Trace EmulatedWalletApi TxOutRef'
+init w = outp <$> walletAction w (F.initialise (PubKey 1) (PubKey 2) contract) where
+    outp = snd . head . filter (isPayToScriptOut . fst) . txOutRefs . head
+
+adjustMargin :: Wallet -> [TxOutRef'] -> FutureData -> UTXO.Value -> Trace EmulatedWalletApi TxOutRef'
+adjustMargin w refs fd vl =
+    outp <$> walletAction w (F.adjustMargin refs contract fd vl) where
+        outp = snd . head . filter (isPayToScriptOut . fst) . txOutRefs . head
+
+-- | Initialise the futures contract with contributions from wallets 1 and 2,
+--   and update all wallets. Running `initBoth` will increase the block height
+--   by 2.
+initBoth :: Trace EmulatedWalletApi [TxOutRef']
+initBoth = do
+    updateAll
+    ins <- traverse init [w1, w2]
+    updateAll
+    return ins
+
+
+initialiseFuture :: Property
+initialiseFuture = checkTrace $ do
+    void initBoth
+    traverse_ (uncurry assertOwnFundsEq) [
+        (w1, startingBalance - initMargin),
+        (w2, startingBalance - initMargin)]
+
+settle :: Property
+settle = checkTrace $ do
+    ins <- initBoth
+    let
+        im = fromIntegral initMargin
+        cur = FutureData (PubKey 1) (PubKey 2) im im
+        spotPrice = 1124
+        delta = fromIntegral $ units * (spotPrice - forwardPrice)
+        ov  = OracleValue (Signed (oracle, (10, spotPrice)))
+
+    -- advance the clock to block height 10
+    void $ addBlocks 8
+    void $ walletAction w2 (F.settle ins contract cur ov)
+    updateAll
+    traverse_ (uncurry assertOwnFundsEq) [
+        (w1, startingBalance + delta),
+        (w2, startingBalance - delta)]
+
+settleEarly :: Property
+settleEarly = checkTrace $ do
+    ins <- initBoth
+    let
+        im = fromIntegral initMargin
+        cur = FutureData (PubKey 1) (PubKey 2) im im
+
+        -- In this example, the price moves up (in favour of the long position)
+        -- Wallet 2 fails to make the required margin payment, so wallet 1
+        -- can the entire margin of wallet 2, including the penalty fee.
+        -- This illustrates how the participants are incentivised to keep
+        -- up with the variation margin.
+        (_, upper) = marginRange
+        spotPrice = upper + 1
+        ov  = OracleValue (Signed (oracle, (8, spotPrice)))
+
+    -- advance the clock to block height 8
+    void $ addBlocks 6
+    void $ walletAction w1 (F.settleEarly ins contract cur ov)
+    updateAll
+    traverse_ (uncurry assertOwnFundsEq) [
+        (w1, startingBalance + initMargin),
+        (w2, startingBalance - initMargin)]
+
+increaseMargin :: Property
+increaseMargin = checkTrace $ do
+    ins <- initBoth
+    let
+        im = fromIntegral initMargin
+        cur = FutureData (PubKey 1) (PubKey 2) im im
+        increase = fromIntegral units * 5
+
+    -- advance the clock to block height 8
+    void $ addBlocks 6
+
+    -- Commit an additional `units * 5` amount of funds
+    ins' <- adjustMargin w2 ins cur increase
+    updateAll
+    traverse_ (uncurry assertOwnFundsEq) [(w2, startingBalance - (initMargin + increase))]
+    -- advance the clock to block height 10
+    void $ addBlocks 2
+
+    -- Now the contract has ended successfully and wallet 2 gets some of its
+    -- margin back.
+    let
+        im' = fromIntegral $ initMargin + increase
+        cur' = cur { futureDataMarginShort = im' }
+
+        (_, upper) = marginRange
+        -- Note that this price would have caused the contract to end
+        -- prematurely if it hadn't been for the increase (compare with
+        -- settleEarly above)
+        spotPrice = upper + 1
+
+        delta = fromIntegral $ units * (spotPrice - forwardPrice)
+        ov  = OracleValue (Signed (oracle, (10, spotPrice)))
+
+    void $ walletAction w2 (F.settle [ins'] contract cur' ov)
+    updateAll
+
+    -- NOTE: At this point, (initMargin - penalty) < delta < im'
+    --       Meaning that it is still more profitable for wallet 2
+    --       to see the contract through (via `settle`) than to
+    --       simply ignore it and hence lose its entire margin im'.
+    traverse_ (uncurry assertOwnFundsEq) [
+        (w1, startingBalance + delta),
+        (w2, startingBalance - delta)]
+
+-- | A futures contract over 187 units with a forward price of 1233, due at
+--   10 blocks.
+contract :: Future
+contract = Future {
+    futureDeliveryDate  = 10,
+    futureUnits         = units,
+    futureUnitPrice     = forwardPrice,
+    futureInitialMargin = im,
+    futurePriceOracle   = oracle,
+    futureMarginPenalty = penalty
+    } where
+        im = penalty + (units * forwardPrice `div` 20) -- 5%
+
+-- | Margin penalty
+penalty :: Runtime.Value
+penalty = 1000
+
+-- | The forward price agreed at the beginning of the contract.
+forwardPrice :: Runtime.Value
+forwardPrice = 1123
+
+-- | Range within which the underlying asset's price can move before the first
+--   margin payment is necessary.
+--   If the price approaches the lower range, then the buyer (long position,
+--   Wallet 1) has to increase their margin, and vice versa.
+marginRange :: (Runtime.Value, Runtime.Value)
+marginRange = (forwardPrice - delta, forwardPrice + delta) where
+    delta = forwardPrice `div` 20
+
+-- | How many units of the underlying asset are covered by the contract.
+units :: Int
+units = 187
+
+-- | Wallet 1. Holder of the "long" position in the contract.
+w1 :: Wallet
+w1 = Wallet 1
+
+-- | Wallet 2. Holder of the "short" position in the contract.
+w2 :: Wallet
+w2 = Wallet 2
+
+oracle :: PubKey
+oracle = PubKey 17
+
+initMargin :: UTXO.Value
+initMargin = fromIntegral $ futureInitialMargin contract
+
+-- | Funds available to wallets at the beginning.
+startingBalance :: UTXO.Value
+startingBalance = 1000000
+
+-- | Run a trace with the given scenario and check that the emulator finished
+--   successfully with an empty transaction pool.
+checkTrace :: Trace EmulatedWalletApi () -> Property
+checkTrace t = property $ do
+    let
+        ib = Map.fromList [(PubKey 1, startingBalance), (PubKey 2, startingBalance)]
+        model = Gen.generatorModel { Gen.gmInitialBalance = ib }
+    (result, st) <- forAll $ Gen.runTraceOn model t
+    Hedgehog.assert (isRight result)
+    Hedgehog.assert ([] == emTxPool st)
+
+-- | Validate all pending transactions and notify all wallets
+updateAll :: Trace EmulatedWalletApi ()
+updateAll =
+    blockchainActions >>= void . walletsNotifyBlock [w1, w2]

--- a/wallet-api/src/Wallet/UTXO/Runtime.hs
+++ b/wallet-api/src/Wallet/UTXO/Runtime.hs
@@ -38,6 +38,12 @@ import           Language.Plutus.Lift (LiftPlc (..), TypeablePlc (..))
 import           Wallet.UTXO.Types    (PubKey (..), Signature (..))
 import qualified Wallet.UTXO.Types    as UTXO
 
+-- Ignore newtype warnings related to `Oracle` and `Signed` because it causes
+-- problems with the plugin
+--
+-- TODO: Remove annotation once `newtype Oracle = (...)` works
+{-# ANN module "HLint: ignore Use newtype instead of data" #-}
+
 data PendingTxOutType =
     PubKeyTxOut PubKey -- ^ Pub key address
     | DataTxOut -- ^ The data script of the pending transaction output (see note [Script types in pending transactions])
@@ -91,13 +97,13 @@ instance LiftPlc (PendingTx ValidatorHash)
 
 -- `OracleValue a` is the value observed at a time signed by
 -- an oracle.
-newtype OracleValue a = OracleValue (Signed (Height, a))
+data OracleValue a = OracleValue (Signed (Height, a))
     deriving Generic
 
 instance TypeablePlc a => TypeablePlc (OracleValue a)
 instance (TypeablePlc a, LiftPlc a) => LiftPlc (OracleValue a)
 
-newtype Signed a = Signed (PubKey, a)
+data Signed a = Signed (PubKey, a)
     deriving Generic
 
 instance TypeablePlc a => TypeablePlc (Signed a)

--- a/wallet-api/src/Wallet/UTXO/Runtime.hs
+++ b/wallet-api/src/Wallet/UTXO/Runtime.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleInstances #-}
 -- | A model of the types involved in transactions. These types are intented to
 --   be used in PLC scripts.
 module Wallet.UTXO.Runtime (-- * Transactions and related types
@@ -75,17 +76,18 @@ instance TypeablePlc PendingTxIn
 instance LiftPlc PendingTxIn
 
 -- | A pending transaction as seen by validator scripts.
-data PendingTx = PendingTx {
+data PendingTx a = PendingTx {
     pendingTxInputs      :: [PendingTxIn], -- ^ Transaction inputs
     pendingTxOutputs     :: [PendingTxOut],
     pendingTxFee         :: Value,
     pendingTxForge       :: Value,
     pendingTxBlockHeight :: Height,
-    pendingTxSignatures  :: [Signature]
-    } deriving Generic
+    pendingTxSignatures  :: [Signature],
+    pendingTxOwnHash     :: a -- ^ Hash of the validator script that is currently running
+    } deriving (Functor, Generic)
 
-instance TypeablePlc PendingTx
-instance LiftPlc PendingTx
+instance TypeablePlc (PendingTx ValidatorHash)
+instance LiftPlc (PendingTx ValidatorHash)
 
 -- `OracleValue a` is the value observed at a time signed by
 -- an oracle.


### PR DESCRIPTION
* Add a futures contract that demonstrates variable margins, oracles and
  "actions" that can be performed on a contract (through the redeemer
  script)