### PR TITLE
PIR: learn about provenances

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Type.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Type.hs
@@ -522,10 +522,10 @@ mkScottConstructorBody resultTypeName caseNamesAndTypes argNamesAndTypes index m
     let
         -- data types are always in kind Type
         resultKind = PLC.Type ()
-        thisConstructor = PLC.mkVar $ caseNamesAndTypes !! index
+        thisConstructor = PLC.mkVar () $ caseNamesAndTypes !! index
         -- See Note [Iterated abstraction and application]
         -- c_i a_1 .. a_m
-        applied = foldl' (\acc a -> PLC.Apply () acc a) thisConstructor (fmap PLC.mkVar argNamesAndTypes)
+        applied = foldl' (\acc a -> PLC.Apply () acc a) thisConstructor (fmap (PLC.mkVar ()) argNamesAndTypes)
         -- \c_1 .. c_n . applied
         cfuncs = PLC.mkIterLamAbs () caseNamesAndTypes applied
         -- no need for a body value check here, we know it's a lambda (see Note [Value restriction])

--- a/core-to-plc/src/Language/Plutus/Lift.hs
+++ b/core-to-plc/src/Language/Plutus/Lift.hs
@@ -210,7 +210,7 @@ instance (GGetConstructorTypes f, GGetConstructorArgs f, Datatype d)  => GLiftPl
                 let ty = mkIterTyFun () tys (TyVar () r)
                 pure $ VarDecl () arg ty
 
-        pure $ TyAbs () r (Type ()) $ mkIterLamAbs () cases $ mkIterApp () (mkVar $ cases !! index) (snd constr)
+        pure $ TyAbs () r (Type ()) $ mkIterLamAbs () cases $ mkIterApp () (mkVar () $ cases !! index) (snd constr)
 
 -- Auxiliary generic functions
 

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -31,6 +31,8 @@ module Language.PlutusCore
     , getNormalizedType
     , defaultVersion
     , allBuiltinNames
+    , termLoc
+    , tyLoc
     -- * Lexer
     , AlexPosn (..)
     -- * Views

