### PR TITLE
[CGP-295] Consider builtin type applications to be neutral

### DIFF
--- a/language-plutus-core/test/types/addInteger.plc
+++ b/language-plutus-core/test/types/addInteger.plc
@@ -1,7 +1,7 @@
 (program 0.1.0
-  [
-    (lam x t
-      [(builtin addInteger) x y])
-    z
-  ]
+  (lam x [(con integer) (con 8)]
+    (lam y [(con integer) (con 8)]
+      [{(builtin addInteger) (con 8)} x y]
+    )
+  )
 )

--- a/language-plutus-core/test/types/addInteger.plc.golden
+++ b/language-plutus-core/test/types/addInteger.plc.golden
@@ -1,1 +1,1 @@
-Error at 3:12. Type variable t is not in scope.
+(fun [(con integer) (con 8)] (fun [(con integer) (con 8)] [(con integer) (con 8)]))


### PR DESCRIPTION
As we discussed in a meeting some time ago (and is detailed in https://iohk.myjetbrains.com/youtrack/issue/CGP-295), the old version of the spec lacked a special case to make builtin type applications into type values, which means that you can't typecheck any programs with integer types in annotations in on-chain mode. (The reason this hasn't been driving me up the wall is that all the programs I generate get typechecked in off-chain mode, but I believe it's annoying @kwxm a fair bit.)

The approach we decided to take was to switch to fully-saturated builtins, and @psygnisfive has made this change in the spec. However, the implementation hasn't caught up, and is unlikely to catch up for some time (likely well after PlutusFest). So we are still stuck with the bug at the moment.

However, there is a very easy and logical fix: mirror the special case for builtin value applications for builtin type applications. This simply requires making builtin types and type integers into neutral types. I think we should do this since I believe it's the change we would have made if we'd *hadn't* decided to move to fully saturated builtins, and we're unlikely to get the right fix any time soon.