### PR TITLE
plutus-tx: add a basic tutorial

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -87,7 +87,10 @@ let
       enableHaddockHydra enableBenchmarks fasterBuild enableDebugging
       enableSplitCheck customOverlays;
         pkgsGenerated = ./pkgs;
-        filter = localLib.isPlutus;
+        # split check is broken for things with test tool dependencies
+        filter = let
+          pkgList = pkgs.lib.remove "plutus-tx" localLib.plutusPkgList;
+          in name: builtins.elem name pkgList;
         requiredOverlay = ./nix/overlays/required.nix;
         ghc = pkgs.haskell.compiler.ghc843;
     };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55570,6 +55570,8 @@ license = stdenv.lib.licenses.mit;
 , containers
 , hedgehog
 , language-plutus-core
+, lens
+, mmorph
 , mtl
 , stdenv
 , tasty
@@ -55585,6 +55587,8 @@ libraryHaskellDepends = [
 base
 containers
 language-plutus-core
+lens
+mmorph
 mtl
 ];
 testHaskellDepends = [
@@ -55681,7 +55685,9 @@ license = stdenv.lib.licenses.bsd3;
 ({
   mkDerivation
 , base
+, doctest
 , language-plutus-core
+, markdown-unlit
 , plutus-tx-plugin
 , stdenv
 , tasty
@@ -55699,10 +55705,15 @@ template-haskell
 ];
 testHaskellDepends = [
 base
+doctest
 language-plutus-core
+markdown-unlit
 plutus-tx-plugin
 tasty
 template-haskell
+];
+testToolDepends = [
+markdown-unlit
 ];
 doHaddock = false;
 description = "The PlutusTx compiler frontend";

--- a/plutus-tx/README.lhs
+++ b/plutus-tx/README.lhs
@@ -1,0 +1,1 @@
+README.md

--- a/plutus-tx/README.md
+++ b/plutus-tx/README.md
@@ -36,9 +36,9 @@ Not supported, and support not planned:
 Let's write some code!
 
 ```haskell
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DataKinds       #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 import Language.PlutusTx.TH
 import Language.PlutusTx.Lift
 import Language.PlutusCore

--- a/plutus-tx/README.md
+++ b/plutus-tx/README.md
@@ -1,3 +1,228 @@
-# Plutus TH frontend
+# plutus-tx: PlutusTx Haskell support
 
-This provides Template Haskell functionality for writing Plutus Core programs.
+This provides support for writing PlutusTx programs in Haskell using Template Haskell.
+
+This package just provides support for PlutusTx, if you are looking for support for
+writing smart contracts using PlutusTx, please look in `wallet-api`.
+
+## Haskell language support
+
+In general, most "straightforward" Haskell should work. More advanced features may
+or may not work, depending on whether they rely on features of GHC Core that aren't
+supported. Most syntactic language extensions should be fine, you may get into trouble
+with more advanced type system extensions.
+
+TODO: link to GitHub issues for planned items once we're using them.
+
+Not supported, but support planned:
+- Mutually recursive datatypes (support planned)
+    - Self-recursive datatypes are supported
+- Record selectors (support planned)
+- Functions defined outside the PlutusTx expression
+
+Not supported, and support not planned:
+- Datatypes beyond simple "Haskell98" datatypes
+    - GADTs, constrained constructors, etc.
+- Abstract datatypes
+- Numeric types other than `Int`
+- Literal patterns
+- Typeclasses
+    - Some `Num`, `Eq`, and `Ord` methods on
+      `Int` and `Bytestring` are supported specially.
+- Anything involving coercions
+
+## Tutorial
+
+Let's write some code!
+
+```haskell
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+import Language.PlutusTx.TH
+import Language.PlutusTx.Lift
+import Language.PlutusCore
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Evaluation.CkMachine
+import qualified Language.Haskell.TH as TH
+import Data.Functor
+```
+
+### Writing basic PlutusTx programs
+
+The `PlcCode` type is an opaque type which contains the serialized Plutus Core code
+corresponding to a Haskell expression. The `plutus` function takes a typed Template Haskell
+`Q (TExp a)`, for any a, and produces a `Q (TExp PlcCode)`, which we then
+have to splice into our program.
+
+The fact that `plutus` takes a TH quote means that what you write inside the quote
+is *just normal Haskell* - there is no PlutusTx-specific syntax, and the PlutusTx compiler will
+tell you if you use any Haskell features which are not supported.
+
+Here's the most basic program we can write: one that just evaluates to the integer `1`.
+
+```haskell
+-- |
+-- >>> prettyPlcDef $ getAst integerOne
+-- (program 1.0.0
+--   (con 8 ! 1)
+-- )
+integerOne :: PlcCode
+-- We don't like unbounded integers in Plutus Core, so we have to pin
+-- down that numeric literal to an `Int` not an `Integer`.
+integerOne = $$(plutus [|| (1 :: Int) ||])
+```
+
+The Plutus Core program will look incomprehensible, which is fine, since you
+mostly won't want to look at the output of the compiler. However, it's instructive to
+look at it here just to get a vague idea of what's going on.
+
+We can already see a few features of Plutus Core here:
+- We have a *versioned* program. This ensures that we always know how to handle
+  programs once they're on the chain.
+- Integers have *sizes*, in this case 8 bytes (64 bits).
+
+Both of these things are handled for us by the compiler.
+
+Here's a slightly more complex program, namely the identity function on integers.
+
+```haskell
+-- |
+-- >>> prettyPlcDef $ getAst integerIdentity
+-- (program 1.0.0
+--   (lam ds [(con integer) (con 8)] ds)
+-- )
+integerIdentity :: PlcCode
+integerIdentity = $$(plutus [|| \(x:: Int) -> x ||])
+```
+
+So far, so familiar: we compiled a lambda into a lambda.
+
+You can also define functions locally to use inside your expression. At the moment you
+*cannot* use functions that are defined outside the PlutusTx expression, although hopefully
+this will be easier in future. You can, however, splice in TH quotes, which lets you define
+some reusable components.
+
+```haskell
+plusOne :: Int -> Int
+plusOne x = x + 1
+
+functions :: PlcCode
+functions = $$(plutus [||
+    let
+        plusOneLocal :: Int -> Int
+        plusOneLocal x = x + 1
+        -- This won't work.
+        -- nonLocalDoesntWork = plusOne 1
+        localWorks = plusOneLocal 1
+        -- You can of course bind this to a name, but for the purposes
+        -- of this tutorial we won't since TH requires it to be in
+        -- another module.
+        thWorks = $$([|| \(x::Int) -> x + 1 ||]) 1
+    in localWorks + thWorks
+    ||])
+```
+
+From this point on we're going to start dealing with more advanced features of
+Haskell, like datatypes. The way these are encoded into Plutus Core is quite
+tricky, so we're going to stop looking at the generated Plutus Core code, but
+it's in there if you're curious.
+
+TODO: when we store the PIR, start showing PIR at this stage (or earlier).
+
+We can use normal Haskell datatypes and pattern matching freely:
+
+```haskell
+matchMaybe :: PlcCode
+matchMaybe = $$(plutus [|| \(x:: Maybe Int) -> case x of
+    Just n -> n
+    Nothing -> 0
+   ||])
+```
+
+This works for your own datatypes too! (See [Haskell language support](#haskell-language-support)
+for some caveats.) Unlike functions, datatypes do not need to be defined inside the
+expression, hence why we can use types like `Maybe` from the `Prelude`.
+
+### Using PlutusTx builtins
+
+PlutusTx has some builtin types and functions available, both for working with primitive
+data (integers and bytestrings), and also for performing chain-specific operations.
+
+The PlutusTx builtins are available via the `Language.PlutusTx.Builtins` module. You
+shouldn't need to use the integer and bytestring builtins directly, these are mapped
+to the corresponding Haskell operations on `Int` and lazy `ByteString` directly. However,
+you may wish to use some of the others.
+
+`error` deserves a special mention. `error` causes the transaction to abort when it is
+evaluated, which is the way that validation failure is signalled.
+
+### Lifting values
+
+This is all very good for defining pieces of code *statically*, but you are
+likely to want to *dynamically* produce Plutus Core programs. For example, you
+might be writing the body of a transaction to initiate a crowdfunding smart contract,
+which would need to be parameterized by user input determining the size of the goal,
+the campaign start and end times, etc.
+
+You can do this by writing the static code as a function, and then passing an
+argument at runtime by *lifting* it and then applying the two programs together. As a
+very simple example, let's write an add-one function.
+
+```haskell
+-- TODO: show PIR here too
+
+-- |
+-- >>> let program = addOneToN 4
+-- >>> prettyPlcDef program
+-- (program 1.0.0
+--   [
+--     [
+--       (lam
+--         addInteger
+--         (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] [(con integer) (con 8)]))
+--         (lam ds [(con integer) (con 8)] [ [ addInteger ds ] (con 8 ! 1) ])
+--       )
+--       { (builtin addInteger) (con 8) }
+--     ]
+--     (con 8 ! 4)
+--   ]
+-- )
+
+-- >>> prettyPlcDef $ runCk program
+-- (con 8 ! 5)
+addOneToN :: Int -> Program TyName Name ()
+addOneToN n =
+    let
+        addOne = $$(plutus [|| \(x:: Int) -> x + 1 ||])
+        -- TODO: This looks terrible
+        arg = Program () (defaultVersion ()) (runQuote $ unsafeLiftPlc n)
+    in applyProgram (getAst addOne) arg
+```
+
+Here we have lifted the Haskell value `4` into a Plutus Core term at runtime.
+In order to do this, a type must have an instance of the `LiftPir` class. In
+practice, you should generate these with the `makeLift` TH function from
+`Laguage.PlutusTx.Lift`. This makes it easy to use the same types both inside your
+PlutusTx program and in the external code that uses it.
+
+The combined program just applies the compiled lambda to the lifted value
+(notice that the lambda is a bit complicated now since we have compiled the addition
+into a builtin). We've then used the CK evaluator for Plutus Core to evaluate
+the program and check that the result was what we expected
+
+This is more or less all you need to get started - from here on it should mostly
+be like writing normal Haskell.
+
+```haskell
+main :: IO ()
+main = do
+    _ <- traverse (putStrLn . show . prettyPlcDef . getAst) [
+        integerOne,
+        integerIdentity,
+        functions,
+        matchMaybe
+        ]
+    putStrLn . show . prettyPlcDef $ runCk $ addOneToN 4
+```

--- a/plutus-tx/doctests.hs
+++ b/plutus-tx/doctests.hs
@@ -1,2 +1,2 @@
 import           Test.DocTest
-main = doctest ["-pgmL markdown-unlit", "-ddump-splices", "-isrc", "README.lhs"]
+main = doctest ["-pgmL markdown-unlit", "-isrc", "README.lhs"]

--- a/plutus-tx/doctests.hs
+++ b/plutus-tx/doctests.hs
@@ -1,0 +1,2 @@
+import           Test.DocTest
+main = doctest ["-pgmL markdown-unlit", "-ddump-splices", "-isrc", "README.lhs"]

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -53,3 +53,29 @@ test-suite plutus-tx-tests
         plutus-tx -any,
         template-haskell -any,
         tasty -any
+
+test-suite plutus-tx-readme
+    type: exitcode-stdio-1.0
+    main-is: README.lhs
+    default-language: Haskell2010
+    build-depends:
+        base >=4.9 && <5,
+        language-plutus-core -any,
+        plutus-tx -any,
+        plutus-tx-plugin -any,
+        template-haskell -any,
+        markdown-unlit -any
+    build-tool-depends: markdown-unlit:markdown-unlit
+    ghc-options: -pgmL markdown-unlit
+
+test-suite plutus-tx-doctests
+    type: exitcode-stdio-1.0
+    main-is: doctests.hs
+    default-language: Haskell2010
+    build-depends:
+        base >=4.9 && <5,
+        plutus-tx -any,
+        markdown-unlit -any,
+        doctest -any
+    build-tool-depends: markdown-unlit:markdown-unlit
+    ghc-options: -pgmL markdown-unlit

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -54,20 +54,6 @@ test-suite plutus-tx-tests
         template-haskell -any,
         tasty -any
 
-test-suite plutus-tx-readme
-    type: exitcode-stdio-1.0
-    main-is: README.lhs
-    default-language: Haskell2010
-    build-depends:
-        base >=4.9 && <5,
-        language-plutus-core -any,
-        plutus-tx -any,
-        plutus-tx-plugin -any,
-        template-haskell -any,
-        markdown-unlit -any
-    build-tool-depends: markdown-unlit:markdown-unlit
-    ghc-options: -pgmL markdown-unlit
-
 test-suite plutus-tx-doctests
     type: exitcode-stdio-1.0
     main-is: doctests.hs

--- a/plutus-tx/src/Language/PlutusTx/TH.hs
+++ b/plutus-tx/src/Language/PlutusTx/TH.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE TemplateHaskell  #-}
 {-# LANGUAGE TypeApplications #-}
 module Language.PlutusTx.TH (
-    module Builtins,
     plutus,
     plutusUntyped,
     PlcCode,
     getSerializedCode,
     getAst) where
 
-import           Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Plugin
 
 import qualified Language.Haskell.TH        as TH

--- a/plutus-tx/src/Language/PlutusTx/TH.hs
+++ b/plutus-tx/src/Language/PlutusTx/TH.hs
@@ -17,25 +17,26 @@ import qualified Language.Haskell.TH.Syntax as TH
 
 -- | Covert a quoted Haskell expression into a corresponding Plutus Core program.
 plutus :: TH.Q (TH.TExp a) -> TH.Q (TH.TExp PlcCode)
-plutus e = do
-    TH.addCorePlugin "Language.PlutusTx.Plugin"
-    loc <- TH.location
-    let locStr = TH.pprint loc
-    -- See note [Typed TH]
-    let
-        partial :: TH.Q (TH.TExp (a -> PlcCode))
-        partial = TH.unsafeTExpCoerce [| \a -> plc @($(TH.litT $ TH.strTyLit locStr)) a |]
-    [|| $$(partial) $$(e) ||]
+-- See note [Typed TH]
+plutus e = TH.unsafeTExpCoerce $ plutusUntyped $ TH.unType <$> e
 
 {- Note [Typed TH]
-It's nice to use typed TH! However, we sadly can't *quite* use it thoroughly, because we want to make a type literal,
-and there's no way to do that properly with typed TH.
+It's nice to use typed TH! However, we sadly can't *quite* use it thoroughly, because we
+want to make a type literal, and there's no way to do that properly with typed TH.
 
-However, we can isolate the badness into as small a box as possible, and then use unsafeTExpCoerce.
+Moreover, we really want to create an expression with the precise form that we want,
+so we can't isolate the badness much. So we pretty much just have to use unsafeTExpCoerce
+and assert that we know what we're doing.
+
+This isn't so bad, since our plc function accepts an argument of any type, so that's always
+going to typecheck, and the result is always a PlcCode, so that's also fine.
 -}
 
 -- | Covert a quoted Haskell expression into a corresponding Plutus Core program.
 plutusUntyped :: TH.Q TH.Exp -> TH.Q TH.Exp
--- Just force our typed version to accept it and then turn it back into an untyped one. This means it will
--- get typechecked again later, which is good because we lied about knowing the type of the argument.
-plutusUntyped e = TH.unType <$> plutus (TH.unsafeTExpCoerce e)
+plutusUntyped e = do
+    TH.addCorePlugin "Language.PlutusTx.Plugin"
+    loc <- TH.location
+    let locStr = TH.pprint loc
+    -- See note [Typed TH]
+    [| plc @($(TH.litT $ TH.strTyLit locStr)) $(e) |]

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -36,9 +36,9 @@ import           GHC.Generics               (Generic)
 
 import           Language.Plutus.Runtime    (Height (..), PendingTx (..), PendingTxIn (..), PendingTxOut, PubKey (..),
                                              ValidatorHash, Value (..))
+import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Lift     (makeLift)
 import           Language.PlutusTx.TH       (plutusUntyped)
-import qualified Language.PlutusTx.TH       as Builtins
 import           Wallet.API                 (EventHandler (..), EventTrigger, Range (..), WalletAPI (..),
                                              WalletAPIError, andT, blockHeightT, fundsAtAddressT, otherError,
                                              ownPubKeyTxOut, payToScript, pubKey, signAndSubmit)

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Future.hs
@@ -29,9 +29,9 @@ import           Control.Monad.Error.Class  (MonadError (..))
 import qualified Data.Set                   as Set
 import           GHC.Generics               (Generic)
 import qualified Language.Plutus.Runtime.TH as TH
+import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Lift     (makeLift)
 import           Language.PlutusTx.TH       (plutusUntyped)
-import qualified Language.PlutusTx.TH       as Builtins
 import           Wallet.API                 (WalletAPI (..), WalletAPIError, otherError, pubKey, signAndSubmit)
 import           Wallet.UTXO                (DataScript (..), TxOutRef', Validator (..), scriptTxIn, scriptTxOut)
 import qualified Wallet.UTXO                as UTXO

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Swap.hs
@@ -12,8 +12,8 @@ module Language.Plutus.Coordination.Contracts.Swap(
 import           Language.Plutus.Runtime    (OracleValue (..), PendingTx (..), PendingTxIn (..), PendingTxOut (..),
                                              PubKey, ValidatorHash, Value (..))
 import qualified Language.Plutus.Runtime.TH as TH
+import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.TH       (plutusUntyped)
-import qualified Language.PlutusTx.TH       as Builtins
 import           Wallet.UTXO                (Height, Validator (..))
 import qualified Wallet.UTXO                as UTXO
 

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
@@ -23,9 +23,9 @@ import           GHC.Generics               (Generic)
 import           Language.Plutus.Runtime    (Height (..), PendingTx (..), PendingTxOut (..), PendingTxOutType (..),
                                              PubKey (..), ValidatorHash, Value (..))
 import qualified Language.Plutus.Runtime.TH as TH
+import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Lift     (makeLift)
 import           Language.PlutusTx.TH       (plutusUntyped)
-import qualified Language.PlutusTx.TH       as Builtins
 import           Prelude                    hiding ((&&))
 import           Wallet.API                 (WalletAPI (..), WalletAPIError, otherError, ownPubKeyTxOut, signAndSubmit)
 import           Wallet.UTXO                (DataScript (..), TxOutRef', Validator (..), scriptTxIn, scriptTxOut)

--- a/plutus-use-cases/src/Language/Plutus/Runtime/TH.hs
+++ b/plutus-use-cases/src/Language/Plutus/Runtime/TH.hs
@@ -32,11 +32,11 @@ module Language.Plutus.Runtime.TH(
     eqTx
     ) where
 
-import           Language.Haskell.TH  (Exp, Q)
-import qualified Language.PlutusTx.TH as Builtins
+import           Language.Haskell.TH        (Exp, Q)
+import qualified Language.PlutusTx.Builtins as Builtins
 import           Wallet.UTXO.Runtime
 
-import           Prelude              (Bool (..), Eq (..), Int, Maybe (..))
+import           Prelude                    (Bool (..), Eq (..), Int, Maybe (..))
 
 -- | Logical AND
 and :: Q Exp

--- a/release.nix
+++ b/release.nix
@@ -31,7 +31,7 @@ let
   mapped = mapTestOn platforms;
   makePlutusTestRuns = system:
   let
-    pred = name: value: fixedLib.isPlutus name && value ? testrun;
+    pred = name: value: fixedLib.isPlutus name && value ? testdata;
     plutusPkgs = import ./. { inherit system; };
     f = name: value: value.testrun;
   in pkgs.lib.mapAttrs f (lib.filterAttrs pred plutusPkgs.haskellPackages);


### PR DESCRIPTION
This adds a basic tutorial on PlutusTx. It's focussed on just the PlutusTx bit, so nothing about how to actually write contracts, just how to use the plugin and the TH stuff.

I've used `markdown-unlits` and `doctest` to extract the Haskell from the tutorial and compile and doctest it,  thus ensuring that it actually works and continues working!

In the process I noticed a number of things that were not good, some of which I have fixed and others of which have TODOs.

Other fixes:
- I didn't realise this, but https://github.com/input-output-hk/plutus/pull/326 changes the shape of the generated expression so we can't recognize it unless GHC does some simplification first! This is very bad, so I went back to the old way, although it means `unsafeTExpCoerce` gets a little further out of its box.
- It's nicer to explicitly import `Language.PlutusTx.Builtins` rather than re-exporting it from `Language.PlutusTx.TH`. There is a separate issue which is whether the `plutus-tx` package should provide these modules (at the moment you have to get them from `plutus-tx-plugin`), but that's for later.