### PR TITLE
plc testlib: make less implicit

### DIFF
--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -35,7 +35,7 @@ main :: IO ()
 main = defaultMain $ runTestNestedIn ["test"] tests
 
 instance GetProgram PlcCode where
-    getProgram = getAst
+    getProgram = catchAll . getAst
 
 tests :: TestNested
 tests = testGroup "conversion" <$> sequence [
@@ -311,12 +311,12 @@ instance LiftPlc (MyMonoRecord)
 
 generics :: TestNested
 generics = testNested "generics" [
-    goldenPlc "int" (runQuote $ lift (1::Int))
-    , goldenPlc "mono" (runQuote $ lift (Mono2 2))
+    goldenPlc "int" (trivialProgram $ runQuote $ lift (1::Int))
+    , goldenPlc "mono" (trivialProgram $ runQuote $ lift (Mono2 2))
     , goldenEval "monoInterop" [ getAst monoCase, (trivialProgram $ runQuote $ lift (Mono1 1 2)) ]
-    , goldenPlc "record" (runQuote $ lift (MyMonoRecord 1 2))
+    , goldenPlc "record" (trivialProgram $ runQuote $ lift (MyMonoRecord 1 2))
     , goldenEval "boolInterop" [ getAst andPlc, (trivialProgram $ runQuote $ lift True), (trivialProgram $ runQuote $ lift True) ]
-    , goldenPlc "list" (runQuote $ lift ([1]::[Int]))
+    , goldenPlc "list" (trivialProgram $ runQuote $ lift ([1]::[Int]))
     , goldenEval "listInterop" [ getAst listMatch, (trivialProgram $ runQuote $ lift ([1]::[Int])) ]
-    , goldenPlc "liftPlc" (runQuote $ lift int)
+    , goldenPlc "liftPlc" (trivialProgram $ runQuote $ lift int)
   ]

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55595,6 +55595,7 @@ license = stdenv.lib.licenses.bsd3;
 , containers
 , language-plutus-core
 , microlens
+, mmorph
 , mtl
 , prettyprinter
 , stdenv
@@ -55615,6 +55616,7 @@ bytestring
 containers
 language-plutus-core
 microlens
+mmorph
 mtl
 prettyprinter
 text
@@ -55624,6 +55626,7 @@ testHaskellDepends = [
 base
 bytestring
 language-plutus-core
+mmorph
 mtl
 prettyprinter
 tasty

--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -56,6 +56,7 @@ library
         language-plutus-core -any,
         microlens -any,
         mtl -any,
+        mmorph -any,
         prettyprinter -any,
         text -any,
         transformers -any
@@ -75,6 +76,7 @@ test-suite plutus-ir-test
         language-plutus-core -any,
         bytestring -any,
         mtl -any,
+        mmorph -any,
         text -any,
         prettyprinter -any,
         tasty -any,


### PR DESCRIPTION
This makes `getProgram` do less, by:
- Not trying to be clever about catching exceptions. The class method
now expects the exceptions to be caught, and the non-catching test
methods just rethrow them to fail the test.
- Not trying to be clever about turning lots of things into `Program`s,
in favour of just scattering a few more explicit conversions around.