### PR TITLE
core-to-plc: fix a number of things to get `Swap` compiling

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Error.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Error.hs
@@ -8,7 +8,8 @@ module Language.Plutus.CoreToPLC.Compiler.Error (
     , WithContext (..)
     , withContext
     , withContextM
-    , throwPlain) where
+    , throwPlain
+    , stripContext) where
 
 import qualified Language.PlutusIR.Compiler as PIR
 
@@ -36,6 +37,11 @@ withContextM mc act = do
 
 throwPlain :: MonadError (WithContext c e) m => e -> m a
 throwPlain = throwError . NoContext
+
+stripContext :: WithContext c e -> e
+stripContext = \case
+    NoContext e -> e
+    WithContext _ e -> stripContext e
 
 instance (PP.Pretty c, PP.Pretty e) => PP.Pretty (WithContext c e) where
     pretty = \case

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
@@ -171,6 +171,9 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
         -- Special kinds of id
         GHC.Var (GHC.idDetails -> GHC.PrimOpId po) -> convPrimitiveOp po
         GHC.Var (GHC.idDetails -> GHC.DataConWorkId dc) -> convDataConRef dc
+        -- TODO: support record selectors. AFAICT GHC doesn't make a pattern-matching function that we can call, so we'd
+        -- have to make the pattern match ourselves
+        GHC.Var (GHC.idDetails -> GHC.RecSelId{}) -> throwPlain $ UnsupportedError "Record selectors, use pattern matching"
         GHC.Var n -> do
             -- Defined names, including builtin names
             maybeDef <- lookupTermDef (GHC.getName n)

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
@@ -105,28 +105,6 @@ convDataConRef dc =
 isErrorId :: GHC.Id -> Bool
 isErrorId ghcId = ghcId `elem` GHC.errorIds
 
-{- Note [Recursive lets]
-We need to define these with a fixpoint. We can derive a fixpoint operator for values
-already.
-
-However, we also need to work out how to encode recursion over multiple values simultaneously.
-The answer is simple - we pass them through as a tuple.
-
-Overall, the translation looks like this. We convert this:
-
-let rec
-  f_1 = b_1
-  ...
-  f_i = b_i
-in
-  result
-
-into this:
-
-($fixN i$ (\choose f1 ... fi . choose b_1 ... b_i))
-(\f1 ... fi . result)
--}
-
 {- Note [GHC runtime errors]
 GHC has a number of runtime errors for things like pattern matching failures and so on.
 

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -161,6 +161,7 @@ monoData = testNested "monomorphic" [
   , goldenPlc "monoCase" monoCase
   , goldenEval "monoConstDest" [ monoCase, monoConstructed ]
   , goldenPlc "defaultCase" defaultCase
+  , goldenPlc "irrefutableMatch" irrefutableMatch
   , goldenEval "monoConstDestDefault" [ monoCase, monoConstructed ]
   , goldenPlc "monoRecord" monoRecord
   , goldenPlc "nonValueCase" nonValueCase
@@ -188,6 +189,9 @@ monoCase = plc @"monoCase" (\(x :: MyMonoData) -> case x of { Mono1 _ b -> b;  M
 
 defaultCase :: PlcCode
 defaultCase = plc @"defaultCase" (\(x :: MyMonoData) -> case x of { Mono3 a -> a ; _ -> 2; })
+
+irrefutableMatch :: PlcCode
+irrefutableMatch = plc @"irrefutableMatch" (\(x :: MyMonoData) -> case x of { Mono2 a -> a })
 
 data MyMonoRecord = MyMonoRecord { a :: Int , b :: Int} deriving Generic
 
@@ -219,7 +223,7 @@ polyConstructed :: PlcCode
 polyConstructed = plc @"polyConstructed" (Poly1 (1::Int) (2::Int))
 
 defaultCasePoly :: PlcCode
-defaultCasePoly = plc @"defaultCase" (\(x :: MyPolyData Int Int) -> case x of { Poly1 a _ -> a ; _ -> 2; })
+defaultCasePoly = plc @"defaultCasePoly" (\(x :: MyPolyData Int Int) -> case x of { Poly1 a _ -> a ; _ -> 2; })
 
 newtypes :: TestNested
 newtypes = testNested "newtypes" [

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -162,6 +162,7 @@ monoData = testNested "monomorphic" [
   , goldenEval "monoConstDest" [ monoCase, monoConstructed ]
   , goldenPlc "defaultCase" defaultCase
   , goldenPlc "irrefutableMatch" irrefutableMatch
+  , goldenPlc "atPattern" atPattern
   , goldenEval "monoConstDestDefault" [ monoCase, monoConstructed ]
   , goldenPlc "monoRecord" monoRecord
   , goldenPlc "nonValueCase" nonValueCase
@@ -192,6 +193,9 @@ defaultCase = plc @"defaultCase" (\(x :: MyMonoData) -> case x of { Mono3 a -> a
 
 irrefutableMatch :: PlcCode
 irrefutableMatch = plc @"irrefutableMatch" (\(x :: MyMonoData) -> case x of { Mono2 a -> a })
+
+atPattern :: PlcCode
+atPattern = plc @"atPattern" (\t@(x::Int, y::Int) -> let fst (a, b) = a in y + fst t)
 
 data MyMonoRecord = MyMonoRecord { a :: Int , b :: Int} deriving Generic
 

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -197,7 +197,7 @@ irrefutableMatch = plc @"irrefutableMatch" (\(x :: MyMonoData) -> case x of { Mo
 atPattern :: PlcCode
 atPattern = plc @"atPattern" (\t@(x::Int, y::Int) -> let fst (a, b) = a in y + fst t)
 
-data MyMonoRecord = MyMonoRecord { a :: Int , b :: Int} deriving Generic
+data MyMonoRecord = MyMonoRecord { mrA :: Int , mrB :: Int} deriving Generic
 
 monoRecord :: PlcCode
 monoRecord = plc @"monoRecord" (\(x :: MyMonoRecord) -> x)
@@ -305,6 +305,7 @@ errors = testNested "errors" [
     goldenPlcCatch "integer" integer
     , goldenPlcCatch "free" free
     , goldenPlcCatch "valueRestriction" valueRestriction
+    , goldenPlcCatch "recordSelector" recordSelector
   ]
 
 integer :: PlcCode
@@ -317,6 +318,9 @@ free = plc @"free" (True && False)
 -- at different types to prevent the obvious specialization.
 valueRestriction :: PlcCode
 valueRestriction = plc @"valueRestriction" (let { f :: forall a . a; f = Builtins.error (); } in (f @Bool, f @Int))
+
+recordSelector :: PlcCode
+recordSelector = plc @"recordSelector" (\(x :: MyMonoRecord) -> mrA x)
 
 instance LiftPlc (MyMonoData)
 instance LiftPlc (MyMonoRecord)

--- a/core-to-plc/test/Spec.hs
+++ b/core-to-plc/test/Spec.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# OPTIONS -fplugin Language.Plutus.CoreToPLC.Plugin -fplugin-opt Language.Plutus.CoreToPLC.Plugin:defer-errors #-}
+{-# OPTIONS -fplugin Language.Plutus.CoreToPLC.Plugin -fplugin-opt Language.Plutus.CoreToPLC.Plugin:defer-errors -fplugin-opt Language.Plutus.CoreToPLC.Plugin:strip-context #-}
 -- the simplifier messes with things otherwise
 {-# OPTIONS_GHC   -O0 #-}
 {-# OPTIONS_GHC   -Wno-orphans #-}

--- a/core-to-plc/test/data/monomorphic/atPattern.plc.golden
+++ b/core-to-plc/test/data/monomorphic/atPattern.plc.golden
@@ -1,0 +1,131 @@
+(program 1.0.0
+  [
+    [
+      {
+        (abs
+          bad_name_86
+          (fun (type) (fun (type) (type)))
+          (lam
+            bad_name_87
+            (all a_88 (type) (all b_89 (type) (fun a_88 (fun b_89 [[bad_name_86 a_88] b_89]))))
+            (lam
+              p_match_90
+              (all a_91 (type) (all b_92 (type) (fun [[bad_name_86 a_91] b_92] [[(lam a_93 (type) (lam b_94 (type) (all out_bad_name_95 (type) (fun (fun a_93 (fun b_94 out_bad_name_95)) out_bad_name_95)))) a_91] b_92])))
+              [
+                (lam
+                  addInteger_96
+                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] [(con integer) (con 64)]))
+                  (lam
+                    t_97
+                    [[bad_name_86 [(con integer) (con 64)]] [(con integer) (con 64)]]
+                    [
+                      (lam
+                        wild_98
+                        [[bad_name_86 [(con integer) (con 64)]] [(con integer) (con 64)]]
+                        [
+                          {
+                            [
+                              {
+                                { p_match_90 [(con integer) (con 64)] }
+                                [(con integer) (con 64)]
+                              }
+                              t_97
+                            ]
+                            [(con integer) (con 64)]
+                          }
+                          (lam
+                            ds_99
+                            [(con integer) (con 64)]
+                            (lam
+                              ds_100
+                              [(con integer) (con 64)]
+                              [
+                                [
+                                  addInteger_96 ds_100
+                                ]
+                                [
+                                  (lam
+                                    ds_101
+                                    [[bad_name_86 [(con integer) (con 64)]] [(con integer) (con 64)]]
+                                    [
+                                      {
+                                        [
+                                          {
+                                            {
+                                              p_match_90
+                                              [(con integer) (con 64)]
+                                            }
+                                            [(con integer) (con 64)]
+                                          }
+                                          ds_101
+                                        ]
+                                        [(con integer) (con 64)]
+                                      }
+                                      (lam
+                                        a_102
+                                        [(con integer) (con 64)]
+                                        (lam
+                                          b_103 [(con integer) (con 64)] a_102
+                                        )
+                                      )
+                                    ]
+                                  )
+                                  wild_98
+                                ]
+                              ]
+                            )
+                          )
+                        ]
+                      )
+                      t_97
+                    ]
+                  )
+                )
+                { (builtin addInteger) (con 64) }
+              ]
+            )
+          )
+        )
+        (lam a_104 (type) (lam b_105 (type) (all out_bad_name_106 (type) (fun (fun a_104 (fun b_105 out_bad_name_106)) out_bad_name_106))))
+      }
+      (abs
+        a_107
+        (type)
+        (abs
+          b_108
+          (type)
+          (lam
+            arg_0_109
+            a_107
+            (lam
+              arg_1_110
+              b_108
+              (abs
+                out_bad_name_111
+                (type)
+                (lam
+                  case_bad_name_112
+                  (fun a_107 (fun b_108 out_bad_name_111))
+                  [ [ case_bad_name_112 arg_0_109 ] arg_1_110 ]
+                )
+              )
+            )
+          )
+        )
+      )
+    ]
+    (abs
+      a_113
+      (type)
+      (abs
+        b_114
+        (type)
+        (lam
+          x_115
+          [[(lam a_116 (type) (lam b_117 (type) (all out_bad_name_118 (type) (fun (fun a_116 (fun b_117 out_bad_name_118)) out_bad_name_118)))) a_113] b_114]
+          x_115
+        )
+      )
+    )
+  ]
+)

--- a/core-to-plc/test/data/monomorphic/defaultCase.plc.golden
+++ b/core-to-plc/test/data/monomorphic/defaultCase.plc.golden
@@ -5,47 +5,47 @@
         [
           {
             (abs
-              MyMonoData_95
+              MyMonoData_96
               (type)
               (lam
-                Mono1_96
-                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_95))
+                Mono1_97
+                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_96))
                 (lam
-                  Mono2_97
-                  (fun [(con integer) (con 64)] MyMonoData_95)
+                  Mono2_98
+                  (fun [(con integer) (con 64)] MyMonoData_96)
                   (lam
-                    Mono3_98
-                    (fun [(con integer) (con 64)] MyMonoData_95)
+                    Mono3_99
+                    (fun [(con integer) (con 64)] MyMonoData_96)
                     (lam
-                      MyMonoData_match_99
-                      (fun MyMonoData_95 (all out_MyMonoData_100 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_100)) (fun (fun [(con integer) (con 64)] out_MyMonoData_100) (fun (fun [(con integer) (con 64)] out_MyMonoData_100) out_MyMonoData_100)))))
+                      MyMonoData_match_100
+                      (fun MyMonoData_96 (all out_MyMonoData_101 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_101)) (fun (fun [(con integer) (con 64)] out_MyMonoData_101) (fun (fun [(con integer) (con 64)] out_MyMonoData_101) out_MyMonoData_101)))))
                       (lam
-                        ds_101
-                        MyMonoData_95
+                        ds_102
+                        MyMonoData_96
                         [
                           [
                             [
                               {
-                                [ MyMonoData_match_99 ds_101 ]
+                                [ MyMonoData_match_100 ds_102 ]
                                 [(con integer) (con 64)]
                               }
                               (lam
-                                default_arg0_102
+                                default_arg0_103
                                 [(con integer) (con 64)]
                                 (lam
-                                  default_arg1_103
+                                  default_arg1_104
                                   [(con integer) (con 64)]
                                   (con 64 ! 2)
                                 )
                               )
                             ]
                             (lam
-                              default_arg0_104
+                              default_arg0_105
                               [(con integer) (con 64)]
                               (con 64 ! 2)
                             )
                           ]
-                          (lam a_105 [(con integer) (con 64)] a_105)
+                          (lam a_106 [(con integer) (con 64)] a_106)
                         ]
                       )
                     )
@@ -53,27 +53,27 @@
                 )
               )
             )
-            (all out_MyMonoData_106 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_106)) (fun (fun [(con integer) (con 64)] out_MyMonoData_106) (fun (fun [(con integer) (con 64)] out_MyMonoData_106) out_MyMonoData_106))))
+            (all out_MyMonoData_107 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_107)) (fun (fun [(con integer) (con 64)] out_MyMonoData_107) (fun (fun [(con integer) (con 64)] out_MyMonoData_107) out_MyMonoData_107))))
           }
           (lam
-            arg_0_107
+            arg_0_108
             [(con integer) (con 64)]
             (lam
-              arg_1_108
+              arg_1_109
               [(con integer) (con 64)]
               (abs
-                out_MyMonoData_109
+                out_MyMonoData_110
                 (type)
                 (lam
-                  case_Mono1_110
-                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_109))
+                  case_Mono1_111
+                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_110))
                   (lam
-                    case_Mono2_111
-                    (fun [(con integer) (con 64)] out_MyMonoData_109)
+                    case_Mono2_112
+                    (fun [(con integer) (con 64)] out_MyMonoData_110)
                     (lam
-                      case_Mono3_112
-                      (fun [(con integer) (con 64)] out_MyMonoData_109)
-                      [ [ case_Mono1_110 arg_0_107 ] arg_1_108 ]
+                      case_Mono3_113
+                      (fun [(con integer) (con 64)] out_MyMonoData_110)
+                      [ [ case_Mono1_111 arg_0_108 ] arg_1_109 ]
                     )
                   )
                 )
@@ -82,21 +82,21 @@
           )
         ]
         (lam
-          arg_0_113
+          arg_0_114
           [(con integer) (con 64)]
           (abs
-            out_MyMonoData_114
+            out_MyMonoData_115
             (type)
             (lam
-              case_Mono1_115
-              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_114))
+              case_Mono1_116
+              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_115))
               (lam
-                case_Mono2_116
-                (fun [(con integer) (con 64)] out_MyMonoData_114)
+                case_Mono2_117
+                (fun [(con integer) (con 64)] out_MyMonoData_115)
                 (lam
-                  case_Mono3_117
-                  (fun [(con integer) (con 64)] out_MyMonoData_114)
-                  [ case_Mono2_116 arg_0_113 ]
+                  case_Mono3_118
+                  (fun [(con integer) (con 64)] out_MyMonoData_115)
+                  [ case_Mono2_117 arg_0_114 ]
                 )
               )
             )
@@ -104,21 +104,21 @@
         )
       ]
       (lam
-        arg_0_118
+        arg_0_119
         [(con integer) (con 64)]
         (abs
-          out_MyMonoData_119
+          out_MyMonoData_120
           (type)
           (lam
-            case_Mono1_120
-            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_119))
+            case_Mono1_121
+            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_120))
             (lam
-              case_Mono2_121
-              (fun [(con integer) (con 64)] out_MyMonoData_119)
+              case_Mono2_122
+              (fun [(con integer) (con 64)] out_MyMonoData_120)
               (lam
-                case_Mono3_122
-                (fun [(con integer) (con 64)] out_MyMonoData_119)
-                [ case_Mono3_122 arg_0_118 ]
+                case_Mono3_123
+                (fun [(con integer) (con 64)] out_MyMonoData_120)
+                [ case_Mono3_123 arg_0_119 ]
               )
             )
           )
@@ -126,9 +126,9 @@
       )
     ]
     (lam
-      x_123
-      (all out_MyMonoData_124 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_124)) (fun (fun [(con integer) (con 64)] out_MyMonoData_124) (fun (fun [(con integer) (con 64)] out_MyMonoData_124) out_MyMonoData_124))))
-      x_123
+      x_124
+      (all out_MyMonoData_125 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_125)) (fun (fun [(con integer) (con 64)] out_MyMonoData_125) (fun (fun [(con integer) (con 64)] out_MyMonoData_125) out_MyMonoData_125))))
+      x_124
     )
   ]
 )

