### PR TITLE
plutus-use-cases: Crowdfunding improvements

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55767,7 +55767,7 @@ license = stdenv.lib.licenses.bsd3;
 , containers
 , core-to-plc
 , hedgehog
-, microlens
+, lens
 , mtl
 , plutus-th
 , stdenv
@@ -55786,6 +55786,7 @@ libraryHaskellDepends = [
 base
 containers
 core-to-plc
+lens
 mtl
 plutus-th
 template-haskell
@@ -55796,7 +55797,6 @@ base
 containers
 core-to-plc
 hedgehog
-microlens
 plutus-th
 tasty
 tasty-hedgehog

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -28,7 +28,8 @@ library
     template-haskell -any,
     plutus-th -any,
     core-to-plc -any,
-    wallet-api -any
+    wallet-api -any,
+    lens -any
   default-language: Haskell2010
   default-extensions: ExplicitForAll ScopedTypeVariables
                       DeriveGeneric StandaloneDeriving DeriveLift
@@ -66,7 +67,6 @@ test-suite plutus-use-cases-test
         wallet-api -any,
         plutus-use-cases,
         plutus-th -any,
-        microlens -any,
         core-to-plc -any,
         template-haskell -any
   ghc-options:

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS -fplugin=Language.Plutus.CoreToPLC.Plugin -fplugin-opt Language.Plutus.CoreToPLC.Plugin:dont-typecheck #-}
 module Language.Plutus.Coordination.Contracts.CrowdFunding (
     -- * Campaign parameters
@@ -17,37 +18,36 @@ module Language.Plutus.Coordination.Contracts.CrowdFunding (
     , CampaignActor
     -- * Functionality for campaign contributors
     , contribute
-    , contributionScript
-    , refund
-    , refundTrigger
     -- * Functionality for campaign owners
     , collect
-    , collectFundsTrigger
+    , campaignAddress
     ) where
 
 import           Control.Applicative        (Applicative (..))
-import           Control.Monad              (Monad (..))
+import           Control.Lens
+import           Control.Monad              (Monad (..), void)
 import           Control.Monad.Error.Class  (MonadError (..))
 import           Data.Foldable              (foldMap)
+import qualified Data.Map                   as Map
+import           Data.Maybe                 (fromMaybe)
 import           Data.Monoid                (Sum (..))
 import qualified Data.Set                   as Set
 import           GHC.Generics               (Generic)
 
 import           Language.Plutus.Lift       (LiftPlc (..), TypeablePlc (..))
-import           Language.Plutus.Runtime    (Height (..), PendingTx (..), PendingTxIn (..), PubKey (..), ValidatorHash,
-                                             Value (..), getHeight)
+import           Language.Plutus.Runtime    (Height (..), PendingTx (..), PendingTxIn (..), PendingTxOut, PubKey (..),
+                                             ValidatorHash, Value (..))
 import           Language.Plutus.TH         (plutus)
 import qualified Language.Plutus.TH         as Builtins
-import           Wallet.API                 (EventTrigger (..), Range (..), WalletAPI (..), WalletAPIError, andT,
-                                             blockHeightT, fundsAtAddressT, otherError, ownPubKeyTxOut, pubKey,
-                                             signAndSubmit)
-import           Wallet.UTXO                (Address', DataScript (..), TxOutRef', Validator (..), scriptTxIn,
-                                             scriptTxOut)
+import           Wallet.API                 (BlockchainAction (..), EventTrigger (..), Range (..), WalletAPI (..),
+                                             WalletAPIError, andT, blockHeightT, fundsAtAddressT, otherError,
+                                             ownPubKeyTxOut, payToScript, pubKey, signAndSubmit)
+import           Wallet.UTXO                (DataScript (..), TxId', Validator (..), scriptTxIn)
 import qualified Wallet.UTXO                as UTXO
 
 import qualified Language.Plutus.Runtime.TH as TH
-import           Prelude                    (Bool (..), Int, Num (..), Ord (..), fromIntegral, snd, succ, ($), (.),
-                                             (<$>))
+import           Prelude                    (Bool (..), Int, Num (..), Ord (..), fromIntegral, fst, snd, succ, ($), (.),
+                                             (<$>), (==))
 
 -- | A crowdfunding campaign.
 data Campaign = Campaign
@@ -61,6 +61,12 @@ type CampaignActor = PubKey
 
 instance LiftPlc Campaign
 instance TypeablePlc Campaign
+
+data CampaignAction = Collect | Refund
+    deriving Generic
+
+instance LiftPlc CampaignAction
+instance TypeablePlc CampaignAction
 
 -- | Contribute funds to the campaign (contributor)
 --
@@ -77,10 +83,28 @@ contribute cmp value = do
     -- TODO: Remove duplicate definition of Value
     --       (Value = Integer in Haskell land but Value = Int in PLC land)
     let v' = UTXO.Value $ fromIntegral value
-    (payment, change) <- createPaymentWithChange v'
-    let o = scriptTxOut v' (contributionScript cmp) ds
+    tx <- payToScript (campaignAddress cmp) v' ds
 
-    signAndSubmit payment [o, change]
+    register (refundTrigger cmp) (refund (UTXO.hashTx tx) cmp)
+
+-- | Register a [[BlockchainAction]] to collect all the funds of a campaign
+--
+collect :: (Monad m, WalletAPI m) => Campaign -> m ()
+collect cmp = register (collectFundsTrigger cmp) $ BlockchainAction $ \_ am -> do
+        let scr        = contributionScript cmp
+            contributions = am ^. at (campaignAddress cmp) . to (Map.toList . fromMaybe Map.empty)
+            red        = UTXO.Redeemer $ UTXO.lifted Collect
+            con (r, _) = scriptTxIn r scr red
+            ins        = con <$> contributions
+            value = getSum $ foldMap (Sum . snd) contributions
+
+        oo <- ownPubKeyTxOut value
+        void $ signAndSubmit (Set.fromList ins) [oo]
+
+
+-- | The address of a [[Campaign]]
+campaignAddress :: Campaign -> UTXO.Address'
+campaignAddress = UTXO.scriptAddress . contributionScript
 
 -- | The validator script that determines whether the campaign owner can
 --   retrieve the funds or the contributors can claim a refund.
@@ -105,12 +129,8 @@ contributionScript cmp  = Validator val where
 
     --   See note [Contracts and Validator Scripts] in
     --       Language.Plutus.Coordination.Contracts
-    inner = UTXO.fromPlcCode $(plutus [| (\Campaign{..} () (a :: CampaignActor) (p :: PendingTx ValidatorHash) ->
+    inner = UTXO.fromPlcCode $(plutus [| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx ValidatorHash) ->
         let
-            -- | Check that a transaction input is signed by the private key of the given
-            --   public key.
-            signedBy :: PendingTxIn -> CampaignActor -> Bool
-            signedBy = $(TH.txInSignedBy)
 
             infixr 3 &&
             (&&) :: Bool -> Bool -> Bool
@@ -121,7 +141,7 @@ contributionScript cmp  = Validator val where
             signedByT :: PendingTx ValidatorHash -> CampaignActor -> Bool
             signedByT = $(TH.txSignedBy)
 
-            PendingTx ps _ _ _ (Height h) _ _ = p
+            PendingTx ps outs _ _ (Height h) _ _ = p
 
             deadline :: Int
             deadline = let Height h' = campaignDeadline in h'
@@ -132,66 +152,61 @@ contributionScript cmp  = Validator val where
             target :: Int
             target = let Value v = campaignTarget in v
 
-            isValid = 
-                case ps of
-                    pt1:pt2:_ ->
-                        -- the "successful campaign" branch
-                        let
-                            PendingTxIn _ _ (Value v1) = pt1
-                            PendingTxIn _ _ (Value v2) = pt2
-                            pledgedFunds = v1 + v2
+            -- | The total value of all contributions
+            totalInputs :: Int
+            totalInputs =
+                let v (PendingTxIn _ _ (Value vl)) = vl in
+                $(TH.foldr) (\i total -> total + v i) 0 ps
 
-                            payToOwner = h > deadline &&
-                                        h <= collectionDeadline &&
-                                        pledgedFunds >= target &&
-                                        signedByT p campaignOwner
-                        in payToOwner
-                    pt:_ -> -- the "refund" branch
-                        let
-                            -- Check that a refund transaction only spends the
-                            -- amount that was pledged by the contributor
-                            -- identified by `a :: CampaignActor`
-                            contributorOnly = signedBy pt a
-                            refundable   = h > collectionDeadline &&
-                                                        contributorOnly &&
-                                                        signedByT p a
-                            -- In case of a refund, we can only collect the funds that
-                            -- were committed by this contributor
-                        in refundable
-                    _ -> False
+            isValid = case act of
+                Refund -> -- the "refund" branch
+                    let
+                        -- Check that all outputs are paid to the public key
+                        -- of the contributor (that is, to the `a` argument of the data script)
+
+                        contributorTxOut :: PendingTxOut -> Bool
+                        contributorTxOut o = $(TH.maybe) False (\pk -> $(TH.eqPubKey) pk a) ($(TH.pubKeyOutput) o)
+
+                        contributorOnly = $(TH.all) contributorTxOut outs
+
+                        refundable   = h > collectionDeadline &&
+                                                    contributorOnly &&
+                                                    signedByT p a
+
+                    in refundable
+                Collect -> -- the "successful campaign" branch
+                    let
+                        payToOwner = h > deadline &&
+                                    h <= collectionDeadline &&
+                                    totalInputs >= target &&
+                                    signedByT p campaignOwner
+                    in payToOwner
         in
         if isValid then () else Builtins.error ()) |])
 
--- | Given the campaign data and the output from the contributing transaction,
---   make a trigger that fires when the transaction can be refunded.
-refundTrigger :: Campaign -> Address' -> EventTrigger
-refundTrigger Campaign{..} t = andT
-    (fundsAtAddressT t  (GEQ 1))
-    (blockHeightT (GEQ $ fromIntegral $ succ $ getHeight campaignCollectionDeadline))
+-- | An event trigger that fires when a refund of campaign contributions can be claimed
+refundTrigger :: Campaign -> EventTrigger
+refundTrigger c = andT
+    (fundsAtAddressT (campaignAddress c) $ GEQ 1)
+    (blockHeightT (GEQ $ fromIntegral $ succ $ getHeight $ campaignCollectionDeadline c))
 
--- | Given the public key of the campaign owner, generate an event trigger that
--- fires when the funds can be collected.
-collectFundsTrigger :: Campaign -> Address' -> EventTrigger
-collectFundsTrigger Campaign{..} ts = andT
-    (fundsAtAddressT ts $ GEQ $ UTXO.Value $ fromIntegral campaignTarget)
-    (blockHeightT $ fromIntegral . getHeight <$> Interval campaignDeadline campaignCollectionDeadline)
+-- | An event trigger that fires when the funds for a campaign can be collected
+collectFundsTrigger :: Campaign -> EventTrigger
+collectFundsTrigger c = andT
+    (fundsAtAddressT (campaignAddress c) $ GEQ $ UTXO.Value $ fromIntegral $ campaignTarget c)
+    (blockHeightT $ fromIntegral . getHeight <$> Interval (campaignDeadline c) (campaignCollectionDeadline c))
 
-refund :: (Monad m, WalletAPI m) => Campaign -> TxOutRef' -> UTXO.Value -> m ()
-refund c ref val = do
-    oo <- ownPubKeyTxOut val
-    let scr = contributionScript c
-        i   = scriptTxIn ref scr UTXO.unitRedeemer
-    signAndSubmit (Set.singleton i) [oo]
+-- | Claim a refund of our campaign contribution
+refund :: (Monad m, WalletAPI m) => TxId' -> Campaign -> BlockchainAction m
+refund txid cmp = BlockchainAction $ \_ am -> do
+    let adr     = campaignAddress cmp
+        utxo    = fromMaybe Map.empty $ am ^. at adr
+        ourUtxo = Map.toList $ Map.filterWithKey (\k _ -> txid == UTXO.txOutRefId k) utxo
+        scr   = contributionScript cmp
+        red   = UTXO.Redeemer $ UTXO.lifted Refund
+        i ref = scriptTxIn ref scr red
+        inputs = Set.fromList $ i . fst <$> ourUtxo
+        value  = getSum $ foldMap (Sum . snd) ourUtxo
 
--- | Collect all campaign funds (campaign owner)
---
---
-collect :: (Monad m, WalletAPI m) => Campaign -> [(TxOutRef', UTXO.Value)] -> m ()
-collect cmp contributions = do
-    oo <- ownPubKeyTxOut value
-    let scr        = contributionScript cmp
-        con (r, _) = scriptTxIn r scr UTXO.unitRedeemer
-        ins        = con <$> contributions
-    signAndSubmit (Set.fromList ins) [oo]
-    where
-      value = getSum $ foldMap (Sum . snd) contributions
+    out <- ownPubKeyTxOut value
+    void $ signAndSubmit inputs [out]

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
@@ -81,7 +81,7 @@ vestFunds vst value = do
     let vs = validatorScript vst
         o = scriptTxOut v' vs (DataScript $ UTXO.lifted vd)
         vd =  VestingData (validatorScriptHash vst) 0
-    signAndSubmit payment [o, change]
+    _ <- signAndSubmit payment [o, change]
     pure vd
 
 -- | Retrieve some of the vested funds.
@@ -100,7 +100,7 @@ retrieveFunds vs vd r vnow = do
         remaining = (fromIntegral $ totalAmount vs) - vnow
         vd' = vd {vestingDataPaidOut = fromIntegral vnow + vestingDataPaidOut vd }
         inp = scriptTxIn r val UTXO.unitRedeemer
-    signAndSubmit (Set.singleton inp) [oo, o]
+    _ <- signAndSubmit (Set.singleton inp) [oo, o]
     pure vd'
 
 validatorScriptHash :: Vesting -> ValidatorHash

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
@@ -134,9 +134,9 @@ validatorScript v = Validator val where
             -- order (1 PubKey output, followed by 0 or 1 script outputs)
             amountSpent :: Int
             amountSpent = case os of
-                ((PendingTxOut (Value v') _ (PubKeyTxOut pk))::PendingTxOut):(_::[PendingTxOut])
+                PendingTxOut (Value v') _ (PubKeyTxOut pk):_
                     | pk `eqPk` vestingOwner -> v'
-                (_::[PendingTxOut]) -> Builtins.error ()
+                _ -> Builtins.error ()
 
             -- Value that has been released so far under the scheme
             currentThreshold =
@@ -149,7 +149,7 @@ validatorScript v = Validator val where
                 -- Nothing has been released yet
                 else 0
 
-            paidOut = let Value v = vestingDataPaidOut in v
+            paidOut = let Value v' = vestingDataPaidOut in v'
             newAmount = paidOut + amountSpent
 
             -- Verify that the amount taken out, plus the amount already taken
@@ -160,9 +160,9 @@ validatorScript v = Validator val where
             -- Check that the remaining output is locked by the same validation
             -- script
             txnOutputsValid = case os of
-                (_::PendingTxOut):(PendingTxOut _ (Just (vl', _))  DataTxOut::PendingTxOut):(_::[PendingTxOut]) ->
+                _:PendingTxOut _ (Just (vl', _)) DataTxOut:_ ->
                     vl' `eqBs` vestingDataHash
-                (_::[PendingTxOut]) -> Builtins.error ()
+                _ -> Builtins.error ()
 
             isValid = amountsValid && txnOutputsValid
         in

--- a/plutus-use-cases/src/Language/Plutus/Runtime/TH.hs
+++ b/plutus-use-cases/src/Language/Plutus/Runtime/TH.hs
@@ -14,6 +14,11 @@ module Language.Plutus.Runtime.TH(
     isJust,
     isNothing,
     maybe,
+    -- * Lists
+    map,
+    foldr,
+    length,
+    all,
     -- * Signatures
     txSignedBy,
     txInSignedBy,
@@ -101,6 +106,44 @@ maybe = [| \b f m ->
     case m of
         Nothing -> b
         Just a  -> f a |]
+
+map :: Q Exp
+map = [|
+    \f l ->
+        let go ls = case ls of
+                x:xs -> f x : go xs
+                _    -> []
+        in go l
+        |]
+
+foldr :: Q Exp
+foldr = [|
+    \f b l ->
+        let go cur as = case as of
+                []    -> cur
+                a:as' -> go (f a cur) as'
+        in go b l
+    |]
+
+length :: Q Exp
+length = [|
+    \l ->
+        -- it would be nice to define length in terms of foldr,
+        -- but we can't, due to staging restrictions.
+        let go lst = case lst of
+                []   -> 0::Int
+                _:xs -> 1 + go xs
+        in go l
+    |]
+
+all :: Q Exp
+all = [|
+    \pred l ->
+        let go lst = case lst of
+                []   -> True
+                x:xs -> pred x && go xs
+        in go l
+    |]
 
 -- | Returns the public key that locks the transaction output
 pubKeyOutput :: Q Exp

--- a/plutus-use-cases/src/Language/Plutus/Runtime/TH.hs
+++ b/plutus-use-cases/src/Language/Plutus/Runtime/TH.hs
@@ -65,8 +65,8 @@ txSignedBy = [|
 
             go :: [Signature] -> Bool
             go l = case l of
-                        (s :: Signature):(r::[Signature]) -> if signedBy s then True else go r
-                        ([]::[Signature])                 -> False
+                        s:r -> if signedBy s then True else go r
+                        []  -> False
         in
             go sigs
     |]
@@ -84,8 +84,8 @@ txInSignedBy = [|
 
             go :: [Signature] -> Bool
             go l = case l of
-                        (s :: Signature):(r::[Signature]) -> if signedBy s then True else go r
-                        ([]::[Signature])                 -> False
+                        s:r -> if signedBy s then True else go r
+                        []  -> False
         in go sigs
 
     |]

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -77,9 +77,9 @@ makeContribution = checkCFTrace scenario1 $ do
     let w = Wallet 2
         contribution = 600
         rest = startingBalance - fromIntegral contribution
-    blockchainActions >>= walletNotifyBlock w
+    processPending >>= walletNotifyBlock w
     contrib2 (cfCampaign scenario1) contribution
-    blockchainActions >>= walletNotifyBlock w
+    processPending >>= walletNotifyBlock w
     assertOwnFundsEq w rest
 
 -- | Run a campaign with two contributions where the campaign owner collects
@@ -199,4 +199,4 @@ checkCFTrace CFScenario{cfInitialBalances} t = property $ do
 -- | Validate all pending transactions and notify the wallets
 updateAll :: CFScenario -> Trace EmulatedWalletApi [Tx]
 updateAll CFScenario{cfWallets} =
-    blockchainActions >>= walletsNotifyBlock cfWallets
+    processPending >>= walletsNotifyBlock cfWallets

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -6,6 +6,7 @@
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns -fno-warn-unused-do-bind #-}
 module Spec.Crowdfunding(tests) where
 
+import           Control.Monad                                       (void)
 import           Data.Either                                         (isRight)
 import           Data.Foldable                                       (traverse_)
 import qualified Data.Map                                            as Map
@@ -18,7 +19,7 @@ import           Wallet.API                                          (PubKey (..
 import           Wallet.Emulator                                     hiding (Value)
 import qualified Wallet.Generators                                   as Gen
 
-import           Language.Plutus.Coordination.Contracts.CrowdFunding (Campaign (..), contribute, refund)
+import           Language.Plutus.Coordination.Contracts.CrowdFunding (Campaign (..), contribute)
 import qualified Language.Plutus.Coordination.Contracts.CrowdFunding as CF
 import qualified Language.Plutus.Runtime                             as Runtime
 import qualified Wallet.UTXO                                         as UTXO
@@ -35,21 +36,21 @@ tests = testGroup "crowdfunding" [
 -- | Make a contribution to the campaign from a wallet. Returns the reference
 --   to the transaction output that is locked by the campaign's validator
 --   script (and can be collected by the campaign owner)
-contrib :: Wallet -> Campaign -> Runtime.Value -> Trace EmulatedWalletApi  TxOutRef'
-contrib w cmp v = exContrib <$> walletAction w (contribute cmp v) where
-    exContrib = snd . head . filter (isPayToScriptOut . fst) . txOutRefs . head
+contrib :: Wallet -> Runtime.Value -> Trace EmulatedWalletApi ()
+contrib w v = void $ walletAction w (contribute cmp v) where
+    cmp = cfCampaign scenario1
 
 -- | Make a contribution from wallet 2
-contrib2 :: Campaign -> Runtime.Value -> Trace EmulatedWalletApi  TxOutRef'
+contrib2 :: Runtime.Value -> Trace EmulatedWalletApi ()
 contrib2 = contrib (Wallet 2)
 
 -- | Make a contribution from wallet 3
-contrib3 :: Campaign -> Runtime.Value -> Trace EmulatedWalletApi  TxOutRef'
+contrib3 :: Runtime.Value -> Trace EmulatedWalletApi ()
 contrib3 = contrib (Wallet 3)
 
 -- | Collect the contributions of a crowdfunding campaign
-collect :: Wallet -> Campaign -> [(TxOutRef', UTXO.Value)] -> Trace EmulatedWalletApi  [Tx]
-collect w c  = walletAction w . CF.collect c
+collect :: Wallet -> Trace EmulatedWalletApi ()
+collect w = void $ walletAction w $ CF.collect $ cfCampaign scenario1
 
 -- | The scenario used in the property tests. In includes a campaign
 --   definition and the initial distribution of funds to the wallets
@@ -62,49 +63,47 @@ scenario1 = CFScenario{..} where
         campaignCollectionDeadline = Runtime.Height 15,
         campaignOwner              = PubKey 1
         }
-    cfWallets = Wallet <$> [1..3]
+    cfWallets = [w1, w2, w3]
     cfInitialBalances = Map.fromList [
         (PubKey 1, startingBalance),
         (PubKey 2, startingBalance),
         (PubKey 3, startingBalance)]
 
+w1, w2, w3 :: Wallet
+w1 = Wallet 1
+w2 = Wallet 2
+w3 = Wallet 3
 
--- | Generate a transaction that contributes some funds to a campaign.
+-- | Generate a transaction that contributes 600 ada to a campaign.
 --   NOTE: This doesn't actually run the validation script. The script
 --         will be run when the funds are retrieved
 makeContribution :: Property
 makeContribution = checkCFTrace scenario1 $ do
     let w = Wallet 2
-        contribution = 600
-        rest = startingBalance - fromIntegral contribution
-    processPending >>= walletNotifyBlock w
-    contrib2 (cfCampaign scenario1) contribution
-    processPending >>= walletNotifyBlock w
+        rest = startingBalance - 600
+    contrib2 600
+    processPending >>= notifyBlock
     assertOwnFundsEq w rest
 
 -- | Run a campaign with two contributions where the campaign owner collects
 --   the funds at the end
 successfulCampaign :: Property
 successfulCampaign = checkCFTrace scenario1 $ do
-    let CFScenario c [w1, w2, w3] _ = scenario1
-        updateAll' = updateAll scenario1
-    updateAll'
+    collect w1
 
     -- wallets 2 and 3 each contribute some funds
-    con2 <- contrib2 c 600
-    con3 <- contrib3 c 800
-    updateAll'
+    contrib2 600 >> contrib3 800
+    processPending >>= notifyBlock
 
     -- the campaign ends at blockheight 10 (specified in `scenario1`)
     -- so we add a number of empty blocks to ensure that the target
     -- height has ben reached.
-    addBlocks 10
+    blcks <- addBlocks 10
 
-    -- Wallet 1 can now collect the contributions. We need the definition
-    -- of the campaign, and the UTXOs representing contributions along with
-    -- how much money each contribution is worth.
-    collect w1 c [(con2, 600), (con3, 800)]
-    updateAll'
+    -- Once we have notified the wallets of the new blocks, wallet 1 will submit
+    -- the "collect funds" transaction, consuming the two contributions
+    notifyBlocks blcks
+    processPending >>= notifyBlock
 
     -- At the end we verify that the funds owned by wallets 2 and 3 have
     -- decreased by the amount of their contributions. Wallet 1, which started
@@ -114,18 +113,15 @@ successfulCampaign = checkCFTrace scenario1 $ do
 -- | Check that the campaign owner cannot collect the monies before the campaign deadline
 cantCollectEarly :: Property
 cantCollectEarly = checkCFTrace scenario1 $ do
-    let CFScenario c [w1, w2, w3] _ = scenario1
-        updateAll' = updateAll scenario1
-    updateAll'
-    con2 <- contrib2 c 600
-    con3 <- contrib3 c 800
-    updateAll'
+    contrib2 600 >> contrib3 800
+    processPending >>= notifyBlock
 
     -- Unlike in the `successfulCampaign` trace we don't advance the time before
     -- attempting to `collect` the funds. As a result, the transaction
     -- generated by `collect` will fail to validate and the funds remain locked.
-    collect w1 c [(con2, 600), (con3, 800)]
-    updateAll'
+    collect w1
+    processPending >>= notifyBlock
+
     traverse_ (uncurry assertOwnFundsEq) [(w2, startingBalance - 600), (w3, startingBalance - 800), (w1, startingBalance)]
 
 
@@ -133,39 +129,32 @@ cantCollectEarly = checkCFTrace scenario1 $ do
 --   collection deadline
 cantCollectLate :: Property
 cantCollectLate = checkCFTrace scenario1 $ do
-    let CFScenario c [w1, w2, w3] _ = scenario1
-        updateAll' = updateAll scenario1
-    updateAll'
-    con2 <- contrib2 c 600
-    con3 <- contrib3 c 800
-    updateAll'
+    contrib2 600 >> contrib3 800
+    processPending >>= notifyBlock
+    collect w1
 
     -- The deadline for collecting the funds is at 15 blocks (defined in
-    -- `scenario1`), so an attempt by the campaign owner to collect the funds
-    -- after that should fail.
-    addBlocks 15
-    collect w1 c [(con2, 600), (con3, 800)]
-    updateAll'
-    traverse_ (uncurry assertOwnFundsEq) [(w2, startingBalance - 600), (w3, startingBalance - 800), (w1, startingBalance)]
+    -- `scenario1`). With `addBlocks 15` we add 15 new blocks *before* notifying
+    -- the wallets of them. The trigger for `collectFunds` is still going to
+    -- fire, but the transaction will be rejected (because when that
+    -- transaction is validated, the blockchain is already too long, so the
+    -- validation script fails).
+    addBlocks 15 >>= notifyBlocks
+    processPending >>= notifyBlock
+
+    traverse_ (uncurry assertOwnFundsEq) [(w2, startingBalance), (w3, startingBalance), (w1, startingBalance)]
 
 -- | Run a successful campaign that ends with a refund
 canRefund :: Property
 canRefund = checkCFTrace scenario1 $ do
-    let CFScenario c [w1, w2, w3] _ = scenario1
-        updateAll' = updateAll scenario1
-    updateAll'
-    con2 <- contrib2 c 600
-    con3 <- contrib3 c 800
-    updateAll'
+    contrib2 600 >> contrib3 800
+    processPending >>= notifyBlock
 
     -- If the funds contributed to the campaign haven't been collected after 15
     -- blocks (as specified in `scenario1`) then the contributors can claim a
     -- refund.
-    addBlocks 15
-    walletAction w2 (refund c con2 600)
-    updateAll'
-    walletAction w3 (refund c con3 800)
-    updateAll'
+    addBlocks 15 >>= notifyBlocks
+    processPending >>= notifyBlock
 
     -- Now all wallets are back to their starting balances.
     -- NB On the real blockchain they would have slightly less than their
@@ -192,11 +181,14 @@ startingBalance = 1000
 checkCFTrace :: CFScenario -> Trace EmulatedWalletApi () -> Property
 checkCFTrace CFScenario{cfInitialBalances} t = property $ do
     let model = Gen.generatorModel { Gen.gmInitialBalance = cfInitialBalances }
-    (result, st) <- forAll $ Gen.runTraceOn model t
+    (result, st) <- forAll $ Gen.runTraceOn model (processPending >>= notifyBlock >> t)
     Hedgehog.assert (isRight result)
     Hedgehog.assert ([] == emTxPool st)
 
--- | Validate all pending transactions and notify the wallets
-updateAll :: CFScenario -> Trace EmulatedWalletApi [Tx]
-updateAll CFScenario{cfWallets} =
-    processPending >>= walletsNotifyBlock cfWallets
+-- | Notify all wallets in the campaign of the new blocks.
+notifyBlocks :: [Block] -> Trace EmulatedWalletApi ()
+notifyBlocks = traverse_ notifyBlock
+
+-- | Notify all wallets in the campaign of a new block
+notifyBlock :: Block -> Trace EmulatedWalletApi ()
+notifyBlock = void . walletsNotifyBlock [w1, w2, w3]

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -208,4 +208,4 @@ checkTrace t = property $ do
 -- | Validate all pending transactions and notify all wallets
 updateAll :: Trace EmulatedWalletApi ()
 updateAll =
-    blockchainActions >>= void . walletsNotifyBlock [w1, w2]
+    processPending >>= void . walletsNotifyBlock [w1, w2]

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -154,4 +154,4 @@ checkVestingTrace VestingScenario{vsInitialBalances} t = property $ do
 -- | Validate all pending transactions and notify the wallets
 updateAll :: VestingScenario -> Trace EmulatedWalletApi [Tx]
 updateAll VestingScenario{vsWallets} =
-    blockchainActions >>= walletsNotifyBlock vsWallets
+    processPending >>= walletsNotifyBlock vsWallets

--- a/wallet-api/src/Wallet/Emulator/AddressMap.hs
+++ b/wallet-api/src/Wallet/Emulator/AddressMap.hs
@@ -7,7 +7,8 @@ module Wallet.Emulator.AddressMap(
     values,
     fromTxOutputs,
     knownAddresses,
-    updateAddresses
+    updateAddresses,
+    restrict
     ) where
 
 import           Control.Lens   (At (..), Index, IxValue, Ixed (..), lens, (&), (.~), (^.))
@@ -106,6 +107,10 @@ inputs ::
 inputs addrs = Map.fromListWith Set.union
     . fmap (fmap Set.singleton . swap)
     . mapMaybe ((\a -> sequence (a, Map.lookup a addrs)) . txInRef)
+
+-- | Restrict an [[AddressMap]] to a set of addresses.
+restrict :: AddressMap -> Set.Set Address' -> AddressMap
+restrict (AddressMap mp) = AddressMap . Map.restrictKeys mp
 
 swap :: (a, b) -> (b, a)
 swap (x, y) = (y, x)

--- a/wallet-api/src/Wallet/Emulator/AddressMap.hs
+++ b/wallet-api/src/Wallet/Emulator/AddressMap.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TypeFamilies    #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE TypeFamilies       #-}
 module Wallet.Emulator.AddressMap(
     AddressMap(..),
     addAddress,
@@ -11,20 +13,49 @@ module Wallet.Emulator.AddressMap(
     restrict
     ) where
 
-import           Control.Lens   (At (..), Index, IxValue, Ixed (..), lens, (&), (.~), (^.))
-import           Data.Map       (Map)
-import qualified Data.Map       as Map
-import           Data.Maybe     (mapMaybe)
-import           Data.Monoid    (Monoid (..), Sum (..))
-import           Data.Semigroup (Semigroup (..))
-import qualified Data.Set       as Set
+import qualified Codec.CBOR.Write       as Write
+import           Codec.Serialise        (deserialiseOrFail)
+import           Codec.Serialise.Class  (Serialise, encode)
+import           Control.Lens           (At (..), Index, IxValue, Ixed (..), lens, (&), (.~), (^.))
+import           Data.Aeson             (FromJSON (..), ToJSON (..), withText)
+import qualified Data.Aeson             as JSON
+import           Data.Bifunctor         (first)
+import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy   as BSL
+import           Data.Map               (Map)
+import qualified Data.Map               as Map
+import           Data.Maybe             (mapMaybe)
+import           Data.Monoid            (Monoid (..), Sum (..))
+import           Data.Semigroup         (Semigroup (..))
+import qualified Data.Set               as Set
+import qualified Data.Text.Encoding     as TE
+import           GHC.Generics           (Generic)
 
-import           Wallet.UTXO    (Address', Tx (..), TxIn (..), TxIn', TxOut (..), TxOutRef (..), TxOutRef', Value,
-                                 hashTx)
+import           Wallet.UTXO            (Address', Tx (..), TxIn (..), TxIn', TxOut (..), TxOutRef (..), TxOutRef',
+                                         Value, hashTx)
 
 -- | A map of [[Address']]es and their unspent outputs
 newtype AddressMap = AddressMap { getAddressMap :: Map Address' (Map TxOutRef' Value) }
     deriving Show
+    deriving stock (Generic)
+    deriving newtype (Serialise)
+
+-- NB: The ToJSON and FromJSON instance for AddressMap use the `Serialise`
+-- instance with a base64 encoding, similar to the instances in Types.hs.
+-- I chose this approach over the generic deriving mechanism because that would
+-- have required `ToJSONKey` and `FromJSONKey` instances for `Address'` and
+-- `TxOutRef'` which ultimately would have introduced more boilerplate code
+-- than what we have here.
+
+instance ToJSON AddressMap where
+    toJSON = JSON.String . TE.decodeUtf8 . Base64.encode . Write.toStrictByteString . encode
+
+instance FromJSON AddressMap where
+    parseJSON = withText "AddressMap" $ \s -> do
+        let ev = do
+                eun64 <- Base64.decode . TE.encodeUtf8 $ s
+                first show $ deserialiseOrFail $ BSL.fromStrict eun64
+        either fail pure ev
 
 instance Semigroup AddressMap where
     (AddressMap l) <> (AddressMap r) = AddressMap (Map.unionWith add l r) where

--- a/wallet-api/src/Wallet/Emulator/Client.hs
+++ b/wallet-api/src/Wallet/Emulator/Client.hs
@@ -17,21 +17,22 @@ module Wallet.Emulator.Client
   , process
   ) where
 
-import           Control.Monad             (void)
-import           Control.Monad.Except      (ExceptT (ExceptT), throwError)
-import           Control.Monad.Operational (interpretWithMonad)
-import           Control.Monad.Reader      (MonadReader, ReaderT, asks, lift, runReaderT)
-import           Control.Monad.Writer      (MonadWriter, WriterT, runWriterT, tell)
-import           Data.Foldable             (fold)
-import           Data.Proxy                (Proxy (Proxy))
-import           Data.Set                  (Set)
-import           Servant.API               ((:<|>) ((:<|>)), NoContent)
-import           Servant.Client            (ClientEnv, ClientM, ServantError, client, runClientM)
-import           Wallet.API                (KeyPair, WalletAPI (..))
-import           Wallet.Emulator.Http      (API)
-import           Wallet.Emulator.Types     (Assertion (IsValidated, OwnFundsEqual), Event (..),
-                                            Notification (BlockHeight, BlockValidated), Trace, Wallet)
-import           Wallet.UTXO               (Block, Height, Tx, TxIn', TxOut', Value)
+import           Control.Monad              (void)
+import           Control.Monad.Except       (ExceptT (ExceptT), throwError)
+import           Control.Monad.Operational  (interpretWithMonad)
+import           Control.Monad.Reader       (MonadReader, ReaderT, asks, lift, runReaderT)
+import           Control.Monad.Writer       (MonadWriter, WriterT, runWriterT, tell)
+import           Data.Foldable              (fold)
+import           Data.Proxy                 (Proxy (Proxy))
+import           Data.Set                   (Set)
+import           Servant.API                ((:<|>) ((:<|>)), NoContent)
+import           Servant.Client             (ClientEnv, ClientM, ServantError, client, runClientM)
+import           Wallet.API                 (KeyPair, WalletAPI (..))
+import           Wallet.Emulator.AddressMap (AddressMap)
+import           Wallet.Emulator.Http       (API)
+import           Wallet.Emulator.Types      (Assertion (IsValidated, OwnFundsEqual), Event (..),
+                                             Notification (BlockHeight, BlockValidated), Trace, Wallet)
+import           Wallet.UTXO                (Block, Height, Tx, TxIn', TxOut', Value)
 
 api :: Proxy API
 api = Proxy
@@ -45,10 +46,12 @@ submitTxn' :: Wallet -> Tx -> ClientM [Tx]
 getTransactions :: ClientM [Tx]
 processPending :: ClientM [Tx]
 blockValidated :: Wallet -> Block -> ClientM ()
-blockHeight :: Wallet -> Height -> ClientM ()
+getAddresses :: Wallet -> ClientM AddressMap
+getBlockHeight :: Wallet -> ClientM Height
+setBlockHeight :: Wallet -> Height -> ClientM ()
 assertOwnFundsEq :: Wallet -> Value -> ClientM NoContent
 assertIsValidated :: Tx -> ClientM NoContent
-(wallets :<|> fetchWallet :<|> createWallet :<|> myKeyPair' :<|> createPaymentWithChange' :<|> submitTxn' :<|> getTransactions) :<|> (blockValidated :<|> blockHeight) :<|> processPending  :<|> (assertOwnFundsEq :<|> assertIsValidated) =
+(wallets :<|> fetchWallet :<|> createWallet :<|> myKeyPair' :<|> createPaymentWithChange' :<|> submitTxn' :<|> getAddresses :<|> getBlockHeight :<|> getTransactions) :<|> (blockValidated :<|> setBlockHeight) :<|> processPending  :<|> (assertOwnFundsEq :<|> assertIsValidated) =
   client api
 
 data Environment = Environment
@@ -91,10 +94,12 @@ instance WalletAPI WalletClient where
   myKeyPair = liftWallet myKeyPair'
   createPaymentWithChange value = liftWallet (`createPaymentWithChange'` value)
   register _ _ = pure () -- TODO: Keep track of triggers in emulated wallet
+  watchedAddresses = liftWallet getAddresses
+  blockHeight = liftWallet getBlockHeight
 
 handleNotification :: Notification -> (Wallet -> ClientM ())
 handleNotification (BlockValidated block) = (`blockValidated` block)
-handleNotification (BlockHeight height)   = (`blockHeight` height)
+handleNotification (BlockHeight height)   = (`setBlockHeight` height)
 
 assert :: Assertion -> ClientM ()
 assert (IsValidated tx)             = void $ assertIsValidated tx

--- a/wallet-api/src/Wallet/Emulator/Client.hs
+++ b/wallet-api/src/Wallet/Emulator/Client.hs
@@ -11,7 +11,7 @@ module Wallet.Emulator.Client
   , getTransactions
   , blockValidated
   , blockHeight
-  , blockchainActions
+  , processPending
   , assertOwnFundsEq
   , assertIsValidated
   , process
@@ -43,12 +43,12 @@ myKeyPair' :: Wallet -> ClientM KeyPair
 createPaymentWithChange' :: Wallet -> Value -> ClientM (Set TxIn', TxOut')
 submitTxn' :: Wallet -> Tx -> ClientM [Tx]
 getTransactions :: ClientM [Tx]
-blockchainActions :: ClientM [Tx]
+processPending :: ClientM [Tx]
 blockValidated :: Wallet -> Block -> ClientM ()
 blockHeight :: Wallet -> Height -> ClientM ()
 assertOwnFundsEq :: Wallet -> Value -> ClientM NoContent
 assertIsValidated :: Tx -> ClientM NoContent
-(wallets :<|> fetchWallet :<|> createWallet :<|> myKeyPair' :<|> createPaymentWithChange' :<|> submitTxn' :<|> getTransactions) :<|> (blockValidated :<|> blockHeight) :<|> blockchainActions  :<|> (assertOwnFundsEq :<|> assertIsValidated) =
+(wallets :<|> fetchWallet :<|> createWallet :<|> myKeyPair' :<|> createPaymentWithChange' :<|> submitTxn' :<|> getTransactions) :<|> (blockValidated :<|> blockHeight) :<|> processPending  :<|> (assertOwnFundsEq :<|> assertIsValidated) =
   client api
 
 data Environment = Environment
@@ -109,7 +109,7 @@ eval clientEnv =
       traverse
         (runWalletAction clientEnv wallet . liftWallet . handleNotification)
         trigger
-    BlockchainActions -> ExceptT $ runClientM blockchainActions clientEnv
+    BlockchainProcessPending -> ExceptT $ runClientM processPending clientEnv
     Assertion a -> ExceptT $ runClientM (assert a) clientEnv
 
 process :: ClientEnv -> Trace WalletClient a -> ExceptT ServantError IO a

--- a/wallet-api/src/Wallet/Emulator/Http.hs
+++ b/wallet-api/src/Wallet/Emulator/Http.hs
@@ -157,7 +157,7 @@ walletHandlers state =
       wallets :<|> fetchWallet :<|> createWallet :<|> myKeyPair :<|> createPaymentWithChange :<|>
       submitTxn :<|>
       getTransactions
-    controlApi = blockchainActions
+    controlApi = processPending
     walletControlApi = blockValidated :<|> blockHeight
     assertionsApi = assertOwnFundsEq :<|> assertIsValidated
 
@@ -228,13 +228,13 @@ runStateSTM var action = do
   writeTVar var newState
   pure res
 
-blockchainActions :: (MonadReader ServerState m, MonadIO m) => m [Tx]
-blockchainActions = do
+processPending :: (MonadReader ServerState m, MonadIO m) => m [Tx]
+processPending = do
   var <- asks getState
-  liftIO . atomically $ blockchainActionsSTM var
+  liftIO . atomically $ processPendingSTM var
 
-blockchainActionsSTM :: TVar EmulatorState -> STM [Tx]
-blockchainActionsSTM var = do
+processPendingSTM :: TVar EmulatorState -> STM [Tx]
+processPendingSTM var = do
   es <- readTVar var
   let processed = validateEm es <$> emTxPool es
       validated = catMaybes processed

--- a/wallet-api/src/Wallet/Emulator/Http.hs
+++ b/wallet-api/src/Wallet/Emulator/Http.hs
@@ -27,12 +27,13 @@ import           Data.Maybe                 (catMaybes)
 import           Data.Proxy                 (Proxy (Proxy))
 import           Data.Set                   (Set)
 import qualified Data.Set                   as Set
-import           Servant                    (Application, Handler, ServantErr (errBody), Server, err404, err500,
+import           Servant                    (Application, Handler, ServantErr (errBody), Server, err404, err500, err501,
                                              hoistServer, serve, throwError)
 import           Servant.API                ((:<|>) ((:<|>)), (:>), Capture, Get, JSON, NoContent (NoContent), Post,
                                              ReqBody)
 import           Wallet.API                 (KeyPair)
 import qualified Wallet.API                 as WAPI
+import           Wallet.Emulator.AddressMap (AddressMap)
 import           Wallet.Emulator.Types      (Assertion (IsValidated, OwnFundsEqual), EmulatedWalletApi,
                                              EmulatorState (emWalletState), Notification (BlockHeight, BlockValidated),
                                              Wallet, WalletState, assert, chain, emTxPool, emptyEmulatorState,
@@ -46,13 +47,14 @@ type WalletAPI
      :<|> "wallets" :> Capture "walletid" Wallet :> Get '[ JSON] Wallet
      :<|> "wallets" :> ReqBody '[ JSON] Wallet :> Post '[ JSON] NoContent
      :<|> "wallets" :> Capture "walletid" Wallet :> "my-key-pair" :> Get '[ JSON] KeyPair
-     :<|> "wallets" :> Capture "walletid" Wallet :> "payments" :> ReqBody '[ JSON] Value :> Post '[ JSON] ( Set TxIn'
-                                                                                                          , TxOut')
+     :<|> "wallets" :> Capture "walletid" Wallet :> "payments" :> ReqBody '[ JSON] Value :> Post '[ JSON] (Set TxIn', TxOut')
 -- This is where the line between wallet API and control API is crossed
 -- Returning the [Tx] only makes sense when running a WalletAPI m => m () inside a Trace, but not on the wallet API on its own,
 --   otherwise the signature of submitTxn would be submitTxn :: Tx -> m [Tx]
 -- Unfortunately we need to return the Tx here because we have to reference it later. So I can't see a way around this change.
      :<|> "wallets" :> Capture "walletid" Wallet :> "transactions" :> ReqBody '[ JSON] Tx :> Post '[ JSON] [Tx]
+     :<|> "wallets" :> Capture "walletid" Wallet :> "watched-addresses" :> Get '[JSON] AddressMap
+     :<|> "wallets" :> Capture "walletid" Wallet :> "block-height" :> Get '[JSON] Height
      :<|> "wallets" :> "transactions" :> Get '[ JSON] [Tx]
 
 type WalletControlAPI
@@ -132,6 +134,16 @@ getTransactions = do
   states <- liftIO $ readTVarIO var
   view (txPool . to pure) states
 
+getWatchedAddresses :: MonadError ServantErr m
+  => Wallet
+  -> m AddressMap
+getWatchedAddresses _ = throwError err501 -- not implemented
+
+getBlockHeight :: MonadError ServantErr m
+  => Wallet
+  -> m Height
+getBlockHeight _ = throwError err501 -- not implemented
+
 -- | Concrete monad stack for server server
 newtype AppM a = AppM
   { unM :: ReaderT ServerState (ExceptT ServantErr IO) a
@@ -156,6 +168,8 @@ walletHandlers state =
     walletApi =
       wallets :<|> fetchWallet :<|> createWallet :<|> myKeyPair :<|> createPaymentWithChange :<|>
       submitTxn :<|>
+      getWatchedAddresses :<|>
+      getBlockHeight :<|>
       getTransactions
     controlApi = processPending
     walletControlApi = blockValidated :<|> blockHeight

--- a/wallet-api/src/Wallet/UTXO/Runtime.hs
+++ b/wallet-api/src/Wallet/UTXO/Runtime.hs
@@ -6,9 +6,7 @@
 module Wallet.UTXO.Runtime (-- * Transactions and related types
                 PubKey(..)
               , Value(..)
-              , getValue
               , Height(..)
-              , getHeight
               , PendingTxOutRef(..)
               , Signature(..)
               -- ** Hashes (see note [Hashes in validator scripts])
@@ -113,14 +111,11 @@ instance (TypeablePlc a, LiftPlc a) => LiftPlc (Signed a)
 -- | Ada value
 --
 -- TODO: Use [[Wallet.UTXO.Types.Value]] when Integer is supported
-data Value = Value Int
+data Value = Value { getValue ::  Int }
     deriving (Eq, Ord, Show, Generic)
 
 instance TypeablePlc Value
 instance LiftPlc Value
-
-getValue :: Value -> Int
-getValue (Value i) = i
 
 instance Enum Value where
     toEnum = Value
@@ -212,11 +207,8 @@ plcDigest = serialise
 
 -- | Blockchain height
 --   TODO: Use [[Wallet.UTXO.Height]] when Integer is supported
-data Height = Height Int
+data Height = Height { getHeight :: Int }
     deriving (Eq, Ord, Show, Generic)
 
 instance TypeablePlc Height
 instance LiftPlc Height
-
-getHeight :: Height -> Int
-getHeight (Height h) = h

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -120,7 +120,8 @@ eventTrace = property $ do
         $ Gen.runTraceOn Gen.generatorModel
         $ do
             processPending >>= walletNotifyBlock w
-            let mkPayment = BlockchainAction $ \_ _ -> payToPubKey 100 (PubKey 2)
+            let mkPayment =
+                    BlockchainAction $ \_ _ -> void $ payToPubKey 100 (PubKey 2)
                 trigger = blockHeightT (GEQ 3)
 
             -- schedule the `mkPayment` action to run when block height 3 is
@@ -144,7 +145,8 @@ watchFundsAtAddress = property $ do
         $ Gen.runTraceOn Gen.generatorModel
         $ do
             processPending >>= walletNotifyBlock w
-            let mkPayment = BlockchainAction $ \_ _ -> payToPubKey 100 (PubKey 2)
+            let mkPayment =
+                    BlockchainAction $ \_ _ -> void $ payToPubKey 100 (PubKey 2)
                 t1 = blockHeightT (Interval 3 4)
                 t2 = fundsAtAddressT (pubKeyAddress pkTarget) (GEQ 1)
             walletNotifyBlock w =<<

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -63,13 +63,13 @@ txnValid = property $ do
 txnIndex :: Property
 txnIndex = property $ do
     (m, txn) <- forAll genChainTxn
-    let (result, st) = Gen.runTrace m $ blockchainActions >> simpleTrace txn
+    let (result, st) = Gen.runTrace m $ processPending >> simpleTrace txn
     Hedgehog.assert (Index.initialise (emChain st) == emIndex st)
 
 txnIndexValid :: Property
 txnIndexValid = property $ do
     (m, txn) <- forAll genChainTxn
-    let (result, st) = Gen.runTrace m blockchainActions
+    let (result, st) = Gen.runTrace m processPending
         idx = emIndex st
     Hedgehog.assert (Right () == Index.runValidation (Index.validateTransaction 0 txn) idx)
 
@@ -78,13 +78,13 @@ txnIndexValid = property $ do
 simpleTrace :: Tx -> Trace EmulatedWalletApi ()
 simpleTrace txn = do
     [txn'] <- walletAction (Wallet 1) $ submitTxn txn
-    block <- blockchainActions
+    block <- processPending
     assertIsValidated txn'
 
 validTrace :: Property
 validTrace = property $ do
     (m, txn) <- forAll genChainTxn
-    let (result, st) = Gen.runTrace m $ blockchainActions >> simpleTrace txn
+    let (result, st) = Gen.runTrace m $ processPending >> simpleTrace txn
     Hedgehog.assert (isRight result)
     Hedgehog.assert ([] == emTxPool st)
 
@@ -109,7 +109,7 @@ notifyWallet = property $ do
     let w = Wallet 1
     (e, EmulatorState{ emWalletState = st }) <- forAll
         $ Gen.runTraceOn Gen.generatorModel
-        $ blockchainActions >>= walletNotifyBlock w
+        $ processPending >>= walletNotifyBlock w
     let ttl = Map.lookup w st
     Hedgehog.assert $ (getSum . foldMap Sum . view ownFunds <$> ttl) == Just initialBalance
 
@@ -119,7 +119,7 @@ eventTrace = property $ do
     (e, EmulatorState{ emWalletState = st }) <- forAll
         $ Gen.runTraceOn Gen.generatorModel
         $ do
-            blockchainActions >>= walletNotifyBlock w
+            processPending >>= walletNotifyBlock w
             let mkPayment = BlockchainAction $ \_ _ -> payToPubKey 100 (PubKey 2)
                 trigger = blockHeightT (GEQ 3)
 
@@ -130,7 +130,7 @@ eventTrace = property $ do
 
             -- advance the clock to trigger `mkPayment`
             addBlocks 2 >>= traverse_ (walletNotifyBlock w)
-            void (blockchainActions >>= walletNotifyBlock w)
+            void (processPending >>= walletNotifyBlock w)
     let ttl = Map.lookup w st
 
     -- if `mkPayment` was run then the funds of wallet 1 should be reduced by 100
@@ -143,7 +143,7 @@ watchFundsAtAddress = property $ do
     (e, EmulatorState{ emWalletState = st }) <- forAll
         $ Gen.runTraceOn Gen.generatorModel
         $ do
-            blockchainActions >>= walletNotifyBlock w
+            processPending >>= walletNotifyBlock w
             let mkPayment = BlockchainAction $ \_ _ -> payToPubKey 100 (PubKey 2)
                 t1 = blockHeightT (Interval 3 4)
                 t2 = fundsAtAddressT (pubKeyAddress pkTarget) (GEQ 1)
@@ -155,7 +155,7 @@ watchFundsAtAddress = property $ do
             -- after 3 blocks, t1 should fire, triggering the first payment of 100 to PubKey 2
             -- after 4 blocks, t2 should fire, triggering the second payment of 100
             addBlocks 3 >>= traverse_ (walletNotifyBlock w)
-            void (blockchainActions >>= walletNotifyBlock w)
+            void (processPending >>= walletNotifyBlock w)
     let ttl = Map.lookup w st
     Hedgehog.assert $ (getSum . foldMap Sum . view ownFunds <$> ttl) == Just (initialBalance - 200)
 

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -120,7 +120,7 @@ eventTrace = property $ do
         $ Gen.runTraceOn Gen.generatorModel
         $ do
             blockchainActions >>= walletNotifyBlock w
-            let mkPayment = payToPubKey 100 (PubKey 2)
+            let mkPayment = BlockchainAction $ \_ _ -> payToPubKey 100 (PubKey 2)
                 trigger = blockHeightT (GEQ 3)
 
             -- schedule the `mkPayment` action to run when block height 3 is
@@ -144,7 +144,7 @@ watchFundsAtAddress = property $ do
         $ Gen.runTraceOn Gen.generatorModel
         $ do
             blockchainActions >>= walletNotifyBlock w
-            let mkPayment = payToPubKey 100 pkTarget
+            let mkPayment = BlockchainAction $ \_ _ -> payToPubKey 100 (PubKey 2)
                 t1 = blockHeightT (Interval 3 4)
                 t2 = fundsAtAddressT (pubKeyAddress pkTarget) (GEQ 1)
             walletNotifyBlock w =<<

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -121,7 +121,7 @@ eventTrace = property $ do
         $ do
             processPending >>= walletNotifyBlock w
             let mkPayment =
-                    BlockchainAction $ \_ _ -> void $ payToPubKey 100 (PubKey 2)
+                    EventHandler $ \_ -> void $ payToPubKey 100 (PubKey 2)
                 trigger = blockHeightT (GEQ 3)
 
             -- schedule the `mkPayment` action to run when block height 3 is
@@ -146,7 +146,7 @@ watchFundsAtAddress = property $ do
         $ do
             processPending >>= walletNotifyBlock w
             let mkPayment =
-                    BlockchainAction $ \_ _ -> void $ payToPubKey 100 (PubKey 2)
+                    EventHandler $ \_ -> void $ payToPubKey 100 (PubKey 2)
                 t1 = blockHeightT (Interval 3 4)
                 t2 = fundsAtAddressT (pubKeyAddress pkTarget) (GEQ 1)
             walletNotifyBlock w =<<


### PR DESCRIPTION
* Use blockchain triggers to handle refund and collect outcomes of the contract
* Extend contract to handle an arbitrary number of contributions
* Remove most type annotations in the script
* When registering an action in the wallet API, the user now gets the list of the unspent outputs at the relevant addresses (otherwise we can't consume anything from that address in response to the trigger)
