### PR TITLE
[CGP-411] Declarative Type System

### DIFF
--- a/plutus-core-spec/figures/PlutusCoreReduction.tex
+++ b/plutus-core-spec/figures/PlutusCoreReduction.tex
@@ -61,7 +61,7 @@
                        %&   &     & \inLamLeftFrame{x}{M}                   & \textrm{$\lambda$}\\
                        &   &     & \inAppLeftFrame{M}                      & \textrm{left app}\\
                        &   &     & \inAppRightFrame{V}                     & \textrm{right app}\\
-                       &   &     & \inBuiltin{bn}{A*}{V^*}{\_}{M^*}        & \textrm{builtin}\\
+                       &   &     & \inBuiltin{bn}{A^*}{V^*}{\_}{M^*}        & \textrm{builtin}\\
     \end{array}\]
     \caption{Grammar of Reduction Frames}
     \label{fig:Plutus_core_reduction_frames}

--- a/plutus-core-spec/figures/PlutusCoreReduction.tex
+++ b/plutus-core-spec/figures/PlutusCoreReduction.tex
@@ -40,10 +40,26 @@
         \UnaryInfC{\(\typeStep{\ctxsubst{f}{A}}{\ctxsubst{f}{A'}}\)}
     \end{prooftree}
 
-
-
     \caption{Type Reduction via Contextual Dynamics}
     \label{fig:Plutus_core_type_reduction}
+\end{figure*}
+
+
+
+\begin{figure*}[t]
+	\judgmentdef{\(A = A'\)}{Type $A$ is equal to type $A'$}
+	
+	\begin{prooftree}
+		\AxiomC{\(\typeMultistep{A}{S}\)}
+		\AxiomC{\(\typeMultistep{A'}{S'}\)}
+		\AxiomC{\(S \equiv S'\)}
+		\TrinaryInfC{\(A = A'\)}
+	\end{prooftree}
+	
+	\judgmentdef{\(A \equiv A'\)}{Type $A$ is syntactically identical to type $A'$ modulo $\alpha$ conversion. (Inductive definition omitted.)}
+	
+	\caption{Type Equality and Equivalence}
+	\label{fig:Plutus_core_type_equality_and_equivalence}
 \end{figure*}
 
 

--- a/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
+++ b/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
@@ -202,7 +202,7 @@
         \UnaryInfC{\(D_i = \subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{B_i}\)}
         \alwaysSingleLine
         \RightLabel{builtin}
-        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\builtin{bn}{A_0, ..., A_m}{M_0, ..., M_n}}{\subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{C}}}\)}
+        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\builtin{bn}{A_0 ... A_m}{M_0 ... M_n}}{\subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{C}}}\)}
     \end{prooftree}
 
     \begin{prooftree}

--- a/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
+++ b/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
@@ -93,7 +93,7 @@
 
     \begin{prooftree}
         \AxiomC{\(\hypJ{\Gamma, \typeJ{\alpha}{\typeK{}}}{\istypeJ{A}{K}}\)}
-        \AxiomC{\(K \equiv \typeK{}\)}
+        \AxiomC{\(K = \typeK{}\)}
         \RightLabel{tyfix}
         \BinaryInfC{\(\hypJ{\Gamma}{\istypeJ{\fixT{\alpha}{A}}{\typeK{}}}\)}
     \end{prooftree}
@@ -156,7 +156,7 @@
 
     \begin{prooftree}
         \AxiomC{\(\hypJ{\Gamma}{\istermJ{L}{C}}\)}
-        \AxiomC{\(\typeMultistep{C}{\allT{\alpha}{K}{B}}\)}
+        \AxiomC{\(C = \allT{\alpha}{K}{B}\)}
         \AxiomC{\(\hypJ{\Gamma}{\istypeJ{A}{K}}\)}
         \RightLabel{inst}
         \TrinaryInfC{\(\hypJ{\Gamma}{\istermJ{\inst{L}{A}}{\subst{A}{\alpha}{B}}}\)}
@@ -174,7 +174,7 @@
 
     \begin{prooftree}
         \AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{C}}\)}
-        \AxiomC{\(\typeMultistep{C}{\fixT{\alpha}{A}}\)}
+        \AxiomC{\(C = \fixT{\alpha}{A}\)}
         \RightLabel{unwrap}
         \BinaryInfC{\(\hypJ{\Gamma}{\istermJ{\unwrap{M}}{\subst{\fixT{\alpha}{A}}{\alpha}{A}}}\)}
     \end{prooftree}