--- a/core-to-plc/test/data/monomorphic/irrefutableMatch.plc.golden
+++ b/core-to-plc/test/data/monomorphic/irrefutableMatch.plc.golden
@@ -1,0 +1,200 @@
+(program 1.0.0
+  [
+    [
+      {
+        (abs
+          unit_108
+          (type)
+          (lam
+            unit_109
+            unit_108
+            (lam
+              p_match_110
+              (fun unit_108 (all out_unit_111 (type) (fun out_unit_111 out_unit_111)))
+              [
+                [
+                  [
+                    [
+                      {
+                        (abs
+                          MyMonoData_112
+                          (type)
+                          (lam
+                            Mono1_113
+                            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_112))
+                            (lam
+                              Mono2_114
+                              (fun [(con integer) (con 64)] MyMonoData_112)
+                              (lam
+                                Mono3_115
+                                (fun [(con integer) (con 64)] MyMonoData_112)
+                                (lam
+                                  MyMonoData_match_116
+                                  (fun MyMonoData_112 (all out_MyMonoData_117 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_117)) (fun (fun [(con integer) (con 64)] out_MyMonoData_117) (fun (fun [(con integer) (con 64)] out_MyMonoData_117) out_MyMonoData_117)))))
+                                  (lam
+                                    ds_118
+                                    MyMonoData_112
+                                    [
+                                      [
+                                        [
+                                          [
+                                            {
+                                              [
+                                                MyMonoData_match_116 ds_118
+                                              ]
+                                              (fun unit_108 [(con integer) (con 64)])
+                                            }
+                                            (lam
+                                              default_arg0_119
+                                              [(con integer) (con 64)]
+                                              (lam
+                                                default_arg1_120
+                                                [(con integer) (con 64)]
+                                                (lam
+                                                  thunk_121
+                                                  unit_108
+                                                  [
+                                                    {
+                                                      (abs
+                                                        e_122
+                                                        (type)
+                                                        (lam
+                                                          thunk_123
+                                                          unit_108
+                                                          (error e_122)
+                                                        )
+                                                      )
+                                                      [(con integer) (con 64)]
+                                                    }
+                                                    unit_109
+                                                  ]
+                                                )
+                                              )
+                                            )
+                                          ]
+                                          (lam
+                                            a_124
+                                            [(con integer) (con 64)]
+                                            (lam thunk_125 unit_108 a_124)
+                                          )
+                                        ]
+                                        (lam
+                                          default_arg0_126
+                                          [(con integer) (con 64)]
+                                          (lam
+                                            thunk_127
+                                            unit_108
+                                            [
+                                              {
+                                                (abs
+                                                  e_128
+                                                  (type)
+                                                  (lam
+                                                    thunk_129
+                                                    unit_108
+                                                    (error e_128)
+                                                  )
+                                                )
+                                                [(con integer) (con 64)]
+                                              }
+                                              unit_109
+                                            ]
+                                          )
+                                        )
+                                      ]
+                                      unit_109
+                                    ]
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                        (all out_MyMonoData_130 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_130)) (fun (fun [(con integer) (con 64)] out_MyMonoData_130) (fun (fun [(con integer) (con 64)] out_MyMonoData_130) out_MyMonoData_130))))
+                      }
+                      (lam
+                        arg_0_131
+                        [(con integer) (con 64)]
+                        (lam
+                          arg_1_132
+                          [(con integer) (con 64)]
+                          (abs
+                            out_MyMonoData_133
+                            (type)
+                            (lam
+                              case_Mono1_134
+                              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_133))
+                              (lam
+                                case_Mono2_135
+                                (fun [(con integer) (con 64)] out_MyMonoData_133)
+                                (lam
+                                  case_Mono3_136
+                                  (fun [(con integer) (con 64)] out_MyMonoData_133)
+                                  [ [ case_Mono1_134 arg_0_131 ] arg_1_132 ]
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    ]
+                    (lam
+                      arg_0_137
+                      [(con integer) (con 64)]
+                      (abs
+                        out_MyMonoData_138
+                        (type)
+                        (lam
+                          case_Mono1_139
+                          (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_138))
+                          (lam
+                            case_Mono2_140
+                            (fun [(con integer) (con 64)] out_MyMonoData_138)
+                            (lam
+                              case_Mono3_141
+                              (fun [(con integer) (con 64)] out_MyMonoData_138)
+                              [ case_Mono2_140 arg_0_137 ]
+                            )
+                          )
+                        )
+                      )
+                    )
+                  ]
+                  (lam
+                    arg_0_142
+                    [(con integer) (con 64)]
+                    (abs
+                      out_MyMonoData_143
+                      (type)
+                      (lam
+                        case_Mono1_144
+                        (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_143))
+                        (lam
+                          case_Mono2_145
+                          (fun [(con integer) (con 64)] out_MyMonoData_143)
+                          (lam
+                            case_Mono3_146
+                            (fun [(con integer) (con 64)] out_MyMonoData_143)
+                            [ case_Mono3_146 arg_0_142 ]
+                          )
+                        )
+                      )
+                    )
+                  )
+                ]
+                (lam
+                  x_147
+                  (all out_MyMonoData_148 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_148)) (fun (fun [(con integer) (con 64)] out_MyMonoData_148) (fun (fun [(con integer) (con 64)] out_MyMonoData_148) out_MyMonoData_148))))
+                  x_147
+                )
+              ]
+            )
+          )
+        )
+        (all out_unit_149 (type) (fun out_unit_149 out_unit_149))
+      }
+      (abs out_unit_150 (type) (lam case_unit_151 out_unit_150 case_unit_151))
+    ]
+    (lam x_152 (all out_unit_153 (type) (fun out_unit_153 out_unit_153)) x_152)
+  ]
+)

--- a/core-to-plc/test/data/monomorphic/irrefutableMatch.plc.golden
+++ b/core-to-plc/test/data/monomorphic/irrefutableMatch.plc.golden
@@ -3,106 +3,106 @@
     [
       {
         (abs
-          unit_108
+          unit_109
           (type)
           (lam
+            unit_110
             unit_109
-            unit_108
             (lam
-              p_match_110
-              (fun unit_108 (all out_unit_111 (type) (fun out_unit_111 out_unit_111)))
+              p_match_111
+              (fun unit_109 (all out_unit_112 (type) (fun out_unit_112 out_unit_112)))
               [
                 [
                   [
                     [
                       {
                         (abs
-                          MyMonoData_112
+                          MyMonoData_113
                           (type)
                           (lam
-                            Mono1_113
-                            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_112))
+                            Mono1_114
+                            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_113))
                             (lam
-                              Mono2_114
-                              (fun [(con integer) (con 64)] MyMonoData_112)
+                              Mono2_115
+                              (fun [(con integer) (con 64)] MyMonoData_113)
                               (lam
-                                Mono3_115
-                                (fun [(con integer) (con 64)] MyMonoData_112)
+                                Mono3_116
+                                (fun [(con integer) (con 64)] MyMonoData_113)
                                 (lam
-                                  MyMonoData_match_116
-                                  (fun MyMonoData_112 (all out_MyMonoData_117 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_117)) (fun (fun [(con integer) (con 64)] out_MyMonoData_117) (fun (fun [(con integer) (con 64)] out_MyMonoData_117) out_MyMonoData_117)))))
+                                  MyMonoData_match_117
+                                  (fun MyMonoData_113 (all out_MyMonoData_118 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_118)) (fun (fun [(con integer) (con 64)] out_MyMonoData_118) (fun (fun [(con integer) (con 64)] out_MyMonoData_118) out_MyMonoData_118)))))
                                   (lam
-                                    ds_118
-                                    MyMonoData_112
+                                    ds_119
+                                    MyMonoData_113
                                     [
                                       [
                                         [
                                           [
                                             {
                                               [
-                                                MyMonoData_match_116 ds_118
+                                                MyMonoData_match_117 ds_119
                                               ]
-                                              (fun unit_108 [(con integer) (con 64)])
+                                              (fun unit_109 [(con integer) (con 64)])
                                             }
                                             (lam
-                                              default_arg0_119
+                                              default_arg0_120
                                               [(con integer) (con 64)]
                                               (lam
-                                                default_arg1_120
+                                                default_arg1_121
                                                 [(con integer) (con 64)]
                                                 (lam
-                                                  thunk_121
-                                                  unit_108
+                                                  thunk_122
+                                                  unit_109
                                                   [
                                                     {
                                                       (abs
-                                                        e_122
+                                                        e_123
                                                         (type)
                                                         (lam
-                                                          thunk_123
-                                                          unit_108
-                                                          (error e_122)
+                                                          thunk_124
+                                                          unit_109
+                                                          (error e_123)
                                                         )
                                                       )
                                                       [(con integer) (con 64)]
                                                     }
-                                                    unit_109
+                                                    unit_110
                                                   ]
                                                 )
                                               )
                                             )
                                           ]
                                           (lam
-                                            a_124
+                                            a_125
                                             [(con integer) (con 64)]
-                                            (lam thunk_125 unit_108 a_124)
+                                            (lam thunk_126 unit_109 a_125)
                                           )
                                         ]
                                         (lam
-                                          default_arg0_126
+                                          default_arg0_127
                                           [(con integer) (con 64)]
                                           (lam
-                                            thunk_127
-                                            unit_108
+                                            thunk_128
+                                            unit_109
                                             [
                                               {
                                                 (abs
-                                                  e_128
+                                                  e_129
                                                   (type)
                                                   (lam
-                                                    thunk_129
-                                                    unit_108
-                                                    (error e_128)
+                                                    thunk_130
+                                                    unit_109
+                                                    (error e_129)
                                                   )
                                                 )
                                                 [(con integer) (con 64)]
                                               }
-                                              unit_109
+                                              unit_110
                                             ]
                                           )
                                         )
                                       ]
-                                      unit_109
+                                      unit_110
                                     ]
                                   )
                                 )
@@ -110,27 +110,27 @@
                             )
                           )
                         )
-                        (all out_MyMonoData_130 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_130)) (fun (fun [(con integer) (con 64)] out_MyMonoData_130) (fun (fun [(con integer) (con 64)] out_MyMonoData_130) out_MyMonoData_130))))
+                        (all out_MyMonoData_131 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_131)) (fun (fun [(con integer) (con 64)] out_MyMonoData_131) (fun (fun [(con integer) (con 64)] out_MyMonoData_131) out_MyMonoData_131))))
                       }
                       (lam
-                        arg_0_131
+                        arg_0_132
                         [(con integer) (con 64)]
                         (lam
-                          arg_1_132
+                          arg_1_133
                           [(con integer) (con 64)]
                           (abs
-                            out_MyMonoData_133
+                            out_MyMonoData_134
                             (type)
                             (lam
-                              case_Mono1_134
-                              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_133))
+                              case_Mono1_135
+                              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_134))
                               (lam
-                                case_Mono2_135
-                                (fun [(con integer) (con 64)] out_MyMonoData_133)
+                                case_Mono2_136
+                                (fun [(con integer) (con 64)] out_MyMonoData_134)
                                 (lam
-                                  case_Mono3_136
-                                  (fun [(con integer) (con 64)] out_MyMonoData_133)
-                                  [ [ case_Mono1_134 arg_0_131 ] arg_1_132 ]
+                                  case_Mono3_137
+                                  (fun [(con integer) (con 64)] out_MyMonoData_134)
+                                  [ [ case_Mono1_135 arg_0_132 ] arg_1_133 ]
                                 )
                               )
                             )
@@ -139,21 +139,21 @@
                       )
                     ]
                     (lam
-                      arg_0_137
+                      arg_0_138
                       [(con integer) (con 64)]
                       (abs
-                        out_MyMonoData_138
+                        out_MyMonoData_139
                         (type)
                         (lam
-                          case_Mono1_139
-                          (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_138))
+                          case_Mono1_140
+                          (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_139))
                           (lam
-                            case_Mono2_140
-                            (fun [(con integer) (con 64)] out_MyMonoData_138)
+                            case_Mono2_141
+                            (fun [(con integer) (con 64)] out_MyMonoData_139)
                             (lam
-                              case_Mono3_141
-                              (fun [(con integer) (con 64)] out_MyMonoData_138)
-                              [ case_Mono2_140 arg_0_137 ]
+                              case_Mono3_142
+                              (fun [(con integer) (con 64)] out_MyMonoData_139)
+                              [ case_Mono2_141 arg_0_138 ]
                             )
                           )
                         )
@@ -161,21 +161,21 @@
                     )
                   ]
                   (lam
-                    arg_0_142
+                    arg_0_143
                     [(con integer) (con 64)]
                     (abs
-                      out_MyMonoData_143
+                      out_MyMonoData_144
                       (type)
                       (lam
-                        case_Mono1_144
-                        (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_143))
+                        case_Mono1_145
+                        (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_144))
                         (lam
-                          case_Mono2_145
-                          (fun [(con integer) (con 64)] out_MyMonoData_143)
+                          case_Mono2_146
+                          (fun [(con integer) (con 64)] out_MyMonoData_144)
                           (lam
-                            case_Mono3_146
-                            (fun [(con integer) (con 64)] out_MyMonoData_143)
-                            [ case_Mono3_146 arg_0_142 ]
+                            case_Mono3_147
+                            (fun [(con integer) (con 64)] out_MyMonoData_144)
+                            [ case_Mono3_147 arg_0_143 ]
                           )
                         )
                       )
@@ -183,18 +183,18 @@
                   )
                 ]
                 (lam
-                  x_147
-                  (all out_MyMonoData_148 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_148)) (fun (fun [(con integer) (con 64)] out_MyMonoData_148) (fun (fun [(con integer) (con 64)] out_MyMonoData_148) out_MyMonoData_148))))
-                  x_147
+                  x_148
+                  (all out_MyMonoData_149 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_149)) (fun (fun [(con integer) (con 64)] out_MyMonoData_149) (fun (fun [(con integer) (con 64)] out_MyMonoData_149) out_MyMonoData_149))))
+                  x_148
                 )
               ]
             )
           )
         )
-        (all out_unit_149 (type) (fun out_unit_149 out_unit_149))
+        (all out_unit_150 (type) (fun out_unit_150 out_unit_150))
       }
-      (abs out_unit_150 (type) (lam case_unit_151 out_unit_150 case_unit_151))
+      (abs out_unit_151 (type) (lam case_unit_152 out_unit_151 case_unit_152))
     ]
-    (lam x_152 (all out_unit_153 (type) (fun out_unit_153 out_unit_153)) x_152)
+    (lam x_153 (all out_unit_154 (type) (fun out_unit_154 out_unit_154)) x_153)
   ]
 )

--- a/core-to-plc/test/data/monomorphic/monoCase.plc.golden
+++ b/core-to-plc/test/data/monomorphic/monoCase.plc.golden
@@ -5,39 +5,39 @@
         [
           {
             (abs
-              MyMonoData_95
+              MyMonoData_96
               (type)
               (lam
-                Mono1_96
-                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_95))
+                Mono1_97
+                (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] MyMonoData_96))
                 (lam
-                  Mono2_97
-                  (fun [(con integer) (con 64)] MyMonoData_95)
+                  Mono2_98
+                  (fun [(con integer) (con 64)] MyMonoData_96)
                   (lam
-                    Mono3_98
-                    (fun [(con integer) (con 64)] MyMonoData_95)
+                    Mono3_99
+                    (fun [(con integer) (con 64)] MyMonoData_96)
                     (lam
-                      MyMonoData_match_99
-                      (fun MyMonoData_95 (all out_MyMonoData_100 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_100)) (fun (fun [(con integer) (con 64)] out_MyMonoData_100) (fun (fun [(con integer) (con 64)] out_MyMonoData_100) out_MyMonoData_100)))))
+                      MyMonoData_match_100
+                      (fun MyMonoData_96 (all out_MyMonoData_101 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_101)) (fun (fun [(con integer) (con 64)] out_MyMonoData_101) (fun (fun [(con integer) (con 64)] out_MyMonoData_101) out_MyMonoData_101)))))
                       (lam
-                        ds_101
-                        MyMonoData_95
+                        ds_102
+                        MyMonoData_96
                         [
                           [
                             [
                               {
-                                [ MyMonoData_match_99 ds_101 ]
+                                [ MyMonoData_match_100 ds_102 ]
                                 [(con integer) (con 64)]
                               }
                               (lam
-                                ds_102
+                                ds_103
                                 [(con integer) (con 64)]
-                                (lam b_103 [(con integer) (con 64)] b_103)
+                                (lam b_104 [(con integer) (con 64)] b_104)
                               )
                             ]
-                            (lam a_104 [(con integer) (con 64)] a_104)
+                            (lam a_105 [(con integer) (con 64)] a_105)
                           ]
-                          (lam a_105 [(con integer) (con 64)] a_105)
+                          (lam a_106 [(con integer) (con 64)] a_106)
                         ]
                       )
                     )
@@ -45,27 +45,27 @@
                 )
               )
             )
-            (all out_MyMonoData_106 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_106)) (fun (fun [(con integer) (con 64)] out_MyMonoData_106) (fun (fun [(con integer) (con 64)] out_MyMonoData_106) out_MyMonoData_106))))
+            (all out_MyMonoData_107 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_107)) (fun (fun [(con integer) (con 64)] out_MyMonoData_107) (fun (fun [(con integer) (con 64)] out_MyMonoData_107) out_MyMonoData_107))))
           }
           (lam
-            arg_0_107
+            arg_0_108
             [(con integer) (con 64)]
             (lam
-              arg_1_108
+              arg_1_109
               [(con integer) (con 64)]
               (abs
-                out_MyMonoData_109
+                out_MyMonoData_110
                 (type)
                 (lam
-                  case_Mono1_110
-                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_109))
+                  case_Mono1_111
+                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_110))
                   (lam
-                    case_Mono2_111
-                    (fun [(con integer) (con 64)] out_MyMonoData_109)
+                    case_Mono2_112
+                    (fun [(con integer) (con 64)] out_MyMonoData_110)
                     (lam
-                      case_Mono3_112
-                      (fun [(con integer) (con 64)] out_MyMonoData_109)
-                      [ [ case_Mono1_110 arg_0_107 ] arg_1_108 ]
+                      case_Mono3_113
+                      (fun [(con integer) (con 64)] out_MyMonoData_110)
+                      [ [ case_Mono1_111 arg_0_108 ] arg_1_109 ]
                     )
                   )
                 )
@@ -74,21 +74,21 @@
           )
         ]
         (lam
-          arg_0_113
+          arg_0_114
           [(con integer) (con 64)]
           (abs
-            out_MyMonoData_114
+            out_MyMonoData_115
             (type)
             (lam
-              case_Mono1_115
-              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_114))
+              case_Mono1_116
+              (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_115))
               (lam
-                case_Mono2_116
-                (fun [(con integer) (con 64)] out_MyMonoData_114)
+                case_Mono2_117
+                (fun [(con integer) (con 64)] out_MyMonoData_115)
                 (lam
-                  case_Mono3_117
-                  (fun [(con integer) (con 64)] out_MyMonoData_114)
-                  [ case_Mono2_116 arg_0_113 ]
+                  case_Mono3_118
+                  (fun [(con integer) (con 64)] out_MyMonoData_115)
+                  [ case_Mono2_117 arg_0_114 ]
                 )
               )
             )
@@ -96,21 +96,21 @@
         )
       ]
       (lam
-        arg_0_118
+        arg_0_119
         [(con integer) (con 64)]
         (abs
-          out_MyMonoData_119
+          out_MyMonoData_120
           (type)
           (lam
-            case_Mono1_120
-            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_119))
+            case_Mono1_121
+            (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_120))
             (lam
-              case_Mono2_121
-              (fun [(con integer) (con 64)] out_MyMonoData_119)
+              case_Mono2_122
+              (fun [(con integer) (con 64)] out_MyMonoData_120)
               (lam
-                case_Mono3_122
-                (fun [(con integer) (con 64)] out_MyMonoData_119)
-                [ case_Mono3_122 arg_0_118 ]
+                case_Mono3_123
+                (fun [(con integer) (con 64)] out_MyMonoData_120)
+                [ case_Mono3_123 arg_0_119 ]
               )
             )
           )
@@ -118,9 +118,9 @@
       )
     ]
     (lam
-      x_123
-      (all out_MyMonoData_124 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_124)) (fun (fun [(con integer) (con 64)] out_MyMonoData_124) (fun (fun [(con integer) (con 64)] out_MyMonoData_124) out_MyMonoData_124))))
-      x_123
+      x_124
+      (all out_MyMonoData_125 (type) (fun (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] out_MyMonoData_125)) (fun (fun [(con integer) (con 64)] out_MyMonoData_125) (fun (fun [(con integer) (con 64)] out_MyMonoData_125) out_MyMonoData_125))))
+      x_124
     )
   ]
 )

