### PR TITLE
plutus-th: use addCorePlugin

### DIFF
--- a/plutus-th/src/Language/Plutus/TH.hs
+++ b/plutus-th/src/Language/Plutus/TH.hs
@@ -12,13 +12,13 @@ import           Language.Plutus.CoreToPLC.Builtins as Builtins
 import           Language.Plutus.CoreToPLC.Plugin
 
 import qualified Language.Haskell.TH                as TH
+import qualified Language.Haskell.TH.Syntax         as TH
 
 -- | Covert a quoted Haskell expression into a corresponding Plutus Core program. Produces an expression of type
 -- 'PlcCode'.
 plutus :: TH.Q TH.Exp -> TH.Q TH.Exp
--- We would like to do `addCorePlugin "Language.Plutus.CoreToPLC.Plugin"``, but this needs template-haskell-2.13.0.0,
--- which is in the next LTS snapshot.
 plutus e = do
+    TH.addCorePlugin "Language.Plutus.CoreToPLC.Plugin"
     loc <- TH.location
     let locStr = TH.pprint loc
     [| plc @($(TH.litT $ TH.strTyLit locStr)) $(e) |]

--- a/plutus-th/test/Spec.hs
+++ b/plutus-th/test/Spec.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
--- remove when we can use addCorePlugin
-{-# OPTIONS -fplugin=Language.Plutus.CoreToPLC.Plugin #-}
 
 -- | Most tests for this functionality are in the plugin package, this is mainly just checking that the wiring machinery
 -- works.


### PR DESCRIPTION
This means that users of the TH function don't need the `OPTIONS`
pragma unless they actually need to pass options to the plugin. Sadly,
most of the current users do, since they need to turn off typechecking
until we sort out recursive types.