@@ -188,7 +188,7 @@
 
     \begin{prooftree}
         \AxiomC{\(\hypJ{\Gamma}{\istermJ{L}{C}}\)}
-        \AxiomC{\(\typeMultistep{C}{\funT{A}{B}}\)}
+        \AxiomC{\(C = \funT{A}{B}\)}
         \AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{A'}}\)}
         \AxiomC{\(A = A'\)}
         \RightLabel{app}

--- a/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
+++ b/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
@@ -198,7 +198,8 @@
     \begin{prooftree}
         \alwaysNoLine
         \AxiomC{$bn$ has signature $\sig{\alpha_0 :: K_0, ..., \alpha_m :: K_m}{B_0, ..., B_n}{C}$ in Fig. \ref{fig:Plutus_core_builtins}}
-        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{M_i}{\subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{B_i}}}\)}
+        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{M_i}{D_i}}\)}
+        \UnaryInfC{\(D_i = \subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{B_i}\)}
         \alwaysSingleLine
         \RightLabel{builtin}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\builtin{bn}{A_0, ..., A_m}{M_0, ..., M_n}}{\subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{C}}}\)}

--- a/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
+++ b/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
@@ -93,7 +93,7 @@
 
     \begin{prooftree}
         \AxiomC{\(\hypJ{\Gamma, \typeJ{\alpha}{\typeK{}}}{\istypeJ{A}{K}}\)}
-        \AxiomC{\(K = \typeK{}\)}
+        \AxiomC{\(K \equiv \typeK{}\)}
         \RightLabel{tyfix}
         \BinaryInfC{\(\hypJ{\Gamma}{\istypeJ{\fixT{\alpha}{A}}{\typeK{}}}\)}
     \end{prooftree}
@@ -134,12 +134,12 @@
 
 
 \begin{figure*}[t]
-    \judgmentdef{\(\hypJ{\Gamma}{\istermJ{M}{S}}\)}{In context $\Gamma$, term $M$ has normal type $S$}
+    \judgmentdef{\(\hypJ{\Gamma}{\istermJ{M}{A}}\)}{In context $\Gamma$, term $M$ has type $A$}
 
     \begin{prooftree}
-        \AxiomC{\(\ctxni{\Gamma}{\termJ{x}{S}}\)}
+        \AxiomC{\(\ctxni{\Gamma}{\termJ{x}{A}}\)}
         \RightLabel{var}
-        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{x}{S}}\)}
+        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{x}{A}}\)}
     \end{prooftree}
 
     \begin{prooftree}
@@ -149,61 +149,65 @@
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{\(\hypJ{\Gamma, \typeJ{\alpha}{K}}{\istermJ{M}{T}}\)}
+        \AxiomC{\(\hypJ{\Gamma, \typeJ{\alpha}{K}}{\istermJ{M}{B}}\)}
         \RightLabel{abs}
-        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\abs{\alpha}{K}{M}}{\allT{\alpha}{K}{T}}}\)}
+        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\abs{\alpha}{K}{M}}{\allT{\alpha}{K}{B}}}\)}
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{\(\hypJ{\Gamma}{\istermJ{L}{\allT{\alpha}{K}{T}}}\)}
+        \AxiomC{\(\hypJ{\Gamma}{\istermJ{L}{C}}\)}
+        \AxiomC{\(\typeMultistep{C}{\allT{\alpha}{K}{B}}\)}
         \AxiomC{\(\hypJ{\Gamma}{\istypeJ{A}{K}}\)}
         \RightLabel{inst}
-        \BinaryInfC{\(\hypJ{\Gamma}{\istermJ{\inst{L}{A}}{\normalform{\subst{S}{\alpha}{T}}}}\)}
+        \TrinaryInfC{\(\hypJ{\Gamma}{\istermJ{\inst{L}{A}}{\subst{A}{\alpha}{B}}}\)}
     \end{prooftree}
 
     \begin{prooftree}
         \AxiomC{\(\Gamma \vdash Q :: \typeK{}\)}
-        \AxiomC{\(Q = \mathcal{E}\{\fixT{\alpha}{S}\}\)}
-		\AxiomC{\(\Gamma \vdash M : \mathcal{E}\{[\fixT{\alpha}{S}/\alpha]S\}\)}
+        \AxiomC{\(Q = \mathcal{E}\{\fixT{\alpha}{A}\}\)}
+		\AxiomC{\(\Gamma \vdash M : \mathcal{E}\{[\fixT{\alpha}{A}/\alpha]A\}\)}
 		\RightLabel{wrap}