--- a/core-to-plc/test/data/monomorphic/nonValueCase.plc.golden
+++ b/core-to-plc/test/data/monomorphic/nonValueCase.plc.golden
@@ -4,115 +4,115 @@
       [
         {
           (abs
-            MyEnum_86
+            MyEnum_87
             (type)
             (lam
-              Enum1_87
-              MyEnum_86
+              Enum1_88
+              MyEnum_87
               (lam
-                Enum2_88
-                MyEnum_86
+                Enum2_89
+                MyEnum_87
                 (lam
-                  MyEnum_match_89
-                  (fun MyEnum_86 (all out_MyEnum_90 (type) (fun out_MyEnum_90 (fun out_MyEnum_90 out_MyEnum_90))))
+                  MyEnum_match_90
+                  (fun MyEnum_87 (all out_MyEnum_91 (type) (fun out_MyEnum_91 (fun out_MyEnum_91 out_MyEnum_91))))
                   [
                     [
                       {
                         (abs
-                          unit_91
+                          unit_92
                           (type)
                           (lam
+                            unit_93
                             unit_92
-                            unit_91
                             (lam
-                              p_match_93
-                              (fun unit_91 (all out_unit_94 (type) (fun out_unit_94 out_unit_94)))
+                              p_match_94
+                              (fun unit_92 (all out_unit_95 (type) (fun out_unit_95 out_unit_95)))
                               [
                                 (lam
-                                  error_95
-                                  (all a_96 (type) (fun unit_91 a_96))
+                                  error_96
+                                  (all a_97 (type) (fun unit_92 a_97))
                                   (lam
-                                    ds_97
-                                    MyEnum_86
+                                    ds_98
+                                    MyEnum_87
                                     [
                                       [
                                         [
                                           {
                                             [
-                                              MyEnum_match_89 ds_97
+                                              MyEnum_match_90 ds_98
                                             ]
-                                            (fun unit_91 [(con integer) (con 64)])
+                                            (fun unit_92 [(con integer) (con 64)])
                                           }
-                                          (lam thunk_98 unit_91 (con 64 ! 1))
+                                          (lam thunk_99 unit_92 (con 64 ! 1))
                                         ]
                                         (lam
-                                          thunk_99
-                                          unit_91
+                                          thunk_100
+                                          unit_92
                                           [
                                             {
-                                              error_95 [(con integer) (con 64)]
+                                              error_96 [(con integer) (con 64)]
                                             }
-                                            unit_92
+                                            unit_93
                                           ]
                                         )
                                       ]
-                                      unit_92
+                                      unit_93
                                     ]
                                   )
                                 )
                                 (abs
-                                  e_100
+                                  e_101
                                   (type)
-                                  (lam thunk_101 unit_91 (error e_100))
+                                  (lam thunk_102 unit_92 (error e_101))
                                 )
                               ]
                             )
                           )
                         )
-                        (all out_unit_102 (type) (fun out_unit_102 out_unit_102))
+                        (all out_unit_103 (type) (fun out_unit_103 out_unit_103))
                       }
                       (abs
-                        out_unit_103
+                        out_unit_104
                         (type)
-                        (lam case_unit_104 out_unit_103 case_unit_104)
+                        (lam case_unit_105 out_unit_104 case_unit_105)
                       )
                     ]
                     (lam
-                      x_105
-                      (all out_unit_106 (type) (fun out_unit_106 out_unit_106))
-                      x_105
+                      x_106
+                      (all out_unit_107 (type) (fun out_unit_107 out_unit_107))
+                      x_106
                     )
                   ]
                 )
               )
             )
           )
-          (all out_MyEnum_107 (type) (fun out_MyEnum_107 (fun out_MyEnum_107 out_MyEnum_107)))
+          (all out_MyEnum_108 (type) (fun out_MyEnum_108 (fun out_MyEnum_108 out_MyEnum_108)))
         }
         (abs
-          out_MyEnum_108
+          out_MyEnum_109
           (type)
           (lam
-            case_Enum1_109
-            out_MyEnum_108
-            (lam case_Enum2_110 out_MyEnum_108 case_Enum1_109)
+            case_Enum1_110
+            out_MyEnum_109
+            (lam case_Enum2_111 out_MyEnum_109 case_Enum1_110)
           )
         )
       ]
       (abs
-        out_MyEnum_111
+        out_MyEnum_112
         (type)
         (lam
-          case_Enum1_112
-          out_MyEnum_111
-          (lam case_Enum2_113 out_MyEnum_111 case_Enum2_113)
+          case_Enum1_113
+          out_MyEnum_112
+          (lam case_Enum2_114 out_MyEnum_112 case_Enum2_114)
         )
       )
     ]
     (lam
-      x_114
-      (all out_MyEnum_115 (type) (fun out_MyEnum_115 (fun out_MyEnum_115 out_MyEnum_115)))
-      x_114
+      x_115
+      (all out_MyEnum_116 (type) (fun out_MyEnum_116 (fun out_MyEnum_116 out_MyEnum_116)))
+      x_115
     )
   ]
 )

--- a/core-to-plc/test/data/polymorphic/defaultCasePoly.plc.golden
+++ b/core-to-plc/test/data/polymorphic/defaultCasePoly.plc.golden
@@ -4,40 +4,40 @@
       [
         {
           (abs
-            MyPolyData_88
+            MyPolyData_89
             (fun (type) (fun (type) (type)))
             (lam
-              Poly1_89
-              (all a_90 (type) (all b_91 (type) (fun a_90 (fun b_91 [[MyPolyData_88 a_90] b_91]))))
+              Poly1_90
+              (all a_91 (type) (all b_92 (type) (fun a_91 (fun b_92 [[MyPolyData_89 a_91] b_92]))))
               (lam
-                Poly2_92
-                (all a_93 (type) (all b_94 (type) (fun a_93 [[MyPolyData_88 a_93] b_94])))
+                Poly2_93
+                (all a_94 (type) (all b_95 (type) (fun a_94 [[MyPolyData_89 a_94] b_95])))
                 (lam
-                  MyPolyData_match_95
-                  (all a_96 (type) (all b_97 (type) (fun [[MyPolyData_88 a_96] b_97] [[(lam a_98 (type) (lam b_99 (type) (all out_MyPolyData_100 (type) (fun (fun a_98 (fun b_99 out_MyPolyData_100)) (fun (fun a_98 out_MyPolyData_100) out_MyPolyData_100))))) a_96] b_97])))
+                  MyPolyData_match_96
+                  (all a_97 (type) (all b_98 (type) (fun [[MyPolyData_89 a_97] b_98] [[(lam a_99 (type) (lam b_100 (type) (all out_MyPolyData_101 (type) (fun (fun a_99 (fun b_100 out_MyPolyData_101)) (fun (fun a_99 out_MyPolyData_101) out_MyPolyData_101))))) a_97] b_98])))
                   (lam
-                    ds_101
-                    [[MyPolyData_88 [(con integer) (con 64)]] [(con integer) (con 64)]]
+                    ds_102
+                    [[MyPolyData_89 [(con integer) (con 64)]] [(con integer) (con 64)]]
                     [
                       [
                         {
                           [
                             {
-                              { MyPolyData_match_95 [(con integer) (con 64)] }
+                              { MyPolyData_match_96 [(con integer) (con 64)] }
                               [(con integer) (con 64)]
                             }
-                            ds_101
+                            ds_102
                           ]
                           [(con integer) (con 64)]
                         }
                         (lam
-                          a_102
+                          a_103
                           [(con integer) (con 64)]
-                          (lam ds_103 [(con integer) (con 64)] a_102)
+                          (lam ds_104 [(con integer) (con 64)] a_103)
                         )
                       ]
                       (lam
-                        default_arg0_104 [(con integer) (con 64)] (con 64 ! 2)
+                        default_arg0_105 [(con integer) (con 64)] (con 64 ! 2)
                       )
                     ]
                   )
@@ -45,30 +45,30 @@
               )
             )
           )
-          (lam a_105 (type) (lam b_106 (type) (all out_MyPolyData_107 (type) (fun (fun a_105 (fun b_106 out_MyPolyData_107)) (fun (fun a_105 out_MyPolyData_107) out_MyPolyData_107)))))
+          (lam a_106 (type) (lam b_107 (type) (all out_MyPolyData_108 (type) (fun (fun a_106 (fun b_107 out_MyPolyData_108)) (fun (fun a_106 out_MyPolyData_108) out_MyPolyData_108)))))
         }
         (abs
-          a_108
+          a_109
           (type)
           (abs
-            b_109
+            b_110
             (type)
             (lam
-              arg_0_110
-              a_108
+              arg_0_111
+              a_109
               (lam
-                arg_1_111
-                b_109
+                arg_1_112
+                b_110
                 (abs
-                  out_MyPolyData_112
+                  out_MyPolyData_113
                   (type)
                   (lam
-                    case_Poly1_113
-                    (fun a_108 (fun b_109 out_MyPolyData_112))
+                    case_Poly1_114
+                    (fun a_109 (fun b_110 out_MyPolyData_113))
                     (lam
-                      case_Poly2_114
-                      (fun a_108 out_MyPolyData_112)
-                      [ [ case_Poly1_113 arg_0_110 ] arg_1_111 ]
+                      case_Poly2_115
+                      (fun a_109 out_MyPolyData_113)
+                      [ [ case_Poly1_114 arg_0_111 ] arg_1_112 ]
                     )
                   )
                 )
@@ -78,24 +78,24 @@
         )
       ]
       (abs
-        a_115
+        a_116
         (type)
         (abs
-          b_116
+          b_117
           (type)
           (lam
-            arg_0_117
-            a_115
+            arg_0_118
+            a_116
             (abs
-              out_MyPolyData_118
+              out_MyPolyData_119
               (type)
               (lam
-                case_Poly1_119
-                (fun a_115 (fun b_116 out_MyPolyData_118))
+                case_Poly1_120
+                (fun a_116 (fun b_117 out_MyPolyData_119))
                 (lam
-                  case_Poly2_120
-                  (fun a_115 out_MyPolyData_118)
-                  [ case_Poly2_120 arg_0_117 ]
+                  case_Poly2_121
+                  (fun a_116 out_MyPolyData_119)
+                  [ case_Poly2_121 arg_0_118 ]
                 )
               )
             )
@@ -104,15 +104,15 @@
       )
     ]
     (abs
-      a_121
+      a_122
       (type)
       (abs
-        b_122
+        b_123
         (type)
         (lam
-          x_123
-          [[(lam a_124 (type) (lam b_125 (type) (all out_MyPolyData_126 (type) (fun (fun a_124 (fun b_125 out_MyPolyData_126)) (fun (fun a_124 out_MyPolyData_126) out_MyPolyData_126))))) a_121] b_122]
-          x_123
+          x_124
+          [[(lam a_125 (type) (lam b_126 (type) (all out_MyPolyData_127 (type) (fun (fun a_125 (fun b_126 out_MyPolyData_127)) (fun (fun a_125 out_MyPolyData_127) out_MyPolyData_127))))) a_122] b_123]
+          x_124
         )
       )
     )

--- a/core-to-plc/test/errors/free.plc.golden
+++ b/core-to-plc/test/errors/free.plc.golden
@@ -1,5 +1,1 @@
-Error: Used but not defined in the current conversion: Variable &&
-Context: Converting expr: &&
-Context: Converting expr: && True
-Context: Converting expr: && True False
-Context: Converting expr at "free"
+Used but not defined in the current conversion: Variable &&

--- a/core-to-plc/test/errors/integer.plc.golden
+++ b/core-to-plc/test/errors/integer.plc.golden
@@ -1,3 +1,1 @@
-Error: Unsupported: Literal (unbounded) integer
-Context: Converting expr: 1
-Context: Converting expr at "integer"
+Unsupported: Literal (unbounded) integer

--- a/core-to-plc/test/errors/recordSelector.plc.golden
+++ b/core-to-plc/test/errors/recordSelector.plc.golden
@@ -1,5 +1,1 @@
-Error: Unsupported: Record selectors, use pattern matching
-Context: Converting expr: mrA
-Context: Converting expr: mrA ds_dCsk
-Context: Converting expr: \ (ds_dCsk :: MyMonoRecord) -> mrA ds_dCsk
-Context: Converting expr at "recordSelector"
+Unsupported: Record selectors, use pattern matching

--- a/core-to-plc/test/errors/recordSelector.plc.golden
+++ b/core-to-plc/test/errors/recordSelector.plc.golden
@@ -1,0 +1,5 @@
+Error: Unsupported: Record selectors, use pattern matching
+Context: Converting expr: mrA
+Context: Converting expr: mrA ds_dCsk
+Context: Converting expr: \ (ds_dCsk :: MyMonoRecord) -> mrA ds_dCsk
+Context: Converting expr at "recordSelector"

--- a/core-to-plc/test/errors/valueRestriction.plc.golden
+++ b/core-to-plc/test/errors/valueRestriction.plc.golden
@@ -1,8 +1,1 @@
-Error: Violation of the value restriction: Type abstraction body is not a value
-Context: Converting expr: \ (@ a) -> error @ a ()
-Context: Converting expr: let {
-                            f :: forall a. a
-                            [LclId]
-                            f = \ (@ a) -> error @ a () } in
-                          (f @ Bool, f @ Int)
-Context: Converting expr at "valueRestriction"
+Violation of the value restriction: Type abstraction body is not a value

--- a/core-to-plc/test/generics/boolInterop.plc.golden
+++ b/core-to-plc/test/generics/boolInterop.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_103
+  out_Bool_106
   (type)
   (lam
-    case_True_104 out_Bool_103 (lam case_False_105 out_Bool_103 case_True_104)
+    case_True_107 out_Bool_106 (lam case_False_108 out_Bool_106 case_True_107)
   )
 )

--- a/core-to-plc/test/primitives/and.plc.golden
+++ b/core-to-plc/test/primitives/and.plc.golden
@@ -3,64 +3,64 @@
     [
       {
         (abs
-          unit_87
+          unit_90
           (type)
           (lam
-            unit_88
-            unit_87
+            unit_91
+            unit_90
             (lam
-              p_match_89
-              (fun unit_87 (all out_unit_90 (type) (fun out_unit_90 out_unit_90)))
+              p_match_92
+              (fun unit_90 (all out_unit_93 (type) (fun out_unit_93 out_unit_93)))
               [
                 [
                   [
                     {
                       (abs
-                        Bool_91
+                        Bool_94
                         (type)
                         (lam
-                          True_92
-                          Bool_91
+                          True_95
+                          Bool_94
                           (lam
-                            False_93
-                            Bool_91
+                            False_96
+                            Bool_94
                             (lam
-                              Bool_match_94
-                              (fun Bool_91 (all out_Bool_95 (type) (fun out_Bool_95 (fun out_Bool_95 out_Bool_95))))
+                              Bool_match_97
+                              (fun Bool_94 (all out_Bool_98 (type) (fun out_Bool_98 (fun out_Bool_98 out_Bool_98))))
                               (lam
-                                ds_96
-                                Bool_91
+                                ds_99
+                                Bool_94
                                 (lam
-                                  ds_97
-                                  Bool_91
+                                  ds_100
+                                  Bool_94
                                   [
                                     [
                                       [
                                         {
-                                          [ Bool_match_94 ds_96 ]
-                                          (fun unit_87 Bool_91)
+                                          [ Bool_match_97 ds_99 ]
+                                          (fun unit_90 Bool_94)
                                         }
                                         (lam
-                                          thunk_98
-                                          unit_87
+                                          thunk_101
+                                          unit_90
                                           [
                                             [
                                               [
                                                 {
-                                                  [ Bool_match_94 ds_97 ]
-                                                  (fun unit_87 Bool_91)
+                                                  [ Bool_match_97 ds_100 ]
+                                                  (fun unit_90 Bool_94)
                                                 }
-                                                (lam thunk_99 unit_87 True_92)
+                                                (lam thunk_102 unit_90 True_95)
                                               ]
-                                              (lam thunk_100 unit_87 False_93)
+                                              (lam thunk_103 unit_90 False_96)
                                             ]
-                                            unit_88
+                                            unit_91
                                           ]
                                         )
                                       ]
-                                      (lam thunk_101 unit_87 False_93)
+                                      (lam thunk_104 unit_90 False_96)
                                     ]
-                                    unit_88
+                                    unit_91
                                   ]
                                 )
                               )
@@ -68,41 +68,41 @@
                           )
                         )
                       )
-                      (all out_Bool_102 (type) (fun out_Bool_102 (fun out_Bool_102 out_Bool_102)))
+                      (all out_Bool_105 (type) (fun out_Bool_105 (fun out_Bool_105 out_Bool_105)))
                     }
                     (abs
-                      out_Bool_103
+                      out_Bool_106
                       (type)
                       (lam
-                        case_True_104
-                        out_Bool_103
-                        (lam case_False_105 out_Bool_103 case_True_104)
+                        case_True_107
+                        out_Bool_106
+                        (lam case_False_108 out_Bool_106 case_True_107)
                       )
                     )
                   ]
                   (abs
-                    out_Bool_106
+                    out_Bool_109
                     (type)
                     (lam
-                      case_True_107
-                      out_Bool_106
-                      (lam case_False_108 out_Bool_106 case_False_108)
+                      case_True_110
+                      out_Bool_109
+                      (lam case_False_111 out_Bool_109 case_False_111)
                     )
                   )
                 ]
                 (lam
-                  x_109
-                  (all out_Bool_110 (type) (fun out_Bool_110 (fun out_Bool_110 out_Bool_110)))
-                  x_109
+                  x_112
+                  (all out_Bool_113 (type) (fun out_Bool_113 (fun out_Bool_113 out_Bool_113)))
+                  x_112
                 )
               ]
             )
           )
         )
-        (all out_unit_111 (type) (fun out_unit_111 out_unit_111))
+        (all out_unit_114 (type) (fun out_unit_114 out_unit_114))
       }
-      (abs out_unit_112 (type) (lam case_unit_113 out_unit_112 case_unit_113))
+      (abs out_unit_115 (type) (lam case_unit_116 out_unit_115 case_unit_116))
     ]
-    (lam x_114 (all out_unit_115 (type) (fun out_unit_115 out_unit_115)) x_114)
+    (lam x_117 (all out_unit_118 (type) (fun out_unit_118 out_unit_118)) x_117)
   ]
 )

--- a/core-to-plc/test/primitives/andApply.plc.golden
+++ b/core-to-plc/test/primitives/andApply.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_106
+  out_Bool_109
   (type)
   (lam
-    case_True_107 out_Bool_106 (lam case_False_108 out_Bool_106 case_False_108)
+    case_True_110 out_Bool_109 (lam case_False_111 out_Bool_109 case_False_111)
   )
 )

--- a/core-to-plc/test/primitives/ifThenElse.plc.golden
+++ b/core-to-plc/test/primitives/ifThenElse.plc.golden
@@ -3,82 +3,82 @@
     [
       {
         (abs
-          unit_83
+          unit_84
           (type)
           (lam
+            unit_85
             unit_84
-            unit_83
             (lam
-              p_match_85
-              (fun unit_83 (all out_unit_86 (type) (fun out_unit_86 out_unit_86)))
+              p_match_86
+              (fun unit_84 (all out_unit_87 (type) (fun out_unit_87 out_unit_87)))
               [
                 [
                   [
                     {
                       (abs
-                        Bool_87
+                        Bool_88
                         (type)
                         (lam
-                          True_88
-                          Bool_87
+                          True_89
+                          Bool_88
                           (lam
-                            False_89
-                            Bool_87
+                            False_90
+                            Bool_88
                             (lam
-                              Bool_match_90
-                              (fun Bool_87 (all out_Bool_91 (type) (fun out_Bool_91 (fun out_Bool_91 out_Bool_91))))
+                              Bool_match_91
+                              (fun Bool_88 (all out_Bool_92 (type) (fun out_Bool_92 (fun out_Bool_92 out_Bool_92))))
                               [
                                 (lam
-                                  equalsInteger_92
-                                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] Bool_87))
+                                  equalsInteger_93
+                                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] Bool_88))
                                   (lam
-                                    ds_93
+                                    ds_94
                                     [(con integer) (con 64)]
                                     (lam
-                                      ds_94
+                                      ds_95
                                       [(con integer) (con 64)]
                                       [
                                         [
                                           [
                                             {
                                               [
-                                                Bool_match_90
+                                                Bool_match_91
                                                 [
-                                                  [ equalsInteger_92 ds_93 ]
-                                                  ds_94
+                                                  [ equalsInteger_93 ds_94 ]
+                                                  ds_95
                                                 ]
                                               ]
-                                              (fun unit_83 [(con integer) (con 64)])
+                                              (fun unit_84 [(con integer) (con 64)])
                                             }
-                                            (lam thunk_95 unit_83 ds_93)
+                                            (lam thunk_96 unit_84 ds_94)
                                           ]
-                                          (lam thunk_96 unit_83 ds_94)
+                                          (lam thunk_97 unit_84 ds_95)
                                         ]
-                                        unit_84
+                                        unit_85
                                       ]
                                     )
                                   )
                                 )
                                 (lam
-                                  arg_97
+                                  arg_98
                                   [(con integer) (con 64)]
                                   (lam
-                                    arg_98
+                                    arg_99
                                     [(con integer) (con 64)]
                                     [
                                       (lam
-                                        b_99
-                                        (all a_100 (type) (fun a_100 (fun a_100 a_100)))
+                                        b_100
+                                        (all a_101 (type) (fun a_101 (fun a_101 a_101)))
                                         [
-                                          [ { b_99 Bool_87 } True_88 ] False_89
+                                          [ { b_100 Bool_88 } True_89 ] False_90
                                         ]
                                       )
                                       [
                                         [
                                           { (builtin equalsInteger) (con 64) }
-                                          arg_97
+                                          arg_98
                                         ]
-                                        arg_98
+                                        arg_99
                                       ]
                                     ]
                                   )
@@ -88,41 +88,41 @@
                           )
                         )
                       )
-                      (all out_Bool_101 (type) (fun out_Bool_101 (fun out_Bool_101 out_Bool_101)))
+                      (all out_Bool_102 (type) (fun out_Bool_102 (fun out_Bool_102 out_Bool_102)))
                     }
                     (abs
-                      out_Bool_102
+                      out_Bool_103
                       (type)
                       (lam
-                        case_True_103
-                        out_Bool_102
-                        (lam case_False_104 out_Bool_102 case_True_103)
+                        case_True_104
+                        out_Bool_103
+                        (lam case_False_105 out_Bool_103 case_True_104)
                       )
                     )
                   ]
                   (abs
-                    out_Bool_105
+                    out_Bool_106
                     (type)
                     (lam
-                      case_True_106
-                      out_Bool_105
-                      (lam case_False_107 out_Bool_105 case_False_107)
+                      case_True_107
+                      out_Bool_106
+                      (lam case_False_108 out_Bool_106 case_False_108)
                     )
                   )
                 ]
                 (lam
-                  x_108
-                  (all out_Bool_109 (type) (fun out_Bool_109 (fun out_Bool_109 out_Bool_109)))
-                  x_108
+                  x_109
+                  (all out_Bool_110 (type) (fun out_Bool_110 (fun out_Bool_110 out_Bool_110)))
+                  x_109
                 )
               ]
             )
           )
         )
-        (all out_unit_110 (type) (fun out_unit_110 out_unit_110))
+        (all out_unit_111 (type) (fun out_unit_111 out_unit_111))
       }
