### PR TITLE
language-plutus-core: serialize annotations

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
+-- | Serialise instances for Plutus Core types. Make sure to read the Note [Stable encoding of PLC]
+-- before touching anything in this file.
 module Language.PlutusCore.CBOR () where
 
 import           Codec.CBOR.Decoding
@@ -8,10 +10,32 @@ import           Codec.CBOR.Encoding
 import           Codec.Serialise
 import qualified Data.ByteString.Lazy           as BSL
 import           Data.Functor.Foldable          hiding (fold)
+import           Language.PlutusCore.Lexer      (AlexPosn)
 import           Language.PlutusCore.Lexer.Type hiding (name)
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Type
 import           PlutusPrelude
+
+{- Note [Stable encoding of PLC]
+READ THIS BEFORE TOUCHING ANYTHING IN THIS FILE
+
+We need the encoding of PLC on the blockchain to be *extremely* stable. It *must not* change
+arbitrarily, otherwise we'll be unable to read back old transactions and validate them.
+
+Consequently we don't use the derivable instances of `Serialise` for the PLC types that go
+on the chain.
+
+However, the instances in this file *are* constrained by instances for names, type names,
+and annotations. What's to stop the instances for *those* changing, thus changing
+the overall encoding on the chain?
+
+The answer is that what goes on the chain is *always* a `Program TyName Name ()`. The instances
+for `TyName` and `Name` are nailed down here, and the instance for `()` is standard.
+
+However, having this flexibility allows us to encode e.g. PLC with substantial annotations
+(like position information) in situation where the stability is *not* critical, such as
+for testing.
+-}
 
 instance Serialise TypeBuiltin where
     encode bi =
@@ -89,103 +113,105 @@ instance Serialise Unique where
     encode (Unique i) = encodeInt i
     decode = Unique <$> decodeInt
 
-instance Serialise (Name ()) where
+instance Serialise a => Serialise (Name a) where
     -- TODO: should we encode the name or not?
-    encode (Name _ bs u) = encodeBytes (BSL.toStrict bs) <> encode u
-    decode = Name () <$> fmap BSL.fromStrict decodeBytes <*> decode
+    encode (Name x bs u) = encode x <> encodeBytes (BSL.toStrict bs) <> encode u
+    decode = Name <$> decode <*> fmap BSL.fromStrict decodeBytes <*> decode
 
-instance Serialise (TyName ()) where
+instance Serialise a => Serialise (TyName a) where
     encode (TyName n) = encode n
     decode = TyName <$> decode
 
-instance Serialise (Version ()) where
-    encode (Version _ n n' n'') = fold [ encode n, encode n', encode n'' ]
-    decode = Version () <$> decode <*> decode <*> decode
+instance Serialise a => Serialise (Version a) where
+    encode (Version x n n' n'') = fold [ encode x, encode n, encode n', encode n'' ]
+    decode = Version <$> decode <*> decode <*> decode <*> decode
 
-instance Serialise (Kind ()) where
+instance Serialise a => Serialise (Kind a) where
     encode = cata a where
-        a TypeF{}             = encodeTag 0
-        a (KindArrowF _ k k') = fold [ encodeTag 1, k , k' ]
-        a SizeF{}             = encodeTag 2
+        a (TypeF x)           = encodeTag 0 <> encode x
+        a (KindArrowF x k k') = fold [ encodeTag 1, encode x, k , k' ]
+        a (SizeF x)           = encodeTag 2 <> encode x
 
     decode = go =<< decodeTag
-        where go 0 = pure (Type ())
-              go 1 = KindArrow () <$> decode <*> decode
-              go 2 = pure (Size ())
+        where go 0 = Type <$> decode
+              go 1 = KindArrow <$> decode <*> decode <*> decode
+              go 2 = Size <$> decode
               go _ = fail "Failed to decode Kind ()"
 
-instance Serialise (tyname ()) => Serialise (Type tyname ()) where
+instance (Serialise a, Serialise (tyname a)) => Serialise (Type tyname a) where
     encode = cata a where