-		\TrinaryInfC{\(\hypJ{\Gamma}{\istermJ{\wrap{\alpha}{S}{M}}{Q}}\)}
+		\TrinaryInfC{\(\hypJ{\Gamma}{\istermJ{\wrap{\alpha}{A}{M}}{Q}}\)}
     \end{prooftree}
     
     Where $\mathcal{E}$ is an elimination context $\mathcal{E} ::= \bullet \mid [\mathcal{E} \,\, A]$, $A$ a type, such that $\mathcal{E}\{Q\}$ denotes the type expression obtained by replacing the $\bullet$ in $\mathcal{E}$ with $Q$. That is, $[\bullet\,\, A]\{B\} = [B\,\,A]$, and so on. 
 
     \begin{prooftree}
-        \AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{\fixT{\alpha}{T}}}\)}
+        \AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{C}}\)}
+        \AxiomC{\(\typeMultistep{C}{\fixT{\alpha}{A}}\)}
         \RightLabel{unwrap}
-        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\unwrap{M}}{\normalform{\subst{\fixT{\alpha}{T}}{\alpha}{T}}}}\)}
+        \BinaryInfC{\(\hypJ{\Gamma}{\istermJ{\unwrap{M}}{\subst{\fixT{\alpha}{A}}{\alpha}{A}}}\)}
     \end{prooftree}
 
     \begin{prooftree}
         \AxiomC{\(\hypJ{\Gamma}{\istypeJ{A}{\typeK{}}}\)}
-        \AxiomC{\(\hypJ{\Gamma, \termJ{y}{\normalform{A}}}{\istermJ{M}{T}}\)}
+        \AxiomC{\(\hypJ{\Gamma, \termJ{y}{A}}{\istermJ{M}{B}}\)}
         \RightLabel{lam}
-        \BinaryInfC{\(\hypJ{\Gamma}{\istermJ{\lam{y}{A}{M}}{\funT{\normalform{A}}{T}}}\)}
+        \BinaryInfC{\(\hypJ{\Gamma}{\istermJ{\lam{y}{A}{M}}{\funT{A}{B}}}\)}
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{\(\hypJ{\Gamma}{\istermJ{L}{\funT{S}{T}}}\)}
-        \AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{S}}\)}
+        \AxiomC{\(\hypJ{\Gamma}{\istermJ{L}{C}}\)}
+        \AxiomC{\(\typeMultistep{C}{\funT{A}{B}}\)}
+        \AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{A'}}\)}
+        \AxiomC{\(A = A'\)}
         \RightLabel{app}
-        \BinaryInfC{\(\hypJ{\Gamma}{\istermJ{\app{L}{M}}{T}}\)}
+        \QuaternaryInfC{\(\hypJ{\Gamma}{\istermJ{\app{L}{M}}{B}}\)}
     \end{prooftree}
 
     \begin{prooftree}
         \alwaysNoLine
         \AxiomC{$bn$ has signature $\sig{\alpha_0 :: K_0, ..., \alpha_m :: K_m}{B_0, ..., B_n}{C}$ in Fig. \ref{fig:Plutus_core_builtins}}
-        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{M_i}{\normalform{\subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{B_i}}}}\)}
+        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{M_i}{\subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{B_i}}}\)}
         \alwaysSingleLine
         \RightLabel{builtin}
-        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\builtin{bn}{A_0, ..., A_m}{M_0, ..., M_n}}{\normalform{\subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{C}}}}\)}
+        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\builtin{bn}{A_0, ..., A_m}{M_0, ..., M_n}}{\subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{C}}}\)}
     \end{prooftree}
 
     \begin{prooftree}
         \AxiomC{\(\hypJ{\Gamma}{\istypeJ{A}{\typeK{}}}\)}
         \RightLabel{error}
-        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\error{A}}{\normalform{A}}}\)}
+        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\error{A}}{A}}\)}
     \end{prooftree}
 
     \caption{Type Synthesis}

--- a/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
+++ b/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
@@ -6,7 +6,7 @@
     \[\begin{array}{lrclr}
         \textrm{Ctx} & \Gamma  & ::= & \epsilon                    & \textrm{empty context} \\
                      &         &     & \Gamma, \typeJ{\alpha}{K}   & \textrm{type variable} \\
-                     &         &     & \Gamma, \termJ{x}{S}        & \textrm{term variable} \\
+                     &         &     & \Gamma, \termJ{x}{A}        & \textrm{term variable} \\
     \end{array}\]
 
 
