### PR TITLE
[CGP-376] Blockchain event triggers in wallet API

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -77596,6 +77596,7 @@ license = stdenv.lib.licenses.mit;
 , containers
 , core-to-plc
 , cryptonite
+, deriving-compat
 , errors
 , free
 , ghc
@@ -77604,6 +77605,7 @@ license = stdenv.lib.licenses.mit;
 , language-plutus-core
 , memory
 , microlens
+, microlens-ghc
 , mmorph
 , monad-stm
 , mtl
@@ -77611,6 +77613,7 @@ license = stdenv.lib.licenses.mit;
 , operational
 , plutus-th
 , prettyprinter
+, recursion-schemes
 , serialise
 , servant
 , servant-client
@@ -77643,6 +77646,7 @@ cborg
 containers
 core-to-plc
 cryptonite
+deriving-compat
 errors
 free
 ghc
@@ -77651,6 +77655,7 @@ hedgehog
 language-plutus-core
 memory
 microlens
+microlens-ghc
 mmorph
 monad-stm
 mtl
@@ -77658,6 +77663,7 @@ natural-transformation
 operational
 plutus-th
 prettyprinter
+recursion-schemes
 serialise
 servant
 servant-client

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -38,8 +38,9 @@ import           Language.Plutus.Runtime    (Height, PendingTx (..), PendingTxIn
                                              Value)
 import           Language.Plutus.TH         (plutus)
 import qualified Language.Plutus.TH         as Builtins
-import           Wallet.API                 (EventTrigger (..), Range (..), WalletAPI (..), WalletAPIError, otherError,
-                                             pubKey, signAndSubmit)
+import           Wallet.API                 (EventTrigger (..), Range (..), WalletAPI (..), WalletAPIError, andT,
+                                             blockHeightT, fundsAtAddressT, otherError, ownPubKeyTxOut, pubKey,
+                                             signAndSubmit)
 import           Wallet.UTXO                (Address', DataScript (..), TxOutRef', Validator (..), scriptTxIn,
                                              scriptTxOut)
 import qualified Wallet.UTXO                as UTXO
@@ -157,20 +158,20 @@ contributionScript cmp  = Validator val where
 -- | Given the campaign data and the output from the contributing transaction,
 --   make a trigger that fires when the transaction can be refunded.
 refundTrigger :: Campaign -> Address' -> EventTrigger
-refundTrigger Campaign{..} t = And
-    (FundsAtAddress [t]  (GEQ 1))
-    (BlockHeightRange (GEQ $ fromIntegral $ succ campaignCollectionDeadline))
+refundTrigger Campaign{..} t = andT
+    (fundsAtAddressT t  (GEQ 1))
+    (blockHeightT (GEQ $ fromIntegral $ succ campaignCollectionDeadline))
 
 -- | Given the public key of the campaign owner, generate an event trigger that
 -- fires when the funds can be collected.
