### PR TITLE
core-to-plc/pir: minor tidying

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,7 +1,7 @@
 ---
 - functions:
   - {name: unsafePerformIO, within: [PlutusPrelude, Language.PlutusCore.Generators.Internal.Entity]}
-  - {name: error, within: [Main, PlutusPrelude, Language.PlutusCore.StdLib.Meta, Evaluation.Constant.Success, Language.PlutusCore.Constant.Apply, Language.PlutusCore.Constant.Typed, Language.PlutusCore.Evaluation.CkMachine, Language.PlutusCore.TypeSynthesis, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Generators.Internal.Utils, Language.PlutusCore.Constant.Make, Language.PlutusCore.TH, Language.Plutus.CoreToPLC.Error, Language.PlutusIR.Compiler.Datatype]}
+  - {name: error, within: [Main, PlutusPrelude, Language.PlutusCore.StdLib.Meta, Evaluation.Constant.Success, Language.PlutusCore.Constant.Apply, Language.PlutusCore.Constant.Typed, Language.PlutusCore.Evaluation.CkMachine, Language.PlutusCore.TypeSynthesis, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Generators.Internal.Utils, Language.PlutusCore.Constant.Make, Language.PlutusCore.TH, Language.Plutus.CoreToPLC.Utils, Language.PlutusIR.Compiler.Datatype]}
   - {name: undefined, within: [Language.PlutusCore.Constant.Apply, Language.Plutus.Lift]}
   - {name: fromJust, within: [Language.Plutus.Lift]}
   - {name: foldl, within: []}

--- a/core-to-plc/core-to-plc.cabal
+++ b/core-to-plc/core-to-plc.cabal
@@ -25,19 +25,19 @@ flag development
 
 library
     exposed-modules:
-        Language.Plutus.CoreToPLC.Plugin
-        Language.Plutus.CoreToPLC.Error
-        Language.Plutus.CoreToPLC.Builtins
         Language.Plutus.Lift
+        Language.Plutus.CoreToPLC.Plugin
+        Language.Plutus.CoreToPLC.Builtins
+        Language.Plutus.CoreToPLC.Compiler.Error
     hs-source-dirs: src
     other-modules:
-        Language.Plutus.CoreToPLC.Laziness
         Language.Plutus.CoreToPLC.PLCTypes
         Language.Plutus.CoreToPLC.PIRTypes
         Language.Plutus.CoreToPLC.Utils
         Language.Plutus.CoreToPLC.Compiler.Binders
         Language.Plutus.CoreToPLC.Compiler.Builtins
         Language.Plutus.CoreToPLC.Compiler.Definitions
+        Language.Plutus.CoreToPLC.Compiler.Laziness
         Language.Plutus.CoreToPLC.Compiler.Expr
         Language.Plutus.CoreToPLC.Compiler.Names
         Language.Plutus.CoreToPLC.Compiler.Kind

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Builtins.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Builtins.hs
@@ -1,8 +1,35 @@
 -- | Primitive names and functions for working with Plutus Core builtins.
-module Language.Plutus.CoreToPLC.Builtins where
+module Language.Plutus.CoreToPLC.Builtins (
+                                -- * Bytestring builtins
+                                concatenate
+                                , takeByteString
+                                , dropByteString
+                                , sha2_256
+                                , sha3_256
+                                , verifySignature
+                                , equalsByteString
+                                -- * Blockchain builtins
+                                , txhash
+                                , blocknum
+                                -- * Integer builtins
+                                , addInteger
+                                , subtractInteger
+                                , multiplyInteger
+                                , divideInteger
+                                , remainderInteger
+                                , greaterThanInteger
+                                , greaterThanEqInteger
+                                , lessThanInteger
+                                , lessThanEqInteger
+                                , equalsInteger
+                                -- * Error
+                                , error
+                                ) where
 
 import           Data.ByteString.Lazy