-      (abs out_unit_111 (type) (lam case_unit_112 out_unit_111 case_unit_112))
+      (abs out_unit_112 (type) (lam case_unit_113 out_unit_112 case_unit_113))
     ]
-    (lam x_113 (all out_unit_114 (type) (fun out_unit_114 out_unit_114)) x_113)
+    (lam x_114 (all out_unit_115 (type) (fun out_unit_115 out_unit_115)) x_114)
   ]
 )

--- a/core-to-plc/test/primitives/tupleMatch.plc.golden
+++ b/core-to-plc/test/primitives/tupleMatch.plc.golden
@@ -3,59 +3,59 @@
     [
       {
         (abs
-          bad_name_81
+          bad_name_82
           (fun (type) (fun (type) (type)))
           (lam
-            bad_name_82
-            (all a_83 (type) (all b_84 (type) (fun a_83 (fun b_84 [[bad_name_81 a_83] b_84]))))
+            bad_name_83
+            (all a_84 (type) (all b_85 (type) (fun a_84 (fun b_85 [[bad_name_82 a_84] b_85]))))
             (lam
-              p_match_85
-              (all a_86 (type) (all b_87 (type) (fun [[bad_name_81 a_86] b_87] [[(lam a_88 (type) (lam b_89 (type) (all out_bad_name_90 (type) (fun (fun a_88 (fun b_89 out_bad_name_90)) out_bad_name_90)))) a_86] b_87])))
+              p_match_86
+              (all a_87 (type) (all b_88 (type) (fun [[bad_name_82 a_87] b_88] [[(lam a_89 (type) (lam b_90 (type) (all out_bad_name_91 (type) (fun (fun a_89 (fun b_90 out_bad_name_91)) out_bad_name_91)))) a_87] b_88])))
               (lam
-                ds_91
-                [[bad_name_81 [(con integer) (con 64)]] [(con integer) (con 64)]]
+                ds_92
+                [[bad_name_82 [(con integer) (con 64)]] [(con integer) (con 64)]]
                 [
                   {
                     [
                       {
-                        { p_match_85 [(con integer) (con 64)] }
+                        { p_match_86 [(con integer) (con 64)] }
                         [(con integer) (con 64)]
                       }
-                      ds_91
+                      ds_92
                     ]
                     [(con integer) (con 64)]
                   }
                   (lam
-                    a_92
+                    a_93
                     [(con integer) (con 64)]
-                    (lam b_93 [(con integer) (con 64)] a_92)
+                    (lam b_94 [(con integer) (con 64)] a_93)
                   )
                 ]
               )
             )
           )
         )
-        (lam a_94 (type) (lam b_95 (type) (all out_bad_name_96 (type) (fun (fun a_94 (fun b_95 out_bad_name_96)) out_bad_name_96))))
+        (lam a_95 (type) (lam b_96 (type) (all out_bad_name_97 (type) (fun (fun a_95 (fun b_96 out_bad_name_97)) out_bad_name_97))))
       }
       (abs
-        a_97
+        a_98
         (type)
         (abs
-          b_98
+          b_99
           (type)
           (lam
-            arg_0_99
-            a_97
+            arg_0_100
+            a_98
             (lam
-              arg_1_100
-              b_98
+              arg_1_101
+              b_99
               (abs
-                out_bad_name_101
+                out_bad_name_102
                 (type)
                 (lam
-                  case_bad_name_102
-                  (fun a_97 (fun b_98 out_bad_name_101))
-                  [ [ case_bad_name_102 arg_0_99 ] arg_1_100 ]
+                  case_bad_name_103
+                  (fun a_98 (fun b_99 out_bad_name_102))
+                  [ [ case_bad_name_103 arg_0_100 ] arg_1_101 ]
                 )
               )
             )
@@ -64,15 +64,15 @@
       )
     ]
     (abs
-      a_103
+      a_104
       (type)
       (abs
-        b_104
+        b_105
         (type)
         (lam
-          x_105
-          [[(lam a_106 (type) (lam b_107 (type) (all out_bad_name_108 (type) (fun (fun a_106 (fun b_107 out_bad_name_108)) out_bad_name_108)))) a_103] b_104]
-          x_105
+          x_106
+          [[(lam a_107 (type) (lam b_108 (type) (all out_bad_name_109 (type) (fun (fun a_107 (fun b_108 out_bad_name_109)) out_bad_name_109)))) a_104] b_105]
+          x_106
         )
       )
     )

--- a/core-to-plc/test/primitives/void.plc.golden
+++ b/core-to-plc/test/primitives/void.plc.golden
@@ -3,179 +3,179 @@
     [
       {
         (abs
-          unit_107
+          unit_110
           (type)
           (lam
-            unit_108
-            unit_107
+            unit_111
+            unit_110
             (lam
-              p_match_109
-              (fun unit_107 (all out_unit_110 (type) (fun out_unit_110 out_unit_110)))
+              p_match_112
+              (fun unit_110 (all out_unit_113 (type) (fun out_unit_113 out_unit_113)))
               [
                 [
                   [
                     {
                       (abs
-                        Bool_111
+                        Bool_114
                         (type)
                         (lam
-                          True_112
-                          Bool_111
+                          True_115
+                          Bool_114
                           (lam
-                            False_113
-                            Bool_111
+                            False_116
+                            Bool_114
                             (lam
-                              Bool_match_114
-                              (fun Bool_111 (all out_Bool_115 (type) (fun out_Bool_115 (fun out_Bool_115 out_Bool_115))))
+                              Bool_match_117
+                              (fun Bool_114 (all out_Bool_118 (type) (fun out_Bool_118 (fun out_Bool_118 out_Bool_118))))
                               [
                                 (lam
-                                  equalsInteger_116
-                                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] Bool_111))
+                                  equalsInteger_119
+                                  (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] Bool_114))
                                   (lam
-                                    ds_117
+                                    ds_120
                                     [(con integer) (con 64)]
                                     (lam
-                                      ds_118
+                                      ds_121
                                       [(con integer) (con 64)]
                                       [
                                         (lam
-                                          eta_119
-                                          Bool_111
+                                          eta_122
+                                          Bool_114
                                           [
                                             (lam
-                                              eta_120
-                                              Bool_111
+                                              eta_123
+                                              Bool_114
                                               [
                                                 [
                                                   (lam
-                                                    x_121
-                                                    Bool_111
+                                                    x_124
+                                                    Bool_114
                                                     (lam
-                                                      y_122
-                                                      Bool_111
+                                                      y_125
+                                                      Bool_114
                                                       [
                                                         (lam
-                                                          fail_123
-                                                          (fun (all a_124 (type) (fun unit_107 a_124)) Bool_111)
+                                                          fail_126
+                                                          (fun (all a_127 (type) (fun unit_110 a_127)) Bool_114)
                                                           [
                                                             [
                                                               [
                                                                 {
                                                                   [
-                                                                    Bool_match_114
-                                                                    x_121
+                                                                    Bool_match_117
+                                                                    x_124
                                                                   ]
-                                                                  (fun unit_107 Bool_111)
+                                                                  (fun unit_110 Bool_114)
                                                                 }
                                                                 (lam
-                                                                  thunk_125
-                                                                  unit_107
+                                                                  thunk_128
+                                                                  unit_110
                                                                   [
                                                                     [
                                                                       [
                                                                         {
                                                                           [
-                                                                            Bool_match_114
-                                                                            y_122
+                                                                            Bool_match_117
+                                                                            y_125
                                                                           ]
-                                                                          (fun unit_107 Bool_111)
+                                                                          (fun unit_110 Bool_114)
                                                                         }
                                                                         (lam
-                                                                          thunk_126
-                                                                          unit_107
-                                                                          True_112
+                                                                          thunk_129
+                                                                          unit_110
+                                                                          True_115
                                                                         )
                                                                       ]
                                                                       (lam
-                                                                        thunk_127
-                                                                        unit_107
+                                                                        thunk_130
+                                                                        unit_110
                                                                         [
-                                                                          fail_123
+                                                                          fail_126
                                                                           (abs
-                                                                            e_128
+                                                                            e_131
                                                                             (type)
                                                                             (lam
-                                                                              thunk_129
-                                                                              unit_107
+                                                                              thunk_132
+                                                                              unit_110
                                                                               (error
-                                                                                e_128
+                                                                                e_131
                                                                               )
                                                                             )
                                                                           )
                                                                         ]
                                                                       )
                                                                     ]
-                                                                    unit_108
+                                                                    unit_111
                                                                   ]
                                                                 )
                                                               ]
                                                               (lam
-                                                                thunk_130
-                                                                unit_107
+                                                                thunk_133
+                                                                unit_110
                                                                 [
-                                                                  fail_123
+                                                                  fail_126
                                                                   (abs
-                                                                    e_131
+                                                                    e_134
                                                                     (type)
                                                                     (lam
-                                                                      thunk_132
-                                                                      unit_107
+                                                                      thunk_135
+                                                                      unit_110
                                                                       (error
-                                                                        e_131
+                                                                        e_134
                                                                       )
                                                                     )
                                                                   )
                                                                 ]
                                                               )
                                                             ]
-                                                            unit_108
+                                                            unit_111
                                                           ]
                                                         )
                                                         (lam
-                                                          ds_133
-                                                          (all a_134 (type) (fun unit_107 a_134))
-                                                          False_113
+                                                          ds_136
+                                                          (all a_137 (type) (fun unit_110 a_137))
+                                                          False_116
                                                         )
                                                       ]
                                                     )
                                                   )
-                                                  eta_119
+                                                  eta_122
                                                 ]
-                                                eta_120
+                                                eta_123
                                               ]
                                             )
                                             [
-                                              [ equalsInteger_116 ds_118 ]
-                                              ds_117
+                                              [ equalsInteger_119 ds_121 ]
+                                              ds_120
                                             ]
                                           ]
                                         )
-                                        [ [ equalsInteger_116 ds_117 ] ds_118 ]
+                                        [ [ equalsInteger_119 ds_120 ] ds_121 ]
                                       ]
                                     )
                                   )
                                 )
                                 (lam
-                                  arg_135
+                                  arg_138
                                   [(con integer) (con 64)]
                                   (lam
-                                    arg_136
+                                    arg_139
                                     [(con integer) (con 64)]
                                     [
                                       (lam
-                                        b_137
-                                        (all a_138 (type) (fun a_138 (fun a_138 a_138)))
+                                        b_140
+                                        (all a_141 (type) (fun a_141 (fun a_141 a_141)))
                                         [
-                                          [ { b_137 Bool_111 } True_112 ]
-                                          False_113
+                                          [ { b_140 Bool_114 } True_115 ]
+                                          False_116
                                         ]
                                       )
                                       [
                                         [
                                           { (builtin equalsInteger) (con 64) }
-                                          arg_135
+                                          arg_138
                                         ]
-                                        arg_136
+                                        arg_139
                                       ]
                                     ]
                                   )
@@ -185,41 +185,41 @@
                           )
                         )
                       )
-                      (all out_Bool_139 (type) (fun out_Bool_139 (fun out_Bool_139 out_Bool_139)))
+                      (all out_Bool_142 (type) (fun out_Bool_142 (fun out_Bool_142 out_Bool_142)))
                     }
                     (abs
-                      out_Bool_140
+                      out_Bool_143
                       (type)
                       (lam
-                        case_True_141
-                        out_Bool_140
-                        (lam case_False_142 out_Bool_140 case_True_141)
+                        case_True_144
+                        out_Bool_143
+                        (lam case_False_145 out_Bool_143 case_True_144)
                       )
                     )
                   ]
                   (abs
-                    out_Bool_143
+                    out_Bool_146
                     (type)
                     (lam
-                      case_True_144
-                      out_Bool_143
-                      (lam case_False_145 out_Bool_143 case_False_145)
+                      case_True_147
+                      out_Bool_146
+                      (lam case_False_148 out_Bool_146 case_False_148)
                     )
                   )
                 ]
                 (lam
-                  x_146
-                  (all out_Bool_147 (type) (fun out_Bool_147 (fun out_Bool_147 out_Bool_147)))
-                  x_146
+                  x_149
+                  (all out_Bool_150 (type) (fun out_Bool_150 (fun out_Bool_150 out_Bool_150)))
+                  x_149
                 )
               ]
             )
           )
         )
-        (all out_unit_148 (type) (fun out_unit_148 out_unit_148))
+        (all out_unit_151 (type) (fun out_unit_151 out_unit_151))
       }
-      (abs out_unit_149 (type) (lam case_unit_150 out_unit_149 case_unit_150))
+      (abs out_unit_152 (type) (lam case_unit_153 out_unit_152 case_unit_153))
     ]
-    (lam x_151 (all out_unit_152 (type) (fun out_unit_152 out_unit_152)) x_151)
+    (lam x_154 (all out_unit_155 (type) (fun out_unit_155 out_unit_155)) x_154)
   ]
 )

