### PR TITLE
Build: build lazy machine doc with nix and on CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For example:
 nix build -f default.nix localPackages.language-plutus-core
 ```
 
-The Plutus Core specification is also built this way, as the attribute `plutus-core-spec`.
+The Plutus Core specification is also built this way, as the attribute `docs.plutus-core-spec`.
 
 ### Binary caches
 

--- a/default.nix
+++ b/default.nix
@@ -106,7 +106,10 @@ let
         inherit src;
       };
     };
-    plutus-core-spec = pkgs.callPackage ./plutus-core-spec {};
+    docs = {
+      plutus-core-spec = pkgs.callPackage ./plutus-core-spec {};
+      lazy-machine = pkgs.callPackage ./docs/fomega/lazy-machine {};
+    };
     inherit (pkgs) stack2nix;
   });
 

--- a/docs/fomega/lazy-machine/README.md
+++ b/docs/fomega/lazy-machine/README.md
@@ -1,6 +1,7 @@
 This directory contains a document describing the implementation of a lazy
 abstract machine for Plutus Core and some benchmarking results for the lazy
-machine and others.  To build the PDF, type `make`.
+machine and others.  To build the PDF, type `make`, or run 
+`nix build -f default.nix docs.lazy-machine` from the root.
 
 The `benchmarking` subdirectory contains scripts to run some timing benchmarks
 and plot the results.  This will probably only work on Linux (or maybe OSX with

--- a/docs/fomega/lazy-machine/default.nix
+++ b/docs/fomega/lazy-machine/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, lib, texlive }:
+
+let
+  tex = texlive.combine {
+    inherit (texlive)
+    scheme-small
+    collection-latexextra
+    collection-mathscience
+    latexmk;
+  };
+in
+stdenv.mkDerivation {
+  name = "lazy-machine";
+  buildInputs = [ tex ];
+  src = ./.;
+  installPhase = "install -D lazy-plutus-core.pdf $out/lazy-plutus-core.pdf";
+
+  meta = with lib; {
+    description = "Lazy machine discussion";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -22,10 +22,11 @@ let
   pkgs = import fixedNixpkgs { config = {}; };
   shellEnv = import ./shell.nix { };
   haskellPackages = map (name: lib.nameValuePair name supportedSystems) fixedLib.plutusPkgList;
+  # don't need to build the docs on anything other than one platform
+  docs = map (name: lib.nameValuePair name [ "x86_64-linux" ]) (builtins.attrNames plutusPkgs.docs);
   platforms = {
     inherit haskellPackages;
-    # don't need to build the spec on anything other than one platform
-    plutus-core-spec = [ "x86_64-linux" ];
+    inherit docs;
   };
   mapped = mapTestOn platforms;
   makePlutusTestRuns = system:

--- a/release.nix
+++ b/release.nix
@@ -47,12 +47,6 @@ in pkgs.lib.fix (jobsets:  mapped // {
       in
     [
       (builtins.concatLists (map lib.attrValues (all jobsets.all-plutus-tests)))
-      # TODO: generify to just add everything in tests and docs
-      jobsets.tests.hlint
-      jobsets.tests.shellcheck
-      jobsets.tests.stylishHaskell
-      jobsets.docs.plutus-core-spec
-      jobsets.docs.lazy-machine
-    ];
+    ] ++ (builtins.attrValues jobsets.tests) ++ (builtins.attrValues jobsets.docs);
   });
 })

--- a/release.nix
+++ b/release.nix
@@ -36,7 +36,7 @@ let
     f = name: value: value.testrun;
   in pkgs.lib.mapAttrs f (lib.filterAttrs pred plutusPkgs.haskellPackages);
 in pkgs.lib.fix (jobsets:  mapped // {
-  inherit (plutusPkgs) tests;
+  inherit (plutusPkgs) tests docs;
   all-plutus-tests = builtins.listToAttrs (map (arch: { name = arch; value = makePlutusTestRuns arch; }) supportedSystems);
   required = pkgs.lib.hydraJob (pkgs.releaseTools.aggregate {
     name = "plutus-required-checks";
@@ -47,9 +47,12 @@ in pkgs.lib.fix (jobsets:  mapped // {
       in
     [
       (builtins.concatLists (map lib.attrValues (all jobsets.all-plutus-tests)))
+      # TODO: generify to just add everything in tests and docs
       jobsets.tests.hlint
       jobsets.tests.shellcheck
       jobsets.tests.stylishHaskell
+      jobsets.docs.plutus-core-spec
+      jobsets.docs.lazy-machine
     ];
   });
 })


### PR DESCRIPTION
So the lazy machine doc can be built with nix and built by CI.

I tried to make it so everything in the `docs` attr set gets built on linux, let's see if I succeeded.