-import           Language.Plutus.CoreToPLC.Error
+import           Prelude                         hiding (error)
+
+import           Language.Plutus.CoreToPLC.Utils (mustBeReplaced)
 
 -- TODO: resizing primitives? better handling of sizes?
 

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Builtins.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Builtins.hs
@@ -17,13 +17,13 @@ module Language.Plutus.CoreToPLC.Compiler.Builtins (
 
 import qualified Language.Plutus.CoreToPLC.Builtins                  as Builtins
 import           Language.Plutus.CoreToPLC.Compiler.Definitions
+import           Language.Plutus.CoreToPLC.Compiler.Error
 import {-# SOURCE #-} Language.Plutus.CoreToPLC.Compiler.Expr
 import           Language.Plutus.CoreToPLC.Compiler.Names
 import {-# SOURCE #-} Language.Plutus.CoreToPLC.Compiler.Type
 import           Language.Plutus.CoreToPLC.Compiler.Types
 import           Language.Plutus.CoreToPLC.Compiler.Utils
 import           Language.Plutus.CoreToPLC.Compiler.ValueRestriction
-import           Language.Plutus.CoreToPLC.Error
 import           Language.Plutus.CoreToPLC.PIRTypes
 import           Language.Plutus.CoreToPLC.Utils
 

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Definitions.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Definitions.hs
@@ -13,8 +13,8 @@ module Language.Plutus.CoreToPLC.Compiler.Definitions (
     , lookupMatch
     , wrapWithDefs) where
 
+import           Language.Plutus.CoreToPLC.Compiler.Error
 import           Language.Plutus.CoreToPLC.Compiler.Types
-import           Language.Plutus.CoreToPLC.Error
 import           Language.Plutus.CoreToPLC.PIRTypes
 
 import qualified Language.PlutusIR                        as PIR

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Error.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Error.hs
@@ -2,14 +2,13 @@
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
-module Language.Plutus.CoreToPLC.Error (
+module Language.Plutus.CoreToPLC.Compiler.Error (
     ConvError
     , Error (..)
     , WithContext (..)
     , withContext
     , withContextM
-    , throwPlain
-    , mustBeReplaced) where
+    , throwPlain) where
 
 import qualified Language.PlutusIR.Compiler as PIR
 
@@ -65,6 +64,3 @@ instance (PP.Pretty a) => PLC.PrettyBy PLC.PrettyConfigPlc (Error a) where
         UnsupportedError e -> "Unsupported:" PP.<+> PP.pretty e
         FreeVariableError e -> "Used but not defined in the current conversion:" PP.<+> PP.pretty e
         ValueRestrictionError e -> "Violation of the value restriction:" PP.<+> PP.pretty e
-
-mustBeReplaced :: a
-mustBeReplaced = error "This must be replaced by the core-to-plc plugin during compilation"

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Error.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Error.hs
@@ -46,7 +46,7 @@ instance (PP.Pretty c, PP.Pretty e) => PP.Pretty (WithContext c e) where
             ]
 
 data Error a = PLCError (PLC.Error a)
-             | PIRError (PIR.CompError (PIR.Provenance a))
+             | PIRError (PIR.Error (PIR.Provenance a))
              | ConversionError T.Text
              | UnsupportedError T.Text
              | FreeVariableError T.Text

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
@@ -9,13 +9,13 @@ module Language.Plutus.CoreToPLC.Compiler.Expr (convExpr, convExprWithDefs, conv
 import           Language.Plutus.CoreToPLC.Compiler.Binders
 import           Language.Plutus.CoreToPLC.Compiler.Builtins
 import           Language.Plutus.CoreToPLC.Compiler.Definitions
+import           Language.Plutus.CoreToPLC.Compiler.Error
+import           Language.Plutus.CoreToPLC.Compiler.Laziness
 import           Language.Plutus.CoreToPLC.Compiler.Names
 import           Language.Plutus.CoreToPLC.Compiler.Primitives
 import           Language.Plutus.CoreToPLC.Compiler.Type
 import           Language.Plutus.CoreToPLC.Compiler.Types
 import           Language.Plutus.CoreToPLC.Compiler.Utils
-import           Language.Plutus.CoreToPLC.Error
-import           Language.Plutus.CoreToPLC.Laziness
 import           Language.Plutus.CoreToPLC.PIRTypes
 import           Language.Plutus.CoreToPLC.Utils
 

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Kind.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Kind.hs
@@ -5,9 +5,9 @@
 -- | Functions for compiling GHC kinds into PlutusCore kinds.
 module Language.Plutus.CoreToPLC.Compiler.Kind (convKind) where
 
+import           Language.Plutus.CoreToPLC.Compiler.Error
 import           Language.Plutus.CoreToPLC.Compiler.Types
 import           Language.Plutus.CoreToPLC.Compiler.Utils
-import           Language.Plutus.CoreToPLC.Error
 
 import qualified GhcPlugins                               as GHC
 import qualified Kind                                     as GHC

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Laziness.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Laziness.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | Simulating laziness.
-module Language.Plutus.CoreToPLC.Laziness where
+module Language.Plutus.CoreToPLC.Compiler.Laziness where
 
 import {-# SOURCE #-} Language.Plutus.CoreToPLC.Compiler.Expr
 import {-# SOURCE #-} Language.Plutus.CoreToPLC.Compiler.Type

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Names.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Names.hs
@@ -5,11 +5,12 @@
 -- | Functions for compiling GHC names into Plutus Core names.
 module Language.Plutus.CoreToPLC.Compiler.Names where
 
+import           PlutusPrelude                            (strToBs)
+
 import           Language.Plutus.CoreToPLC.Compiler.Kind
 import {-# SOURCE #-} Language.Plutus.CoreToPLC.Compiler.Type
 import           Language.Plutus.CoreToPLC.Compiler.Types
 import           Language.Plutus.CoreToPLC.PLCTypes
-import           Language.Plutus.CoreToPLC.Utils
 
 import qualified GhcPlugins                               as GHC
 

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Primitives.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Primitives.hs
@@ -9,9 +9,9 @@ module Language.Plutus.CoreToPLC.Compiler.Primitives where
 
 import qualified Language.Plutus.CoreToPLC.Builtins          as Builtins
 import           Language.Plutus.CoreToPLC.Compiler.Builtins
+import           Language.Plutus.CoreToPLC.Compiler.Error
 import           Language.Plutus.CoreToPLC.Compiler.Types
 import           Language.Plutus.CoreToPLC.Compiler.Utils
-import           Language.Plutus.CoreToPLC.Error
 import           Language.Plutus.CoreToPLC.PIRTypes
 
 import qualified GhcPlugins                                  as GHC

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Type.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Type.hs
@@ -21,13 +21,13 @@ module Language.Plutus.CoreToPLC.Compiler.Type (
 import           Language.Plutus.CoreToPLC.Compiler.Binders
 import           Language.Plutus.CoreToPLC.Compiler.Builtins
 import           Language.Plutus.CoreToPLC.Compiler.Definitions
+import           Language.Plutus.CoreToPLC.Compiler.Error
 import {-# SOURCE #-} Language.Plutus.CoreToPLC.Compiler.Expr
 import           Language.Plutus.CoreToPLC.Compiler.Kind
+import           Language.Plutus.CoreToPLC.Compiler.Laziness
 import           Language.Plutus.CoreToPLC.Compiler.Names
 import           Language.Plutus.CoreToPLC.Compiler.Types
 import           Language.Plutus.CoreToPLC.Compiler.Utils
-import           Language.Plutus.CoreToPLC.Error
-import           Language.Plutus.CoreToPLC.Laziness
 import           Language.Plutus.CoreToPLC.PIRTypes
 
 import qualified GhcPlugins                                     as GHC

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Types.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Types.hs
@@ -5,24 +5,24 @@
 
 module Language.Plutus.CoreToPLC.Compiler.Types where
 
-import           Language.Plutus.CoreToPLC.Error
+import           Language.Plutus.CoreToPLC.Compiler.Error
 import           Language.Plutus.CoreToPLC.PIRTypes
 import           Language.Plutus.CoreToPLC.PLCTypes
 
 import           Language.PlutusCore.Quote
 
-import qualified GhcPlugins                         as GHC
+import qualified GhcPlugins                               as GHC
 
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Control.Monad.State
 
-import qualified Data.List.NonEmpty                 as NE
-import qualified Data.Map                           as Map
-import qualified Data.Set                           as Set
+import qualified Data.List.NonEmpty                       as NE
+import qualified Data.Map                                 as Map
+import qualified Data.Set                                 as Set
 import           Lens.Micro
 
-import qualified Language.Haskell.TH.Syntax         as TH
+import qualified Language.Haskell.TH.Syntax               as TH
 
 type BuiltinNameInfo = Map.Map TH.Name GHC.TyThing
 

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Utils.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Utils.hs
@@ -3,8 +3,8 @@
 
 module Language.Plutus.CoreToPLC.Compiler.Utils where
 
+import           Language.Plutus.CoreToPLC.Compiler.Error
 import           Language.Plutus.CoreToPLC.Compiler.Types
-import           Language.Plutus.CoreToPLC.Error
 
 import qualified GhcPlugins                               as GHC
 

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/ValueRestriction.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/ValueRestriction.hs
@@ -6,13 +6,13 @@
 -- | Functions for dealing with the Plutus Core value restriction.
 module Language.Plutus.CoreToPLC.Compiler.ValueRestriction where
 
+import           Language.Plutus.CoreToPLC.Compiler.Error
+import           Language.Plutus.CoreToPLC.Compiler.Laziness
 import           Language.Plutus.CoreToPLC.Compiler.Types
-import           Language.Plutus.CoreToPLC.Error
-import           Language.Plutus.CoreToPLC.Laziness
 import           Language.Plutus.CoreToPLC.PIRTypes
 
-import qualified Language.PlutusIR                        as PIR
-import qualified Language.PlutusIR.Value                  as PIR
+import qualified Language.PlutusIR                           as PIR
+import qualified Language.PlutusIR.Value                     as PIR
 
 import           Control.Monad.Reader
 

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Plugin.hs
@@ -11,12 +11,13 @@
 module Language.Plutus.CoreToPLC.Plugin (PlcCode, getSerializedCode, getAst, plugin, plc) where
 
 import           Language.Plutus.CoreToPLC.Compiler.Builtins
+import           Language.Plutus.CoreToPLC.Compiler.Error
 import           Language.Plutus.CoreToPLC.Compiler.Expr
 import           Language.Plutus.CoreToPLC.Compiler.Types
 import           Language.Plutus.CoreToPLC.Compiler.Utils
-import           Language.Plutus.CoreToPLC.Error
 import           Language.Plutus.CoreToPLC.PIRTypes
 import           Language.Plutus.CoreToPLC.PLCTypes
+import           Language.Plutus.CoreToPLC.Utils
 import           Language.Plutus.Lift
 
 import qualified GhcPlugins                                  as GHC

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Utils.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Utils.hs
@@ -3,20 +3,10 @@
 
 module Language.Plutus.CoreToPLC.Utils where
 
-import qualified Language.PlutusCore  as PLC
-import qualified Language.PlutusIR    as PIR
-
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.Text            as T
-import qualified Data.Text.Encoding   as TE
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusIR   as PIR
 
 import           GHC.Natural
-
-strToBs :: String -> BSL.ByteString
-strToBs = BSL.fromStrict . TE.encodeUtf8 . T.pack
-
-bsToStr :: BSL.ByteString -> String
-bsToStr = T.unpack . TE.decodeUtf8 . BSL.toStrict
 
 instSize :: Natural -> PIR.Term tyname name () -> PIR.Term tyname name ()
 instSize n t = PIR.TyInst () t (PLC.TyInt () n)
@@ -36,3 +26,6 @@ haskellIntSize = 64
 -- This is mostly so they are compatible with the output of the SHA functions
 haskellBSSize :: Natural
 haskellBSSize = 256
+
+mustBeReplaced :: a
+mustBeReplaced = error "This must be replaced by the core-to-plc plugin during compilation"

--- a/core-to-plc/src/Language/Plutus/Lift.hs
+++ b/core-to-plc/src/Language/Plutus/Lift.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE TypeOperators       #-}
 module Language.Plutus.Lift (TypeablePlc (..), LiftPlc (..)) where
 
+import           PlutusPrelude                   (strToBs)
+
 import           Language.Plutus.CoreToPLC.Utils
 
 import           Language.PlutusCore

--- a/plutus-ir/src/Language/PlutusIR/Compiler.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler.hs
@@ -3,7 +3,7 @@ module Language.PlutusIR.Compiler (
     compileTerm,
     compileProgram,
     Compiling,
-    CompError (..),
+    Error (..),
     Provenance (..)) where
 
 import           Language.PlutusIR

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
-module Language.PlutusIR.Compiler.Error (CompError (..)) where
+module Language.PlutusIR.Compiler.Error (Error (..)) where
 
 import qualified Language.PlutusCore        as PLC
 import qualified Language.PlutusCore.Pretty as PLC
@@ -13,18 +13,18 @@ import           Data.Text.Prettyprint.Doc  ((<+>), (<>))
 import qualified Data.Text.Prettyprint.Doc  as PP
 import           Data.Typeable
 
-data CompError a = CompilationError a T.Text -- ^ A generic compilation error.
-                 | UnsupportedError a T.Text -- ^ An error relating specifically to an unsupported feature.
-                 | PLCError (PLC.Error a) -- ^ An error from running some PLC function, lifted into this error type for convenience.
-                 deriving (Typeable)
+data Error a = CompilationError a T.Text -- ^ A generic compilation error.
+               | UnsupportedError a T.Text -- ^ An error relating specifically to an unsupported feature.
+               | PLCError (PLC.Error a) -- ^ An error from running some PLC function, lifted into this error type for convenience.
+               deriving (Typeable)
 
-instance (PP.Pretty a) => Show (CompError a) where
+instance (PP.Pretty a) => Show (Error a) where
     show e = show $ PLC.prettyPlcClassicDebug e
 
-instance PP.Pretty a => PLC.PrettyBy PLC.PrettyConfigPlc (CompError a) where
+instance PP.Pretty a => PLC.PrettyBy PLC.PrettyConfigPlc (Error a) where
     prettyBy config = \case
         CompilationError x e -> "Error during compilation" <+> PP.pretty x <> ":" <+> PP.pretty e
         UnsupportedError x e -> "Unsupported construct at" <+> PP.pretty x <> ":" <+> PP.pretty e
         PLCError e -> PLC.prettyBy config e
 
-instance (PP.Pretty a, Typeable a) => Exception (CompError a)
+instance (PP.Pretty a, Typeable a) => Exception (Error a)

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
@@ -19,6 +19,6 @@ type PLCType a = PLC.Type PLC.TyName (Provenance a)
 type PIRTerm a = PIR.Term PIR.TyName PIR.Name (Provenance a)
 type PIRType a = PIR.Type PIR.TyName (Provenance a)
 
-type Compiling m a = (Monad m, MonadReader (Provenance a) m, MonadError (CompError (Provenance a)) m, MonadQuote m)
+type Compiling m a = (Monad m, MonadReader (Provenance a) m, MonadError (Error (Provenance a)) m, MonadQuote m)
 
 type TermDef tyname name a = PLC.Def (PLC.VarDecl tyname name a) (PIR.Term tyname name a)

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -48,7 +48,7 @@ asIfThrown
     -> ExceptT SomeException IO a
 asIfThrown = withExceptT SomeException . hoist (pure . runIdentity)
 
-compileAndMaybeTypecheck :: Bool -> Quote (Term TyName Name a) -> Except (CompError (Provenance a)) (PLC.Term TyName Name (Provenance a))
+compileAndMaybeTypecheck :: Bool -> Quote (Term TyName Name a) -> Except (Error (Provenance a)) (PLC.Term TyName Name (Provenance a))
 compileAndMaybeTypecheck doTypecheck pir = flip runReaderT NoProvenance $ runQuoteT $ do
     -- it is important we run the two computations in the same Quote together, otherwise we might make
     -- names during compilation that are not fresh


### PR DESCRIPTION
- Rename `CompError` to `Error` for consistency.
- Add an export list to `Builitns`
- Move a couple of modules to more logical locations.