### PR TITLE
core-to-plc: compile (trivially) via PIR

### DIFF
--- a/core-to-plc/core-to-plc.cabal
+++ b/core-to-plc/core-to-plc.cabal
@@ -33,6 +33,7 @@ library
     other-modules:
         Language.Plutus.CoreToPLC.Laziness
         Language.Plutus.CoreToPLC.PLCTypes
+        Language.Plutus.CoreToPLC.PIRTypes
         Language.Plutus.CoreToPLC.Utils
         Language.Plutus.CoreToPLC.Compiler.Binders
         Language.Plutus.CoreToPLC.Compiler.Builtins
@@ -68,6 +69,7 @@ library
         mmorph -any,
         microlens -any,
         mtl -any,
+        plutus-ir -any,
         prettyprinter -any,
         serialise -any,
         template-haskell -any,

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Error.hs
@@ -11,6 +11,8 @@ module Language.Plutus.CoreToPLC.Error (
     , throwPlain
     , mustBeReplaced) where
 
+import qualified Language.PlutusIR.Compiler as PIR
+
 import qualified Language.PlutusCore        as PLC
 import qualified Language.PlutusCore.Pretty as PLC
 
@@ -45,6 +47,7 @@ instance (PP.Pretty c, PP.Pretty e) => PP.Pretty (WithContext c e) where
             ]
 
 data Error a = PLCError (PLC.Error a)
+             | PIRError (PIR.CompError (PIR.Provenance a))
              | ConversionError T.Text
              | UnsupportedError T.Text
              | FreeVariableError T.Text
@@ -57,6 +60,7 @@ instance (PP.Pretty a) => PP.Pretty (Error a) where
 instance (PP.Pretty a) => PLC.PrettyBy PLC.PrettyConfigPlc (Error a) where
     prettyBy config = \case
         PLCError e -> PLC.prettyBy config e
+        PIRError e -> PLC.prettyBy config e
         ConversionError e -> "Error during conversion:" PP.<+> PP.pretty e
         UnsupportedError e -> "Unsupported:" PP.<+> PP.pretty e
         FreeVariableError e -> "Used but not defined in the current conversion:" PP.<+> PP.pretty e

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/PIRTypes.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/PIRTypes.hs
@@ -1,0 +1,13 @@
+module Language.Plutus.CoreToPLC.PIRTypes where
+
+import qualified Language.PlutusIR as PIR
+
+type PIRKind = PIR.Kind ()
+type PIRType = PIR.Type PIR.TyName ()
+type PIRTerm = PIR.Term PIR.TyName PIR.Name ()
+type PIRProgram = PIR.Program PIR.TyName PIR.Name ()
+
+type PIRBinding = PIR.Binding PIR.TyName PIR.Name ()
+
+type PIRVar = PIR.VarDecl PIR.TyName PIR.Name ()
+type PIRTyVar = PIR.TyVarDecl PIR.TyName ()

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/PLCTypes.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/PLCTypes.hs
@@ -6,6 +6,7 @@ import qualified Language.PlutusCore.MkPlc as PLC
 type PLCKind = PLC.Kind ()
 type PLCType = PLC.Type PLC.TyName ()
 type PLCTerm = PLC.Term PLC.TyName PLC.Name ()
+type PLCProgram = PLC.Program PLC.TyName PLC.Name ()
 
 type PLCVar = PLC.VarDecl PLC.TyName PLC.Name ()
 type PLCTyVar = PLC.TyVarDecl PLC.TyName ()

--- a/core-to-plc/test/basic/monoId.plc.golden
+++ b/core-to-plc/test/basic/monoId.plc.golden
@@ -1,3 +1,3 @@
 (program 1.0.0
-  (lam ds_0 [(con integer) (con 64)] ds_0)
+  (lam ds_1 [(con integer) (con 64)] ds_1)
 )

--- a/core-to-plc/test/basic/monoK.plc.golden
+++ b/core-to-plc/test/basic/monoK.plc.golden
@@ -1,3 +1,3 @@
 (program 1.0.0
-  (lam ds_0 [(con integer) (con 64)] (lam ds_1 [(con integer) (con 64)] ds_0))
+  (lam ds_2 [(con integer) (con 64)] (lam ds_3 [(con integer) (con 64)] ds_2))
 )

--- a/core-to-plc/test/data/monomorphic/defaultCase.plc.golden
+++ b/core-to-plc/test/data/monomorphic/defaultCase.plc.golden
@@ -5,47 +5,47 @@
         [
           {
             (abs
-              MyMonoData_2
+              MyMonoData_30
               (type)
               (lam
-                Mono1_20
-                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_2))
+                Mono1_31
+                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_30))
                 (lam
-                  Mono2_21
-                  (fun [(con integer) (con 64)] MyMonoData_2)
+                  Mono2_32
+                  (fun [(con integer) (con 64)] MyMonoData_30)
                   (lam
-                    Mono3_22
-                    (fun [(con integer) (con 64)] MyMonoData_2)
+                    Mono3_33
+                    (fun [(con integer) (con 64)] MyMonoData_30)
                     (lam
-                      MyMonoData_match_23
-                      (fun MyMonoData_2 (all MyMonoData_matchOut_24 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_24)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_24) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_24) MyMonoData_matchOut_24)))))
+                      MyMonoData_match_34
+                      (fun MyMonoData_30 (all MyMonoData_matchOut_35 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_35)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_35) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_35) MyMonoData_matchOut_35)))))
                       (lam
-                        ds_25
-                        MyMonoData_2
+                        ds_36
+                        MyMonoData_30
                         [
                           [
                             [
                               {
-                                [ MyMonoData_match_23 ds_25 ]
+                                [ MyMonoData_match_34 ds_36 ]
                                 [(con integer) (con 64)]
                               }
                               (lam
-                                default_arg0_26
+                                default_arg0_37
                                 [(con integer) (con 64)]
                                 (lam
-                                  default_arg1_27
+                                  default_arg1_38
                                   [(con integer) (con 64)]
                                   (con 64 ! 2)
                                 )
                               )
                             ]
                             (lam
-                              default_arg0_28
+                              default_arg0_39
                               [(con integer) (con 64)]
                               (con 64 ! 2)
                             )
                           ]
-                          (lam a_29 [(con integer) (con 64)] a_29)
+                          (lam a_40 [(con integer) (con 64)] a_40)
                         ]
                       )
                     )
@@ -53,27 +53,27 @@
                 )
               )
             )
-            (all MyMonoData_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_1)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) MyMonoData_matchOut_1))))
+            (all MyMonoData_matchOut_41 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_41)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_41) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_41) MyMonoData_matchOut_41))))
           }
           (lam
-            Mono1_arg0_7
+            Mono1_arg0_42
             [(con integer) (con 64)]
             (lam
-              Mono1_arg1_8
+              Mono1_arg1_43
               [(con integer) (con 64)]
               (abs
-                MyMonoData_matchOut_3
+                MyMonoData_matchOut_44
                 (type)
                 (lam
-                  Mono1_4
-                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_3))
+                  Mono1_45
+                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_44))
                   (lam
-                    Mono2_5
-                    (fun [(con integer) (con 64)] MyMonoData_matchOut_3)
+                    Mono2_46
+                    (fun [(con integer) (con 64)] MyMonoData_matchOut_44)
                     (lam
-                      Mono3_6
-                      (fun [(con integer) (con 64)] MyMonoData_matchOut_3)
-                      [ [ Mono1_4 Mono1_arg0_7 ] Mono1_arg1_8 ]
+                      Mono3_47
+                      (fun [(con integer) (con 64)] MyMonoData_matchOut_44)
+                      [ [ Mono1_45 Mono1_arg0_42 ] Mono1_arg1_43 ]
                     )
                   )
                 )
@@ -82,21 +82,21 @@
           )
         ]
         (lam
-          Mono2_arg0_13
+          Mono2_arg0_48
           [(con integer) (con 64)]
           (abs
-            MyMonoData_matchOut_9
+            MyMonoData_matchOut_49
             (type)
             (lam
-              Mono1_10
-              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_9))
+              Mono1_50
+              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_49))
               (lam
-                Mono2_11
-                (fun [(con integer) (con 64)] MyMonoData_matchOut_9)
+                Mono2_51
+                (fun [(con integer) (con 64)] MyMonoData_matchOut_49)
                 (lam
-                  Mono3_12
-                  (fun [(con integer) (con 64)] MyMonoData_matchOut_9)
-                  [ Mono2_11 Mono2_arg0_13 ]
+                  Mono3_52
+                  (fun [(con integer) (con 64)] MyMonoData_matchOut_49)
+                  [ Mono2_51 Mono2_arg0_48 ]
                 )
               )
             )
@@ -104,21 +104,21 @@
         )
       ]
       (lam
-        Mono3_arg0_18
+        Mono3_arg0_53
         [(con integer) (con 64)]
         (abs
-          MyMonoData_matchOut_14
+          MyMonoData_matchOut_54
           (type)
           (lam
-            Mono1_15
-            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_14))
+            Mono1_55
+            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_54))
             (lam
-              Mono2_16
-              (fun [(con integer) (con 64)] MyMonoData_matchOut_14)
+              Mono2_56
+              (fun [(con integer) (con 64)] MyMonoData_matchOut_54)
               (lam
-                Mono3_17
-                (fun [(con integer) (con 64)] MyMonoData_matchOut_14)
-                [ Mono3_17 Mono3_arg0_18 ]
+                Mono3_57
+                (fun [(con integer) (con 64)] MyMonoData_matchOut_54)
+                [ Mono3_57 Mono3_arg0_53 ]
               )
             )
           )
@@ -126,9 +126,9 @@
       )
     ]
     (lam
-      x_19
-      (all MyMonoData_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_1)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) MyMonoData_matchOut_1))))
-      x_19
+      x_58
+      (all MyMonoData_matchOut_59 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_59)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_59) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_59) MyMonoData_matchOut_59))))
+      x_58
     )
   ]
 )

--- a/core-to-plc/test/data/monomorphic/enum.plc.golden
+++ b/core-to-plc/test/data/monomorphic/enum.plc.golden
@@ -4,41 +4,46 @@
       [
         {
           (abs
-            MyEnum_2
+            MyEnum_14
             (type)
             (lam
-              Enum1_10
-              MyEnum_2
+              Enum1_15
+              MyEnum_14
               (lam
-                Enum2_11
-                MyEnum_2
+                Enum2_16
+                MyEnum_14
                 (lam
-                  MyEnum_match_12
-                  (fun MyEnum_2 (all MyEnum_matchOut_13 (type) (fun MyEnum_matchOut_13 (fun MyEnum_matchOut_13 MyEnum_matchOut_13))))
-                  Enum1_10
+                  MyEnum_match_17
+                  (fun MyEnum_14 (all MyEnum_matchOut_18 (type) (fun MyEnum_matchOut_18 (fun MyEnum_matchOut_18 MyEnum_matchOut_18))))
+                  Enum1_15
                 )
               )
             )
           )
-          (all MyEnum_matchOut_1 (type) (fun MyEnum_matchOut_1 (fun MyEnum_matchOut_1 MyEnum_matchOut_1)))
+          (all MyEnum_matchOut_19 (type) (fun MyEnum_matchOut_19 (fun MyEnum_matchOut_19 MyEnum_matchOut_19)))
         }
         (abs
-          MyEnum_matchOut_3
+          MyEnum_matchOut_20
           (type)
-          (lam Enum1_4 MyEnum_matchOut_3 (lam Enum2_5 MyEnum_matchOut_3 Enum1_4)
+          (lam
+            Enum1_21
+            MyEnum_matchOut_20
+            (lam Enum2_22 MyEnum_matchOut_20 Enum1_21)
           )
         )
       ]
       (abs
-        MyEnum_matchOut_6
+        MyEnum_matchOut_23
         (type)
-        (lam Enum1_7 MyEnum_matchOut_6 (lam Enum2_8 MyEnum_matchOut_6 Enum2_8))
+        (lam
+          Enum1_24 MyEnum_matchOut_23 (lam Enum2_25 MyEnum_matchOut_23 Enum2_25)
+        )
       )
     ]
     (lam
-      x_9
-      (all MyEnum_matchOut_1 (type) (fun MyEnum_matchOut_1 (fun MyEnum_matchOut_1 MyEnum_matchOut_1)))
-      x_9
+      x_26
+      (all MyEnum_matchOut_27 (type) (fun MyEnum_matchOut_27 (fun MyEnum_matchOut_27 MyEnum_matchOut_27)))
+      x_26
     )
   ]
 )

--- a/core-to-plc/test/data/monomorphic/monoCase.plc.golden
+++ b/core-to-plc/test/data/monomorphic/monoCase.plc.golden
@@ -5,39 +5,39 @@
         [
           {
             (abs
-              MyMonoData_2
+              MyMonoData_30
               (type)
               (lam
-                Mono1_20
-                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_2))
+                Mono1_31
+                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_30))
                 (lam
-                  Mono2_21
-                  (fun [(con integer) (con 64)] MyMonoData_2)
+                  Mono2_32
+                  (fun [(con integer) (con 64)] MyMonoData_30)
                   (lam
-                    Mono3_22
-                    (fun [(con integer) (con 64)] MyMonoData_2)
+                    Mono3_33
+                    (fun [(con integer) (con 64)] MyMonoData_30)
                     (lam
-                      MyMonoData_match_23
-                      (fun MyMonoData_2 (all MyMonoData_matchOut_24 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_24)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_24) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_24) MyMonoData_matchOut_24)))))
+                      MyMonoData_match_34
+                      (fun MyMonoData_30 (all MyMonoData_matchOut_35 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_35)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_35) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_35) MyMonoData_matchOut_35)))))
                       (lam
-                        ds_25
-                        MyMonoData_2
+                        ds_36
+                        MyMonoData_30
                         [
                           [
                             [
                               {
-                                [ MyMonoData_match_23 ds_25 ]
+                                [ MyMonoData_match_34 ds_36 ]
                                 [(con integer) (con 64)]
                               }
                               (lam
-                                a_26
+                                a_37
                                 [(con integer) (con 64)]
-                                (lam b_27 [(con integer) (con 64)] b_27)
+                                (lam b_38 [(con integer) (con 64)] b_38)
                               )
                             ]
-                            (lam a_28 [(con integer) (con 64)] a_28)
+                            (lam a_39 [(con integer) (con 64)] a_39)
                           ]
-                          (lam a_29 [(con integer) (con 64)] a_29)
+                          (lam a_40 [(con integer) (con 64)] a_40)
                         ]
                       )
                     )
@@ -45,27 +45,27 @@
                 )
               )
             )
-            (all MyMonoData_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_1)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) MyMonoData_matchOut_1))))
+            (all MyMonoData_matchOut_41 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_41)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_41) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_41) MyMonoData_matchOut_41))))
           }
           (lam
-            Mono1_arg0_7
+            Mono1_arg0_42
             [(con integer) (con 64)]
             (lam
-              Mono1_arg1_8
+              Mono1_arg1_43
               [(con integer) (con 64)]
               (abs
-                MyMonoData_matchOut_3
+                MyMonoData_matchOut_44
                 (type)
                 (lam
-                  Mono1_4
-                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_3))
+                  Mono1_45
+                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_44))
                   (lam
-                    Mono2_5
-                    (fun [(con integer) (con 64)] MyMonoData_matchOut_3)
+                    Mono2_46
+                    (fun [(con integer) (con 64)] MyMonoData_matchOut_44)
                     (lam
-                      Mono3_6
-                      (fun [(con integer) (con 64)] MyMonoData_matchOut_3)
-                      [ [ Mono1_4 Mono1_arg0_7 ] Mono1_arg1_8 ]
+                      Mono3_47
+                      (fun [(con integer) (con 64)] MyMonoData_matchOut_44)
+                      [ [ Mono1_45 Mono1_arg0_42 ] Mono1_arg1_43 ]
                     )
                   )
                 )
@@ -74,21 +74,21 @@
           )
         ]
         (lam
-          Mono2_arg0_13
+          Mono2_arg0_48
           [(con integer) (con 64)]
           (abs
-            MyMonoData_matchOut_9
+            MyMonoData_matchOut_49
             (type)
             (lam
-              Mono1_10
-              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_9))
+              Mono1_50
+              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_49))
               (lam
-                Mono2_11
-                (fun [(con integer) (con 64)] MyMonoData_matchOut_9)
+                Mono2_51
+                (fun [(con integer) (con 64)] MyMonoData_matchOut_49)
                 (lam
-                  Mono3_12
-                  (fun [(con integer) (con 64)] MyMonoData_matchOut_9)
-                  [ Mono2_11 Mono2_arg0_13 ]
+                  Mono3_52
+                  (fun [(con integer) (con 64)] MyMonoData_matchOut_49)
+                  [ Mono2_51 Mono2_arg0_48 ]
                 )
               )
             )
@@ -96,21 +96,21 @@
         )
       ]
       (lam
-        Mono3_arg0_18
+        Mono3_arg0_53
         [(con integer) (con 64)]
         (abs
-          MyMonoData_matchOut_14
+          MyMonoData_matchOut_54
           (type)
           (lam
-            Mono1_15
-            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_14))
+            Mono1_55
+            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_54))
             (lam
-              Mono2_16
-              (fun [(con integer) (con 64)] MyMonoData_matchOut_14)
+              Mono2_56
+              (fun [(con integer) (con 64)] MyMonoData_matchOut_54)
               (lam
-                Mono3_17
-                (fun [(con integer) (con 64)] MyMonoData_matchOut_14)
-                [ Mono3_17 Mono3_arg0_18 ]
+                Mono3_57
+                (fun [(con integer) (con 64)] MyMonoData_matchOut_54)
+                [ Mono3_57 Mono3_arg0_53 ]
               )
             )
           )
@@ -118,9 +118,9 @@
       )
     ]
     (lam
-      x_19
-      (all MyMonoData_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_1)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) MyMonoData_matchOut_1))))
-      x_19
+      x_58
+      (all MyMonoData_matchOut_59 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_59)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_59) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_59) MyMonoData_matchOut_59))))
+      x_58
     )
   ]
 )

--- a/core-to-plc/test/data/monomorphic/monoConstructed.plc.golden
+++ b/core-to-plc/test/data/monomorphic/monoConstructed.plc.golden
@@ -5,47 +5,47 @@
         [
           {
             (abs
-              MyMonoData_2
+              MyMonoData_25
               (type)
               (lam
-                Mono1_20
-                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_2))
+                Mono1_26
+                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_25))
                 (lam
-                  Mono2_21
-                  (fun [(con integer) (con 64)] MyMonoData_2)
+                  Mono2_27
+                  (fun [(con integer) (con 64)] MyMonoData_25)
                   (lam
-                    Mono3_22
-                    (fun [(con integer) (con 64)] MyMonoData_2)
+                    Mono3_28
+                    (fun [(con integer) (con 64)] MyMonoData_25)
                     (lam
-                      MyMonoData_match_23
-                      (fun MyMonoData_2 (all MyMonoData_matchOut_24 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_24)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_24) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_24) MyMonoData_matchOut_24)))))
-                      [ Mono2_21 (con 64 ! 1) ]
+                      MyMonoData_match_29
+                      (fun MyMonoData_25 (all MyMonoData_matchOut_30 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_30)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_30) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_30) MyMonoData_matchOut_30)))))
+                      [ Mono2_27 (con 64 ! 1) ]
                     )
                   )
                 )
               )
             )
-            (all MyMonoData_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_1)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) MyMonoData_matchOut_1))))
+            (all MyMonoData_matchOut_31 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_31)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_31) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_31) MyMonoData_matchOut_31))))
           }
           (lam
-            Mono1_arg0_7
+            Mono1_arg0_32
             [(con integer) (con 64)]
             (lam
-              Mono1_arg1_8
+              Mono1_arg1_33
               [(con integer) (con 64)]
               (abs
-                MyMonoData_matchOut_3
+                MyMonoData_matchOut_34
                 (type)
                 (lam
-                  Mono1_4
-                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_3))
+                  Mono1_35
+                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_34))
                   (lam
-                    Mono2_5
-                    (fun [(con integer) (con 64)] MyMonoData_matchOut_3)
+                    Mono2_36
+                    (fun [(con integer) (con 64)] MyMonoData_matchOut_34)
                     (lam
-                      Mono3_6
-                      (fun [(con integer) (con 64)] MyMonoData_matchOut_3)
-                      [ [ Mono1_4 Mono1_arg0_7 ] Mono1_arg1_8 ]
+                      Mono3_37
+                      (fun [(con integer) (con 64)] MyMonoData_matchOut_34)
+                      [ [ Mono1_35 Mono1_arg0_32 ] Mono1_arg1_33 ]
                     )
                   )
                 )
@@ -54,21 +54,21 @@
           )
         ]
         (lam
-          Mono2_arg0_13
+          Mono2_arg0_38
           [(con integer) (con 64)]
           (abs
-            MyMonoData_matchOut_9
+            MyMonoData_matchOut_39
             (type)
             (lam
-              Mono1_10
-              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_9))
+              Mono1_40
+              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_39))
               (lam
-                Mono2_11
-                (fun [(con integer) (con 64)] MyMonoData_matchOut_9)
+                Mono2_41
+                (fun [(con integer) (con 64)] MyMonoData_matchOut_39)
                 (lam
-                  Mono3_12
-                  (fun [(con integer) (con 64)] MyMonoData_matchOut_9)
-                  [ Mono2_11 Mono2_arg0_13 ]
+                  Mono3_42
+                  (fun [(con integer) (con 64)] MyMonoData_matchOut_39)
+                  [ Mono2_41 Mono2_arg0_38 ]
                 )
               )
             )
@@ -76,21 +76,21 @@
         )
       ]
       (lam
-        Mono3_arg0_18
+        Mono3_arg0_43
         [(con integer) (con 64)]
         (abs
-          MyMonoData_matchOut_14
+          MyMonoData_matchOut_44
           (type)
           (lam
-            Mono1_15
-            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_14))
+            Mono1_45
+            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_44))
             (lam
-              Mono2_16
-              (fun [(con integer) (con 64)] MyMonoData_matchOut_14)
+              Mono2_46
+              (fun [(con integer) (con 64)] MyMonoData_matchOut_44)
               (lam
-                Mono3_17
-                (fun [(con integer) (con 64)] MyMonoData_matchOut_14)
-                [ Mono3_17 Mono3_arg0_18 ]
+                Mono3_47
+                (fun [(con integer) (con 64)] MyMonoData_matchOut_44)
+                [ Mono3_47 Mono3_arg0_43 ]
               )
             )
           )
