### PR TITLE
[CGP-418] [AST] Added 'String's to the AST

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -70,6 +70,7 @@ library
         Language.PlutusCore.Lexer.Type
         Language.PlutusCore.Parser
         Language.PlutusCore.Constant.Apply
+        Language.PlutusCore.Constant.Dynamic.BuiltinName
         Language.PlutusCore.Constant.Dynamic.Call
         Language.PlutusCore.Constant.Dynamic.Emit
         Language.PlutusCore.Constant.Dynamic.Instances

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -42,11 +42,13 @@ instance Serialise TypeBuiltin where
         TyByteString -> encodeTag 0
         TyInteger    -> encodeTag 1
         TySize       -> encodeTag 2
+        TyString     -> encodeTag 3
 
     decode = go =<< decodeTag
         where go 0 = pure TyByteString
               go 1 = pure TyInteger
               go 2 = pure TySize
+              go 3 = pure TyString
               go _ = fail "Failed to decode TypeBuiltin"
 
 instance Serialise BuiltinName where
@@ -176,10 +178,12 @@ instance Serialise a => Serialise (Constant a) where
     encode (BuiltinInt x n i) = fold [ encodeTag 0, encode x, encode n, encodeInteger i ]
     encode (BuiltinBS x n bs) = fold [ encodeTag 1, encode x, encode n, encodeBytes (BSL.toStrict bs) ]
     encode (BuiltinSize x n)  = encodeTag 2 <> encode x <> encode n
+    encode (BuiltinStr x s)   = encodeTag 3 <> encode x <> encode s
     decode = go =<< decodeTag
         where go 0 = BuiltinInt <$> decode <*> decode <*> decodeInteger
               go 1 = BuiltinBS <$> decode <*> decode <*> fmap BSL.fromStrict decodeBytes
               go 2 = BuiltinSize <$> decode <*> decode
+              go 3 = BuiltinStr <$> decode <*> decode
               go _ = fail "Failed to decode Constant ()"
 
 instance (Serialise a, Serialise (tyname a), Serialise (name a)) => Serialise (Term tyname name a) where

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
@@ -15,20 +15,21 @@ module Language.PlutusCore.Constant.Apply
     , applyBuiltinName
     ) where
 
+import           Language.PlutusCore.Constant.Dynamic.Instances ()
 import           Language.PlutusCore.Constant.Function
 import           Language.PlutusCore.Constant.Make
 import           Language.PlutusCore.Constant.Name
 import           Language.PlutusCore.Constant.Typed
-import           Language.PlutusCore.Lexer.Type        (BuiltinName (..))
+import           Language.PlutusCore.Lexer.Type                 (BuiltinName (..))
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
-import           Control.Monad.Trans.Class             (lift)
-import qualified Data.ByteString.Lazy                  as BSL
-import           Data.IntMap.Strict                    (IntMap)
-import qualified Data.IntMap.Strict                    as IntMap
+import           Control.Monad.Trans.Class                      (lift)
+import qualified Data.ByteString.Lazy                           as BSL
+import           Data.IntMap.Strict                             (IntMap)
+import qualified Data.IntMap.Strict                             as IntMap
 
 -- | The type of constant applications errors.
 data ConstAppError

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic.hs
@@ -4,7 +4,8 @@ module Language.PlutusCore.Constant.Dynamic
     ( module Export
     ) where
 
