### PR TITLE
plutus-exe: learn to control normalization requirements

### DIFF
--- a/plutus-exe/src/Main.hs
+++ b/plutus-exe/src/Main.hs
@@ -75,7 +75,7 @@ main = do
         Typecheck (TypecheckOptions inp) -> do
             contents <- getInput inp
             let bsContents = (BSL.fromStrict . encodeUtf8 . T.pack) contents
-            case (PLC.runQuoteT . PLC.parseTypecheck PLC.defaultTypecheckerGas) bsContents of
+            case (PLC.runQuoteT . PLC.parseTypecheck PLC.defaultTypecheckerCfg) bsContents of
                 Left (e :: PLC.Error PLC.AlexPosn) -> do
                     T.putStrLn $ PLC.prettyPlcDefText e
                     exitFailure

--- a/plutus-exe/src/Main.hs
+++ b/plutus-exe/src/Main.hs
@@ -39,7 +39,8 @@ stdInput = flag' StdInput
   (  long "stdin"
   <> help "Read from stdin" )
 
-newtype TypecheckOptions = TypecheckOptions Input
+data NormalizationMode = Required | NotRequired deriving (Show, Read)
+data TypecheckOptions = TypecheckOptions Input NormalizationMode
 data EvalMode = CK | CEK deriving (Show, Read)
 data EvalOptions = EvalOptions Input EvalMode
 data Command = Typecheck TypecheckOptions | Eval EvalOptions
@@ -53,8 +54,16 @@ plutusOpts = hsubparser (
     <> command "evaluate" (info (Eval <$> evalOpts) (progDesc "Evaluate a Plutus Core program"))
   )
 
+normalizationMode :: Parser NormalizationMode
+normalizationMode = option auto
+  (  long "normalized-types"
+  <> metavar "MODE"
+  <> value NotRequired
+  <> showDefault
+  <> help "Whether type annotations must be normalized or not (one of Required or NotRequired)" )
+
 typecheckOpts :: Parser TypecheckOptions
-typecheckOpts = TypecheckOptions <$> input
+typecheckOpts = TypecheckOptions <$> input <*> normalizationMode
 
 evalMode :: Parser EvalMode
 evalMode = option auto
@@ -68,30 +77,37 @@ evalMode = option auto
 evalOpts :: Parser EvalOptions
 evalOpts = EvalOptions <$> input <*> evalMode
 
+runTypecheck :: TypecheckOptions -> IO ()
+runTypecheck (TypecheckOptions inp mode) = do
+    contents <- getInput inp
+    let bsContents = (BSL.fromStrict . encodeUtf8 . T.pack) contents
+    let cfg = PLC.TypeCheckCfg PLC.defaultTypecheckerGas $ PLC.TypeConfig (case mode of {NotRequired -> True; Required -> False}) mempty
+    case (PLC.runQuoteT . PLC.parseTypecheck cfg) bsContents of
+        Left (e :: PLC.Error PLC.AlexPosn) -> do
+            T.putStrLn $ PLC.prettyPlcDefText e
+            exitFailure
+        Right ty -> do
+            T.putStrLn $ PLC.prettyPlcDefText ty
+            exitSuccess
+
+runEval :: EvalOptions -> IO ()
+runEval (EvalOptions inp mode) = do
+    contents <- getInput inp
+    let bsContents = (BSL.fromStrict . encodeUtf8 . T.pack) contents
+    let evalFn = case mode of
+            CK  -> PLC.runCk
+            CEK -> PLC.runCek mempty
+    case evalFn .void <$> PLC.parseScoped bsContents of
+        Left (e :: PLC.Error PLC.AlexPosn) -> do
+            T.putStrLn $ PLC.prettyPlcDefText e
+            exitFailure
+        Right v -> do
+            T.putStrLn $ PLC.prettyPlcDefText v
+            exitSuccess
+
 main :: IO ()
 main = do
     options <- customExecParser (prefs showHelpOnEmpty) plutus
     case options of
-        Typecheck (TypecheckOptions inp) -> do
-            contents <- getInput inp
-            let bsContents = (BSL.fromStrict . encodeUtf8 . T.pack) contents
-            case (PLC.runQuoteT . PLC.parseTypecheck PLC.defaultTypecheckerCfg) bsContents of
-                Left (e :: PLC.Error PLC.AlexPosn) -> do
-                    T.putStrLn $ PLC.prettyPlcDefText e
-                    exitFailure
-                Right ty -> do
-                    T.putStrLn $ PLC.prettyPlcDefText ty
-                    exitSuccess
-        Eval (EvalOptions inp mode) -> do
-            contents <- getInput inp
-            let bsContents = (BSL.fromStrict . encodeUtf8 . T.pack) contents
-            let evalFn = case mode of
-                    CK  -> PLC.runCk
-                    CEK -> PLC.runCek mempty
-            case evalFn .void <$> PLC.parseScoped bsContents of
-                Left (e :: PLC.Error PLC.AlexPosn) -> do
-                    T.putStrLn $ PLC.prettyPlcDefText e
-                    exitFailure
-                Right v -> do
-                    T.putStrLn $ PLC.prettyPlcDefText v
-                    exitSuccess
+        Typecheck tos -> runTypecheck tos
+        Eval eos      -> runEval eos


### PR DESCRIPTION
- `language-plutus-core` learns to allow clients to control the normalization via passing an entire `TypeCheckCfg`.
- `plutus-exe` learns a flag to control the normalization checking mode. The default is to allow normalized types, which I think is the right one since the executable is mainly a development tool.