@@ -98,9 +98,9 @@
       )
     ]
     (lam
-      x_19
-      (all MyMonoData_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_1)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) MyMonoData_matchOut_1))))
-      x_19
+      x_48
+      (all MyMonoData_matchOut_49 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_49)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_49) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_49) MyMonoData_matchOut_49))))
+      x_48
     )
   ]
 )

--- a/core-to-plc/test/data/monomorphic/monoConstructor.plc.golden
+++ b/core-to-plc/test/data/monomorphic/monoConstructor.plc.golden
@@ -5,47 +5,47 @@
         [
           {
             (abs
-              MyMonoData_2
+              MyMonoData_25
               (type)
               (lam
-                Mono1_20
-                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_2))
+                Mono1_26
+                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_25))
                 (lam
-                  Mono2_21
-                  (fun [(con integer) (con 64)] MyMonoData_2)
+                  Mono2_27
+                  (fun [(con integer) (con 64)] MyMonoData_25)
                   (lam
-                    Mono3_22
-                    (fun [(con integer) (con 64)] MyMonoData_2)
+                    Mono3_28
+                    (fun [(con integer) (con 64)] MyMonoData_25)
                     (lam
-                      MyMonoData_match_23
-                      (fun MyMonoData_2 (all MyMonoData_matchOut_24 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_24)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_24) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_24) MyMonoData_matchOut_24)))))
-                      Mono1_20
+                      MyMonoData_match_29
+                      (fun MyMonoData_25 (all MyMonoData_matchOut_30 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_30)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_30) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_30) MyMonoData_matchOut_30)))))
+                      Mono1_26
                     )
                   )
                 )
               )
             )
-            (all MyMonoData_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_1)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) MyMonoData_matchOut_1))))
+            (all MyMonoData_matchOut_31 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_31)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_31) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_31) MyMonoData_matchOut_31))))
           }
           (lam
-            Mono1_arg0_7
+            Mono1_arg0_32
             [(con integer) (con 64)]
             (lam
-              Mono1_arg1_8
+              Mono1_arg1_33
               [(con integer) (con 64)]
               (abs
-                MyMonoData_matchOut_3
+                MyMonoData_matchOut_34
                 (type)
                 (lam
-                  Mono1_4
-                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_3))
+                  Mono1_35
+                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_34))
                   (lam
-                    Mono2_5
-                    (fun [(con integer) (con 64)] MyMonoData_matchOut_3)
+                    Mono2_36
+                    (fun [(con integer) (con 64)] MyMonoData_matchOut_34)
                     (lam
-                      Mono3_6
-                      (fun [(con integer) (con 64)] MyMonoData_matchOut_3)
-                      [ [ Mono1_4 Mono1_arg0_7 ] Mono1_arg1_8 ]
+                      Mono3_37
+                      (fun [(con integer) (con 64)] MyMonoData_matchOut_34)
+                      [ [ Mono1_35 Mono1_arg0_32 ] Mono1_arg1_33 ]
                     )
                   )
                 )
@@ -54,21 +54,21 @@
           )
         ]
         (lam
-          Mono2_arg0_13
+          Mono2_arg0_38
           [(con integer) (con 64)]
           (abs
-            MyMonoData_matchOut_9
+            MyMonoData_matchOut_39
             (type)
             (lam
-              Mono1_10
-              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_9))
+              Mono1_40
+              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_39))
               (lam
-                Mono2_11
-                (fun [(con integer) (con 64)] MyMonoData_matchOut_9)
+                Mono2_41
+                (fun [(con integer) (con 64)] MyMonoData_matchOut_39)
                 (lam
-                  Mono3_12
-                  (fun [(con integer) (con 64)] MyMonoData_matchOut_9)
-                  [ Mono2_11 Mono2_arg0_13 ]
+                  Mono3_42
+                  (fun [(con integer) (con 64)] MyMonoData_matchOut_39)
+                  [ Mono2_41 Mono2_arg0_38 ]
                 )
               )
             )
@@ -76,21 +76,21 @@
         )
       ]
       (lam
-        Mono3_arg0_18
+        Mono3_arg0_43
         [(con integer) (con 64)]
         (abs
-          MyMonoData_matchOut_14
+          MyMonoData_matchOut_44
           (type)
           (lam
-            Mono1_15
-            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_14))
+            Mono1_45
+            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_44))
             (lam
-              Mono2_16
-              (fun [(con integer) (con 64)] MyMonoData_matchOut_14)
+              Mono2_46
+              (fun [(con integer) (con 64)] MyMonoData_matchOut_44)
               (lam
-                Mono3_17
-                (fun [(con integer) (con 64)] MyMonoData_matchOut_14)
-                [ Mono3_17 Mono3_arg0_18 ]
+                Mono3_47
+                (fun [(con integer) (con 64)] MyMonoData_matchOut_44)
+                [ Mono3_47 Mono3_arg0_43 ]
               )
             )
           )
@@ -98,9 +98,9 @@
       )
     ]
     (lam
-      x_19
-      (all MyMonoData_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_1)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) MyMonoData_matchOut_1))))
-      x_19
+      x_48
+      (all MyMonoData_matchOut_49 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_49)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_49) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_49) MyMonoData_matchOut_49))))
+      x_48
     )
   ]
 )

--- a/core-to-plc/test/data/monomorphic/monoDataType.plc.golden
+++ b/core-to-plc/test/data/monomorphic/monoDataType.plc.golden
@@ -5,47 +5,47 @@
         [
           {
             (abs
-              MyMonoData_2
+              MyMonoData_26
               (type)
               (lam
-                Mono1_20
-                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_2))
+                Mono1_27
+                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_26))
                 (lam
-                  Mono2_21
-                  (fun [(con integer) (con 64)] MyMonoData_2)
+                  Mono2_28
+                  (fun [(con integer) (con 64)] MyMonoData_26)
                   (lam
-                    Mono3_22
-                    (fun [(con integer) (con 64)] MyMonoData_2)
+                    Mono3_29
+                    (fun [(con integer) (con 64)] MyMonoData_26)
                     (lam
-                      MyMonoData_match_23
-                      (fun MyMonoData_2 (all MyMonoData_matchOut_24 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_24)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_24) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_24) MyMonoData_matchOut_24)))))
-                      (lam ds_25 MyMonoData_2 ds_25)
+                      MyMonoData_match_30
+                      (fun MyMonoData_26 (all MyMonoData_matchOut_31 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_31)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_31) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_31) MyMonoData_matchOut_31)))))
+                      (lam ds_32 MyMonoData_26 ds_32)
                     )
                   )
                 )
               )
             )
-            (all MyMonoData_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_1)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) MyMonoData_matchOut_1))))
+            (all MyMonoData_matchOut_33 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_33)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_33) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_33) MyMonoData_matchOut_33))))
           }
           (lam
-            Mono1_arg0_7
+            Mono1_arg0_34
             [(con integer) (con 64)]
             (lam
-              Mono1_arg1_8
+              Mono1_arg1_35
               [(con integer) (con 64)]
               (abs
-                MyMonoData_matchOut_3
+                MyMonoData_matchOut_36
                 (type)
                 (lam
-                  Mono1_4
-                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_3))
+                  Mono1_37
+                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_36))
                   (lam
-                    Mono2_5
-                    (fun [(con integer) (con 64)] MyMonoData_matchOut_3)
+                    Mono2_38
+                    (fun [(con integer) (con 64)] MyMonoData_matchOut_36)
                     (lam
-                      Mono3_6
-                      (fun [(con integer) (con 64)] MyMonoData_matchOut_3)
-                      [ [ Mono1_4 Mono1_arg0_7 ] Mono1_arg1_8 ]
+                      Mono3_39
+                      (fun [(con integer) (con 64)] MyMonoData_matchOut_36)
+                      [ [ Mono1_37 Mono1_arg0_34 ] Mono1_arg1_35 ]
                     )
                   )
                 )
@@ -54,21 +54,21 @@
           )
         ]
         (lam
-          Mono2_arg0_13
+          Mono2_arg0_40
           [(con integer) (con 64)]
           (abs
-            MyMonoData_matchOut_9
+            MyMonoData_matchOut_41
             (type)
             (lam
-              Mono1_10
-              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_9))
+              Mono1_42
+              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_41))
               (lam
-                Mono2_11
-                (fun [(con integer) (con 64)] MyMonoData_matchOut_9)
+                Mono2_43
+                (fun [(con integer) (con 64)] MyMonoData_matchOut_41)
                 (lam
-                  Mono3_12
-                  (fun [(con integer) (con 64)] MyMonoData_matchOut_9)
-                  [ Mono2_11 Mono2_arg0_13 ]
+                  Mono3_44
+                  (fun [(con integer) (con 64)] MyMonoData_matchOut_41)
+                  [ Mono2_43 Mono2_arg0_40 ]
                 )
               )
             )
@@ -76,21 +76,21 @@
         )
       ]
       (lam
-        Mono3_arg0_18
+        Mono3_arg0_45
         [(con integer) (con 64)]
         (abs
-          MyMonoData_matchOut_14
+          MyMonoData_matchOut_46
           (type)
           (lam
-            Mono1_15
-            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_14))
+            Mono1_47
+            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_46))
             (lam
-              Mono2_16
-              (fun [(con integer) (con 64)] MyMonoData_matchOut_14)
+              Mono2_48
+              (fun [(con integer) (con 64)] MyMonoData_matchOut_46)
               (lam
-                Mono3_17
-                (fun [(con integer) (con 64)] MyMonoData_matchOut_14)
-                [ Mono3_17 Mono3_arg0_18 ]
+                Mono3_49
+                (fun [(con integer) (con 64)] MyMonoData_matchOut_46)
+                [ Mono3_49 Mono3_arg0_45 ]
               )
             )
           )
@@ -98,9 +98,9 @@
       )
     ]
     (lam
-      x_19
-      (all MyMonoData_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_1)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_1) MyMonoData_matchOut_1))))
-      x_19
+      x_50
+      (all MyMonoData_matchOut_51 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_matchOut_51)) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_51) (fun (fun [(con integer) (con 64)] MyMonoData_matchOut_51) MyMonoData_matchOut_51))))
+      x_50
     )
   ]
 )

--- a/core-to-plc/test/data/monomorphic/monoRecord.plc.golden
+++ b/core-to-plc/test/data/monomorphic/monoRecord.plc.golden
@@ -3,42 +3,42 @@
     [
       {
         (abs
-          MyMonoRecord_2
+          MyMonoRecord_12
           (type)
           (lam
-            MyMonoRecord_8
-            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoRecord_2))
+            MyMonoRecord_13
+            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoRecord_12))
             (lam
-              MyMonoRecord_match_9
-              (fun MyMonoRecord_2 (all MyMonoRecord_matchOut_10 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoRecord_matchOut_10)) MyMonoRecord_matchOut_10)))
-              (lam ds_11 MyMonoRecord_2 ds_11)
+              MyMonoRecord_match_14
+              (fun MyMonoRecord_12 (all MyMonoRecord_matchOut_15 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoRecord_matchOut_15)) MyMonoRecord_matchOut_15)))
+              (lam ds_16 MyMonoRecord_12 ds_16)
             )
           )
         )
-        (all MyMonoRecord_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoRecord_matchOut_1)) MyMonoRecord_matchOut_1))
+        (all MyMonoRecord_matchOut_17 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoRecord_matchOut_17)) MyMonoRecord_matchOut_17))
       }
       (lam
-        MyMonoRecord_arg0_5
+        MyMonoRecord_arg0_18
         [(con integer) (con 64)]
         (lam
-          MyMonoRecord_arg1_6
+          MyMonoRecord_arg1_19
           [(con integer) (con 64)]
           (abs
-            MyMonoRecord_matchOut_3
+            MyMonoRecord_matchOut_20
             (type)
             (lam
-              MyMonoRecord_4
-              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoRecord_matchOut_3))
-              [ [ MyMonoRecord_4 MyMonoRecord_arg0_5 ] MyMonoRecord_arg1_6 ]
+              MyMonoRecord_21
+              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoRecord_matchOut_20))
+              [ [ MyMonoRecord_21 MyMonoRecord_arg0_18 ] MyMonoRecord_arg1_19 ]
             )
           )
         )
       )
     ]
     (lam
-      x_7
-      (all MyMonoRecord_matchOut_1 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoRecord_matchOut_1)) MyMonoRecord_matchOut_1))
-      x_7
+      x_22
+      (all MyMonoRecord_matchOut_23 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoRecord_matchOut_23)) MyMonoRecord_matchOut_23))
+      x_22
     )
   ]
 )

--- a/core-to-plc/test/data/monomorphic/nonValueCase.plc.golden
+++ b/core-to-plc/test/data/monomorphic/nonValueCase.plc.golden
@@ -4,85 +4,90 @@
       [
         {
           (abs
-            MyEnum_2
+            MyEnum_44
             (type)
             (lam
-              Enum1_10
-              MyEnum_2
+              Enum1_45
+              MyEnum_44
               (lam
-                Enum2_11
-                MyEnum_2
+                Enum2_46
+                MyEnum_44
                 (lam
-                  MyEnum_match_12
-                  (fun MyEnum_2 (all MyEnum_matchOut_13 (type) (fun MyEnum_matchOut_13 (fun MyEnum_matchOut_13 MyEnum_matchOut_13))))
+                  MyEnum_match_47
+                  (fun MyEnum_44 (all MyEnum_matchOut_48 (type) (fun MyEnum_matchOut_48 (fun MyEnum_matchOut_48 MyEnum_matchOut_48))))
                   (lam
-                    ds_14
-                    MyEnum_2
+                    ds_49
+                    MyEnum_44
                     [
                       [
                         [
                           {
                             [
-                              MyEnum_match_12 ds_14
+                              MyEnum_match_47 ds_49
                             ]
-                            (fun (all a_29 (type) (fun a_29 a_29)) [(con integer) (con 64)])
+                            (fun (all a_50 (type) (fun a_50 a_50)) [(con integer) (con 64)])
                           }
                           (lam
-                            thunk_30
-                            (all a_32 (type) (fun a_32 a_32))
+                            thunk_51
+                            (all a_52 (type) (fun a_52 a_52))
                             (con 64 ! 1)
                           )
                         ]
                         (lam
-                          thunk_37
-                          (all a_39 (type) (fun a_39 a_39))
+                          thunk_53
+                          (all a_54 (type) (fun a_54 a_54))
                           [
                             {
                               (abs
-                                e_33
+                                e_55
                                 (type)
                                 (lam
-                                  thunk_34
-                                  (all a_36 (type) (fun a_36 a_36))
-                                  (error e_33)
+                                  thunk_56
+                                  (all a_57 (type) (fun a_57 a_57))
+                                  (error e_55)
                                 )
                               )
                               [(con integer) (con 64)]
                             }
                             (abs
-                              p_matchOut_22
+                              p_matchOut_58
                               (type)
-                              (lam unit_23 p_matchOut_22 unit_23)
+                              (lam unit_59 p_matchOut_58 unit_59)
                             )
                           ]
                         )
                       ]
-                      (abs a_42 (type) (lam x_43 a_42 x_43))
+                      (abs a_60 (type) (lam x_61 a_60 x_61))
                     ]
                   )
                 )
               )
             )
           )
-          (all MyEnum_matchOut_1 (type) (fun MyEnum_matchOut_1 (fun MyEnum_matchOut_1 MyEnum_matchOut_1)))
+          (all MyEnum_matchOut_62 (type) (fun MyEnum_matchOut_62 (fun MyEnum_matchOut_62 MyEnum_matchOut_62)))
         }
         (abs
-          MyEnum_matchOut_3
+          MyEnum_matchOut_63
           (type)
-          (lam Enum1_4 MyEnum_matchOut_3 (lam Enum2_5 MyEnum_matchOut_3 Enum1_4)
+          (lam
+            Enum1_64
+            MyEnum_matchOut_63
+            (lam Enum2_65 MyEnum_matchOut_63 Enum1_64)
           )
         )
       ]
       (abs
-        MyEnum_matchOut_6
+        MyEnum_matchOut_66
         (type)
-        (lam Enum1_7 MyEnum_matchOut_6 (lam Enum2_8 MyEnum_matchOut_6 Enum2_8))
+        (lam
+          Enum1_67 MyEnum_matchOut_66 (lam Enum2_68 MyEnum_matchOut_66 Enum2_68)
+        )
       )
     ]
     (lam
-      x_9
-      (all MyEnum_matchOut_1 (type) (fun MyEnum_matchOut_1 (fun MyEnum_matchOut_1 MyEnum_matchOut_1)))
-      x_9
+      x_69
+      (all MyEnum_matchOut_70 (type) (fun MyEnum_matchOut_70 (fun MyEnum_matchOut_70 MyEnum_matchOut_70)))
+      x_69
     )
   ]
 )

--- a/core-to-plc/test/data/newtypes/basicNewtype.plc.golden
+++ b/core-to-plc/test/data/newtypes/basicNewtype.plc.golden
@@ -3,38 +3,38 @@
     [
       {
         (abs
-          MyNewtype_2
+          MyNewtype_11
           (type)
           (lam
-            MyNewtype_7
-            (fun [(con integer) (con 64)] MyNewtype_2)
+            MyNewtype_12
+            (fun [(con integer) (con 64)] MyNewtype_11)
             (lam
-              MyNewtype_match_8
-              (fun MyNewtype_2 (all MyNewtype_matchOut_9 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_9) MyNewtype_matchOut_9)))
-              (lam ds_10 MyNewtype_2 ds_10)
+              MyNewtype_match_13
+              (fun MyNewtype_11 (all MyNewtype_matchOut_14 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_14) MyNewtype_matchOut_14)))
+              (lam ds_15 MyNewtype_11 ds_15)
             )
           )
         )
-        (all MyNewtype_matchOut_1 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_1) MyNewtype_matchOut_1))
+        (all MyNewtype_matchOut_16 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_16) MyNewtype_matchOut_16))
       }
       (lam
-        MyNewtype_arg0_5
+        MyNewtype_arg0_17
         [(con integer) (con 64)]
         (abs
-          MyNewtype_matchOut_3
+          MyNewtype_matchOut_18
           (type)
           (lam
-            MyNewtype_4
-            (fun [(con integer) (con 64)] MyNewtype_matchOut_3)
-            [ MyNewtype_4 MyNewtype_arg0_5 ]
+            MyNewtype_19
+            (fun [(con integer) (con 64)] MyNewtype_matchOut_18)
+            [ MyNewtype_19 MyNewtype_arg0_17 ]
           )
         )
       )
     ]
     (lam
-      x_6
-      (all MyNewtype_matchOut_1 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_1) MyNewtype_matchOut_1))
-      x_6
+      x_20
+      (all MyNewtype_matchOut_21 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_21) MyNewtype_matchOut_21))
+      x_20
     )
   ]
 )

--- a/core-to-plc/test/data/newtypes/nestedNewtypeMatch.plc.golden
+++ b/core-to-plc/test/data/newtypes/nestedNewtypeMatch.plc.golden
@@ -3,93 +3,93 @@
     [
       {
         (abs
-          MyNewtype_4
+          MyNewtype_23
           (type)
           (lam
-            MyNewtype_9
-            (fun [(con integer) (con 64)] MyNewtype_4)
+            MyNewtype_24
+            (fun [(con integer) (con 64)] MyNewtype_23)
             (lam
-              MyNewtype_match_10
-              (fun MyNewtype_4 (all MyNewtype_matchOut_11 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_11) MyNewtype_matchOut_11)))
+              MyNewtype_match_25
+              (fun MyNewtype_23 (all MyNewtype_matchOut_26 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_26) MyNewtype_matchOut_26)))
               [
                 [
                   {
                     (abs
-                      MyNewtype2_12
+                      MyNewtype2_27
                       (type)
                       (lam
-                        MyNewtype2_17
-                        (fun MyNewtype_4 MyNewtype2_12)
+                        MyNewtype2_28
+                        (fun MyNewtype_23 MyNewtype2_27)
                         (lam
-                          MyNewtype2_match_18
-                          (fun MyNewtype2_12 (all MyNewtype2_matchOut_19 (type) (fun (fun MyNewtype_4 MyNewtype2_matchOut_19) MyNewtype2_matchOut_19)))
+                          MyNewtype2_match_29
+                          (fun MyNewtype2_27 (all MyNewtype2_matchOut_30 (type) (fun (fun MyNewtype_23 MyNewtype2_matchOut_30) MyNewtype2_matchOut_30)))
                           (lam
-                            ds_20
-                            MyNewtype2_12
+                            ds_31
+                            MyNewtype2_27
                             [
                               {
                                 [
-                                  MyNewtype_match_10
+                                  MyNewtype_match_25
                                   [
                                     {
-                                      [ MyNewtype2_match_18 ds_20 ] MyNewtype_4
+                                      [ MyNewtype2_match_29 ds_31 ] MyNewtype_23
                                     }
-                                    (lam inner_21 MyNewtype_4 inner_21)
+                                    (lam inner_32 MyNewtype_23 inner_32)
                                   ]
                                 ]
                                 [(con integer) (con 64)]
                               }
-                              (lam inner_22 [(con integer) (con 64)] inner_22)
+                              (lam inner_33 [(con integer) (con 64)] inner_33)
                             ]
                           )
                         )
                       )
                     )
-                    (all MyNewtype2_matchOut_1 (type) (fun (fun MyNewtype_4 MyNewtype2_matchOut_1) MyNewtype2_matchOut_1))
+                    (all MyNewtype2_matchOut_34 (type) (fun (fun MyNewtype_23 MyNewtype2_matchOut_34) MyNewtype2_matchOut_34))
                   }
                   (lam
-                    MyNewtype2_arg0_15
-                    MyNewtype_4
+                    MyNewtype2_arg0_35
+                    MyNewtype_23
                     (abs
-                      MyNewtype2_matchOut_13
+                      MyNewtype2_matchOut_36
                       (type)
                       (lam
-                        MyNewtype2_14
-                        (fun MyNewtype_4 MyNewtype2_matchOut_13)
-                        [ MyNewtype2_14 MyNewtype2_arg0_15 ]
+                        MyNewtype2_37
+                        (fun MyNewtype_23 MyNewtype2_matchOut_36)
+                        [ MyNewtype2_37 MyNewtype2_arg0_35 ]
                       )
                     )
                   )
                 ]
                 (lam
-                  x_16
-                  (all MyNewtype2_matchOut_1 (type) (fun (fun MyNewtype_4 MyNewtype2_matchOut_1) MyNewtype2_matchOut_1))
-                  x_16
+                  x_38
+                  (all MyNewtype2_matchOut_39 (type) (fun (fun MyNewtype_23 MyNewtype2_matchOut_39) MyNewtype2_matchOut_39))
+                  x_38
                 )
               ]
             )
           )
         )