-import           Language.PlutusCore.Constant.Dynamic.Call      as Export
-import           Language.PlutusCore.Constant.Dynamic.Emit      as Export
-import           Language.PlutusCore.Constant.Dynamic.Instances as Export ()
-import           Language.PlutusCore.Constant.Dynamic.OnChain   as Export
+import           Language.PlutusCore.Constant.Dynamic.BuiltinName as Export
+import           Language.PlutusCore.Constant.Dynamic.Call        as Export
+import           Language.PlutusCore.Constant.Dynamic.Emit        as Export
+import           Language.PlutusCore.Constant.Dynamic.Instances   as Export
+import           Language.PlutusCore.Constant.Dynamic.OnChain     as Export

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/BuiltinName.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/BuiltinName.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module Language.PlutusCore.Constant.Dynamic.BuiltinName
+    ( dynamicIntToStringName
+    , dynamicIntToStringMeaning
+    , dynamicIntToStringDefinition
+    , dynamicIntToString
+    , dynamicAppendName
+    , dynamicAppendMeaning
+    , dynamicAppendDefinition
+    , dynamicAppend
+    ) where
+
+import           Language.PlutusCore.Constant.Dynamic.Instances ()
+import           Language.PlutusCore.Constant.Make
+import           Language.PlutusCore.Constant.Typed
+import           Language.PlutusCore.Lexer.Type
+import           Language.PlutusCore.Type
+
+dynamicIntToStringName :: DynamicBuiltinName
+dynamicIntToStringName = DynamicBuiltinName "intToString"
+
+dynamicIntToStringMeaning :: DynamicBuiltinNameMeaning
+dynamicIntToStringMeaning = DynamicBuiltinNameMeaning sch show where
+    sch =
+        TypeSchemeAllSize $ \s ->
+            TypeSchemeBuiltin (TypedBuiltinSized (SizeBound s) TypedBuiltinSizedInt) `TypeSchemeArrow`
+            TypeSchemeBuiltin (TypedBuiltinDyn @String)
+
+dynamicIntToStringDefinition :: DynamicBuiltinNameDefinition
+dynamicIntToStringDefinition =
+    DynamicBuiltinNameDefinition dynamicIntToStringName dynamicIntToStringMeaning
+
+dynamicIntToString :: Term tyname name ()
+dynamicIntToString = dynamicBuiltinNameAsTerm dynamicIntToStringName
+
+dynamicAppendName :: DynamicBuiltinName
+dynamicAppendName = DynamicBuiltinName "append"
+
+dynamicAppendMeaning :: DynamicBuiltinNameMeaning
+dynamicAppendMeaning = DynamicBuiltinNameMeaning sch (++) where
+    sch =
+        TypeSchemeBuiltin (TypedBuiltinDyn @String) `TypeSchemeArrow`
+        TypeSchemeBuiltin (TypedBuiltinDyn @String) `TypeSchemeArrow`
+        TypeSchemeBuiltin (TypedBuiltinDyn @String)
+
+dynamicAppendDefinition :: DynamicBuiltinNameDefinition
+dynamicAppendDefinition =
+    DynamicBuiltinNameDefinition dynamicAppendName dynamicAppendMeaning
+
+dynamicAppend :: Term tyname name ()
+dynamicAppend = dynamicBuiltinNameAsTerm dynamicAppendName

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Make.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Make.hs
@@ -17,6 +17,7 @@ module Language.PlutusCore.Constant.Make
     , makeDynBuiltinIntSizedAs
     , makeBuiltinInt
     , makeBuiltinBS
+    , makeBuiltinStr
     , makeSizedConstant
     , makeBuiltinBool
     , makeBuiltin
@@ -129,6 +130,9 @@ makeBuiltinInt size int = checkBoundsInt size int ? BuiltinInt () size int
 -- | Check whether a 'ByteString' is in bounds (see 'checkBoundsBS') and return it as a 'Constant'.
 makeBuiltinBS :: Size -> BSL.ByteString -> Maybe (Constant ())
 makeBuiltinBS size bs = checkBoundsBS size bs ? BuiltinBS () size bs
+
+makeBuiltinStr :: String -> Constant ()
+makeBuiltinStr = BuiltinStr ()
 
 -- | Convert a Haskell value to the corresponding PLC constant indexed by size
 -- checking all constraints (e.g. an 'Integer' is in appropriate bounds) along the way.