--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -28,16 +28,16 @@ data VarDecl tyname name a = VarDecl {varDeclAnn::a, varDeclName::name a, varDec
     deriving (Functor, Show, Eq, Generic)
 
 -- | Make a 'Var' referencing the given 'VarDecl'.
-mkVar :: VarDecl tyname name () -> Term tyname name ()
-mkVar = Var () . varDeclName
+mkVar :: a -> VarDecl tyname name a -> Term tyname name a
+mkVar x = Var x . varDeclName
 
 -- | A "type variable declaration", i.e. a name and a kind for a type variable.
 data TyVarDecl tyname a = TyVarDecl {tyVarDeclAnn::a, tyVarDeclName::tyname a, tyVarDeclKind::Kind a}
     deriving (Functor, Show, Eq, Generic)
 
 -- | Make a 'TyVar' referencing the given 'TyVarDecl'.
-mkTyVar :: TyVarDecl tyname () -> Type tyname ()
-mkTyVar = TyVar () . tyVarDeclName
+mkTyVar :: a -> TyVarDecl tyname a -> Type tyname a
+mkTyVar x = TyVar x . tyVarDeclName
 
 -- | A definition. Pretty much just a pair with more descriptive names.
 data Def var val = Def { defVar::var, defVal::val}

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
@@ -238,7 +238,7 @@ getBuiltinFixN n = do
                 Apply () (TyInst () (Var () k) (TyVar () b)) $
                 mkIterLamAbs () fs $
                 -- this is an ugly but straightforward way of getting the right fi
-                Apply () (mkVar (fs !! i)) (Var () x)
+                Apply () (mkVar () (fs !! i)) (Var () x)
 
     -- a list of all the branches
     branches <- forM (zip asbs [0..]) $ uncurry branch

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Tuple.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Tuple.hs
@@ -28,7 +28,7 @@ getBuiltinTuple arity = do
         pure $ TyVarDecl () tn $ Type ()
 
     resultType <- liftQuote $ freshTyName () "r"
-    let caseType = mkIterTyFun () (fmap mkTyVar tyVars) (TyVar () resultType)
+    let caseType = mkIterTyFun () (fmap (mkTyVar ()) tyVars) (TyVar () resultType)
     pure $
         -- \T_1 .. T_n
         mkIterTyLam () tyVars $
@@ -55,10 +55,10 @@ getBuiltinTupleConstructor arity = do
 
     args <- for [0..(arity -1)] $ \i -> do
         n <- liftQuote $ freshName () $ strToBs $ "arg_" ++ show i
-        pure $ VarDecl () n $ mkTyVar $ tyVars !! i
+        pure $ VarDecl () n $ mkTyVar () $ tyVars !! i
 
     caseArg <- liftQuote $ freshName () "case"
-    let caseTy = mkIterTyFun () (fmap mkTyVar tyVars) (TyVar () resultType)
+    let caseTy = mkIterTyFun () (fmap (mkTyVar ()) tyVars) (TyVar () resultType)
     pure $
         -- /\T_1 .. T_n
         mkIterTyAbs () tyVars $
@@ -69,7 +69,7 @@ getBuiltinTupleConstructor arity = do
         -- \case
         LamAbs () caseArg caseTy $
         -- case arg_1 .. arg_n
-        mkIterApp () (Var () caseArg) $ fmap mkVar args
+        mkIterApp () (Var () caseArg) $ fmap (mkVar ()) args
 
 -- | Given an arity @n@ and an index @i@, create a function for accessing the i'th component of a n-tuple.
 --
@@ -86,13 +86,13 @@ getBuiltinTupleAccessor arity index = rename =<< do
 
     tupleTy <- do
         genericTuple <- getBuiltinTuple arity
-        pure $ mkIterTyApp () genericTuple (fmap mkTyVar tyVars)
-    let selectedTy = mkTyVar $ tyVars !! index
+        pure $ mkIterTyApp () genericTuple (fmap (mkTyVar ()) tyVars)
+    let selectedTy = mkTyVar () $ tyVars !! index
 
     args <- for [0..(arity -1)] $ \i -> do
         n <- liftQuote $ freshName () $ strToBs $ "arg_" ++ show i
-        pure $ VarDecl () n $ mkTyVar $ tyVars !! i
-    let selectedArg = mkVar $ args !! index
+        pure $ VarDecl () n $ mkTyVar () $ tyVars !! i
+    let selectedArg = mkVar () $ args !! index
 
     tupleArg <- liftQuote $ freshName () "tuple"
     pure $

--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -32,6 +32,7 @@ library
         Language.PlutusIR.Compiler.Error
         Language.PlutusIR.Compiler.Term
         Language.PlutusIR.Compiler.Datatype
+        Language.PlutusIR.Compiler.Provenance
         Language.PlutusIR.Compiler.Recursion
         Language.PlutusIR.Compiler.Types
     default-language: Haskell2010

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -9,9 +9,12 @@ module Language.PlutusIR (
     Name (..),
     VarDecl (..),
     TyVarDecl (..),
+    varDeclNameString,
+    tyVarDeclNameString,
     Kind (..),
     Type (..),
     Datatype (..),
+    datatypeNameString,
     Recursivity (..),
     Binding (..),
     Term (..),
@@ -32,6 +35,15 @@ import           GHC.Generics               (Generic)
 
 data Datatype tyname name a = Datatype a (TyVarDecl tyname a) [TyVarDecl tyname a] (name a) [VarDecl tyname name a]
     deriving (Functor, Show, Eq, Generic)
+
+varDeclNameString :: VarDecl name Name a -> String
+varDeclNameString = bsToStr . PLC.nameString . varDeclName
+
+tyVarDeclNameString :: TyVarDecl TyName a -> String
+tyVarDeclNameString = bsToStr . PLC.nameString . PLC.unTyName . tyVarDeclName
+
+datatypeNameString :: Datatype TyName name a -> String
+datatypeNameString (Datatype _ tn _ _ _) = tyVarDeclNameString tn
 
 -- Bindings
 

--- a/plutus-ir/src/Language/PlutusIR/Compiler.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler.hs
@@ -3,17 +3,19 @@ module Language.PlutusIR.Compiler (
     compileTerm,
     Compiling,
     CompError (..),
-    runCompiling) where
+    Provenance (..)) where
 
 import           Language.PlutusIR
+
 import           Language.PlutusIR.Compiler.Error
-import qualified Language.PlutusIR.Compiler.Term  as Term
+import           Language.PlutusIR.Compiler.Provenance
+import qualified Language.PlutusIR.Compiler.Term       as Term
 import           Language.PlutusIR.Compiler.Types
 
-import qualified Language.PlutusCore              as PLC
+import qualified Language.PlutusCore                   as PLC
 
 import           Control.Monad
 
 -- | Compile a 'Term' into a PLC Term. Note: the result *does* have globally unique names.
-compileTerm :: Compiling m => Term TyName Name () -> m (PLC.Term TyName Name ())
-compileTerm = PLC.rename <=< Term.compileTerm
+compileTerm :: Compiling m a => Term TyName Name a -> m (PLCTerm a)
+compileTerm = (PLC.rename <=< Term.compileTerm) . original

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
@@ -4,16 +4,18 @@
 module Language.PlutusIR.Compiler.Datatype (compileDatatype) where
 
 import           Language.PlutusIR
+import           Language.PlutusIR.Compiler.Provenance
+import           Language.PlutusIR.Compiler.Types
 
-import           PlutusPrelude             (strToBs)
+import           PlutusPrelude                         (strToBs)
 
-import qualified Language.PlutusCore       as PLC
-import qualified Language.PlutusCore.MkPlc as PLC
+import qualified Language.PlutusCore                   as PLC
+import qualified Language.PlutusCore.MkPlc             as PLC
 import           Language.PlutusCore.Quote
-import qualified Language.PlutusCore.Subst as PLC
+import qualified Language.PlutusCore.Subst             as PLC
 
-import           Data.List
-import           Data.Maybe
+import           Control.Monad.Reader
+
 import           Data.Semigroup
 import           Data.Traversable
 
@@ -43,11 +45,11 @@ constructorArgTypes :: VarDecl tyname name a -> [PLC.Type tyname a]
 constructorArgTypes = funTyArgs . varDeclType
 
 -- | "Unveil" a datatype definition in a type, by replacing uses of the name as a type variable with the concrete definition.
-unveilDatatype :: Type TyName () -> Datatype TyName Name () -> Type TyName () -> Type TyName ()
+unveilDatatype :: Eq (tyname a) => Type tyname a -> Datatype tyname name a -> Type tyname a -> Type tyname a
 unveilDatatype dty (Datatype _ tn _ _ _) = PLC.substTy (\n -> if n == tyVarDeclName tn then Just dty else Nothing)
 
-resultTypeName :: MonadQuote m => Datatype TyName Name () -> m (TyName ())
-resultTypeName (Datatype _ tn _ _ _) = liftQuote $ freshTyName () $ "out_" <> (nameString $ unTyName $ tyVarDeclName tn)
+resultTypeName :: Compiling m a => Datatype TyName Name (Provenance a) -> m (TyName (Provenance a))
+resultTypeName (Datatype _ tn _ _ _) = ask >>= \p -> liftQuote $ freshTyName p $ "out_" <> (nameString $ unTyName $ tyVarDeclName tn)
 
 -- Datatypes
 
@@ -209,22 +211,23 @@ For a (self-)recursive datatype we have to change three things:
 -- See note [Scott encoding of datatypes]
 -- | Make the "Scott-encoded" type for a 'Datatype', with type variables free.
 -- @mkScottTy Maybe = forall out_Maybe. out_Maybe -> (a -> out_Maybe) -> out_Maybe@
-mkScottTy :: MonadQuote m => Datatype TyName Name () -> m (PLC.Type TyName ())
+mkScottTy :: forall m a . Compiling m a => Datatype TyName Name (Provenance a) -> m (PLCType a)
 mkScottTy d@(Datatype _ _ _ _ constrs) = do
+    p <- ask
     resultType <- resultTypeName d
-    let caseTys = fmap (constructorCaseType (PLC.TyVar () resultType)) constrs
+    let caseTys = fmap (constructorCaseType (PLC.TyVar p resultType)) constrs
     pure $
         -- forall resultType
-        PLC.TyForall () resultType (PLC.Type ()) $
+        PLC.TyForall p resultType (PLC.Type p) $
         -- c_1 -> .. -> c_n -> resultType
-        PLC.mkIterTyFun () caseTys (PLC.TyVar () resultType)
+        PLC.mkIterTyFun p caseTys (PLC.TyVar p resultType)
 
 -- | Make the "pattern functor" of a 'Datatype'. This is just the normal type, but with the
 -- type variable for the type itself free. In the case of non-recursive datatypes this is just the
 -- datatype.
 -- @mkDatatypePatternFunctor List = \(a :: *) -> forall (r :: *) . r -> (a -> List a -> r) -> r@
-mkDatatypePatternFunctor :: MonadQuote m => Datatype TyName Name () -> m (PLC.Type TyName ())
-mkDatatypePatternFunctor d@(Datatype _ _ tvs _ _) = PLC.mkIterTyLam () tvs <$> mkScottTy d
+mkDatatypePatternFunctor :: Compiling m a => Datatype TyName Name (Provenance a) -> m (PLCType a)
+mkDatatypePatternFunctor d@(Datatype _ _ tvs _ _) = local (DatatypeComponent PatternFunctor) $ PLC.mkIterTyLam <$> ask <*> pure tvs <*> mkScottTy d
 
 -- | Make the real PLC type corresponding to a 'Datatype' with the given pattern functor.
 -- @
@@ -232,13 +235,13 @@ mkDatatypePatternFunctor d@(Datatype _ _ tvs _ _) = PLC.mkIterTyLam () tvs <$> m
 --         = fix list . <pattern functor of List>
 --         = fix list . \(a :: *) -> forall (r :: *) . r -> (a -> List a -> r) -> r
 -- @
-mkDatatypeType :: MonadQuote m => Recursivity -> Type TyName () -> Datatype TyName Name () -> m (PLC.Type TyName ())
-mkDatatypeType r pf (Datatype _ tn _ _ _) = pure $ case r of
-    NonRec -> pf
+mkDatatypeType :: Compiling m a => Recursivity -> PLCType a -> Datatype TyName Name (Provenance a) -> m (PLCType a)
+mkDatatypeType r pf (Datatype _ tn _ _ _) = local (DatatypeComponent DatatypeType) $ case r of
+    NonRec -> pure pf
     -- See note [Recursive datatypes]
     -- We are reusing the same type name for the fixpoint variable. This is fine
     -- so long as we do renaming later, since we only reuse the name inside an inner binder
-    Rec    -> PLC.TyFix () (tyVarDeclName tn) pf
+    Rec    -> ask >>= \p -> pure $ PLC.TyFix p (tyVarDeclName tn) pf
 
 -- Constructors
 
@@ -247,11 +250,11 @@ mkDatatypeType r pf (Datatype _ tn _ _ _) = pure $ case r of
 -- @
 --     mkConstructorType List Cons = forall (a :: *) . a -> List a -> List a
 -- @
-mkConstructorType :: MonadQuote m => Datatype TyName Name () -> VarDecl TyName Name () -> m (PLC.Type TyName ())
+mkConstructorType :: Compiling m a => Datatype TyName Name (Provenance a) -> VarDecl TyName Name (Provenance a) -> m (PLCType a)
 -- this type appears *inside* the scope of the abstraction for the datatype so we can just reference the name and
 -- we don't need to do anything to the declared type
 -- see note [Abstract data types]
-mkConstructorType (Datatype _ _ tvs _ _) constr = pure $ PLC.mkIterTyForall () tvs (varDeclType constr)
+mkConstructorType (Datatype _ _ tvs _ _) constr = local (DatatypeComponent ConstructorType) $ PLC.mkIterTyForall <$> ask <*> pure tvs <*> pure (varDeclType constr)
 
 -- See note [Scott encoding of datatypes]
 -- | Make a constructor of a 'Datatype' with the given pattern functor. The constructor argument mostly serves to identify the constructor
@@ -262,8 +265,9 @@ mkConstructorType (Datatype _ _ tvs _ _) constr = pure $ PLC.mkIterTyForall () t
 --             wrap <pattern functor of List> /\(out_List :: *) .
 --                 \(case_Nil : out_List) (case_Cons : a -> List a -> out_List) . case_Cons arg1 arg2
 -- @
-mkConstructor :: MonadQuote m => Recursivity -> Type TyName () -> Type TyName () -> Datatype TyName Name () -> VarDecl TyName Name () -> m (PLC.Term TyName Name ())
-mkConstructor r dty pf d@(Datatype _ tn tvs _ constrs) constr = do
+mkConstructor :: Compiling m a => Recursivity -> PLCType a -> PLCType a -> Datatype TyName Name (Provenance a) -> Int -> m (PLCTerm a)
+mkConstructor r dty pf d@(Datatype _ tn tvs _ constrs) index = local (DatatypeComponent Constructor) $ do
+    p <- ask
     resultType <- resultTypeName d
 
     -- case arguments and their types
@@ -271,13 +275,13 @@ mkConstructor r dty pf d@(Datatype _ tn tvs _ constrs) constr = do
           -- these types appear *outside* the scope of the abstraction for the datatype, *but* the name of the datatype will be in
           -- scope from the wrap, so we can still use it, and we don't need to do anything to the declared types
           -- see note [Abstract data types]
-          let caseTypes = fmap (constructorCaseType (PLC.TyVar () resultType)) constrs
-          caseArgNames <- for constrs (\c -> liftQuote $ freshName () $ "case_" <> (nameString $ varDeclName c))
-          pure $ zipWith (VarDecl ()) caseArgNames caseTypes
+          let caseTypes = fmap (constructorCaseType (PLC.TyVar p resultType)) constrs
+          caseArgNames <- for constrs (\c -> liftQuote $ freshName p $ "case_" <> (nameString $ varDeclName c))
+          pure $ zipWith (VarDecl p) caseArgNames caseTypes
 
     -- This is inelegant, but it should never fail
-    let index = fromMaybe (error "Should never fail") $ elemIndex constr constrs
-    let thisCase = PLC.mkVar () $ casesAndTypes !! index
+    let constr = constrs !! index
+    let thisCase = PLC.mkVar p $ casesAndTypes !! index
 
     -- constructor args and their types
     argsAndTypes <- do
@@ -286,28 +290,28 @@ mkConstructor r dty pf d@(Datatype _ tn tvs _ constrs) constr = do
           -- see note [Abstract data types]
         let argTypes = unveilDatatype dty d <$> constructorArgTypes constr
         -- we don't have any names for these things, we just had the type, so we call them "arg_i
-        argNames <- for [0..(length argTypes -1)] (\i -> liftQuote $ freshName () $ strToBs $ "arg_" ++ show i)
-        pure $ zipWith (VarDecl ()) argNames argTypes
+        argNames <- for [0..(length argTypes -1)] (\i -> liftQuote $ freshName p $ strToBs $ "arg_" ++ show i)
+        pure $ zipWith (VarDecl p) argNames argTypes
 
     -- See Note [Recursive datatypes]
     let maybeWrap t = case r of
-            Rec    -> PLC.Wrap () (tyVarDeclName tn) pf t
+            Rec    -> PLC.Wrap p (setProvenance p $ tyVarDeclName tn) pf t
             NonRec -> t
 
     pure $
         -- /\t_1 .. t_n
-        PLC.mkIterTyAbs () tvs $
+        PLC.mkIterTyAbs p tvs $
         -- \arg_1 .. arg_m
-        PLC.mkIterLamAbs () argsAndTypes $
+        PLC.mkIterLamAbs p argsAndTypes $
         -- wrap
         maybeWrap $
         -- no need for a body value check here, we know it's a lambda (see Note [Value restriction])
         -- forall out
-        PLC.TyAbs () resultType (PLC.Type ()) $
+        PLC.TyAbs p resultType (PLC.Type p) $
         -- \case_1 .. case_j
-        PLC.mkIterLamAbs () casesAndTypes $
+        PLC.mkIterLamAbs p casesAndTypes $
         -- c_i arg_1 .. arg_m
-        PLC.mkIterApp () thisCase (fmap (PLC.mkVar ()) argsAndTypes)
+        PLC.mkIterApp p thisCase (fmap (PLC.mkVar p) argsAndTypes)
 
 -- Destructors
 
@@ -318,27 +322,29 @@ mkConstructor r dty pf d@(Datatype _ tn tvs _ constrs) constr = do
 --        = /\(a :: *) -> \(x : (<definition of List> a)) -> unwrap x
 --        = /\(a :: *) -> \(x : (fix List . \(a :: *) -> forall (r :: *) . r -> (a -> List a -> r) -> r) a) -> unwrap x
 -- @
-mkDestructor :: MonadQuote m => Recursivity -> Type TyName () -> Datatype TyName Name () -> m (PLC.Term TyName Name ())
-mkDestructor r dty (Datatype _ _ tvs _ _) = do
+mkDestructor :: Compiling m a => Recursivity -> PLCType a -> Datatype TyName Name (Provenance a) -> m (PLCTerm a)
+mkDestructor r dty (Datatype _ _ tvs _ _) = local (DatatypeComponent Destructor) $ do
+    p <- ask
+
     -- See note [Recursive datatypes]
     let maybeUnwrap body = case r of
-            Rec    -> PLC.Unwrap () body
+            Rec    -> PLC.Unwrap p body
             NonRec -> body
 
     -- This term appears *outside* the scope of the abstraction for the datatype, so we need to put in the Scott-encoded type here
     -- see note [Abstract data types]
     -- dty t_1 .. t_n
-    let appliedReal = PLC.mkIterTyApp () dty (fmap (PLC.mkTyVar ()) tvs)
+    let appliedReal = PLC.mkIterTyApp p dty (fmap (PLC.mkTyVar p) tvs)
 
-    x <- liftQuote $ freshName () "x"
+    xn <- liftQuote $ freshName p "x"
     pure $
         -- /\t_1 .. t_n
-        PLC.mkIterTyAbs () tvs $
+        PLC.mkIterTyAbs p tvs $
         -- \x
-        PLC.LamAbs () x appliedReal $
+        PLC.LamAbs p xn appliedReal $
         -- unwrap
         maybeUnwrap $
-        PLC.Var () x
+        PLC.Var p xn
 
 -- See note [Scott encoding of datatypes]
 -- | Make the type of a destructor for a 'Datatype'.
@@ -347,42 +353,45 @@ mkDestructor r dty (Datatype _ _ tvs _ _) = do
 --         = forall (a :: *) . (List a) -> ((<pattern functor of List>) a)
 --         = forall (a :: *) . (List a) -> ((\(a :: *) -> forall (out_List :: *) . (out_List -> (a -> List a -> out_List) -> out_List)) a)
 -- @
-mkDestructorTy :: MonadQuote m => PLC.Type TyName () -> Datatype TyName Name () -> m (PLC.Type TyName ())
-mkDestructorTy pf (Datatype _ tn tvs _ _) =
-    let
-        -- we essentially "unveil" the abstract type, so this
-        -- is a function from the (instantiated) abstract type
-        -- to the (unwrapped, i.e. the pattern functor of the) "real" Scott-encoded type that we can use as
-        -- a destructor
+mkDestructorTy :: Compiling m a => PLCType a -> Datatype TyName Name (Provenance a) -> m (PLCType a)
+mkDestructorTy pf (Datatype _ tn tvs _ _) = local (DatatypeComponent DestructorType) $ do
+    p <- ask
 
-        -- these types appears *inside* the scope of the abstraction for the datatype, so we can use a references to the name
-        -- and we don't need to do anything to the pattern functor
-        -- see note [Abstract data types]
-        -- t t_1 .. t_n
-        appliedAbstract = PLC.mkIterTyApp () (PLC.mkTyVar () tn) (fmap (PLC.mkTyVar ()) tvs)
-        -- pf t_1 .. t_n
-        appliedPattern = PLC.mkIterTyApp () pf (fmap (PLC.mkTyVar ()) tvs)
-    in pure $
-        -- forall t_1 .. t_n
-         PLC.mkIterTyForall () tvs $
-         PLC.TyFun () appliedAbstract appliedPattern
+    -- we essentially "unveil" the abstract type, so this
+    -- is a function from the (instantiated) abstract type
+    -- to the (unwrapped, i.e. the pattern functor of the) "real" Scott-encoded type that we can use as
+    -- a destructor
+
+    -- these types appears *inside* the scope of the abstraction for the datatype, so we can use a references to the name
+    -- and we don't need to do anything to the pattern functor
+    -- see note [Abstract data types]
+    -- t t_1 .. t_n
+    let appliedAbstract = PLC.mkIterTyApp p (PLC.mkTyVar p tn) (fmap (PLC.mkTyVar p) tvs)
+    -- pf t_1 .. t_n
+    let appliedPattern = PLC.mkIterTyApp p pf (fmap (PLC.mkTyVar p) tvs)
+    -- forall t_1 .. t_n
+    pure $
+        PLC.mkIterTyForall p tvs $
+        PLC.TyFun p appliedAbstract appliedPattern
 
 -- The main function
 
 -- | Compile a 'Datatype' bound with the given body.
-compileDatatype :: MonadQuote m => Recursivity -> PLC.Term TyName Name () -> Datatype TyName Name () -> m (PLC.Term TyName Name ())
+compileDatatype :: Compiling m a => Recursivity -> PLCTerm a -> Datatype TyName Name (Provenance a) -> m (PLCTerm a)
 compileDatatype r body d@(Datatype _ tn _ destr constrs) = do
+    p <- ask
+
     -- we compute the pattern functor and pass it around to avoid recomputing it
     pf <- mkDatatypePatternFunctor d
     concreteTyDef <- PLC.Def tn <$> mkDatatypeType r pf d
 
-    constrDefs <- for constrs $ \c -> do
+    constrDefs <- for (zip constrs [0..]) $ \(c, i) -> do
         constrTy <- mkConstructorType d c
-        PLC.Def (VarDecl () (varDeclName c) constrTy) <$> mkConstructor r (PLC.defVal concreteTyDef) pf d c
+        PLC.Def (VarDecl p (varDeclName c) constrTy) <$> mkConstructor r (PLC.defVal concreteTyDef) pf d i
 
     destrDef <- do
         destTy <- mkDestructorTy pf d
-        PLC.Def (VarDecl () destr destTy) <$> mkDestructor r (PLC.defVal concreteTyDef) d
+        PLC.Def (VarDecl p destr destTy) <$> mkDestructor r (PLC.defVal concreteTyDef) d
 
     let
         tyVars = [PLC.defVar concreteTyDef]
@@ -390,4 +399,4 @@ compileDatatype r body d@(Datatype _ tn _ destr constrs) = do
         vars = fmap PLC.defVar constrDefs ++ [PLC.defVar destrDef]
         vals = fmap PLC.defVal constrDefs ++ [PLC.defVal destrDef]
     -- See note [Abstract data types]
-    pure $ PLC.mkIterApp () (PLC.mkIterInst () (PLC.mkIterTyAbs () tyVars (PLC.mkIterLamAbs () vars body)) tys) vals
+    pure $ PLC.mkIterApp p (PLC.mkIterInst p (PLC.mkIterTyAbs p tyVars (PLC.mkIterLamAbs p vars body)) tys) vals

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
@@ -277,7 +277,7 @@ mkConstructor r dty pf d@(Datatype _ tn tvs _ constrs) constr = do
 
     -- This is inelegant, but it should never fail
     let index = fromMaybe (error "Should never fail") $ elemIndex constr constrs
-    let thisCase = PLC.mkVar $ casesAndTypes !! index
+    let thisCase = PLC.mkVar () $ casesAndTypes !! index
 
     -- constructor args and their types
     argsAndTypes <- do
@@ -307,7 +307,7 @@ mkConstructor r dty pf d@(Datatype _ tn tvs _ constrs) constr = do
         -- \case_1 .. case_j
         PLC.mkIterLamAbs () casesAndTypes $
         -- c_i arg_1 .. arg_m
-        PLC.mkIterApp () thisCase (fmap PLC.mkVar argsAndTypes)
+        PLC.mkIterApp () thisCase (fmap (PLC.mkVar ()) argsAndTypes)
 
 -- Destructors
 
@@ -328,7 +328,7 @@ mkDestructor r dty (Datatype _ _ tvs _ _) = do
     -- This term appears *outside* the scope of the abstraction for the datatype, so we need to put in the Scott-encoded type here
     -- see note [Abstract data types]
     -- dty t_1 .. t_n
-    let appliedReal = PLC.mkIterTyApp () dty (fmap PLC.mkTyVar tvs)
+    let appliedReal = PLC.mkIterTyApp () dty (fmap (PLC.mkTyVar ()) tvs)
 
     x <- liftQuote $ freshName () "x"
     pure $
@@ -359,9 +359,9 @@ mkDestructorTy pf (Datatype _ tn tvs _ _) =
         -- and we don't need to do anything to the pattern functor
         -- see note [Abstract data types]
         -- t t_1 .. t_n
-        appliedAbstract = PLC.mkIterTyApp () (PLC.mkTyVar tn) (fmap PLC.mkTyVar tvs)
+        appliedAbstract = PLC.mkIterTyApp () (PLC.mkTyVar () tn) (fmap (PLC.mkTyVar ()) tvs)
         -- pf t_1 .. t_n
-        appliedPattern = PLC.mkIterTyApp () pf (fmap PLC.mkTyVar tvs)
+        appliedPattern = PLC.mkIterTyApp () pf (fmap (PLC.mkTyVar ()) tvs)
     in pure $
         -- forall t_1 .. t_n
          PLC.mkIterTyForall () tvs $

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
@@ -6,15 +6,25 @@ module Language.PlutusIR.Compiler.Error (CompError (..)) where
 import qualified Language.PlutusCore        as PLC
 import qualified Language.PlutusCore.Pretty as PLC
 
-import qualified Data.Text                  as T
-import qualified Data.Text.Prettyprint.Doc  as PP
+import           Control.Exception
 
-data CompError a = CompilationError T.Text -- ^ A generic compilation error.
-                 | UnsupportedError T.Text -- ^ An error relating specifically to an unsupported feature.
+import qualified Data.Text                  as T
+import           Data.Text.Prettyprint.Doc  ((<+>), (<>))
+import qualified Data.Text.Prettyprint.Doc  as PP
+import           Data.Typeable
+
+data CompError a = CompilationError a T.Text -- ^ A generic compilation error.
+                 | UnsupportedError a T.Text -- ^ An error relating specifically to an unsupported feature.
                  | PLCError (PLC.Error a) -- ^ An error from running some PLC function, lifted into this error type for convenience.
+                 deriving (Typeable)
+
+instance (PP.Pretty a) => Show (CompError a) where
+    show e = show $ PLC.prettyPlcClassicDebug e
 
 instance PP.Pretty a => PLC.PrettyBy PLC.PrettyConfigPlc (CompError a) where
     prettyBy config = \case
-        CompilationError e -> "Error during compilation:" PP.<+> PP.pretty e
-        UnsupportedError e -> "Unsupported:" PP.<+> PP.pretty e
+        CompilationError x e -> "Error during compilation" <+> PP.pretty x <> ":" <+> PP.pretty e
+        UnsupportedError x e -> "Unsupported construct at" <+> PP.pretty x <> ":" <+> PP.pretty e
         PLCError e -> PLC.prettyBy config e
+
+instance (PP.Pretty a, Typeable a) => Exception (CompError a)

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Provenance.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Provenance.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+-- | Module handling provenances of terms.
+module Language.PlutusIR.Compiler.Provenance where
+
+import           Language.PlutusIR
+
+import qualified Language.PlutusCore.Pretty as PLC
+
+import           Data.Text.Prettyprint.Doc  ((<+>), (<>))
+import qualified Data.Text.Prettyprint.Doc  as PP
+
+-- | Indicates where a value comes from.
+--
+-- This is either an original annotation or a pieces of context explaining how the term
+-- relates to a previous 'Provenance'. We also provide 'NoProvenance' for convenience.
+--
+-- The provenance should always be just the original annotation, if we have one. It should only be another
+-- kind of provenance if we're in the process of generating some term that doesn't correspond directly to a term in
+-- the original AST.
+data Provenance a = Original a
+                  | LetBinding Recursivity (Provenance a)
+                  | TermBinding String (Provenance a)
+                  | TypeBinding String (Provenance a)
+                  | DatatypeComponent DatatypeComponent (Provenance a)
+                  | NoProvenance
+                  deriving (Show, Eq)
+
+data DatatypeComponent = Constructor
+                       | ConstructorType
+                       | Destructor
+                       | DestructorType
+                       | DatatypeType
+                       | PatternFunctor
+                       deriving (Show, Eq)
+
+instance PP.Pretty DatatypeComponent where
+    pretty = \case
+        Constructor -> "constructor"
+        ConstructorType -> "constructor type"
+        Destructor -> "destructor"
+        DestructorType -> "destructor type"
+        DatatypeType -> "datatype type"
+        PatternFunctor -> "pattern functor"
+
+data GeneratedKind = RecursiveLet
+    deriving (Show, Eq)
+
+instance PP.Pretty GeneratedKind where
+    pretty = \case
+        RecursiveLet -> "recursive let"
+
+-- | Set the provenance on a term to the given value.
+setProvenance :: Functor f => Provenance b -> f a -> f (Provenance b)
+setProvenance = (<$)
+
+-- | Mark all the annotations on a term as original. Useful for preparing terms for the PIR compiler.
+original :: Functor f => f a -> f (Provenance a)
+original = fmap Original
+
+instance PP.Pretty a => PP.Pretty (Provenance a) where
+    pretty = \case
+        DatatypeComponent c p -> PP.pretty c <> ";" <+> "from" <+> PLC.pretty p
+        Original p -> PLC.pretty p
+        LetBinding r p ->
+            let
+                rstr = case r of
+                    NonRec -> "non-recursive"
+                    Rec    -> "recursive"
+            in "(" <> rstr <> ")" <+> "let binding" <> ";" <+> "from" <+> PLC.pretty p
+        TermBinding n p -> "term binding" <+> "of" <+> PLC.pretty n <> ";" <+> "from" <+> PLC.pretty p
+        TypeBinding n p -> "type binding" <+> "of" <+> PLC.pretty n <> ";" <+> "from" <+> PLC.pretty p
+        NoProvenance -> "<unknown>"

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Recursion.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Recursion.hs
@@ -6,11 +6,13 @@ module Language.PlutusIR.Compiler.Recursion where
 
 import           Language.PlutusIR
 import           Language.PlutusIR.Compiler.Error
+import           Language.PlutusIR.Compiler.Provenance
 import {-# SOURCE #-} Language.PlutusIR.Compiler.Term
 import           Language.PlutusIR.Compiler.Types
 
 import           Control.Monad
 import           Control.Monad.Except
+import           Control.Monad.Reader
 
 import qualified Language.PlutusCore                        as PLC
 import qualified Language.PlutusCore.MkPlc                  as PLC
@@ -58,57 +60,63 @@ Here we merely have to provide it with the types of the f_is, which we *do* know
 
  -- See note [Recursive lets]
 -- | Compile a mutually recursive list of var decls bound in a body.
-compileRecTerms :: Compiling m => PLC.Term TyName Name () -> [TermDef TyName Name ()] -> m (PLC.Term TyName Name ())
-compileRecTerms body bs = PLC.Apply () <$> mkTupleBinder body (fmap PLC.defVar bs) <*> mkFixpoint bs
+compileRecTerms :: Compiling m a => PLCTerm a -> [TermDef TyName Name (Provenance a)] -> m (PLCTerm a)
+compileRecTerms body bs = do
+    p <- ask
+    PLC.Apply p <$> mkTupleBinder body (fmap PLC.defVar bs) <*> mkFixpoint bs
 
 -- | Given a list of var decls, create a tuples of values that computes their mutually recursive fixpoint.
-mkFixpoint :: Compiling m => [TermDef TyName Name ()] -> m (PLC.Term TyName Name ())
+mkFixpoint :: Compiling m a => [TermDef TyName Name (Provenance a)] -> m (PLCTerm a)
 mkFixpoint bs = do
+    p <- ask
+
     let tys = fmap (PLC.varDeclType . PLC.defVar) bs
     -- The pairs of types we'll need for fixN
     asbs <- forM tys $ \case
-        PLC.TyFun () i o -> pure (i, o)
-        _ -> throwError $ CompilationError "Recursive values must be of function type. You may need to manually add unit arguments."
+        PLC.TyFun _ i o -> pure (i, o)
+        t -> throwError $ CompilationError (PLC.tyLoc t) "Recursive values must be of function type. You may need to manually add unit arguments."
 
-    q <- liftQuote $ freshTyName () "Q"
-    choose <- liftQuote $ freshName () "choose"
-    let chooseTy = PLC.mkIterTyFun () tys (PLC.TyVar () q)
+    q <- liftQuote $ freshTyName p "Q"
+    choose <- liftQuote $ freshName p "choose"
+    let chooseTy = PLC.mkIterTyFun p tys (PLC.TyVar p q)
 
     -- \f1 ... fn -> choose b1 ... bn
     bsLam <- do
           rhss <- traverse (compileTerm . PLC.defVal) bs
-          let chosen =  PLC.mkIterApp () (PLC.Var () choose) rhss
-              abstracted = PLC.mkIterLamAbs () (fmap PLC.defVar bs) chosen
+          let chosen =  PLC.mkIterApp p (PLC.Var p choose) rhss
+              abstracted = PLC.mkIterLamAbs p (fmap PLC.defVar bs) chosen
           pure abstracted
 
     -- abstract out Q and choose
-    let cLam = PLC.TyAbs () q (PLC.Type ()) $ PLC.LamAbs () choose chooseTy bsLam
+    let cLam = PLC.TyAbs p q (PLC.Type p) $ PLC.LamAbs p choose chooseTy bsLam
 
     -- fixN {A1 B1 ... An Bn}
     instantiatedFix <- do
-        fixN <- liftQuote $ Function.getBuiltinFixN (length bs)
-        pure $ PLC.mkIterInst () fixN $ foldMap (\(a, b) -> [a, b]) asbs
+        fixN <- setProvenance p <$> (liftQuote $ Function.getBuiltinFixN (length bs))
+        pure $ PLC.mkIterInst p fixN $ foldMap (\(a, b) -> [a, b]) asbs
 
-    pure $ PLC.Apply () instantiatedFix cLam
+    pure $ PLC.Apply p instantiatedFix cLam
 
 -- TODO: move to MkPlc?
 -- | Given a term, and a list of var decls, creates a function which takes a tuple of values for each decl, and binds
 -- them in the body.
-mkTupleBinder :: MonadQuote m => PLC.Term TyName Name () -> [VarDecl TyName Name ()] -> m (PLC.Term TyName Name ())
+mkTupleBinder :: Compiling m a => PLCTerm a -> [VarDecl TyName Name (Provenance a)] -> m (PLCTerm a)
 mkTupleBinder body vars = do
+    p <- ask
+
     let tys = fmap PLC.varDeclType vars
 
     tupleTy <- do
-        ntuple <- Tuple.getBuiltinTuple (length tys)
-        pure $ PLC.mkIterTyApp () ntuple tys
+        ntuple <- setProvenance p <$> Tuple.getBuiltinTuple (length tys)
+        pure $ PLC.mkIterTyApp p ntuple tys
 
-    tupleArg <- liftQuote $ freshName () "tuple"
+    tupleArg <- liftQuote $ freshName p "tuple"
 
     -- _i tuple
     accesses <- forM [0..(length tys -1)] $ \i -> do
-            naccessor <- Tuple.getBuiltinTupleAccessor (length tys) i
-            let accessor = PLC.mkIterInst () naccessor tys
-            pure $ PLC.Apply () accessor (PLC.Var () tupleArg)
+            naccessor <- setProvenance p <$> Tuple.getBuiltinTupleAccessor (length tys) i
+            let accessor = PLC.mkIterInst p naccessor tys
+            pure $ PLC.Apply p accessor (PLC.Var p tupleArg)
     let defsAndAccesses = zipWith PLC.Def vars accesses
 
     -- let
@@ -117,7 +125,7 @@ mkTupleBinder body vars = do
     --   f_i = _i tuple
     -- in
     --   result
-    let finalBound = foldr (\def acc -> PLC.mkTermLet () def acc) body defsAndAccesses
+    let finalBound = foldr (\def acc -> PLC.mkTermLet p def acc) body defsAndAccesses
 
     -- \tuple -> finalBound
-    pure $ PLC.LamAbs () tupleArg tupleTy finalBound
+    pure $ PLC.LamAbs p tupleArg tupleTy finalBound

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Term.hs-boot
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Term.hs-boot
@@ -1,9 +1,6 @@
 {-# LANGUAGE FlexibleContexts  #-}
 module Language.PlutusIR.Compiler.Term (compileTerm) where
 
-import           Language.PlutusIR
 import           Language.PlutusIR.Compiler.Types
 
-import qualified Language.PlutusCore                 as PLC
-
-compileTerm :: Compiling m => Term TyName Name () -> m (PLC.Term TyName Name ())
+compileTerm :: Compiling m a => PIRTerm a -> m (PLCTerm a)

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
@@ -2,17 +2,23 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Language.PlutusIR.Compiler.Types where
 
-import           Language.PlutusIR
+import qualified Language.PlutusIR                     as PIR
 import           Language.PlutusIR.Compiler.Error
+import           Language.PlutusIR.Compiler.Provenance
 
 import           Control.Monad.Except
+import           Control.Monad.Reader
 
-import qualified Language.PlutusCore.MkPlc        as PLC
+import qualified Language.PlutusCore                   as PLC
+import qualified Language.PlutusCore.MkPlc             as PLC
 import           Language.PlutusCore.Quote
 
-type Compiling m = (Monad m, MonadError (CompError ()) m, MonadQuote m)
+type PLCTerm a = PLC.Term PLC.TyName PLC.Name (Provenance a)
+type PLCType a = PLC.Type PLC.TyName (Provenance a)
 
-runCompiling :: QuoteT (Except (CompError())) a -> Either (CompError ()) a
-runCompiling = runExcept . runQuoteT
+type PIRTerm a = PIR.Term PIR.TyName PIR.Name (Provenance a)
+type PIRType a = PIR.Type PIR.TyName (Provenance a)
 
-type TermDef tyname name a = PLC.Def (PLC.VarDecl tyname name a) (Term tyname name a)
+type Compiling m a = (Monad m, MonadReader (Provenance a) m, MonadError (CompError (Provenance a)) m, MonadQuote m)
+
+type TermDef tyname name a = PLC.Def (PLC.VarDecl tyname name a) (PIR.Term tyname name a)

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -14,7 +14,6 @@ import           Language.PlutusIR.Compiler
 
 import qualified Language.PlutusCore                  as PLC
 import qualified Language.PlutusCore.MkPlc            as PLC
-import qualified Language.PlutusCore.Pretty           as PLC
 
 import qualified Language.PlutusCore.StdLib.Data.Bool as Bool
 import qualified Language.PlutusCore.StdLib.Data.Nat  as Nat
@@ -24,20 +23,31 @@ import           Language.PlutusCore.StdLib.Type
 
 import           Test.Tasty
 
+import           Control.Exception
 import           Control.Monad
 import           Control.Monad.Except
+import           Control.Monad.Reader
 
 main :: IO ()
 main = defaultMain $ runTestNestedIn ["test"] tests
 
-instance GetProgram (Quote (Term TyName Name ())) where
-    getProgram = trivialProgram . compileAndMaybeTypecheck False
+-- for throwing away the annotation
+instance GetProgram (PLC.Term TyName Name (Provenance ())) where
+    getProgram = getProgram . void
 
-goldenPir :: String -> Term TyName Name () -> TestNested
+-- normal compilation with typechecking
+instance GetProgram (Quote (Term TyName Name ())) where
+    getProgram = getProgram . compileAndMaybeTypecheck True
+
+-- convenience so we can also compile without typechecking
+instance (Exception e, GetProgram a) => GetProgram (Except e a) where
+    getProgram = either throw id . runExcept . fmap getProgram
+
+goldenPir :: String -> Term TyName Name a -> TestNested
 goldenPir name value = nestedGoldenVsDoc name $ prettyDef value
 
-compileAndMaybeTypecheck :: Bool -> Quote (Term TyName Name ()) -> PLC.Term TyName Name ()
-compileAndMaybeTypecheck doTypecheck pir = either (error . show . PLC.prettyPlcClassicDebug) id $ runExcept $ runQuoteT $ do
+compileAndMaybeTypecheck :: Bool -> Quote (Term TyName Name a) -> Except (CompError (Provenance a)) (PLC.Term TyName Name (Provenance a))
+compileAndMaybeTypecheck doTypecheck pir = flip runReaderT NoProvenance $ runQuoteT $ do
     -- it is important we run the two computations in the same Quote together, otherwise we might make
     -- names during compilation that are not fresh
     compiled <- compileTerm =<< liftQuote pir
@@ -48,14 +58,12 @@ compileAndMaybeTypecheck doTypecheck pir = either (error . show . PLC.prettyPlcC
             PLC.typecheckTerm (PLC.TypeCheckCfg PLC.defaultTypecheckerGas $ PLC.TypeConfig True mempty) annotated
     pure compiled
 
-compile :: Quote (Term TyName Name ()) -> PLC.Term TyName Name ()
-compile = compileAndMaybeTypecheck True
-
 tests :: TestNested
 tests = testGroup "plutus-ir" <$> sequence [
     prettyprinting,
     datatypes,
-    recursion
+    recursion,
+    errors
     ]
 
 prettyprinting :: TestNested
@@ -143,14 +151,14 @@ listMatch = do
 
 datatypes :: TestNested
 datatypes = testNested "datatypes" [
-    goldenPlc "maybe" (compile maybePir),
+    goldenPlc "maybe" maybePir,
     goldenPlc "listMatch" (compileAndMaybeTypecheck False listMatch),
-    goldenEval "listMatchEval" [listMatch]
+    goldenEval "listMatchEval" [compileAndMaybeTypecheck False listMatch]
     ]
 
 recursion :: TestNested
 recursion = testNested "recursion" [
-    goldenPlc "even3" (compile evenOdd),
+    goldenPlc "even3" evenOdd,
     goldenEval "even3Eval" [evenOdd]
     ]
 
@@ -196,3 +204,70 @@ evenOdd = do
                 TermBind () (VarDecl () oddd oddTy) oddF
             ] $
         Apply () (Var () evenn) (Var () arg)
+
+errors :: TestNested
+errors = testNested "errors" [
+    goldenPlcCatch "mutuallyRecursiveTypes" mutuallyRecursiveTypes,
+    goldenPlcCatch "mutuallyRecursiveValues" mutuallyRecursiveValues
+    ]
+
+mutuallyRecursiveTypes :: Quote (Term TyName Name ())
+mutuallyRecursiveTypes = do
+    tree <- freshTyName () "Tree"
+    a <- freshTyName () "a"
+    let treeA arg = TyApp () (TyVar () tree) (TyVar () arg)
+    node <- freshName () "Node"
+    matchTree <- freshName () "match_Tree"
+
+    forest <- freshTyName () "Forest"
+    a2 <- freshTyName () "a"
+    let forestA arg = TyApp () (TyVar () forest) (TyVar () arg)
+    nil <- freshName () "Nil"
+    cons <- freshName () "Cons"
+    matchForest <- freshName () "match_Forest"
+
+    unit <- Unit.getBuiltinUnit
+    pure $
+        Let ()
+            Rec
+            [
+                DatatypeBind () $
+                Datatype ()
+                    (TyVarDecl () tree (KindArrow () (Type ()) (Type ())))
+                    [
+                        TyVarDecl () a (Type ())
+                    ]
+                matchTree
+                [
+                    VarDecl () node (TyFun () (TyVar () a) (TyFun () (forestA a) (treeA a)))
+                ],
+                DatatypeBind () $
+                Datatype ()
+                    (TyVarDecl () forest (KindArrow () (Type ()) (Type ())))
+                    [
+                        TyVarDecl () a2 (Type ())
+                    ]
+                matchForest
+                [
+                    VarDecl () nil (forestA a2),
+                    VarDecl () cons (TyFun () (treeA a2) (TyFun () (forestA a2) (forestA a2)))
+                ]
+            ] $
+        TyInst () (Var () nil) unit
+
+mutuallyRecursiveValues :: Quote (Term TyName Name ())
+mutuallyRecursiveValues = do
+    x <- freshName () "x"
+    y <- freshName () "y"
+
+    unit <- Unit.getBuiltinUnit
+    unitval <- embedIntoIR <$> Unit.getBuiltinUnitval
+
+    pure $
+        Let ()
+            Rec
+            [
+                TermBind () (VarDecl () x unit) (Var () y),
+                TermBind () (VarDecl () y unit) unitval
+            ] $
+        Var () x

--- a/plutus-ir/test/errors/mutuallyRecursiveTypes.plc.golden
+++ b/plutus-ir/test/errors/mutuallyRecursiveTypes.plc.golden
@@ -1,0 +1,1 @@
+Unsupported construct at (recursive) let binding; from (): Mutually recursive types are not supported

--- a/plutus-ir/test/errors/mutuallyRecursiveValues.plc.golden
+++ b/plutus-ir/test/errors/mutuallyRecursiveValues.plc.golden
@@ -1,0 +1,1 @@
+Error during compilation (): Recursive values must be of function type. You may need to manually add unit arguments.


### PR DESCRIPTION
This adds the concept of a `Provenance` to PIR. A `Provenance` is either an underlying annotation, or a piece of context relating the current term to another `Provenance`.

In practice this means that we can say something like `A type error occurred in the pattern functor for List; at <location>`, which is handy.

At the moment we don't have any terms with interesting underlying annotations, so this is not so useful. Even once we hook this up to `core-to-plc`, that still gives everything annotation `()`! But that can be changed - the nice thing about `Provenance`s is that they make sense across domains. So we can eventually say `A type error occurred in the pattern functor for List; from the Haskell datatype List; at <location>`.

This also answers a separate question: don't I already do something like this with the error contexts in `core-to-plc`? The answer is yes, they convey similar information, but conceptually they tell you what the code was doing when something went wrong, whereas the `Provenance` tells you where the piece of data that was being processed came from, and I think we want both. I'll probably move some of the error contexts stuff into a  `core-to-plc` `Provenance` in future.

Notes:
- There's a bit of noise from:
    - Changing to use type synonyms throughout `plutus-ir`.
    - Adding a type parameter for the annotation so we're generic over the underlying annotation.
- Most of the rest of the diff is just making sure that everything gets an appropriate `Provenance`.