### PR TITLE
plutus-th: add back typed TH function, make it the default

### DIFF
--- a/plutus-th/test/Spec.hs
+++ b/plutus-th/test/Spec.hs
@@ -30,11 +30,11 @@ tests = testGroup "plutus-th" <$> sequence [
   ]
 
 simple :: PlcCode
-simple = $(plutus [| \(x::Bool) -> if x then (1::Int) else (2::Int) |])
+simple = $$(plutus [|| \(x::Bool) -> if x then (1::Int) else (2::Int) ||])
 
 -- similar to the power example for Feldspar - should be completely unrolled at compile time
 powerPlc :: PlcCode
-powerPlc = $(plutus [| $(power (4::Int)) |])
+powerPlc = $$(plutus [|| $$(power (4::Int)) ||])
 
 andPlc :: PlcCode
-andPlc = $(plutus [| $(andTH) True False |])
+andPlc = $$(plutus [|| $$(andTH) True False ||])

--- a/plutus-th/test/TestTH.hs
+++ b/plutus-th/test/TestTH.hs
@@ -6,14 +6,14 @@ import           Language.Haskell.TH
 
 {-# ANN module "HLint: ignore" #-}
 
-power :: Int -> Q Exp
+power :: Int -> Q (TExp (Int -> Int))
 power n =
     if n <= 0 then
-        [| \ _ -> (1::Int) |]
+        [|| \ _ -> (1::Int) ||]
     else if even n then
-        [| \(x::Int) -> let y = $(power (n `div` (2::Int))) x in y * y |]
+        [|| \(x::Int) -> let y = $$(power (n `div` (2::Int))) x in y * y ||]
     else
-        [| \(x::Int) -> x * ($(power (n - (1::Int))) x) |]
+        [|| \(x::Int) -> x * ($$(power (n - (1::Int))) x) ||]
 
-andTH :: Q Exp
-andTH = [|\(a :: Bool) -> \(b::Bool) -> if a then if b then True else False else False|]
+andTH :: Q (TExp (Bool -> Bool -> Bool))
+andTH = [||\(a :: Bool) -> \(b::Bool) -> if a then if b then True else False else False||]

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -37,7 +37,7 @@ import           GHC.Generics               (Generic)
 import           Language.Plutus.Lift       (makeLift)
 import           Language.Plutus.Runtime    (Height (..), PendingTx (..), PendingTxIn (..), PendingTxOut, PubKey (..),
                                              ValidatorHash, Value (..))
-import           Language.Plutus.TH         (plutus)
+import           Language.Plutus.TH         (plutusUntyped)
 import qualified Language.Plutus.TH         as Builtins
 import           Wallet.API                 (EventHandler (..), EventTrigger, Range (..), WalletAPI (..),
                                              WalletAPIError, andT, blockHeightT, fundsAtAddressT, otherError,
@@ -128,7 +128,7 @@ contributionScript cmp  = Validator val where
 
     --   See note [Contracts and Validator Scripts] in
     --       Language.Plutus.Coordination.Contracts
-    inner = UTXO.fromPlcCode $(plutus [| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx ValidatorHash) ->
+    inner = UTXO.fromPlcCode $(plutusUntyped [| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx ValidatorHash) ->
         let
 
             infixr 3 &&

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Future.hs
@@ -30,7 +30,7 @@ import qualified Data.Set                   as Set
 import           GHC.Generics               (Generic)
 import           Language.Plutus.Lift       (makeLift)
 import qualified Language.Plutus.Runtime.TH as TH
-import           Language.Plutus.TH         (plutus)
+import           Language.Plutus.TH         (plutusUntyped)
 import qualified Language.Plutus.TH         as Builtins
 import           Wallet.API                 (WalletAPI (..), WalletAPIError, otherError, pubKey, signAndSubmit)
 import           Wallet.UTXO                (DataScript (..), TxOutRef', Validator (..), scriptTxIn, scriptTxOut)
@@ -197,7 +197,7 @@ data FutureRedeemer =
 validatorScript :: Future -> Validator
 validatorScript ft = Validator val where
     val = UTXO.applyScript inner (UTXO.lifted ft)
-    inner = UTXO.fromPlcCode $(plutus [|
+    inner = UTXO.fromPlcCode $(plutusUntyped [|
         \Future{..} (r :: FutureRedeemer) FutureData{..} (p :: (PendingTx ValidatorHash)) ->
 
             let

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
@@ -12,7 +12,7 @@ module Language.Plutus.Coordination.Contracts.Swap(
 import           Language.Plutus.Runtime    (OracleValue (..), PendingTx (..), PendingTxIn (..), PendingTxOut (..),
                                              PubKey, ValidatorHash, Value (..))
 import qualified Language.Plutus.Runtime.TH as TH
-import           Language.Plutus.TH         (plutus)
+import           Language.Plutus.TH         (plutusUntyped)
 import qualified Language.Plutus.TH         as Builtins
 import           Wallet.UTXO                (Height, Validator (..))
 import qualified Wallet.UTXO                as UTXO
@@ -59,7 +59,7 @@ type SwapOracle = OracleValue (Ratio Int)
 --       Language.Plutus.Coordination.Contracts
 swapValidator :: Swap -> Validator
 swapValidator _ = Validator result where
-    result = UTXO.fromPlcCode $(plutus [| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx ValidatorHash) Swap{..} ->
+    result = UTXO.fromPlcCode $(plutusUntyped [| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx ValidatorHash) Swap{..} ->
         let
             infixr 3 &&
             (&&) :: Bool -> Bool -> Bool

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
@@ -24,7 +24,7 @@ import           Language.Plutus.Lift       (makeLift)
 import           Language.Plutus.Runtime    (Height (..), PendingTx (..), PendingTxOut (..), PendingTxOutType (..),
                                              PubKey (..), ValidatorHash, Value (..))
 import qualified Language.Plutus.Runtime.TH as TH
-import           Language.Plutus.TH         (plutus)
+import           Language.Plutus.TH         (plutusUntyped)
 import qualified Language.Plutus.TH         as Builtins
 import           Prelude                    hiding ((&&))
 import           Wallet.API                 (WalletAPI (..), WalletAPIError, otherError, ownPubKeyTxOut, signAndSubmit)
@@ -110,7 +110,7 @@ validatorScriptHash =
 validatorScript :: Vesting -> Validator
 validatorScript v = Validator val where
     val = UTXO.applyScript inner (UTXO.lifted v)
-    inner = UTXO.fromPlcCode $(plutus [| \Vesting{..} () VestingData{..} (p :: PendingTx ValidatorHash) ->
+    inner = UTXO.fromPlcCode $(plutusUntyped [| \Vesting{..} () VestingData{..} (p :: PendingTx ValidatorHash) ->
         let
 
             eqBs :: ValidatorHash -> ValidatorHash -> Bool

--- a/wallet-api/src/Wallet/UTXO/Types.hs
+++ b/wallet-api/src/Wallet/UTXO/Types.hs
@@ -676,7 +676,7 @@ runScript (ValidationData valData) (Validator validator) (Redeemer redeemer) (Da
 
 -- | () as a data script
 unitData :: DataScript
-unitData = DataScript $ fromPlcCode $(plutus [| () |])
+unitData = DataScript $ fromPlcCode $$(plutus [|| () ||])
 
 -- | \() () () -> () as a validator
 --
@@ -689,15 +689,15 @@ unitData = DataScript $ fromPlcCode $(plutus [| () |])
 --       you need to provide `unitData`, `unitRedeemer` and
 --       `unitValidationData` to consume it.
 emptyValidator :: Validator
-emptyValidator = Validator $ fromPlcCode $(plutus [| \() () () -> () |])
+emptyValidator = Validator $ fromPlcCode $$(plutus [|| \() () () -> () ||])
 
 -- | () as a redeemer
 unitRedeemer :: Redeemer
-unitRedeemer = Redeemer $ fromPlcCode $(plutus [| () |])
+unitRedeemer = Redeemer $ fromPlcCode $$(plutus [|| () ||])
 
 -- | () as validation data
 unitValidationData :: ValidationData
-unitValidationData = ValidationData $ fromPlcCode $(plutus [| () |])
+unitValidationData = ValidationData $ fromPlcCode $$(plutus [|| () ||])
 
 -- | Transaction output locked by the empty validator and unit data scripts.
 simpleOutput :: Value -> TxOut'


### PR DESCRIPTION
We used to have a typed TH version of the `plutus` function, but I removed it because I couldn't do the type literal stuff properly with typed TH and I was squeamish about `unsafeTExpCoerce`.

Writing a tutorial for using `plutus-th`, I was embarassed not to have the typed TH function available, since it's just a lot better to work with. So I've got over my queasiness and boxed the `unsafeTExpCoerce` into a small box.

I also made it the default, and replaced the current usages with `plutusUntyped`. I think @j-mueller wanted the typed version anyway, but using it properly will require changing all the helper functions in `plutus-use-cases` to be typed too, so I'll let him do that as and when he feels like it.