--- a/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
@@ -28,6 +28,7 @@ import           Numeric                            (showHex)
 data TypeBuiltin = TyByteString
                  | TyInteger
                  | TySize
+                 | TyString
                  deriving (Show, Eq, Ord, Generic, NFData, Lift)
 
 -- | Builtin functions
@@ -230,6 +231,7 @@ instance Pretty TypeBuiltin where
     pretty TyInteger    = "integer"
     pretty TyByteString = "bytestring"
     pretty TySize       = "size"
+    pretty TyString     = "string"
 
 instance Pretty (Version a) where
     pretty (Version _ i j k) = pretty i <> "." <> pretty j <> "." <> pretty k

--- a/language-plutus-core/src/Language/PlutusCore/Pretty/Classic.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty/Classic.hs
@@ -39,6 +39,7 @@ instance PrettyBy (PrettyConfigClassic configName) (Constant a) where
     prettyBy _ (BuiltinInt _ s i) = pretty s <+> "!" <+> pretty i
     prettyBy _ (BuiltinSize _ s)  = pretty s
     prettyBy _ (BuiltinBS _ s b)  = pretty s <+> "!" <+> prettyBytes b
+    prettyBy _ (BuiltinStr _ s)   = pretty s
 
 instance PrettyBy (PrettyConfigClassic configName) (Builtin a) where
     prettyBy _ (BuiltinName    _ n) = pretty n

--- a/language-plutus-core/src/Language/PlutusCore/Pretty/Readable.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty/Readable.hs
@@ -214,6 +214,7 @@ instance PrettyBy (PrettyConfigReadable configName) (Constant a) where
         BuiltinInt _ size int -> pretty size <> "!" <> pretty int
         BuiltinSize _ size    -> pretty size
         BuiltinBS _ size bs   -> pretty size <> "!" <> prettyBytes bs
+        BuiltinStr _ str      -> pretty str
 
 instance PrettyBy (PrettyConfigReadable configName) (Builtin a) where
     prettyBy config = unitaryDoc config . \case

--- a/language-plutus-core/src/Language/PlutusCore/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Type.hs
@@ -242,6 +242,7 @@ data Builtin a = BuiltinName a BuiltinName
 data Constant a = BuiltinInt a Natural Integer
                 | BuiltinBS a Natural BSL.ByteString
                 | BuiltinSize a Natural
+                | BuiltinStr a String
                 deriving (Functor, Show, Eq, Generic, NFData, Lift)
 
 -- TODO make this parametric in tyname as well

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -68,6 +68,7 @@ kindOfTypeBuiltin :: TypeBuiltin -> Kind ()
 kindOfTypeBuiltin TyInteger    = sizeToType
 kindOfTypeBuiltin TyByteString = sizeToType
 kindOfTypeBuiltin TySize       = sizeToType
+kindOfTypeBuiltin TyString     = Type ()
 
 -- | Annotate a 'Type'. Invariant: the type must be in normal form. The invariant is not checked.
 -- In case a type is open, an 'OpenTypeOfBuiltin' is returned.
@@ -193,6 +194,7 @@ typeOfConstant :: Constant a -> NormalizedType TyNameWithKind ()
 typeOfConstant (BuiltinInt  _ size _) = applySizedNormalized TyInteger    size
 typeOfConstant (BuiltinBS   _ size _) = applySizedNormalized TyByteString size
 typeOfConstant (BuiltinSize _ size)   = applySizedNormalized TySize       size
+typeOfConstant (BuiltinStr _ _)       = NormalizedType $ TyBuiltin () TyString
 
 typeOfBuiltin :: Builtin a -> TypeCheckM a (NormalizedType TyNameWithKind ())
 typeOfBuiltin (BuiltinName    ann name) = normalizedAnnotatedTypeOfBuiltinName ann name