-        a (TyVarF _ tn)        = encodeTag 0 <> encode tn
-        a (TyFunF _ t t')      = encodeTag 1 <> t <> t'
-        a (TyFixF _ tn t)      = encodeTag 2 <> encode tn <> t
-        a (TyForallF _ tn k t) = encodeTag 3 <> encode tn <> encode k <> t
-        a (TyBuiltinF _ bi)    = encodeTag 4 <> encode bi
-        a (TyIntF _ n)         = encodeTag 5 <> encode n
-        a (TyLamF _ n k t)     = encodeTag 6 <> encode n <> encode k <> t
-        a (TyAppF _ t t')      = encodeTag 7 <> t <> t'
+        a (TyVarF x tn)        = encodeTag 0 <> encode x <> encode tn
+        a (TyFunF x t t')      = encodeTag 1 <> encode x <> t <> t'
+        a (TyFixF x tn t)      = encodeTag 2 <> encode x <> encode tn <> t
+        a (TyForallF x tn k t) = encodeTag 3 <> encode x <> encode tn <> encode k <> t
+        a (TyBuiltinF x bi)    = encodeTag 4 <> encode x <> encode bi
+        a (TyIntF x n)         = encodeTag 5 <> encode x <> encode n
+        a (TyLamF x n k t)     = encodeTag 6 <> encode x <> encode n <> encode k <> t
+        a (TyAppF x t t')      = encodeTag 7 <> encode x <> t <> t'
 
     decode = go =<< decodeTag
-        where go 0 = TyVar () <$> decode
-              go 1 = TyFun () <$> decode <*> decode
-              go 2 = TyFix () <$> decode <*> decode
-              go 3 = TyForall () <$> decode <*> decode <*> decode
-              go 4 = TyBuiltin () <$> decode
-              go 5 = TyInt () <$> decode
-              go 6 = TyLam () <$> decode <*> decode <*> decode
-              go 7 = TyApp () <$> decode <*> decode
+        where go 0 = TyVar <$> decode <*> decode
+              go 1 = TyFun <$> decode <*> decode <*> decode
+              go 2 = TyFix <$> decode <*> decode <*> decode
+              go 3 = TyForall <$> decode <*> decode <*> decode <*> decode
+              go 4 = TyBuiltin <$> decode <*> decode
+              go 5 = TyInt <$> decode <*> decode
+              go 6 = TyLam <$> decode <*> decode <*> decode <*> decode
+              go 7 = TyApp <$> decode <*> decode <*> decode
               go _ = fail "Failed to decode Type TyName ()"
 
 instance Serialise DynamicBuiltinName where
     encode (DynamicBuiltinName name) = encode name
     decode = DynamicBuiltinName <$> decode
 
-instance Serialise (Builtin ()) where
-    encode (BuiltinName _ bn)     = encodeTag 0 <> encode bn
-    encode (DynBuiltinName _ dbn) = encodeTag 1 <> encode dbn
+instance Serialise a => Serialise (Builtin a) where
+    encode (BuiltinName x bn)     = encodeTag 0 <> encode x <> encode bn
+    encode (DynBuiltinName x dbn) = encodeTag 1 <> encode x <> encode dbn
 
     decode = go =<< decodeTag
-        where go 0 = BuiltinName () <$> decode
-              go 1 = DynBuiltinName () <$> decode
+        where go 0 = BuiltinName <$> decode <*> decode
+              go 1 = DynBuiltinName <$> decode <*> decode
               go _ = fail "Failed to decode Builtin ()"
 
 
-instance Serialise (Constant ()) where
-    encode (BuiltinInt _ n i) = fold [ encodeTag 0, encode n, encodeInteger i ]
-    encode (BuiltinBS _ n bs) = fold [ encodeTag 1, encode n, encodeBytes (BSL.toStrict bs) ]
-    encode (BuiltinSize _ n)  = encodeTag 2 <> encode n
+instance Serialise a => Serialise (Constant a) where
+    encode (BuiltinInt x n i) = fold [ encodeTag 0, encode x, encode n, encodeInteger i ]
+    encode (BuiltinBS x n bs) = fold [ encodeTag 1, encode x, encode n, encodeBytes (BSL.toStrict bs) ]
+    encode (BuiltinSize x n)  = encodeTag 2 <> encode x <> encode n
     decode = go =<< decodeTag
-        where go 0 = BuiltinInt () <$> decode <*> decodeInteger
-              go 1 = BuiltinBS () <$> decode <*> fmap BSL.fromStrict decodeBytes
-              go 2 = BuiltinSize () <$> decode
+        where go 0 = BuiltinInt <$> decode <*> decode <*> decodeInteger
+              go 1 = BuiltinBS <$> decode <*> decode <*> fmap BSL.fromStrict decodeBytes
+              go 2 = BuiltinSize <$> decode <*> decode
               go _ = fail "Failed to decode Constant ()"
 
-instance (Serialise (tyname ()), Serialise (name ())) => Serialise (Term tyname name ()) where
+instance (Serialise a, Serialise (tyname a), Serialise (name a)) => Serialise (Term tyname name a) where
     encode = cata a where
-        a (VarF _ n)         = encodeTag 0 <> encode n
-        a (TyAbsF _ tn k t)  = encodeTag 1 <> encode tn <> encode k <> t
-        a (LamAbsF _ n ty t) = encodeTag 2 <> encode n <> encode ty <> t
-        a (ApplyF _ t t')    = encodeTag 3 <> t <> t'
-        a (ConstantF _ c)    = encodeTag 4 <> encode c
-        a (TyInstF _ t ty)   = encodeTag 5 <> t <> encode ty
-        a (UnwrapF _ t)      = encodeTag 6 <> t
-        a (WrapF _ tn ty t)  = encodeTag 7 <> encode tn <> encode ty <> t
-        a (ErrorF _ ty)      = encodeTag 8 <> encode ty
-        a (BuiltinF _ bi)    = encodeTag 9 <> encode bi
+        a (VarF x n)         = encodeTag 0 <> encode x <> encode n
+        a (TyAbsF x tn k t)  = encodeTag 1 <> encode x <> encode tn <> encode k <> t
+        a (LamAbsF x n ty t) = encodeTag 2 <> encode x <> encode n <> encode ty <> t
+        a (ApplyF x t t')    = encodeTag 3 <> encode x <> t <> t'
+        a (ConstantF x c)    = encodeTag 4 <> encode x <> encode c
+        a (TyInstF x t ty)   = encodeTag 5 <> encode x <> t <> encode ty
+        a (UnwrapF x t)      = encodeTag 6 <> encode x <> t
+        a (WrapF x tn ty t)  = encodeTag 7 <> encode x <> encode tn <> encode ty <> t
+        a (ErrorF x ty)      = encodeTag 8 <> encode x <> encode ty
+        a (BuiltinF x bi)    = encodeTag 9 <> encode x <> encode bi
 
     decode = go =<< decodeTag
-        where go 0 = Var () <$> decode
-              go 1 = TyAbs () <$> decode <*> decode <*> decode
-              go 2 = LamAbs () <$> decode <*> decode <*> decode
-              go 3 = Apply () <$> decode <*> decode
-              go 4 = Constant () <$> decode
-              go 5 = TyInst () <$> decode <*> decode
-              go 6 = Unwrap () <$> decode
-              go 7 = Wrap () <$> decode <*> decode <*> decode
-              go 8 = Error () <$> decode
-              go 9 = Builtin () <$> decode
+        where go 0 = Var <$> decode <*> decode
+              go 1 = TyAbs <$> decode <*> decode <*> decode <*> decode
+              go 2 = LamAbs <$> decode <*> decode <*> decode <*> decode
+              go 3 = Apply <$> decode <*> decode <*> decode
+              go 4 = Constant <$> decode <*> decode
+              go 5 = TyInst <$> decode <*> decode <*> decode
+              go 6 = Unwrap <$> decode <*> decode
+              go 7 = Wrap <$> decode <*> decode <*> decode <*> decode
+              go 8 = Error <$> decode <*> decode
+              go 9 = Builtin <$> decode <*> decode
               go _ = fail "Failed to decode Term TyName Name ()"
 
-instance (Serialise (tyname ()), Serialise (name ())) => Serialise (Program tyname name ()) where
-    encode (Program _ v t) = encode v <> encode t
-    decode = Program () <$> decode <*> decode
+instance (Serialise a, Serialise (tyname a), Serialise (name a)) => Serialise (Program tyname name a) where
+    encode (Program x v t) = encode x <> encode v <> encode t
+    decode = Program <$> decode <*> decode <*> decode
+
+instance Serialise AlexPosn

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -4,7 +4,6 @@ module Main ( main
             ) where
 
 import           Codec.Serialise
-import           Control.Monad
 import           Control.Monad.Trans.Except   (runExceptT)
 import qualified Data.ByteString.Lazy         as BSL
 import qualified Data.Text                    as T
@@ -74,7 +73,7 @@ propCBOR = property $ do
     prog <- forAll genProgram
     let
         trip = deserialiseOrFail . serialise
-        compared = (==) <$> trip (void prog) <*> pure (void prog)
+        compared = (==) <$> trip prog <*> pure prog
     Hedgehog.assert (fromRight False compared)
 
 -- Generate a random 'Program', pretty-print it, and parse the pretty-printed


### PR DESCRIPTION
Serialize annotations on PLC terms. This is helpful because we want to
serialize position/provenance information along with terms on the
mockchain for diagnostic purposes.

As a proof of concept, the round-tripping test now includes the positions.

This *does* change the encoding of the PLC that we will put on the chain,
because now we write in all the unit annotations. However, it doesn't
put us in danger of the encoding changing in future, because we will
always be setting the annotation type to `()`. I don't think the additional
cost of serializing a byte for each unit annotation is a problem in
terms of serialization size, so I'm inclined to just accept that for
simplicity.

I've written a more extensive note about making sure the encoding is
stable in the code. I think at some point we should perhaps check in
some serialised programs and then have a test that makes sure that
we continue to be able to deserialise them.