### PR TITLE
[CGP-424] Add emulator events

### DIFF
--- a/wallet-api/src/Wallet/Emulator/Http.hs
+++ b/wallet-api/src/Wallet/Emulator/Http.hs
@@ -23,7 +23,6 @@ import           Control.Monad.State        (State, runState)
 import           Control.Natural            (type (~>))
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified Data.Map                   as Map
-import           Data.Maybe                 (catMaybes)
 import           Data.Proxy                 (Proxy (Proxy))
 import           Data.Set                   (Set)
 import qualified Data.Set                   as Set
@@ -37,7 +36,7 @@ import           Wallet.Emulator.AddressMap (AddressMap)
 import           Wallet.Emulator.Types      (Assertion (IsValidated, OwnFundsEqual), EmulatedWalletApi,
                                              EmulatorState (emWalletState), Notification (BlockHeight, BlockValidated),
                                              Wallet, WalletState, assert, chain, emTxPool, emptyEmulatorState,
-                                             emptyWalletState, liftEmulatedWallet, txPool, validateEm, walletStates)
+                                             emptyWalletState, liftEmulatedWallet, txPool, walletStates)
 
 import qualified Wallet.Emulator.Types      as Types
 import           Wallet.UTXO                (Block, Height, Tx, TxIn', TxOut', Value)
@@ -250,9 +249,7 @@ processPending = do
 processPendingSTM :: TVar EmulatorState -> STM [Tx]
 processPendingSTM var = do
   es <- readTVar var
-  let processed = validateEm es <$> emTxPool es
-      validated = catMaybes processed
-      block = validated
+  let (block, _) = Types.validateBlock es (emTxPool es)
       newState = addBlock block . emptyPool $ es
   writeTVar var newState
   pure block

--- a/wallet-api/src/Wallet/Emulator/Log.hs
+++ b/wallet-api/src/Wallet/Emulator/Log.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Wallet.Emulator.Log(
+    EmulatorEvent(..)
+    ) where
+
+import           Data.Aeson        (FromJSON, ToJSON)
+import           GHC.Generics      (Generic)
+
+import qualified Wallet.UTXO.Index as UTXO
+import qualified Wallet.UTXO.Types as UTXO
+
+-- | Events produced by the mockchain
+data EmulatorEvent =
+    TxnSubmit UTXO.TxId'
+    -- ^ A transaction has been added to the global pool of pending transactions
+    | TxnValidate UTXO.TxId'
+    -- ^ A transaction has been validated and added to the blockchain
+    | TxnValidationFail UTXO.TxId' UTXO.ValidationError
+    -- ^ A transaction failed  to validate
+    | BlockAdd UTXO.Height
+    -- ^ A block has been added to the blockchain
+    deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON EmulatorEvent
+instance ToJSON EmulatorEvent

--- a/wallet-api/src/Wallet/UTXO/Index.hs
+++ b/wallet-api/src/Wallet/UTXO/Index.hs
@@ -28,6 +28,7 @@ module Wallet.UTXO.Index(
 import           Control.Monad.Except (MonadError (..), liftEither)
 import           Control.Monad.Reader (MonadReader (..), ReaderT (..), ask)
 import           Crypto.Hash          (Digest, SHA256)
+import           Data.Aeson           (FromJSON, ToJSON)
 import           Data.Foldable        (foldl', traverse_)
 import qualified Data.Map             as Map
 import           Data.Semigroup       (Semigroup, Sum (..))
@@ -85,7 +86,10 @@ data ValidationError =
     -- ^ The transaction produces an output with a negative value
     | ScriptFailure
     -- ^ (for pay-to-script outputs) Evaluation of the validator script failed
-    deriving (Eq, Show, Generic)
+    deriving (Eq, Ord, Show, Generic)
+
+instance FromJSON ValidationError
+instance ToJSON ValidationError
 
 newtype Validation a = Validation { _runValidation :: (ReaderT UtxoIndex (Either ValidationError)) a }
     deriving (Functor, Applicative, Monad, MonadReader UtxoIndex, MonadError ValidationError)

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -14,6 +14,7 @@ import           Test.Tasty
 import           Test.Tasty.Hedgehog (testProperty)
 
 import           Wallet.Emulator
+import qualified Wallet.Emulator.Log as Log
 import           Wallet.Generators   (Mockchain (..))
 import qualified Wallet.Generators   as Gen
 import           Wallet.UTXO         (unitValidationData)
@@ -95,6 +96,10 @@ invalidTrace = property $ do
         (result, st) = Gen.runTrace m $ simpleTrace invalidTxn
     Hedgehog.assert (isLeft result)
     Hedgehog.assert ([] == emTxPool st)
+    Hedgehog.assert (not (null $ emLog st))
+    Hedgehog.assert (case emLog st of
+        Log.BlockAdd _ : Log.TxnValidationFail _ _ : _ -> True
+        _                                              -> False)
 
 splitVal :: Property
 splitVal = property $ do

--- a/wallet-api/wallet-api.cabal
+++ b/wallet-api/wallet-api.cabal
@@ -30,6 +30,7 @@ library
         Wallet.Emulator.AddressMap
         Wallet.Emulator.Client
         Wallet.Emulator.Http
+        Wallet.Emulator.Log
         Wallet.Emulator.Types
         Wallet.Generators
         Wallet.UTXO


### PR DESCRIPTION
* Emulator keeps a log of blockchain-related events such as transaction
  validation