--- a/plutus-core-interpreter/test/DynamicBuiltins/Logging.hs
+++ b/plutus-core-interpreter/test/DynamicBuiltins/Logging.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
 
 module DynamicBuiltins.Logging
     ( test_logging
@@ -19,19 +18,6 @@ import           Control.Monad.IO.Class
 import           Data.Functor.Identity
 import           Test.Tasty
 import           Test.Tasty.HUnit
-
-dynamicIntToStringName :: DynamicBuiltinName
-dynamicIntToStringName = DynamicBuiltinName "intToString"
-
-dynamicIntToStringMeaning :: DynamicBuiltinNameMeaning
-dynamicIntToStringMeaning = DynamicBuiltinNameMeaning sch show where
-    sch =
-        TypeSchemeAllSize $ \s ->
-            TypeSchemeBuiltin (TypedBuiltinSized (SizeBound s) TypedBuiltinSizedInt) `TypeSchemeArrow`
-            TypeSchemeBuiltin (TypedBuiltinDyn @String)
-
-dynamicIntToString :: Term tyname name ()
-dynamicIntToString = dynamicBuiltinNameAsTerm dynamicIntToStringName
 
 handleDynamicIntToString :: OnChainHandler "intToString" f r r
 handleDynamicIntToString = handleDynamicByMeaning dynamicIntToStringMeaning

--- a/plutus-core-interpreter/test/DynamicBuiltins/String.hs
+++ b/plutus-core-interpreter/test/DynamicBuiltins/String.hs
@@ -27,9 +27,9 @@ test_stringRoundtrip = testProperty "stringRoundtrip" . property $ do
     let mayStr' = runQuote (makeDynamicBuiltin str) >>= sequence . readDynamicBuiltinCek
     Just (Right str) === mayStr'
 
-test_listOfStringsRoundtrip :: TestTree
-test_listOfStringsRoundtrip = testProperty "listOfStringsRoundtrip" . property $ do
-    strs <- forAll . Gen.list (Range.linear 0 10) $ Gen.string (Range.linear 0 10) Gen.unicode
+test_plcListOfStringsRoundtrip :: TestTree
+test_plcListOfStringsRoundtrip = testProperty "listOfStringsRoundtrip" . property $ do
+    strs <- forAll . fmap PlcList . Gen.list (Range.linear 0 10) $ Gen.string (Range.linear 0 10) Gen.unicode
     let mayStrs' = runQuote (makeDynamicBuiltin strs) >>= sequence . readDynamicBuiltinCek
     Just (Right strs) === mayStrs'
 
@@ -56,18 +56,18 @@ test_collectChars = testProperty "collectChars" . property $ do
                     . LamAbs () y unit
                     $ Var () y
             let step arg rest = mkIterApp () ignore [Apply () emit arg, rest]
-            chars <- traverse unsafeMakeDynamicBuiltin str
+            chars <- traverse (unsafeMakeDynamicBuiltin . PlcChar) str
             return $ foldr step unitval chars
     case errOrRes of
         Left _                      -> failure
         Right EvaluationFailure     -> failure
         Right (EvaluationSuccess _) -> return ()
-    str === str'
+    str === map unPlcChar str'
 
 test_dynamicStrings :: TestTree
 test_dynamicStrings =
     testGroup "dynamicStrings"
         [ test_stringRoundtrip
-        , test_listOfStringsRoundtrip
+        , test_plcListOfStringsRoundtrip
         , test_collectChars
         ]


### PR DESCRIPTION
Turns out to be trivial.

A bit hacky, because we just do everything through `KnownDynamicBuiltinType` (which I now realize should be renamed to `KnownBuiltinType`), but it's hacky not because we use `KnownDynamicBuiltinType`, but because we do not use it for old stuff like `boolean` and perhaps even `integer` and others.

This does not solve the problem with logging and the heavy handling machinery. We still need to emit strings somehow. Unless you want to juggle them on the PLC side which is fine, but I think is tedious.

Two tests are commented out, because they no longer work, because we can't convert a `Char` or a `[String]` to PLC.

Feel free to merge or ignore.