### PR TITLE
wallet-api: `data Height` and `data Value`

### DIFF
--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
@@ -21,8 +21,8 @@ import           Control.Monad.Error.Class  (MonadError (..))
 import qualified Data.Set                   as Set
 import           GHC.Generics               (Generic)
 import           Language.Plutus.Lift       (LiftPlc (..), TypeablePlc (..))
-import           Language.Plutus.Runtime    (Height, PendingTx (..), PendingTxOut (..), PendingTxOutType (..),
-                                             PubKey (..), ValidatorHash, Value)
+import           Language.Plutus.Runtime    (Height (..), PendingTx (..), PendingTxOut (..), PendingTxOutType (..),
+                                             PubKey (..), ValidatorHash, Value (..))
 import qualified Language.Plutus.Runtime.TH as TH
 import           Language.Plutus.TH         (plutus)
 import qualified Language.Plutus.TH         as Builtins
@@ -126,15 +126,15 @@ validatorScript v = Validator val where
             (&&) :: Bool -> Bool -> Bool
             (&&) = $( TH.and )
 
-            PendingTx _ os _ _ h _ _ = p
-            VestingTranche d1 a1 = vestingTranche1
-            VestingTranche d2 a2 = vestingTranche2
+            PendingTx _ os _ _ (Height h) _ _ = p
+            VestingTranche (Height d1) (Value a1) = vestingTranche1
+            VestingTranche (Height d2) (Value a2) = vestingTranche2
 
             -- We assume here that the txn outputs are always given in the same
             -- order (1 PubKey output, followed by 0 or 1 script outputs)
-            amountSpent :: Value
+            amountSpent :: Int
             amountSpent = case os of
