### PR TITLE
plutus-ir: use the stdlib's RecursiveType machinery

### DIFF
--- a/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
@@ -12,9 +12,36 @@ import           Control.Monad.Reader
 import qualified Language.PlutusCore                   as PLC
 import qualified Language.PlutusCore.MkPlc             as PLC
 import           Language.PlutusCore.Quote
+import qualified Language.PlutusCore.StdLib.Type       as Types
 
 type PLCTerm a = PLC.Term PLC.TyName PLC.Name (Provenance a)
 type PLCType a = PLC.Type PLC.TyName (Provenance a)
+
+-- | A possibly recursive type.
+data PLCRecType a = PlainType (PLCType a) | RecursiveType (Types.RecursiveType PLC.TyName (Provenance a))
+
+-- The 'Quote' is mainly so this is forwards compatible with the ifix version.
+-- | Make a 'Types.RecursiveType' for the given provenance, name, and pattern functor.
+mkRecursiveType :: Provenance a -> PLC.TyName (Provenance a) -> PLCType a -> Quote (Types.RecursiveType PLC.TyName (Provenance a))
+mkRecursiveType ann tn pf = pure $ Types.RecursiveType (\t -> PLC.Wrap ann tn pf t) (PLC.TyFix ann tn pf)
+
+-- | Get the actual type inside a 'PLCRecType'.
+getType :: PLCRecType a -> PLCType a
+getType r = case r of
+    PlainType t                                                -> t
+    RecursiveType Types.RecursiveType {Types._recursiveType=t} -> t
+
+-- | Wrap a term appropriately for a possibly recursive type.
+wrap :: Provenance a -> PLCRecType a -> PLCTerm a -> PLCTerm a
+wrap p r t = case r of
+    PlainType _                                                      -> t
+    RecursiveType Types.RecursiveType {Types._recursiveWrap=wrapper} -> setProvenance p $ wrapper t
+
+-- | Unwrap a term appropriately for a possibly recursive type.
+unwrap :: Provenance a -> PLCRecType a -> PLCTerm a -> PLCTerm a
+unwrap p r t = case r of
+    PlainType _                          -> t
+    RecursiveType Types.RecursiveType {} -> PLC.Unwrap p t
 
 type PIRTerm a = PIR.Term PIR.TyName PIR.Name (Provenance a)
 type PIRType a = PIR.Type PIR.TyName (Provenance a)


### PR DESCRIPTION
This delegates the job of building the `Fix` types and `Wrap`s to the `RecursiveType` functions in the stdlib. In fact this not doing any work for us at all - we are just hiding our normal construction inside it. However, we should be able to just drop in `makeRecursiveType` from https://github.com/input-output-hk/plutus/pull/245 and have this work with the `ifix` machinery.

Usually when using this you would want to be using `rename` appropriately, but in the PIR compiler we just run it at the end, so we don't bother here.

As a minor bonus we can use whether or not we have a `RecursiveType` to make decisions about whether or not to wrap, rather than passing around a `Recursivity`, which was slightly overloading the meaning of that type anyway.