### PR TITLE
pir: add a simple dead binding removal pass

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -25,6 +25,7 @@
 - ignore: {name: Move brackets to avoid $}
 # this aids clarity since you can name the parameters
 - ignore: {name: Avoid lambda}
+- ignore: {name: Avoid lambda using `infix`}
 # whether this is better is very variable
 - ignore: {name: Use infix}
 # hlint can't handle typed TH: https://github.com/haskell-suite/haskell-src-exts/issues/383

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -43,6 +43,7 @@ library
         Language.PlutusCore.Pretty
         Language.PlutusCore.View
         Language.PlutusCore.Subst
+        Language.PlutusCore.Name
         Language.PlutusCore.StdLib.Data.Bool
         Language.PlutusCore.StdLib.Data.ChurchNat
         Language.PlutusCore.StdLib.Data.Function
@@ -64,7 +65,6 @@ library
     hs-source-dirs: src prelude stdlib generators common
     other-modules:
         Language.PlutusCore.Type
-        Language.PlutusCore.Name
         Language.PlutusCore.Lexer
         Language.PlutusCore.Lexer.Type
         Language.PlutusCore.Parser

--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -29,6 +29,7 @@ library
         Language.PlutusIR.Compiler
         Language.PlutusIR.MkPir
         Language.PlutusIR.Value
+        Language.PlutusIR.Optimizer.DeadCode
     hs-source-dirs: src
     other-modules:
         Language.PlutusIR.Compiler.Error
@@ -70,6 +71,8 @@ test-suite plutus-ir-test
     main-is: Spec.hs
     hs-source-dirs: test
     other-modules:
+        OptimizerSpec
+        TestLib
     default-language: Haskell2010
     build-depends:
         base >=4.9 && <5,

