### PR TITLE
core-to-plc: support integral methods

### DIFF
--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
@@ -155,6 +155,13 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
                 (GHC.Type (GHC.eqType GHC.intTy -> True)))
             -- last arg is typeclass dictionary
             _ -> convNumMethod (GHC.getName n)
+        GHC.App (GHC.App
+                -- integral class method
+                (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId ((==) GHC.integralClassName . GHC.getName -> True)))
+                -- we only support applying to int
+                (GHC.Type (GHC.eqType GHC.intTy -> True)))
+            -- last arg is typeclass dictionary
+            _ -> convIntegralMethod (GHC.getName n)
         -- void# - values of type void get represented as error, since they should be unreachable
         GHC.Var n | n == GHC.voidPrimId || n == GHC.voidArgId -> errorFunc
         -- See note [GHC runtime errors]

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Expr.hs
@@ -135,33 +135,16 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
         GHC.App (GHC.Var (isPrimitiveWrapper -> True)) arg -> convExpr arg
         -- special typeclass method calls
         GHC.App (GHC.App
-                -- eq class method
-                (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId ((==) GHC.eqClassName . GHC.getName -> True)))
+                (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId (GHC.getName -> className)))
                 -- we only support applying to int
                 (GHC.Type (GHC.eqType GHC.intTy -> True)))
             -- last arg is typeclass dictionary
-            _ -> convEqMethod (GHC.getName n)
-        GHC.App (GHC.App
-                -- ord class method
-                (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId ((==) GHC.ordClassName . GHC.getName -> True)))
-                -- we only support applying to int
-                (GHC.Type (GHC.eqType GHC.intTy -> True)))
-            -- last arg is typeclass dictionary
-            _ -> convOrdMethod (GHC.getName n)
-        GHC.App (GHC.App
-                -- num class method
-                (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId ((==) GHC.numClassName . GHC.getName -> True)))
-                -- we only support applying to int
-                (GHC.Type (GHC.eqType GHC.intTy -> True)))
-            -- last arg is typeclass dictionary
-            _ -> convNumMethod (GHC.getName n)
-        GHC.App (GHC.App
-                -- integral class method
-                (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId ((==) GHC.integralClassName . GHC.getName -> True)))
-                -- we only support applying to int
-                (GHC.Type (GHC.eqType GHC.intTy -> True)))
-            -- last arg is typeclass dictionary
-            _ -> convIntegralMethod (GHC.getName n)
+            _ -> case className of
+                     ((==) GHC.eqClassName -> True) -> convEqMethod (GHC.getName n)
+                     ((==) GHC.ordClassName -> True) -> convOrdMethod (GHC.getName n)
+                     ((==) GHC.numClassName -> True) -> convNumMethod (GHC.getName n)
+                     ((==) GHC.integralClassName -> True) -> convIntegralMethod (GHC.getName n)
+                     _ -> throwSd UnsupportedError $ "Typeclass method:" GHC.<+> GHC.ppr n
         -- void# - values of type void get represented as error, since they should be unreachable
         GHC.Var n | n == GHC.voidPrimId || n == GHC.voidArgId -> errorFunc
         -- See note [GHC runtime errors]

--- a/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Primitives.hs
+++ b/core-to-plc/src/Language/Plutus/CoreToPLC/Compiler/Primitives.hs
@@ -57,3 +57,9 @@ convNumMethod name
     | GHC.getOccString name == "+" = lookupBuiltinTerm 'Builtins.addInteger
     | GHC.getOccString name == "*" = lookupBuiltinTerm 'Builtins.multiplyInteger
     | otherwise = throwSd UnsupportedError $ "Num method:" GHC.<+> GHC.ppr name
+
+convIntegralMethod :: (Converting m) => GHC.Name -> m PIRTerm
+convIntegralMethod name
+    | GHC.getOccString name == "div" = lookupBuiltinTerm 'Builtins.divideInteger
+    | GHC.getOccString name == "rem" = lookupBuiltinTerm 'Builtins.remainderInteger
+    | otherwise = throwSd UnsupportedError $ "Integral method:" GHC.<+> GHC.ppr name

--- a/core-to-plc/test/Plugin/Spec.hs
+++ b/core-to-plc/test/Plugin/Spec.hs
@@ -71,6 +71,7 @@ primitives = testNested "primitives" [
   , goldenEval "intEqApply" [ intEq, int, int ]
   , goldenPlc "void" void
   , goldenPlc "intPlus" intPlus
+  , goldenPlc "intDiv" intDiv
   , goldenEval "intPlusApply" [ intPlus, int, int2 ]
   , goldenPlc "error" errorPlc
   , goldenPlc "ifThenElse" ifThenElse
@@ -114,6 +115,9 @@ void = plc @"void" (\(x::Int) (y::Int) -> let a x' y' = case (x', y') of { (True
 
 intPlus :: PlcCode
 intPlus = plc @"intPlus" (\(x::Int) (y::Int) -> x + y)
+
+intDiv :: PlcCode
+intDiv = plc @"intDiv" (\(x::Int) (y::Int) -> x `div` y)
 
 errorPlc :: PlcCode
 errorPlc = plc @"errorPlc" (Builtins.error @Int)

--- a/core-to-plc/test/Plugin/primitives/intDiv.plc.golden
+++ b/core-to-plc/test/Plugin/primitives/intDiv.plc.golden
@@ -1,0 +1,15 @@
+(program 1.0.0
+  [
+    (lam
+      divideInteger_69
+      (fun [(con integer) (con 64)] (fun [(con integer) (con 64)] [(con integer) (con 64)]))
+      (lam
+        ds_70
+        [(con integer) (con 64)]
+        (lam ds_71 [(con integer) (con 64)] [ [ divideInteger_69 ds_70 ] ds_71 ]
+        )
+      )
+    )
+    { (builtin divideInteger) (con 64) }
+  ]
+)


### PR DESCRIPTION
Need this for `div` and `rem` on `Int`.