### PR TITLE
Add basic sanity checking for unique usage

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -45,6 +45,7 @@ library
         Language.PlutusCore.View
         Language.PlutusCore.Subst
         Language.PlutusCore.Name
+        Language.PlutusCore.Check.Uniques
         Language.PlutusCore.StdLib.Data.Bool
         Language.PlutusCore.StdLib.Data.ChurchNat
         Language.PlutusCore.StdLib.Data.Function
@@ -89,6 +90,7 @@ library
         Language.PlutusCore.TypeSynthesis
         Language.PlutusCore.Normalize
         Language.PlutusCore.CBOR
+        Language.PlutusCore.Analysis.Definitions
         Language.PlutusCore.Generators.Internal.Denotation
         Language.PlutusCore.Generators.Internal.Entity
         Language.PlutusCore.Generators.Internal.TypeEvalCheck
@@ -174,6 +176,7 @@ test-suite language-plutus-core-test
         Evaluation.Constant.Resize
         Generators
         Pretty.Readable
+        Check.Spec
         TypeSynthesis.Spec
         Quotation.Spec
     default-language: Haskell2010

--- a/language-plutus-core/prelude/PlutusPrelude.hs
+++ b/language-plutus-core/prelude/PlutusPrelude.hs
@@ -22,6 +22,9 @@ module PlutusPrelude ( -- * Reëxports from base
                      , fromRight
                      , isRight
                      , void
+                     , ($>)
+                     , (<$)
+                     , through
                      , coerce
                      , Generic
                      , NFData
@@ -100,7 +103,7 @@ import           Data.Coerce                             (Coercible, coerce)
 import           Data.Either                             (fromRight, isRight)
 import           Data.Foldable                           (fold, toList)
 import           Data.Function                           (on)
-import           Data.Functor                            (void)
+import           Data.Functor                            (void, ($>), (<$))
 import           Data.Functor.Foldable                   (Base, Corecursive, Recursive, embed, project)
 import           Data.List                               (foldl')
 import           Data.List.NonEmpty                      (NonEmpty (..))
@@ -200,6 +203,10 @@ prettyTextBy = docText .* prettyBy
 
 (<<*>>) :: (Applicative f1, Applicative f2) => f1 (f2 (a -> b)) -> f1 (f2 a) -> f1 (f2 b)
 f <<*>> a = getCompose $ Compose f <*> Compose a
+
+-- | Makes an effectful function ignore its result value and return its input value.
+through :: Functor f => (a -> f b) -> (a -> f a)
+through f x = f x $> x
 
 -- | Fold a monadic function over a 'Foldable'. The monadic version of 'foldMap'.
 foldMapM :: (Foldable f, Monad m, Monoid b) => (a -> m b) -> f a -> m b

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -91,6 +91,7 @@ module Language.PlutusCore
     , Error (..)
     , AsError (..)
     , UnknownDynamicBuiltinNameError (..)
+    , UniqueError (..)
     -- * Base functors
     , TermF (..)
     , TypeF (..)
@@ -122,6 +123,7 @@ import qualified Data.Text                                as T
 import           Data.Text.Prettyprint.Doc
 import           Language.PlutusCore.CBOR                 ()
 import           Language.PlutusCore.Check.Normal
+import qualified Language.PlutusCore.Check.Uniques        as Uniques
 import           Language.PlutusCore.Error
 import           Language.PlutusCore.Evaluation.CkMachine
 import           Language.PlutusCore.Lexer
@@ -161,11 +163,18 @@ checkFile :: FilePath -> IO (Maybe T.Text)
 checkFile = fmap (either (pure . prettyText) id . fmap (fmap prettyPlcDefText . check) . parse) . BSL.readFile
 
 -- | Print the type of a program contained in a 'ByteString'
-printType :: (AsParseError e AlexPosn, AsRenameError e AlexPosn, AsTypeError e AlexPosn, MonadError e m) => BSL.ByteString -> m T.Text
+printType
+    :: (AsParseError e AlexPosn, AsUniqueError e AlexPosn, AsRenameError e AlexPosn, AsTypeError e AlexPosn, MonadError e m)
+    => BSL.ByteString
+    -> m T.Text
 printType = printNormalizeType False
 
 -- | Print the type of a program contained in a 'ByteString'
-printNormalizeType :: (AsParseError e AlexPosn, AsRenameError e AlexPosn, AsTypeError e AlexPosn, MonadError e m) => Bool -> BSL.ByteString -> m T.Text
+printNormalizeType
+    :: (AsParseError e AlexPosn, AsUniqueError e AlexPosn, AsRenameError e AlexPosn, AsTypeError e AlexPosn, MonadError e m)
+    => Bool
+    -> BSL.ByteString
+    -> m T.Text
 printNormalizeType norm bs = runQuoteT $ prettyPlcDefText <$> do
     scoped <- parseScoped bs
     annotated <- annotateProgram scoped
@@ -173,12 +182,17 @@ printNormalizeType norm bs = runQuoteT $ prettyPlcDefText <$> do
 
 -- | Parse and rewrite so that names are globally unique, not just unique within
 -- their scope.
-parseScoped :: (AsParseError e AlexPosn, MonadError e m) => BSL.ByteString -> m (Program TyName Name AlexPosn)
-parseScoped str = runQuoteT $ parseProgram str >>= rename
+parseScoped
+    :: (AsParseError e AlexPosn, AsUniqueError e AlexPosn, MonadError e m)
+    => BSL.ByteString
+    -> m (Program TyName Name AlexPosn)
+-- don't require there to be no free variables at this point, we might be parsing an open term
+parseScoped = runQuoteT . (through (Uniques.checkProgram (const True)) <=< rename <=< parseProgram)
 
 -- | Parse a program and typecheck it.
 parseTypecheck
     :: (AsParseError e AlexPosn,
+        AsUniqueError e AlexPosn,
         AsNormalizationError e TyName Name AlexPosn,
         AsRenameError e AlexPosn,
         AsTypeError e AlexPosn,
@@ -188,16 +202,27 @@ parseTypecheck
 parseTypecheck cfg = typecheckPipeline cfg <=< parseScoped
 
 -- | Typecheck a program.
-typecheckPipeline :: (AsNormalizationError e TyName Name a, AsRenameError e a, AsTypeError e a, MonadError e m, MonadQuote m) => TypeCheckCfg -> Program TyName Name a -> m (NormalizedType TyNameWithKind ())
-typecheckPipeline cfg p = do
-    unless (_typeConfigNormalize $ _cfgTypeConfig cfg) $ checkProgram p
-    typecheckProgram cfg =<< annotateProgram p
+typecheckPipeline
+    :: (AsNormalizationError e TyName Name a,
+        AsRenameError e a,
+        AsTypeError e a,
+        MonadError e m,
+        MonadQuote m)
+    => TypeCheckCfg
+    -> Program TyName Name a
+    -> m (NormalizedType TyNameWithKind ())
+typecheckPipeline cfg =
+    typecheckProgram cfg
+    <=< annotateProgram
+    <=< through (unless (_typeConfigNormalize $ _cfgTypeConfig cfg) . checkProgram)
 
-formatDoc :: (AsParseError e AlexPosn, MonadError e m) => BSL.ByteString -> m (Doc a)
-formatDoc bs = runQuoteT $ prettyPlcDef <$> parseProgram bs
+formatDoc :: (AsParseError e AlexPosn, MonadError e m) => PrettyConfigPlc -> BSL.ByteString -> m (Doc a)
+-- don't use parseScoped since we don't bother running sanity checks when we format
+formatDoc cfg = runQuoteT . fmap (prettyBy cfg) . (rename <=< parseProgram)
 
 format :: (AsParseError e AlexPosn, MonadError e m) => PrettyConfigPlc -> BSL.ByteString -> m T.Text
-format cfg = fmap (prettyTextBy cfg) . parseScoped
+-- don't use parseScoped since we don't bother running sanity checks when we format
+format cfg = runQuoteT . fmap (prettyTextBy cfg) . (rename <=< parseProgram)
 
 -- | The default version of Plutus Core supported by this library.
 defaultVersion :: a -> Version a

--- a/language-plutus-core/src/Language/PlutusCore/Analysis/Definitions.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Analysis/Definitions.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE LambdaCase #-}
+-- | Definition analysis for Plutus Core.
+module Language.PlutusCore.Analysis.Definitions (UniqueInfos, ScopeType, termDefs, typeDefs, runTermDefs, runTypeDefs) where
+
+import           Language.PlutusCore.Error
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Type
+
+import           Data.Functor.Foldable
+
+import           Control.Lens              hiding (use, uses)
+import           Control.Monad.Except
+import           Control.Monad.State
+import           Control.Monad.Writer
+
+import           Data.Coerce
+import           Data.Foldable
+import qualified Data.IntMap               as IM
+import qualified Data.Set                  as Set
+
+{- Note [Unique usage errors]
+The definitions analysis can find a number of problems with usage of uniques, however
+clients may not always want to throw an error on all of them, hence we simply return
+them all and allow the client to chose if they want to throw some of them.
+-}
+
+-- | Information about a unique, a pair of a definition if we have one and a set of uses.
+type UniqueInfo a = (Maybe (ScopedLoc a), Set.Set (ScopedLoc a))
+type UniqueInfos a = IM.IntMap (UniqueInfo a)
+
+data ScopedLoc a = ScopedLoc ScopeType a deriving (Eq, Ord)
+
+-- | Tag for distinguishing between whether we are talking about the term scope
+-- for variables or the type scope for variables.
+data ScopeType = TermScope | TypeScope deriving (Eq, Ord)
+
+lookupDef
+    :: (Ord a,
+        MonadState (UniqueInfos a) m)
+    => Unique
+    -> m (UniqueInfo a)
+lookupDef u = do
+    previousDef <- gets $ IM.lookup (unUnique u)
+    case previousDef of
+        Just d -> pure d
+        Nothing -> do
+            let empty = (Nothing, mempty)
+            modify $ IM.insert (unUnique u) empty
+            pure empty
+
+addDef
+    :: (Ord a,
+        HasUnique n unique,
+        MonadState (UniqueInfos a) m,
+        MonadWriter [UniqueError a] m)
+    => n -- ^ The variable
+    -> a -- ^ The annotation of the variable
+    -> ScopeType -- ^ The scope type
+    -> m ()
+addDef n newDef tpe = do
+    let u = n ^. unique . coerced
+    let def = ScopedLoc tpe newDef
+
+    d@(_, uses) <- lookupDef u
+    checkUndefined u def d
+    modify $ IM.insert (unUnique u) (Just def, uses)
+
+-- | Check that a variable is currently undefined.
+checkUndefined
+    :: (MonadState (UniqueInfos a) m,
+        MonadWriter [UniqueError a] m)
+    => Unique -- ^ The variable
+    -> ScopedLoc a -- ^ The new definition
+    -> UniqueInfo a -- ^ The existing info
+    -> m ()
+checkUndefined u (ScopedLoc _ newDef) info = case info of
+    (Just (ScopedLoc _ prevDef), _) -> tell [MultiplyDefined u prevDef newDef]
+    _                               -> pure ()
+
+addUsage
+    :: (Ord a,
+        HasUnique n unique,
+        MonadState (UniqueInfos a) m,
+        MonadWriter [UniqueError a] m)
+    => n -- ^ The variable
+    -> a -- ^ The annotation of the variable
+    -> ScopeType -- ^ The scope type
+    -> m ()
+addUsage n newUse tpe = do
+    let u = coerce $ n ^. unique
+    let use = ScopedLoc tpe newUse
+
+    d@(def, uses) <- lookupDef u
+    checkCoherency u use d
+    checkDefined u use d
+
+    modify $ IM.insert (unUnique u) (def, Set.insert use uses)
+
+checkDefined
+    :: (MonadWriter [UniqueError a] m)
+    => Unique -- ^ The unique
+    -> ScopedLoc a -- ^ The new definition
+    -> UniqueInfo a -- ^ The existing info
+    -> m ()
+checkDefined u (ScopedLoc _ loc) (def, _) = case def of
+    Nothing -> tell [FreeVariable u loc]
+    Just _  -> pure ()
+
+checkCoherency
+    :: (MonadWriter [UniqueError a] m)
+    => Unique -- ^ The unique
+    -> ScopedLoc a -- ^ The new definition
+    -> UniqueInfo a -- ^ The existing info
+    -> m ()
+checkCoherency u (ScopedLoc tpe loc) (def, uses) = do
+    for_ def checkLoc
+    for_ (Set.toList uses) checkLoc
+
+    where
+        checkLoc (ScopedLoc tpe' loc') = when (tpe' /= tpe) $ tell [IncoherentUsage u loc' loc]
+
+termDefs
+    :: (Ord a,
+        HasUnique (name a) TermUnique,
+        HasUnique (tyname a) TypeUnique,
+        MonadState (UniqueInfos a) m,
+        MonadWriter [UniqueError a] m)
+    => Term tyname name a
+    -> m ()
+termDefs = cata $ \case
+    VarF a n         -> addUsage n a TermScope
+    LamAbsF a n ty t -> addDef n a TermScope >> typeDefs ty >> t
+    WrapF a tn ty t  -> addDef tn a TypeScope >> typeDefs ty >> t
+    TyAbsF a tn _ t  -> addDef tn a TypeScope >> t
+    TyInstF _ t ty   -> t >> typeDefs ty
+    x                -> sequence_ x
+
+typeDefs
+    :: (Ord a,
+        HasUnique (tyname a) TypeUnique,
+        MonadState (UniqueInfos a) m,
+        MonadWriter [UniqueError a] m)
+    => Type tyname a
+    -> m ()
+typeDefs = cata $ \case
+    TyVarF a n         -> addUsage n a TypeScope
+    TyFixF a n t       -> addDef n a TypeScope >> t
+    TyForallF a tn _ t -> addDef tn a TypeScope >> t
+    TyLamF a tn _ t    -> addDef tn a TypeScope >> t
+    x                  -> sequence_ x
+
+runTermDefs
+    :: (Ord a,
+        HasUnique (name a) TermUnique,
+        HasUnique (tyname a) TypeUnique,
+        Monad m)
+    => Term tyname name a
+    -> m (UniqueInfos a, [UniqueError a])
+runTermDefs = runWriterT . flip execStateT mempty . termDefs
+
+runTypeDefs
+    :: (Ord a,
+        HasUnique (tyname a) TypeUnique,
+        Monad m)
+    => Type tyname a
+    -> m (UniqueInfos a, [UniqueError a])
+runTypeDefs = runWriterT . flip execStateT mempty . typeDefs

--- a/language-plutus-core/src/Language/PlutusCore/Check/Uniques.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Uniques.hs
@@ -1,0 +1,47 @@
+module Language.PlutusCore.Check.Uniques (checkProgram, checkTerm, checkType) where
+
+import           Language.PlutusCore.Analysis.Definitions
+import           Language.PlutusCore.Error
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Type
+
+import           Control.Monad.Error.Lens
+import           Control.Monad.Except
+
+import           Data.Foldable
+
+checkProgram
+    :: (Ord a,
+        HasUnique (name a) TermUnique,
+        HasUnique (tyname a) TypeUnique,
+        AsUniqueError e a,
+        MonadError e m)
+    => (UniqueError a -> Bool)
+    -> Program tyname name a
+    -> m ()
+checkProgram p (Program _ _ t) = checkTerm p t
+
+checkTerm
+    :: (Ord a,
+        HasUnique (name a) TermUnique,
+        HasUnique (tyname a) TypeUnique,
+        AsUniqueError e a,
+        MonadError e m)
+    => (UniqueError a -> Bool)
+    -> Term tyname name a
+    -> m ()
+checkTerm p t = do
+    (_, errs) <- runTermDefs t
+    for_ errs $ \e -> when (p e) $ throwing _UniqueError e
+
+checkType
+    :: (Ord a,
+        HasUnique (tyname a) TypeUnique,
+        AsUniqueError e a,
+        MonadError e m)
+    => (UniqueError a -> Bool)
+    -> Type tyname a
+    -> m ()
+checkType p t = do
+    (_, errs) <- runTypeDefs t
+    for_ errs $ \e -> when (p e) $ throwing _UniqueError e

--- a/language-plutus-core/src/Language/PlutusCore/Lexer.x
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer.x
@@ -123,6 +123,7 @@ tokens :-
 deriving instance Generic AlexPosn
 deriving instance NFData AlexPosn
 deriving instance Lift AlexPosn
+deriving instance Ord AlexPosn
 
 instance Pretty (AlexPosn) where
     pretty (AlexPn _ line col) = pretty line <> ":" <> pretty col

--- a/language-plutus-core/src/Language/PlutusCore/Name.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Name.hs
@@ -81,7 +81,7 @@ identifierStateFrom u = (mempty, mempty, u)
 -- | A unique identifier
 newtype Unique = Unique { unUnique :: Int }
     deriving (Eq, Show, Ord, Lift)
-    deriving newtype (NFData)
+    deriving newtype (NFData, Pretty)
 
 -- | The unique of a type-level name.
 newtype TypeUnique = TypeUnique

--- a/language-plutus-core/src/Language/PlutusCore/Quote.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Quote.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DefaultSignatures     #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 -- just for the type equality constraint
 {-# LANGUAGE GADTs                 #-}
@@ -12,6 +13,10 @@ module Language.PlutusCore.Quote (
             , freshTyName
             , freshenName
             , freshenTyName
+            , markNonFresh
+            , markNonFreshTerm
+            , markNonFreshType
+            , markNonFreshProgram
             , QuoteT
             , Quote
             , MonadQuote
@@ -19,16 +24,20 @@ module Language.PlutusCore.Quote (
             , liftQuote
             ) where
 
+import           Control.Lens             (coerced)
 import           Control.Monad.Except
 import           Control.Monad.Morph      as MM
 import           Control.Monad.Reader
 import           Control.Monad.State
 
 import qualified Data.ByteString.Lazy     as BSL
+import           Data.Functor.Foldable
 import           Data.Functor.Identity
+import qualified Data.Set                 as Set
 import           Hedgehog                 (GenT)
 
 import           Language.PlutusCore.Name
+import           Language.PlutusCore.Type
 import           PlutusPrelude
 
 -- | The state contains the "next" 'Unique' that should be used for a name
@@ -70,25 +79,79 @@ type Quote = QuoteT Identity
 runQuote :: Quote a -> a
 runQuote = runIdentity . runQuoteT
 
+-- | Marks all the 'Unique's in a type as used, so they will not be generated in future. Useful if you
+-- have a type which was not generated in 'Quote'.
+markNonFreshType
+    :: (HasUnique (tyname a) TypeUnique, MonadQuote m)
+    => Type tyname a
+    -> m ()
+markNonFreshType = markNonFresh . maximum . collectTypeUniques
+
+-- | Marks all the 'Unique's in a term as used, so they will not be generated in future. Useful if you
+-- have a term which was not generated in 'Quote'.
+markNonFreshTerm
+    :: (HasUnique (tyname a) TypeUnique, HasUnique (name a) TermUnique, MonadQuote m)
+    => Term tyname name a
+    -> m ()
+markNonFreshTerm = markNonFresh . maximum . collectTermUniques
+
+-- | Marks all the 'Unique's in a program as used, so they will not be generated in future. Useful if you
+-- have a program which was not generated in 'Quote'.
+markNonFreshProgram
+    :: (HasUnique (tyname a) TypeUnique, HasUnique (name a) TermUnique, MonadQuote m)
+    => Program tyname name a
+    -> m ()
+markNonFreshProgram (Program _ _ body)= markNonFreshTerm body
+
+-- | Mark a given 'Unique' (and implicitly all 'Unique's less than it) as used, so they will not be generated in future.
+markNonFresh :: MonadQuote m => Unique -> m ()
+markNonFresh nonFresh = liftQuote $ do
+    nextU <- get
+    put $ Unique (max (unUnique nonFresh + 1) (unUnique nextU))
+
+collectTypeUniques :: (HasUnique (tyname a) TypeUnique) => Type tyname a -> Set.Set Unique
+collectTypeUniques = cata f where
+    f = \case
+        TyVarF _ tn        -> Set.singleton (tn ^. unique . coerced)
+        TyFixF _ tn t      -> Set.insert (tn ^. unique . coerced) t
+        TyForallF _ tn _ t -> Set.insert (tn ^. unique . coerced) t
+        TyLamF _ tn _ t    -> Set.insert (tn ^. unique . coerced) t
+        TyAppF _ t1 t2     -> t1 <> t2
+        TyFunF _ t1 t2     -> t1 <> t2
+        _                  -> mempty
+
+collectTermUniques :: (HasUnique (tyname a) TypeUnique, HasUnique (name a) TermUnique) => Term tyname name a -> Set.Set Unique
+collectTermUniques = cata f where
+    f = \case
+        VarF _ n         -> Set.singleton (n ^. unique . coerced)
+        LamAbsF _ n ty t -> Set.insert (n ^. unique . coerced) (collectTypeUniques ty <> t)
+        WrapF _ tn ty t  -> Set.insert (tn ^. unique . coerced) (collectTypeUniques ty <> t)
+        TyAbsF _ tn _ t  -> Set.insert (tn ^. unique . coerced) t
+        TyInstF _ t ty   -> t <> collectTypeUniques ty
+        ApplyF _ t1 t2   -> t1 <> t2
+        UnwrapF _ t      -> t
+        ErrorF _ ty      -> collectTypeUniques ty
+        _                -> mempty
+
 -- | Get a fresh 'Unique'.
-freshUnique :: (Monad m) => QuoteT m Unique
-freshUnique = do
+freshUnique :: MonadQuote m => m Unique
+freshUnique = liftQuote $ do
     nextU <- get
     put $ Unique (unUnique nextU + 1)
     pure nextU
 
 -- | Get a fresh 'Name', given the annotation an the name.
-freshName :: (Monad m) => a -> BSL.ByteString -> QuoteT m (Name a)
+freshName :: Monad m => a -> BSL.ByteString -> QuoteT m (Name a)
 freshName ann str = Name ann str <$> freshUnique
 
 -- | Make a copy of the given 'Name' that is distinct from the old one.
-freshenName :: (Monad m) =>  Name a -> QuoteT m (Name a)
+freshenName :: Monad m =>  Name a -> QuoteT m (Name a)
 freshenName (Name ann str _) = Name ann str <$> freshUnique
 
 -- | Get a fresh 'TyName', given the annotation an the name.
-freshTyName :: (Monad m) => a -> BSL.ByteString -> QuoteT m (TyName a)
+freshTyName :: Monad m => a -> BSL.ByteString -> QuoteT m (TyName a)
 freshTyName = fmap TyName .* freshName
 
 -- | Make a copy of the given 'TyName' that is distinct from the old one.
-freshenTyName :: (Monad m) =>  TyName a -> QuoteT m (TyName a)
+freshenTyName :: Monad m =>  TyName a -> QuoteT m (TyName a)
 freshenTyName (TyName name) = TyName <$> freshenName name

--- a/language-plutus-core/src/Language/PlutusCore/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Type.hs
@@ -269,7 +269,7 @@ data TermF tyname name a x = VarF a (name a)
                            | UnwrapF a x
                            | WrapF a (tyname a) (Type tyname a) x
                            | ErrorF a (Type tyname a)
-                           deriving (Functor)
+                           deriving (Functor, Traversable, Foldable)
 
 type instance Base (Term tyname name a) = TermF tyname name a
 

--- a/language-plutus-core/test/Check/Spec.hs
+++ b/language-plutus-core/test/Check/Spec.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Check.Spec (tests) where
+
+import           Language.PlutusCore
+import qualified Language.PlutusCore.Check.Uniques as Uniques
+import           Language.PlutusCore.Quote
+import           PlutusPrelude
+
+import           Control.Monad.Except
+import           Generators
+import           Hedgehog                          hiding (Var)
+import           Test.Tasty
+import           Test.Tasty.Hedgehog
+import           Test.Tasty.HUnit
+
+tests :: TestTree
+tests = testGroup "checks"
+    [ testProperty "renaming ensures global uniqueness" propRenameCheck
+    , shadowed
+    , multiplyDefined
+    , incoherentUse
+    ]
+
+data Tag = Tag Int | Ignore deriving (Show, Eq, Ord)
+
+checkTermUniques :: (Ord a, MonadError (UniqueError a) m) => Term TyName Name a -> m ()
+checkTermUniques = Uniques.checkTerm (\case FreeVariable{} -> False; _ -> True)
+
+shadowed :: TestTree
+shadowed =
+    let
+        u = Unique (-1)
+        checked = runExcept $ runQuoteT $ do
+            ty <- freshTyName Ignore "ty"
+            let n = Name Ignore "yo" u
+            let term =
+                    LamAbs (Tag 1) n (TyVar Ignore ty) $
+                    LamAbs (Tag 2) n (TyVar Ignore ty) $
+                    Var Ignore n
+            checkTermUniques term
+        assertion = checked @?= Left (MultiplyDefined u (Tag 1) (Tag 2))
+    in testCase "shadowed" assertion
+
+multiplyDefined :: TestTree
+multiplyDefined =
+    let
+        u = Unique (-1)
+        checked = runExcept $ runQuoteT $ do
+            ty <- freshTyName Ignore "ty"
+            let n = Name Ignore "yo" u
+            let term =
+                    Apply Ignore
+                    (LamAbs (Tag 1) n (TyVar Ignore ty) (Var Ignore n))
+                    (LamAbs (Tag 2) n (TyVar Ignore ty) (Var Ignore n))
+            checkTermUniques term
+        assertion = checked @?= Left (MultiplyDefined u (Tag 1) (Tag 2))
+    in testCase "multiplyDefined" assertion
+
+incoherentUse :: TestTree
+incoherentUse =
+    let
+        u = Unique 0
+        checked = runExcept $ runQuoteT $ do
+            let n = Name Ignore "yo" u
+            let ty = TyName n
+            let term =
+                    LamAbs (Tag 1) n (TyVar (Tag 2) ty) $
+                    TyInst Ignore (Var (Tag 3) n) (TyVar (Tag 4) ty)
+            checkTermUniques term
+        assertion = checked @?= Left (IncoherentUsage u (Tag 1) (Tag 2))
+    in testCase "incoherentUse" assertion
+
+propRenameCheck :: Property
+propRenameCheck = property $ do
+    prog <- forAll genProgram
+    -- we didn't generate prog in Quote, so mark all the uniques as non-fresh
+    renamed <- runQuoteT $ (rename <=< through markNonFreshProgram) prog
+    annotateShow renamed
+    Hedgehog.evalExceptT $ checkUniques renamed
+        where
+            checkUniques :: (Ord a, MonadError (UniqueError a) m) => Program TyName Name a -> m ()
+            -- the renamer will fix incoherency between *bound* variables, but it ignores free variables, so
+            -- we can still get incoherent usage errors, ignore them for now
+            checkUniques = Uniques.checkProgram (\case { FreeVariable{} -> False; IncoherentUsage {} -> False; _ -> True})

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -3,7 +3,9 @@
 module Main ( main
             ) where
 
+import qualified Check.Spec                   as Check
 import           Codec.Serialise
+import           Control.Monad.Except
 import           Control.Monad.Trans.Except   (runExceptT)
 import qualified Data.ByteString.Lazy         as BSL
 import qualified Data.Text                    as T
@@ -108,6 +110,7 @@ allTests plcFiles rwFiles typeFiles typeNormalizeFiles typeErrorFiles = testGrou
     , test_constant
     , test_evaluateCk
     , Quotation.tests
+    , Check.tests
     ]
 
 type TestFunction a = BSL.ByteString -> Either (Error a) T.Text
@@ -253,13 +256,13 @@ tests :: TestTree
 tests = testCase "example programs" $ fold
     [ fmt "(program 0.1.0 [(builtin addInteger) x y])" @?= Right "(program 0.1.0\n  [ [ (builtin addInteger) x ] y ]\n)"
     , fmt "(program 0.1.0 doesn't)" @?= Right "(program 0.1.0\n  doesn't\n)"
-    , fmt "{- program " @?= Left (LexErr "Error in nested comment at line 1, column 12")
+    , fmt "{- program " @?= Left (ParseErrorE (LexErr "Error in nested comment at line 1, column 12"))
     , testLam @?= Right "(con integer)"
     , testRebindShadowedVariable @?= True
     , testRebindCapturedVariable @?= True
     , testEqTerm @?= True
     ]
     where
-        fmt :: BSL.ByteString -> Either (ParseError AlexPosn) T.Text
+        fmt :: BSL.ByteString -> Either (Error AlexPosn) T.Text
         fmt = format cfg
         cfg = defPrettyConfigPlcClassic defPrettyConfigPlcOptions

--- a/language-plutus-core/test/types/addInteger.plc
+++ b/language-plutus-core/test/types/addInteger.plc
@@ -1,7 +1,7 @@
 (program 0.1.0
-  [
-    (lam x t
-      [(builtin addInteger) x y])
-    z
-  ]
+  (lam x [(con integer) (con 8)]
+    (lam y [(con integer) (con 8)]
+      [{(builtin addInteger) (con 8)} x y]
+    )
+  )
 )

--- a/language-plutus-core/test/types/addInteger.plc.golden
+++ b/language-plutus-core/test/types/addInteger.plc.golden
@@ -1,1 +1,1 @@
-Error at 3:12. Type variable t is not in scope.
+(fun [(con integer) (con 8)] (fun [(con integer) (con 8)] [(con integer) (con 8)]))


### PR DESCRIPTION
This adds some analysis code for variable usages, along with a
checker for a number of issues:
- Free variables
- Incoherently used variables (i.e. in both the term and type scopes)
- Multiply defined variables

We can then check that after running the renamer we pass the appropriate
checks.

This turned up one annoying issue. The renamer normally fixes "incoherent usage" issues for bound variables by renaming the two definitions (and hence uses) to be separate. However, it doesn't rename free variables, so if you have incoherently used free variables it won't fix it.