### PR TITLE
plutus-ir: implement dead-code checker in terms of dependency graphs

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55717,6 +55717,7 @@ license = stdenv.lib.licenses.bsd3;
 "plutus-ir" = callPackage
 ({
   mkDerivation
+, algebraic-graphs
 , base
 , bytestring
 , containers
@@ -55738,6 +55739,7 @@ pname = "plutus-ir";
 version = "0.1.0.0";
 src = .././plutus-ir;
 libraryHaskellDepends = [
+algebraic-graphs
 base
 bytestring
 containers

--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -32,6 +32,8 @@ library
         Language.PlutusIR.Optimizer.DeadCode
     hs-source-dirs: src
     other-modules:
+        Language.PlutusIR.Analysis.Dependencies
+        Language.PlutusIR.Analysis.Usages
         Language.PlutusIR.Compiler.Error
         Language.PlutusIR.Compiler.Term
         Language.PlutusIR.Compiler.Datatype
@@ -61,7 +63,8 @@ library
         mmorph -any,
         prettyprinter -any,
         text -any,
-        transformers -any
+        transformers -any,
+        algebraic-graphs -any
 
     if (flag(development) && impl(ghc <8.4))
         ghc-options: -Werror

--- a/plutus-ir/src/Language/PlutusIR/Analysis/Dependencies.hs
+++ b/plutus-ir/src/Language/PlutusIR/Analysis/Dependencies.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs            #-}
+{-# LANGUAGE LambdaCase       #-}
+-- | Functions for computing the dependency graph of variables within a term or type.
+module Language.PlutusIR.Analysis.Dependencies (Node (..), DepGraph, runTermDeps, runTypeDeps) where
+
+import qualified Language.PlutusCore               as PLC
+import qualified Language.PlutusCore.Name          as PLC
+
+import           Language.PlutusIR
+import qualified Language.PlutusIR.Analysis.Usages as Usages
+
+import           Control.Lens
+import           Control.Monad.Reader
+
+import qualified Algebra.Graph.Class               as G
+import qualified Data.Set                          as Set
+
+-- | A node in a dependency graph. Either a specific 'PLC.Unique', or a specific
+-- node indicating the root of the graph. We need the root node because when computing the
+-- dependency graph of, say, a term, there will not be a binding for the term itself which
+-- we can use to represent it in the graph.
+data Node = Variable PLC.Unique | Root deriving (Show, Eq, Ord)
+
+-- | A constraint requiring @g@ to be a 'G.Graph' (so we can compute e.g. a @Relation@ from it), whose
+-- vertices are 'Node's.
+type DepGraph g = (G.Graph g, (G.Vertex g)~Node)
+
+-- | Compute the dependency graph of a 'Term'. The 'Root' node will correspond to the term itself.
+--
+-- For example, the graph of @[(let (nonrec) (vardecl x t) y) [x z]]@ is
+-- @
+--     ROOT -> x
+--     ROOT -> z
+--     x -> y
+--     x -> t
+-- @
+runTermDeps
+    :: (DepGraph g, PLC.HasUnique (tyname a) PLC.TypeUnique, PLC.HasUnique (name a) PLC.TermUnique)
+    => Term tyname name a
+    -> g
+runTermDeps t = runReader (termDeps t) Root
+
+-- | Compute the dependency graph of a 'Type'. The 'Root' node will correspond to the type itself.
+--
+-- This graph will always be simply a star from 'Root', since types have no internal let-bindings.
+--
+-- For example, the graph of @(all a (type) [f a])@ is:
+-- @
+--     ROOT -> f
+--     ROOT -> a
+-- @
+--
+runTypeDeps
+    :: (DepGraph g, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => Type tyname a
+    -> g
+runTypeDeps t = runReader (typeDeps t) Root
+
+-- | Record some dependencies on the current node.
+recordDeps
+    :: (DepGraph g, MonadReader Node m)
+    => [PLC.Unique]
+    -> m g
+recordDeps us = do
+    current <- ask
+    pure $ G.connect (G.vertices [current]) (G.vertices (fmap Variable us))
+
+-- | Process the given action with the given name as the current node.
+withCurrent
+    :: (MonadReader Node m, PLC.HasUnique n u)
+    => n
+    -> m g
+    -> m g
+withCurrent n = local (const $ Variable $ n ^. PLC.unique . coerced)
+
+bindingDeps
+    :: (DepGraph g, MonadReader Node m, PLC.HasUnique (tyname a) PLC.TypeUnique, PLC.HasUnique (name a) PLC.TermUnique)
+    => Binding tyname name a
+    -> m g
+bindingDeps b = case b of
+    TermBind _ d@(VarDecl _ n _) rhs -> do
+        vDeps <- varDeclDeps d
+        tDeps <- withCurrent n $ termDeps rhs
+        pure $ G.overlay vDeps tDeps
+    TypeBind _ d@(TyVarDecl _ n _) rhs -> do
+        vDeps <- tyVarDeclDeps d
+        tDeps <- withCurrent n $ typeDeps rhs
+        pure $ G.overlay vDeps tDeps
+    DatatypeBind _ (Datatype _ d tvs _ constrs) -> do
+        vDeps <- tyVarDeclDeps d
+        tvDeps <- traverse tyVarDeclDeps tvs
+        cstrDeps <- traverse varDeclDeps constrs
+        pure $ G.overlays $ [vDeps] ++ tvDeps ++ cstrDeps
+
+varDeclDeps
+    :: (DepGraph g, MonadReader Node m, PLC.HasUnique (tyname a) PLC.TypeUnique, PLC.HasUnique (name a) PLC.TermUnique)
+    => VarDecl tyname name a
+    -> m g
+varDeclDeps (VarDecl _ n ty) = withCurrent n $ typeDeps ty
+
+-- Here for completeness, but doesn't do much
+tyVarDeclDeps
+    :: (G.Graph g, MonadReader Node m)
+    => TyVarDecl tyname a
+    -> m g
+tyVarDeclDeps _ = pure G.empty
+
+-- | Compute the dependency graph of a term. Takes an initial 'Node' indicating what the term itself depends on
+-- (usually 'Root' if it is the real term you are interested in).
+termDeps
+    :: (DepGraph g, MonadReader Node m, PLC.HasUnique (tyname a) PLC.TypeUnique, PLC.HasUnique (name a) PLC.TermUnique)
+    => Term tyname name a
+    -> m g
+termDeps = \case
+    Let _ _ bs t -> do
+        bGraphs <- traverse bindingDeps bs
+        bodyGraph <- termDeps t
+        pure $ G.overlays $ bGraphs ++ [bodyGraph]
+    Var _ n -> recordDeps [n ^. PLC.unique . coerced]
+    TyAbs _ _ _ t -> termDeps t
+    LamAbs _ _ ty t -> G.overlay <$> typeDeps ty <*> termDeps t
+    Apply _ t1 t2 -> G.overlay <$> termDeps t1 <*> termDeps t2
+    TyInst _ t ty -> G.overlay <$> termDeps t <*> typeDeps ty
+    Error _ ty -> typeDeps ty
+    Wrap _ _ ty t -> G.overlay <$> typeDeps ty <*> termDeps t
+    Unwrap _ t -> termDeps t
+    Constant{} -> pure G.empty
+    Builtin{} -> pure G.empty
+
+-- | Compute the dependency graph of a type. Takes an initial 'Node' indicating what the type itself depends on
+-- (usually 'Root' if it is the real type you are interested in).
+typeDeps
+    :: (DepGraph g, MonadReader Node m, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => Type tyname a
+    -> m g
+typeDeps ty =
+    -- The dependency graph of a type is very simple since it doesn't have any internal let-bindings. So we just
+    -- need to find all the used variables and mark them as dependencies of the current node.
+    let
+        used = Usages.allUsed $ Usages.runTypeUsages ty
+    in recordDeps (Set.toList used)

--- a/plutus-ir/src/Language/PlutusIR/Analysis/Usages.hs
+++ b/plutus-ir/src/Language/PlutusIR/Analysis/Usages.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase       #-}
+-- | Functions for computing variable usage inside terms and types.
+module Language.PlutusIR.Analysis.Usages (runTermUsages, runTypeUsages, Usages, isUsed, allUsed) where
+
+import           Language.PlutusIR
+
+import qualified Language.PlutusCore      as PLC
+import qualified Language.PlutusCore.Name as PLC
+
+import           Control.Lens
+import           Control.Monad.State
+
+import           Data.Coerce
+import           Data.Foldable
+import qualified Data.Map                 as Map
+import qualified Data.Set                 as Set
+
+-- | Variable uses, as a map from the 'PLC.Unique' to its usage count. Unused variables may be missing
+-- or have usage count 0.
+type Usages = Map.Map PLC.Unique Int
+
+addUsage :: (PLC.HasUnique n unique) => n -> Usages -> Usages
+addUsage n usages =
+    let
+        u = coerce $ n ^. PLC.unique
+        old = Map.findWithDefault 0 u usages
+    in Map.insert u (old+1) usages
+
+isUsed :: (PLC.HasUnique n unique) => n -> Usages -> Bool
+isUsed n usages = Map.findWithDefault 0 (n ^. PLC.unique . coerced) usages > 0
+
+allUsed :: Usages -> Set.Set PLC.Unique
+allUsed usages = Map.keysSet $ Map.filter (> 0) usages
+
+-- | Compute the 'Usages' for a 'Term'.
+runTermUsages
+    :: (PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => Term tyname name a
+    -> Usages
+runTermUsages term = execState (termUsages term) mempty
+
+-- | Compute the 'Usages' for a 'Type'.
+runTypeUsages
+    ::(PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => Type tyname a
+    -> Usages
+runTypeUsages ty = execState (typeUsages ty) mempty
+
+termUsages
+    :: (MonadState Usages m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => Term tyname name a
+    -> m ()
+termUsages term = case term of
+    Let _ _ bs t    -> traverse_ bindingUsages bs >> termUsages t
+    Var _ n         -> modify (addUsage n)
+    TyAbs _ _ _ t   -> termUsages t
+    LamAbs _ _ ty t -> typeUsages ty >> termUsages t
+    Apply _ t1 t2   -> termUsages t1 >> termUsages t2
+    TyInst _ t ty   -> termUsages t >> typeUsages ty
+    Error _ ty      -> typeUsages ty
+    Wrap _ _ ty t   -> typeUsages ty >> termUsages t
+    Unwrap _ t      -> termUsages t
+    Constant _ _    -> pure ()
+    Builtin _ _     -> pure ()
+
+varDeclUsages
+    :: (MonadState Usages m, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => VarDecl tyname name a
+    -> m ()
+varDeclUsages (VarDecl _ _ ty) = typeUsages ty
+
+-- Here for completeness but doesn't do much. Would matter if we had kind variables we had to check for.
+tyVarDeclUsages
+    :: (MonadState Usages m)
+    => TyVarDecl tyname a
+    -> m ()
+tyVarDeclUsages _ = pure ()
+
+bindingUsages
+    :: (MonadState Usages m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => Binding tyname name a
+    -> m ()
+bindingUsages = \case
+    TermBind _ _ rhs -> termUsages rhs
+    TypeBind _ _ rhs -> typeUsages rhs
+    DatatypeBind _ (Datatype _ d tvs _ constrs) -> do
+        tyVarDeclUsages d
+        traverse_ tyVarDeclUsages tvs
+        traverse_ varDeclUsages constrs
+
+-- TODO: move to language-plutus-core
+typeUsages
+    :: (MonadState Usages m, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    => Type tyname a
+    -> m ()
+typeUsages ty = case ty of
+    TyVar _ n        -> modify (addUsage n)
+    TyFun _ t1 t2    -> typeUsages t1 >> typeUsages t2
+    TyFix _ _ t      -> typeUsages t
+    TyForall _ _ _ t -> typeUsages t
+    TyLam _ _ _ t    -> typeUsages t
+    TyApp _ t1 t2    -> typeUsages t1 >> typeUsages t2
+    TyBuiltin _ _    -> pure ()
+    TyInt _ _        -> pure ()

--- a/plutus-ir/src/Language/PlutusIR/Optimizer/DeadCode.hs
+++ b/plutus-ir/src/Language/PlutusIR/Optimizer/DeadCode.hs
@@ -4,75 +4,59 @@
 module Language.PlutusIR.Optimizer.DeadCode (removeDeadBindings) where
 
 import           Language.PlutusIR
+import qualified Language.PlutusIR.Analysis.Dependencies as Deps
 
-import qualified Language.PlutusCore      as PLC
-import qualified Language.PlutusCore.Name as PLC
+import qualified Language.PlutusCore                     as PLC
+import qualified Language.PlutusCore.Name                as PLC
 
 import           Control.Lens
 import           Control.Monad
-import           Control.Monad.State
+import           Control.Monad.Reader
 
 import           Data.Coerce
-import qualified Data.IntMap              as IM
+import qualified Data.Set                                as Set
+
+import qualified Algebra.Graph                           as G
+import qualified Algebra.Graph.AdjacencyMap              as AM
+import qualified Algebra.Graph.ToGraph                   as T
 
 -- | Remove all the dead let bindings in a term.
 removeDeadBindings
     :: (PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
     => Term tyname name a
     -> Term tyname name a
-removeDeadBindings t = evalState (processTerm t) mempty
+removeDeadBindings t =
+    let
+        depGraph :: G.Graph Deps.Node
+        depGraph = Deps.runTermDeps t
+        liveNodes :: Liveness
+        liveNodes = Set.fromList $ AM.reachable Deps.Root (T.toAdjacencyMap depGraph)
+    in runReader (processTerm t) liveNodes
 
-type Usages = IM.IntMap Int
+type Liveness = Set.Set Deps.Node
 
-addUsage :: (PLC.HasUnique n unique) => n -> Usages -> Usages
-addUsage n usages =
+live :: (MonadReader Liveness m, PLC.HasUnique n unique) => n -> m Bool
+live n =
     let
         u = coerce $ n ^. PLC.unique
-        old = IM.findWithDefault 0 (PLC.unUnique u) usages
-    in IM.insert (PLC.unUnique u) (old+1) usages
-
-hasUsage :: (PLC.HasUnique n unique) => n -> Usages -> Bool
-hasUsage n usages =
-    let
-        u = coerce $ n ^. PLC.unique
-    in IM.findWithDefault 0 (PLC.unUnique u) usages > 0
+    in asks $ Set.member (Deps.Variable u)
 
 liveBinding
-    :: (MonadState Usages m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    :: (MonadReader Liveness m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
     => Binding tyname name a
     -> m Bool
 liveBinding b =
     let
         -- TODO: HasUnique instances for VarDecl and TyVarDecl?
-        hasUsageVarDecl (VarDecl _ n _) = hasUsage n
-        hasUsageTyVarDecl (TyVarDecl _ n _) = hasUsage n
+        liveVarDecl (VarDecl _ n _) = live n
+        liveTyVarDecl (TyVarDecl _ n _) = live n
     in case b of
-        TermBind _ d _ -> gets $ hasUsageVarDecl d
-        TypeBind _ d _ -> gets $ hasUsageTyVarDecl d
-        DatatypeBind _ (Datatype _ d _ destr constrs) -> do
-            usages <- get
-            let used = hasUsageTyVarDecl d usages || hasUsage destr usages || any (\c -> hasUsageVarDecl c usages) constrs
-            pure used
-
-{- Note [Simultaneous usage analysis and dead binding elimination]
-It's tempting to say that usage analysis and dead binding elmination should be
-separate passes. We could proceed for each let by:
-- Processing the body.
-- Getting the usages for the body.
-- Removing dead bindings.
-
-But this is quadratic, because it traverses subterms many times. The problem is that
-the usage information for subterms remains relevant when processing superterms, and
-it is very wasteful to recompute it. Possibly there is an elegant way to separate
-the code without making the computation wasteful, but for now we simply do the two
-operations interleaved.
-
-(It would be especially nice if we could move e.g. the usage analysis for types into
-the Plutus Core library.)
--}
+        TermBind _ d _ -> liveVarDecl d
+        TypeBind _ d _ -> liveTyVarDecl d
+        DatatypeBind _ (Datatype _ d _ destr constrs) -> or <$> (sequence $ [liveTyVarDecl d,  live destr] ++ fmap liveVarDecl constrs)
 
 processTerm
-    :: (MonadState Usages m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    :: (MonadReader Liveness m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
     => Term tyname name a
     -> m (Term tyname name a)
 processTerm term = case term of
@@ -80,17 +64,7 @@ processTerm term = case term of
         t' <- processTerm t
 
         -- throw away dead bindings
-        liveBindings <- case r of
-            NonRec -> filterM liveBinding bs
-            Rec    -> do
-                -- TODO: more precise tracking of deadness of recursive bindings, probably will
-                -- require a fancier algorithm or a proper dependency graph
-                liveness <- traverse liveBinding bs
-                -- if any binding is live assume they all are, otherwise we can
-                -- safely ditch them all
-                if or liveness
-                then pure bs
-                else pure []
+        liveBindings <- filterM liveBinding bs
 
         -- now handle usages and dead bindings with the bindings themselves
         processedBindings <- traverse processBinding liveBindings
@@ -99,51 +73,22 @@ processTerm term = case term of
         if null processedBindings
         then pure t'
         else pure $ Let x r processedBindings t'
-    Var x n -> do
-        modify (addUsage n)
-        pure $ Var x n
     TyAbs x tn k t -> TyAbs x tn k <$> processTerm t
-    LamAbs x n ty t -> LamAbs x n <$> processTy ty <*> processTerm t
+    LamAbs x n ty t -> LamAbs x n ty <$> processTerm t
     Apply x t1 t2 -> Apply x <$> processTerm t1 <*> processTerm t2
-    Constant x c -> pure $ Constant x c
-    Builtin x bi -> pure $ Builtin x bi
-    TyInst x t ty -> TyInst x <$> processTerm t <*> processTy ty
-    Error x ty -> Error x <$> processTy ty
-    Wrap x n ty t -> Wrap x n <$> processTy ty <*> processTerm t
+    TyInst x t ty -> TyInst x <$> processTerm t <*> pure ty
+    Wrap x n ty t -> Wrap x n ty <$> processTerm t
     Unwrap x t -> Unwrap x <$> processTerm t
-
-processVarDecl
-    :: (MonadState Usages m, PLC.HasUnique (tyname a) PLC.TypeUnique)
-    => VarDecl tyname name a
-    -> m (VarDecl tyname name a)
-processVarDecl (VarDecl x n ty) = VarDecl x n <$> processTy ty
-
-processTyVarDecl
-    :: (MonadState Usages m)
-    => TyVarDecl tyname a
-    -> m (TyVarDecl tyname a)
-processTyVarDecl (TyVarDecl x n k) = pure $ TyVarDecl x n k
+    t@Constant{} -> pure t
+    t@Builtin{} -> pure t
+    t@Var{} -> pure t
+    t@Error{} -> pure t
 
 processBinding
-    :: (MonadState Usages m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
+    :: (MonadReader Liveness m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
     => Binding tyname name a
     -> m (Binding tyname name a)
 processBinding = \case
     TermBind x d rhs -> TermBind x d <$> processTerm rhs
-    TypeBind x d rhs -> TypeBind x d <$> processTy rhs
-    DatatypeBind x (Datatype x' d tvs destr constrs) -> do
-        dt <- Datatype x' <$> processTyVarDecl d <*> traverse processTyVarDecl tvs <*> pure destr <*> traverse processVarDecl constrs
-        pure $ DatatypeBind x dt
-
-processTy :: (MonadState Usages m, PLC.HasUnique (tyname a) PLC.TypeUnique) => Type tyname a -> m (Type tyname a)
-processTy ty = case ty of
-    TyVar x n -> do
-        modify (addUsage n)
-        pure $ TyVar x n
-    TyFun x t1 t2 -> TyFun x <$> processTy t1 <*> processTy t2
-    TyFix x n t -> TyFix x n <$> processTy t
-    TyForall x tn k t -> TyForall x tn k <$> processTy t
-    TyBuiltin x b -> pure $ TyBuiltin x b
-    TyInt x n -> pure $ TyInt x n
-    TyLam x n k t -> TyLam x n k <$> processTy t
-    TyApp x t1 t2 -> TyApp x <$> processTy t1 <*> processTy t2
+    b@TypeBind{} -> pure b
+    b@DatatypeBind{} -> pure b

--- a/plutus-ir/test/OptimizerSpec.hs
+++ b/plutus-ir/test/OptimizerSpec.hs
@@ -2,22 +2,17 @@
 module OptimizerSpec where
 
 import           Common
-import           PlcTestUtils
 import           TestLib
 
 import           Language.PlutusCore.Quote
 
 import           Language.PlutusIR
-import           Language.PlutusIR.Compiler
 import           Language.PlutusIR.MkPir
 import           Language.PlutusIR.Optimizer.DeadCode
 
 import qualified Language.PlutusCore                  as PLC
-import qualified Language.PlutusCore.MkPlc            as PLC
 
 import qualified Language.PlutusCore.StdLib.Data.Unit as Unit
-
-import           Test.Tasty
 
 optimizer :: TestNested
 optimizer = testNested "optimizer" [
@@ -141,8 +136,6 @@ recBindingComplex = removeDeadBindings <$> do
     uv <- freshName () "unitval"
     unit <- Unit.getBuiltinUnit
     unitVal <- embedIntoIR <$> Unit.getBuiltinUnitval
-    -- TODO: the term binding is live but the the type binding isn't, but
-    -- we are paranoid so we keep it
     pure $ Let () Rec [
         TypeBind () (TyVarDecl () u (PLC.Type ())) unit,
         TermBind () (VarDecl () uv unit) unitVal

--- a/plutus-ir/test/optimizer/deadCode/recBindingComplex.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/recBindingComplex.plc.golden
@@ -1,6 +1,5 @@
 (let
   (rec)
-  (typebind (tyvardecl unit (type)) (all a (type) (fun a a)))
   (termbind
     (vardecl unitval (all a (type) (fun a a))) (abs a (type) (lam x a x))
   )


### PR DESCRIPTION
This is a pretty inessential PR implemented mostly for my own satisfaction. It makes things a bit nicer and a bit more made of separately usable components. As a bonus, it does now have better handling of recursive lets, improving the results on one of the tests.

- PIR learns a variable usage analysis
    - The usage analysis for types could be moved to `language-plutus-core` in future.
- PIR learns a variable dependency graph analysis using algebraic graphs
    - This delegates to the usage analysis in the case of types, as they have no internal let-bindings.
- The dead-binding analysis simply uses the dependency graph to compute the set of live bindings, and then uses that.