-        (all MyNewtype_matchOut_3 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_3) MyNewtype_matchOut_3))
+        (all MyNewtype_matchOut_40 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_40) MyNewtype_matchOut_40))
       }
       (lam
-        MyNewtype_arg0_7
+        MyNewtype_arg0_41
         [(con integer) (con 64)]
         (abs
-          MyNewtype_matchOut_5
+          MyNewtype_matchOut_42
           (type)
           (lam
-            MyNewtype_6
-            (fun [(con integer) (con 64)] MyNewtype_matchOut_5)
-            [ MyNewtype_6 MyNewtype_arg0_7 ]
+            MyNewtype_43
+            (fun [(con integer) (con 64)] MyNewtype_matchOut_42)
+            [ MyNewtype_43 MyNewtype_arg0_41 ]
           )
         )
       )
     ]
     (lam
-      x_8
-      (all MyNewtype_matchOut_3 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_3) MyNewtype_matchOut_3))
-      x_8
+      x_44
+      (all MyNewtype_matchOut_45 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_45) MyNewtype_matchOut_45))
+      x_44
     )
   ]
 )

--- a/core-to-plc/test/data/newtypes/newtypeCreate.plc.golden
+++ b/core-to-plc/test/data/newtypes/newtypeCreate.plc.golden
@@ -3,38 +3,38 @@
     [
       {
         (abs
-          MyNewtype_3
+          MyNewtype_11
           (type)
           (lam
-            MyNewtype_8
-            (fun [(con integer) (con 64)] MyNewtype_3)
+            MyNewtype_12
+            (fun [(con integer) (con 64)] MyNewtype_11)
             (lam
-              MyNewtype_match_9
-              (fun MyNewtype_3 (all MyNewtype_matchOut_10 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_10) MyNewtype_matchOut_10)))
-              (lam ds_0 [(con integer) (con 64)] [ MyNewtype_8 ds_0 ])
+              MyNewtype_match_13
+              (fun MyNewtype_11 (all MyNewtype_matchOut_14 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_14) MyNewtype_matchOut_14)))
+              (lam ds_15 [(con integer) (con 64)] [ MyNewtype_12 ds_15 ])
             )
           )
         )
-        (all MyNewtype_matchOut_2 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_2) MyNewtype_matchOut_2))
+        (all MyNewtype_matchOut_16 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_16) MyNewtype_matchOut_16))
       }
       (lam
-        MyNewtype_arg0_6
+        MyNewtype_arg0_17
         [(con integer) (con 64)]
         (abs
-          MyNewtype_matchOut_4
+          MyNewtype_matchOut_18
           (type)
           (lam
-            MyNewtype_5
-            (fun [(con integer) (con 64)] MyNewtype_matchOut_4)
-            [ MyNewtype_5 MyNewtype_arg0_6 ]
+            MyNewtype_19
+            (fun [(con integer) (con 64)] MyNewtype_matchOut_18)
+            [ MyNewtype_19 MyNewtype_arg0_17 ]
           )
         )
       )
     ]
     (lam
-      x_7
-      (all MyNewtype_matchOut_2 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_2) MyNewtype_matchOut_2))
-      x_7
+      x_20
+      (all MyNewtype_matchOut_21 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_21) MyNewtype_matchOut_21))
+      x_20
     )
   ]
 )

--- a/core-to-plc/test/data/newtypes/newtypeCreate2.plc.golden
+++ b/core-to-plc/test/data/newtypes/newtypeCreate2.plc.golden
@@ -3,38 +3,38 @@
     [
       {
         (abs
-          MyNewtype_2
+          MyNewtype_10
           (type)
           (lam
-            MyNewtype_7
-            (fun [(con integer) (con 64)] MyNewtype_2)
+            MyNewtype_11
+            (fun [(con integer) (con 64)] MyNewtype_10)
             (lam
-              MyNewtype_match_8
-              (fun MyNewtype_2 (all MyNewtype_matchOut_9 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_9) MyNewtype_matchOut_9)))
-              [ MyNewtype_7 (con 64 ! 1) ]
+              MyNewtype_match_12
+              (fun MyNewtype_10 (all MyNewtype_matchOut_13 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_13) MyNewtype_matchOut_13)))
+              [ MyNewtype_11 (con 64 ! 1) ]
             )
           )
         )
-        (all MyNewtype_matchOut_1 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_1) MyNewtype_matchOut_1))
+        (all MyNewtype_matchOut_14 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_14) MyNewtype_matchOut_14))
       }
       (lam
-        MyNewtype_arg0_5
+        MyNewtype_arg0_15
         [(con integer) (con 64)]
         (abs
-          MyNewtype_matchOut_3
+          MyNewtype_matchOut_16
           (type)
           (lam
-            MyNewtype_4
-            (fun [(con integer) (con 64)] MyNewtype_matchOut_3)
-            [ MyNewtype_4 MyNewtype_arg0_5 ]
+            MyNewtype_17
+            (fun [(con integer) (con 64)] MyNewtype_matchOut_16)
+            [ MyNewtype_17 MyNewtype_arg0_15 ]
           )
         )
       )
     ]
     (lam
-      x_6
-      (all MyNewtype_matchOut_1 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_1) MyNewtype_matchOut_1))
-      x_6
+      x_18
+      (all MyNewtype_matchOut_19 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_19) MyNewtype_matchOut_19))
+      x_18
     )
   ]
 )

--- a/core-to-plc/test/data/newtypes/newtypeMatch.plc.golden
+++ b/core-to-plc/test/data/newtypes/newtypeMatch.plc.golden
@@ -3,45 +3,45 @@
     [
       {
         (abs
-          MyNewtype_2
+          MyNewtype_12
           (type)
           (lam
-            MyNewtype_7
-            (fun [(con integer) (con 64)] MyNewtype_2)
+            MyNewtype_13
+            (fun [(con integer) (con 64)] MyNewtype_12)
             (lam
-              MyNewtype_match_8
-              (fun MyNewtype_2 (all MyNewtype_matchOut_9 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_9) MyNewtype_matchOut_9)))
+              MyNewtype_match_14
+              (fun MyNewtype_12 (all MyNewtype_matchOut_15 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_15) MyNewtype_matchOut_15)))
               (lam
-                ds_10
-                MyNewtype_2
+                ds_16
+                MyNewtype_12
                 [
-                  { [ MyNewtype_match_8 ds_10 ] [(con integer) (con 64)] }
-                  (lam inner_11 [(con integer) (con 64)] inner_11)
+                  { [ MyNewtype_match_14 ds_16 ] [(con integer) (con 64)] }
+                  (lam inner_17 [(con integer) (con 64)] inner_17)
                 ]
               )
             )
           )
         )
-        (all MyNewtype_matchOut_1 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_1) MyNewtype_matchOut_1))
+        (all MyNewtype_matchOut_18 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_18) MyNewtype_matchOut_18))
       }
       (lam
-        MyNewtype_arg0_5
+        MyNewtype_arg0_19
         [(con integer) (con 64)]
         (abs
-          MyNewtype_matchOut_3
+          MyNewtype_matchOut_20
           (type)
           (lam
-            MyNewtype_4
-            (fun [(con integer) (con 64)] MyNewtype_matchOut_3)
-            [ MyNewtype_4 MyNewtype_arg0_5 ]
+            MyNewtype_21
+            (fun [(con integer) (con 64)] MyNewtype_matchOut_20)
+            [ MyNewtype_21 MyNewtype_arg0_19 ]
           )
         )
       )
     ]
     (lam
-      x_6
-      (all MyNewtype_matchOut_1 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_1) MyNewtype_matchOut_1))
-      x_6
+      x_22
+      (all MyNewtype_matchOut_23 (type) (fun (fun [(con integer) (con 64)] MyNewtype_matchOut_23) MyNewtype_matchOut_23))
+      x_22
     )
   ]
 )

