### PR TITLE
Fix some warnings

### DIFF
--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Denotation.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Denotation.hs
@@ -22,7 +22,6 @@ import qualified Data.ByteString.Lazy         as BSL
 import           Data.Dependent.Map           (DMap)
 import qualified Data.Dependent.Map           as DMap
 import           Data.Functor.Compose
-import           Data.Semigroup
 
 -- | Haskell denotation of a PLC object. An object can be a 'BuiltinName' or a variable for example.
 data Denotation object size r = forall a. Denotation

--- a/language-plutus-core/prelude/PlutusPrelude.hs
+++ b/language-plutus-core/prelude/PlutusPrelude.hs
@@ -28,7 +28,6 @@ module PlutusPrelude ( -- * Reëxports from base
                      , Natural
                      , NonEmpty (..)
                      , Word8
-                     , Semigroup (..)
                      , Alternative (..)
                      , Exception
                      , PairT (..)
@@ -104,7 +103,6 @@ import           Data.Functor.Foldable                   (Base, Corecursive, Rec
 import           Data.List                               (foldl')
 import           Data.List.NonEmpty                      (NonEmpty (..))
 import           Data.Maybe                              (isJust)
-import           Data.Semigroup
 import qualified Data.Text                               as T
 import qualified Data.Text.Encoding                      as TE
 import           Data.Text.Prettyprint.Doc

--- a/language-plutus-core/test/Evaluation/Constant/Failure.hs
+++ b/language-plutus-core/test/Evaluation/Constant/Failure.hs
@@ -13,7 +13,6 @@ import           Evaluation.Constant.Apply
 
 import           Control.Monad.Morph
 import           Data.Maybe
-import           Data.Semigroup
 import           Hedgehog
 import           Test.Tasty
 import           Test.Tasty.Hedgehog

--- a/language-plutus-core/test/Evaluation/Constant/Success.hs
+++ b/language-plutus-core/test/Evaluation/Constant/Success.hs
@@ -11,7 +11,6 @@ import           Evaluation.Constant.Apply
 import           Control.Monad.Morph
 import qualified Data.ByteString.Lazy           as BSL
 import           Data.Maybe
-import           Data.Semigroup
 import           Hedgehog
 import           Test.Tasty
 import           Test.Tasty.Hedgehog

--- a/language-plutus-core/test/Evaluation/Constant/SuccessFailure.hs
+++ b/language-plutus-core/test/Evaluation/Constant/SuccessFailure.hs
@@ -6,7 +6,6 @@ import           Language.PlutusCore.Constant
 
 import           Evaluation.Constant.Apply
 
-import           Data.Semigroup
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
 

--- a/plutus-core-interpreter/test/Main.hs
+++ b/plutus-core-interpreter/test/Main.hs
@@ -1,4 +1,4 @@
-module Main where
+module Main (main) where
 
 import           CekMachine
 import           DynamicBuiltins.Spec

--- a/plutus-exe/src/Main.hs
+++ b/plutus-exe/src/Main.hs
@@ -9,7 +9,6 @@ import qualified Language.PlutusCore.Pretty                 as PLC
 import           Control.Monad
 
 import qualified Data.ByteString.Lazy                       as BSL
-import           Data.Semigroup                             ((<>))
 import qualified Data.Text                                  as T
 import           Data.Text.Encoding                         (encodeUtf8)
 import qualified Data.Text.IO                               as T

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
@@ -16,7 +16,6 @@ import qualified Language.PlutusCore.Subst             as PLC
 
 import           Control.Monad.Reader
 
-import           Data.Semigroup
 import           Data.Traversable
 
 -- Utilities

--- a/wallet-api/src/Wallet/UTXO/Types.hs
+++ b/wallet-api/src/Wallet/UTXO/Types.hs
@@ -118,7 +118,6 @@ import           Data.Map                                 (Map)
 import qualified Data.Map                                 as Map
 import           Data.Maybe                               (fromMaybe, isJust, listToMaybe)
 import           Data.Monoid                              (Sum (..))
-import           Data.Semigroup                           (Semigroup (..))
 import qualified Data.Set                                 as Set
 import qualified Data.Text.Encoding                       as TE
 import           GHC.Generics                             (Generic)


### PR DESCRIPTION
Our CI `-Werror` got lost when we switched to `iohk-nix`. I'm working with @disassembler to get it working, but we do need to stay warning-free othewise that PR will be a pain!

This fixes a few warnings that have snuck in, mainly due to the newer version of `base` that we're compiling with. (We *do* have the correct bounds for `base` in our cabal files - `Semigroup` was added in 4.9. I'm not sure how this worked before TBH).