@@ -20,7 +20,7 @@
 
     \begin{prooftree}
         \AxiomC{}
-        \UnaryInfC{\(\ctxni{\Gamma, \termJ{x}{S}}{\termJ{x}{S}}\)}
+        \UnaryInfC{\(\ctxni{\Gamma, \termJ{x}{A}}{\termJ{x}{A}}\)}
     \end{prooftree}
 
     \begin{prooftree}
@@ -35,14 +35,14 @@
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{\(\ctxni{\Gamma}{\termJ{x}{S}}\)}
-        \UnaryInfC{\(\ctxni{\Gamma, \typeJ{\beta}{J}}{\termJ{x}{S}}\)}
+        \AxiomC{\(\ctxni{\Gamma}{\termJ{x}{A}}\)}
+        \UnaryInfC{\(\ctxni{\Gamma, \typeJ{\beta}{J}}{\termJ{x}{A}}\)}
     \end{prooftree}
 
      \begin{prooftree}
-        \AxiomC{\(\ctxni{\Gamma}{\termJ{x}{S}}\)}
+        \AxiomC{\(\ctxni{\Gamma}{\termJ{x}{A}}\)}
         \AxiomC{\(x \not= y\)}
-        \BinaryInfC{\(\ctxni{\Gamma, \termJ{y}{T}}{\termJ{x}{S}}\)}
+        \BinaryInfC{\(\ctxni{\Gamma, \termJ{y}{B}}{\termJ{x}{A}}\)}
     \end{prooftree}
 
 
@@ -63,8 +63,8 @@
     \begin{prooftree}
         \AxiomC{\(\validJ{\Gamma}\)}
         \AxiomC{$x$ is free in $\Gamma$}
-        \AxiomC{\(\hypJ{\Gamma}{\istypeJ{S}{\typeK{}}}\)}
-        \TrinaryInfC{\(\Gamma, \termJ{x}{S}\)}
+        \AxiomC{\(\hypJ{\Gamma}{\istypeJ{A}{\typeK{}}}\)}
+        \TrinaryInfC{\(\Gamma, \termJ{x}{A}\)}
     \end{prooftree}
 
 

--- a/plutus-core-spec/main.tex
+++ b/plutus-core-spec/main.tex
@@ -448,6 +448,7 @@
 
 \newcommand{\ctxsubst}[2]{#1\{#2\}}
 \newcommand{\typeStep}[2]{#1 ~ \rightarrow_{ty} ~ #2}
+\newcommand{\typeMultistep}[2]{#1 ~ \rightarrow_{ty}^{*} ~ #2}
 \newcommand{\step}[2]{#1 ~ \rightarrow ~ #2}
 \newcommand{\multistepIndexed}[3]{#1 ~ \rightarrow^{#2} ~ #3}
 \newcommand{\normalform}[1]{\lfloor #1 \rfloor}


### PR DESCRIPTION
Pursuant to [CGP 411](https://iohk.myjetbrains.com/youtrack/issue/CGP-411).

This branch replaces the main type system we currently have w/ one that uses a declarative equality for types only. In all the places where we rely on type normalization and normality, we explicit reduction and equality.

Of particular note, the judgment `Γ ⊢ M : S` is now `Γ ⊢ M : A` where the type can be an arbitrary type, thereby necessitating that every places we relied on its normality, we instead explicitly reduce. This means that in eliminators, where we would normally simply "match" on the synthesized type to verify that it has the right form (eg. `A → B` or `∀a. B`), we instead have to reduce it (eg. `C →ty* A → B`). Equality itself is only ever used to equate two synthesized types (i.e. in the rule for function application) because all other places we care about reduction, we only have the one synthesized type, not two types to compare.

This does suggest one way to efficiently implement this, however: normalize types only to WHNF unless equality is required, where instead we'd use full HNF.

Also note: The relation `→ty` is defined as relating two _types_, not a type and a normal type, which means that its transitive closure also relates two types. For many purposes that's fine, but we probably implicitly want somewhere to think instead of defining it as relating a type and a normal type, permitting the reflexive case only when the type is normal:

```
   A → A'    A' →* S
   ----------------
         A →* S

   -------
   S →* S
```