--- a/core-to-plc/test/data/polymorphic/polyConstructed.plc.golden
+++ b/core-to-plc/test/data/polymorphic/polyConstructed.plc.golden
@@ -4,21 +4,21 @@
       [
         {
           (abs
-            MyPolyData_4
+            MyPolyData_31
             (fun (type) (fun (type) (type)))
             (lam
-              Poly1_21
-              (all a_22 (type) (all b_23 (type) (fun a_22 (fun b_23 [[MyPolyData_4 a_22] b_23]))))
+              Poly1_32
+              (all a_33 (type) (all b_34 (type) (fun a_33 (fun b_34 [[MyPolyData_31 a_33] b_34]))))
               (lam
-                Poly2_24
-                (all a_25 (type) (all b_26 (type) (fun a_25 [[MyPolyData_4 a_25] b_26])))
+                Poly2_35
+                (all a_36 (type) (all b_37 (type) (fun a_36 [[MyPolyData_31 a_36] b_37])))
                 (lam
-                  MyPolyData_match_27
-                  (all a_28 (type) (all b_29 (type) (fun [[MyPolyData_4 a_28] b_29] (all MyPolyData_matchOut_30 (type) (fun (fun a_28 (fun b_29 MyPolyData_matchOut_30)) (fun (fun a_28 MyPolyData_matchOut_30) MyPolyData_matchOut_30))))))
+                  MyPolyData_match_38
+                  (all a_39 (type) (all b_40 (type) (fun [[MyPolyData_31 a_39] b_40] (all MyPolyData_matchOut_41 (type) (fun (fun a_39 (fun b_40 MyPolyData_matchOut_41)) (fun (fun a_39 MyPolyData_matchOut_41) MyPolyData_matchOut_41))))))
                   [
                     [
                       {
-                        { Poly1_21 [(con integer) (con 64)] }
+                        { Poly1_32 [(con integer) (con 64)] }
                         [(con integer) (con 64)]
                       }
                       (con 64 ! 1)
@@ -29,30 +29,30 @@
               )
             )
           )
-          (lam a_1 (type) (lam b_2 (type) (all MyPolyData_matchOut_3 (type) (fun (fun a_1 (fun b_2 MyPolyData_matchOut_3)) (fun (fun a_1 MyPolyData_matchOut_3) MyPolyData_matchOut_3)))))
+          (lam a_42 (type) (lam b_43 (type) (all MyPolyData_matchOut_44 (type) (fun (fun a_42 (fun b_43 MyPolyData_matchOut_44)) (fun (fun a_42 MyPolyData_matchOut_44) MyPolyData_matchOut_44)))))
         }
         (abs
-          a_5
+          a_45
           (type)
           (abs
-            b_6
+            b_46
             (type)
             (lam
-              Poly1_arg0_10
-              a_5
+              Poly1_arg0_47
+              a_45
               (lam
-                Poly1_arg1_11
-                b_6
+                Poly1_arg1_48
+                b_46
                 (abs
-                  MyPolyData_matchOut_7
+                  MyPolyData_matchOut_49
                   (type)
                   (lam
-                    Poly1_8
-                    (fun a_5 (fun b_6 MyPolyData_matchOut_7))
+                    Poly1_50
+                    (fun a_45 (fun b_46 MyPolyData_matchOut_49))
                     (lam
-                      Poly2_9
-                      (fun a_5 MyPolyData_matchOut_7)
-                      [ [ Poly1_8 Poly1_arg0_10 ] Poly1_arg1_11 ]
+                      Poly2_51
+                      (fun a_45 MyPolyData_matchOut_49)
+                      [ [ Poly1_50 Poly1_arg0_47 ] Poly1_arg1_48 ]
                     )
                   )
                 )
@@ -62,24 +62,24 @@
         )
       ]
       (abs
-        a_12
+        a_52
         (type)
         (abs
-          b_13
+          b_53
           (type)
           (lam
-            Poly2_arg0_17
-            a_12
+            Poly2_arg0_54
+            a_52
             (abs
-              MyPolyData_matchOut_14
+              MyPolyData_matchOut_55
               (type)
               (lam
-                Poly1_15
-                (fun a_12 (fun b_13 MyPolyData_matchOut_14))
+                Poly1_56
+                (fun a_52 (fun b_53 MyPolyData_matchOut_55))
                 (lam
-                  Poly2_16
-                  (fun a_12 MyPolyData_matchOut_14)
-                  [ Poly2_16 Poly2_arg0_17 ]
+                  Poly2_57
+                  (fun a_52 MyPolyData_matchOut_55)
+                  [ Poly2_57 Poly2_arg0_54 ]
                 )
               )
             )
@@ -88,15 +88,15 @@
       )
     ]
     (abs
-      a_18
+      a_58
       (type)
       (abs
-        b_19
+        b_59
         (type)
         (lam
-          x_20
-          [[(lam a_1 (type) (lam b_2 (type) (all MyPolyData_matchOut_3 (type) (fun (fun a_1 (fun b_2 MyPolyData_matchOut_3)) (fun (fun a_1 MyPolyData_matchOut_3) MyPolyData_matchOut_3))))) a_18] b_19]
-          x_20
+          x_60
+          [[(lam a_61 (type) (lam b_62 (type) (all MyPolyData_matchOut_63 (type) (fun (fun a_61 (fun b_62 MyPolyData_matchOut_63)) (fun (fun a_61 MyPolyData_matchOut_63) MyPolyData_matchOut_63))))) a_58] b_59]
+          x_60
         )
       )
     )

--- a/core-to-plc/test/data/polymorphic/polyDataType.plc.golden
+++ b/core-to-plc/test/data/polymorphic/polyDataType.plc.golden
@@ -4,50 +4,50 @@
       [
         {
           (abs
-            MyPolyData_4
+            MyPolyData_32
             (fun (type) (fun (type) (type)))
             (lam
-              Poly1_21
-              (all a_22 (type) (all b_23 (type) (fun a_22 (fun b_23 [[MyPolyData_4 a_22] b_23]))))
+              Poly1_33
+              (all a_34 (type) (all b_35 (type) (fun a_34 (fun b_35 [[MyPolyData_32 a_34] b_35]))))
               (lam
-                Poly2_24
-                (all a_25 (type) (all b_26 (type) (fun a_25 [[MyPolyData_4 a_25] b_26])))
+                Poly2_36
+                (all a_37 (type) (all b_38 (type) (fun a_37 [[MyPolyData_32 a_37] b_38])))
                 (lam
-                  MyPolyData_match_27
-                  (all a_28 (type) (all b_29 (type) (fun [[MyPolyData_4 a_28] b_29] (all MyPolyData_matchOut_30 (type) (fun (fun a_28 (fun b_29 MyPolyData_matchOut_30)) (fun (fun a_28 MyPolyData_matchOut_30) MyPolyData_matchOut_30))))))
+                  MyPolyData_match_39
+                  (all a_40 (type) (all b_41 (type) (fun [[MyPolyData_32 a_40] b_41] (all MyPolyData_matchOut_42 (type) (fun (fun a_40 (fun b_41 MyPolyData_matchOut_42)) (fun (fun a_40 MyPolyData_matchOut_42) MyPolyData_matchOut_42))))))
                   (lam
-                    ds_31
-                    [[MyPolyData_4 [(con integer) (con 64)]] [(con integer) (con 64)]]
-                    ds_31
+                    ds_43
+                    [[MyPolyData_32 [(con integer) (con 64)]] [(con integer) (con 64)]]
+                    ds_43
                   )
                 )
               )
             )
           )
-          (lam a_1 (type) (lam b_2 (type) (all MyPolyData_matchOut_3 (type) (fun (fun a_1 (fun b_2 MyPolyData_matchOut_3)) (fun (fun a_1 MyPolyData_matchOut_3) MyPolyData_matchOut_3)))))
+          (lam a_44 (type) (lam b_45 (type) (all MyPolyData_matchOut_46 (type) (fun (fun a_44 (fun b_45 MyPolyData_matchOut_46)) (fun (fun a_44 MyPolyData_matchOut_46) MyPolyData_matchOut_46)))))
         }
         (abs
-          a_5
+          a_47
           (type)
           (abs
-            b_6
+            b_48
             (type)
             (lam
-              Poly1_arg0_10
-              a_5
+              Poly1_arg0_49
+              a_47
               (lam
-                Poly1_arg1_11
-                b_6
+                Poly1_arg1_50
+                b_48
                 (abs
-                  MyPolyData_matchOut_7
+                  MyPolyData_matchOut_51
                   (type)
                   (lam
-                    Poly1_8
-                    (fun a_5 (fun b_6 MyPolyData_matchOut_7))
+                    Poly1_52
+                    (fun a_47 (fun b_48 MyPolyData_matchOut_51))
                     (lam
-                      Poly2_9
-                      (fun a_5 MyPolyData_matchOut_7)
-                      [ [ Poly1_8 Poly1_arg0_10 ] Poly1_arg1_11 ]
+                      Poly2_53
+                      (fun a_47 MyPolyData_matchOut_51)
+                      [ [ Poly1_52 Poly1_arg0_49 ] Poly1_arg1_50 ]
                     )
                   )
                 )
@@ -57,24 +57,24 @@
         )
       ]
       (abs
-        a_12
+        a_54
         (type)
         (abs
-          b_13
+          b_55
           (type)
           (lam
-            Poly2_arg0_17
-            a_12
+            Poly2_arg0_56
+            a_54
             (abs
-              MyPolyData_matchOut_14
+              MyPolyData_matchOut_57
               (type)
               (lam
-                Poly1_15
-                (fun a_12 (fun b_13 MyPolyData_matchOut_14))
+                Poly1_58
+                (fun a_54 (fun b_55 MyPolyData_matchOut_57))
                 (lam
-                  Poly2_16
-                  (fun a_12 MyPolyData_matchOut_14)
-                  [ Poly2_16 Poly2_arg0_17 ]
+                  Poly2_59
+                  (fun a_54 MyPolyData_matchOut_57)
+                  [ Poly2_59 Poly2_arg0_56 ]
                 )
               )
             )
@@ -83,15 +83,15 @@
       )
     ]
     (abs
-      a_18
+      a_60
       (type)
       (abs
-        b_19
+        b_61
         (type)
         (lam
-          x_20
-          [[(lam a_1 (type) (lam b_2 (type) (all MyPolyData_matchOut_3 (type) (fun (fun a_1 (fun b_2 MyPolyData_matchOut_3)) (fun (fun a_1 MyPolyData_matchOut_3) MyPolyData_matchOut_3))))) a_18] b_19]
-          x_20
+          x_62
+          [[(lam a_63 (type) (lam b_64 (type) (all MyPolyData_matchOut_65 (type) (fun (fun a_63 (fun b_64 MyPolyData_matchOut_65)) (fun (fun a_63 MyPolyData_matchOut_65) MyPolyData_matchOut_65))))) a_60] b_61]
+          x_62
         )
       )
     )

--- a/core-to-plc/test/generics/boolInterop.plc.golden
+++ b/core-to-plc/test/generics/boolInterop.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  Bool_matchOut_3
+  Bool_matchOut_41
   (type)
-  (lam True_4 Bool_matchOut_3 (lam False_5 Bool_matchOut_3 True_4))
+  (lam True_42 Bool_matchOut_41 (lam False_43 Bool_matchOut_41 True_42))
 )

--- a/core-to-plc/test/primitives/and.plc.golden
+++ b/core-to-plc/test/primitives/and.plc.golden
@@ -1,71 +1,77 @@
 (program 1.0.0
   (lam
-    ds_14
-    (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
+    ds_28
+    (all Bool_matchOut_29 (type) (fun Bool_matchOut_29 (fun Bool_matchOut_29 Bool_matchOut_29)))
     (lam
-      ds_15
-      (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
+      ds_30
+      (all Bool_matchOut_31 (type) (fun Bool_matchOut_31 (fun Bool_matchOut_31 Bool_matchOut_31)))
       [
         [
           [
             {
               [
                 (lam
-                  x_9
-                  (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
-                  x_9
+                  x_32
+                  (all Bool_matchOut_33 (type) (fun Bool_matchOut_33 (fun Bool_matchOut_33 Bool_matchOut_33)))
+                  x_32
                 )
-                ds_14
+                ds_28
               ]
-              (fun (all a_17 (type) (fun a_17 a_17)) (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1))))
+              (fun (all a_34 (type) (fun a_34 a_34)) (all Bool_matchOut_35 (type) (fun Bool_matchOut_35 (fun Bool_matchOut_35 Bool_matchOut_35))))
             }
             (lam
-              thunk_18
-              (all a_20 (type) (fun a_20 a_20))
+              thunk_36
+              (all a_37 (type) (fun a_37 a_37))
               [
                 [
                   {
                     [
                       (lam
-                        x_9
-                        (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
-                        x_9
+                        x_38
+                        (all Bool_matchOut_39 (type) (fun Bool_matchOut_39 (fun Bool_matchOut_39 Bool_matchOut_39)))
+                        x_38
                       )
-                      ds_15
+                      ds_30
                     ]
-                    (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
+                    (all Bool_matchOut_40 (type) (fun Bool_matchOut_40 (fun Bool_matchOut_40 Bool_matchOut_40)))
                   }
                   (abs
-                    Bool_matchOut_3
+                    Bool_matchOut_41
                     (type)
                     (lam
-                      True_4
-                      Bool_matchOut_3
-                      (lam False_5 Bool_matchOut_3 True_4)
+                      True_42
+                      Bool_matchOut_41
+                      (lam False_43 Bool_matchOut_41 True_42)
                     )
                   )
                 ]
                 (abs
-                  Bool_matchOut_6
+                  Bool_matchOut_44
                   (type)
                   (lam
-                    True_7 Bool_matchOut_6 (lam False_8 Bool_matchOut_6 False_8)
+                    True_45
+                    Bool_matchOut_44
+                    (lam False_46 Bool_matchOut_44 False_46)
                   )
                 )
               ]
             )
           ]
           (lam
-            thunk_21
-            (all a_23 (type) (fun a_23 a_23))
+            thunk_47
+            (all a_48 (type) (fun a_48 a_48))
             (abs
-              Bool_matchOut_6
+              Bool_matchOut_49
               (type)
-              (lam True_7 Bool_matchOut_6 (lam False_8 Bool_matchOut_6 False_8))
+              (lam
+                True_50
+                Bool_matchOut_49
+                (lam False_51 Bool_matchOut_49 False_51)
+              )
             )
           )
         ]
-        (abs a_26 (type) (lam x_27 a_26 x_27))
+        (abs a_52 (type) (lam x_53 a_52 x_53))
       ]
     )
   )

--- a/core-to-plc/test/primitives/andApply.plc.golden
+++ b/core-to-plc/test/primitives/andApply.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  Bool_matchOut_6
+  Bool_matchOut_44
   (type)
-  (lam True_7 Bool_matchOut_6 (lam False_8 Bool_matchOut_6 False_8))
+  (lam True_45 Bool_matchOut_44 (lam False_46 Bool_matchOut_44 False_46))
 )

--- a/core-to-plc/test/primitives/bool.plc.golden
+++ b/core-to-plc/test/primitives/bool.plc.golden
@@ -1,7 +1,7 @@
 (program 1.0.0
   (abs
-    Bool_matchOut_3
+    Bool_matchOut_14
     (type)
-    (lam True_4 Bool_matchOut_3 (lam False_5 Bool_matchOut_3 True_4))
+    (lam True_15 Bool_matchOut_14 (lam False_16 Bool_matchOut_14 True_15))
   )
 )

--- a/core-to-plc/test/primitives/bytestring.plc.golden
+++ b/core-to-plc/test/primitives/bytestring.plc.golden
@@ -1,3 +1,3 @@
 (program 1.0.0
-  (lam ds_0 [(con bytestring) (con 64)] ds_0)
+  (lam ds_1 [(con bytestring) (con 64)] ds_1)
 )

--- a/core-to-plc/test/primitives/error.plc.golden
+++ b/core-to-plc/test/primitives/error.plc.golden
@@ -1,6 +1,6 @@
 (program 1.0.0
   {
-    (abs e_0 (type) (lam thunk_1 (all a_3 (type) (fun a_3 a_3)) (error e_0)))
+    (abs e_4 (type) (lam thunk_5 (all a_6 (type) (fun a_6 a_6)) (error e_4)))
     [(con integer) (con 64)]
   }
 )

--- a/core-to-plc/test/primitives/ifThenElse.plc.golden
+++ b/core-to-plc/test/primitives/ifThenElse.plc.golden
@@ -1,9 +1,9 @@
 (program 1.0.0
   (lam
-    ds_0
+    ds_28
     [(con integer) (con 64)]
     (lam
-      ds_1
+      ds_29
       [(con integer) (con 64)]
       [
         [
@@ -11,19 +11,19 @@
             {
               [
                 (lam
-                  x_11
-                  (all Bool_matchOut_3 (type) (fun Bool_matchOut_3 (fun Bool_matchOut_3 Bool_matchOut_3)))
-                  x_11
+                  x_30
+                  (all Bool_matchOut_31 (type) (fun Bool_matchOut_31 (fun Bool_matchOut_31 Bool_matchOut_31)))
+                  x_30
                 )
-                [ [ { (con equalsInteger) (con 64) } ds_0 ] ds_1 ]
+                [ [ { (con equalsInteger) (con 64) } ds_28 ] ds_29 ]
               ]
-              (fun (all a_17 (type) (fun a_17 a_17)) [(con integer) (con 64)])
+              (fun (all a_32 (type) (fun a_32 a_32)) [(con integer) (con 64)])
             }
-            (lam thunk_18 (all a_20 (type) (fun a_20 a_20)) ds_0)
+            (lam thunk_33 (all a_34 (type) (fun a_34 a_34)) ds_28)
           ]
-          (lam thunk_21 (all a_23 (type) (fun a_23 a_23)) ds_1)
+          (lam thunk_35 (all a_36 (type) (fun a_36 a_36)) ds_29)
         ]
-        (abs a_26 (type) (lam x_27 a_26 x_27))
+        (abs a_37 (type) (lam x_38 a_37 x_38))
       ]
     )
   )

--- a/core-to-plc/test/primitives/intCompare.plc.golden
+++ b/core-to-plc/test/primitives/intCompare.plc.golden
@@ -1,11 +1,11 @@
 (program 1.0.0
   (lam
-    ds_0
+    ds_2
     [(con integer) (con 64)]
     (lam
-      ds_1
+      ds_3
       [(con integer) (con 64)]
-      [ [ { (con lessThanInteger) (con 64) } ds_0 ] ds_1 ]
+      [ [ { (con lessThanInteger) (con 64) } ds_2 ] ds_3 ]
     )
   )
 )

--- a/core-to-plc/test/primitives/intEq.plc.golden
+++ b/core-to-plc/test/primitives/intEq.plc.golden
@@ -1,11 +1,11 @@
 (program 1.0.0
   (lam
-    ds_0
+    ds_2
     [(con integer) (con 64)]
     (lam
-      ds_1
+      ds_3
       [(con integer) (con 64)]
-      [ [ { (con equalsInteger) (con 64) } ds_0 ] ds_1 ]
+      [ [ { (con equalsInteger) (con 64) } ds_2 ] ds_3 ]
     )
   )
 )

--- a/core-to-plc/test/primitives/intPlus.plc.golden
+++ b/core-to-plc/test/primitives/intPlus.plc.golden
@@ -1,11 +1,11 @@
 (program 1.0.0
   (lam
-    ds_0
+    ds_2
     [(con integer) (con 64)]
     (lam
-      ds_1
+      ds_3
       [(con integer) (con 64)]
-      [ [ { (con addInteger) (con 64) } ds_0 ] ds_1 ]
+      [ [ { (con addInteger) (con 64) } ds_2 ] ds_3 ]
     )
   )
 )

--- a/core-to-plc/test/primitives/tuple.plc.golden
+++ b/core-to-plc/test/primitives/tuple.plc.golden
@@ -3,18 +3,18 @@
     [
       {
         (abs
-          bad_name_4
+          bad_name_21
           (fun (type) (fun (type) (type)))
           (lam
-            bad_name_14
-            (all a_15 (type) (all b_16 (type) (fun a_15 (fun b_16 [[bad_name_4 a_15] b_16]))))
+            bad_name_22
+            (all a_23 (type) (all b_24 (type) (fun a_23 (fun b_24 [[bad_name_21 a_23] b_24]))))
             (lam
-              p_match_17
-              (all a_18 (type) (all b_19 (type) (fun [[bad_name_4 a_18] b_19] (all p_matchOut_20 (type) (fun (fun a_18 (fun b_19 p_matchOut_20)) p_matchOut_20)))))
+              p_match_25
+              (all a_26 (type) (all b_27 (type) (fun [[bad_name_21 a_26] b_27] (all p_matchOut_28 (type) (fun (fun a_26 (fun b_27 p_matchOut_28)) p_matchOut_28)))))
               [
                 [
                   {
-                    { bad_name_14 [(con integer) (con 64)] }
+                    { bad_name_22 [(con integer) (con 64)] }
                     [(con integer) (con 64)]
                   }
                   (con 64 ! 1)
@@ -24,27 +24,27 @@
             )
           )
         )
-        (lam a_1 (type) (lam b_2 (type) (all p_matchOut_3 (type) (fun (fun a_1 (fun b_2 p_matchOut_3)) p_matchOut_3))))
+        (lam a_29 (type) (lam b_30 (type) (all p_matchOut_31 (type) (fun (fun a_29 (fun b_30 p_matchOut_31)) p_matchOut_31))))
       }
       (abs
-        a_5
+        a_32
         (type)
         (abs
-          b_6
+          b_33
           (type)
           (lam
-            p_arg0_9
-            a_5
+            p_arg0_34
+            a_32
             (lam
-              p_arg1_10
-              b_6
+              p_arg1_35
+              b_33
               (abs
-                p_matchOut_7
+                p_matchOut_36
                 (type)
                 (lam
-                  bad_name_8
-                  (fun a_5 (fun b_6 p_matchOut_7))
-                  [ [ bad_name_8 p_arg0_9 ] p_arg1_10 ]
+                  bad_name_37
+                  (fun a_32 (fun b_33 p_matchOut_36))
+                  [ [ bad_name_37 p_arg0_34 ] p_arg1_35 ]
                 )
               )
             )
@@ -53,15 +53,15 @@
       )
     ]
     (abs
-      a_11
+      a_38
       (type)
       (abs
-        b_12
+        b_39
         (type)
         (lam
-          x_13
-          [[(lam a_1 (type) (lam b_2 (type) (all p_matchOut_3 (type) (fun (fun a_1 (fun b_2 p_matchOut_3)) p_matchOut_3)))) a_11] b_12]
-          x_13
+          x_40
+          [[(lam a_41 (type) (lam b_42 (type) (all p_matchOut_43 (type) (fun (fun a_41 (fun b_42 p_matchOut_43)) p_matchOut_43)))) a_38] b_39]
+          x_40
         )
       )
     )

--- a/core-to-plc/test/primitives/tupleMatch.plc.golden
+++ b/core-to-plc/test/primitives/tupleMatch.plc.golden
@@ -3,59 +3,59 @@
     [
       {
         (abs
-          bad_name_4
+          bad_name_24
           (fun (type) (fun (type) (type)))
           (lam
-            bad_name_14
-            (all a_15 (type) (all b_16 (type) (fun a_15 (fun b_16 [[bad_name_4 a_15] b_16]))))
+            bad_name_25
+            (all a_26 (type) (all b_27 (type) (fun a_26 (fun b_27 [[bad_name_24 a_26] b_27]))))
             (lam
-              p_match_17
-              (all a_18 (type) (all b_19 (type) (fun [[bad_name_4 a_18] b_19] (all p_matchOut_20 (type) (fun (fun a_18 (fun b_19 p_matchOut_20)) p_matchOut_20)))))
+              p_match_28
+              (all a_29 (type) (all b_30 (type) (fun [[bad_name_24 a_29] b_30] (all p_matchOut_31 (type) (fun (fun a_29 (fun b_30 p_matchOut_31)) p_matchOut_31)))))
               (lam
-                ds_21
-                [[bad_name_4 [(con integer) (con 64)]] [(con integer) (con 64)]]
+                ds_32
+                [[bad_name_24 [(con integer) (con 64)]] [(con integer) (con 64)]]
                 [
                   {
                     [
                       {
-                        { p_match_17 [(con integer) (con 64)] }
+                        { p_match_28 [(con integer) (con 64)] }
                         [(con integer) (con 64)]
                       }
-                      ds_21
+                      ds_32
                     ]
                     [(con integer) (con 64)]
                   }
                   (lam
-                    a_22
+                    a_33
                     [(con integer) (con 64)]
-                    (lam b_23 [(con integer) (con 64)] a_22)
+                    (lam b_34 [(con integer) (con 64)] a_33)
                   )
                 ]
               )
             )
           )
         )
-        (lam a_1 (type) (lam b_2 (type) (all p_matchOut_3 (type) (fun (fun a_1 (fun b_2 p_matchOut_3)) p_matchOut_3))))
+        (lam a_35 (type) (lam b_36 (type) (all p_matchOut_37 (type) (fun (fun a_35 (fun b_36 p_matchOut_37)) p_matchOut_37))))
       }
       (abs
-        a_5
+        a_38
         (type)
         (abs
-          b_6
+          b_39
           (type)
           (lam
-            p_arg0_9
-            a_5
+            p_arg0_40
+            a_38
             (lam
-              p_arg1_10
-              b_6
+              p_arg1_41
+              b_39
               (abs
-                p_matchOut_7
+                p_matchOut_42
                 (type)
                 (lam
-                  bad_name_8
-                  (fun a_5 (fun b_6 p_matchOut_7))
-                  [ [ bad_name_8 p_arg0_9 ] p_arg1_10 ]
+                  bad_name_43
+                  (fun a_38 (fun b_39 p_matchOut_42))
+                  [ [ bad_name_43 p_arg0_40 ] p_arg1_41 ]
                 )
               )
             )
@@ -64,15 +64,15 @@
       )
     ]
     (abs
-      a_11
+      a_44
       (type)
       (abs
-        b_12
+        b_45
         (type)
         (lam
-          x_13
-          [[(lam a_1 (type) (lam b_2 (type) (all p_matchOut_3 (type) (fun (fun a_1 (fun b_2 p_matchOut_3)) p_matchOut_3)))) a_11] b_12]
-          x_13
+          x_46
+          [[(lam a_47 (type) (lam b_48 (type) (all p_matchOut_49 (type) (fun (fun a_47 (fun b_48 p_matchOut_49)) p_matchOut_49)))) a_44] b_45]
+          x_46
         )
       )
     )

--- a/core-to-plc/test/primitives/verify.plc.golden
+++ b/core-to-plc/test/primitives/verify.plc.golden
@@ -1,21 +1,21 @@
 (program 1.0.0
   (lam
-    ds_0
+    ds_3
     [(con bytestring) (con 64)]
     (lam
-      ds_1
+      ds_4
       [(con bytestring) (con 64)]
       (lam
-        ds_2
+        ds_5
         [(con bytestring) (con 64)]
         [
           [
             [
-              { { { (con verifySignature) (con 64) } (con 64) } (con 64) } ds_0
+              { { { (con verifySignature) (con 64) } (con 64) } (con 64) } ds_3
             ]
-            ds_1
+            ds_4
           ]
-          ds_2
+          ds_5
         ]
       )
     )

--- a/core-to-plc/test/primitives/void.plc.golden
+++ b/core-to-plc/test/primitives/void.plc.golden
@@ -1,143 +1,145 @@
 (program 1.0.0
   (lam
-    ds_0
+    ds_88
     [(con integer) (con 64)]
     (lam
-      ds_1
+      ds_89
       [(con integer) (con 64)]
       [
         (lam
-          eta_16
-          (all Bool_matchOut_3 (type) (fun Bool_matchOut_3 (fun Bool_matchOut_3 Bool_matchOut_3)))
+          eta_90
+          (all Bool_matchOut_91 (type) (fun Bool_matchOut_91 (fun Bool_matchOut_91 Bool_matchOut_91)))
           [
             (lam
-              eta_17
-              (all Bool_matchOut_3 (type) (fun Bool_matchOut_3 (fun Bool_matchOut_3 Bool_matchOut_3)))
+              eta_92
+              (all Bool_matchOut_93 (type) (fun Bool_matchOut_93 (fun Bool_matchOut_93 Bool_matchOut_93)))
               [
                 [
                   (lam
-                    x_18
-                    (all Bool_matchOut_3 (type) (fun Bool_matchOut_3 (fun Bool_matchOut_3 Bool_matchOut_3)))
+                    x_94
+                    (all Bool_matchOut_95 (type) (fun Bool_matchOut_95 (fun Bool_matchOut_95 Bool_matchOut_95)))
                     (lam
-                      y_19
-                      (all Bool_matchOut_3 (type) (fun Bool_matchOut_3 (fun Bool_matchOut_3 Bool_matchOut_3)))
+                      y_96
+                      (all Bool_matchOut_97 (type) (fun Bool_matchOut_97 (fun Bool_matchOut_97 Bool_matchOut_97)))
                       [
                         (lam
-                          fail_27
-                          (fun (all a_24 (type) (fun (all a_26 (type) (fun a_26 a_26)) a_24)) (all Bool_matchOut_3 (type) (fun Bool_matchOut_3 (fun Bool_matchOut_3 Bool_matchOut_3))))
+                          fail_98
+                          (fun (all a_99 (type) (fun (all a_100 (type) (fun a_100 a_100)) a_99)) (all Bool_matchOut_101 (type) (fun Bool_matchOut_101 (fun Bool_matchOut_101 Bool_matchOut_101))))
                           [
                             [
                               [
                                 {
                                   [
                                     (lam
-                                      x_11
-                                      (all Bool_matchOut_3 (type) (fun Bool_matchOut_3 (fun Bool_matchOut_3 Bool_matchOut_3)))
-                                      x_11
+                                      x_102
+                                      (all Bool_matchOut_103 (type) (fun Bool_matchOut_103 (fun Bool_matchOut_103 Bool_matchOut_103)))
+                                      x_102
                                     )
-                                    x_18
+                                    x_94
                                   ]
-                                  (fun (all a_53 (type) (fun a_53 a_53)) (all Bool_matchOut_3 (type) (fun Bool_matchOut_3 (fun Bool_matchOut_3 Bool_matchOut_3))))
+                                  (fun (all a_104 (type) (fun a_104 a_104)) (all Bool_matchOut_105 (type) (fun Bool_matchOut_105 (fun Bool_matchOut_105 Bool_matchOut_105))))
                                 }
                                 (lam
-                                  thunk_74
-                                  (all a_76 (type) (fun a_76 a_76))
+                                  thunk_106
+                                  (all a_107 (type) (fun a_107 a_107))
                                   [
                                     [
                                       [
                                         {
                                           [
                                             (lam
-                                              x_11
-                                              (all Bool_matchOut_3 (type) (fun Bool_matchOut_3 (fun Bool_matchOut_3 Bool_matchOut_3)))
-                                              x_11
+                                              x_108
+                                              (all Bool_matchOut_109 (type) (fun Bool_matchOut_109 (fun Bool_matchOut_109 Bool_matchOut_109)))
+                                              x_108
                                             )
-                                            y_19
+                                            y_96
                                           ]
-                                          (fun (all a_59 (type) (fun a_59 a_59)) (all Bool_matchOut_3 (type) (fun Bool_matchOut_3 (fun Bool_matchOut_3 Bool_matchOut_3))))
+                                          (fun (all a_110 (type) (fun a_110 a_110)) (all Bool_matchOut_111 (type) (fun Bool_matchOut_111 (fun Bool_matchOut_111 Bool_matchOut_111))))
                                         }
                                         (lam
-                                          thunk_60
-                                          (all a_62 (type) (fun a_62 a_62))
+                                          thunk_112
+                                          (all a_113 (type) (fun a_113 a_113))
                                           (abs
-                                            Bool_matchOut_5
+                                            Bool_matchOut_114
                                             (type)
                                             (lam
-                                              True_6
-                                              Bool_matchOut_5
+                                              True_115
+                                              Bool_matchOut_114
                                               (lam
-                                                False_7 Bool_matchOut_5 True_6
+                                                False_116
+                                                Bool_matchOut_114
+                                                True_115
                                               )
                                             )
                                           )
                                         )
                                       ]
                                       (lam
-                                        thunk_67
-                                        (all a_69 (type) (fun a_69 a_69))
+                                        thunk_117
+                                        (all a_118 (type) (fun a_118 a_118))
                                         [
-                                          fail_27
+                                          fail_98
                                           (abs
-                                            e_63
+                                            e_119
                                             (type)
                                             (lam
-                                              thunk_64
-                                              (all a_66 (type) (fun a_66 a_66))
-                                              (error e_63)
+                                              thunk_120
+                                              (all a_121 (type) (fun a_121 a_121))
+                                              (error e_119)
                                             )
                                           )
                                         ]
                                       )
                                     ]
-                                    (abs a_72 (type) (lam x_73 a_72 x_73))
+                                    (abs a_122 (type) (lam x_123 a_122 x_123))
                                   ]
                                 )
                               ]
                               (lam
-                                thunk_81
-                                (all a_83 (type) (fun a_83 a_83))
+                                thunk_124
+                                (all a_125 (type) (fun a_125 a_125))
                                 [
-                                  fail_27
+                                  fail_98
                                   (abs
-                                    e_77
+                                    e_126
                                     (type)
                                     (lam
-                                      thunk_78
-                                      (all a_80 (type) (fun a_80 a_80))
-                                      (error e_77)
+                                      thunk_127
+                                      (all a_128 (type) (fun a_128 a_128))
+                                      (error e_126)
                                     )
                                   )
                                 ]
                               )
                             ]
-                            (abs a_86 (type) (lam x_87 a_86 x_87))
+                            (abs a_129 (type) (lam x_130 a_129 x_130))
                           ]
                         )
                         (lam
-                          ds_23
-                          (all a_20 (type) (fun (all a_22 (type) (fun a_22 a_22)) a_20))
+                          ds_131
+                          (all a_132 (type) (fun (all a_133 (type) (fun a_133 a_133)) a_132))
                           (abs
-                            Bool_matchOut_8
+                            Bool_matchOut_134
                             (type)
                             (lam
-                              True_9
-                              Bool_matchOut_8
-                              (lam False_10 Bool_matchOut_8 False_10)
+                              True_135
+                              Bool_matchOut_134
+                              (lam False_136 Bool_matchOut_134 False_136)
                             )
                           )
                         )
                       ]
                     )
                   )
-                  eta_16
+                  eta_90
                 ]
-                eta_17
+                eta_92
               ]
             )
-            [ [ { (con equalsInteger) (con 64) } ds_1 ] ds_0 ]
+            [ [ { (con equalsInteger) (con 64) } ds_89 ] ds_88 ]
           ]
         )
-        [ [ { (con equalsInteger) (con 64) } ds_0 ] ds_1 ]
+        [ [ { (con equalsInteger) (con 64) } ds_88 ] ds_89 ]
       ]
     )
   )

--- a/core-to-plc/test/recursiveFunctions/even.plc.golden
+++ b/core-to-plc/test/recursiveFunctions/even.plc.golden
@@ -7,82 +7,82 @@
             {
               {
                 (abs
-                  a_44
+                  a_104
                   (type)
                   (abs
-                    b_45
+                    b_105
                     (type)
                     (abs
-                      a_46
+                      a_106
                       (type)
                       (abs
-                        b_47
+                        b_107
                         (type)
                         [
                           {
                             (abs
-                              F_48
+                              F_108
                               (fun (type) (type))
                               (lam
-                                by_49
-                                (fun (all Q_50 (type) (fun [F_48 Q_50] Q_50)) (all Q_51 (type) (fun [F_48 Q_51] Q_51)))
+                                by_109
+                                (fun (all Q_110 (type) (fun [F_108 Q_110] Q_110)) (all Q_111 (type) (fun [F_108 Q_111] Q_111)))
                                 [
                                   {
                                     {
                                       (abs
-                                        a_63
+                                        a_112
                                         (type)
                                         (abs
-                                          b_64
+                                          b_113
                                           (type)
                                           (lam
-                                            f_65
-                                            (fun (fun a_63 b_64) (fun a_63 b_64))
+                                            f_114
+                                            (fun (fun a_112 b_113) (fun a_112 b_113))
                                             [
                                               {
                                                 (abs
-                                                  a_66
+                                                  a_115
                                                   (type)
                                                   (lam
-                                                    s_67
-                                                    [(lam a_68 (type) (fix self_69 (fun self_69 a_68))) a_66]
-                                                    [ (unwrap s_67) s_67 ]
+                                                    s_116
+                                                    [(lam a_117 (type) (fix self_118 (fun self_118 a_117))) a_115]
+                                                    [ (unwrap s_116) s_116 ]
                                                   )
                                                 )
-                                                (fun a_63 b_64)
+                                                (fun a_112 b_113)
                                               }
                                               (wrap
-                                                self_70
-                                                [(lam a_71 (type) (fun self_70 a_71)) (fun a_63 b_64)]
+                                                self_119
+                                                [(lam a_120 (type) (fun self_119 a_120)) (fun a_112 b_113)]
                                                 (lam
-                                                  s_72
-                                                  [(lam a_73 (type) (fix self_74 (fun self_74 a_73))) (fun a_63 b_64)]
+                                                  s_121
+                                                  [(lam a_122 (type) (fix self_123 (fun self_123 a_122))) (fun a_112 b_113)]
                                                   (lam
-                                                    x_75
-                                                    a_63
+                                                    x_124
+                                                    a_112
                                                     [
                                                       [
-                                                        f_65
+                                                        f_114
                                                         [
                                                           {
                                                             (abs
-                                                              a_76
+                                                              a_125
                                                               (type)
                                                               (lam
-                                                                s_77
-                                                                [(lam a_78 (type) (fix self_79 (fun self_79 a_78))) a_76]
+                                                                s_126
+                                                                [(lam a_127 (type) (fix self_128 (fun self_128 a_127))) a_125]
                                                                 [
-                                                                  (unwrap s_77)
-                                                                  s_77
+                                                                  (unwrap s_126)
+                                                                  s_126
                                                                 ]
                                                               )
                                                             )
-                                                            (fun a_63 b_64)
+                                                            (fun a_112 b_113)
                                                           }
-                                                          s_72
+                                                          s_121
                                                         ]
                                                       ]
-                                                      x_75
+                                                      x_124
                                                     ]
                                                   )
                                                 )
@@ -91,42 +91,44 @@
                                           )
                                         )
                                       )
-                                      (all Q_80 (type) (fun [F_48 Q_80] [F_48 Q_80]))
+                                      (all Q_129 (type) (fun [F_108 Q_129] [F_108 Q_129]))
                                     }
-                                    (all Q_81 (type) (fun [F_48 Q_81] Q_81))
+                                    (all Q_130 (type) (fun [F_108 Q_130] Q_130))
                                   }
                                   (lam
-                                    rec_82
-                                    (fun (all Q_83 (type) (fun [F_48 Q_83] [F_48 Q_83])) (all Q_84 (type) (fun [F_48 Q_84] Q_84)))
+                                    rec_131
+                                    (fun (all Q_132 (type) (fun [F_108 Q_132] [F_108 Q_132])) (all Q_133 (type) (fun [F_108 Q_133] Q_133)))
                                     (lam
-                                      h_85
-                                      (all Q_86 (type) (fun [F_48 Q_86] [F_48 Q_86]))
+                                      h_134
+                                      (all Q_135 (type) (fun [F_108 Q_135] [F_108 Q_135]))
                                       (abs
-                                        R_87
+                                        R_136
                                         (type)
                                         (lam
-                                          fr_88
-                                          [F_48 R_87]
+                                          fr_137
+                                          [F_108 R_136]
                                           [
                                             {
                                               [
-                                                by_49
+                                                by_109
                                                 (abs
-                                                  Q_89
+                                                  Q_138
                                                   (type)
                                                   (lam
-                                                    fq_90
-                                                    [F_48 Q_89]
+                                                    fq_139
+                                                    [F_108 Q_138]
                                                     [
-                                                      { [ rec_82 h_85 ] Q_89 }
-                                                      [ { h_85 Q_89 } fq_90 ]
+                                                      {
+                                                        [ rec_131 h_134 ] Q_138
+                                                      }
+                                                      [ { h_134 Q_138 } fq_139 ]
                                                     ]
                                                   )
                                                 )
                                               ]
-                                              R_87
+                                              R_136
                                             }
-                                            fr_88
+                                            fr_137
                                           ]
                                         )
                                       )
@@ -135,45 +137,49 @@
                                 ]
                               )
                             )
-                            (lam X_91 (type) (fun (fun a_44 b_45) (fun (fun a_46 b_47) X_91)))
+                            (lam X_140 (type) (fun (fun a_104 b_105) (fun (fun a_106 b_107) X_140)))
                           }
                           (lam
-                            k_93
-                            (all Q_94 (type) (fun (fun (fun a_44 b_45) (fun (fun a_46 b_47) Q_94)) Q_94))
+                            k_141
+                            (all Q_142 (type) (fun (fun (fun a_104 b_105) (fun (fun a_106 b_107) Q_142)) Q_142))
                             (abs
-                              S_92
+                              S_143
                               (type)
                               (lam
-                                h_95
-                                (fun (fun a_44 b_45) (fun (fun a_46 b_47) S_92))
+                                h_144
+                                (fun (fun a_104 b_105) (fun (fun a_106 b_107) S_143))
                                 [
                                   [
-                                    h_95
+                                    h_144
                                     (lam
-                                      x_98
-                                      a_44
+                                      x_145
+                                      a_104
                                       [
-                                        { k_93 b_45 }
+                                        { k_141 b_105 }
                                         (lam
-                                          f_96
-                                          (fun a_44 b_45)
+                                          f_146
+                                          (fun a_104 b_105)
                                           (lam
-                                            f_97 (fun a_46 b_47) [ f_96 x_98 ]
+                                            f_147
+                                            (fun a_106 b_107)
+                                            [ f_146 x_145 ]
                                           )
                                         )
                                       ]
                                     )
                                   ]
                                   (lam
-                                    x_101
-                                    a_46
+                                    x_148
+                                    a_106
                                     [
-                                      { k_93 b_47 }
+                                      { k_141 b_107 }
                                       (lam
-                                        f_99
-                                        (fun a_44 b_45)
+                                        f_149
+                                        (fun a_104 b_105)
                                         (lam
-                                          f_100 (fun a_46 b_47) [ f_100 x_101 ]
+                                          f_150
+                                          (fun a_106 b_107)
+                                          [ f_150 x_148 ]
                                         )
                                       )
                                     ]
@@ -189,29 +195,29 @@
                 )
                 [(con integer) (con 64)]
               }
-              (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
+              (all Bool_matchOut_151 (type) (fun Bool_matchOut_151 (fun Bool_matchOut_151 Bool_matchOut_151)))
             }
             [(con integer) (con 64)]
           }
-          (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
+          (all Bool_matchOut_152 (type) (fun Bool_matchOut_152 (fun Bool_matchOut_152 Bool_matchOut_152)))
         }
         (abs
-          Q_14
+          Q_153
           (type)
           (lam
-            choose_15
-            (fun (fun [(con integer) (con 64)] (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))) (fun (fun [(con integer) (con 64)] (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))) Q_14))
+            choose_154
+            (fun (fun [(con integer) (con 64)] (all Bool_matchOut_155 (type) (fun Bool_matchOut_155 (fun Bool_matchOut_155 Bool_matchOut_155)))) (fun (fun [(con integer) (con 64)] (all Bool_matchOut_156 (type) (fun Bool_matchOut_156 (fun Bool_matchOut_156 Bool_matchOut_156)))) Q_153))
             (lam
-              odd_16
-              (fun [(con integer) (con 64)] (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1))))
+              odd_157
+              (fun [(con integer) (con 64)] (all Bool_matchOut_158 (type) (fun Bool_matchOut_158 (fun Bool_matchOut_158 Bool_matchOut_158))))
               (lam
-                even_17
-                (fun [(con integer) (con 64)] (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1))))
+                even_159
+                (fun [(con integer) (con 64)] (all Bool_matchOut_160 (type) (fun Bool_matchOut_160 (fun Bool_matchOut_160 Bool_matchOut_160))))
                 [
                   [
-                    choose_15
+                    choose_154
                     (lam
-                      n_18
+                      n_161
                       [(con integer) (con 64)]
                       [
                         [
@@ -219,49 +225,49 @@
                             {
                               [
                                 (lam
-                                  x_9
-                                  (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
-                                  x_9
+                                  x_162
+                                  (all Bool_matchOut_163 (type) (fun Bool_matchOut_163 (fun Bool_matchOut_163 Bool_matchOut_163)))
+                                  x_162
                                 )
                                 [
-                                  [ { (con equalsInteger) (con 64) } n_18 ]
+                                  [ { (con equalsInteger) (con 64) } n_161 ]
                                   (con 64 ! 0)
                                 ]
                               ]
-                              (fun (all a_20 (type) (fun a_20 a_20)) (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1))))
+                              (fun (all a_164 (type) (fun a_164 a_164)) (all Bool_matchOut_165 (type) (fun Bool_matchOut_165 (fun Bool_matchOut_165 Bool_matchOut_165))))
                             }
                             (lam
-                              thunk_21
-                              (all a_23 (type) (fun a_23 a_23))
+                              thunk_166
+                              (all a_167 (type) (fun a_167 a_167))
                               (abs
-                                Bool_matchOut_6
+                                Bool_matchOut_168
                                 (type)
                                 (lam
-                                  True_7
-                                  Bool_matchOut_6
-                                  (lam False_8 Bool_matchOut_6 False_8)
+                                  True_169
+                                  Bool_matchOut_168
+                                  (lam False_170 Bool_matchOut_168 False_170)
                                 )
                               )
                             )
                           ]
                           (lam
-                            thunk_24
-                            (all a_26 (type) (fun a_26 a_26))
+                            thunk_171
+                            (all a_172 (type) (fun a_172 a_172))
                             [
-                              even_17
+                              even_159
                               [
-                                [ { (con subtractInteger) (con 64) } n_18 ]
+                                [ { (con subtractInteger) (con 64) } n_161 ]
                                 (con 64 ! 1)
                               ]
                             ]
                           )
                         ]
-                        (abs a_29 (type) (lam x_30 a_29 x_30))
+                        (abs a_173 (type) (lam x_174 a_173 x_174))
                       ]
                     )
                   ]
                   (lam
-                    n_31
+                    n_175
                     [(con integer) (con 64)]
                     [
                       [
@@ -269,44 +275,44 @@
                           {
                             [
                               (lam
-                                x_9
-                                (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
-                                x_9
+                                x_176
+                                (all Bool_matchOut_177 (type) (fun Bool_matchOut_177 (fun Bool_matchOut_177 Bool_matchOut_177)))
+                                x_176
                               )
                               [
-                                [ { (con equalsInteger) (con 64) } n_31 ]
+                                [ { (con equalsInteger) (con 64) } n_175 ]
                                 (con 64 ! 0)
                               ]
                             ]
-                            (fun (all a_33 (type) (fun a_33 a_33)) (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1))))
+                            (fun (all a_178 (type) (fun a_178 a_178)) (all Bool_matchOut_179 (type) (fun Bool_matchOut_179 (fun Bool_matchOut_179 Bool_matchOut_179))))
                           }
                           (lam
-                            thunk_34
-                            (all a_36 (type) (fun a_36 a_36))
+                            thunk_180
+                            (all a_181 (type) (fun a_181 a_181))
                             (abs
-                              Bool_matchOut_3
+                              Bool_matchOut_182
                               (type)
                               (lam
-                                True_4
-                                Bool_matchOut_3
-                                (lam False_5 Bool_matchOut_3 True_4)
+                                True_183
+                                Bool_matchOut_182
+                                (lam False_184 Bool_matchOut_182 True_183)
                               )
                             )
                           )
                         ]
                         (lam
-                          thunk_37
-                          (all a_39 (type) (fun a_39 a_39))
+                          thunk_185
+                          (all a_186 (type) (fun a_186 a_186))
                           [
-                            odd_16
+                            odd_157
                             [
-                              [ { (con subtractInteger) (con 64) } n_31 ]
+                              [ { (con subtractInteger) (con 64) } n_175 ]
                               (con 64 ! 1)
                             ]
                           ]
                         )
                       ]
-                      (abs a_42 (type) (lam x_43 a_42 x_43))
+                      (abs a_187 (type) (lam x_188 a_187 x_188))
                     ]
                   )
                 ]
@@ -315,15 +321,15 @@
           )
         )
       ]
-      (fun [(con integer) (con 64)] (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1))))
+      (fun [(con integer) (con 64)] (all Bool_matchOut_189 (type) (fun Bool_matchOut_189 (fun Bool_matchOut_189 Bool_matchOut_189))))
     }
     (lam
-      odd_102
-      (fun [(con integer) (con 64)] (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1))))
+      odd_190
+      (fun [(con integer) (con 64)] (all Bool_matchOut_191 (type) (fun Bool_matchOut_191 (fun Bool_matchOut_191 Bool_matchOut_191))))
       (lam
-        even_103
-        (fun [(con integer) (con 64)] (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1))))
-        even_103
+        even_192
+        (fun [(con integer) (con 64)] (all Bool_matchOut_193 (type) (fun Bool_matchOut_193 (fun Bool_matchOut_193 Bool_matchOut_193))))
+        even_192
       )
     )
   ]

--- a/core-to-plc/test/recursiveFunctions/even3.plc.golden
+++ b/core-to-plc/test/recursiveFunctions/even3.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  Bool_matchOut_6
+  Bool_matchOut_168
   (type)
-  (lam True_7 Bool_matchOut_6 (lam False_8 Bool_matchOut_6 False_8))
+  (lam True_169 Bool_matchOut_168 (lam False_170 Bool_matchOut_168 False_170))
 )

--- a/core-to-plc/test/recursiveFunctions/even4.plc.golden
+++ b/core-to-plc/test/recursiveFunctions/even4.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  Bool_matchOut_3
+  Bool_matchOut_182
   (type)
-  (lam True_4 Bool_matchOut_3 (lam False_5 Bool_matchOut_3 True_4))
+  (lam True_183 Bool_matchOut_182 (lam False_184 Bool_matchOut_182 True_183))
 )

--- a/core-to-plc/test/recursiveFunctions/fib.plc.golden
+++ b/core-to-plc/test/recursiveFunctions/fib.plc.golden
@@ -5,73 +5,73 @@
         {
           {
             (abs
-              a_54
+              a_107
               (type)
               (abs
-                b_55
+                b_108
                 (type)
                 [
                   {
                     (abs
-                      F_56
+                      F_109
                       (fun (type) (type))
                       (lam
-                        by_57
-                        (fun (all Q_58 (type) (fun [F_56 Q_58] Q_58)) (all Q_59 (type) (fun [F_56 Q_59] Q_59)))
+                        by_110
+                        (fun (all Q_111 (type) (fun [F_109 Q_111] Q_111)) (all Q_112 (type) (fun [F_109 Q_112] Q_112)))
                         [
                           {
                             {
                               (abs
-                                a_71
+                                a_113
                                 (type)
                                 (abs
-                                  b_72
+                                  b_114
                                   (type)
                                   (lam
-                                    f_73
-                                    (fun (fun a_71 b_72) (fun a_71 b_72))
+                                    f_115
+                                    (fun (fun a_113 b_114) (fun a_113 b_114))
                                     [
                                       {
                                         (abs
-                                          a_74
+                                          a_116
                                           (type)
                                           (lam
-                                            s_75
-                                            [(lam a_76 (type) (fix self_77 (fun self_77 a_76))) a_74]
-                                            [ (unwrap s_75) s_75 ]
+                                            s_117
+                                            [(lam a_118 (type) (fix self_119 (fun self_119 a_118))) a_116]
+                                            [ (unwrap s_117) s_117 ]
                                           )
                                         )
-                                        (fun a_71 b_72)
+                                        (fun a_113 b_114)
                                       }
                                       (wrap
-                                        self_78
-                                        [(lam a_79 (type) (fun self_78 a_79)) (fun a_71 b_72)]
+                                        self_120
+                                        [(lam a_121 (type) (fun self_120 a_121)) (fun a_113 b_114)]
                                         (lam
-                                          s_80
-                                          [(lam a_81 (type) (fix self_82 (fun self_82 a_81))) (fun a_71 b_72)]
+                                          s_122
+                                          [(lam a_123 (type) (fix self_124 (fun self_124 a_123))) (fun a_113 b_114)]
                                           (lam
-                                            x_83
-                                            a_71
+                                            x_125
+                                            a_113
                                             [
                                               [
-                                                f_73
+                                                f_115
                                                 [
                                                   {
                                                     (abs
-                                                      a_84
+                                                      a_126
                                                       (type)
                                                       (lam
-                                                        s_85
-                                                        [(lam a_86 (type) (fix self_87 (fun self_87 a_86))) a_84]
-                                                        [ (unwrap s_85) s_85 ]
+                                                        s_127
+                                                        [(lam a_128 (type) (fix self_129 (fun self_129 a_128))) a_126]
+                                                        [ (unwrap s_127) s_127 ]
                                                       )
                                                     )
-                                                    (fun a_71 b_72)
+                                                    (fun a_113 b_114)
                                                   }
-                                                  s_80
+                                                  s_122
                                                 ]
                                               ]
-                                              x_83
+                                              x_125
                                             ]
                                           )
                                         )
@@ -80,42 +80,42 @@
                                   )
                                 )
                               )
-                              (all Q_88 (type) (fun [F_56 Q_88] [F_56 Q_88]))
+                              (all Q_130 (type) (fun [F_109 Q_130] [F_109 Q_130]))
                             }
-                            (all Q_89 (type) (fun [F_56 Q_89] Q_89))
+                            (all Q_131 (type) (fun [F_109 Q_131] Q_131))
                           }
                           (lam
-                            rec_90
-                            (fun (all Q_91 (type) (fun [F_56 Q_91] [F_56 Q_91])) (all Q_92 (type) (fun [F_56 Q_92] Q_92)))
+                            rec_132
+                            (fun (all Q_133 (type) (fun [F_109 Q_133] [F_109 Q_133])) (all Q_134 (type) (fun [F_109 Q_134] Q_134)))
                             (lam
-                              h_93
-                              (all Q_94 (type) (fun [F_56 Q_94] [F_56 Q_94]))
+                              h_135
+                              (all Q_136 (type) (fun [F_109 Q_136] [F_109 Q_136]))
                               (abs
-                                R_95
+                                R_137
                                 (type)
                                 (lam
-                                  fr_96
-                                  [F_56 R_95]
+                                  fr_138
+                                  [F_109 R_137]
                                   [
                                     {
                                       [
-                                        by_57
+                                        by_110
                                         (abs
-                                          Q_97
+                                          Q_139
                                           (type)
                                           (lam
-                                            fq_98
-                                            [F_56 Q_97]
+                                            fq_140
+                                            [F_109 Q_139]
                                             [
-                                              { [ rec_90 h_93 ] Q_97 }
-                                              [ { h_93 Q_97 } fq_98 ]
+                                              { [ rec_132 h_135 ] Q_139 }
+                                              [ { h_135 Q_139 } fq_140 ]
                                             ]
                                           )
                                         )
                                       ]
-                                      R_95
+                                      R_137
                                     }
-                                    fr_96
+                                    fr_138
                                   ]
                                 )
                               )
@@ -124,25 +124,25 @@
                         ]
                       )
                     )
-                    (lam X_99 (type) (fun (fun a_54 b_55) X_99))
+                    (lam X_141 (type) (fun (fun a_107 b_108) X_141))
                   }
                   (lam
-                    k_101
-                    (all Q_102 (type) (fun (fun (fun a_54 b_55) Q_102) Q_102))
+                    k_142
+                    (all Q_143 (type) (fun (fun (fun a_107 b_108) Q_143) Q_143))
                     (abs
-                      S_100
+                      S_144
                       (type)
                       (lam
-                        h_103
-                        (fun (fun a_54 b_55) S_100)
+                        h_145
+                        (fun (fun a_107 b_108) S_144)
                         [
-                          h_103
+                          h_145
                           (lam
-                            x_105
-                            a_54
+                            x_146
+                            a_107
                             [
-                              { k_101 b_55 }
-                              (lam f_104 (fun a_54 b_55) [ f_104 x_105 ])
+                              { k_142 b_108 }
+                              (lam f_147 (fun a_107 b_108) [ f_147 x_146 ])
                             ]
                           )
                         ]
@@ -157,18 +157,18 @@
           [(con integer) (con 64)]
         }
         (abs
-          Q_0
+          Q_148
           (type)
           (lam
-            choose_1
-            (fun (fun [(con integer) (con 64)] [(con integer) (con 64)]) Q_0)
+            choose_149
+            (fun (fun [(con integer) (con 64)] [(con integer) (con 64)]) Q_148)
             (lam
-              fib_2
+              fib_150
               (fun [(con integer) (con 64)] [(con integer) (con 64)])
               [
-                choose_1
+                choose_149
                 (lam
-                  n_3
+                  n_151
                   [(con integer) (con 64)]
                   [
                     [
@@ -176,78 +176,80 @@
                         {
                           [
                             (lam
-                              x_13
-                              (all Bool_matchOut_5 (type) (fun Bool_matchOut_5 (fun Bool_matchOut_5 Bool_matchOut_5)))
-                              x_13
+                              x_152
+                              (all Bool_matchOut_153 (type) (fun Bool_matchOut_153 (fun Bool_matchOut_153 Bool_matchOut_153)))
+                              x_152
                             )
                             [
-                              [ { (con equalsInteger) (con 64) } n_3 ]
+                              [ { (con equalsInteger) (con 64) } n_151 ]
                               (con 64 ! 0)
                             ]
                           ]
-                          (fun (all a_31 (type) (fun a_31 a_31)) [(con integer) (con 64)])
+                          (fun (all a_154 (type) (fun a_154 a_154)) [(con integer) (con 64)])
                         }
                         (lam
-                          thunk_32
-                          (all a_34 (type) (fun a_34 a_34))
+                          thunk_155
+                          (all a_156 (type) (fun a_156 a_156))
                           (con 64 ! 0)
                         )
                       ]
                       (lam
-                        thunk_47
-                        (all a_49 (type) (fun a_49 a_49))
+                        thunk_157
+                        (all a_158 (type) (fun a_158 a_158))
                         [
                           [
                             [
                               {
                                 [
                                   (lam
-                                    x_13
-                                    (all Bool_matchOut_5 (type) (fun Bool_matchOut_5 (fun Bool_matchOut_5 Bool_matchOut_5)))
-                                    x_13
+                                    x_159
+                                    (all Bool_matchOut_160 (type) (fun Bool_matchOut_160 (fun Bool_matchOut_160 Bool_matchOut_160)))
+                                    x_159
                                   )
                                   [
-                                    [ { (con equalsInteger) (con 64) } n_3 ]
+                                    [ { (con equalsInteger) (con 64) } n_151 ]
                                     (con 64 ! 1)
                                   ]
                                 ]
-                                (fun (all a_36 (type) (fun a_36 a_36)) [(con integer) (con 64)])
+                                (fun (all a_161 (type) (fun a_161 a_161)) [(con integer) (con 64)])
                               }
                               (lam
-                                thunk_37
-                                (all a_39 (type) (fun a_39 a_39))
+                                thunk_162
+                                (all a_163 (type) (fun a_163 a_163))
                                 (con 64 ! 1)
                               )
                             ]
                             (lam
-                              thunk_40
-                              (all a_42 (type) (fun a_42 a_42))
+                              thunk_164
+                              (all a_165 (type) (fun a_165 a_165))
                               [
                                 [
                                   { (con addInteger) (con 64) }
                                   [
-                                    fib_2
+                                    fib_150
                                     [
-                                      [ { (con subtractInteger) (con 64) } n_3 ]
+                                      [
+                                        { (con subtractInteger) (con 64) } n_151
+                                      ]
                                       (con 64 ! 1)
                                     ]
                                   ]
                                 ]
                                 [
-                                  fib_2
+                                  fib_150
                                   [
-                                    [ { (con subtractInteger) (con 64) } n_3 ]
+                                    [ { (con subtractInteger) (con 64) } n_151 ]
                                     (con 64 ! 2)
                                   ]
                                 ]
                               ]
                             )
                           ]
-                          (abs a_45 (type) (lam x_46 a_45 x_46))
+                          (abs a_166 (type) (lam x_167 a_166 x_167))
                         ]
                       )
                     ]
-                    (abs a_52 (type) (lam x_53 a_52 x_53))
+                    (abs a_168 (type) (lam x_169 a_168 x_169))
                   ]
                 )
               ]
@@ -257,7 +259,7 @@
       ]
       (fun [(con integer) (con 64)] [(con integer) (con 64)])
     }
-    (lam fib_106 (fun [(con integer) (con 64)] [(con integer) (con 64)]) fib_106
+    (lam fib_170 (fun [(con integer) (con 64)] [(con integer) (con 64)]) fib_170
     )
   ]
 )

--- a/core-to-plc/test/recursiveFunctions/sum.plc.golden
+++ b/core-to-plc/test/recursiveFunctions/sum.plc.golden
@@ -4,97 +4,98 @@
       [
         {
           (abs
-            list_3
+            list_82
             (fun (type) (type))
             (lam
-              list_16
-              (all a_17 (type) [list_3 a_17])
+              list_83
+              (all a_84 (type) [list_82 a_84])
               (lam
-                cons_18
-                (all a_19 (type) (fun a_19 (fun [list_3 a_19] [list_3 a_19])))
+                cons_85
+                (all a_86 (type) (fun a_86 (fun [list_82 a_86] [list_82 a_86])))
                 (lam
-                  p_match_20
-                  (all a_21 (type) (fun [list_3 a_21] (all p_matchOut_22 (type) (fun p_matchOut_22 (fun (fun a_21 (fun [list_3 a_21] p_matchOut_22)) p_matchOut_22)))))
+                  p_match_87
+                  (all a_88 (type) (fun [list_82 a_88] (all p_matchOut_89 (type) (fun p_matchOut_89 (fun (fun a_88 (fun [list_82 a_88] p_matchOut_89)) p_matchOut_89)))))
                   [
                     {
                       [
                         {
                           {
                             (abs
-                              a_29
+                              a_90
                               (type)
                               (abs
-                                b_30
+                                b_91
                                 (type)
                                 [
                                   {
                                     (abs
-                                      F_31
+                                      F_92
                                       (fun (type) (type))
                                       (lam
-                                        by_32
-                                        (fun (all Q_33 (type) (fun [F_31 Q_33] Q_33)) (all Q_34 (type) (fun [F_31 Q_34] Q_34)))
+                                        by_93
+                                        (fun (all Q_94 (type) (fun [F_92 Q_94] Q_94)) (all Q_95 (type) (fun [F_92 Q_95] Q_95)))
                                         [
                                           {
                                             {
                                               (abs
-                                                a_46
+                                                a_96
                                                 (type)
                                                 (abs
-                                                  b_47
+                                                  b_97
                                                   (type)
                                                   (lam
-                                                    f_48
-                                                    (fun (fun a_46 b_47) (fun a_46 b_47))
+                                                    f_98
+                                                    (fun (fun a_96 b_97) (fun a_96 b_97))
                                                     [
                                                       {
                                                         (abs
-                                                          a_49
+                                                          a_99
                                                           (type)
                                                           (lam
-                                                            s_50
-                                                            [(lam a_51 (type) (fix self_52 (fun self_52 a_51))) a_49]
+                                                            s_100
+                                                            [(lam a_101 (type) (fix self_102 (fun self_102 a_101))) a_99]
                                                             [
-                                                              (unwrap s_50) s_50
+                                                              (unwrap s_100)
+                                                              s_100
                                                             ]
                                                           )
                                                         )
-                                                        (fun a_46 b_47)
+                                                        (fun a_96 b_97)
                                                       }
                                                       (wrap
-                                                        self_53
-                                                        [(lam a_54 (type) (fun self_53 a_54)) (fun a_46 b_47)]
+                                                        self_103
+                                                        [(lam a_104 (type) (fun self_103 a_104)) (fun a_96 b_97)]
                                                         (lam
-                                                          s_55
-                                                          [(lam a_56 (type) (fix self_57 (fun self_57 a_56))) (fun a_46 b_47)]
+                                                          s_105
+                                                          [(lam a_106 (type) (fix self_107 (fun self_107 a_106))) (fun a_96 b_97)]
                                                           (lam
-                                                            x_58
-                                                            a_46
+                                                            x_108
+                                                            a_96
                                                             [
                                                               [
-                                                                f_48
+                                                                f_98
                                                                 [
                                                                   {
                                                                     (abs
-                                                                      a_59
+                                                                      a_109
                                                                       (type)
                                                                       (lam
-                                                                        s_60
-                                                                        [(lam a_61 (type) (fix self_62 (fun self_62 a_61))) a_59]
+                                                                        s_110
+                                                                        [(lam a_111 (type) (fix self_112 (fun self_112 a_111))) a_109]
                                                                         [
                                                                           (unwrap
-                                                                            s_60
+                                                                            s_110
                                                                           )
-                                                                          s_60
+                                                                          s_110
                                                                         ]
                                                                       )
                                                                     )
-                                                                    (fun a_46 b_47)
+                                                                    (fun a_96 b_97)
                                                                   }
-                                                                  s_55
+                                                                  s_105
                                                                 ]
                                                               ]
-                                                              x_58
+                                                              x_108
                                                             ]
                                                           )
                                                         )
@@ -103,48 +104,50 @@
                                                   )
                                                 )
                                               )
-                                              (all Q_63 (type) (fun [F_31 Q_63] [F_31 Q_63]))
+                                              (all Q_113 (type) (fun [F_92 Q_113] [F_92 Q_113]))
                                             }
-                                            (all Q_64 (type) (fun [F_31 Q_64] Q_64))
+                                            (all Q_114 (type) (fun [F_92 Q_114] Q_114))
                                           }
                                           (lam
-                                            rec_65
-                                            (fun (all Q_66 (type) (fun [F_31 Q_66] [F_31 Q_66])) (all Q_67 (type) (fun [F_31 Q_67] Q_67)))
+                                            rec_115
+                                            (fun (all Q_116 (type) (fun [F_92 Q_116] [F_92 Q_116])) (all Q_117 (type) (fun [F_92 Q_117] Q_117)))
                                             (lam
-                                              h_68
-                                              (all Q_69 (type) (fun [F_31 Q_69] [F_31 Q_69]))
+                                              h_118
+                                              (all Q_119 (type) (fun [F_92 Q_119] [F_92 Q_119]))
                                               (abs
-                                                R_70
+                                                R_120
                                                 (type)
                                                 (lam
-                                                  fr_71
-                                                  [F_31 R_70]
+                                                  fr_121
+                                                  [F_92 R_120]
                                                   [
                                                     {
                                                       [
-                                                        by_32
+                                                        by_93
                                                         (abs
-                                                          Q_72
+                                                          Q_122
                                                           (type)
                                                           (lam
-                                                            fq_73
-                                                            [F_31 Q_72]
+                                                            fq_123
+                                                            [F_92 Q_122]
                                                             [
                                                               {
-                                                                [ rec_65 h_68 ]
-                                                                Q_72
+                                                                [
+                                                                  rec_115 h_118
+                                                                ]
+                                                                Q_122
                                                               }
                                                               [
-                                                                { h_68 Q_72 }
-                                                                fq_73
+                                                                { h_118 Q_122 }
+                                                                fq_123
                                                               ]
                                                             ]
                                                           )
                                                         )
                                                       ]
-                                                      R_70
+                                                      R_120
                                                     }
-                                                    fr_71
+                                                    fr_121
                                                   ]
                                                 )
                                               )
@@ -153,28 +156,28 @@
                                         ]
                                       )
                                     )
-                                    (lam X_74 (type) (fun (fun a_29 b_30) X_74))
+                                    (lam X_124 (type) (fun (fun a_90 b_91) X_124))
                                   }
                                   (lam
-                                    k_76
-                                    (all Q_77 (type) (fun (fun (fun a_29 b_30) Q_77) Q_77))
+                                    k_125
+                                    (all Q_126 (type) (fun (fun (fun a_90 b_91) Q_126) Q_126))
                                     (abs
-                                      S_75
+                                      S_127
                                       (type)
                                       (lam
-                                        h_78
-                                        (fun (fun a_29 b_30) S_75)
+                                        h_128
+                                        (fun (fun a_90 b_91) S_127)
                                         [
-                                          h_78
+                                          h_128
                                           (lam
-                                            x_80
-                                            a_29
+                                            x_129
+                                            a_90
                                             [
-                                              { k_76 b_30 }
+                                              { k_125 b_91 }
                                               (lam
-                                                f_79
-                                                (fun a_29 b_30)
-                                                [ f_79 x_80 ]
+                                                f_130
+                                                (fun a_90 b_91)
+                                                [ f_130 x_129 ]
                                               )
                                             ]
                                           )
@@ -185,46 +188,48 @@
                                 ]
                               )
                             )
-                            [list_3 [(con integer) (con 64)]]
+                            [list_82 [(con integer) (con 64)]]
                           }
                           [(con integer) (con 64)]
                         }
                         (abs
-                          Q_23
+                          Q_131
                           (type)
                           (lam
-                            choose_24
-                            (fun (fun [list_3 [(con integer) (con 64)]] [(con integer) (con 64)]) Q_23)
+                            choose_132
+                            (fun (fun [list_82 [(con integer) (con 64)]] [(con integer) (con 64)]) Q_131)
                             (lam
-                              sum_25
-                              (fun [list_3 [(con integer) (con 64)]] [(con integer) (con 64)])
+                              sum_133
+                              (fun [list_82 [(con integer) (con 64)]] [(con integer) (con 64)])
                               [
-                                choose_24
+                                choose_132
                                 (lam
-                                  ds_26
-                                  [list_3 [(con integer) (con 64)]]
+                                  ds_134
+                                  [list_82 [(con integer) (con 64)]]
                                   [
                                     [
                                       {
                                         [
                                           {
-                                            p_match_20 [(con integer) (con 64)]
+                                            p_match_87 [(con integer) (con 64)]
                                           }
-                                          ds_26
+                                          ds_134
                                         ]
                                         [(con integer) (con 64)]
                                       }
                                       (con 64 ! 0)
                                     ]
                                     (lam
-                                      x_27
+                                      x_135
                                       [(con integer) (con 64)]
                                       (lam
-                                        xs_28
-                                        [list_3 [(con integer) (con 64)]]
+                                        xs_136
+                                        [list_82 [(con integer) (con 64)]]
                                         [
-                                          [ { (con addInteger) (con 64) } x_27 ]
-                                          [ sum_25 xs_28 ]
+                                          [
+                                            { (con addInteger) (con 64) } x_135
+                                          ]
+                                          [ sum_133 xs_136 ]
                                         ]
                                       )
                                     )
@@ -235,36 +240,36 @@
                           )
                         )
                       ]
-                      (fun [list_3 [(con integer) (con 64)]] [(con integer) (con 64)])
+                      (fun [list_82 [(con integer) (con 64)]] [(con integer) (con 64)])
                     }
                     (lam
-                      sum_81
-                      (fun [list_3 [(con integer) (con 64)]] [(con integer) (con 64)])
-                      sum_81
+                      sum_137
+                      (fun [list_82 [(con integer) (con 64)]] [(con integer) (con 64)])
+                      sum_137
                     )
                   ]
                 )
               )
             )
           )
-          (fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2)))))
+          (fix list_138 (lam a_139 (type) (all p_matchOut_140 (type) (fun p_matchOut_140 (fun (fun a_139 (fun [list_138 a_139] p_matchOut_140)) p_matchOut_140)))))
         }
         (abs
-          a_4
+          a_141
           (type)
           (wrap
-            list_0
-            (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))
+            list_142
+            (lam a_143 (type) (all p_matchOut_144 (type) (fun p_matchOut_144 (fun (fun a_143 (fun [list_142 a_143] p_matchOut_144)) p_matchOut_144))))
             (abs
-              p_matchOut_5
+              p_matchOut_145
               (type)
               (lam
-                list_6
-                p_matchOut_5
+                list_146
+                p_matchOut_145
                 (lam
-                  cons_7
-                  (fun a_4 (fun [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_4] p_matchOut_5))
-                  list_6
+                  cons_147
+                  (fun a_141 (fun [(fix list_148 (lam a_149 (type) (all p_matchOut_150 (type) (fun p_matchOut_150 (fun (fun a_149 (fun [list_148 a_149] p_matchOut_150)) p_matchOut_150))))) a_141] p_matchOut_145))
+                  list_146
                 )
               )
             )
@@ -272,27 +277,27 @@
         )
       ]
       (abs
-        a_8
+        a_151
         (type)
         (lam
-          p_arg0_12
-          a_8
+          p_arg0_152
+          a_151
           (lam
-            p_arg1_13
-            [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_8]
+            p_arg1_153
+            [(fix list_154 (lam a_155 (type) (all p_matchOut_156 (type) (fun p_matchOut_156 (fun (fun a_155 (fun [list_154 a_155] p_matchOut_156)) p_matchOut_156))))) a_151]
             (wrap
-              list_0
-              (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))
+              list_157
+              (lam a_158 (type) (all p_matchOut_159 (type) (fun p_matchOut_159 (fun (fun a_158 (fun [list_157 a_158] p_matchOut_159)) p_matchOut_159))))
               (abs
-                p_matchOut_9
+                p_matchOut_160
                 (type)
                 (lam
-                  list_10
-                  p_matchOut_9
+                  list_161
+                  p_matchOut_160
                   (lam
-                    cons_11
-                    (fun a_8 (fun [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_8] p_matchOut_9))
-                    [ [ cons_11 p_arg0_12 ] p_arg1_13 ]
+                    cons_162
+                    (fun a_151 (fun [(fix list_163 (lam a_164 (type) (all p_matchOut_165 (type) (fun p_matchOut_165 (fun (fun a_164 (fun [list_163 a_164] p_matchOut_165)) p_matchOut_165))))) a_151] p_matchOut_160))
+                    [ [ cons_162 p_arg0_152 ] p_arg1_153 ]
                   )
                 )
               )
@@ -302,12 +307,12 @@
       )
     ]
     (abs
-      a_14
+      a_166
       (type)
       (lam
-        x_15
-        [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_14]
-        (unwrap x_15)
+        x_167
+        [(fix list_168 (lam a_169 (type) (all p_matchOut_170 (type) (fun p_matchOut_170 (fun (fun a_169 (fun [list_168 a_169] p_matchOut_170)) p_matchOut_170))))) a_166]
+        (unwrap x_167)
       )
     )
   ]

--- a/core-to-plc/test/recursiveTypes/listConstruct.plc.golden
+++ b/core-to-plc/test/recursiveTypes/listConstruct.plc.golden
@@ -4,40 +4,40 @@
       [
         {
           (abs
-            list_3
+            list_23
             (fun (type) (type))
             (lam
-              list_16
-              (all a_17 (type) [list_3 a_17])
+              list_24
+              (all a_25 (type) [list_23 a_25])
               (lam
-                cons_18
-                (all a_19 (type) (fun a_19 (fun [list_3 a_19] [list_3 a_19])))
+                cons_26
+                (all a_27 (type) (fun a_27 (fun [list_23 a_27] [list_23 a_27])))
                 (lam
-                  p_match_20
-                  (all a_21 (type) (fun [list_3 a_21] (all p_matchOut_22 (type) (fun p_matchOut_22 (fun (fun a_21 (fun [list_3 a_21] p_matchOut_22)) p_matchOut_22)))))
-                  { list_16 [(con integer) (con 64)] }
+                  p_match_28
+                  (all a_29 (type) (fun [list_23 a_29] (all p_matchOut_30 (type) (fun p_matchOut_30 (fun (fun a_29 (fun [list_23 a_29] p_matchOut_30)) p_matchOut_30)))))
+                  { list_24 [(con integer) (con 64)] }
                 )
               )
             )
           )
-          (fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2)))))
+          (fix list_31 (lam a_32 (type) (all p_matchOut_33 (type) (fun p_matchOut_33 (fun (fun a_32 (fun [list_31 a_32] p_matchOut_33)) p_matchOut_33)))))
         }
         (abs
-          a_4
+          a_34
           (type)
           (wrap
-            list_0
-            (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))
+            list_35
+            (lam a_36 (type) (all p_matchOut_37 (type) (fun p_matchOut_37 (fun (fun a_36 (fun [list_35 a_36] p_matchOut_37)) p_matchOut_37))))
             (abs
-              p_matchOut_5
+              p_matchOut_38
               (type)
               (lam
-                list_6
-                p_matchOut_5
+                list_39
+                p_matchOut_38
                 (lam
-                  cons_7
-                  (fun a_4 (fun [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_4] p_matchOut_5))
-                  list_6
+                  cons_40
+                  (fun a_34 (fun [(fix list_41 (lam a_42 (type) (all p_matchOut_43 (type) (fun p_matchOut_43 (fun (fun a_42 (fun [list_41 a_42] p_matchOut_43)) p_matchOut_43))))) a_34] p_matchOut_38))
+                  list_39
                 )
               )
             )
@@ -45,27 +45,27 @@
         )
       ]
       (abs
-        a_8
+        a_44
         (type)
         (lam
-          p_arg0_12
-          a_8
+          p_arg0_45
+          a_44
           (lam
-            p_arg1_13
-            [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_8]
+            p_arg1_46
+            [(fix list_47 (lam a_48 (type) (all p_matchOut_49 (type) (fun p_matchOut_49 (fun (fun a_48 (fun [list_47 a_48] p_matchOut_49)) p_matchOut_49))))) a_44]
             (wrap
-              list_0
-              (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))
+              list_50
+              (lam a_51 (type) (all p_matchOut_52 (type) (fun p_matchOut_52 (fun (fun a_51 (fun [list_50 a_51] p_matchOut_52)) p_matchOut_52))))
               (abs
-                p_matchOut_9
+                p_matchOut_53
                 (type)
                 (lam
-                  list_10
-                  p_matchOut_9
+                  list_54
+                  p_matchOut_53
                   (lam
-                    cons_11
-                    (fun a_8 (fun [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_8] p_matchOut_9))
-                    [ [ cons_11 p_arg0_12 ] p_arg1_13 ]
+                    cons_55
+                    (fun a_44 (fun [(fix list_56 (lam a_57 (type) (all p_matchOut_58 (type) (fun p_matchOut_58 (fun (fun a_57 (fun [list_56 a_57] p_matchOut_58)) p_matchOut_58))))) a_44] p_matchOut_53))
+                    [ [ cons_55 p_arg0_45 ] p_arg1_46 ]
                   )
                 )
               )
@@ -75,12 +75,12 @@
       )
     ]
     (abs
-      a_14
+      a_59
       (type)
       (lam
-        x_15
-        [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_14]
-        (unwrap x_15)
+        x_60
+        [(fix list_61 (lam a_62 (type) (all p_matchOut_63 (type) (fun p_matchOut_63 (fun (fun a_62 (fun [list_61 a_62] p_matchOut_63)) p_matchOut_63))))) a_59]
+        (unwrap x_60)
       )
     )
   ]

--- a/core-to-plc/test/recursiveTypes/listConstruct2.plc.golden
+++ b/core-to-plc/test/recursiveTypes/listConstruct2.plc.golden
@@ -4,43 +4,43 @@
       [
         {
           (abs
-            list_3
+            list_23
             (fun (type) (type))
             (lam
-              list_16
-              (all a_17 (type) [list_3 a_17])
+              list_24
+              (all a_25 (type) [list_23 a_25])
               (lam
-                cons_18
-                (all a_19 (type) (fun a_19 (fun [list_3 a_19] [list_3 a_19])))
+                cons_26
+                (all a_27 (type) (fun a_27 (fun [list_23 a_27] [list_23 a_27])))
                 (lam
-                  p_match_20
-                  (all a_21 (type) (fun [list_3 a_21] (all p_matchOut_22 (type) (fun p_matchOut_22 (fun (fun a_21 (fun [list_3 a_21] p_matchOut_22)) p_matchOut_22)))))
+                  p_match_28
+                  (all a_29 (type) (fun [list_23 a_29] (all p_matchOut_30 (type) (fun p_matchOut_30 (fun (fun a_29 (fun [list_23 a_29] p_matchOut_30)) p_matchOut_30)))))
                   [
-                    [ { cons_18 [(con integer) (con 64)] } (con 64 ! 1) ]
-                    { list_16 [(con integer) (con 64)] }
+                    [ { cons_26 [(con integer) (con 64)] } (con 64 ! 1) ]
+                    { list_24 [(con integer) (con 64)] }
                   ]
                 )
               )
             )
           )
-          (fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2)))))
+          (fix list_31 (lam a_32 (type) (all p_matchOut_33 (type) (fun p_matchOut_33 (fun (fun a_32 (fun [list_31 a_32] p_matchOut_33)) p_matchOut_33)))))
         }
         (abs
-          a_4
+          a_34
           (type)
           (wrap
-            list_0
-            (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))
+            list_35
+            (lam a_36 (type) (all p_matchOut_37 (type) (fun p_matchOut_37 (fun (fun a_36 (fun [list_35 a_36] p_matchOut_37)) p_matchOut_37))))
             (abs
-              p_matchOut_5
+              p_matchOut_38
               (type)
               (lam
-                list_6
-                p_matchOut_5
+                list_39
+                p_matchOut_38
                 (lam
-                  cons_7
-                  (fun a_4 (fun [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_4] p_matchOut_5))
-                  list_6
+                  cons_40
+                  (fun a_34 (fun [(fix list_41 (lam a_42 (type) (all p_matchOut_43 (type) (fun p_matchOut_43 (fun (fun a_42 (fun [list_41 a_42] p_matchOut_43)) p_matchOut_43))))) a_34] p_matchOut_38))
+                  list_39
                 )
               )
             )
@@ -48,27 +48,27 @@
         )
       ]
       (abs
-        a_8
+        a_44
         (type)
         (lam
-          p_arg0_12
-          a_8
+          p_arg0_45
+          a_44
           (lam
-            p_arg1_13
-            [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_8]
+            p_arg1_46
+            [(fix list_47 (lam a_48 (type) (all p_matchOut_49 (type) (fun p_matchOut_49 (fun (fun a_48 (fun [list_47 a_48] p_matchOut_49)) p_matchOut_49))))) a_44]
             (wrap
-              list_0
-              (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))
+              list_50
+              (lam a_51 (type) (all p_matchOut_52 (type) (fun p_matchOut_52 (fun (fun a_51 (fun [list_50 a_51] p_matchOut_52)) p_matchOut_52))))
               (abs
-                p_matchOut_9
+                p_matchOut_53
                 (type)
                 (lam
-                  list_10
-                  p_matchOut_9
+                  list_54
+                  p_matchOut_53
                   (lam
-                    cons_11
-                    (fun a_8 (fun [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_8] p_matchOut_9))
-                    [ [ cons_11 p_arg0_12 ] p_arg1_13 ]
+                    cons_55
+                    (fun a_44 (fun [(fix list_56 (lam a_57 (type) (all p_matchOut_58 (type) (fun p_matchOut_58 (fun (fun a_57 (fun [list_56 a_57] p_matchOut_58)) p_matchOut_58))))) a_44] p_matchOut_53))
+                    [ [ cons_55 p_arg0_45 ] p_arg1_46 ]
                   )
                 )
               )
@@ -78,12 +78,12 @@
       )
     ]
     (abs
-      a_14
+      a_59
       (type)
       (lam
-        x_15
-        [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_14]
-        (unwrap x_15)
+        x_60
+        [(fix list_61 (lam a_62 (type) (all p_matchOut_63 (type) (fun p_matchOut_63 (fun (fun a_62 (fun [list_61 a_62] p_matchOut_63)) p_matchOut_63))))) a_59]
+        (unwrap x_60)
       )
     )
   ]

--- a/core-to-plc/test/recursiveTypes/listConstruct3.plc.golden
+++ b/core-to-plc/test/recursiveTypes/listConstruct3.plc.golden
@@ -4,24 +4,24 @@
       [
         {
           (abs
-            list_3
+            list_23
             (fun (type) (type))
             (lam
-              list_16
-              (all a_17 (type) [list_3 a_17])
+              list_24
+              (all a_25 (type) [list_23 a_25])
               (lam
-                cons_18
-                (all a_19 (type) (fun a_19 (fun [list_3 a_19] [list_3 a_19])))
+                cons_26
+                (all a_27 (type) (fun a_27 (fun [list_23 a_27] [list_23 a_27])))
                 (lam
-                  p_match_20
-                  (all a_21 (type) (fun [list_3 a_21] (all p_matchOut_22 (type) (fun p_matchOut_22 (fun (fun a_21 (fun [list_3 a_21] p_matchOut_22)) p_matchOut_22)))))
+                  p_match_28
+                  (all a_29 (type) (fun [list_23 a_29] (all p_matchOut_30 (type) (fun p_matchOut_30 (fun (fun a_29 (fun [list_23 a_29] p_matchOut_30)) p_matchOut_30)))))
                   [
-                    [ { cons_18 [(con integer) (con 64)] } (con 64 ! 1) ]
+                    [ { cons_26 [(con integer) (con 64)] } (con 64 ! 1) ]
                     [
-                      [ { cons_18 [(con integer) (con 64)] } (con 64 ! 2) ]
+                      [ { cons_26 [(con integer) (con 64)] } (con 64 ! 2) ]
                       [
-                        [ { cons_18 [(con integer) (con 64)] } (con 64 ! 3) ]
-                        { list_16 [(con integer) (con 64)] }
+                        [ { cons_26 [(con integer) (con 64)] } (con 64 ! 3) ]
+                        { list_24 [(con integer) (con 64)] }
                       ]
                     ]
                   ]
@@ -29,24 +29,24 @@
               )
             )
           )
-          (fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2)))))
+          (fix list_31 (lam a_32 (type) (all p_matchOut_33 (type) (fun p_matchOut_33 (fun (fun a_32 (fun [list_31 a_32] p_matchOut_33)) p_matchOut_33)))))
         }
         (abs
-          a_4
+          a_34
           (type)
           (wrap
-            list_0
-            (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))
+            list_35
+            (lam a_36 (type) (all p_matchOut_37 (type) (fun p_matchOut_37 (fun (fun a_36 (fun [list_35 a_36] p_matchOut_37)) p_matchOut_37))))
             (abs
-              p_matchOut_5
+              p_matchOut_38
               (type)
               (lam
-                list_6
-                p_matchOut_5
+                list_39
+                p_matchOut_38
                 (lam
-                  cons_7
-                  (fun a_4 (fun [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_4] p_matchOut_5))
-                  list_6
+                  cons_40
+                  (fun a_34 (fun [(fix list_41 (lam a_42 (type) (all p_matchOut_43 (type) (fun p_matchOut_43 (fun (fun a_42 (fun [list_41 a_42] p_matchOut_43)) p_matchOut_43))))) a_34] p_matchOut_38))
+                  list_39
                 )
               )
             )
@@ -54,27 +54,27 @@
         )
       ]
       (abs
-        a_8
+        a_44
         (type)
         (lam
-          p_arg0_12
-          a_8
+          p_arg0_45
+          a_44
           (lam
-            p_arg1_13
-            [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_8]
+            p_arg1_46
+            [(fix list_47 (lam a_48 (type) (all p_matchOut_49 (type) (fun p_matchOut_49 (fun (fun a_48 (fun [list_47 a_48] p_matchOut_49)) p_matchOut_49))))) a_44]
             (wrap
-              list_0
-              (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))
+              list_50
+              (lam a_51 (type) (all p_matchOut_52 (type) (fun p_matchOut_52 (fun (fun a_51 (fun [list_50 a_51] p_matchOut_52)) p_matchOut_52))))
               (abs
-                p_matchOut_9
+                p_matchOut_53
                 (type)
                 (lam
-                  list_10
-                  p_matchOut_9
+                  list_54
+                  p_matchOut_53
                   (lam
-                    cons_11
-                    (fun a_8 (fun [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_8] p_matchOut_9))
-                    [ [ cons_11 p_arg0_12 ] p_arg1_13 ]
+                    cons_55
+                    (fun a_44 (fun [(fix list_56 (lam a_57 (type) (all p_matchOut_58 (type) (fun p_matchOut_58 (fun (fun a_57 (fun [list_56 a_57] p_matchOut_58)) p_matchOut_58))))) a_44] p_matchOut_53))
+                    [ [ cons_55 p_arg0_45 ] p_arg1_46 ]
                   )
                 )
               )
@@ -84,12 +84,12 @@
       )
     ]
     (abs
-      a_14
+      a_59
       (type)
       (lam
-        x_15
-        [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_14]
-        (unwrap x_15)
+        x_60
+        [(fix list_61 (lam a_62 (type) (all p_matchOut_63 (type) (fun p_matchOut_63 (fun (fun a_62 (fun [list_61 a_62] p_matchOut_63)) p_matchOut_63))))) a_59]
+        (unwrap x_60)
       )
     )
   ]

--- a/core-to-plc/test/recursiveTypes/listMatch.plc.golden
+++ b/core-to-plc/test/recursiveTypes/listMatch.plc.golden
@@ -4,32 +4,32 @@
       [
         {
           (abs
-            list_3
+            list_26
             (fun (type) (type))
             (lam
-              list_16
-              (all a_17 (type) [list_3 a_17])
+              list_27
+              (all a_28 (type) [list_26 a_28])
               (lam
-                cons_18
-                (all a_19 (type) (fun a_19 (fun [list_3 a_19] [list_3 a_19])))
+                cons_29
+                (all a_30 (type) (fun a_30 (fun [list_26 a_30] [list_26 a_30])))
                 (lam
-                  p_match_20
-                  (all a_21 (type) (fun [list_3 a_21] (all p_matchOut_22 (type) (fun p_matchOut_22 (fun (fun a_21 (fun [list_3 a_21] p_matchOut_22)) p_matchOut_22)))))
+                  p_match_31
+                  (all a_32 (type) (fun [list_26 a_32] (all p_matchOut_33 (type) (fun p_matchOut_33 (fun (fun a_32 (fun [list_26 a_32] p_matchOut_33)) p_matchOut_33)))))
                   (lam
-                    ds_23
-                    [list_3 [(con integer) (con 64)]]
+                    ds_34
+                    [list_26 [(con integer) (con 64)]]
                     [
                       [
                         {
-                          [ { p_match_20 [(con integer) (con 64)] } ds_23 ]
+                          [ { p_match_31 [(con integer) (con 64)] } ds_34 ]
                           [(con integer) (con 64)]
                         }
                         (con 64 ! 0)
                       ]
                       (lam
-                        x_24
+                        x_35
                         [(con integer) (con 64)]
-                        (lam ds_25 [list_3 [(con integer) (con 64)]] x_24)
+                        (lam ds_36 [list_26 [(con integer) (con 64)]] x_35)
                       )
                     ]
                   )
@@ -37,24 +37,24 @@
               )
             )
           )
-          (fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2)))))
+          (fix list_37 (lam a_38 (type) (all p_matchOut_39 (type) (fun p_matchOut_39 (fun (fun a_38 (fun [list_37 a_38] p_matchOut_39)) p_matchOut_39)))))
         }
         (abs
-          a_4
+          a_40
           (type)
           (wrap
-            list_0
-            (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))
+            list_41
+            (lam a_42 (type) (all p_matchOut_43 (type) (fun p_matchOut_43 (fun (fun a_42 (fun [list_41 a_42] p_matchOut_43)) p_matchOut_43))))
             (abs
-              p_matchOut_5
+              p_matchOut_44
               (type)
               (lam
-                list_6
-                p_matchOut_5
+                list_45
+                p_matchOut_44
                 (lam
-                  cons_7
-                  (fun a_4 (fun [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_4] p_matchOut_5))
-                  list_6
+                  cons_46
+                  (fun a_40 (fun [(fix list_47 (lam a_48 (type) (all p_matchOut_49 (type) (fun p_matchOut_49 (fun (fun a_48 (fun [list_47 a_48] p_matchOut_49)) p_matchOut_49))))) a_40] p_matchOut_44))
+                  list_45
                 )
               )
             )
@@ -62,27 +62,27 @@
         )
       ]
       (abs
-        a_8
+        a_50
         (type)
         (lam
-          p_arg0_12
-          a_8
+          p_arg0_51
+          a_50
           (lam
-            p_arg1_13
-            [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_8]
+            p_arg1_52
+            [(fix list_53 (lam a_54 (type) (all p_matchOut_55 (type) (fun p_matchOut_55 (fun (fun a_54 (fun [list_53 a_54] p_matchOut_55)) p_matchOut_55))))) a_50]
             (wrap
-              list_0
-              (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))
+              list_56
+              (lam a_57 (type) (all p_matchOut_58 (type) (fun p_matchOut_58 (fun (fun a_57 (fun [list_56 a_57] p_matchOut_58)) p_matchOut_58))))
               (abs
-                p_matchOut_9
+                p_matchOut_59
                 (type)
                 (lam
-                  list_10
-                  p_matchOut_9
+                  list_60
+                  p_matchOut_59
                   (lam
-                    cons_11
-                    (fun a_8 (fun [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_8] p_matchOut_9))
-                    [ [ cons_11 p_arg0_12 ] p_arg1_13 ]
+                    cons_61
+                    (fun a_50 (fun [(fix list_62 (lam a_63 (type) (all p_matchOut_64 (type) (fun p_matchOut_64 (fun (fun a_63 (fun [list_62 a_63] p_matchOut_64)) p_matchOut_64))))) a_50] p_matchOut_59))
+                    [ [ cons_61 p_arg0_51 ] p_arg1_52 ]
                   )
                 )
               )
@@ -92,12 +92,12 @@
       )
     ]
     (abs
-      a_14
+      a_65
       (type)
       (lam
-        x_15
-        [(fix list_0 (lam a_1 (type) (all p_matchOut_2 (type) (fun p_matchOut_2 (fun (fun a_1 (fun [list_0 a_1] p_matchOut_2)) p_matchOut_2))))) a_14]
-        (unwrap x_15)
+        x_66
+        [(fix list_67 (lam a_68 (type) (all p_matchOut_69 (type) (fun p_matchOut_69 (fun (fun a_68 (fun [list_67 a_68] p_matchOut_69)) p_matchOut_69))))) a_65]
+        (unwrap x_66)
       )
     )
   ]

--- a/core-to-plc/test/recursiveTypes/ptreeConstruct.plc.golden
+++ b/core-to-plc/test/recursiveTypes/ptreeConstruct.plc.golden
@@ -3,58 +3,58 @@
     [
       {
         (abs
-          bad_name_7
+          bad_name_44
           (fun (type) (fun (type) (type)))
           (lam
-            bad_name_17
-            (all a_18 (type) (all b_19 (type) (fun a_18 (fun b_19 [[bad_name_7 a_18] b_19]))))
+            bad_name_45
+            (all a_46 (type) (all b_47 (type) (fun a_46 (fun b_47 [[bad_name_44 a_46] b_47]))))
             (lam
-              p_match_20
-              (all a_21 (type) (all b_22 (type) (fun [[bad_name_7 a_21] b_22] (all p_matchOut_23 (type) (fun (fun a_21 (fun b_22 p_matchOut_23)) p_matchOut_23)))))
+              p_match_48
+              (all a_49 (type) (all b_50 (type) (fun [[bad_name_44 a_49] b_50] (all p_matchOut_51 (type) (fun (fun a_49 (fun b_50 p_matchOut_51)) p_matchOut_51)))))
               [
                 [
                   [
                     {
                       (abs
-                        B_24
+                        B_52
                         (fun (type) (type))
                         (lam
-                          One_37
-                          (all a_38 (type) (fun a_38 [B_24 a_38]))
+                          One_53
+                          (all a_54 (type) (fun a_54 [B_52 a_54]))
                           (lam
-                            Two_39
-                            (all a_40 (type) (fun [B_24 [[bad_name_7 a_40] a_40]] [B_24 a_40]))
+                            Two_55
+                            (all a_56 (type) (fun [B_52 [[bad_name_44 a_56] a_56]] [B_52 a_56]))
                             (lam
-                              B_match_41
-                              (all a_42 (type) (fun [B_24 a_42] (all B_matchOut_43 (type) (fun (fun a_42 B_matchOut_43) (fun (fun [B_24 [[bad_name_7 a_42] a_42]] B_matchOut_43) B_matchOut_43)))))
+                              B_match_57
+                              (all a_58 (type) (fun [B_52 a_58] (all B_matchOut_59 (type) (fun (fun a_58 B_matchOut_59) (fun (fun [B_52 [[bad_name_44 a_58] a_58]] B_matchOut_59) B_matchOut_59)))))
                               [
                                 {
-                                  Two_39 [(con integer) (con 64)]
+                                  Two_55 [(con integer) (con 64)]
                                 }
                                 [
                                   {
-                                    Two_39
-                                    [[bad_name_7 [(con integer) (con 64)]] [(con integer) (con 64)]]
+                                    Two_55
+                                    [[bad_name_44 [(con integer) (con 64)]] [(con integer) (con 64)]]
                                   }
                                   [
                                     {
-                                      One_37
-                                      [[bad_name_7 [[bad_name_7 [(con integer) (con 64)]] [(con integer) (con 64)]]] [[bad_name_7 [(con integer) (con 64)]] [(con integer) (con 64)]]]
+                                      One_53
+                                      [[bad_name_44 [[bad_name_44 [(con integer) (con 64)]] [(con integer) (con 64)]]] [[bad_name_44 [(con integer) (con 64)]] [(con integer) (con 64)]]]
                                     }
                                     [
                                       [
                                         {
                                           {
-                                            bad_name_17
-                                            [[bad_name_7 [(con integer) (con 64)]] [(con integer) (con 64)]]
+                                            bad_name_45
+                                            [[bad_name_44 [(con integer) (con 64)]] [(con integer) (con 64)]]
                                           }
-                                          [[bad_name_7 [(con integer) (con 64)]] [(con integer) (con 64)]]
+                                          [[bad_name_44 [(con integer) (con 64)]] [(con integer) (con 64)]]
                                         }
                                         [
                                           [
                                             {
                                               {
-                                                bad_name_17
+                                                bad_name_45
                                                 [(con integer) (con 64)]
                                               }
                                               [(con integer) (con 64)]
@@ -68,7 +68,7 @@
                                         [
                                           {
                                             {
-                                              bad_name_17
+                                              bad_name_45
                                               [(con integer) (con 64)]
                                             }
                                             [(con integer) (con 64)]
@@ -85,27 +85,27 @@
                           )
                         )
                       )
-                      (fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2)))))
+                      (fix B_60 (lam a_61 (type) (all B_matchOut_62 (type) (fun (fun a_61 B_matchOut_62) (fun (fun [B_60 [[bad_name_44 a_61] a_61]] B_matchOut_62) B_matchOut_62)))))
                     }
                     (abs
-                      a_25
+                      a_63
                       (type)
                       (lam
-                        One_arg0_29
-                        a_25
+                        One_arg0_64
+                        a_63
                         (wrap
-                          B_0
-                          (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
+                          B_65
+                          (lam a_66 (type) (all B_matchOut_67 (type) (fun (fun a_66 B_matchOut_67) (fun (fun [B_65 [[bad_name_44 a_66] a_66]] B_matchOut_67) B_matchOut_67))))
                           (abs
-                            B_matchOut_26
+                            B_matchOut_68
                             (type)
                             (lam
-                              One_27
-                              (fun a_25 B_matchOut_26)
+                              One_69
+                              (fun a_63 B_matchOut_68)
                               (lam
-                                Two_28
-                                (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_25] a_25]] B_matchOut_26)
-                                [ One_27 One_arg0_29 ]
+                                Two_70
+                                (fun [(fix B_71 (lam a_72 (type) (all B_matchOut_73 (type) (fun (fun a_72 B_matchOut_73) (fun (fun [B_71 [[bad_name_44 a_72] a_72]] B_matchOut_73) B_matchOut_73))))) [[bad_name_44 a_63] a_63]] B_matchOut_68)
+                                [ One_69 One_arg0_64 ]
                               )
                             )
                           )
@@ -114,24 +114,24 @@
                     )
                   ]
                   (abs
-                    a_30
+                    a_74
                     (type)
                     (lam
-                      Two_arg0_34
-                      [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]]
+                      Two_arg0_75
+                      [(fix B_76 (lam a_77 (type) (all B_matchOut_78 (type) (fun (fun a_77 B_matchOut_78) (fun (fun [B_76 [[bad_name_44 a_77] a_77]] B_matchOut_78) B_matchOut_78))))) [[bad_name_44 a_74] a_74]]
                       (wrap
-                        B_0
-                        (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
+                        B_79
+                        (lam a_80 (type) (all B_matchOut_81 (type) (fun (fun a_80 B_matchOut_81) (fun (fun [B_79 [[bad_name_44 a_80] a_80]] B_matchOut_81) B_matchOut_81))))
                         (abs
-                          B_matchOut_31
+                          B_matchOut_82
                           (type)
                           (lam
-                            One_32
-                            (fun a_30 B_matchOut_31)
+                            One_83
+                            (fun a_74 B_matchOut_82)
                             (lam
-                              Two_33
-                              (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]] B_matchOut_31)
-                              [ Two_33 Two_arg0_34 ]
+                              Two_84
+                              (fun [(fix B_85 (lam a_86 (type) (all B_matchOut_87 (type) (fun (fun a_86 B_matchOut_87) (fun (fun [B_85 [[bad_name_44 a_86] a_86]] B_matchOut_87) B_matchOut_87))))) [[bad_name_44 a_74] a_74]] B_matchOut_82)
+                              [ Two_84 Two_arg0_75 ]
                             )
                           )
                         )
@@ -140,39 +140,39 @@
                   )
                 ]
                 (abs
-                  a_35
+                  a_88
                   (type)
                   (lam
-                    x_36
-                    [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) a_35]
-                    (unwrap x_36)
+                    x_89
+                    [(fix B_90 (lam a_91 (type) (all B_matchOut_92 (type) (fun (fun a_91 B_matchOut_92) (fun (fun [B_90 [[bad_name_44 a_91] a_91]] B_matchOut_92) B_matchOut_92))))) a_88]
+                    (unwrap x_89)
                   )
                 )
               ]
             )
           )
         )
-        (lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6))))
+        (lam a_93 (type) (lam b_94 (type) (all p_matchOut_95 (type) (fun (fun a_93 (fun b_94 p_matchOut_95)) p_matchOut_95))))
       }
       (abs
-        a_8
+        a_96
         (type)
         (abs
-          b_9
+          b_97
           (type)
           (lam
-            p_arg0_12
-            a_8
+            p_arg0_98
+            a_96
             (lam
-              p_arg1_13
-              b_9
+              p_arg1_99
+              b_97
               (abs
-                p_matchOut_10
+                p_matchOut_100
                 (type)
                 (lam
-                  bad_name_11
-                  (fun a_8 (fun b_9 p_matchOut_10))
-                  [ [ bad_name_11 p_arg0_12 ] p_arg1_13 ]
+                  bad_name_101
+                  (fun a_96 (fun b_97 p_matchOut_100))
+                  [ [ bad_name_101 p_arg0_98 ] p_arg1_99 ]
                 )
               )
             )
@@ -181,15 +181,15 @@
       )
     ]
     (abs
-      a_14
+      a_102
       (type)
       (abs
-        b_15
+        b_103
         (type)
         (lam
-          x_16
-          [[(lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6)))) a_14] b_15]
-          x_16
+          x_104
+          [[(lam a_105 (type) (lam b_106 (type) (all p_matchOut_107 (type) (fun (fun a_105 (fun b_106 p_matchOut_107)) p_matchOut_107)))) a_102] b_103]
+          x_104
         )
       )
     )

--- a/core-to-plc/test/recursiveTypes/ptreeMatch.plc.golden
+++ b/core-to-plc/test/recursiveTypes/ptreeMatch.plc.golden
@@ -3,47 +3,47 @@
     [
       {
         (abs
-          bad_name_7
+          bad_name_47
           (fun (type) (fun (type) (type)))
           (lam
-            bad_name_17
-            (all a_18 (type) (all b_19 (type) (fun a_18 (fun b_19 [[bad_name_7 a_18] b_19]))))
+            bad_name_48
+            (all a_49 (type) (all b_50 (type) (fun a_49 (fun b_50 [[bad_name_47 a_49] b_50]))))
             (lam
-              p_match_20
-              (all a_21 (type) (all b_22 (type) (fun [[bad_name_7 a_21] b_22] (all p_matchOut_23 (type) (fun (fun a_21 (fun b_22 p_matchOut_23)) p_matchOut_23)))))
+              p_match_51
+              (all a_52 (type) (all b_53 (type) (fun [[bad_name_47 a_52] b_53] (all p_matchOut_54 (type) (fun (fun a_52 (fun b_53 p_matchOut_54)) p_matchOut_54)))))
               [
                 [
                   [
                     {
                       (abs
-                        B_24
+                        B_55
                         (fun (type) (type))
                         (lam
-                          One_37
-                          (all a_38 (type) (fun a_38 [B_24 a_38]))
+                          One_56
+                          (all a_57 (type) (fun a_57 [B_55 a_57]))
                           (lam
-                            Two_39
-                            (all a_40 (type) (fun [B_24 [[bad_name_7 a_40] a_40]] [B_24 a_40]))
+                            Two_58
+                            (all a_59 (type) (fun [B_55 [[bad_name_47 a_59] a_59]] [B_55 a_59]))
                             (lam
-                              B_match_41
-                              (all a_42 (type) (fun [B_24 a_42] (all B_matchOut_43 (type) (fun (fun a_42 B_matchOut_43) (fun (fun [B_24 [[bad_name_7 a_42] a_42]] B_matchOut_43) B_matchOut_43)))))
+                              B_match_60
+                              (all a_61 (type) (fun [B_55 a_61] (all B_matchOut_62 (type) (fun (fun a_61 B_matchOut_62) (fun (fun [B_55 [[bad_name_47 a_61] a_61]] B_matchOut_62) B_matchOut_62)))))
                               (lam
-                                ds_44
-                                [B_24 [(con integer) (con 64)]]
+                                ds_63
+                                [B_55 [(con integer) (con 64)]]
                                 [
                                   [
                                     {
                                       [
-                                        { B_match_41 [(con integer) (con 64)] }
-                                        ds_44
+                                        { B_match_60 [(con integer) (con 64)] }
+                                        ds_63
                                       ]
                                       [(con integer) (con 64)]
                                     }
-                                    (lam a_45 [(con integer) (con 64)] a_45)
+                                    (lam a_64 [(con integer) (con 64)] a_64)
                                   ]
                                   (lam
-                                    ds_46
-                                    [B_24 [[bad_name_7 [(con integer) (con 64)]] [(con integer) (con 64)]]]
+                                    ds_65
+                                    [B_55 [[bad_name_47 [(con integer) (con 64)]] [(con integer) (con 64)]]]
                                     (con 64 ! 2)
                                   )
                                 ]
@@ -52,27 +52,27 @@
                           )
                         )
                       )
-                      (fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2)))))
+                      (fix B_66 (lam a_67 (type) (all B_matchOut_68 (type) (fun (fun a_67 B_matchOut_68) (fun (fun [B_66 [[bad_name_47 a_67] a_67]] B_matchOut_68) B_matchOut_68)))))
                     }
                     (abs
-                      a_25
+                      a_69
                       (type)
                       (lam
-                        One_arg0_29
-                        a_25
+                        One_arg0_70
+                        a_69
                         (wrap
-                          B_0
-                          (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
+                          B_71
+                          (lam a_72 (type) (all B_matchOut_73 (type) (fun (fun a_72 B_matchOut_73) (fun (fun [B_71 [[bad_name_47 a_72] a_72]] B_matchOut_73) B_matchOut_73))))
                           (abs
-                            B_matchOut_26
+                            B_matchOut_74
                             (type)
                             (lam
-                              One_27
-                              (fun a_25 B_matchOut_26)
+                              One_75
+                              (fun a_69 B_matchOut_74)
                               (lam
-                                Two_28
-                                (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_25] a_25]] B_matchOut_26)
-                                [ One_27 One_arg0_29 ]
+                                Two_76
+                                (fun [(fix B_77 (lam a_78 (type) (all B_matchOut_79 (type) (fun (fun a_78 B_matchOut_79) (fun (fun [B_77 [[bad_name_47 a_78] a_78]] B_matchOut_79) B_matchOut_79))))) [[bad_name_47 a_69] a_69]] B_matchOut_74)
+                                [ One_75 One_arg0_70 ]
                               )
                             )
                           )
@@ -81,24 +81,24 @@
                     )
                   ]
                   (abs
-                    a_30
+                    a_80
                     (type)
                     (lam
-                      Two_arg0_34
-                      [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]]
+                      Two_arg0_81
+                      [(fix B_82 (lam a_83 (type) (all B_matchOut_84 (type) (fun (fun a_83 B_matchOut_84) (fun (fun [B_82 [[bad_name_47 a_83] a_83]] B_matchOut_84) B_matchOut_84))))) [[bad_name_47 a_80] a_80]]
                       (wrap
-                        B_0
-                        (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))
+                        B_85
+                        (lam a_86 (type) (all B_matchOut_87 (type) (fun (fun a_86 B_matchOut_87) (fun (fun [B_85 [[bad_name_47 a_86] a_86]] B_matchOut_87) B_matchOut_87))))
                         (abs
-                          B_matchOut_31
+                          B_matchOut_88
                           (type)
                           (lam
-                            One_32
-                            (fun a_30 B_matchOut_31)
+                            One_89
+                            (fun a_80 B_matchOut_88)
                             (lam
-                              Two_33
-                              (fun [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) [[bad_name_7 a_30] a_30]] B_matchOut_31)
-                              [ Two_33 Two_arg0_34 ]
+                              Two_90
+                              (fun [(fix B_91 (lam a_92 (type) (all B_matchOut_93 (type) (fun (fun a_92 B_matchOut_93) (fun (fun [B_91 [[bad_name_47 a_92] a_92]] B_matchOut_93) B_matchOut_93))))) [[bad_name_47 a_80] a_80]] B_matchOut_88)
+                              [ Two_90 Two_arg0_81 ]
                             )
                           )
                         )
@@ -107,39 +107,39 @@
                   )
                 ]
                 (abs
-                  a_35
+                  a_94
                   (type)
                   (lam
-                    x_36
-                    [(fix B_0 (lam a_1 (type) (all B_matchOut_2 (type) (fun (fun a_1 B_matchOut_2) (fun (fun [B_0 [[bad_name_7 a_1] a_1]] B_matchOut_2) B_matchOut_2))))) a_35]
-                    (unwrap x_36)
+                    x_95
+                    [(fix B_96 (lam a_97 (type) (all B_matchOut_98 (type) (fun (fun a_97 B_matchOut_98) (fun (fun [B_96 [[bad_name_47 a_97] a_97]] B_matchOut_98) B_matchOut_98))))) a_94]
+                    (unwrap x_95)
                   )
                 )
               ]
             )
           )
         )
-        (lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6))))
+        (lam a_99 (type) (lam b_100 (type) (all p_matchOut_101 (type) (fun (fun a_99 (fun b_100 p_matchOut_101)) p_matchOut_101))))
       }
       (abs
-        a_8
+        a_102
         (type)
         (abs
-          b_9
+          b_103
           (type)
           (lam
-            p_arg0_12
-            a_8
+            p_arg0_104
+            a_102
             (lam
-              p_arg1_13
-              b_9
+              p_arg1_105
+              b_103
               (abs
-                p_matchOut_10
+                p_matchOut_106
                 (type)
                 (lam
-                  bad_name_11
-                  (fun a_8 (fun b_9 p_matchOut_10))
-                  [ [ bad_name_11 p_arg0_12 ] p_arg1_13 ]
+                  bad_name_107
+                  (fun a_102 (fun b_103 p_matchOut_106))
+                  [ [ bad_name_107 p_arg0_104 ] p_arg1_105 ]
                 )
               )
             )
@@ -148,15 +148,15 @@
       )
     ]
     (abs
-      a_14
+      a_108
       (type)
       (abs
-        b_15
+        b_109
         (type)
         (lam
-          x_16
-          [[(lam a_4 (type) (lam b_5 (type) (all p_matchOut_6 (type) (fun (fun a_4 (fun b_5 p_matchOut_6)) p_matchOut_6)))) a_14] b_15]
-          x_16
+          x_110
+          [[(lam a_111 (type) (lam b_112 (type) (all p_matchOut_113 (type) (fun (fun a_111 (fun b_112 p_matchOut_113)) p_matchOut_113)))) a_108] b_109]
+          x_110
         )
       )
     )

--- a/core-to-plc/test/structure/letFun.plc.golden
+++ b/core-to-plc/test/structure/letFun.plc.golden
@@ -1,17 +1,17 @@
 (program 1.0.0
   (lam
-    ds_0
+    ds_3
     [(con integer) (con 64)]
     (lam
-      ds_1
+      ds_4
       [(con integer) (con 64)]
       [
         (lam
-          z_2
+          z_5
           [(con integer) (con 64)]
-          [ [ { (con equalsInteger) (con 64) } ds_0 ] z_2 ]
+          [ [ { (con equalsInteger) (con 64) } ds_3 ] z_5 ]
         )
-        ds_1
+        ds_4
       ]
     )
   )

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15614,6 +15614,7 @@ license = stdenv.lib.licenses.mit;
 , microlens
 , mmorph
 , mtl
+, plutus-ir
 , prettyprinter
 , serialise
 , stdenv
@@ -15639,6 +15640,7 @@ language-plutus-core
 microlens
 mmorph
 mtl
+plutus-ir
 prettyprinter
 serialise
 template-haskell

--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -27,9 +27,10 @@ library
     exposed-modules:
         Language.PlutusIR
         Language.PlutusIR.Compiler
+        Language.PlutusIR.MkPir
+        Language.PlutusIR.Value
     hs-source-dirs: src
     other-modules:
-        Language.PlutusIR.Value
         Language.PlutusIR.Compiler.Error
         Language.PlutusIR.Compiler.Term
         Language.PlutusIR.Compiler.Datatype

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -18,6 +18,7 @@ module Language.PlutusIR (
     Recursivity (..),
     Binding (..),
     Term (..),
+    Program (..),
     prettyDef,
     embedIntoIR
     ) where
@@ -107,6 +108,9 @@ embedIntoIR = \case
     PLC.Unwrap a t -> Unwrap a (embedIntoIR t)
     PLC.Wrap a tn ty t -> Wrap a tn ty (embedIntoIR t)
 
+-- no version as PIR is not versioned
+data Program tyname name a = Program a (Term tyname name a)
+
 -- Pretty-printing
 
 instance (PLC.PrettyClassicBy configName (tyname a), PLC.PrettyClassicBy configName (name a)) =>
@@ -151,5 +155,9 @@ instance (PLC.PrettyClassicBy configName (tyname a), PLC.PrettyClassicBy configN
         Wrap _ n ty t -> parens' ("wrap" </> vsep' [ prettyBy config n, prettyBy config ty, prettyBy config t ])
         Unwrap _ t -> parens' ("unwrap" </> prettyBy config t)
 
-prettyDef :: Term TyName Name a -> Doc ann
+instance (PLC.PrettyClassicBy configName (tyname a), PLC.PrettyClassicBy configName (name a)) =>
+        PrettyBy (PLC.PrettyConfigClassic configName) (Program tyname name a) where
+    prettyBy config (Program _ t) = parens' ("program" </> prettyBy config t)
+
+prettyDef :: (PLC.PrettyBy (PLC.PrettyConfigClassic PLC.PrettyConfigName) a) => a -> Doc ann
 prettyDef = prettyBy $ PLC.PrettyConfigClassic PLC.defPrettyConfigName

--- a/plutus-ir/src/Language/PlutusIR/Compiler.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Language.PlutusIR.Compiler (
     compileTerm,
+    compileProgram,
     Compiling,
     CompError (..),
     Provenance (..)) where
@@ -19,3 +20,7 @@ import           Control.Monad
 -- | Compile a 'Term' into a PLC Term. Note: the result *does* have globally unique names.
 compileTerm :: Compiling m a => Term TyName Name a -> m (PLCTerm a)
 compileTerm = (PLC.rename <=< Term.compileTerm) . original
+
+-- | Compile a 'Program' into a PLC Program. Note: the result *does* have globally unique names.
+compileProgram :: Compiling m a => Program TyName Name a -> m (PLC.Program TyName Name (Provenance a))
+compileProgram (Program a t) = PLC.Program (Original a) (PLC.defaultVersion (Original a)) <$> compileTerm t

--- a/plutus-ir/src/Language/PlutusIR/MkPir.hs
+++ b/plutus-ir/src/Language/PlutusIR/MkPir.hs
@@ -1,0 +1,93 @@
+
+module Language.PlutusIR.MkPir ( TermDef
+                               , TypeDef
+                               , mkVar
+                               , mkTyVar
+                               , mkIterTyForall
+                               , mkIterTyLam
+                               , mkIterApp
+                               , mkIterTyFun
+                               , mkIterLamAbs
+                               , mkIterInst
+                               , mkIterTyAbs
+                               , mkIterTyApp
+                               ) where
+
+import           Language.PlutusIR
+
+import           Language.PlutusCore.MkPlc (Def (..), mkTyVar)
+
+import           Data.List                 (foldl')
+
+-- | A term definition as a variable.
+type TermDef tyname name a = Def (VarDecl tyname name a) (Term tyname name a)
+-- | A type definition as a type variable.
+type TypeDef tyname a = Def (TyVarDecl tyname a) (Type tyname a)
+
+-- | Make a 'Var' referencing the given 'VarDecl'.
+mkVar :: a -> VarDecl tyname name a -> Term tyname name a
+mkVar x = Var x . varDeclName
+
+-- | Make an iterated application.
+mkIterApp
+    :: a
+    -> Term tyname name a -- ^ @f@
+    -> [Term tyname name a] -- ^@[ x0 ... xn ]@
+    -> Term tyname name a -- ^ @[f x0 ... xn ]@
+mkIterApp x = foldl' (Apply x)
+
+-- | Make an iterated instantiation.
+mkIterInst
+    :: a
+    -> Term tyname name a -- ^ @a@
+    -> [Type tyname a] -- ^ @ [ x0 ... xn ] @
+    -> Term tyname name a -- ^ @{ a x0 ... xn }@
+mkIterInst x = foldl' (TyInst x)
+
+-- | Lambda abstract a list of names.
+mkIterLamAbs
+    :: a
+    -> [VarDecl tyname name a]
+    -> Term tyname name a
+    -> Term tyname name a
+mkIterLamAbs x args body = foldr (\(VarDecl _ n ty) acc -> LamAbs x n ty acc) body args
+
+-- | Type abstract a list of names.
+mkIterTyAbs
+    :: a
+    -> [TyVarDecl tyname a]
+    -> Term tyname name a
+    -> Term tyname name a
+mkIterTyAbs x args body = foldr (\(TyVarDecl _ n k) acc -> TyAbs x n k acc) body args
+
+-- | Make an iterated type application.
+mkIterTyApp
+    :: a
+    -> Type tyname a -- ^ @f@
+    -> [Type tyname a] -- ^ @[ x0 ... xn ]@
+    -> Type tyname a -- ^ @[ f x0 ... xn ]@
+mkIterTyApp x = foldl' (TyApp x)
+
+-- | Make an iterated function type.
+mkIterTyFun
+    :: a
+    -> [Type tyname a]
+    -> Type tyname a
+    -> Type tyname a
+mkIterTyFun x tys target = foldr (\ty acc -> TyFun x ty acc) target tys
+
+-- | Universally quantify a list of names.
+mkIterTyForall
+    :: a
+    -> [TyVarDecl tyname a]
+    -> Type tyname a
+    -> Type tyname a
+mkIterTyForall x args body = foldr (\(TyVarDecl _ n k) acc -> TyForall x n k acc) body args
+
+-- | Lambda abstract a list of names.
+mkIterTyLam
+    :: a
+    -> [TyVarDecl tyname a]
+    -> Type tyname a
+    -> Type tyname a
+mkIterTyLam x args body = foldr (\(TyVarDecl _ n k) acc -> TyLam x n k acc) body args

--- a/plutus-th/test/and.plc.golden
+++ b/plutus-th/test/and.plc.golden
@@ -1,38 +1,41 @@
 (program 1.0.0
   [
     (lam
-      ds_14
-      (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
+      ds_15
+      (all Bool_matchOut_16 (type) (fun Bool_matchOut_16 (fun Bool_matchOut_16 Bool_matchOut_16)))
       [
         [
           {
             [
               (lam
-                x_9
-                (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
-                x_9
+                x_17
+                (all Bool_matchOut_18 (type) (fun Bool_matchOut_18 (fun Bool_matchOut_18 Bool_matchOut_18)))
+                x_17
               )
-              ds_14
+              ds_15
             ]
-            (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
+            (all Bool_matchOut_19 (type) (fun Bool_matchOut_19 (fun Bool_matchOut_19 Bool_matchOut_19)))
           }
           (abs
-            Bool_matchOut_3
+            Bool_matchOut_20
             (type)
-            (lam True_4 Bool_matchOut_3 (lam False_5 Bool_matchOut_3 True_4))
+            (lam
+              True_21 Bool_matchOut_20 (lam False_22 Bool_matchOut_20 True_21)
+            )
           )
         ]
         (abs
-          Bool_matchOut_6
+          Bool_matchOut_23
           (type)
-          (lam True_7 Bool_matchOut_6 (lam False_8 Bool_matchOut_6 False_8))
+          (lam True_24 Bool_matchOut_23 (lam False_25 Bool_matchOut_23 False_25)
+          )
         )
       ]
     )
     (abs
-      Bool_matchOut_6
+      Bool_matchOut_26
       (type)
-      (lam True_7 Bool_matchOut_6 (lam False_8 Bool_matchOut_6 False_8))
+      (lam True_27 Bool_matchOut_26 (lam False_28 Bool_matchOut_26 False_28))
     )
   ]
 )

--- a/plutus-th/test/power.plc.golden
+++ b/plutus-th/test/power.plc.golden
@@ -1,20 +1,20 @@
 (program 1.0.0
   (lam
-    ds_0
+    ds_3
     [(con integer) (con 64)]
     [
       (lam
-        y_2
+        y_4
         [(con integer) (con 64)]
-        [ [ { (con multiplyInteger) (con 64) } y_2 ] y_2 ]
+        [ [ { (con multiplyInteger) (con 64) } y_4 ] y_4 ]
       )
       [
         (lam
-          y_1
+          y_5
           [(con integer) (con 64)]
-          [ [ { (con multiplyInteger) (con 64) } y_1 ] y_1 ]
+          [ [ { (con multiplyInteger) (con 64) } y_5 ] y_5 ]
         )
-        [ [ { (con multiplyInteger) (con 64) } ds_0 ] (con 64 ! 1) ]
+        [ [ { (con multiplyInteger) (con 64) } ds_3 ] (con 64 ! 1) ]
       ]
     ]
   )

--- a/plutus-th/test/simple.plc.golden
+++ b/plutus-th/test/simple.plc.golden
@@ -1,17 +1,17 @@
 (program 1.0.0
   (lam
-    ds_14
-    (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
+    ds_15
+    (all Bool_matchOut_16 (type) (fun Bool_matchOut_16 (fun Bool_matchOut_16 Bool_matchOut_16)))
     [
       [
         {
           [
             (lam
-              x_9
-              (all Bool_matchOut_1 (type) (fun Bool_matchOut_1 (fun Bool_matchOut_1 Bool_matchOut_1)))
-              x_9
+              x_17
+              (all Bool_matchOut_18 (type) (fun Bool_matchOut_18 (fun Bool_matchOut_18 Bool_matchOut_18)))
+              x_17
             )
-            ds_14
+            ds_15
           ]
           [(con integer) (con 64)]
         }


### PR DESCRIPTION
This makes it so that the Core plugin goes via PIR in a very trivial way: it does the trivial embedding of PLC into PIR, and then invokes the compiler (which will just lower it back again).

However, this does put the dependencies in place and set up the plugin scaffolding, which is useful.

There are annoying test diffs due to uniques changing - there are a bunch more such annoying diffs in the future, but I'll try and batch them to keep things sensible.