-                ((PendingTxOut v' _ (PubKeyTxOut pk))::PendingTxOut):(_::[PendingTxOut])
+                ((PendingTxOut (Value v') _ (PubKeyTxOut pk))::PendingTxOut):(_::[PendingTxOut])
                     | pk `eqPk` vestingOwner -> v'
                 (_::[PendingTxOut]) -> Builtins.error ()
 
@@ -149,7 +149,8 @@ validatorScript v = Validator val where
                 -- Nothing has been released yet
                 else 0
 
-            newAmount = vestingDataPaidOut + amountSpent
+            paidOut = let Value v = vestingDataPaidOut in v
+            newAmount = paidOut + amountSpent
 
             -- Verify that the amount taken out, plus the amount already taken
             -- out before, does not exceed the threshold that is currently

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -57,9 +57,9 @@ collect w c  = walletAction w . CF.collect c
 scenario1 :: CFScenario
 scenario1 = CFScenario{..} where
     cfCampaign = Campaign {
-        campaignDeadline = 10,
+        campaignDeadline = Runtime.Height 10,
         campaignTarget   = 1000,
-        campaignCollectionDeadline = 15,
+        campaignCollectionDeadline = Runtime.Height 15,
         campaignOwner              = PubKey 1
         }
     cfWallets = Wallet <$> [1..3]

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -64,8 +64,8 @@ settle = checkTrace $ do
         im = fromIntegral initMargin
         cur = FutureData (PubKey 1) (PubKey 2) im im
         spotPrice = 1124
-        delta = fromIntegral $ units * (spotPrice - forwardPrice)
-        ov  = OracleValue (Signed (oracle, (10, spotPrice)))
+        delta = fromIntegral $ units * (Runtime.getValue $ spotPrice - forwardPrice)
+        ov  = OracleValue (Signed (oracle, (Runtime.Height 10, spotPrice)))
 
     -- advance the clock to block height 10
     void $ addBlocks 8
@@ -89,7 +89,7 @@ settleEarly = checkTrace $ do
         -- up with the variation margin.
         (_, upper) = marginRange
         spotPrice = upper + 1
-        ov  = OracleValue (Signed (oracle, (8, spotPrice)))
+        ov  = OracleValue (Signed (oracle, (Runtime.Height 8, spotPrice)))
 
     -- advance the clock to block height 8
     void $ addBlocks 6
@@ -129,8 +129,8 @@ increaseMargin = checkTrace $ do
         -- settleEarly above)
         spotPrice = upper + 1
 
-        delta = fromIntegral $ units * (spotPrice - forwardPrice)
-        ov  = OracleValue (Signed (oracle, (10, spotPrice)))
+        delta = fromIntegral $ units * (Runtime.getValue $ spotPrice - forwardPrice)
+        ov  = OracleValue (Signed (oracle, (Runtime.Height 10, spotPrice)))
 
     void $ walletAction w2 (F.settle [ins'] contract cur' ov)
     updateAll
@@ -147,14 +147,14 @@ increaseMargin = checkTrace $ do
 --   10 blocks.
 contract :: Future
 contract = Future {
-    futureDeliveryDate  = 10,
+    futureDeliveryDate  = Runtime.Height 10,
     futureUnits         = units,
     futureUnitPrice     = forwardPrice,
     futureInitialMargin = im,
     futurePriceOracle   = oracle,
     futureMarginPenalty = penalty
     } where
-        im = penalty + (units * forwardPrice `div` 20) -- 5%
+        im = penalty + (Runtime.Value units * forwardPrice `div` 20) -- 5%
 
 -- | Margin penalty
 penalty :: Runtime.Value

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -39,8 +39,8 @@ tests = testGroup "vesting" [
 scen1 :: VestingScenario
 scen1 = VestingScenario{..} where
     vsVestingScheme = Vesting {
-        vestingTranche1 = VestingTranche 10 200,
-        vestingTranche2 = VestingTranche 20 400,
+        vestingTranche1 = VestingTranche (Runtime.Height 10) 200,
+        vestingTranche2 = VestingTranche (Runtime.Height 20) 400,
         vestingOwner    = PubKey 1 }
     vsWallets = Wallet <$> [1, 2]
     vsInitialBalances = Map.fromList [

--- a/wallet-api/src/Wallet/UTXO/Index.hs
+++ b/wallet-api/src/Wallet/UTXO/Index.hs
@@ -206,7 +206,7 @@ validationData h tx = rump <$> ins where
         , pendingTxOutputs = mkOut <$> txOutputs tx
         , pendingTxForge = fromIntegral $ txForge tx
         , pendingTxFee = fromIntegral $ txFee tx
-        , pendingTxBlockHeight = fromIntegral h
+        , pendingTxBlockHeight = Runtime.Height $ fromIntegral h
         , pendingTxSignatures = txSignatures tx
         , pendingTxOwnHash    = ()
         }

--- a/wallet-api/src/Wallet/UTXO/Runtime.hs
+++ b/wallet-api/src/Wallet/UTXO/Runtime.hs
@@ -5,8 +5,10 @@
 --   be used in PLC scripts.
 module Wallet.UTXO.Runtime (-- * Transactions and related types
                 PubKey(..)
-              , Value
-              , Height
+              , Value(..)
+              , getValue
+              , Height(..)
+              , getHeight
               , PendingTxOutRef(..)
               , Signature(..)
               -- ** Hashes (see note [Hashes in validator scripts])
@@ -111,7 +113,33 @@ instance (TypeablePlc a, LiftPlc a) => LiftPlc (Signed a)
 -- | Ada value
 --
 -- TODO: Use [[Wallet.UTXO.Types.Value]] when Integer is supported
-type Value = Int
+data Value = Value Int
+    deriving (Eq, Ord, Show, Generic)
+
+instance TypeablePlc Value
+instance LiftPlc Value
+
+getValue :: Value -> Int
+getValue (Value i) = i
+
+instance Enum Value where
+    toEnum = Value
+    fromEnum = getValue
+
+instance Num Value where
+    (Value l) + (Value r) = Value (l + r)
+    (Value l) * (Value r) = Value (l * r)
+    abs (Value v)         = Value (abs v)
+    signum (Value v)      = Value (signum v)
+    fromInteger           = Value . fromInteger
+    negate (Value v)      = Value (negate v)
+
+instance Real Value where
+    toRational (Value v) = toRational v
+
+instance Integral Value where
+    quotRem (Value l) (Value r) = let (l', r') = quotRem l r in (Value l', Value r')
+    toInteger (Value i) = toInteger i
 
 {- Note [Hashes in validator scripts]
 
@@ -184,4 +212,11 @@ plcDigest = serialise
 
 -- | Blockchain height
 --   TODO: Use [[Wallet.UTXO.Height]] when Integer is supported
-type Height = Int
+data Height = Height Int
+    deriving (Eq, Ord, Show, Generic)
+
+instance TypeablePlc Height
+instance LiftPlc Height
+
+getHeight :: Height -> Int
+getHeight (Height h) = h


### PR DESCRIPTION
* Use data types instead of type synonyms for the runtime
  representations of blockchain height and value, so that we can offer a
  better user experience for entering values of those types