--- a/plutus-ir/src/Language/PlutusIR/Optimizer/DeadCode.hs
+++ b/plutus-ir/src/Language/PlutusIR/Optimizer/DeadCode.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase       #-}
+-- | Optimization passes for removing dead code, mainly dead let bindings.
+module Language.PlutusIR.Optimizer.DeadCode (removeDeadBindings) where
+
+import           Language.PlutusIR
+
+import qualified Language.PlutusCore      as PLC
+import qualified Language.PlutusCore.Name as PLC
+
+import           Control.Monad
+import           Control.Monad.State
+
+import           Data.Coerce
+import qualified Data.IntMap              as IM
+
+import           Lens.Micro
+
+-- | Remove all the dead let bindings in a term.
+removeDeadBindings
+    :: (PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => Term tyname name a
+    -> Term tyname name a
+removeDeadBindings t = evalState (processTerm t) mempty
+
+type Usages = IM.IntMap Int
+
+addUsage :: (PLC.HasUnique n unique) => n -> Usages -> Usages
+addUsage n usages =
+    let
+        u = coerce $ n ^. PLC.unique
+        old = IM.findWithDefault 0 (PLC.unUnique u) usages
+    in IM.insert (PLC.unUnique u) (old+1) usages
+
+hasUsage :: (PLC.HasUnique n unique) => n -> Usages -> Bool
+hasUsage n usages =
+    let
+        u = coerce $ n ^. PLC.unique
+    in IM.findWithDefault 0 (PLC.unUnique u) usages > 0
+
+liveBinding
+    :: (MonadState Usages m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => Binding tyname name a
+    -> m Bool
+liveBinding b =
+    let
+        -- TODO: HasUnique instances for VarDecl and TyVarDecl?
+        hasUsageVarDecl (VarDecl _ n _) = hasUsage n
+        hasUsageTyVarDecl (TyVarDecl _ n _) = hasUsage n
+    in case b of
+        TermBind _ d _ -> gets $ hasUsageVarDecl d
+        TypeBind _ d _ -> gets $ hasUsageTyVarDecl d
+        DatatypeBind _ (Datatype _ d _ destr constrs) -> do
+            usages <- get
+            let used = hasUsageTyVarDecl d usages || hasUsage destr usages || any (\c -> hasUsageVarDecl c usages) constrs
+            pure used
+
+{- Note [Simultaneous usage analysis and dead binding elimination]
+It's tempting to say that usage analysis and dead binding elmination should be
+separate passes. We could proceed for each let by:
+- Processing the body.
+- Getting the usages for the body.
+- Removing dead bindings.
+
+But this is quadratic, because it traverses subterms many times. The problem is that
+the usage information for subterms remains relevant when processing superterms, and
+it is very wasteful to recompute it. Possibly there is an elegant way to separate
+the code without making the computation wasteful, but for now we simply do the two
+operations interleaved.
+
+(It would be especially nice if we could move e.g. the usage analysis for types into
+the Plutus Core library.)
+-}
+
+processTerm
+    :: (MonadState Usages m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => Term tyname name a
+    -> m (Term tyname name a)
+processTerm term = case term of
+    Let x r bs t -> do
+        t' <- processTerm t
+
+        -- throw away dead bindings
+        liveBindings <- case r of
+            NonRec -> filterM liveBinding bs
+            Rec    -> do
+                -- TODO: more precise tracking of deadness of recursive bindings, probably will
+                -- require a fancier algorithm or a proper dependency graph
+                liveness <- traverse liveBinding bs
+                -- if any binding is live assume they all are, otherwise we can
+                -- safely ditch them all
+                if or liveness
+                then pure bs
+                else pure []
+
+        -- now handle usages and dead bindings with the bindings themselves
+        processedBindings <- traverse processBinding liveBindings
+
+        -- if we've removed all the bindings then drop the let
+        if null processedBindings
+        then pure t'
+        else pure $ Let x r processedBindings t'
+    Var x n -> do
+        modify (addUsage n)
+        pure $ Var x n
+    TyAbs x tn k t -> TyAbs x tn k <$> processTerm t
+    LamAbs x n ty t -> LamAbs x n <$> processTy ty <*> processTerm t
+    Apply x t1 t2 -> Apply x <$> processTerm t1 <*> processTerm t2
+    Constant x c -> pure $ Constant x c
+    TyInst x t ty -> TyInst x <$> processTerm t <*> processTy ty
+    Error x ty -> Error x <$> processTy ty
+    Wrap x n ty t -> Wrap x n <$> processTy ty <*> processTerm t
+    Unwrap x t -> Unwrap x <$> processTerm t
+
+processVarDecl
+    :: (MonadState Usages m, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => VarDecl tyname name a
+    -> m (VarDecl tyname name a)
+processVarDecl (VarDecl x n ty) = VarDecl x n <$> processTy ty
+
+processTyVarDecl
+    :: (MonadState Usages m)
+    => TyVarDecl tyname a
+    -> m (TyVarDecl tyname a)
+processTyVarDecl (TyVarDecl x n k) = pure $ TyVarDecl x n k
+
+processBinding
+    :: (MonadState Usages m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => Binding tyname name a
+    -> m (Binding tyname name a)
+processBinding = \case
+    TermBind x d rhs -> TermBind x d <$> processTerm rhs
+    TypeBind x d rhs -> TypeBind x d <$> processTy rhs
+    DatatypeBind x (Datatype x' d tvs destr constrs) -> do
+        dt <- Datatype x' <$> processTyVarDecl d <*> traverse processTyVarDecl tvs <*> pure destr <*> traverse processVarDecl constrs
+        pure $ DatatypeBind x dt
+
+processTy :: (MonadState Usages m, PLC.HasUnique (tyname a) PLC.TypeUnique) => Type tyname a -> m (Type tyname a)
+processTy ty = case ty of
+    TyVar x n -> do
+        modify (addUsage n)
+        pure $ TyVar x n
+    TyFun x t1 t2 -> TyFun x <$> processTy t1 <*> processTy t2
+    TyFix x n t -> TyFix x n <$> processTy t
+    TyForall x tn k t -> TyForall x tn k <$> processTy t
+    TyBuiltin x b -> pure $ TyBuiltin x b
+    TyInt x n -> pure $ TyInt x n
+    TyLam x n k t -> TyLam x n k <$> processTy t
+    TyApp x t1 t2 -> TyApp x <$> processTy t1 <*> processTy t2

--- a/plutus-ir/test/OptimizerSpec.hs
+++ b/plutus-ir/test/OptimizerSpec.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE OverloadedStrings #-}
+module OptimizerSpec where
+
+import           Common
+import           PlcTestUtils
+import           TestLib
+
+import           Language.PlutusCore.Quote
+
+import           Language.PlutusIR
+import           Language.PlutusIR.Compiler
+import           Language.PlutusIR.MkPir
+import           Language.PlutusIR.Optimizer.DeadCode
+
+import qualified Language.PlutusCore                  as PLC
+import qualified Language.PlutusCore.MkPlc            as PLC
+
+import qualified Language.PlutusCore.StdLib.Data.Unit as Unit
+
+import           Test.Tasty
+
+optimizer :: TestNested
+optimizer = testNested "optimizer" [
+    deadCode
+    ]
+
+deadCode :: TestNested
+deadCode = testNested "deadCode" [
+    goldenPir "typeLet" (runQuote typeLet)
+    , goldenPir "termLet" (runQuote termLet)
+    , goldenPir "datatypeLiveType" (runQuote datatypeLiveType)
+    , goldenPir "datatypeLiveConstr" (runQuote datatypeLiveConstr)
+    , goldenPir "datatypeLiveDestr" (runQuote datatypeLiveDestr)
+    , goldenPir "datatypeDead" (runQuote datatypeDead)
+    , goldenPir "singleBinding" (runQuote singleBinding)
+    , goldenPir "nestedBindings" (runQuote nestedBindings)
+    , goldenPir "recBindingSimple" (runQuote recBindingSimple)
+    , goldenPir "recBindingComplex" (runQuote recBindingComplex)
+    ]
+
+typeLet :: Quote (Term TyName Name ())
+typeLet = removeDeadBindings <$> do
+    u <- freshTyName () "unit"
+    unit <- Unit.getBuiltinUnit
+    unitVal <- embedIntoIR <$> Unit.getBuiltinUnitval
+    pure $ Let () NonRec [
+        TypeBind () (TyVarDecl () u (PLC.Type ())) unit
+        ] unitVal
+
+termLet :: Quote (Term TyName Name ())
+termLet = removeDeadBindings <$> do
+    uv <- freshName () "unitval"
+    unit <- Unit.getBuiltinUnit
+    unitVal <- embedIntoIR <$> Unit.getBuiltinUnitval
+    pure $ Let () NonRec [
+        TermBind () (VarDecl () uv unit) unitVal
+        ] unitVal
+
+datatypeLiveType :: Quote (Term TyName Name ())
+datatypeLiveType = removeDeadBindings <$> do
+    mb@(Datatype _ d _ _ _) <- maybeDatatype
+
+    pure $
+        Let ()
+            NonRec
+            [
+                DatatypeBind () mb
+            ] (Error () (mkTyVar () d))
+
+datatypeLiveConstr :: Quote (Term TyName Name ())
+datatypeLiveConstr = removeDeadBindings <$> do
+    mb@(Datatype _ _ _ _ [nothing, _]) <- maybeDatatype
+
+    pure $
+        Let ()
+            NonRec
+            [
+                DatatypeBind () mb
+            ] (mkVar () nothing)
+
+datatypeLiveDestr :: Quote (Term TyName Name ())
+datatypeLiveDestr = removeDeadBindings <$> do
+    mb@(Datatype _ _ _ match _) <- maybeDatatype
+
+    pure $
+        Let ()
+            NonRec
+            [
+                DatatypeBind () mb
+            ] (Var () match)
+
+datatypeDead :: Quote (Term TyName Name ())
+datatypeDead = removeDeadBindings <$> do
+    mb <- maybeDatatype
+    unitVal <- embedIntoIR <$> Unit.getBuiltinUnitval
+
+    pure $
+        Let ()
+            NonRec
+            [
+                DatatypeBind () mb
+            ] unitVal
+
+singleBinding :: Quote (Term TyName Name ())
+singleBinding = removeDeadBindings <$> do
+    u <- freshTyName () "unit"
+    uv <- freshName () "unitval"
+    unit <- Unit.getBuiltinUnit
+    unitVal <- embedIntoIR <$> Unit.getBuiltinUnitval
+    pure $ Let () NonRec [
+        TypeBind () (TyVarDecl () u (PLC.Type ())) unit,
+        TermBind () (VarDecl () uv unit) unitVal
+        ] (Var () uv)
+
+nestedBindings :: Quote (Term TyName Name ())
+nestedBindings = removeDeadBindings <$> do
+    u <- freshTyName () "unit"
+    uv <- freshName () "unitval"
+    unit <- Unit.getBuiltinUnit
+    unitVal <- embedIntoIR <$> Unit.getBuiltinUnitval
+    pure $
+        Let () NonRec [
+        TypeBind () (TyVarDecl () u (PLC.Type ())) unit
+        ] $
+        Let () NonRec [
+        TermBind () (VarDecl () uv unit) unitVal
+        ] (Var () uv)
+
+recBindingSimple :: Quote (Term TyName Name ())
+recBindingSimple = removeDeadBindings <$> do
+    uv <- freshName () "unitval"
+    unit <- Unit.getBuiltinUnit
+    unitVal <- embedIntoIR <$> Unit.getBuiltinUnitval
+    pure $ Let () Rec [
+        TermBind () (VarDecl () uv unit) unitVal
+        ] unitVal
+
+recBindingComplex :: Quote (Term TyName Name ())
+recBindingComplex = removeDeadBindings <$> do
+    u <- freshTyName () "unit"
+    uv <- freshName () "unitval"
+    unit <- Unit.getBuiltinUnit
+    unitVal <- embedIntoIR <$> Unit.getBuiltinUnitval
+    -- TODO: the term binding is live but the the type binding isn't, but
+    -- we are paranoid so we keep it
+    pure $ Let () Rec [
+        TypeBind () (TyVarDecl () u (PLC.Type ())) unit,
+        TermBind () (VarDecl () uv unit) unitVal
+        ] (Var () uv)

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -6,11 +6,15 @@ module Main (main) where
 
 import           Common
 import           PlcTestUtils
+import           TestLib
+
+import           OptimizerSpec
 
 import           Language.PlutusCore.Quote
 
 import           Language.PlutusIR
 import           Language.PlutusIR.Compiler
+import           Language.PlutusIR.MkPir
 
 import qualified Language.PlutusCore                  as PLC
 import qualified Language.PlutusCore.MkPlc            as PLC
@@ -56,15 +60,13 @@ compileAndMaybeTypecheck doTypecheck pir = flip runReaderT NoProvenance $ runQuo
             PLC.typecheckTerm (PLC.TypeCheckCfg PLC.defaultTypecheckerGas $ PLC.TypeConfig True mempty) annotated
     pure compiled
 
-goldenPir :: String -> Term TyName Name a -> TestNested
-goldenPir name value = nestedGoldenVsDoc name $ prettyDef value
-
 tests :: TestNested
 tests = testGroup "plutus-ir" <$> sequence [
     prettyprinting,
     datatypes,
     recursion,
-    errors
+    errors,
+    optimizer
     ]
 
 prettyprinting :: TestNested
@@ -84,70 +86,44 @@ basic = runQuote $ do
 
 maybePir :: Quote (Term TyName Name ())
 maybePir = do
-    m <- freshTyName () "Maybe"
-    a <- freshTyName () "a"
-    match <- freshName () "match_Maybe"
-    nothing <- freshName () "Nothing"
-    just <- freshName () "Just"
+    mb@(Datatype _ _ _ _ [_, just]) <- maybeDatatype
+
     unit <- Unit.getBuiltinUnit
     unitval <- embedIntoIR <$> Unit.getBuiltinUnitval
+
     pure $
         Let ()
             NonRec
             [
-                DatatypeBind () $
-                Datatype ()
-                    (TyVarDecl () m (KindArrow () (Type ()) (Type ())))
-                    [
-                        TyVarDecl () a (Type ())
-                    ]
-                match
-                [
-                    VarDecl () nothing (TyApp () (TyVar () m) (TyVar () a)),
-                    VarDecl () just (TyFun () (TyVar () a) (TyApp () (TyVar () m) (TyVar () a)))
-                ]
+                DatatypeBind () mb
             ] $
-        Apply () (TyInst () (Var () just) unit) unitval
+        Apply () (TyInst () (mkVar () just) unit) unitval
 
 listMatch :: Quote (Term TyName Name ())
 listMatch = do
-    m <- freshTyName () "List"
-    a <- freshTyName () "a"
-    let ma = TyApp () (TyVar () m) (TyVar () a)
-    match <- freshName () "match_List"
-    nil <- freshName () "Nil"
-    cons <- freshName () "Cons"
+    lb@(Datatype _ l _ match [nil, _]) <- listDatatype
+
     unit <- Unit.getBuiltinUnit
-    unitval <- Unit.getBuiltinUnitval
+    unitval <- embedIntoIR <$> Unit.getBuiltinUnitval
 
     h <- freshName () "head"
     t <- freshName () "tail"
 
-    let unitMatch = PLC.TyInst () (PLC.Var () match) unit
-    let unitNil = PLC.TyInst () (PLC.Var () nil) unit
+    let unitMatch = TyInst () (Var () match) unit
+    let unitNil = TyInst () (mkVar () nil) unit
+
     pure $
         Let ()
             Rec
             [
-                DatatypeBind () $
-                Datatype ()
-                    (TyVarDecl () m (KindArrow () (Type ()) (Type ())))
-                    [
-                        TyVarDecl () a (Type ())
-                    ]
-                match
-                [
-                    VarDecl () nil ma,
-                    VarDecl () cons (TyFun () (TyVar () a) (TyFun () ma ma))
-                ]
+                DatatypeBind () lb
             ] $
-            -- embed so we can use PLC construction functions
-            embedIntoIR $ PLC.mkIterApp () (PLC.TyInst () (PLC.Apply () unitMatch unitNil) unit)
+            mkIterApp () (TyInst () (Apply () unitMatch unitNil) unit)
                 [
                     -- nil case
                     unitval,
                     -- cons case
-                    PLC.mkIterLamAbs () [PLC.VarDecl () h unit, PLC.VarDecl () t (PLC.TyApp () (PLC.TyVar () m) unit)] $ PLC.Var () h
+                    mkIterLamAbs () [VarDecl () h unit, VarDecl () t (TyApp () (mkTyVar () l) unit)] $ Var () h
                 ]
 
 datatypes :: TestNested
@@ -214,47 +190,17 @@ errors = testNested "errors" [
 
 mutuallyRecursiveTypes :: Quote (Term TyName Name ())
 mutuallyRecursiveTypes = do
-    tree <- freshTyName () "Tree"
-    a <- freshTyName () "a"
-    let treeA arg = TyApp () (TyVar () tree) (TyVar () arg)
-    node <- freshName () "Node"
-    matchTree <- freshName () "match_Tree"
-
-    forest <- freshTyName () "Forest"
-    a2 <- freshTyName () "a"
-    let forestA arg = TyApp () (TyVar () forest) (TyVar () arg)
-    nil <- freshName () "Nil"
-    cons <- freshName () "Cons"
-    matchForest <- freshName () "match_Forest"
+    (treeDt, forestDt@(Datatype _ _ _ _ [nil, _])) <- treeForestDatatype
 
     unit <- Unit.getBuiltinUnit
     pure $
         Let ()
             Rec
             [
-                DatatypeBind () $
-                Datatype ()
-                    (TyVarDecl () tree (KindArrow () (Type ()) (Type ())))
-                    [
-                        TyVarDecl () a (Type ())
-                    ]
-                matchTree
-                [
-                    VarDecl () node (TyFun () (TyVar () a) (TyFun () (forestA a) (treeA a)))
-                ],
-                DatatypeBind () $
-                Datatype ()
-                    (TyVarDecl () forest (KindArrow () (Type ()) (Type ())))
-                    [
-                        TyVarDecl () a2 (Type ())
-                    ]
-                matchForest
-                [
-                    VarDecl () nil (forestA a2),
-                    VarDecl () cons (TyFun () (treeA a2) (TyFun () (forestA a2) (forestA a2)))
-                ]
+                DatatypeBind () treeDt,
+                DatatypeBind () forestDt
             ] $
-        TyInst () (Var () nil) unit
+        TyInst () (mkVar () nil) unit
 
 mutuallyRecursiveValues :: Quote (Term TyName Name ())
 mutuallyRecursiveValues = do

--- a/plutus-ir/test/TestLib.hs
+++ b/plutus-ir/test/TestLib.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE OverloadedStrings #-}
+module TestLib where
+
+import           Common
+
+import           Language.PlutusCore.Quote
+import           Language.PlutusIR
+
+goldenPir :: String -> Term TyName Name a -> TestNested
+goldenPir name value = nestedGoldenVsDoc name $ prettyDef value
+
+maybeDatatype :: Quote (Datatype TyName Name ())
+maybeDatatype = do
+    m <- freshTyName () "Maybe"
+    a <- freshTyName () "a"
+    match <- freshName () "match_Maybe"
+    nothing <- freshName () "Nothing"
+    just <- freshName () "Just"
+
+    pure $
+        Datatype ()
+            (TyVarDecl () m (KindArrow () (Type ()) (Type ())))
+            [
+                TyVarDecl () a (Type ())
+            ]
+        match
+        [
+            VarDecl () nothing (TyApp () (TyVar () m) (TyVar () a)),
+            VarDecl () just (TyFun () (TyVar () a) (TyApp () (TyVar () m) (TyVar () a)))
+        ]
+
+listDatatype :: Quote (Datatype TyName Name ())
+listDatatype = do
+    m <- freshTyName () "List"
+    a <- freshTyName () "a"
+    let ma = TyApp () (TyVar () m) (TyVar () a)
+    match <- freshName () "match_List"
+    nil <- freshName () "Nil"
+    cons <- freshName () "Cons"
+
+    pure $
+        Datatype ()
+            (TyVarDecl () m (KindArrow () (Type ()) (Type ())))
+            [
+                TyVarDecl () a (Type ())
+            ]
+        match
+        [
+            VarDecl () nil ma,
+            VarDecl () cons (TyFun () (TyVar () a) (TyFun () ma ma))
+        ]
+
+treeForestDatatype :: Quote (Datatype TyName Name (), Datatype TyName Name ())
+treeForestDatatype = do
+    tree <- freshTyName () "Tree"
+    a <- freshTyName () "a"
+    let treeA arg = TyApp () (TyVar () tree) (TyVar () arg)
+    node <- freshName () "Node"
+    matchTree <- freshName () "match_Tree"
+
+    forest <- freshTyName () "Forest"
+    a2 <- freshTyName () "a"
+    let forestA arg = TyApp () (TyVar () forest) (TyVar () arg)
+    nil <- freshName () "Nil"
+    cons <- freshName () "Cons"
+    matchForest <- freshName () "match_Forest"
+
+    let treeDt = Datatype ()
+          (TyVarDecl () tree (KindArrow () (Type ()) (Type ())))
+          [
+              TyVarDecl () a (Type ())
+          ]
+          matchTree
+          [
+              VarDecl () node (TyFun () (TyVar () a) (TyFun () (forestA a) (treeA a)))
+          ]
+    let forestDt = Datatype ()
+          (TyVarDecl () forest (KindArrow () (Type ()) (Type ())))
+          [
+              TyVarDecl () a2 (Type ())
+          ]
+          matchForest
+          [
+              VarDecl () nil (forestA a2),
+              VarDecl () cons (TyFun () (treeA a2) (TyFun () (forestA a2) (forestA a2)))
+          ]
+    pure (treeDt, forestDt)

--- a/plutus-ir/test/optimizer/deadCode/datatypeDead.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/datatypeDead.plc.golden
@@ -1,0 +1,1 @@
+(abs a (type) (lam x a x))

--- a/plutus-ir/test/optimizer/deadCode/datatypeLiveConstr.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/datatypeLiveConstr.plc.golden
@@ -1,0 +1,12 @@
+(let
+  (nonrec)
+  (datatypebind
+    (datatype
+      (tyvardecl Maybe (fun (type) (type)))
+      (tyvardecl a (type))
+      match_Maybe
+      (vardecl Nothing [Maybe a]) (vardecl Just (fun a [Maybe a]))
+    )
+  )
+  Nothing
+)

--- a/plutus-ir/test/optimizer/deadCode/datatypeLiveDestr.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/datatypeLiveDestr.plc.golden
@@ -1,0 +1,12 @@
+(let
+  (nonrec)
+  (datatypebind
+    (datatype
+      (tyvardecl Maybe (fun (type) (type)))
+      (tyvardecl a (type))
+      match_Maybe
+      (vardecl Nothing [Maybe a]) (vardecl Just (fun a [Maybe a]))
+    )
+  )
+  match_Maybe
+)

--- a/plutus-ir/test/optimizer/deadCode/datatypeLiveType.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/datatypeLiveType.plc.golden
@@ -1,0 +1,12 @@
+(let
+  (nonrec)
+  (datatypebind
+    (datatype
+      (tyvardecl Maybe (fun (type) (type)))
+      (tyvardecl a (type))
+      match_Maybe
+      (vardecl Nothing [Maybe a]) (vardecl Just (fun a [Maybe a]))
+    )
+  )
+  (error Maybe)
+)

--- a/plutus-ir/test/optimizer/deadCode/nestedBindings.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/nestedBindings.plc.golden
@@ -1,0 +1,7 @@
+(let
+  (nonrec)
+  (termbind
+    (vardecl unitval (all a (type) (fun a a))) (abs a (type) (lam x a x))
+  )
+  unitval
+)

--- a/plutus-ir/test/optimizer/deadCode/recBindingComplex.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/recBindingComplex.plc.golden
@@ -1,0 +1,8 @@
+(let
+  (rec)
+  (typebind (tyvardecl unit (type)) (all a (type) (fun a a)))
+  (termbind
+    (vardecl unitval (all a (type) (fun a a))) (abs a (type) (lam x a x))
+  )
+  unitval
+)

--- a/plutus-ir/test/optimizer/deadCode/recBindingSimple.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/recBindingSimple.plc.golden
@@ -1,0 +1,1 @@
+(abs a (type) (lam x a x))

--- a/plutus-ir/test/optimizer/deadCode/singleBinding.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/singleBinding.plc.golden
@@ -1,0 +1,7 @@
+(let
+  (nonrec)
+  (termbind
+    (vardecl unitval (all a (type) (fun a a))) (abs a (type) (lam x a x))
+  )
+  unitval
+)

--- a/plutus-ir/test/optimizer/deadCode/termLet.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/termLet.plc.golden
@@ -1,0 +1,1 @@
+(abs a (type) (lam x a x))

--- a/plutus-ir/test/optimizer/deadCode/typeLet.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/typeLet.plc.golden
@@ -1,0 +1,1 @@
+(abs a (type) (lam x a x))


### PR DESCRIPTION
This adds a simple optimization pass to the PIR library that removes
unused let bindings. At the moment it is fairly stupid, and doesn't
attempt to separate out usage checking or handle complex recursive
bindings.

The context for this is that I am planning to change the codegen for builtins in the plugin to unconditionally generate bindings for all the builtins. Most of these won't be used, so this pass will clear that up so we don't get illegible codegen for simple cases.

(If anyone has any clever suggestions about how to separate out the usage analysis or handle recursive bindings cleanly then let me know - I have some ideas but they'd be a bit more work).