--- a/core-to-plc/test/recursiveFunctions/even.plc.golden
+++ b/core-to-plc/test/recursiveFunctions/even.plc.golden
@@ -3,87 +3,87 @@
     [
       {
         (abs
-          unit_183
+          unit_185
           (type)
           (lam
-            unit_184
-            unit_183
+            unit_186
+            unit_185
             (lam
-              p_match_185
-              (fun unit_183 (all out_unit_186 (type) (fun out_unit_186 out_unit_186)))
+              p_match_187
+              (fun unit_185 (all out_unit_188 (type) (fun out_unit_188 out_unit_188)))
               [
                 (lam
-                  subtractInteger_187
+                  subtractInteger_189
                   (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] [(con integer) (con 64)]))
                   [
                     [
                       [
                         {
                           (abs
-                            Bool_188
+                            Bool_190
                             (type)
                             (lam
-                              True_189
-                              Bool_188
+                              True_191
+                              Bool_190
                               (lam
-                                False_190
-                                Bool_188
+                                False_192
+                                Bool_190
                                 (lam
-                                  Bool_match_191
-                                  (fun Bool_188 (all out_Bool_192 (type) (fun out_Bool_192 (fun out_Bool_192 out_Bool_192))))
+                                  Bool_match_193
+                                  (fun Bool_190 (all out_Bool_194 (type) (fun out_Bool_194 (fun out_Bool_194 out_Bool_194))))
                                   [
                                     (lam
-                                      equalsInteger_193
-                                      (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] Bool_188))
+                                      equalsInteger_195
+                                      (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] Bool_190))
                                       [
                                         (lam
-                                          tuple_194
-                                          [[(lam t_0_195 (type) (lam t_1_196 (type) (all r_197 (type) (fun (fun t_0_195 (fun t_1_196 r_197)) r_197)))) (fun [(con integer) (con 64)] Bool_188)] (fun [(con integer) (con 64)] Bool_188)]
+                                          tuple_196
+                                          [[(lam t_0_197 (type) (lam t_1_198 (type) (all r_199 (type) (fun (fun t_0_197 (fun t_1_198 r_199)) r_199)))) (fun [(con integer) (con 64)] Bool_190)] (fun [(con integer) (con 64)] Bool_190)]
                                           [
                                             (lam
-                                              odd_198
-                                              (fun [(con integer) (con 64)] Bool_188)
+                                              odd_200
+                                              (fun [(con integer) (con 64)] Bool_190)
                                               [
                                                 (lam
-                                                  even_199
-                                                  (fun [(con integer) (con 64)] Bool_188)
-                                                  even_199
+                                                  even_201
+                                                  (fun [(con integer) (con 64)] Bool_190)
+                                                  even_201
                                                 )
                                                 [
                                                   {
                                                     {
                                                       (abs
-                                                        t_0_200
+                                                        t_0_202
                                                         (type)
                                                         (abs
-                                                          t_1_201
+                                                          t_1_203
                                                           (type)
                                                           (lam
-                                                            tuple_202
-                                                            [[(lam t_0_203 (type) (lam t_1_204 (type) (all r_205 (type) (fun (fun t_0_203 (fun t_1_204 r_205)) r_205)))) t_0_200] t_1_201]
+                                                            tuple_204
+                                                            [[(lam t_0_205 (type) (lam t_1_206 (type) (all r_207 (type) (fun (fun t_0_205 (fun t_1_206 r_207)) r_207)))) t_0_202] t_1_203]
                                                             [
                                                               {
-                                                                tuple_202
-                                                                t_1_201
+                                                                tuple_204
+                                                                t_1_203
                                                               }
                                                               (lam
-                                                                arg_0_206
-                                                                t_0_200
+                                                                arg_0_208
+                                                                t_0_202
                                                                 (lam
-                                                                  arg_1_207
-                                                                  t_1_201
-                                                                  arg_1_207
+                                                                  arg_1_209
+                                                                  t_1_203
+                                                                  arg_1_209
                                                                 )
                                                               )
                                                             ]
                                                           )
                                                         )
                                                       )
-                                                      (fun [(con integer) (con 64)] Bool_188)
+                                                      (fun [(con integer) (con 64)] Bool_190)
                                                     }
-                                                    (fun [(con integer) (con 64)] Bool_188)
+                                                    (fun [(con integer) (con 64)] Bool_190)
                                                   }
-                                                  tuple_194
+                                                  tuple_196
                                                 ]
                                               ]
                                             )
@@ -91,34 +91,34 @@
                                               {
                                                 {
                                                   (abs
-                                                    t_0_208
+                                                    t_0_210
                                                     (type)
                                                     (abs
-                                                      t_1_209
+                                                      t_1_211
                                                       (type)
                                                       (lam
-                                                        tuple_210
-                                                        [[(lam t_0_211 (type) (lam t_1_212 (type) (all r_213 (type) (fun (fun t_0_211 (fun t_1_212 r_213)) r_213)))) t_0_208] t_1_209]
+                                                        tuple_212
+                                                        [[(lam t_0_213 (type) (lam t_1_214 (type) (all r_215 (type) (fun (fun t_0_213 (fun t_1_214 r_215)) r_215)))) t_0_210] t_1_211]
                                                         [
-                                                          { tuple_210 t_0_208 }
+                                                          { tuple_212 t_0_210 }
                                                           (lam
-                                                            arg_0_214
-                                                            t_0_208
+                                                            arg_0_216
+                                                            t_0_210
                                                             (lam
-                                                              arg_1_215
-                                                              t_1_209
-                                                              arg_0_214
+                                                              arg_1_217
+                                                              t_1_211
+                                                              arg_0_216
                                                             )
                                                           )
                                                         ]
                                                       )
                                                     )
                                                   )
-                                                  (fun [(con integer) (con 64)] Bool_188)
+                                                  (fun [(con integer) (con 64)] Bool_190)
                                                 }
-                                                (fun [(con integer) (con 64)] Bool_188)
+                                                (fun [(con integer) (con 64)] Bool_190)
                                               }
-                                              tuple_194
+                                              tuple_196
                                             ]
                                           ]
                                         )
@@ -128,89 +128,89 @@
                                               {
                                                 {
                                                   (abs
-                                                    a_216
+                                                    a_218
                                                     (type)
                                                     (abs
-                                                      b_217
+                                                      b_219
                                                       (type)
                                                       (abs
-                                                        a_218
+                                                        a_220
                                                         (type)
                                                         (abs
-                                                          b_219
+                                                          b_221
                                                           (type)
                                                           [
                                                             {
                                                               (abs
-                                                                F_220
+                                                                F_222
                                                                 (fun (type) (type))
                                                                 (lam
-                                                                  by_221
-                                                                  (fun (all Q_222 (type) (fun [F_220 Q_222] Q_222)) (all Q_223 (type) (fun [F_220 Q_223] Q_223)))
+                                                                  by_223
+                                                                  (fun (all Q_224 (type) (fun [F_222 Q_224] Q_224)) (all Q_225 (type) (fun [F_222 Q_225] Q_225)))
                                                                   [
                                                                     {
                                                                       {
                                                                         (abs
-                                                                          a_224
+                                                                          a_226
                                                                           (type)
                                                                           (abs
-                                                                            b_225
+                                                                            b_227
                                                                             (type)
                                                                             (lam
-                                                                              f_226
-                                                                              (fun (fun a_224 b_225) (fun a_224 b_225))
+                                                                              f_228
+                                                                              (fun (fun a_226 b_227) (fun a_226 b_227))
                                                                               [
                                                                                 {
                                                                                   (abs
-                                                                                    a_227
+                                                                                    a_229
                                                                                     (type)
                                                                                     (lam
-                                                                                      s_228
-                                                                                      [(lam a_229 (type) (fix self_230 (fun self_230 a_229))) a_227]
+                                                                                      s_230
+                                                                                      [(lam a_231 (type) (fix self_232 (fun self_232 a_231))) a_229]
                                                                                       [
                                                                                         (unwrap
-                                                                                          s_228
+                                                                                          s_230
                                                                                         )
-                                                                                        s_228
+                                                                                        s_230
                                                                                       ]
                                                                                     )
                                                                                   )
-                                                                                  (fun a_224 b_225)
+                                                                                  (fun a_226 b_227)
                                                                                 }
                                                                                 (wrap
-                                                                                  self_231
-                                                                                  [(lam a_232 (type) (fun self_231 a_232)) (fun a_224 b_225)]
+                                                                                  self_233
+                                                                                  [(lam a_234 (type) (fun self_233 a_234)) (fun a_226 b_227)]
                                                                                   (lam
-                                                                                    s_233
-                                                                                    [(lam a_234 (type) (fix self_235 (fun self_235 a_234))) (fun a_224 b_225)]
+                                                                                    s_235
+                                                                                    [(lam a_236 (type) (fix self_237 (fun self_237 a_236))) (fun a_226 b_227)]
                                                                                     (lam
-                                                                                      x_236
-                                                                                      a_224
+                                                                                      x_238
+                                                                                      a_226
                                                                                       [
                                                                                         [
-                                                                                          f_226
+                                                                                          f_228
                                                                                           [
                                                                                             {
                                                                                               (abs
-                                                                                                a_237
+                                                                                                a_239
                                                                                                 (type)
                                                                                                 (lam
-                                                                                                  s_238
-                                                                                                  [(lam a_239 (type) (fix self_240 (fun self_240 a_239))) a_237]
+                                                                                                  s_240
+                                                                                                  [(lam a_241 (type) (fix self_242 (fun self_242 a_241))) a_239]
                                                                                                   [
                                                                                                     (unwrap
-                                                                                                      s_238
+                                                                                                      s_240
                                                                                                     )
-                                                                                                    s_238
+                                                                                                    s_240
                                                                                                   ]
                                                                                                 )
                                                                                               )
-                                                                                              (fun a_224 b_225)
+                                                                                              (fun a_226 b_227)
                                                                                             }
-                                                                                            s_233
+                                                                                            s_235
                                                                                           ]
                                                                                         ]
-                                                                                        x_236
+                                                                                        x_238
                                                                                       ]
                                                                                     )
                                                                                   )
@@ -219,54 +219,54 @@
                                                                             )
                                                                           )
                                                                         )
-                                                                        (all Q_241 (type) (fun [F_220 Q_241] [F_220 Q_241]))
+                                                                        (all Q_243 (type) (fun [F_222 Q_243] [F_222 Q_243]))
                                                                       }
-                                                                      (all Q_242 (type) (fun [F_220 Q_242] Q_242))
+                                                                      (all Q_244 (type) (fun [F_222 Q_244] Q_244))
                                                                     }
                                                                     (lam
-                                                                      rec_243
-                                                                      (fun (all Q_244 (type) (fun [F_220 Q_244] [F_220 Q_244])) (all Q_245 (type) (fun [F_220 Q_245] Q_245)))
+                                                                      rec_245
+                                                                      (fun (all Q_246 (type) (fun [F_222 Q_246] [F_222 Q_246])) (all Q_247 (type) (fun [F_222 Q_247] Q_247)))
                                                                       (lam
-                                                                        h_246
-                                                                        (all Q_247 (type) (fun [F_220 Q_247] [F_220 Q_247]))
+                                                                        h_248
+                                                                        (all Q_249 (type) (fun [F_222 Q_249] [F_222 Q_249]))
                                                                         (abs
-                                                                          R_248
+                                                                          R_250
                                                                           (type)
                                                                           (lam
-                                                                            fr_249
-                                                                            [F_220 R_248]
+                                                                            fr_251
+                                                                            [F_222 R_250]
                                                                             [
                                                                               {
                                                                                 [
-                                                                                  by_221
+                                                                                  by_223
                                                                                   (abs
-                                                                                    Q_250
+                                                                                    Q_252
                                                                                     (type)
                                                                                     (lam
-                                                                                      fq_251
-                                                                                      [F_220 Q_250]
+                                                                                      fq_253
+                                                                                      [F_222 Q_252]
                                                                                       [
                                                                                         {
                                                                                           [
-                                                                                            rec_243
-                                                                                            h_246
+                                                                                            rec_245
+                                                                                            h_248
                                                                                           ]
-                                                                                          Q_250
+                                                                                          Q_252
                                                                                         }
                                                                                         [
                                                                                           {
-                                                                                            h_246
-                                                                                            Q_250
+                                                                                            h_248
+                                                                                            Q_252
                                                                                           }
-                                                                                          fq_251
+                                                                                          fq_253
                                                                                         ]
                                                                                       ]
                                                                                     )
                                                                                   )
                                                                                 ]
-                                                                                R_248
+                                                                                R_250
                                                                               }
-                                                                              fr_249
+                                                                              fr_251
                                                                             ]
                                                                           )
                                                                         )
@@ -275,37 +275,37 @@
                                                                   ]
                                                                 )
                                                               )
-                                                              (lam X_252 (type) (fun (fun a_216 b_217) (fun (fun a_218 b_219) X_252)))
+                                                              (lam X_254 (type) (fun (fun a_218 b_219) (fun (fun a_220 b_221) X_254)))
                                                             }
                                                             (lam
-                                                              k_253
-                                                              (all Q_254 (type) (fun (fun (fun a_216 b_217) (fun (fun a_218 b_219) Q_254)) Q_254))
+                                                              k_255
+                                                              (all Q_256 (type) (fun (fun (fun a_218 b_219) (fun (fun a_220 b_221) Q_256)) Q_256))
                                                               (abs
-                                                                S_255
+                                                                S_257
                                                                 (type)
                                                                 (lam
-                                                                  h_256
-                                                                  (fun (fun a_216 b_217) (fun (fun a_218 b_219) S_255))
+                                                                  h_258
+                                                                  (fun (fun a_218 b_219) (fun (fun a_220 b_221) S_257))
                                                                   [
                                                                     [
-                                                                      h_256
+                                                                      h_258
                                                                       (lam
-                                                                        x_257
-                                                                        a_216
+                                                                        x_259
+                                                                        a_218
                                                                         [
                                                                           {
-                                                                            k_253
-                                                                            b_217
+                                                                            k_255
+                                                                            b_219
                                                                           }
                                                                           (lam
-                                                                            f_258
-                                                                            (fun a_216 b_217)
+                                                                            f_260
+                                                                            (fun a_218 b_219)
                                                                             (lam
-                                                                              f_259
-                                                                              (fun a_218 b_219)
+                                                                              f_261
+                                                                              (fun a_220 b_221)
                                                                               [
-                                                                                f_258
-                                                                                x_257
+                                                                                f_260
+                                                                                x_259
                                                                               ]
                                                                             )
                                                                           )
@@ -313,22 +313,22 @@
                                                                       )
                                                                     ]
                                                                     (lam
-                                                                      x_260
-                                                                      a_218
+                                                                      x_262
+                                                                      a_220
                                                                       [
                                                                         {
-                                                                          k_253
-                                                                          b_219
+                                                                          k_255
+                                                                          b_221
                                                                         }
                                                                         (lam
-                                                                          f_261
-                                                                          (fun a_216 b_217)
+                                                                          f_263
+                                                                          (fun a_218 b_219)
                                                                           (lam
-                                                                            f_262
-                                                                            (fun a_218 b_219)
+                                                                            f_264
+                                                                            (fun a_220 b_221)
                                                                             [
-                                                                              f_262
-                                                                              x_260
+                                                                              f_264
+                                                                              x_262
                                                                             ]
                                                                           )
                                                                         )
@@ -345,112 +345,112 @@
                                                   )
                                                   [(con integer) (con 64)]
                                                 }
-                                                Bool_188
+                                                Bool_190
                                               }
                                               [(con integer) (con 64)]
                                             }
-                                            Bool_188
+                                            Bool_190
                                           }
                                           (abs
-                                            Q_263
+                                            Q_265
                                             (type)
                                             (lam
-                                              choose_264
-                                              (fun (fun [(con integer) (con 64)] Bool_188) (fun (fun [(con integer) (con 64)] Bool_188) Q_263))
+                                              choose_266
+                                              (fun (fun [(con integer) (con 64)] Bool_190) (fun (fun [(con integer) (con 64)] Bool_190) Q_265))
                                               (lam
-                                                odd_265
-                                                (fun [(con integer) (con 64)] Bool_188)
+                                                odd_267
+                                                (fun [(con integer) (con 64)] Bool_190)
                                                 (lam
-                                                  even_266
-                                                  (fun [(con integer) (con 64)] Bool_188)
+                                                  even_268
+                                                  (fun [(con integer) (con 64)] Bool_190)
                                                   [
                                                     [
-                                                      choose_264
+                                                      choose_266
                                                       (lam
-                                                        n_267
+                                                        n_269
                                                         [(con integer) (con 64)]
                                                         [
                                                           [
                                                             [
                                                               {
                                                                 [
-                                                                  Bool_match_191
+                                                                  Bool_match_193
                                                                   [
                                                                     [
-                                                                      equalsInteger_193
-                                                                      n_267
+                                                                      equalsInteger_195
+                                                                      n_269
                                                                     ]
                                                                     (con 64 ! 0)
                                                                   ]
                                                                 ]
-                                                                (fun unit_183 Bool_188)
+                                                                (fun unit_185 Bool_190)
                                                               }
                                                               (lam
-                                                                thunk_268
-                                                                unit_183
-                                                                False_190
+                                                                thunk_270
+                                                                unit_185
+                                                                False_192
                                                               )
                                                             ]
                                                             (lam
-                                                              thunk_269
-                                                              unit_183
+                                                              thunk_271
+                                                              unit_185
                                                               [
-                                                                even_266
+                                                                even_268
                                                                 [
                                                                   [
-                                                                    subtractInteger_187
-                                                                    n_267
+                                                                    subtractInteger_189
+                                                                    n_269
                                                                   ]
                                                                   (con 64 ! 1)
                                                                 ]
                                                               ]
                                                             )
                                                           ]
-                                                          unit_184
+                                                          unit_186
                                                         ]
                                                       )
                                                     ]
                                                     (lam
-                                                      n_270
+                                                      n_272
                                                       [(con integer) (con 64)]
                                                       [
                                                         [
                                                           [
                                                             {
                                                               [
-                                                                Bool_match_191
+                                                                Bool_match_193
                                                                 [
                                                                   [
-                                                                    equalsInteger_193
-                                                                    n_270
+                                                                    equalsInteger_195
+                                                                    n_272
                                                                   ]
                                                                   (con 64 ! 0)
                                                                 ]
                                                               ]
-                                                              (fun unit_183 Bool_188)
+                                                              (fun unit_185 Bool_190)
                                                             }
                                                             (lam
-                                                              thunk_271
-                                                              unit_183
-                                                              True_189
+                                                              thunk_273
+                                                              unit_185
+                                                              True_191
                                                             )
                                                           ]
                                                           (lam
-                                                            thunk_272
-                                                            unit_183
+                                                            thunk_274
+                                                            unit_185
                                                             [
-                                                              odd_265
+                                                              odd_267
                                                               [
                                                                 [
-                                                                  subtractInteger_187
-                                                                  n_270
+                                                                  subtractInteger_189
+                                                                  n_272
                                                                 ]
                                                                 (con 64 ! 1)
                                                               ]
                                                             ]
                                                           )
                                                         ]
-                                                        unit_184
+                                                        unit_186
                                                       ]
                                                     )
                                                   ]
@@ -462,18 +462,18 @@
                                       ]
                                     )
                                     (lam
-                                      arg_273
+                                      arg_275
                                       [(con integer) (con 64)]
                                       (lam
-                                        arg_274
+                                        arg_276
                                         [(con integer) (con 64)]
                                         [
                                           (lam
-                                            b_275
-                                            (all a_276 (type) (fun a_276 (fun a_276 a_276)))
+                                            b_277
+                                            (all a_278 (type) (fun a_278 (fun a_278 a_278)))
                                             [
-                                              [ { b_275 Bool_188 } True_189 ]
-                                              False_190
+                                              [ { b_277 Bool_190 } True_191 ]
+                                              False_192
                                             ]
                                           )
                                           [
@@ -481,9 +481,9 @@
                                               {
                                                 (builtin equalsInteger) (con 64)
                                               }
-                                              arg_273
+                                              arg_275
                                             ]
-                                            arg_274
+                                            arg_276
                                           ]
                                         ]
                                       )
@@ -493,32 +493,32 @@
                               )
                             )
                           )
-                          (all out_Bool_277 (type) (fun out_Bool_277 (fun out_Bool_277 out_Bool_277)))
+                          (all out_Bool_279 (type) (fun out_Bool_279 (fun out_Bool_279 out_Bool_279)))
                         }
                         (abs
-                          out_Bool_278
+                          out_Bool_280
                           (type)
                           (lam
-                            case_True_279
-                            out_Bool_278
-                            (lam case_False_280 out_Bool_278 case_True_279)
+                            case_True_281
+                            out_Bool_280
+                            (lam case_False_282 out_Bool_280 case_True_281)
                           )
                         )
                       ]
                       (abs
-                        out_Bool_281
+                        out_Bool_283
                         (type)
                         (lam
-                          case_True_282
-                          out_Bool_281
-                          (lam case_False_283 out_Bool_281 case_False_283)
+                          case_True_284
+                          out_Bool_283
+                          (lam case_False_285 out_Bool_283 case_False_285)
                         )
                       )
                     ]
                     (lam
-                      x_284
-                      (all out_Bool_285 (type) (fun out_Bool_285 (fun out_Bool_285 out_Bool_285)))
-                      x_284
+                      x_286
+                      (all out_Bool_287 (type) (fun out_Bool_287 (fun out_Bool_287 out_Bool_287)))
+                      x_286
                     )
                   ]
                 )
@@ -527,10 +527,10 @@
             )
           )
         )
-        (all out_unit_286 (type) (fun out_unit_286 out_unit_286))
+        (all out_unit_288 (type) (fun out_unit_288 out_unit_288))
       }
-      (abs out_unit_287 (type) (lam case_unit_288 out_unit_287 case_unit_288))
+      (abs out_unit_289 (type) (lam case_unit_290 out_unit_289 case_unit_290))
     ]
-    (lam x_289 (all out_unit_290 (type) (fun out_unit_290 out_unit_290)) x_289)
+    (lam x_291 (all out_unit_292 (type) (fun out_unit_292 out_unit_292)) x_291)
   ]
 )

--- a/core-to-plc/test/recursiveFunctions/even3.plc.golden
+++ b/core-to-plc/test/recursiveFunctions/even3.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_281
+  out_Bool_283
   (type)
   (lam
-    case_True_282 out_Bool_281 (lam case_False_283 out_Bool_281 case_False_283)
+    case_True_284 out_Bool_283 (lam case_False_285 out_Bool_283 case_False_285)
   )
 )

--- a/core-to-plc/test/recursiveFunctions/even4.plc.golden
+++ b/core-to-plc/test/recursiveFunctions/even4.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_278
+  out_Bool_280
   (type)
   (lam
-    case_True_279 out_Bool_278 (lam case_False_280 out_Bool_278 case_True_279)
+    case_True_281 out_Bool_280 (lam case_False_282 out_Bool_280 case_True_281)
   )
 )

--- a/core-to-plc/test/recursiveFunctions/fib.plc.golden
+++ b/core-to-plc/test/recursiveFunctions/fib.plc.golden
@@ -3,73 +3,73 @@
     [
       {
         (abs
-          unit_154
+          unit_157
           (type)
           (lam
-            unit_155
-            unit_154
+            unit_158
+            unit_157
             (lam
-              p_match_156
-              (fun unit_154 (all out_unit_157 (type) (fun out_unit_157 out_unit_157)))
+              p_match_159
+              (fun unit_157 (all out_unit_160 (type) (fun out_unit_160 out_unit_160)))
               [
                 (lam
-                  addInteger_158
+                  addInteger_161
                   (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] [(con integer) (con 64)]))
                   [
                     (lam
-                      subtractInteger_159
+                      subtractInteger_162
                       (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] [(con integer) (con 64)]))
                       [
                         [
                           [
                             {
                               (abs
-                                Bool_160
+                                Bool_163
                                 (type)
                                 (lam
-                                  True_161
-                                  Bool_160
+                                  True_164
+                                  Bool_163
                                   (lam
-                                    False_162
-                                    Bool_160
+                                    False_165
+                                    Bool_163
                                     (lam
-                                      Bool_match_163
-                                      (fun Bool_160 (all out_Bool_164 (type) (fun out_Bool_164 (fun out_Bool_164 out_Bool_164))))
+                                      Bool_match_166
+                                      (fun Bool_163 (all out_Bool_167 (type) (fun out_Bool_167 (fun out_Bool_167 out_Bool_167))))
                                       [
                                         (lam
-                                          equalsInteger_165
-                                          (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] Bool_160))
+                                          equalsInteger_168
+                                          (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] Bool_163))
                                           [
                                             (lam
-                                              tuple_166
-                                              [(lam t_0_167 (type) (all r_168 (type) (fun (fun t_0_167 r_168) r_168))) (fun [(con integer) (con 64)] [(con integer) (con 64)])]
+                                              tuple_169
+                                              [(lam t_0_170 (type) (all r_171 (type) (fun (fun t_0_170 r_171) r_171))) (fun [(con integer) (con 64)] [(con integer) (con 64)])]
                                               [
                                                 (lam
-                                                  fib_169
+                                                  fib_172
                                                   (fun [(con integer) (con 64)] [(con integer) (con 64)])
-                                                  fib_169
+                                                  fib_172
                                                 )
                                                 [
                                                   {
                                                     (abs
-                                                      t_0_170
+                                                      t_0_173
                                                       (type)
                                                       (lam
-                                                        tuple_171
-                                                        [(lam t_0_172 (type) (all r_173 (type) (fun (fun t_0_172 r_173) r_173))) t_0_170]
+                                                        tuple_174
+                                                        [(lam t_0_175 (type) (all r_176 (type) (fun (fun t_0_175 r_176) r_176))) t_0_173]
                                                         [
-                                                          { tuple_171 t_0_170 }
+                                                          { tuple_174 t_0_173 }
                                                           (lam
-                                                            arg_0_174
-                                                            t_0_170
-                                                            arg_0_174
+                                                            arg_0_177
+                                                            t_0_173
+                                                            arg_0_177
                                                           )
                                                         ]
                                                       )
                                                     )
                                                     (fun [(con integer) (con 64)] [(con integer) (con 64)])
                                                   }
-                                                  tuple_166
+                                                  tuple_169
                                                 ]
                                               ]
                                             )
@@ -77,83 +77,83 @@
                                               {
                                                 {
                                                   (abs
-                                                    a_175
+                                                    a_178
                                                     (type)
                                                     (abs
-                                                      b_176
+                                                      b_179
                                                       (type)
                                                       [
                                                         {
                                                           (abs
-                                                            F_177
+                                                            F_180
                                                             (fun (type) (type))
                                                             (lam
-                                                              by_178
-                                                              (fun (all Q_179 (type) (fun [F_177 Q_179] Q_179)) (all Q_180 (type) (fun [F_177 Q_180] Q_180)))
+                                                              by_181
+                                                              (fun (all Q_182 (type) (fun [F_180 Q_182] Q_182)) (all Q_183 (type) (fun [F_180 Q_183] Q_183)))
                                                               [
                                                                 {
                                                                   {
                                                                     (abs
-                                                                      a_181
+                                                                      a_184
                                                                       (type)
                                                                       (abs
-                                                                        b_182
+                                                                        b_185
                                                                         (type)
                                                                         (lam
-                                                                          f_183
-                                                                          (fun (fun a_181 b_182) (fun a_181 b_182))
+                                                                          f_186
+                                                                          (fun (fun a_184 b_185) (fun a_184 b_185))
                                                                           [
                                                                             {
                                                                               (abs
-                                                                                a_184
+                                                                                a_187
                                                                                 (type)
                                                                                 (lam
-                                                                                  s_185
-                                                                                  [(lam a_186 (type) (fix self_187 (fun self_187 a_186))) a_184]
+                                                                                  s_188
+                                                                                  [(lam a_189 (type) (fix self_190 (fun self_190 a_189))) a_187]
                                                                                   [
                                                                                     (unwrap
-                                                                                      s_185
+                                                                                      s_188
                                                                                     )
-                                                                                    s_185
+                                                                                    s_188
                                                                                   ]
                                                                                 )
                                                                               )
-                                                                              (fun a_181 b_182)
+                                                                              (fun a_184 b_185)
                                                                             }
                                                                             (wrap
-                                                                              self_188
-                                                                              [(lam a_189 (type) (fun self_188 a_189)) (fun a_181 b_182)]
+                                                                              self_191
+                                                                              [(lam a_192 (type) (fun self_191 a_192)) (fun a_184 b_185)]
                                                                               (lam
-                                                                                s_190
-                                                                                [(lam a_191 (type) (fix self_192 (fun self_192 a_191))) (fun a_181 b_182)]
+                                                                                s_193
+                                                                                [(lam a_194 (type) (fix self_195 (fun self_195 a_194))) (fun a_184 b_185)]
                                                                                 (lam
-                                                                                  x_193
-                                                                                  a_181
+                                                                                  x_196
+                                                                                  a_184
                                                                                   [
                                                                                     [
-                                                                                      f_183
+                                                                                      f_186
                                                                                       [
                                                                                         {
                                                                                           (abs
-                                                                                            a_194
+                                                                                            a_197
                                                                                             (type)
                                                                                             (lam
-                                                                                              s_195
-                                                                                              [(lam a_196 (type) (fix self_197 (fun self_197 a_196))) a_194]
+                                                                                              s_198
+                                                                                              [(lam a_199 (type) (fix self_200 (fun self_200 a_199))) a_197]
                                                                                               [
                                                                                                 (unwrap
-                                                                                                  s_195
+                                                                                                  s_198
                                                                                                 )
-                                                                                                s_195
+                                                                                                s_198
                                                                                               ]
                                                                                             )
                                                                                           )
-                                                                                          (fun a_181 b_182)
+                                                                                          (fun a_184 b_185)
                                                                                         }
-                                                                                        s_190
+                                                                                        s_193
                                                                                       ]
                                                                                     ]
-                                                                                    x_193
+                                                                                    x_196
                                                                                   ]
                                                                                 )
                                                                               )
@@ -162,54 +162,54 @@
                                                                         )
                                                                       )
                                                                     )
-                                                                    (all Q_198 (type) (fun [F_177 Q_198] [F_177 Q_198]))
+                                                                    (all Q_201 (type) (fun [F_180 Q_201] [F_180 Q_201]))
                                                                   }
-                                                                  (all Q_199 (type) (fun [F_177 Q_199] Q_199))
+                                                                  (all Q_202 (type) (fun [F_180 Q_202] Q_202))
                                                                 }
                                                                 (lam
-                                                                  rec_200
-                                                                  (fun (all Q_201 (type) (fun [F_177 Q_201] [F_177 Q_201])) (all Q_202 (type) (fun [F_177 Q_202] Q_202)))
+                                                                  rec_203
+                                                                  (fun (all Q_204 (type) (fun [F_180 Q_204] [F_180 Q_204])) (all Q_205 (type) (fun [F_180 Q_205] Q_205)))
                                                                   (lam
-                                                                    h_203
-                                                                    (all Q_204 (type) (fun [F_177 Q_204] [F_177 Q_204]))
+                                                                    h_206
+                                                                    (all Q_207 (type) (fun [F_180 Q_207] [F_180 Q_207]))
                                                                     (abs
-                                                                      R_205
+                                                                      R_208
                                                                       (type)
                                                                       (lam
-                                                                        fr_206
-                                                                        [F_177 R_205]
+                                                                        fr_209
+                                                                        [F_180 R_208]
                                                                         [
                                                                           {
                                                                             [
-                                                                              by_178
+                                                                              by_181
                                                                               (abs
-                                                                                Q_207
+                                                                                Q_210
                                                                                 (type)
                                                                                 (lam
-                                                                                  fq_208
-                                                                                  [F_177 Q_207]
+                                                                                  fq_211
+                                                                                  [F_180 Q_210]
                                                                                   [
                                                                                     {
                                                                                       [
-                                                                                        rec_200
-                                                                                        h_203
+                                                                                        rec_203
+                                                                                        h_206
                                                                                       ]
-                                                                                      Q_207
+                                                                                      Q_210
                                                                                     }
                                                                                     [
                                                                                       {
-                                                                                        h_203
-                                                                                        Q_207
+                                                                                        h_206
+                                                                                        Q_210
                                                                                       }
-                                                                                      fq_208
+                                                                                      fq_211
                                                                                     ]
                                                                                   ]
                                                                                 )
                                                                               )
                                                                             ]
-                                                                            R_205
+                                                                            R_208
                                                                           }
-                                                                          fr_206
+                                                                          fr_209
                                                                         ]
                                                                       )
                                                                     )
@@ -218,33 +218,33 @@
                                                               ]
                                                             )
                                                           )
-                                                          (lam X_209 (type) (fun (fun a_175 b_176) X_209))
+                                                          (lam X_212 (type) (fun (fun a_178 b_179) X_212))
                                                         }
                                                         (lam
-                                                          k_210
-                                                          (all Q_211 (type) (fun (fun (fun a_175 b_176) Q_211) Q_211))
+                                                          k_213
+                                                          (all Q_214 (type) (fun (fun (fun a_178 b_179) Q_214) Q_214))
                                                           (abs
-                                                            S_212
+                                                            S_215
                                                             (type)
                                                             (lam
-                                                              h_213
-                                                              (fun (fun a_175 b_176) S_212)
+                                                              h_216
+                                                              (fun (fun a_178 b_179) S_215)
                                                               [
-                                                                h_213
+                                                                h_216
                                                                 (lam
-                                                                  x_214
-                                                                  a_175
+                                                                  x_217
+                                                                  a_178
                                                                   [
                                                                     {
-                                                                      k_210
-                                                                      b_176
+                                                                      k_213
+                                                                      b_179
                                                                     }
                                                                     (lam
-                                                                      f_215
-                                                                      (fun a_175 b_176)
+                                                                      f_218
+                                                                      (fun a_178 b_179)
                                                                       [
-                                                                        f_215
-                                                                        x_214
+                                                                        f_218
+                                                                        x_217
                                                                       ]
                                                                     )
                                                                   ]
@@ -261,82 +261,82 @@
                                                 [(con integer) (con 64)]
                                               }
                                               (abs
-                                                Q_216
+                                                Q_219
                                                 (type)
                                                 (lam
-                                                  choose_217
-                                                  (fun (fun [(con integer) (con 64)] [(con integer) (con 64)]) Q_216)
+                                                  choose_220
+                                                  (fun (fun [(con integer) (con 64)] [(con integer) (con 64)]) Q_219)
                                                   (lam
-                                                    fib_218
+                                                    fib_221
                                                     (fun [(con integer) (con 64)] [(con integer) (con 64)])
                                                     [
-                                                      choose_217
+                                                      choose_220
                                                       (lam
-                                                        n_219
+                                                        n_222
                                                         [(con integer) (con 64)]
                                                         [
                                                           [
                                                             [
                                                               {
                                                                 [
-                                                                  Bool_match_163
+                                                                  Bool_match_166
                                                                   [
                                                                     [
-                                                                      equalsInteger_165
-                                                                      n_219
+                                                                      equalsInteger_168
+                                                                      n_222
                                                                     ]
                                                                     (con 64 ! 0)
                                                                   ]
                                                                 ]
-                                                                (fun unit_154 [(con integer) (con 64)])
+                                                                (fun unit_157 [(con integer) (con 64)])
                                                               }
                                                               (lam
-                                                                thunk_220
-                                                                unit_154
+                                                                thunk_223
+                                                                unit_157
                                                                 (con 64 ! 0)
                                                               )
                                                             ]
                                                             (lam
-                                                              thunk_221
-                                                              unit_154
+                                                              thunk_224
+                                                              unit_157
                                                               [
                                                                 [
                                                                   [
                                                                     {
                                                                       [
-                                                                        Bool_match_163
+                                                                        Bool_match_166
                                                                         [
                                                                           [
-                                                                            equalsInteger_165
-                                                                            n_219
+                                                                            equalsInteger_168
+                                                                            n_222
                                                                           ]
                                                                           (con
                                                                             64 ! 1
                                                                           )
                                                                         ]
                                                                       ]
-                                                                      (fun unit_154 [(con integer) (con 64)])
+                                                                      (fun unit_157 [(con integer) (con 64)])
                                                                     }
                                                                     (lam
-                                                                      thunk_222
-                                                                      unit_154
+                                                                      thunk_225
+                                                                      unit_157
                                                                       (con
                                                                         64 ! 1
                                                                       )
                                                                     )
                                                                   ]
                                                                   (lam
-                                                                    thunk_223
-                                                                    unit_154
+                                                                    thunk_226
+                                                                    unit_157
                                                                     [
                                                                       [
-                                                                        addInteger_158
+                                                                        addInteger_161
                                                                         [
-                                                                          fib_218
+                                                                          fib_221
                                                                           [
                                                                             [
-                                                                              subtractInteger_159
-                                                                              n_219
+                                                                              subtractInteger_162
+                                                                              n_222
                                                                             ]
                                                                             (con
                                                                               64 ! 1
@@ -345,11 +345,11 @@
                                                                         ]
                                                                       ]
                                                                       [
-                                                                        fib_218
+                                                                        fib_221
                                                                         [
                                                                           [
-                                                                            subtractInteger_159
-                                                                            n_219
+                                                                            subtractInteger_162
+                                                                            n_222
                                                                           ]
                                                                           (con
                                                                             64 ! 2
@@ -359,11 +359,11 @@
                                                                     ]
                                                                   )
                                                                 ]
-                                                                unit_155
+                                                                unit_158
                                                               ]
                                                             )
                                                           ]
-                                                          unit_155
+                                                          unit_158
                                                         ]
                                                       )
                                                     ]
@@ -374,20 +374,20 @@
                                           ]
                                         )
                                         (lam
-                                          arg_224
+                                          arg_227
                                           [(con integer) (con 64)]
                                           (lam
-                                            arg_225
+                                            arg_228
                                             [(con integer) (con 64)]
                                             [
                                               (lam
-                                                b_226
-                                                (all a_227 (type) (fun a_227 (fun a_227 a_227)))
+                                                b_229
+                                                (all a_230 (type) (fun a_230 (fun a_230 a_230)))
                                                 [
                                                   [
-                                                    { b_226 Bool_160 } True_161
+                                                    { b_229 Bool_163 } True_164
                                                   ]
-                                                  False_162
+                                                  False_165
                                                 ]
                                               )
                                               [
@@ -396,9 +396,9 @@
                                                     (builtin equalsInteger)
                                                     (con 64)
                                                   }
-                                                  arg_224
+                                                  arg_227
                                                 ]
-                                                arg_225
+                                                arg_228
                                               ]
                                             ]
                                           )
@@ -408,32 +408,32 @@
                                   )
                                 )
                               )
-                              (all out_Bool_228 (type) (fun out_Bool_228 (fun out_Bool_228 out_Bool_228)))
+                              (all out_Bool_231 (type) (fun out_Bool_231 (fun out_Bool_231 out_Bool_231)))
                             }
                             (abs
-                              out_Bool_229
+                              out_Bool_232
                               (type)
                               (lam
-                                case_True_230
-                                out_Bool_229
-                                (lam case_False_231 out_Bool_229 case_True_230)
+                                case_True_233
+                                out_Bool_232
+                                (lam case_False_234 out_Bool_232 case_True_233)
                               )
                             )
                           ]
                           (abs
-                            out_Bool_232
+                            out_Bool_235
                             (type)
                             (lam
-                              case_True_233
-                              out_Bool_232
-                              (lam case_False_234 out_Bool_232 case_False_234)
+                              case_True_236
+                              out_Bool_235
+                              (lam case_False_237 out_Bool_235 case_False_237)
                             )
                           )
                         ]
                         (lam
-                          x_235
-                          (all out_Bool_236 (type) (fun out_Bool_236 (fun out_Bool_236 out_Bool_236)))
-                          x_235
+                          x_238
+                          (all out_Bool_239 (type) (fun out_Bool_239 (fun out_Bool_239 out_Bool_239)))
+                          x_238
                         )
                       ]
                     )
@@ -445,10 +445,10 @@
             )
           )
         )
-        (all out_unit_237 (type) (fun out_unit_237 out_unit_237))
+        (all out_unit_240 (type) (fun out_unit_240 out_unit_240))
       }
-      (abs out_unit_238 (type) (lam case_unit_239 out_unit_238 case_unit_239))
+      (abs out_unit_241 (type) (lam case_unit_242 out_unit_241 case_unit_242))
     ]
-    (lam x_240 (all out_unit_241 (type) (fun out_unit_241 out_unit_241)) x_240)
+    (lam x_243 (all out_unit_244 (type) (fun out_unit_244 out_unit_244)) x_243)
   ]
 )

--- a/core-to-plc/test/recursiveFunctions/sum.plc.golden
+++ b/core-to-plc/test/recursiveFunctions/sum.plc.golden
@@ -4,48 +4,48 @@
       [
         {
           (abs
-            list_153
+            list_154
             (fun (type) (type))
             (lam
-              list_154
-              (all a_155 (type) [list_153 a_155])
+              list_155
+              (all a_156 (type) [list_154 a_156])
               (lam
-                cons_156
-                (all a_157 (type) (fun a_157 (fun [list_153 a_157] [list_153 a_157])))
+                cons_157
+                (all a_158 (type) (fun a_158 (fun [list_154 a_158] [list_154 a_158])))
                 (lam
-                  p_match_158
-                  (all a_159 (type) (fun [list_153 a_159] [(lam a_160 (type) (all out_list_161 (type) (fun out_list_161 (fun (fun a_160 (fun [list_153 a_160] out_list_161)) out_list_161)))) a_159]))
+                  p_match_159
+                  (all a_160 (type) (fun [list_154 a_160] [(lam a_161 (type) (all out_list_162 (type) (fun out_list_162 (fun (fun a_161 (fun [list_154 a_161] out_list_162)) out_list_162)))) a_160]))
                   [
                     (lam
-                      addInteger_162
+                      addInteger_163
                       (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] [(con integer) (con 64)]))
                       [
                         (lam
-                          tuple_163
-                          [(lam t_0_164 (type) (all r_165 (type) (fun (fun t_0_164 r_165) r_165))) (fun [list_153 [(con integer) (con 64)]] [(con integer) (con 64)])]
+                          tuple_164
+                          [(lam t_0_165 (type) (all r_166 (type) (fun (fun t_0_165 r_166) r_166))) (fun [list_154 [(con integer) (con 64)]] [(con integer) (con 64)])]
                           [
                             (lam
-                              sum_166
-                              (fun [list_153 [(con integer) (con 64)]] [(con integer) (con 64)])
-                              sum_166
+                              sum_167
+                              (fun [list_154 [(con integer) (con 64)]] [(con integer) (con 64)])
+                              sum_167
                             )
                             [
                               {
                                 (abs
-                                  t_0_167
+                                  t_0_168
                                   (type)
                                   (lam
-                                    tuple_168
-                                    [(lam t_0_169 (type) (all r_170 (type) (fun (fun t_0_169 r_170) r_170))) t_0_167]
+                                    tuple_169
+                                    [(lam t_0_170 (type) (all r_171 (type) (fun (fun t_0_170 r_171) r_171))) t_0_168]
                                     [
-                                      { tuple_168 t_0_167 }
-                                      (lam arg_0_171 t_0_167 arg_0_171)
+                                      { tuple_169 t_0_168 }
+                                      (lam arg_0_172 t_0_168 arg_0_172)
                                     ]
                                   )
                                 )
-                                (fun [list_153 [(con integer) (con 64)]] [(con integer) (con 64)])
+                                (fun [list_154 [(con integer) (con 64)]] [(con integer) (con 64)])
                               }
-                              tuple_163
+                              tuple_164
                             ]
                           ]
                         )
@@ -53,81 +53,81 @@
                           {
                             {
                               (abs
-                                a_172
+                                a_173
                                 (type)
                                 (abs
-                                  b_173
+                                  b_174
                                   (type)
                                   [
                                     {
                                       (abs
-                                        F_174
+                                        F_175
                                         (fun (type) (type))
                                         (lam
-                                          by_175
-                                          (fun (all Q_176 (type) (fun [F_174 Q_176] Q_176)) (all Q_177 (type) (fun [F_174 Q_177] Q_177)))
+                                          by_176
+                                          (fun (all Q_177 (type) (fun [F_175 Q_177] Q_177)) (all Q_178 (type) (fun [F_175 Q_178] Q_178)))
                                           [
                                             {
                                               {
                                                 (abs
-                                                  a_178
+                                                  a_179
                                                   (type)
                                                   (abs
-                                                    b_179
+                                                    b_180
                                                     (type)
                                                     (lam
-                                                      f_180
-                                                      (fun (fun a_178 b_179) (fun a_178 b_179))
+                                                      f_181
+                                                      (fun (fun a_179 b_180) (fun a_179 b_180))
                                                       [
                                                         {
                                                           (abs
-                                                            a_181
+                                                            a_182
                                                             (type)
                                                             (lam
-                                                              s_182
-                                                              [(lam a_183 (type) (fix self_184 (fun self_184 a_183))) a_181]
+                                                              s_183
+                                                              [(lam a_184 (type) (fix self_185 (fun self_185 a_184))) a_182]
                                                               [
-                                                                (unwrap s_182)
-                                                                s_182
+                                                                (unwrap s_183)
+                                                                s_183
                                                               ]
                                                             )
                                                           )
-                                                          (fun a_178 b_179)
+                                                          (fun a_179 b_180)
                                                         }
                                                         (wrap
-                                                          self_185
-                                                          [(lam a_186 (type) (fun self_185 a_186)) (fun a_178 b_179)]
+                                                          self_186
+                                                          [(lam a_187 (type) (fun self_186 a_187)) (fun a_179 b_180)]
                                                           (lam
-                                                            s_187
-                                                            [(lam a_188 (type) (fix self_189 (fun self_189 a_188))) (fun a_178 b_179)]
+                                                            s_188
+                                                            [(lam a_189 (type) (fix self_190 (fun self_190 a_189))) (fun a_179 b_180)]
                                                             (lam
-                                                              x_190
-                                                              a_178
+                                                              x_191
+                                                              a_179
                                                               [
                                                                 [
-                                                                  f_180
+                                                                  f_181
                                                                   [
                                                                     {
                                                                       (abs
-                                                                        a_191
+                                                                        a_192
                                                                         (type)
                                                                         (lam
-                                                                          s_192
-                                                                          [(lam a_193 (type) (fix self_194 (fun self_194 a_193))) a_191]
+                                                                          s_193
+                                                                          [(lam a_194 (type) (fix self_195 (fun self_195 a_194))) a_192]
                                                                           [
                                                                             (unwrap
-                                                                              s_192
+                                                                              s_193
                                                                             )
-                                                                            s_192
+                                                                            s_193
                                                                           ]
                                                                         )
                                                                       )
-                                                                      (fun a_178 b_179)
+                                                                      (fun a_179 b_180)
                                                                     }
-                                                                    s_187
+                                                                    s_188
                                                                   ]
                                                                 ]
-                                                                x_190
+                                                                x_191
                                                               ]
                                                             )
                                                           )
@@ -136,53 +136,53 @@
                                                     )
                                                   )
                                                 )
-                                                (all Q_195 (type) (fun [F_174 Q_195] [F_174 Q_195]))
+                                                (all Q_196 (type) (fun [F_175 Q_196] [F_175 Q_196]))
                                               }
-                                              (all Q_196 (type) (fun [F_174 Q_196] Q_196))
+                                              (all Q_197 (type) (fun [F_175 Q_197] Q_197))
                                             }
                                             (lam
-                                              rec_197
-                                              (fun (all Q_198 (type) (fun [F_174 Q_198] [F_174 Q_198])) (all Q_199 (type) (fun [F_174 Q_199] Q_199)))
+                                              rec_198
+                                              (fun (all Q_199 (type) (fun [F_175 Q_199] [F_175 Q_199])) (all Q_200 (type) (fun [F_175 Q_200] Q_200)))
                                               (lam
-                                                h_200
-                                                (all Q_201 (type) (fun [F_174 Q_201] [F_174 Q_201]))
+                                                h_201
+                                                (all Q_202 (type) (fun [F_175 Q_202] [F_175 Q_202]))
                                                 (abs
-                                                  R_202
+                                                  R_203
                                                   (type)
                                                   (lam
-                                                    fr_203
-                                                    [F_174 R_202]
+                                                    fr_204
+                                                    [F_175 R_203]
                                                     [
                                                       {
                                                         [
-                                                          by_175
+                                                          by_176
                                                           (abs
-                                                            Q_204
+                                                            Q_205
                                                             (type)
                                                             (lam
-                                                              fq_205
-                                                              [F_174 Q_204]
+                                                              fq_206
+                                                              [F_175 Q_205]
                                                               [
                                                                 {
                                                                   [
-                                                                    rec_197
-                                                                    h_200
+                                                                    rec_198
+                                                                    h_201
                                                                   ]
-                                                                  Q_204
+                                                                  Q_205
                                                                 }
                                                                 [
                                                                   {
-                                                                    h_200 Q_204
+                                                                    h_201 Q_205
                                                                   }
-                                                                  fq_205
+                                                                  fq_206
                                                                 ]
                                                               ]
                                                             )
                                                           )
                                                         ]
-                                                        R_202
+                                                        R_203
                                                       }
-                                                      fr_203
+                                                      fr_204
                                                     ]
                                                   )
                                                 )
@@ -191,28 +191,28 @@
                                           ]
                                         )
                                       )
-                                      (lam X_206 (type) (fun (fun a_172 b_173) X_206))
+                                      (lam X_207 (type) (fun (fun a_173 b_174) X_207))
                                     }
                                     (lam
-                                      k_207
-                                      (all Q_208 (type) (fun (fun (fun a_172 b_173) Q_208) Q_208))
+                                      k_208
+                                      (all Q_209 (type) (fun (fun (fun a_173 b_174) Q_209) Q_209))
                                       (abs
-                                        S_209
+                                        S_210
                                         (type)
                                         (lam
-                                          h_210
-                                          (fun (fun a_172 b_173) S_209)
+                                          h_211
+                                          (fun (fun a_173 b_174) S_210)
                                           [
-                                            h_210
+                                            h_211
                                             (lam
-                                              x_211
-                                              a_172
+                                              x_212
+                                              a_173
                                               [
-                                                { k_207 b_173 }
+                                                { k_208 b_174 }
                                                 (lam
-                                                  f_212
-                                                  (fun a_172 b_173)
-                                                  [ f_212 x_211 ]
+                                                  f_213
+                                                  (fun a_173 b_174)
+                                                  [ f_213 x_212 ]
                                                 )
                                               ]
                                             )
@@ -223,47 +223,47 @@
                                   ]
                                 )
                               )
-                              [list_153 [(con integer) (con 64)]]
+                              [list_154 [(con integer) (con 64)]]
                             }
                             [(con integer) (con 64)]
                           }
                           (abs
-                            Q_213
+                            Q_214
                             (type)
                             (lam
-                              choose_214
-                              (fun (fun [list_153 [(con integer) (con 64)]] [(con integer) (con 64)]) Q_213)
+                              choose_215
+                              (fun (fun [list_154 [(con integer) (con 64)]] [(con integer) (con 64)]) Q_214)
                               (lam
-                                sum_215
-                                (fun [list_153 [(con integer) (con 64)]] [(con integer) (con 64)])
+                                sum_216
+                                (fun [list_154 [(con integer) (con 64)]] [(con integer) (con 64)])
                                 [
-                                  choose_214
+                                  choose_215
                                   (lam
-                                    ds_216
-                                    [list_153 [(con integer) (con 64)]]
+                                    ds_217
+                                    [list_154 [(con integer) (con 64)]]
                                     [
                                       [
                                         {
                                           [
                                             {
-                                              p_match_158
+                                              p_match_159
                                               [(con integer) (con 64)]
                                             }
-                                            ds_216
+                                            ds_217
                                           ]
                                           [(con integer) (con 64)]
                                         }
                                         (con 64 ! 0)
                                       ]
                                       (lam
-                                        x_217
+                                        x_218
                                         [(con integer) (con 64)]
                                         (lam
-                                          xs_218
-                                          [list_153 [(con integer) (con 64)]]
+                                          xs_219
+                                          [list_154 [(con integer) (con 64)]]
                                           [
-                                            [ addInteger_162 x_217 ]
-                                            [ sum_215 xs_218 ]
+                                            [ addInteger_163 x_218 ]
+                                            [ sum_216 xs_219 ]
                                           ]
                                         )
                                       )
@@ -282,24 +282,24 @@
               )
             )
           )
-          (fix list_219 (lam a_220 (type) (all out_list_221 (type) (fun out_list_221 (fun (fun a_220 (fun [list_219 a_220] out_list_221)) out_list_221)))))
+          (fix list_220 (lam a_221 (type) (all out_list_222 (type) (fun out_list_222 (fun (fun a_221 (fun [list_220 a_221] out_list_222)) out_list_222)))))
         }
         (abs
-          a_222
+          a_223
           (type)
           (wrap
-            list_223
-            (lam a_224 (type) (all out_list_225 (type) (fun out_list_225 (fun (fun a_224 (fun [list_223 a_224] out_list_225)) out_list_225))))
+            list_224
+            (lam a_225 (type) (all out_list_226 (type) (fun out_list_226 (fun (fun a_225 (fun [list_224 a_225] out_list_226)) out_list_226))))
             (abs
-              out_list_226
+              out_list_227
               (type)
               (lam
-                case_list_227
-                out_list_226
+                case_list_228
+                out_list_227
                 (lam
-                  case_cons_228
-                  (fun a_222 (fun [list_223 a_222] out_list_226))
-                  case_list_227
+                  case_cons_229
+                  (fun a_223 (fun [list_224 a_223] out_list_227))
+                  case_list_228
                 )
               )
             )
@@ -307,27 +307,27 @@
         )
       ]
       (abs
-        a_229
+        a_230
         (type)
         (lam
-          arg_0_230
-          a_229
+          arg_0_231
+          a_230
           (lam
-            arg_1_231
-            [(fix list_232 (lam a_233 (type) (all out_list_234 (type) (fun out_list_234 (fun (fun a_233 (fun [list_232 a_233] out_list_234)) out_list_234))))) a_229]
+            arg_1_232
+            [(fix list_233 (lam a_234 (type) (all out_list_235 (type) (fun out_list_235 (fun (fun a_234 (fun [list_233 a_234] out_list_235)) out_list_235))))) a_230]
             (wrap
-              list_235
-              (lam a_236 (type) (all out_list_237 (type) (fun out_list_237 (fun (fun a_236 (fun [list_235 a_236] out_list_237)) out_list_237))))
+              list_236
+              (lam a_237 (type) (all out_list_238 (type) (fun out_list_238 (fun (fun a_237 (fun [list_236 a_237] out_list_238)) out_list_238))))
               (abs
-                out_list_238
+                out_list_239
                 (type)
                 (lam
-                  case_list_239
-                  out_list_238
+                  case_list_240
+                  out_list_239
                   (lam
-                    case_cons_240
-                    (fun a_229 (fun [list_235 a_229] out_list_238))
-                    [ [ case_cons_240 arg_0_230 ] arg_1_231 ]
+                    case_cons_241
+                    (fun a_230 (fun [list_236 a_230] out_list_239))
+                    [ [ case_cons_241 arg_0_231 ] arg_1_232 ]
                   )
                 )
               )
@@ -337,12 +337,12 @@
       )
     ]
     (abs
-      a_241
+      a_242
       (type)
       (lam
-        x_242
-        [(fix list_243 (lam a_244 (type) (all out_list_245 (type) (fun out_list_245 (fun (fun a_244 (fun [list_243 a_244] out_list_245)) out_list_245))))) a_241]
-        (unwrap x_242)
+        x_243
+        [(fix list_244 (lam a_245 (type) (all out_list_246 (type) (fun out_list_246 (fun (fun a_245 (fun [list_244 a_245] out_list_246)) out_list_246))))) a_242]
+        (unwrap x_243)
       )
     )
   ]

--- a/core-to-plc/test/recursiveTypes/listMatch.plc.golden
+++ b/core-to-plc/test/recursiveTypes/listMatch.plc.golden
@@ -4,32 +4,32 @@
       [
         {
           (abs
-            list_85
+            list_86
             (fun (type) (type))
             (lam
-              list_86
-              (all a_87 (type) [list_85 a_87])
+              list_87
+              (all a_88 (type) [list_86 a_88])
               (lam
-                cons_88
-                (all a_89 (type) (fun a_89 (fun [list_85 a_89] [list_85 a_89])))
+                cons_89
+                (all a_90 (type) (fun a_90 (fun [list_86 a_90] [list_86 a_90])))
                 (lam
-                  p_match_90
-                  (all a_91 (type) (fun [list_85 a_91] [(lam a_92 (type) (all out_list_93 (type) (fun out_list_93 (fun (fun a_92 (fun [list_85 a_92] out_list_93)) out_list_93)))) a_91]))
+                  p_match_91
+                  (all a_92 (type) (fun [list_86 a_92] [(lam a_93 (type) (all out_list_94 (type) (fun out_list_94 (fun (fun a_93 (fun [list_86 a_93] out_list_94)) out_list_94)))) a_92]))
                   (lam
-                    ds_94
-                    [list_85 [(con integer) (con 64)]]
+                    ds_95
+                    [list_86 [(con integer) (con 64)]]
                     [
                       [
                         {
-                          [ { p_match_90 [(con integer) (con 64)] } ds_94 ]
+                          [ { p_match_91 [(con integer) (con 64)] } ds_95 ]
                           [(con integer) (con 64)]
                         }
                         (con 64 ! 0)
                       ]
                       (lam
-                        x_95
+                        x_96
                         [(con integer) (con 64)]
-                        (lam ds_96 [list_85 [(con integer) (con 64)]] x_95)
+                        (lam ds_97 [list_86 [(con integer) (con 64)]] x_96)
                       )
                     ]
                   )
@@ -37,24 +37,24 @@
               )
             )
           )
-          (fix list_97 (lam a_98 (type) (all out_list_99 (type) (fun out_list_99 (fun (fun a_98 (fun [list_97 a_98] out_list_99)) out_list_99)))))
+          (fix list_98 (lam a_99 (type) (all out_list_100 (type) (fun out_list_100 (fun (fun a_99 (fun [list_98 a_99] out_list_100)) out_list_100)))))
         }
         (abs
-          a_100
+          a_101
           (type)
           (wrap
-            list_101
-            (lam a_102 (type) (all out_list_103 (type) (fun out_list_103 (fun (fun a_102 (fun [list_101 a_102] out_list_103)) out_list_103))))
+            list_102
+            (lam a_103 (type) (all out_list_104 (type) (fun out_list_104 (fun (fun a_103 (fun [list_102 a_103] out_list_104)) out_list_104))))
             (abs
-              out_list_104
+              out_list_105
               (type)
               (lam
-                case_list_105
-                out_list_104
+                case_list_106
+                out_list_105
                 (lam
-                  case_cons_106
-                  (fun a_100 (fun [list_101 a_100] out_list_104))
-                  case_list_105
+                  case_cons_107
+                  (fun a_101 (fun [list_102 a_101] out_list_105))
+                  case_list_106
                 )
               )
             )
@@ -62,27 +62,27 @@
         )
       ]
       (abs
-        a_107
+        a_108
         (type)
         (lam
-          arg_0_108
-          a_107
+          arg_0_109
+          a_108
           (lam
-            arg_1_109
-            [(fix list_110 (lam a_111 (type) (all out_list_112 (type) (fun out_list_112 (fun (fun a_111 (fun [list_110 a_111] out_list_112)) out_list_112))))) a_107]
+            arg_1_110
+            [(fix list_111 (lam a_112 (type) (all out_list_113 (type) (fun out_list_113 (fun (fun a_112 (fun [list_111 a_112] out_list_113)) out_list_113))))) a_108]
             (wrap
-              list_113
-              (lam a_114 (type) (all out_list_115 (type) (fun out_list_115 (fun (fun a_114 (fun [list_113 a_114] out_list_115)) out_list_115))))
+              list_114
+              (lam a_115 (type) (all out_list_116 (type) (fun out_list_116 (fun (fun a_115 (fun [list_114 a_115] out_list_116)) out_list_116))))
               (abs
-                out_list_116
+                out_list_117
                 (type)
                 (lam
-                  case_list_117
-                  out_list_116
+                  case_list_118
+                  out_list_117
                   (lam
-                    case_cons_118
-                    (fun a_107 (fun [list_113 a_107] out_list_116))
-                    [ [ case_cons_118 arg_0_108 ] arg_1_109 ]
+                    case_cons_119
+                    (fun a_108 (fun [list_114 a_108] out_list_117))
+                    [ [ case_cons_119 arg_0_109 ] arg_1_110 ]
                   )
                 )
               )
@@ -92,12 +92,12 @@
       )
     ]
     (abs
-      a_119
+      a_120
       (type)
       (lam
-        x_120
-        [(fix list_121 (lam a_122 (type) (all out_list_123 (type) (fun out_list_123 (fun (fun a_122 (fun [list_121 a_122] out_list_123)) out_list_123))))) a_119]
-        (unwrap x_120)
+        x_121
+        [(fix list_122 (lam a_123 (type) (all out_list_124 (type) (fun out_list_124 (fun (fun a_123 (fun [list_122 a_123] out_list_124)) out_list_124))))) a_120]
+        (unwrap x_121)
       )
     )
   ]

--- a/core-to-plc/test/recursiveTypes/ptreeMatch.plc.golden
+++ b/core-to-plc/test/recursiveTypes/ptreeMatch.plc.golden
@@ -3,47 +3,47 @@
     [
       {
         (abs
-          bad_name_96
+          bad_name_97
           (fun (type) (fun (type) (type)))
           (lam
-            bad_name_97
-            (all a_98 (type) (all b_99 (type) (fun a_98 (fun b_99 [[bad_name_96 a_98] b_99]))))
+            bad_name_98
+            (all a_99 (type) (all b_100 (type) (fun a_99 (fun b_100 [[bad_name_97 a_99] b_100]))))
             (lam
-              p_match_100
-              (all a_101 (type) (all b_102 (type) (fun [[bad_name_96 a_101] b_102] [[(lam a_103 (type) (lam b_104 (type) (all out_bad_name_105 (type) (fun (fun a_103 (fun b_104 out_bad_name_105)) out_bad_name_105)))) a_101] b_102])))
+              p_match_101
+              (all a_102 (type) (all b_103 (type) (fun [[bad_name_97 a_102] b_103] [[(lam a_104 (type) (lam b_105 (type) (all out_bad_name_106 (type) (fun (fun a_104 (fun b_105 out_bad_name_106)) out_bad_name_106)))) a_102] b_103])))
               [
                 [
                   [
                     {
                       (abs
-                        B_106
+                        B_107
                         (fun (type) (type))
                         (lam
-                          One_107
-                          (all a_108 (type) (fun a_108 [B_106 a_108]))
+                          One_108
+                          (all a_109 (type) (fun a_109 [B_107 a_109]))
                           (lam
-                            Two_109
-                            (all a_110 (type) (fun [B_106 [[bad_name_96 a_110] a_110]] [B_106 a_110]))
+                            Two_110
+                            (all a_111 (type) (fun [B_107 [[bad_name_97 a_111] a_111]] [B_107 a_111]))
                             (lam
-                              B_match_111
-                              (all a_112 (type) (fun [B_106 a_112] [(lam a_113 (type) (all out_B_114 (type) (fun (fun a_113 out_B_114) (fun (fun [B_106 [[bad_name_96 a_113] a_113]] out_B_114) out_B_114)))) a_112]))
+                              B_match_112
+                              (all a_113 (type) (fun [B_107 a_113] [(lam a_114 (type) (all out_B_115 (type) (fun (fun a_114 out_B_115) (fun (fun [B_107 [[bad_name_97 a_114] a_114]] out_B_115) out_B_115)))) a_113]))
                               (lam
-                                ds_115
-                                [B_106 [(con integer) (con 64)]]
+                                ds_116
+                                [B_107 [(con integer) (con 64)]]
                                 [
                                   [
                                     {
                                       [
-                                        { B_match_111 [(con integer) (con 64)] }
-                                        ds_115
+                                        { B_match_112 [(con integer) (con 64)] }
+                                        ds_116
                                       ]
                                       [(con integer) (con 64)]
                                     }
-                                    (lam a_116 [(con integer) (con 64)] a_116)
+                                    (lam a_117 [(con integer) (con 64)] a_117)
                                   ]
                                   (lam
-                                    ds_117
-                                    [B_106 [[bad_name_96 [(con integer) (con 64)]] [(con integer) (con 64)]]]
+                                    ds_118
+                                    [B_107 [[bad_name_97 [(con integer) (con 64)]] [(con integer) (con 64)]]]
                                     (con 64 ! 2)
                                   )
                                 ]
@@ -52,27 +52,27 @@
                           )
                         )
                       )
-                      (fix B_118 (lam a_119 (type) (all out_B_120 (type) (fun (fun a_119 out_B_120) (fun (fun [B_118 [[bad_name_96 a_119] a_119]] out_B_120) out_B_120)))))
+                      (fix B_119 (lam a_120 (type) (all out_B_121 (type) (fun (fun a_120 out_B_121) (fun (fun [B_119 [[bad_name_97 a_120] a_120]] out_B_121) out_B_121)))))
                     }
                     (abs
-                      a_121
+                      a_122
                       (type)
                       (lam
-                        arg_0_122
-                        a_121
+                        arg_0_123
+                        a_122
                         (wrap
-                          B_123
-                          (lam a_124 (type) (all out_B_125 (type) (fun (fun a_124 out_B_125) (fun (fun [B_123 [[bad_name_96 a_124] a_124]] out_B_125) out_B_125))))
+                          B_124
+                          (lam a_125 (type) (all out_B_126 (type) (fun (fun a_125 out_B_126) (fun (fun [B_124 [[bad_name_97 a_125] a_125]] out_B_126) out_B_126))))
                           (abs
-                            out_B_126
+                            out_B_127
                             (type)
                             (lam
-                              case_One_127
-                              (fun a_121 out_B_126)
+                              case_One_128
+                              (fun a_122 out_B_127)
                               (lam
-                                case_Two_128
-                                (fun [B_123 [[bad_name_96 a_121] a_121]] out_B_126)
-                                [ case_One_127 arg_0_122 ]
+                                case_Two_129
+                                (fun [B_124 [[bad_name_97 a_122] a_122]] out_B_127)
+                                [ case_One_128 arg_0_123 ]
                               )
                             )
                           )
@@ -81,24 +81,24 @@
                     )
                   ]
                   (abs
-                    a_129
+                    a_130
                     (type)
                     (lam
-                      arg_0_130
-                      [(fix B_131 (lam a_132 (type) (all out_B_133 (type) (fun (fun a_132 out_B_133) (fun (fun [B_131 [[bad_name_96 a_132] a_132]] out_B_133) out_B_133))))) [[bad_name_96 a_129] a_129]]
+                      arg_0_131
+                      [(fix B_132 (lam a_133 (type) (all out_B_134 (type) (fun (fun a_133 out_B_134) (fun (fun [B_132 [[bad_name_97 a_133] a_133]] out_B_134) out_B_134))))) [[bad_name_97 a_130] a_130]]
                       (wrap
-                        B_134
-                        (lam a_135 (type) (all out_B_136 (type) (fun (fun a_135 out_B_136) (fun (fun [B_134 [[bad_name_96 a_135] a_135]] out_B_136) out_B_136))))
+                        B_135
+                        (lam a_136 (type) (all out_B_137 (type) (fun (fun a_136 out_B_137) (fun (fun [B_135 [[bad_name_97 a_136] a_136]] out_B_137) out_B_137))))
                         (abs
-                          out_B_137
+                          out_B_138
                           (type)
                           (lam
-                            case_One_138
-                            (fun a_129 out_B_137)
+                            case_One_139
+                            (fun a_130 out_B_138)
                             (lam
-                              case_Two_139
-                              (fun [B_134 [[bad_name_96 a_129] a_129]] out_B_137)
-                              [ case_Two_139 arg_0_130 ]
+                              case_Two_140
+                              (fun [B_135 [[bad_name_97 a_130] a_130]] out_B_138)
+                              [ case_Two_140 arg_0_131 ]
                             )
                           )
                         )
@@ -107,39 +107,39 @@
                   )
                 ]
                 (abs
-                  a_140
+                  a_141
                   (type)
                   (lam
-                    x_141
-                    [(fix B_142 (lam a_143 (type) (all out_B_144 (type) (fun (fun a_143 out_B_144) (fun (fun [B_142 [[bad_name_96 a_143] a_143]] out_B_144) out_B_144))))) a_140]
-                    (unwrap x_141)
+                    x_142
+                    [(fix B_143 (lam a_144 (type) (all out_B_145 (type) (fun (fun a_144 out_B_145) (fun (fun [B_143 [[bad_name_97 a_144] a_144]] out_B_145) out_B_145))))) a_141]
+                    (unwrap x_142)
                   )
                 )
               ]
             )
           )
         )
-        (lam a_145 (type) (lam b_146 (type) (all out_bad_name_147 (type) (fun (fun a_145 (fun b_146 out_bad_name_147)) out_bad_name_147))))
+        (lam a_146 (type) (lam b_147 (type) (all out_bad_name_148 (type) (fun (fun a_146 (fun b_147 out_bad_name_148)) out_bad_name_148))))
       }
       (abs
-        a_148
+        a_149
         (type)
         (abs
-          b_149
+          b_150
           (type)
           (lam
-            arg_0_150
-            a_148
+            arg_0_151
+            a_149
             (lam
-              arg_1_151
-              b_149
+              arg_1_152
+              b_150
               (abs
-                out_bad_name_152
+                out_bad_name_153
                 (type)
                 (lam
-                  case_bad_name_153
-                  (fun a_148 (fun b_149 out_bad_name_152))
-                  [ [ case_bad_name_153 arg_0_150 ] arg_1_151 ]
+                  case_bad_name_154
+                  (fun a_149 (fun b_150 out_bad_name_153))
+                  [ [ case_bad_name_154 arg_0_151 ] arg_1_152 ]
                 )
               )
             )
@@ -148,15 +148,15 @@
       )
     ]
     (abs
-      a_154
+      a_155
       (type)
       (abs
-        b_155
+        b_156
         (type)
         (lam
-          x_156
-          [[(lam a_157 (type) (lam b_158 (type) (all out_bad_name_159 (type) (fun (fun a_157 (fun b_158 out_bad_name_159)) out_bad_name_159)))) a_154] b_155]
-          x_156
+          x_157
+          [[(lam a_158 (type) (lam b_159 (type) (all out_bad_name_160 (type) (fun (fun a_158 (fun b_159 out_bad_name_160)) out_bad_name_160)))) a_155] b_156]
+          x_157
         )
       )
     )

--- a/plutus-th/test/and.plc.golden
+++ b/plutus-th/test/and.plc.golden
@@ -3,89 +3,89 @@
     [
       {
         (abs
-          unit_82
+          unit_83
           (type)
           (lam
+            unit_84
             unit_83
-            unit_82
             (lam
-              p_match_84
-              (fun unit_82 (all out_unit_85 (type) (fun out_unit_85 out_unit_85)))
+              p_match_85
+              (fun unit_83 (all out_unit_86 (type) (fun out_unit_86 out_unit_86)))
               [
                 [
                   [
                     {
                       (abs
-                        Bool_86
+                        Bool_87
                         (type)
                         (lam
-                          True_87
-                          Bool_86
+                          True_88
+                          Bool_87
                           (lam
-                            False_88
-                            Bool_86
+                            False_89
+                            Bool_87
                             (lam
-                              Bool_match_89
-                              (fun Bool_86 (all out_Bool_90 (type) (fun out_Bool_90 (fun out_Bool_90 out_Bool_90))))
+                              Bool_match_90
+                              (fun Bool_87 (all out_Bool_91 (type) (fun out_Bool_91 (fun out_Bool_91 out_Bool_91))))
                               [
                                 (lam
-                                  ds_91
-                                  Bool_86
+                                  ds_92
+                                  Bool_87
                                   [
                                     [
                                       [
                                         {
-                                          [ Bool_match_89 ds_91 ]
-                                          (fun unit_82 Bool_86)
+                                          [ Bool_match_90 ds_92 ]
+                                          (fun unit_83 Bool_87)
                                         }
-                                        (lam thunk_92 unit_82 True_87)
+                                        (lam thunk_93 unit_83 True_88)
                                       ]
-                                      (lam thunk_93 unit_82 False_88)
+                                      (lam thunk_94 unit_83 False_89)
                                     ]
-                                    unit_83
+                                    unit_84
                                   ]
                                 )
-                                False_88
+                                False_89
                               ]
                             )
                           )
                         )
                       )
-                      (all out_Bool_94 (type) (fun out_Bool_94 (fun out_Bool_94 out_Bool_94)))
+                      (all out_Bool_95 (type) (fun out_Bool_95 (fun out_Bool_95 out_Bool_95)))
                     }
                     (abs
-                      out_Bool_95
+                      out_Bool_96
                       (type)
                       (lam
-                        case_True_96
-                        out_Bool_95
-                        (lam case_False_97 out_Bool_95 case_True_96)
+                        case_True_97
+                        out_Bool_96
+                        (lam case_False_98 out_Bool_96 case_True_97)
                       )
                     )
                   ]
                   (abs
-                    out_Bool_98
+                    out_Bool_99
                     (type)
                     (lam
-                      case_True_99
-                      out_Bool_98
-                      (lam case_False_100 out_Bool_98 case_False_100)
+                      case_True_100
+                      out_Bool_99
+                      (lam case_False_101 out_Bool_99 case_False_101)
                     )
                   )
                 ]
                 (lam
-                  x_101
-                  (all out_Bool_102 (type) (fun out_Bool_102 (fun out_Bool_102 out_Bool_102)))
-                  x_101
+                  x_102
+                  (all out_Bool_103 (type) (fun out_Bool_103 (fun out_Bool_103 out_Bool_103)))
+                  x_102
                 )
               ]
             )
           )
         )
-        (all out_unit_103 (type) (fun out_unit_103 out_unit_103))
+        (all out_unit_104 (type) (fun out_unit_104 out_unit_104))
       }
-      (abs out_unit_104 (type) (lam case_unit_105 out_unit_104 case_unit_105))
+      (abs out_unit_105 (type) (lam case_unit_106 out_unit_105 case_unit_106))
     ]
-    (lam x_106 (all out_unit_107 (type) (fun out_unit_107 out_unit_107)) x_106)
+    (lam x_107 (all out_unit_108 (type) (fun out_unit_108 out_unit_108)) x_107)
   ]
 )

--- a/plutus-th/test/simple.plc.golden
+++ b/plutus-th/test/simple.plc.golden
@@ -4,23 +4,23 @@
       [
         {
           (abs
-            Bool_76
+            Bool_77
             (type)
             (lam
-              True_77
-              Bool_76
+              True_78
+              Bool_77
               (lam
-                False_78
-                Bool_76
+                False_79
+                Bool_77
                 (lam
-                  Bool_match_79
-                  (fun Bool_76 (all out_Bool_80 (type) (fun out_Bool_80 (fun out_Bool_80 out_Bool_80))))
+                  Bool_match_80
+                  (fun Bool_77 (all out_Bool_81 (type) (fun out_Bool_81 (fun out_Bool_81 out_Bool_81))))
                   (lam
-                    ds_81
-                    Bool_76
+                    ds_82
+                    Bool_77
                     [
                       [
-                        { [ Bool_match_79 ds_81 ] [(con integer) (con 64)] }
+                        { [ Bool_match_80 ds_82 ] [(con integer) (con 64)] }
                         (con 64 ! 1)
                       ]
                       (con 64 ! 2)
@@ -30,30 +30,30 @@
               )
             )
           )
-          (all out_Bool_82 (type) (fun out_Bool_82 (fun out_Bool_82 out_Bool_82)))
+          (all out_Bool_83 (type) (fun out_Bool_83 (fun out_Bool_83 out_Bool_83)))
         }
         (abs
-          out_Bool_83
+          out_Bool_84
           (type)
           (lam
-            case_True_84
-            out_Bool_83
-            (lam case_False_85 out_Bool_83 case_True_84)
+            case_True_85
+            out_Bool_84
+            (lam case_False_86 out_Bool_84 case_True_85)
           )
         )
       ]
       (abs
-        out_Bool_86
+        out_Bool_87
         (type)
         (lam
-          case_True_87 out_Bool_86 (lam case_False_88 out_Bool_86 case_False_88)
+          case_True_88 out_Bool_87 (lam case_False_89 out_Bool_87 case_False_89)
         )
       )
     ]
     (lam
-      x_89
-      (all out_Bool_90 (type) (fun out_Bool_90 (fun out_Bool_90 out_Bool_90)))
-      x_89
+      x_90
+      (all out_Bool_91 (type) (fun out_Bool_91 (fun out_Bool_91 out_Bool_91)))
+      x_90
     )
   ]
 )

--- a/wallet-api/src/Wallet/UTXO/Types.hs
+++ b/wallet-api/src/Wallet/UTXO/Types.hs
@@ -327,7 +327,7 @@ instance BA.ByteArrayAccess Redeemer where
         BA.withByteArray . Write.toStrictByteString . encode
 
 -- | Block height
-newtype Height = Height { getHeight :: Integer }
+newtype Height = Height { getHeight :: Int }
     deriving (Eq, Ord, Show, Enum)
     deriving stock (Generic)
     deriving newtype (Num, Real, Integral, Serialise, FromJSON, ToJSON)


### PR DESCRIPTION
- Support the GHC runtime errors from e.g. failed pattern matches.
- Support `@` patterns properly.
    - This is painless at the code level due to PIR, but unfortunately I changed the order in which we compile things so all the uniques change again. Need that clever golden testing lib...
- Explicitly don't support record selectors.
    - This is surprisingly non-trivial to support properly, and can always be replaced by pattern-matching.
- Use our own definition of `Ratio` inside `Swap`.