-collectFundsTrigger :: Campaign -> [Address'] -> EventTrigger
-collectFundsTrigger Campaign{..} ts = And
-    (FundsAtAddress ts $ GEQ $ UTXO.Value $ fromIntegral campaignTarget)
-    (BlockHeightRange $ fromIntegral <$> Interval campaignDeadline campaignCollectionDeadline)
+collectFundsTrigger :: Campaign -> Address' -> EventTrigger
+collectFundsTrigger Campaign{..} ts = andT
+    (fundsAtAddressT ts $ GEQ $ UTXO.Value $ fromIntegral campaignTarget)
+    (blockHeightT $ fromIntegral <$> Interval campaignDeadline campaignCollectionDeadline)
 
 refund :: (Monad m, WalletAPI m) => Campaign -> TxOutRef' -> UTXO.Value -> m ()
 refund c ref val = do
-    oo <- payToPublicKey val
+    oo <- ownPubKeyTxOut val
     let scr = contributionScript c
         i   = scriptTxIn ref scr UTXO.unitRedeemer
     signAndSubmit (Set.singleton i) [oo]
@@ -180,7 +181,7 @@ refund c ref val = do
 --
 collect :: (Monad m, WalletAPI m) => Campaign -> [(TxOutRef', UTXO.Value)] -> m ()
 collect cmp contributions = do
-    oo <- payToPublicKey value
+    oo <- ownPubKeyTxOut value
     let scr        = contributionScript cmp
         con (r, _) = scriptTxIn r scr UTXO.unitRedeemer
         ins        = con <$> contributions

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
@@ -27,7 +27,7 @@ import qualified Language.Plutus.Runtime.TH as TH
 import           Language.Plutus.TH         (plutus)
 import qualified Language.Plutus.TH         as Builtins
 import           Prelude                    hiding ((&&))
-import           Wallet.API                 (WalletAPI (..), WalletAPIError, otherError, signAndSubmit)
+import           Wallet.API                 (WalletAPI (..), WalletAPIError, otherError, ownPubKeyTxOut, signAndSubmit)
 import           Wallet.UTXO                (DataScript (..), TxOutRef', Validator (..), scriptTxIn, scriptTxOut)
 import qualified Wallet.UTXO                as UTXO
 import qualified Wallet.UTXO.Runtime        as Runtime
@@ -94,7 +94,7 @@ retrieveFunds :: (
     -> UTXO.Value -- ^ Value we want to take out now
     -> m VestingData
 retrieveFunds vs vd r vnow = do
-    oo <- payToPublicKey vnow
+    oo <- ownPubKeyTxOut vnow
     let val = validatorScript vs
         o   = scriptTxOut remaining val (DataScript $ UTXO.lifted vd')
         remaining = (fromIntegral $ totalAmount vs) - vnow
@@ -104,7 +104,11 @@ retrieveFunds vs vd r vnow = do
     pure vd'
 
 validatorScriptHash :: Vesting -> ValidatorHash
-validatorScriptHash = Runtime.plcValidatorHash . validatorScript
+validatorScriptHash =
+    Runtime.plcValidatorDigest
+    . UTXO.getAddress
+    . UTXO.scriptAddress
+    . validatorScript
 
 validatorScript :: Vesting -> Validator
 validatorScript v = Validator val where

--- a/wallet-api/src/Wallet/API.hs
+++ b/wallet-api/src/Wallet/API.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TypeFamilies       #-}
 -- | Interface between wallet and Plutus client
 module Wallet.API(
     WalletAPI(..),
-    EventTrigger(..),
     Range(..),
     KeyPair(..),
     PubKey(..),
@@ -12,6 +15,21 @@ module Wallet.API(
     signature,
     createPayment,
     signAndSubmit,
+    payToScript,
+    payToPubKey,
+    ownPubKeyTxOut,
+    -- * Triggers
+    EventTrigger(..),
+    EventTriggerF(..),
+    andT,
+    orT,
+    notT,
+    alwaysT,
+    neverT,
+    blockHeightT,
+    fundsAtAddressT,
+    checkTrigger,
+    addresses,
     -- * Error handling
     WalletAPIError(..),
     insufficientFundsError,
@@ -20,10 +38,18 @@ module Wallet.API(
 
 import           Control.Monad.Error.Class (MonadError (..))
 import           Data.Aeson                (FromJSON, ToJSON)
+import           Data.Eq.Deriving          (deriveEq1)
+import           Data.Functor.Foldable     (Base, Corecursive (..), Fix (..), Recursive (..))
+import qualified Data.Map                  as Map
+import           Data.Ord.Deriving         (deriveOrd1)
 import qualified Data.Set                  as Set
 import           Data.Text                 (Text)
-import           Wallet.UTXO               (Address', Height, PubKey (..), Signature (..), Tx (..), TxIn', TxOut',
-                                            Value)
+import           GHC.Generics              (Generic)
+import           Text.Show.Deriving        (deriveShow1)
+import           Wallet.UTXO               (Address', DataScript, Height, PubKey (..), Signature (..), Tx (..), TxIn',
+                                            TxOut (..), TxOut', TxOutType (..), Value, pubKeyTxOut)
+
+import           Prelude                   hiding (Ordering (..))
 
 newtype PrivateKey = PrivateKey { getPrivateKey :: Int }
     deriving (Eq, Ord, Show)
@@ -50,16 +76,109 @@ data Range a =
     Interval a a -- ^ inclusive-exclusive
     | GEQ a
     | LT a
-    deriving (Eq, Ord, Show, Functor)
+    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+
+inRange :: Ord a => a -> Range a -> Bool
+inRange a = \case
+    Interval l h -> a >= l && a < h
+    GEQ l -> a >= l
+    LT  l -> a <  l
+
+data EventTriggerF f =
+    And f f
+    | Or f f
+    | Not f
+    | PAlways
+    | PNever
+    | BlockHeightRange !(Range Height)
+    | FundsAtAddress !Address' !(Range Value)
+    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+
+$(deriveEq1 ''EventTriggerF)
+$(deriveOrd1 ''EventTriggerF)
+$(deriveShow1 ''EventTriggerF)
+
+type instance Base EventTrigger = EventTriggerF
+
+instance Recursive EventTrigger where
+    project (EventTrigger (Fix k)) = case k of
+        And l r               -> And (EventTrigger l) (EventTrigger r)
+        Or l r                -> Or (EventTrigger l) (EventTrigger r)
+        Not n                 -> Not (EventTrigger n)
+        PAlways               -> PAlways
+        PNever                -> PNever
+        BlockHeightRange r    -> BlockHeightRange r
+        FundsAtAddress addr r -> FundsAtAddress addr r
+
+instance Corecursive EventTrigger where
+    embed t = let f = EventTrigger . Fix in
+        case t of
+            And (EventTrigger l) (EventTrigger r) -> f $ And l r
+            Or (EventTrigger l) (EventTrigger r)  -> f $ Or l r
+            Not (EventTrigger n)                  -> f $ Not n
+            PAlways                               -> f PAlways
+            PNever                                -> f PNever
+            BlockHeightRange r                    -> f $ BlockHeightRange r
+            FundsAtAddress addr r                 -> f $ FundsAtAddress addr r
+
+
+-- | `andT l r` is true when `l` and `r` are true.
+andT :: EventTrigger -> EventTrigger -> EventTrigger
+andT l = embed . And l
+
+-- | `orT l r` is true when `l` or `r` are true.
+orT :: EventTrigger -> EventTrigger -> EventTrigger
+orT l = embed . Or l
+
+-- | `alwaysT` is always true
+alwaysT :: EventTrigger
+alwaysT = embed PAlways
+
+-- | `neverT` is never true
+neverT :: EventTrigger
+neverT = embed PNever
+
+-- | `blockHeightT r` is true when the block height is in the range `r`
+blockHeightT :: Range Height -> EventTrigger
+blockHeightT = embed . BlockHeightRange
+
+-- | `fundsAtAddressT a r` is true when the funds at `a` are in the range `r`
+fundsAtAddressT :: Address' -> Range Value -> EventTrigger
+fundsAtAddressT a = embed . FundsAtAddress a
+
+-- | `notT t` is true when `t` is false
+notT :: EventTrigger -> EventTrigger
+notT = embed . Not
+
+-- | Check if the given block height and UTXOs match the
+--   conditions of an [[EventTrigger]]
+checkTrigger :: Height -> Map.Map Address' Value -> EventTrigger -> Bool
+checkTrigger h mp = cata chk where
+    chk = \case
+        And l r -> l && r
+        Or  l r -> l || r
+        Not r   -> not r
+        PAlways -> True
+        PNever -> False
+        BlockHeightRange r -> h `inRange` r
+        FundsAtAddress a r ->
+            let f = Map.findWithDefault 0 a mp in
+            f `inRange` r
+
+-- | The addresses that an [[EventTrigger]] refers to
+addresses :: EventTrigger -> [Address']
+addresses = cata adr where
+    adr = \case
+        And l r -> l ++ r
+        Or l r  -> l ++ r
+        Not t   -> t
+        PAlways -> []
+        PNever -> []
+        BlockHeightRange _ -> []
+        FundsAtAddress a _ -> [a]
 
 -- | Event triggers the Plutus client can register with the wallet.
-data EventTrigger =
-    BlockHeightRange !(Range Height) -- ^ True when the block height is within the range
-    | FundsAtAddress [Address'] !(Range Value) -- ^ True when the (unspent) funds at a list of addresses are within the range
-    | And EventTrigger EventTrigger -- ^ True when both triggers are true
-    | Or EventTrigger EventTrigger -- ^ True when at least one trigger is true
-    | PAlways -- ^ Always true
-    | PNever -- ^ Never true
+newtype EventTrigger = EventTrigger { getEventTrigger :: Fix EventTriggerF }
     deriving (Eq, Ord, Show)
 
 data WalletAPIError =
@@ -71,11 +190,34 @@ data WalletAPIError =
 class WalletAPI m where
     submitTxn :: Tx -> m ()
     myKeyPair :: m KeyPair
+
+    {- |
+    Create a payment that spends the specified value and returns any
+    leftover funds as change. Fails if we don't have enough funds.
+    -}
     createPaymentWithChange :: Value -> m (Set.Set TxIn', TxOut')
-    -- ^ Create a payment that spends the specified value and returns any
-    --   leftover funds as change. Fails if we don't have enough funds.
+
+    {- |
+    Register an action in `m ()` to be run when condition is true.
+
+    * The action will be run once for each block where the condition holds. For
+      example, `register (blockHeightT (Interval 3 6)) a` causes `a` to be run
+      at blocks 3, 4, and 5.
+
+    * Each time the wallet is notified of a new block, all triggers are checked
+      and the matching ones are run in an unspecified order.
+
+    * The wallet will only watch "known" addresses. There are two ways an
+      address can become a known address.
+      1. When a trigger is registered for it
+      2. When a transaction submitted by this wallet produces an output for it
+      When an address is added to the set of known addresses, it starts out with
+      an initial value of 0. If there already exist unspent transaction outputs
+      at that address on the chain, then those will be ignored.
+
+    * `register c a >> register c b = register c (a >> b)`
+    -}
     register :: EventTrigger -> m () -> m ()
-    payToPublicKey :: Value -> m TxOut' -- ^ Generate a transaction output that pays a value to a public key owned by us
 
 insufficientFundsError :: MonadError WalletAPIError m => Text -> m a
 insufficientFundsError = throwError . InsufficientFunds
@@ -85,6 +227,24 @@ otherError = throwError . OtherError
 
 createPayment :: (Functor m, WalletAPI m) => Value -> m (Set.Set TxIn')
 createPayment vl = fst <$> createPaymentWithChange vl
+
+-- | Transfer some funds to an address locked by a script.
+payToScript :: (Monad m, WalletAPI m) => Address' -> Value -> DataScript -> m ()
+payToScript addr v ds = do
+    (i, own) <- createPaymentWithChange v
+    let  other = TxOut addr v (PayToScript ds)
+    signAndSubmit i [own, other]
+
+-- | Transfer some funds to an address locked by a public key
+payToPubKey :: (Monad m, WalletAPI m) => Value -> PubKey -> m ()
+payToPubKey v pk = do
+    (i, own) <- createPaymentWithChange v
+    let other = pubKeyTxOut v pk
+    signAndSubmit i [own, other]
+
+-- | Create a `TxOut'` that pays to a public key owned by us
+ownPubKeyTxOut :: (Monad m, WalletAPI m) => Value -> m TxOut'
+ownPubKeyTxOut v = pubKeyTxOut v <$> fmap pubKey myKeyPair
 
 -- | Create a transaction, sign it and submit it
 --   TODO: Also compute the fee

--- a/wallet-api/src/Wallet/Emulator/AddressMap.hs
+++ b/wallet-api/src/Wallet/Emulator/AddressMap.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies    #-}
+module Wallet.Emulator.AddressMap(
+    AddressMap(..),
+    addAddress,
+    addAddresses,
+    values,
+    fromTxOutputs,
+    knownAddresses,
+    updateAddresses
+    ) where
+
+import           Data.Map            (Map)
+import qualified Data.Map            as Map
+import           Data.Maybe          (mapMaybe)
+import           Data.Monoid         (Monoid (..), Sum (..))
+import           Data.Semigroup      (Semigroup (..))
+import qualified Data.Set            as Set
+import           Lens.Micro          (lens, (&), (.~), (^.))
+import           Lens.Micro.GHC      ()
+import           Lens.Micro.Internal (At (..), Index, IxValue, Ixed (..))
+
+import           Wallet.UTXO         (Address', Tx (..), TxIn (..), TxIn', TxOut (..), TxOutRef (..), TxOutRef', Value,
+                                      hashTx)
+
+-- | A map of [[Address']]es and their unspent outputs
+newtype AddressMap = AddressMap { getAddressMap :: Map Address' (Map TxOutRef' Value) }
+    deriving Show
+
+instance Semigroup AddressMap where
+    (AddressMap l) <> (AddressMap r) = AddressMap (Map.unionWith add l r) where
+        add = Map.unionWith (+)
+
+instance Monoid AddressMap where
+    mappend = (<>)
+    mempty = AddressMap Map.empty
+
+type instance Index AddressMap = Address'
+type instance IxValue AddressMap = Map TxOutRef' Value
+
+instance Ixed AddressMap where
+    ix adr f (AddressMap mp) = AddressMap <$> ix adr f mp
+
+instance At AddressMap where
+    at idx = lens g s where
+        g (AddressMap mp) = mp ^. at idx
+        s (AddressMap mp) utxo = AddressMap $ mp & at idx .~ utxo
+
+-- | Add an address with no unspent outputs. If the address already exists, do
+--   nothing.
+addAddress :: Address' -> AddressMap -> AddressMap
+addAddress adr (AddressMap mp) = AddressMap $ Map.alter upd adr mp where
+    upd :: Maybe (Map TxOutRef' Value) -> Maybe (Map TxOutRef' Value)
+    upd = maybe (Just Map.empty) Just
+
+-- | Add a list of [[Address']]es with no unspent outputs
+addAddresses :: [Address'] -> AddressMap -> AddressMap
+addAddresses = flip (foldr addAddress)
+
+-- | The total value of unspent outputs at an address
+values :: AddressMap -> Map Address' Value
+values = Map.map (getSum . foldMap Sum) . getAddressMap
+
+-- | An [[AddressMap]] with the unspent outputs of a single transaction
+fromTxOutputs :: Tx -> AddressMap
+fromTxOutputs tx =
+    AddressMap . Map.fromListWith Map.union . fmap mkUtxo . zip [0..] . txOutputs $ tx where
+    mkUtxo (i, TxOut{..}) = (txOutAddress, Map.singleton (TxOutRef h i) txOutValue)
+    h = hashTx tx
+
+-- | A map of unspent transaction outputs to their addresses (the "inverse" of
+--   [[AddressMap]], without the values
+knownAddresses :: AddressMap -> Map TxOutRef' Address'
+knownAddresses = Map.fromList . unRef . Map.toList . getAddressMap where
+    unRef :: [(Address', Map TxOutRef' Value)] -> [(TxOutRef', Address')]
+    unRef lst = do
+        (a, outRefs) <- lst
+        (rf, _) <- Map.toList outRefs
+        pure (rf, a)
+
+-- | Update the [[AddressMap]] with the inputs and outputs of a new
+--   transaction. `updateAddresses` does not add or remove any keys from its
+--   second argument.
+updateAddresses :: Tx -> AddressMap -> AddressMap
+updateAddresses tx utxo = AddressMap $ Map.mapWithKey upd (getAddressMap utxo) where
+    -- adds the newly produced outputs, and removes the consumed outputs, for
+    -- an address `adr`
+    upd adr mp = Map.union (producedAt adr) mp `Map.difference` consumedFrom adr
+
+    -- The TxOutRefs produced by the transaction, for a given address
+    producedAt :: Address' -> Map TxOutRef' Value
+    producedAt adr = Map.findWithDefault Map.empty adr outputs
+
+    -- The TxOutRefs consumed by the transaction, for a given address
+    consumedFrom :: Address' -> Map TxOutRef' ()
+    consumedFrom adr = maybe Map.empty (Map.fromSet (const ())) $ Map.lookup adr consumedInputs
+
+    consumedInputs = inputs (knownAddresses utxo) (Set.toList $ txInputs tx)
+
+    AddressMap outputs = fromTxOutputs tx
+
+-- Inputs consumed by the transaction, index by address.
+inputs ::
+    Map TxOutRef' Address'
+    -- ^ A map of [[TxOutRef']]s to their [[Address']]es
+    -> [TxIn']
+    -> Map Address' (Set.Set TxOutRef')
+inputs addrs = Map.fromListWith Set.union
+    . fmap (fmap Set.singleton . swap)
+    . mapMaybe ((\a -> sequence (a, Map.lookup a addrs)) . txInRef)
+
+swap :: (a, b) -> (b, a)
+swap (x, y) = (y, x)

--- a/wallet-api/src/Wallet/Emulator/Client.hs
+++ b/wallet-api/src/Wallet/Emulator/Client.hs
@@ -41,7 +41,6 @@ fetchWallet :: Wallet -> ClientM Wallet
 createWallet :: Wallet -> ClientM NoContent
 myKeyPair' :: Wallet -> ClientM KeyPair
 createPaymentWithChange' :: Wallet -> Value -> ClientM (Set TxIn', TxOut')
-payToPublicKey' :: Wallet -> Value -> ClientM TxOut'
 submitTxn' :: Wallet -> Tx -> ClientM [Tx]
 getTransactions :: ClientM [Tx]
 blockchainActions :: ClientM [Tx]
@@ -49,7 +48,7 @@ blockValidated :: Wallet -> Block -> ClientM ()
 blockHeight :: Wallet -> Height -> ClientM ()
 assertOwnFundsEq :: Wallet -> Value -> ClientM NoContent
 assertIsValidated :: Tx -> ClientM NoContent
-(wallets :<|> fetchWallet :<|> createWallet :<|> myKeyPair' :<|> createPaymentWithChange' :<|> payToPublicKey' :<|> submitTxn' :<|> getTransactions) :<|> (blockValidated :<|> blockHeight) :<|> blockchainActions  :<|> (assertOwnFundsEq :<|> assertIsValidated) =
+(wallets :<|> fetchWallet :<|> createWallet :<|> myKeyPair' :<|> createPaymentWithChange' :<|> submitTxn' :<|> getTransactions) :<|> (blockValidated :<|> blockHeight) :<|> blockchainActions  :<|> (assertOwnFundsEq :<|> assertIsValidated) =
   client api
 
 data Environment = Environment
@@ -92,7 +91,6 @@ instance WalletAPI WalletClient where
   myKeyPair = liftWallet myKeyPair'
   createPaymentWithChange value = liftWallet (`createPaymentWithChange'` value)
   register _ _ = pure () -- TODO: Keep track of triggers in emulated wallet
-  payToPublicKey value = liftWallet (`payToPublicKey'` value)
 
 handleNotification :: Notification -> (Wallet -> ClientM ())
 handleNotification (BlockValidated block) = (`blockValidated` block)

--- a/wallet-api/src/Wallet/Emulator/Http.hs
+++ b/wallet-api/src/Wallet/Emulator/Http.hs
@@ -49,7 +49,6 @@ type WalletAPI
      :<|> "wallets" :> Capture "walletid" Wallet :> "my-key-pair" :> Get '[ JSON] KeyPair
      :<|> "wallets" :> Capture "walletid" Wallet :> "payments" :> ReqBody '[ JSON] Value :> Post '[ JSON] ( Set TxIn'
                                                                                                           , TxOut')
-     :<|> "wallets" :> Capture "walletid" Wallet :> "pay-to-public-key" :> ReqBody '[ JSON] Value :> Post '[ JSON] TxOut'
 -- This is where the line between wallet API and control API is crossed
 -- Returning the [Tx] only makes sense when running a WalletAPI m => m () inside a Trace, but not on the wallet API on its own,
 --   otherwise the signature of submitTxn would be submitTxn :: Tx -> m [Tx]
@@ -118,13 +117,6 @@ createPaymentWithChange ::
 createPaymentWithChange wallet =
   runWalletAction wallet . WAPI.createPaymentWithChange
 
-payToPublicKey ::
-     (MonadReader ServerState m, MonadIO m, MonadError ServantErr m)
-  => Wallet
-  -> Value
-  -> m TxOut'
-payToPublicKey wallet = runWalletAction wallet . WAPI.payToPublicKey
-
 submitTxn ::
      (MonadReader ServerState m, MonadIO m, MonadError ServantErr m)
   => Wallet
@@ -164,7 +156,6 @@ walletHandlers state =
   where
     walletApi =
       wallets :<|> fetchWallet :<|> createWallet :<|> myKeyPair :<|> createPaymentWithChange :<|>
-      payToPublicKey :<|>
       submitTxn :<|>
       getTransactions
     controlApi = blockchainActions

--- a/wallet-api/src/Wallet/UTXO/Index.hs
+++ b/wallet-api/src/Wallet/UTXO/Index.hs
@@ -148,7 +148,7 @@ data InOutMatch =
 --   both are of the same type (pubkey or pay-to-script)
 matchInputOutput :: ValidationMonad m => TxIn' -> TxOut' -> m InOutMatch
 matchInputOutput i txo = case (txInType i, txOutType txo) of
-    (UTXO.ConsumeScriptAddress v r, UTXO.PayToScript _ d) ->
+    (UTXO.ConsumeScriptAddress v r, UTXO.PayToScript d) ->
         pure $ ScriptMatch v r d (txOutAddress txo)
     (UTXO.ConsumePublicKeyAddress sig, UTXO.PayToPubKey pk) ->
         pure $ PubKeyMatch pk sig
@@ -162,12 +162,12 @@ matchInputOutput i txo = case (txInType i, txOutType txo) of
 checkMatch :: ValidationMonad m => PendingTx () -> InOutMatch -> m ()
 checkMatch v = \case
     ScriptMatch vl r d a
-        | a /= UTXO.scriptAddress vl d ->
+        | a /= UTXO.scriptAddress vl ->
                 throwError $ InvalidScriptHash d
         | otherwise ->
             let v' = ValidationData
                     $ lifted
-                    $ v { pendingTxOwnHash = Runtime.plcValidatorHash vl }
+                    $ v { pendingTxOwnHash = Runtime.plcValidatorDigest (UTXO.getAddress a) }
             in
                 if UTXO.runScript v' vl r d
                 then pure ()
@@ -214,10 +214,10 @@ validationData h tx = rump <$> ins where
 mkOut :: TxOut' -> Runtime.PendingTxOut
 mkOut t = Runtime.PendingTxOut (fromIntegral $ txOutValue t) d tp where
     (d, tp) = case txOutType t of
-        UTXO.PayToScript vh scrpt ->
+        UTXO.PayToScript scrpt ->
             let
                 dataScriptHash = Runtime.plcDataScriptHash scrpt
-                validatorHash  = Runtime.plcValidatorDigest vh
+                validatorHash  = Runtime.plcValidatorDigest (UTXO.getAddress $ txOutAddress t)
             in
                 (Just (validatorHash, dataScriptHash), Runtime.DataTxOut)
         UTXO.PayToPubKey pk -> (Nothing, Runtime.PubKeyTxOut pk)
@@ -231,7 +231,8 @@ mkIn i = Runtime.PendingTxIn <$> ref <*> pure red <*> vl where
             Runtime.PendingTxOutRef hash idx <$> lkpSigs (UTXO.txInRef i)
     red = case txInType i of
         UTXO.ConsumeScriptAddress v r  ->
-            Just (Runtime.plcValidatorHash v, Runtime.plcRedeemerHash r)
+            let h = UTXO.getAddress $ UTXO.scriptAddress v in
+            Just (Runtime.plcValidatorDigest h, Runtime.plcRedeemerHash r)
         UTXO.ConsumePublicKeyAddress _ ->
             Nothing
     vl = fromIntegral <$> valueOf i

--- a/wallet-api/src/Wallet/UTXO/Runtime.hs
+++ b/wallet-api/src/Wallet/UTXO/Runtime.hs
@@ -15,7 +15,6 @@ module Wallet.UTXO.Runtime (-- * Transactions and related types
               , ValidatorHash(..)
               , TxHash(..)
               , plcDataScriptHash
-              , plcValidatorHash
               , plcValidatorDigest
               , plcRedeemerHash
               , plcTxHash
@@ -165,9 +164,6 @@ instance LiftPlc TxHash
 
 plcDataScriptHash :: UTXO.DataScript -> DataScriptHash
 plcDataScriptHash = DataScriptHash . plcHash
-
-plcValidatorHash :: UTXO.Validator -> ValidatorHash
-plcValidatorHash = ValidatorHash . plcHash
 
 plcValidatorDigest :: Digest SHA256 -> ValidatorHash
 plcValidatorDigest = ValidatorHash . plcDigest

--- a/wallet-api/src/Wallet/UTXO/Types.hs
+++ b/wallet-api/src/Wallet/UTXO/Types.hs
@@ -468,7 +468,7 @@ instance BA.ByteArrayAccess TxIn' where
 
 -- | Type of transaction output.
 data TxOutType =
-    PayToScript !(Digest SHA256) !DataScript -- ^ A pay-to-script output with the hash of the validator script, and the full data script
+    PayToScript !DataScript -- ^ A pay-to-script output with the data script
     | PayToPubKey !PubKey -- ^ A pay-to-pubkey output
     deriving (Show, Eq, Ord, Generic, Serialise, ToJSON, FromJSON)
 
@@ -489,8 +489,8 @@ deriving instance FromJSON TxOut'
 -- | The data script that a [[TxOut]] refers to
 txOutData :: TxOut h -> Maybe DataScript
 txOutData TxOut{txOutType = t} = case  t of
-    PayToScript _ s -> Just s
-    PayToPubKey _   -> Nothing
+    PayToScript s -> Just s
+    PayToPubKey _ -> Nothing
 
 -- | The public key that a [[TxOut]] refers to
 txOutPubKey :: TxOut h -> Maybe PubKey
@@ -530,17 +530,16 @@ pubKeyAddress pk = Address $ hash h where
     e = encode pk
 
 -- | The address of a transaction output locked by a validator script
-scriptAddress :: Validator -> DataScript -> Address (Digest SHA256)
-scriptAddress vl ds = Address $ hash h where
+scriptAddress :: Validator -> Address (Digest SHA256)
+scriptAddress vl = Address $ hash h where
     h :: Digest SHA256 = hash $ Write.toStrictByteString e
-    e = encode vl <> encode ds
+    e = encode vl
 
 -- | Create a transaction output locked by a validator script
 scriptTxOut :: Value -> Validator -> DataScript -> TxOut'
 scriptTxOut v vl ds = TxOut a v tp where
-    a = scriptAddress vl ds
-    tp = PayToScript h ds
-    h :: Digest SHA256 = hash $ Write.toStrictByteString $ encode vl
+    a = scriptAddress vl
+    tp = PayToScript ds
 
 -- | Create a transaction output locked by a public key
 pubKeyTxOut :: Value -> PubKey -> TxOut'
@@ -663,8 +662,8 @@ validTx v t bc = inputsAreValid && valueIsPreserved && validValuesTx t where
 validate :: ValidationData -> TxIn' -> TxOut' -> Bool
 validate bs TxIn{ txInType = ti } TxOut{..} =
     case (ti, txOutType) of
-        (ConsumeScriptAddress v r, PayToScript _ d)
-            | txOutAddress /= scriptAddress v d -> False
+        (ConsumeScriptAddress v r, PayToScript d)
+            | txOutAddress /= scriptAddress v -> False
             | otherwise                                    -> runScript bs v r d
         (ConsumePublicKeyAddress sig, PayToPubKey pk) -> sig `signedBy` pk
         _ -> False

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -1,6 +1,8 @@
 module Main(main) where
 
+import           Control.Monad       (void)
 import           Data.Either         (isLeft, isRight)
+import           Data.Foldable       (traverse_)
 import qualified Data.Map            as Map
 import           Data.Monoid         (Sum (..))
 import           Hedgehog            (Property, forAll, property)
@@ -35,7 +37,9 @@ tests = testGroup "all tests" [
     testGroup "traces" [
         testProperty "accept valid txn" validTrace,
         testProperty "reject invalid txn" invalidTrace,
-        testProperty "notify wallet" notifyWallet
+        testProperty "notify wallet" notifyWallet,
+        testProperty "react to blockchain events" eventTrace,
+        testProperty "watch funds at an address" notifyWallet
         ],
     testGroup "Etc." [
         testProperty "splitVal" splitVal
@@ -108,10 +112,60 @@ notifyWallet = property $ do
         $ Gen.runTraceOn Gen.generatorModel
         $ blockchainActions >>= walletNotifyBlock w
     let ttl = Map.lookup w st
-    Hedgehog.assert $ (getSum . foldMap Sum . view ownFunds <$> ttl) == Just 100000
+    Hedgehog.assert $ (getSum . foldMap Sum . view ownFunds <$> ttl) == Just initialBalance
+
+eventTrace :: Property
+eventTrace = property $ do
+    let w = Wallet 1
+    (e, EmulatorState{ emWalletState = st }) <- forAll
+        $ Gen.runTraceOn Gen.generatorModel
+        $ do
+            blockchainActions >>= walletNotifyBlock w
+            let mkPayment = payToPubKey 100 (PubKey 2)
+                trigger = blockHeightT (GEQ 3)
+
+            -- schedule the `mkPayment` action to run when block height 3 is
+            -- reached.
+            b1 <- walletAction (Wallet 1) $ register trigger mkPayment
+            walletNotifyBlock w b1
+
+            -- advance the clock to trigger `mkPayment`
+            addBlocks 2 >>= traverse_ (walletNotifyBlock w)
+            void (blockchainActions >>= walletNotifyBlock w)
+    let ttl = Map.lookup w st
+
+    -- if `mkPayment` was run then the funds of wallet 1 should be reduced by 100
+    Hedgehog.assert $ (getSum . foldMap Sum . view ownFunds <$> ttl) == Just (initialBalance - 100)
+
+watchFundsAtAddress :: Property
+watchFundsAtAddress = property $ do
+    let w = Wallet 1
+        pkTarget = PubKey 2
+    (e, EmulatorState{ emWalletState = st }) <- forAll
+        $ Gen.runTraceOn Gen.generatorModel
+        $ do
+            blockchainActions >>= walletNotifyBlock w
+            let mkPayment = payToPubKey 100 pkTarget
+                t1 = blockHeightT (Interval 3 4)
+                t2 = fundsAtAddressT (pubKeyAddress pkTarget) (GEQ 1)
+            walletNotifyBlock w =<<
+                (walletAction (Wallet 1) $ do
+                    register t1 mkPayment
+                    register t2 mkPayment)
+
+            -- after 3 blocks, t1 should fire, triggering the first payment of 100 to PubKey 2
+            -- after 4 blocks, t2 should fire, triggering the second payment of 100
+            addBlocks 3 >>= traverse_ (walletNotifyBlock w)
+            void (blockchainActions >>= walletNotifyBlock w)
+    let ttl = Map.lookup w st
+    Hedgehog.assert $ (getSum . foldMap Sum . view ownFunds <$> ttl) == Just (initialBalance - 200)
+
 
 genChainTxn :: Hedgehog.MonadGen m => m (Mockchain, Tx)
 genChainTxn = do
     m <- Gen.genMockchain
     txn <- Gen.genValidTransaction m
     pure (m, txn)
+
+initialBalance :: Value
+initialBalance = 100000

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -108,7 +108,7 @@ notifyWallet = property $ do
         $ Gen.runTraceOn Gen.generatorModel
         $ blockchainActions >>= walletNotifyBlock w
     let ttl = Map.lookup w st
-    Hedgehog.assert $ (getSum . foldMap Sum . view ownAddresses <$> ttl) == Just 100000
+    Hedgehog.assert $ (getSum . foldMap Sum . view ownFunds <$> ttl) == Just 100000
 
 genChainTxn :: Hedgehog.MonadGen m => m (Mockchain, Tx)
 genChainTxn = do

--- a/wallet-api/wallet-api.cabal
+++ b/wallet-api/wallet-api.cabal
@@ -43,6 +43,7 @@ library
     exposed-modules:
         Wallet.API
         Wallet.Emulator
+        Wallet.Emulator.AddressMap
         Wallet.Emulator.Client
         Wallet.Emulator.Http
         Wallet.Emulator.Types
@@ -83,6 +84,7 @@ library
         language-plutus-core -any,
         memory -any,
         microlens -any,
+        microlens-ghc -any,
         mmorph -any,
         monad-stm -any,
         mtl -any,
@@ -99,7 +101,9 @@ library
         text -any,
         text -any,
         transformers -any,
-        unordered-containers -any
+        unordered-containers -any,
+        recursion-schemes -any,
+        deriving-compat -any
 
     if (flag(development) && impl(ghc <8.4))
         ghc-options: -Werror


### PR DESCRIPTION
* Implement `register :: EventTrigger -> m () -> m ()` (part of the `WalletAPI` class) for emulator
* Each wallet has a list of registered event triggers that it checks whenever a `NotifyBlock` notification is received from the blockchain
* The `fundsAtAddress` condition required some changes in the way we keep track of funds at an address. Previously each wallet was only interested in a single address (that of its own keypair), but now we have a list of arbitrary addresses with their unspent transaction outputs.
* Also, the address of a pay-to-script output is now the hash of its validator script *only*. Previously it included the hash of the data script. Now we can have a plutus contract with a single address where each payment to that address has a different data script, for example to store some meta data related to that particular payment.