### PR TITLE
plutus-tx: string support

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55688,6 +55688,8 @@ license = stdenv.lib.licenses.bsd3;
 , doctest
 , language-plutus-core
 , markdown-unlit
+, mtl
+, plutus-core-interpreter
 , plutus-tx-plugin
 , stdenv
 , tasty
@@ -55708,6 +55710,8 @@ base
 doctest
 language-plutus-core
 markdown-unlit
+mtl
+plutus-core-interpreter
 plutus-tx-plugin
 tasty
 template-haskell

--- a/plutus-tx-plugin/src/Language/PlutusTx/Builtins.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Builtins.hs
@@ -24,10 +24,15 @@ module Language.PlutusTx.Builtins (
                                 , equalsInteger
                                 -- * Error
                                 , error
+                                -- * Strings
+                                , String
+                                , appendString
+                                , emptyString
+                                , charToString
                                 ) where
 
-import           Data.ByteString.Lazy
-import           Prelude                 hiding (error)
+import           Data.ByteString.Lazy    hiding (append)
+import           Prelude                 hiding (String, error)
 
 import           Language.PlutusTx.Utils (mustBeReplaced)
 
@@ -92,3 +97,15 @@ equalsInteger = mustBeReplaced
 
 error :: () -> a
 error = mustBeReplaced
+
+-- | An opaque type representing PLC strings.
+data String
+
+appendString :: String -> String -> String
+appendString = mustBeReplaced
+
+emptyString :: String
+emptyString = mustBeReplaced
+
+charToString :: Char -> String
+charToString = mustBeReplaced

--- a/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Expr.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE ConstraintKinds   #-}
 {-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns      #-}
 
 -- | Functions for compiling GHC Core expressions into Plutus Core terms.
 module Language.PlutusTx.Compiler.Expr (convExpr, convExprWithDefs, convDataConRef) where
+
+import           PlutusPrelude                          (bsToStr)
 
 import           Language.PlutusTx.Compiler.Binders
 import           Language.PlutusTx.Compiler.Builtins
@@ -30,6 +33,7 @@ import qualified Language.PlutusIR.MkPir                as PIR
 import qualified Language.PlutusIR.Value                as PIR
 
 import qualified Language.PlutusCore                    as PLC
+import qualified Language.PlutusCore.Constant           as PLC
 
 import           Control.Monad.Reader
 
@@ -62,16 +66,29 @@ containing the actual data, but are wrapped in special functions (often ending i
 This is a pain to recognize.
 -}
 
-convLiteral :: Converting m => GHC.Literal -> m (PLC.Constant ())
-convLiteral l = case l of
+convLiteral :: Converting m => GHC.Literal -> m PIRTerm
+convLiteral = \case
     -- TODO: better sizes
-    GHC.MachInt64 i    -> pure $ PLC.BuiltinInt () haskellIntSize i
-    GHC.MachInt i      -> pure $ PLC.BuiltinInt () haskellIntSize i
-    GHC.MachStr bs     -> pure $ PLC.BuiltinBS () haskellBSSize (BSL.fromStrict bs)
+    GHC.MachInt64 i    -> pure $ PIR.Constant () $ PLC.BuiltinInt () haskellIntSize i
+    GHC.MachInt i      -> pure $ PIR.Constant () $ PLC.BuiltinInt () haskellIntSize i
+    GHC.MachStr bs     ->
+        -- Convert the bytestring into a core expression representing the list
+        -- of characters, then compile that!
+        -- Note that we do *not* convert this into a PLC string, but rather a list of characters,
+        -- since that is what other Haskell code will expect.
+        let
+            str = bsToStr (BSL.fromStrict bs)
+            charExprs = fmap GHC.mkCharExpr str
+            listExpr = GHC.mkListExpr GHC.charTy charExprs
+        in convExpr listExpr
+    GHC.MachChar c     -> do
+        maybeEncoded <- PLC.liftQuote $ PLC.makeDynamicBuiltin c
+        case maybeEncoded of
+            Just t  -> pure $ PIR.embedIntoIR t
+            Nothing -> throwPlain $ UnsupportedError "Conversion of character failed"
     GHC.LitInteger _ _ -> throwPlain $ UnsupportedError "Literal (unbounded) integer"
     GHC.MachWord _     -> throwPlain $ UnsupportedError "Literal word"
     GHC.MachWord64 _   -> throwPlain $ UnsupportedError "Literal word64"
-    GHC.MachChar _     -> throwPlain $ UnsupportedError "Literal char"
     GHC.MachFloat _    -> throwPlain $ UnsupportedError "Literal float"
     GHC.MachDouble _   -> throwPlain $ UnsupportedError "Literal double"
     GHC.MachLabel {}   -> throwPlain $ UnsupportedError "Literal label"
@@ -84,7 +101,7 @@ isPrimitiveWrapper i = case GHC.idDetails i of
     _                    -> False
 
 isPrimitiveDataCon :: GHC.DataCon -> Bool
-isPrimitiveDataCon dc = dc == GHC.intDataCon
+isPrimitiveDataCon dc = dc == GHC.intDataCon || dc == GHC.charDataCon
 
 -- | Convert a reference to a data constructor, i.e. a call to it.
 convDataConRef :: Converting m => GHC.DataCon -> m PIRTerm
@@ -172,7 +189,7 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
                 -- the term we get must be closed - we don't resolve most references
                 -- TODO: possibly relax this?
                 Nothing -> throwSd FreeVariableError $ "Variable" GHC.<+> GHC.ppr n GHC.$+$ (GHC.ppr $ GHC.idDetails n)
-        GHC.Lit lit -> PIR.Constant () <$> convLiteral lit
+        GHC.Lit lit -> convLiteral lit
         -- arg can be a type here, in which case it's a type instantiation
         GHC.App l (GHC.Type t) -> PIR.TyInst () <$> convExpr l <*> convType t
         -- otherwise it's a normal application

--- a/plutus-tx-plugin/src/Language/PlutusTx/Utils.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Utils.hs
@@ -17,6 +17,9 @@ appSize n t = PIR.TyApp () t (PLC.TyInt () n)
 mkBuiltin :: PLC.BuiltinName -> PIR.Term tyname name ()
 mkBuiltin n = PIR.Builtin () $ PLC.BuiltinName () n
 
+mkDynBuiltin :: PLC.DynamicBuiltinName -> PIR.Term tyname name ()
+mkDynBuiltin n = PIR.Builtin () $ PLC.DynBuiltinName () n
+
 mkIntFun :: PLC.BuiltinName -> PIR.Term PIR.TyName PIR.Name ()
 mkIntFun name = instSize haskellIntSize (mkBuiltin name)
 

--- a/plutus-tx-plugin/test/Lift/boolInterop.plc.golden
+++ b/plutus-tx-plugin/test/Lift/boolInterop.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_106
+  out_Bool_111
   (type)
   (lam
-    case_True_107 out_Bool_106 (lam case_False_108 out_Bool_106 case_True_107)
+    case_True_112 out_Bool_111 (lam case_False_113 out_Bool_111 case_True_112)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/IllTyped.hs
+++ b/plutus-tx-plugin/test/Plugin/IllTyped.hs
@@ -14,6 +14,9 @@ import           Language.PlutusTx.Plugin
 -- this module does lots of weird stuff deliberately
 {-# ANN module "HLint: ignore" #-}
 
+string :: PlcCode
+string = plc @"string" "test"
+
 listConstruct :: PlcCode
 listConstruct = plc @"listConstruct" ([]::[Int])
 

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -82,9 +82,6 @@ primitives = testNested "primitives" [
   , goldenPlc "verify" verify
   ]
 
-string :: PlcCode
-string = plc @"string" "test"
-
 int :: PlcCode
 int = plc @"int" (1::Int)
 

--- a/plutus-tx-plugin/test/Plugin/basic/monoId.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/basic/monoId.plc.golden
@@ -1,3 +1,3 @@
 (program 1.0.0
-  (lam ds_68 [(con integer) (con 8)] ds_68)
+  (lam ds_73 [(con integer) (con 8)] ds_73)
 )

--- a/plutus-tx-plugin/test/Plugin/basic/monoK.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/basic/monoK.plc.golden
@@ -1,3 +1,3 @@
 (program 1.0.0
-  (lam ds_69 [(con integer) (con 8)] (lam ds_70 [(con integer) (con 8)] ds_69))
+  (lam ds_74 [(con integer) (con 8)] (lam ds_75 [(con integer) (con 8)] ds_74))
 )

--- a/plutus-tx-plugin/test/Plugin/data/monomorphic/atPattern.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/monomorphic/atPattern.plc.golden
@@ -3,80 +3,80 @@
     [
       {
         (abs
-          Tuple2_86
+          Tuple2_91
           (fun (type) (fun (type) (type)))
           (lam
-            Tuple2_87
-            (all a_88 (type) (all b_89 (type) (fun a_88 (fun b_89 [[Tuple2_86 a_88] b_89]))))
+            Tuple2_92
+            (all a_93 (type) (all b_94 (type) (fun a_93 (fun b_94 [[Tuple2_91 a_93] b_94]))))
             (lam
-              Tuple2_match_90
-              (all a_91 (type) (all b_92 (type) (fun [[Tuple2_86 a_91] b_92] [[(lam a_93 (type) (lam b_94 (type) (all out_Tuple2_95 (type) (fun (fun a_93 (fun b_94 out_Tuple2_95)) out_Tuple2_95)))) a_91] b_92])))
+              Tuple2_match_95
+              (all a_96 (type) (all b_97 (type) (fun [[Tuple2_91 a_96] b_97] [[(lam a_98 (type) (lam b_99 (type) (all out_Tuple2_100 (type) (fun (fun a_98 (fun b_99 out_Tuple2_100)) out_Tuple2_100)))) a_96] b_97])))
               [
                 (lam
-                  addInteger_96
+                  addInteger_101
                   (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] [(con integer) (con 8)]))
                   (lam
-                    t_97
-                    [[Tuple2_86 [(con integer) (con 8)]] [(con integer) (con 8)]]
+                    t_102
+                    [[Tuple2_91 [(con integer) (con 8)]] [(con integer) (con 8)]]
                     [
                       (lam
-                        wild_98
-                        [[Tuple2_86 [(con integer) (con 8)]] [(con integer) (con 8)]]
+                        wild_103
+                        [[Tuple2_91 [(con integer) (con 8)]] [(con integer) (con 8)]]
                         [
                           {
                             [
                               {
-                                { Tuple2_match_90 [(con integer) (con 8)] }
+                                { Tuple2_match_95 [(con integer) (con 8)] }
                                 [(con integer) (con 8)]
                               }
-                              t_97
+                              t_102
                             ]
                             [(con integer) (con 8)]
                           }
                           (lam
-                            ds_99
+                            ds_104
                             [(con integer) (con 8)]
                             (lam
-                              ds_100
+                              ds_105
                               [(con integer) (con 8)]
                               [
                                 [
-                                  addInteger_96 ds_100
+                                  addInteger_101 ds_105
                                 ]
                                 [
                                   (lam
-                                    ds_101
-                                    [[Tuple2_86 [(con integer) (con 8)]] [(con integer) (con 8)]]
+                                    ds_106
+                                    [[Tuple2_91 [(con integer) (con 8)]] [(con integer) (con 8)]]
                                     [
                                       {
                                         [
                                           {
                                             {
-                                              Tuple2_match_90
+                                              Tuple2_match_95
                                               [(con integer) (con 8)]
                                             }
                                             [(con integer) (con 8)]
                                           }
-                                          ds_101
+                                          ds_106
                                         ]
                                         [(con integer) (con 8)]
                                       }
                                       (lam
-                                        a_102
+                                        a_107
                                         [(con integer) (con 8)]
-                                        (lam b_103 [(con integer) (con 8)] a_102
+                                        (lam b_108 [(con integer) (con 8)] a_107
                                         )
                                       )
                                     ]
                                   )
-                                  wild_98
+                                  wild_103
                                 ]
                               ]
                             )
                           )
                         ]
                       )
-                      t_97
+                      t_102
                     ]
                   )
                 )
@@ -85,27 +85,27 @@
             )
           )
         )
-        (lam a_104 (type) (lam b_105 (type) (all out_Tuple2_106 (type) (fun (fun a_104 (fun b_105 out_Tuple2_106)) out_Tuple2_106))))
+        (lam a_109 (type) (lam b_110 (type) (all out_Tuple2_111 (type) (fun (fun a_109 (fun b_110 out_Tuple2_111)) out_Tuple2_111))))
       }
       (abs
-        a_107
+        a_112
         (type)
         (abs
-          b_108
+          b_113
           (type)
           (lam
-            arg_0_109
-            a_107
+            arg_0_114
+            a_112
             (lam
-              arg_1_110
-              b_108
+              arg_1_115
+              b_113
               (abs
-                out_Tuple2_111
+                out_Tuple2_116
                 (type)
                 (lam
-                  case_Tuple2_112
-                  (fun a_107 (fun b_108 out_Tuple2_111))
-                  [ [ case_Tuple2_112 arg_0_109 ] arg_1_110 ]
+                  case_Tuple2_117
+                  (fun a_112 (fun b_113 out_Tuple2_116))
+                  [ [ case_Tuple2_117 arg_0_114 ] arg_1_115 ]
                 )
               )
             )
@@ -114,15 +114,15 @@
       )
     ]
     (abs
-      a_113
+      a_118
       (type)
       (abs
-        b_114
+        b_119
         (type)
         (lam
-          x_115
-          [[(lam a_116 (type) (lam b_117 (type) (all out_Tuple2_118 (type) (fun (fun a_116 (fun b_117 out_Tuple2_118)) out_Tuple2_118)))) a_113] b_114]
-          x_115
+          x_120
+          [[(lam a_121 (type) (lam b_122 (type) (all out_Tuple2_123 (type) (fun (fun a_121 (fun b_122 out_Tuple2_123)) out_Tuple2_123)))) a_118] b_119]
+          x_120
         )
       )
     )

--- a/plutus-tx-plugin/test/Plugin/data/monomorphic/defaultCase.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/monomorphic/defaultCase.plc.golden
@@ -5,47 +5,47 @@
         [
           {
             (abs
-              MyMonoData_96
+              MyMonoData_101
               (type)
               (lam
-                Mono1_97
-                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_96))
+                Mono1_102
+                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_101))
                 (lam
-                  Mono2_98
-                  (fun [(con integer) (con 8)] MyMonoData_96)
+                  Mono2_103
+                  (fun [(con integer) (con 8)] MyMonoData_101)
                   (lam
-                    Mono3_99
-                    (fun [(con integer) (con 8)] MyMonoData_96)
+                    Mono3_104
+                    (fun [(con integer) (con 8)] MyMonoData_101)
                     (lam
-                      MyMonoData_match_100
-                      (fun MyMonoData_96 (all out_MyMonoData_101 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_101)) (fun (fun [(con integer) (con 8)] out_MyMonoData_101) (fun (fun [(con integer) (con 8)] out_MyMonoData_101) out_MyMonoData_101)))))
+                      MyMonoData_match_105
+                      (fun MyMonoData_101 (all out_MyMonoData_106 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_106)) (fun (fun [(con integer) (con 8)] out_MyMonoData_106) (fun (fun [(con integer) (con 8)] out_MyMonoData_106) out_MyMonoData_106)))))
                       (lam
-                        ds_102
-                        MyMonoData_96
+                        ds_107
+                        MyMonoData_101
                         [
                           [
                             [
                               {
-                                [ MyMonoData_match_100 ds_102 ]
+                                [ MyMonoData_match_105 ds_107 ]
                                 [(con integer) (con 8)]
                               }
                               (lam
-                                default_arg0_103
+                                default_arg0_108
                                 [(con integer) (con 8)]
                                 (lam
-                                  default_arg1_104
+                                  default_arg1_109
                                   [(con integer) (con 8)]
                                   (con 8 ! 2)
                                 )
                               )
                             ]
                             (lam
-                              default_arg0_105
+                              default_arg0_110
                               [(con integer) (con 8)]
                               (con 8 ! 2)
                             )
                           ]
-                          (lam a_106 [(con integer) (con 8)] a_106)
+                          (lam a_111 [(con integer) (con 8)] a_111)
                         ]
                       )
                     )
@@ -53,27 +53,27 @@
                 )
               )
             )
-            (all out_MyMonoData_107 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_107)) (fun (fun [(con integer) (con 8)] out_MyMonoData_107) (fun (fun [(con integer) (con 8)] out_MyMonoData_107) out_MyMonoData_107))))
+            (all out_MyMonoData_112 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_112)) (fun (fun [(con integer) (con 8)] out_MyMonoData_112) (fun (fun [(con integer) (con 8)] out_MyMonoData_112) out_MyMonoData_112))))
           }
           (lam
-            arg_0_108
+            arg_0_113
             [(con integer) (con 8)]
             (lam
-              arg_1_109
+              arg_1_114
               [(con integer) (con 8)]
               (abs
-                out_MyMonoData_110
+                out_MyMonoData_115
                 (type)
                 (lam
-                  case_Mono1_111
-                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_110))
+                  case_Mono1_116
+                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_115))
                   (lam
-                    case_Mono2_112
-                    (fun [(con integer) (con 8)] out_MyMonoData_110)
+                    case_Mono2_117
+                    (fun [(con integer) (con 8)] out_MyMonoData_115)
                     (lam
-                      case_Mono3_113
-                      (fun [(con integer) (con 8)] out_MyMonoData_110)
-                      [ [ case_Mono1_111 arg_0_108 ] arg_1_109 ]
+                      case_Mono3_118
+                      (fun [(con integer) (con 8)] out_MyMonoData_115)
+                      [ [ case_Mono1_116 arg_0_113 ] arg_1_114 ]
                     )
                   )
                 )
@@ -82,21 +82,21 @@
           )
         ]
         (lam
-          arg_0_114
+          arg_0_119
           [(con integer) (con 8)]
           (abs
-            out_MyMonoData_115
+            out_MyMonoData_120
             (type)
             (lam
-              case_Mono1_116
-              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_115))
+              case_Mono1_121
+              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_120))
               (lam
-                case_Mono2_117
-                (fun [(con integer) (con 8)] out_MyMonoData_115)
+                case_Mono2_122
+                (fun [(con integer) (con 8)] out_MyMonoData_120)
                 (lam
-                  case_Mono3_118
-                  (fun [(con integer) (con 8)] out_MyMonoData_115)
-                  [ case_Mono2_117 arg_0_114 ]
+                  case_Mono3_123
+                  (fun [(con integer) (con 8)] out_MyMonoData_120)
+                  [ case_Mono2_122 arg_0_119 ]
                 )
               )
             )
@@ -104,21 +104,21 @@
         )
       ]
       (lam
-        arg_0_119
+        arg_0_124
         [(con integer) (con 8)]
         (abs
-          out_MyMonoData_120
+          out_MyMonoData_125
           (type)
           (lam
-            case_Mono1_121
-            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_120))
+            case_Mono1_126
+            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_125))
             (lam
-              case_Mono2_122
-              (fun [(con integer) (con 8)] out_MyMonoData_120)
+              case_Mono2_127
+              (fun [(con integer) (con 8)] out_MyMonoData_125)
               (lam
-                case_Mono3_123
-                (fun [(con integer) (con 8)] out_MyMonoData_120)
-                [ case_Mono3_123 arg_0_119 ]
+                case_Mono3_128
+                (fun [(con integer) (con 8)] out_MyMonoData_125)
+                [ case_Mono3_128 arg_0_124 ]
               )
             )
           )
@@ -126,9 +126,9 @@
       )
     ]
     (lam
-      x_124
-      (all out_MyMonoData_125 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_125)) (fun (fun [(con integer) (con 8)] out_MyMonoData_125) (fun (fun [(con integer) (con 8)] out_MyMonoData_125) out_MyMonoData_125))))
-      x_124
+      x_129
+      (all out_MyMonoData_130 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_130)) (fun (fun [(con integer) (con 8)] out_MyMonoData_130) (fun (fun [(con integer) (con 8)] out_MyMonoData_130) out_MyMonoData_130))))
+      x_129
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/monomorphic/enum.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/monomorphic/enum.plc.golden
@@ -4,48 +4,48 @@
       [
         {
           (abs
-            MyEnum_79
+            MyEnum_84
             (type)
             (lam
-              Enum1_80
-              MyEnum_79
+              Enum1_85
+              MyEnum_84
               (lam
-                Enum2_81
-                MyEnum_79
+                Enum2_86
+                MyEnum_84
                 (lam
-                  MyEnum_match_82
-                  (fun MyEnum_79 (all out_MyEnum_83 (type) (fun out_MyEnum_83 (fun out_MyEnum_83 out_MyEnum_83))))
-                  Enum1_80
+                  MyEnum_match_87
+                  (fun MyEnum_84 (all out_MyEnum_88 (type) (fun out_MyEnum_88 (fun out_MyEnum_88 out_MyEnum_88))))
+                  Enum1_85
                 )
               )
             )
           )
-          (all out_MyEnum_84 (type) (fun out_MyEnum_84 (fun out_MyEnum_84 out_MyEnum_84)))
+          (all out_MyEnum_89 (type) (fun out_MyEnum_89 (fun out_MyEnum_89 out_MyEnum_89)))
         }
         (abs
-          out_MyEnum_85
+          out_MyEnum_90
           (type)
           (lam
-            case_Enum1_86
-            out_MyEnum_85
-            (lam case_Enum2_87 out_MyEnum_85 case_Enum1_86)
+            case_Enum1_91
+            out_MyEnum_90
+            (lam case_Enum2_92 out_MyEnum_90 case_Enum1_91)
           )
         )
       ]
       (abs
-        out_MyEnum_88
+        out_MyEnum_93
         (type)
         (lam
-          case_Enum1_89
-          out_MyEnum_88
-          (lam case_Enum2_90 out_MyEnum_88 case_Enum2_90)
+          case_Enum1_94
+          out_MyEnum_93
+          (lam case_Enum2_95 out_MyEnum_93 case_Enum2_95)
         )
       )
     ]
     (lam
-      x_91
-      (all out_MyEnum_92 (type) (fun out_MyEnum_92 (fun out_MyEnum_92 out_MyEnum_92)))
-      x_91
+      x_96
+      (all out_MyEnum_97 (type) (fun out_MyEnum_97 (fun out_MyEnum_97 out_MyEnum_97)))
+      x_96
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/monomorphic/irrefutableMatch.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/monomorphic/irrefutableMatch.plc.golden
@@ -3,106 +3,106 @@
     [
       {
         (abs
-          Unit_109
+          Unit_114
           (type)
           (lam
-            Unit_110
-            Unit_109
+            Unit_115
+            Unit_114
             (lam
-              Unit_match_111
-              (fun Unit_109 (all out_Unit_112 (type) (fun out_Unit_112 out_Unit_112)))
+              Unit_match_116
+              (fun Unit_114 (all out_Unit_117 (type) (fun out_Unit_117 out_Unit_117)))
               [
                 [
                   [
                     [
                       {
                         (abs
-                          MyMonoData_113
+                          MyMonoData_118
                           (type)
                           (lam
-                            Mono1_114
-                            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_113))
+                            Mono1_119
+                            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_118))
                             (lam
-                              Mono2_115
-                              (fun [(con integer) (con 8)] MyMonoData_113)
+                              Mono2_120
+                              (fun [(con integer) (con 8)] MyMonoData_118)
                               (lam
-                                Mono3_116
-                                (fun [(con integer) (con 8)] MyMonoData_113)
+                                Mono3_121
+                                (fun [(con integer) (con 8)] MyMonoData_118)
                                 (lam
-                                  MyMonoData_match_117
-                                  (fun MyMonoData_113 (all out_MyMonoData_118 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_118)) (fun (fun [(con integer) (con 8)] out_MyMonoData_118) (fun (fun [(con integer) (con 8)] out_MyMonoData_118) out_MyMonoData_118)))))
+                                  MyMonoData_match_122
+                                  (fun MyMonoData_118 (all out_MyMonoData_123 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_123)) (fun (fun [(con integer) (con 8)] out_MyMonoData_123) (fun (fun [(con integer) (con 8)] out_MyMonoData_123) out_MyMonoData_123)))))
                                   (lam
-                                    ds_119
-                                    MyMonoData_113
+                                    ds_124
+                                    MyMonoData_118
                                     [
                                       [
                                         [
                                           [
                                             {
                                               [
-                                                MyMonoData_match_117 ds_119
+                                                MyMonoData_match_122 ds_124
                                               ]
-                                              (fun Unit_109 [(con integer) (con 8)])
+                                              (fun Unit_114 [(con integer) (con 8)])
                                             }
                                             (lam
-                                              default_arg0_120
+                                              default_arg0_125
                                               [(con integer) (con 8)]
                                               (lam
-                                                default_arg1_121
+                                                default_arg1_126
                                                 [(con integer) (con 8)]
                                                 (lam
-                                                  thunk_122
-                                                  Unit_109
+                                                  thunk_127
+                                                  Unit_114
                                                   [
                                                     {
                                                       (abs
-                                                        e_123
+                                                        e_128
                                                         (type)
                                                         (lam
-                                                          thunk_124
-                                                          Unit_109
-                                                          (error e_123)
+                                                          thunk_129
+                                                          Unit_114
+                                                          (error e_128)
                                                         )
                                                       )
                                                       [(con integer) (con 8)]
                                                     }
-                                                    Unit_110
+                                                    Unit_115
                                                   ]
                                                 )
                                               )
                                             )
                                           ]
                                           (lam
-                                            a_125
+                                            a_130
                                             [(con integer) (con 8)]
-                                            (lam thunk_126 Unit_109 a_125)
+                                            (lam thunk_131 Unit_114 a_130)
                                           )
                                         ]
                                         (lam
-                                          default_arg0_127
+                                          default_arg0_132
                                           [(con integer) (con 8)]
                                           (lam
-                                            thunk_128
-                                            Unit_109
+                                            thunk_133
+                                            Unit_114
                                             [
                                               {
                                                 (abs
-                                                  e_129
+                                                  e_134
                                                   (type)
                                                   (lam
-                                                    thunk_130
-                                                    Unit_109
-                                                    (error e_129)
+                                                    thunk_135
+                                                    Unit_114
+                                                    (error e_134)
                                                   )
                                                 )
                                                 [(con integer) (con 8)]
                                               }
-                                              Unit_110
+                                              Unit_115
                                             ]
                                           )
                                         )
                                       ]
-                                      Unit_110
+                                      Unit_115
                                     ]
                                   )
                                 )
@@ -110,27 +110,27 @@
                             )
                           )
                         )
-                        (all out_MyMonoData_131 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_131)) (fun (fun [(con integer) (con 8)] out_MyMonoData_131) (fun (fun [(con integer) (con 8)] out_MyMonoData_131) out_MyMonoData_131))))
+                        (all out_MyMonoData_136 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_136)) (fun (fun [(con integer) (con 8)] out_MyMonoData_136) (fun (fun [(con integer) (con 8)] out_MyMonoData_136) out_MyMonoData_136))))
                       }
                       (lam
-                        arg_0_132
+                        arg_0_137
                         [(con integer) (con 8)]
                         (lam
-                          arg_1_133
+                          arg_1_138
                           [(con integer) (con 8)]
                           (abs
-                            out_MyMonoData_134
+                            out_MyMonoData_139
                             (type)
                             (lam
-                              case_Mono1_135
-                              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_134))
+                              case_Mono1_140
+                              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_139))
                               (lam
-                                case_Mono2_136
-                                (fun [(con integer) (con 8)] out_MyMonoData_134)
+                                case_Mono2_141
+                                (fun [(con integer) (con 8)] out_MyMonoData_139)
                                 (lam
-                                  case_Mono3_137
-                                  (fun [(con integer) (con 8)] out_MyMonoData_134)
-                                  [ [ case_Mono1_135 arg_0_132 ] arg_1_133 ]
+                                  case_Mono3_142
+                                  (fun [(con integer) (con 8)] out_MyMonoData_139)
+                                  [ [ case_Mono1_140 arg_0_137 ] arg_1_138 ]
                                 )
                               )
                             )
@@ -139,21 +139,21 @@
                       )
                     ]
                     (lam
-                      arg_0_138
+                      arg_0_143
                       [(con integer) (con 8)]
                       (abs
-                        out_MyMonoData_139
+                        out_MyMonoData_144
                         (type)
                         (lam
-                          case_Mono1_140
-                          (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_139))
+                          case_Mono1_145
+                          (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_144))
                           (lam
-                            case_Mono2_141
-                            (fun [(con integer) (con 8)] out_MyMonoData_139)
+                            case_Mono2_146
+                            (fun [(con integer) (con 8)] out_MyMonoData_144)
                             (lam
-                              case_Mono3_142
-                              (fun [(con integer) (con 8)] out_MyMonoData_139)
-                              [ case_Mono2_141 arg_0_138 ]
+                              case_Mono3_147
+                              (fun [(con integer) (con 8)] out_MyMonoData_144)
+                              [ case_Mono2_146 arg_0_143 ]
                             )
                           )
                         )
@@ -161,21 +161,21 @@
                     )
                   ]
                   (lam
-                    arg_0_143
+                    arg_0_148
                     [(con integer) (con 8)]
                     (abs
-                      out_MyMonoData_144
+                      out_MyMonoData_149
                       (type)
                       (lam
-                        case_Mono1_145
-                        (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_144))
+                        case_Mono1_150
+                        (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_149))
                         (lam
-                          case_Mono2_146
-                          (fun [(con integer) (con 8)] out_MyMonoData_144)
+                          case_Mono2_151
+                          (fun [(con integer) (con 8)] out_MyMonoData_149)
                           (lam
-                            case_Mono3_147
-                            (fun [(con integer) (con 8)] out_MyMonoData_144)
-                            [ case_Mono3_147 arg_0_143 ]
+                            case_Mono3_152
+                            (fun [(con integer) (con 8)] out_MyMonoData_149)
+                            [ case_Mono3_152 arg_0_148 ]
                           )
                         )
                       )
@@ -183,18 +183,18 @@
                   )
                 ]
                 (lam
-                  x_148
-                  (all out_MyMonoData_149 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_149)) (fun (fun [(con integer) (con 8)] out_MyMonoData_149) (fun (fun [(con integer) (con 8)] out_MyMonoData_149) out_MyMonoData_149))))
-                  x_148
+                  x_153
+                  (all out_MyMonoData_154 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_154)) (fun (fun [(con integer) (con 8)] out_MyMonoData_154) (fun (fun [(con integer) (con 8)] out_MyMonoData_154) out_MyMonoData_154))))
+                  x_153
                 )
               ]
             )
           )
         )
-        (all out_Unit_150 (type) (fun out_Unit_150 out_Unit_150))
+        (all out_Unit_155 (type) (fun out_Unit_155 out_Unit_155))
       }
-      (abs out_Unit_151 (type) (lam case_Unit_152 out_Unit_151 case_Unit_152))
+      (abs out_Unit_156 (type) (lam case_Unit_157 out_Unit_156 case_Unit_157))
     ]
-    (lam x_153 (all out_Unit_154 (type) (fun out_Unit_154 out_Unit_154)) x_153)
+    (lam x_158 (all out_Unit_159 (type) (fun out_Unit_159 out_Unit_159)) x_158)
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/monomorphic/monoCase.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/monomorphic/monoCase.plc.golden
@@ -5,39 +5,39 @@
         [
           {
             (abs
-              MyMonoData_96
+              MyMonoData_101
               (type)
               (lam
-                Mono1_97
-                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_96))
+                Mono1_102
+                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_101))
                 (lam
-                  Mono2_98
-                  (fun [(con integer) (con 8)] MyMonoData_96)
+                  Mono2_103
+                  (fun [(con integer) (con 8)] MyMonoData_101)
                   (lam
-                    Mono3_99
-                    (fun [(con integer) (con 8)] MyMonoData_96)
+                    Mono3_104
+                    (fun [(con integer) (con 8)] MyMonoData_101)
                     (lam
-                      MyMonoData_match_100
-                      (fun MyMonoData_96 (all out_MyMonoData_101 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_101)) (fun (fun [(con integer) (con 8)] out_MyMonoData_101) (fun (fun [(con integer) (con 8)] out_MyMonoData_101) out_MyMonoData_101)))))
+                      MyMonoData_match_105
+                      (fun MyMonoData_101 (all out_MyMonoData_106 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_106)) (fun (fun [(con integer) (con 8)] out_MyMonoData_106) (fun (fun [(con integer) (con 8)] out_MyMonoData_106) out_MyMonoData_106)))))
                       (lam
-                        ds_102
-                        MyMonoData_96
+                        ds_107
+                        MyMonoData_101
                         [
                           [
                             [
                               {
-                                [ MyMonoData_match_100 ds_102 ]
+                                [ MyMonoData_match_105 ds_107 ]
                                 [(con integer) (con 8)]
                               }
                               (lam
-                                ds_103
+                                ds_108
                                 [(con integer) (con 8)]
-                                (lam b_104 [(con integer) (con 8)] b_104)
+                                (lam b_109 [(con integer) (con 8)] b_109)
                               )
                             ]
-                            (lam a_105 [(con integer) (con 8)] a_105)
+                            (lam a_110 [(con integer) (con 8)] a_110)
                           ]
-                          (lam a_106 [(con integer) (con 8)] a_106)
+                          (lam a_111 [(con integer) (con 8)] a_111)
                         ]
                       )
                     )
@@ -45,27 +45,27 @@
                 )
               )
             )
-            (all out_MyMonoData_107 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_107)) (fun (fun [(con integer) (con 8)] out_MyMonoData_107) (fun (fun [(con integer) (con 8)] out_MyMonoData_107) out_MyMonoData_107))))
+            (all out_MyMonoData_112 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_112)) (fun (fun [(con integer) (con 8)] out_MyMonoData_112) (fun (fun [(con integer) (con 8)] out_MyMonoData_112) out_MyMonoData_112))))
           }
           (lam
-            arg_0_108
+            arg_0_113
             [(con integer) (con 8)]
             (lam
-              arg_1_109
+              arg_1_114
               [(con integer) (con 8)]
               (abs
-                out_MyMonoData_110
+                out_MyMonoData_115
                 (type)
                 (lam
-                  case_Mono1_111
-                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_110))
+                  case_Mono1_116
+                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_115))
                   (lam
-                    case_Mono2_112
-                    (fun [(con integer) (con 8)] out_MyMonoData_110)
+                    case_Mono2_117
+                    (fun [(con integer) (con 8)] out_MyMonoData_115)
                     (lam
-                      case_Mono3_113
-                      (fun [(con integer) (con 8)] out_MyMonoData_110)
-                      [ [ case_Mono1_111 arg_0_108 ] arg_1_109 ]
+                      case_Mono3_118
+                      (fun [(con integer) (con 8)] out_MyMonoData_115)
+                      [ [ case_Mono1_116 arg_0_113 ] arg_1_114 ]
                     )
                   )
                 )
@@ -74,21 +74,21 @@
           )
         ]
         (lam
-          arg_0_114
+          arg_0_119
           [(con integer) (con 8)]
           (abs
-            out_MyMonoData_115
+            out_MyMonoData_120
             (type)
             (lam
-              case_Mono1_116
-              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_115))
+              case_Mono1_121
+              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_120))
               (lam
-                case_Mono2_117
-                (fun [(con integer) (con 8)] out_MyMonoData_115)
+                case_Mono2_122
+                (fun [(con integer) (con 8)] out_MyMonoData_120)
                 (lam
-                  case_Mono3_118
-                  (fun [(con integer) (con 8)] out_MyMonoData_115)
-                  [ case_Mono2_117 arg_0_114 ]
+                  case_Mono3_123
+                  (fun [(con integer) (con 8)] out_MyMonoData_120)
+                  [ case_Mono2_122 arg_0_119 ]
                 )
               )
             )
@@ -96,21 +96,21 @@
         )
       ]
       (lam
-        arg_0_119
+        arg_0_124
         [(con integer) (con 8)]
         (abs
-          out_MyMonoData_120
+          out_MyMonoData_125
           (type)
           (lam
-            case_Mono1_121
-            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_120))
+            case_Mono1_126
+            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_125))
             (lam
-              case_Mono2_122
-              (fun [(con integer) (con 8)] out_MyMonoData_120)
+              case_Mono2_127
+              (fun [(con integer) (con 8)] out_MyMonoData_125)
               (lam
-                case_Mono3_123
-                (fun [(con integer) (con 8)] out_MyMonoData_120)
-                [ case_Mono3_123 arg_0_119 ]
+                case_Mono3_128
+                (fun [(con integer) (con 8)] out_MyMonoData_125)
+                [ case_Mono3_128 arg_0_124 ]
               )
             )
           )
@@ -118,9 +118,9 @@
       )
     ]
     (lam
-      x_124
-      (all out_MyMonoData_125 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_125)) (fun (fun [(con integer) (con 8)] out_MyMonoData_125) (fun (fun [(con integer) (con 8)] out_MyMonoData_125) out_MyMonoData_125))))
-      x_124
+      x_129
+      (all out_MyMonoData_130 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_130)) (fun (fun [(con integer) (con 8)] out_MyMonoData_130) (fun (fun [(con integer) (con 8)] out_MyMonoData_130) out_MyMonoData_130))))
+      x_129
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/monomorphic/monoConstructed.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/monomorphic/monoConstructed.plc.golden
@@ -5,47 +5,47 @@
         [
           {
             (abs
-              MyMonoData_90
+              MyMonoData_95
               (type)
               (lam
-                Mono1_91
-                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_90))
+                Mono1_96
+                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_95))
                 (lam
-                  Mono2_92
-                  (fun [(con integer) (con 8)] MyMonoData_90)
+                  Mono2_97
+                  (fun [(con integer) (con 8)] MyMonoData_95)
                   (lam
-                    Mono3_93
-                    (fun [(con integer) (con 8)] MyMonoData_90)
+                    Mono3_98
+                    (fun [(con integer) (con 8)] MyMonoData_95)
                     (lam
-                      MyMonoData_match_94
-                      (fun MyMonoData_90 (all out_MyMonoData_95 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_95)) (fun (fun [(con integer) (con 8)] out_MyMonoData_95) (fun (fun [(con integer) (con 8)] out_MyMonoData_95) out_MyMonoData_95)))))
-                      [ Mono2_92 (con 8 ! 1) ]
+                      MyMonoData_match_99
+                      (fun MyMonoData_95 (all out_MyMonoData_100 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_100)) (fun (fun [(con integer) (con 8)] out_MyMonoData_100) (fun (fun [(con integer) (con 8)] out_MyMonoData_100) out_MyMonoData_100)))))
+                      [ Mono2_97 (con 8 ! 1) ]
                     )
                   )
                 )
               )
             )
-            (all out_MyMonoData_96 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_96)) (fun (fun [(con integer) (con 8)] out_MyMonoData_96) (fun (fun [(con integer) (con 8)] out_MyMonoData_96) out_MyMonoData_96))))
+            (all out_MyMonoData_101 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_101)) (fun (fun [(con integer) (con 8)] out_MyMonoData_101) (fun (fun [(con integer) (con 8)] out_MyMonoData_101) out_MyMonoData_101))))
           }
           (lam
-            arg_0_97
+            arg_0_102
             [(con integer) (con 8)]
             (lam
-              arg_1_98
+              arg_1_103
               [(con integer) (con 8)]
               (abs
-                out_MyMonoData_99
+                out_MyMonoData_104
                 (type)
                 (lam
-                  case_Mono1_100
-                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_99))
+                  case_Mono1_105
+                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_104))
                   (lam
-                    case_Mono2_101
-                    (fun [(con integer) (con 8)] out_MyMonoData_99)
+                    case_Mono2_106
+                    (fun [(con integer) (con 8)] out_MyMonoData_104)
                     (lam
-                      case_Mono3_102
-                      (fun [(con integer) (con 8)] out_MyMonoData_99)
-                      [ [ case_Mono1_100 arg_0_97 ] arg_1_98 ]
+                      case_Mono3_107
+                      (fun [(con integer) (con 8)] out_MyMonoData_104)
+                      [ [ case_Mono1_105 arg_0_102 ] arg_1_103 ]
                     )
                   )
                 )
@@ -54,21 +54,21 @@
           )
         ]
         (lam
-          arg_0_103
+          arg_0_108
           [(con integer) (con 8)]
           (abs
-            out_MyMonoData_104
+            out_MyMonoData_109
             (type)
             (lam
-              case_Mono1_105
-              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_104))
+              case_Mono1_110
+              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_109))
               (lam
-                case_Mono2_106
-                (fun [(con integer) (con 8)] out_MyMonoData_104)
+                case_Mono2_111
+                (fun [(con integer) (con 8)] out_MyMonoData_109)
                 (lam
-                  case_Mono3_107
-                  (fun [(con integer) (con 8)] out_MyMonoData_104)
-                  [ case_Mono2_106 arg_0_103 ]
+                  case_Mono3_112
+                  (fun [(con integer) (con 8)] out_MyMonoData_109)
+                  [ case_Mono2_111 arg_0_108 ]
                 )
               )
             )
@@ -76,21 +76,21 @@
         )
       ]
       (lam
-        arg_0_108
+        arg_0_113
         [(con integer) (con 8)]
         (abs
-          out_MyMonoData_109
+          out_MyMonoData_114
           (type)
           (lam
-            case_Mono1_110
-            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_109))
+            case_Mono1_115
+            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_114))
             (lam
-              case_Mono2_111
-              (fun [(con integer) (con 8)] out_MyMonoData_109)
+              case_Mono2_116
+              (fun [(con integer) (con 8)] out_MyMonoData_114)
               (lam
-                case_Mono3_112
-                (fun [(con integer) (con 8)] out_MyMonoData_109)
-                [ case_Mono3_112 arg_0_108 ]
+                case_Mono3_117
+                (fun [(con integer) (con 8)] out_MyMonoData_114)
+                [ case_Mono3_117 arg_0_113 ]
               )
             )
           )
@@ -98,9 +98,9 @@
       )
     ]
     (lam
-      x_113
-      (all out_MyMonoData_114 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_114)) (fun (fun [(con integer) (con 8)] out_MyMonoData_114) (fun (fun [(con integer) (con 8)] out_MyMonoData_114) out_MyMonoData_114))))
-      x_113
+      x_118
+      (all out_MyMonoData_119 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_119)) (fun (fun [(con integer) (con 8)] out_MyMonoData_119) (fun (fun [(con integer) (con 8)] out_MyMonoData_119) out_MyMonoData_119))))
+      x_118
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/monomorphic/monoConstructor.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/monomorphic/monoConstructor.plc.golden
@@ -5,47 +5,47 @@
         [
           {
             (abs
-              MyMonoData_90
+              MyMonoData_95
               (type)
               (lam
-                Mono1_91
-                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_90))
+                Mono1_96
+                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_95))
                 (lam
-                  Mono2_92
-                  (fun [(con integer) (con 8)] MyMonoData_90)
+                  Mono2_97
+                  (fun [(con integer) (con 8)] MyMonoData_95)
                   (lam
-                    Mono3_93
-                    (fun [(con integer) (con 8)] MyMonoData_90)
+                    Mono3_98
+                    (fun [(con integer) (con 8)] MyMonoData_95)
                     (lam
-                      MyMonoData_match_94
-                      (fun MyMonoData_90 (all out_MyMonoData_95 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_95)) (fun (fun [(con integer) (con 8)] out_MyMonoData_95) (fun (fun [(con integer) (con 8)] out_MyMonoData_95) out_MyMonoData_95)))))
-                      Mono1_91
+                      MyMonoData_match_99
+                      (fun MyMonoData_95 (all out_MyMonoData_100 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_100)) (fun (fun [(con integer) (con 8)] out_MyMonoData_100) (fun (fun [(con integer) (con 8)] out_MyMonoData_100) out_MyMonoData_100)))))
+                      Mono1_96
                     )
                   )
                 )
               )
             )
-            (all out_MyMonoData_96 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_96)) (fun (fun [(con integer) (con 8)] out_MyMonoData_96) (fun (fun [(con integer) (con 8)] out_MyMonoData_96) out_MyMonoData_96))))
+            (all out_MyMonoData_101 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_101)) (fun (fun [(con integer) (con 8)] out_MyMonoData_101) (fun (fun [(con integer) (con 8)] out_MyMonoData_101) out_MyMonoData_101))))
           }
           (lam
-            arg_0_97
+            arg_0_102
             [(con integer) (con 8)]
             (lam
-              arg_1_98
+              arg_1_103
               [(con integer) (con 8)]
               (abs
-                out_MyMonoData_99
+                out_MyMonoData_104
                 (type)
                 (lam
-                  case_Mono1_100
-                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_99))
+                  case_Mono1_105
+                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_104))
                   (lam
-                    case_Mono2_101
-                    (fun [(con integer) (con 8)] out_MyMonoData_99)
+                    case_Mono2_106
+                    (fun [(con integer) (con 8)] out_MyMonoData_104)
                     (lam
-                      case_Mono3_102
-                      (fun [(con integer) (con 8)] out_MyMonoData_99)
-                      [ [ case_Mono1_100 arg_0_97 ] arg_1_98 ]
+                      case_Mono3_107
+                      (fun [(con integer) (con 8)] out_MyMonoData_104)
+                      [ [ case_Mono1_105 arg_0_102 ] arg_1_103 ]
                     )
                   )
                 )
@@ -54,21 +54,21 @@
           )
         ]
         (lam
-          arg_0_103
+          arg_0_108
           [(con integer) (con 8)]
           (abs
-            out_MyMonoData_104
+            out_MyMonoData_109
             (type)
             (lam
-              case_Mono1_105
-              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_104))
+              case_Mono1_110
+              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_109))
               (lam
-                case_Mono2_106
-                (fun [(con integer) (con 8)] out_MyMonoData_104)
+                case_Mono2_111
+                (fun [(con integer) (con 8)] out_MyMonoData_109)
                 (lam
-                  case_Mono3_107
-                  (fun [(con integer) (con 8)] out_MyMonoData_104)
-                  [ case_Mono2_106 arg_0_103 ]
+                  case_Mono3_112
+                  (fun [(con integer) (con 8)] out_MyMonoData_109)
+                  [ case_Mono2_111 arg_0_108 ]
                 )
               )
             )
@@ -76,21 +76,21 @@
         )
       ]
       (lam
-        arg_0_108
+        arg_0_113
         [(con integer) (con 8)]
         (abs
-          out_MyMonoData_109
+          out_MyMonoData_114
           (type)
           (lam
-            case_Mono1_110
-            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_109))
+            case_Mono1_115
+            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_114))
             (lam
-              case_Mono2_111
-              (fun [(con integer) (con 8)] out_MyMonoData_109)
+              case_Mono2_116
+              (fun [(con integer) (con 8)] out_MyMonoData_114)
               (lam
-                case_Mono3_112
-                (fun [(con integer) (con 8)] out_MyMonoData_109)
-                [ case_Mono3_112 arg_0_108 ]
+                case_Mono3_117
+                (fun [(con integer) (con 8)] out_MyMonoData_114)
+                [ case_Mono3_117 arg_0_113 ]
               )
             )
           )
@@ -98,9 +98,9 @@
       )
     ]
     (lam
-      x_113
-      (all out_MyMonoData_114 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_114)) (fun (fun [(con integer) (con 8)] out_MyMonoData_114) (fun (fun [(con integer) (con 8)] out_MyMonoData_114) out_MyMonoData_114))))
-      x_113
+      x_118
+      (all out_MyMonoData_119 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_119)) (fun (fun [(con integer) (con 8)] out_MyMonoData_119) (fun (fun [(con integer) (con 8)] out_MyMonoData_119) out_MyMonoData_119))))
+      x_118
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/monomorphic/monoDataType.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/monomorphic/monoDataType.plc.golden
@@ -5,47 +5,47 @@
         [
           {
             (abs
-              MyMonoData_91
+              MyMonoData_96
               (type)
               (lam
-                Mono1_92
-                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_91))
+                Mono1_97
+                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoData_96))
                 (lam
-                  Mono2_93
-                  (fun [(con integer) (con 8)] MyMonoData_91)
+                  Mono2_98
+                  (fun [(con integer) (con 8)] MyMonoData_96)
                   (lam
-                    Mono3_94
-                    (fun [(con integer) (con 8)] MyMonoData_91)
+                    Mono3_99
+                    (fun [(con integer) (con 8)] MyMonoData_96)
                     (lam
-                      MyMonoData_match_95
-                      (fun MyMonoData_91 (all out_MyMonoData_96 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_96)) (fun (fun [(con integer) (con 8)] out_MyMonoData_96) (fun (fun [(con integer) (con 8)] out_MyMonoData_96) out_MyMonoData_96)))))
-                      (lam ds_97 MyMonoData_91 ds_97)
+                      MyMonoData_match_100
+                      (fun MyMonoData_96 (all out_MyMonoData_101 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_101)) (fun (fun [(con integer) (con 8)] out_MyMonoData_101) (fun (fun [(con integer) (con 8)] out_MyMonoData_101) out_MyMonoData_101)))))
+                      (lam ds_102 MyMonoData_96 ds_102)
                     )
                   )
                 )
               )
             )
-            (all out_MyMonoData_98 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_98)) (fun (fun [(con integer) (con 8)] out_MyMonoData_98) (fun (fun [(con integer) (con 8)] out_MyMonoData_98) out_MyMonoData_98))))
+            (all out_MyMonoData_103 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_103)) (fun (fun [(con integer) (con 8)] out_MyMonoData_103) (fun (fun [(con integer) (con 8)] out_MyMonoData_103) out_MyMonoData_103))))
           }
           (lam
-            arg_0_99
+            arg_0_104
             [(con integer) (con 8)]
             (lam
-              arg_1_100
+              arg_1_105
               [(con integer) (con 8)]
               (abs
-                out_MyMonoData_101
+                out_MyMonoData_106
                 (type)
                 (lam
-                  case_Mono1_102
-                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_101))
+                  case_Mono1_107
+                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_106))
                   (lam
-                    case_Mono2_103
-                    (fun [(con integer) (con 8)] out_MyMonoData_101)
+                    case_Mono2_108
+                    (fun [(con integer) (con 8)] out_MyMonoData_106)
                     (lam
-                      case_Mono3_104
-                      (fun [(con integer) (con 8)] out_MyMonoData_101)
-                      [ [ case_Mono1_102 arg_0_99 ] arg_1_100 ]
+                      case_Mono3_109
+                      (fun [(con integer) (con 8)] out_MyMonoData_106)
+                      [ [ case_Mono1_107 arg_0_104 ] arg_1_105 ]
                     )
                   )
                 )
@@ -54,21 +54,21 @@
           )
         ]
         (lam
-          arg_0_105
+          arg_0_110
           [(con integer) (con 8)]
           (abs
-            out_MyMonoData_106
+            out_MyMonoData_111
             (type)
             (lam
-              case_Mono1_107
-              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_106))
+              case_Mono1_112
+              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_111))
               (lam
-                case_Mono2_108
-                (fun [(con integer) (con 8)] out_MyMonoData_106)
+                case_Mono2_113
+                (fun [(con integer) (con 8)] out_MyMonoData_111)
                 (lam
-                  case_Mono3_109
-                  (fun [(con integer) (con 8)] out_MyMonoData_106)
-                  [ case_Mono2_108 arg_0_105 ]
+                  case_Mono3_114
+                  (fun [(con integer) (con 8)] out_MyMonoData_111)
+                  [ case_Mono2_113 arg_0_110 ]
                 )
               )
             )
@@ -76,21 +76,21 @@
         )
       ]
       (lam
-        arg_0_110
+        arg_0_115
         [(con integer) (con 8)]
         (abs
-          out_MyMonoData_111
+          out_MyMonoData_116
           (type)
           (lam
-            case_Mono1_112
-            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_111))
+            case_Mono1_117
+            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_116))
             (lam
-              case_Mono2_113
-              (fun [(con integer) (con 8)] out_MyMonoData_111)
+              case_Mono2_118
+              (fun [(con integer) (con 8)] out_MyMonoData_116)
               (lam
-                case_Mono3_114
-                (fun [(con integer) (con 8)] out_MyMonoData_111)
-                [ case_Mono3_114 arg_0_110 ]
+                case_Mono3_119
+                (fun [(con integer) (con 8)] out_MyMonoData_116)
+                [ case_Mono3_119 arg_0_115 ]
               )
             )
           )
@@ -98,9 +98,9 @@
       )
     ]
     (lam
-      x_115
-      (all out_MyMonoData_116 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_116)) (fun (fun [(con integer) (con 8)] out_MyMonoData_116) (fun (fun [(con integer) (con 8)] out_MyMonoData_116) out_MyMonoData_116))))
-      x_115
+      x_120
+      (all out_MyMonoData_121 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoData_121)) (fun (fun [(con integer) (con 8)] out_MyMonoData_121) (fun (fun [(con integer) (con 8)] out_MyMonoData_121) out_MyMonoData_121))))
+      x_120
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/monomorphic/monoRecord.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/monomorphic/monoRecord.plc.golden
@@ -3,42 +3,42 @@
     [
       {
         (abs
-          MyMonoRecord_77
+          MyMonoRecord_82
           (type)
           (lam
-            MyMonoRecord_78
-            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoRecord_77))
+            MyMonoRecord_83
+            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] MyMonoRecord_82))
             (lam
-              MyMonoRecord_match_79
-              (fun MyMonoRecord_77 (all out_MyMonoRecord_80 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoRecord_80)) out_MyMonoRecord_80)))
-              (lam ds_81 MyMonoRecord_77 ds_81)
+              MyMonoRecord_match_84
+              (fun MyMonoRecord_82 (all out_MyMonoRecord_85 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoRecord_85)) out_MyMonoRecord_85)))
+              (lam ds_86 MyMonoRecord_82 ds_86)
             )
           )
         )
-        (all out_MyMonoRecord_82 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoRecord_82)) out_MyMonoRecord_82))
+        (all out_MyMonoRecord_87 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoRecord_87)) out_MyMonoRecord_87))
       }
       (lam
-        arg_0_83
+        arg_0_88
         [(con integer) (con 8)]
         (lam
-          arg_1_84
+          arg_1_89
           [(con integer) (con 8)]
           (abs
-            out_MyMonoRecord_85
+            out_MyMonoRecord_90
             (type)
             (lam
-              case_MyMonoRecord_86
-              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoRecord_85))
-              [ [ case_MyMonoRecord_86 arg_0_83 ] arg_1_84 ]
+              case_MyMonoRecord_91
+              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoRecord_90))
+              [ [ case_MyMonoRecord_91 arg_0_88 ] arg_1_89 ]
             )
           )
         )
       )
     ]
     (lam
-      x_87
-      (all out_MyMonoRecord_88 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoRecord_88)) out_MyMonoRecord_88))
-      x_87
+      x_92
+      (all out_MyMonoRecord_93 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_MyMonoRecord_93)) out_MyMonoRecord_93))
+      x_92
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/monomorphic/nonValueCase.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/monomorphic/nonValueCase.plc.golden
@@ -4,113 +4,115 @@
       [
         {
           (abs
-            MyEnum_87
+            MyEnum_92
             (type)
             (lam
-              Enum1_88
-              MyEnum_87
+              Enum1_93
+              MyEnum_92
               (lam
-                Enum2_89
-                MyEnum_87
+                Enum2_94
+                MyEnum_92
                 (lam
-                  MyEnum_match_90
-                  (fun MyEnum_87 (all out_MyEnum_91 (type) (fun out_MyEnum_91 (fun out_MyEnum_91 out_MyEnum_91))))
+                  MyEnum_match_95
+                  (fun MyEnum_92 (all out_MyEnum_96 (type) (fun out_MyEnum_96 (fun out_MyEnum_96 out_MyEnum_96))))
                   [
                     [
                       {
                         (abs
-                          Unit_92
+                          Unit_97
                           (type)
                           (lam
-                            Unit_93
-                            Unit_92
+                            Unit_98
+                            Unit_97
                             (lam
-                              Unit_match_94
-                              (fun Unit_92 (all out_Unit_95 (type) (fun out_Unit_95 out_Unit_95)))
+                              Unit_match_99
+                              (fun Unit_97 (all out_Unit_100 (type) (fun out_Unit_100 out_Unit_100)))
                               [
                                 (lam
-                                  error_96
-                                  (all a_97 (type) (fun Unit_92 a_97))
+                                  error_101
+                                  (all a_102 (type) (fun Unit_97 a_102))
                                   (lam
-                                    ds_98
-                                    MyEnum_87
+                                    ds_103
+                                    MyEnum_92
                                     [
                                       [
                                         [
                                           {
                                             [
-                                              MyEnum_match_90 ds_98
+                                              MyEnum_match_95 ds_103
                                             ]
-                                            (fun Unit_92 [(con integer) (con 8)])
+                                            (fun Unit_97 [(con integer) (con 8)])
                                           }
-                                          (lam thunk_99 Unit_92 (con 8 ! 1))
+                                          (lam thunk_104 Unit_97 (con 8 ! 1))
                                         ]
                                         (lam
-                                          thunk_100
-                                          Unit_92
+                                          thunk_105
+                                          Unit_97
                                           [
-                                            { error_96 [(con integer) (con 8)] }
-                                            Unit_93
+                                            {
+                                              error_101 [(con integer) (con 8)]
+                                            }
+                                            Unit_98
                                           ]
                                         )
                                       ]
-                                      Unit_93
+                                      Unit_98
                                     ]
                                   )
                                 )
                                 (abs
-                                  e_101
+                                  e_106
                                   (type)
-                                  (lam thunk_102 Unit_92 (error e_101))
+                                  (lam thunk_107 Unit_97 (error e_106))
                                 )
                               ]
                             )
                           )
                         )
-                        (all out_Unit_103 (type) (fun out_Unit_103 out_Unit_103))
+                        (all out_Unit_108 (type) (fun out_Unit_108 out_Unit_108))
                       }
                       (abs
-                        out_Unit_104
+                        out_Unit_109
                         (type)
-                        (lam case_Unit_105 out_Unit_104 case_Unit_105)
+                        (lam case_Unit_110 out_Unit_109 case_Unit_110)
                       )
                     ]
                     (lam
-                      x_106
-                      (all out_Unit_107 (type) (fun out_Unit_107 out_Unit_107))
-                      x_106
+                      x_111
+                      (all out_Unit_112 (type) (fun out_Unit_112 out_Unit_112))
+                      x_111
                     )
                   ]
                 )
               )
             )
           )
-          (all out_MyEnum_108 (type) (fun out_MyEnum_108 (fun out_MyEnum_108 out_MyEnum_108)))
+          (all out_MyEnum_113 (type) (fun out_MyEnum_113 (fun out_MyEnum_113 out_MyEnum_113)))
         }
         (abs
-          out_MyEnum_109
+          out_MyEnum_114
           (type)
           (lam
-            case_Enum1_110
-            out_MyEnum_109
-            (lam case_Enum2_111 out_MyEnum_109 case_Enum1_110)
+            case_Enum1_115
+            out_MyEnum_114
+            (lam case_Enum2_116 out_MyEnum_114 case_Enum1_115)
           )
         )
       ]
       (abs
-        out_MyEnum_112
+        out_MyEnum_117
         (type)
         (lam
-          case_Enum1_113
-          out_MyEnum_112
-          (lam case_Enum2_114 out_MyEnum_112 case_Enum2_114)
+          case_Enum1_118
+          out_MyEnum_117
+          (lam case_Enum2_119 out_MyEnum_117 case_Enum2_119)
         )
       )
     ]
     (lam
-      x_115
-      (all out_MyEnum_116 (type) (fun out_MyEnum_116 (fun out_MyEnum_116 out_MyEnum_116)))
-      x_115
+      x_120
+      (all out_MyEnum_121 (type) (fun out_MyEnum_121 (fun out_MyEnum_121 out_MyEnum_121)))
+      x_120
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/newtypes/basicNewtype.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/newtypes/basicNewtype.plc.golden
@@ -3,38 +3,38 @@
     [
       {
         (abs
-          MyNewtype_76
+          MyNewtype_81
           (type)
           (lam
-            MyNewtype_77
-            (fun [(con integer) (con 8)] MyNewtype_76)
+            MyNewtype_82
+            (fun [(con integer) (con 8)] MyNewtype_81)
             (lam
-              MyNewtype_match_78
-              (fun MyNewtype_76 (all out_MyNewtype_79 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_79) out_MyNewtype_79)))
-              (lam ds_80 MyNewtype_76 ds_80)
+              MyNewtype_match_83
+              (fun MyNewtype_81 (all out_MyNewtype_84 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_84) out_MyNewtype_84)))
+              (lam ds_85 MyNewtype_81 ds_85)
             )
           )
         )
-        (all out_MyNewtype_81 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_81) out_MyNewtype_81))
+        (all out_MyNewtype_86 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_86) out_MyNewtype_86))
       }
       (lam
-        arg_0_82
+        arg_0_87
         [(con integer) (con 8)]
         (abs
-          out_MyNewtype_83
+          out_MyNewtype_88
           (type)
           (lam
-            case_MyNewtype_84
-            (fun [(con integer) (con 8)] out_MyNewtype_83)
-            [ case_MyNewtype_84 arg_0_82 ]
+            case_MyNewtype_89
+            (fun [(con integer) (con 8)] out_MyNewtype_88)
+            [ case_MyNewtype_89 arg_0_87 ]
           )
         )
       )
     ]
     (lam
-      x_85
-      (all out_MyNewtype_86 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_86) out_MyNewtype_86))
-      x_85
+      x_90
+      (all out_MyNewtype_91 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_91) out_MyNewtype_91))
+      x_90
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/newtypes/nestedNewtypeMatch.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/newtypes/nestedNewtypeMatch.plc.golden
@@ -3,93 +3,93 @@
     [
       {
         (abs
-          MyNewtype_86
+          MyNewtype_91
           (type)
           (lam
-            MyNewtype_87
-            (fun [(con integer) (con 8)] MyNewtype_86)
+            MyNewtype_92
+            (fun [(con integer) (con 8)] MyNewtype_91)
             (lam
-              MyNewtype_match_88
-              (fun MyNewtype_86 (all out_MyNewtype_89 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_89) out_MyNewtype_89)))
+              MyNewtype_match_93
+              (fun MyNewtype_91 (all out_MyNewtype_94 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_94) out_MyNewtype_94)))
               [
                 [
                   {
                     (abs
-                      MyNewtype2_90
+                      MyNewtype2_95
                       (type)
                       (lam
-                        MyNewtype2_91
-                        (fun MyNewtype_86 MyNewtype2_90)
+                        MyNewtype2_96
+                        (fun MyNewtype_91 MyNewtype2_95)
                         (lam
-                          MyNewtype2_match_92
-                          (fun MyNewtype2_90 (all out_MyNewtype2_93 (type) (fun (fun MyNewtype_86 out_MyNewtype2_93) out_MyNewtype2_93)))
+                          MyNewtype2_match_97
+                          (fun MyNewtype2_95 (all out_MyNewtype2_98 (type) (fun (fun MyNewtype_91 out_MyNewtype2_98) out_MyNewtype2_98)))
                           (lam
-                            ds_94
-                            MyNewtype2_90
+                            ds_99
+                            MyNewtype2_95
                             [
                               {
                                 [
-                                  MyNewtype_match_88
+                                  MyNewtype_match_93
                                   [
                                     {
-                                      [ MyNewtype2_match_92 ds_94 ] MyNewtype_86
+                                      [ MyNewtype2_match_97 ds_99 ] MyNewtype_91
                                     }
-                                    (lam inner_95 MyNewtype_86 inner_95)
+                                    (lam inner_100 MyNewtype_91 inner_100)
                                   ]
                                 ]
                                 [(con integer) (con 8)]
                               }
-                              (lam inner_96 [(con integer) (con 8)] inner_96)
+                              (lam inner_101 [(con integer) (con 8)] inner_101)
                             ]
                           )
                         )
                       )
                     )
-                    (all out_MyNewtype2_97 (type) (fun (fun MyNewtype_86 out_MyNewtype2_97) out_MyNewtype2_97))
+                    (all out_MyNewtype2_102 (type) (fun (fun MyNewtype_91 out_MyNewtype2_102) out_MyNewtype2_102))
                   }
                   (lam
-                    arg_0_98
-                    MyNewtype_86
+                    arg_0_103
+                    MyNewtype_91
                     (abs
-                      out_MyNewtype2_99
+                      out_MyNewtype2_104
                       (type)
                       (lam
-                        case_MyNewtype2_100
-                        (fun MyNewtype_86 out_MyNewtype2_99)
-                        [ case_MyNewtype2_100 arg_0_98 ]
+                        case_MyNewtype2_105
+                        (fun MyNewtype_91 out_MyNewtype2_104)
+                        [ case_MyNewtype2_105 arg_0_103 ]
                       )
                     )
                   )
                 ]
                 (lam
-                  x_101
-                  (all out_MyNewtype2_102 (type) (fun (fun MyNewtype_86 out_MyNewtype2_102) out_MyNewtype2_102))
-                  x_101
+                  x_106
+                  (all out_MyNewtype2_107 (type) (fun (fun MyNewtype_91 out_MyNewtype2_107) out_MyNewtype2_107))
+                  x_106
                 )
               ]
             )
           )
         )
-        (all out_MyNewtype_103 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_103) out_MyNewtype_103))
+        (all out_MyNewtype_108 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_108) out_MyNewtype_108))
       }
       (lam
-        arg_0_104
+        arg_0_109
         [(con integer) (con 8)]
         (abs
-          out_MyNewtype_105
+          out_MyNewtype_110
           (type)
           (lam
-            case_MyNewtype_106
-            (fun [(con integer) (con 8)] out_MyNewtype_105)
-            [ case_MyNewtype_106 arg_0_104 ]
+            case_MyNewtype_111
+            (fun [(con integer) (con 8)] out_MyNewtype_110)
+            [ case_MyNewtype_111 arg_0_109 ]
           )
         )
       )
     ]
     (lam
-      x_107
-      (all out_MyNewtype_108 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_108) out_MyNewtype_108))
-      x_107
+      x_112
+      (all out_MyNewtype_113 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_113) out_MyNewtype_113))
+      x_112
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/newtypes/newtypeCreate.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/newtypes/newtypeCreate.plc.golden
@@ -3,38 +3,38 @@
     [
       {
         (abs
-          MyNewtype_76
+          MyNewtype_81
           (type)
           (lam
-            MyNewtype_77
-            (fun [(con integer) (con 8)] MyNewtype_76)
+            MyNewtype_82
+            (fun [(con integer) (con 8)] MyNewtype_81)
             (lam
-              MyNewtype_match_78
-              (fun MyNewtype_76 (all out_MyNewtype_79 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_79) out_MyNewtype_79)))
-              (lam ds_80 [(con integer) (con 8)] [ MyNewtype_77 ds_80 ])
+              MyNewtype_match_83
+              (fun MyNewtype_81 (all out_MyNewtype_84 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_84) out_MyNewtype_84)))
+              (lam ds_85 [(con integer) (con 8)] [ MyNewtype_82 ds_85 ])
             )
           )
         )
-        (all out_MyNewtype_81 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_81) out_MyNewtype_81))
+        (all out_MyNewtype_86 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_86) out_MyNewtype_86))
       }
       (lam
-        arg_0_82
+        arg_0_87
         [(con integer) (con 8)]
         (abs
-          out_MyNewtype_83
+          out_MyNewtype_88
           (type)
           (lam
-            case_MyNewtype_84
-            (fun [(con integer) (con 8)] out_MyNewtype_83)
-            [ case_MyNewtype_84 arg_0_82 ]
+            case_MyNewtype_89
+            (fun [(con integer) (con 8)] out_MyNewtype_88)
+            [ case_MyNewtype_89 arg_0_87 ]
           )
         )
       )
     ]
     (lam
-      x_85
-      (all out_MyNewtype_86 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_86) out_MyNewtype_86))
-      x_85
+      x_90
+      (all out_MyNewtype_91 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_91) out_MyNewtype_91))
+      x_90
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/newtypes/newtypeCreate2.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/newtypes/newtypeCreate2.plc.golden
@@ -3,38 +3,38 @@
     [
       {
         (abs
-          MyNewtype_75
+          MyNewtype_80
           (type)
           (lam
-            MyNewtype_76
-            (fun [(con integer) (con 8)] MyNewtype_75)
+            MyNewtype_81
+            (fun [(con integer) (con 8)] MyNewtype_80)
             (lam
-              MyNewtype_match_77
-              (fun MyNewtype_75 (all out_MyNewtype_78 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_78) out_MyNewtype_78)))
-              [ MyNewtype_76 (con 8 ! 1) ]
+              MyNewtype_match_82
+              (fun MyNewtype_80 (all out_MyNewtype_83 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_83) out_MyNewtype_83)))
+              [ MyNewtype_81 (con 8 ! 1) ]
             )
           )
         )
-        (all out_MyNewtype_79 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_79) out_MyNewtype_79))
+        (all out_MyNewtype_84 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_84) out_MyNewtype_84))
       }
       (lam
-        arg_0_80
+        arg_0_85
         [(con integer) (con 8)]
         (abs
-          out_MyNewtype_81
+          out_MyNewtype_86
           (type)
           (lam
-            case_MyNewtype_82
-            (fun [(con integer) (con 8)] out_MyNewtype_81)
-            [ case_MyNewtype_82 arg_0_80 ]
+            case_MyNewtype_87
+            (fun [(con integer) (con 8)] out_MyNewtype_86)
+            [ case_MyNewtype_87 arg_0_85 ]
           )
         )
       )
     ]
     (lam
-      x_83
-      (all out_MyNewtype_84 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_84) out_MyNewtype_84))
-      x_83
+      x_88
+      (all out_MyNewtype_89 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_89) out_MyNewtype_89))
+      x_88
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/newtypes/newtypeMatch.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/newtypes/newtypeMatch.plc.golden
@@ -3,45 +3,45 @@
     [
       {
         (abs
-          MyNewtype_77
+          MyNewtype_82
           (type)
           (lam
-            MyNewtype_78
-            (fun [(con integer) (con 8)] MyNewtype_77)
+            MyNewtype_83
+            (fun [(con integer) (con 8)] MyNewtype_82)
             (lam
-              MyNewtype_match_79
-              (fun MyNewtype_77 (all out_MyNewtype_80 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_80) out_MyNewtype_80)))
+              MyNewtype_match_84
+              (fun MyNewtype_82 (all out_MyNewtype_85 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_85) out_MyNewtype_85)))
               (lam
-                ds_81
-                MyNewtype_77
+                ds_86
+                MyNewtype_82
                 [
-                  { [ MyNewtype_match_79 ds_81 ] [(con integer) (con 8)] }
-                  (lam inner_82 [(con integer) (con 8)] inner_82)
+                  { [ MyNewtype_match_84 ds_86 ] [(con integer) (con 8)] }
+                  (lam inner_87 [(con integer) (con 8)] inner_87)
                 ]
               )
             )
           )
         )
-        (all out_MyNewtype_83 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_83) out_MyNewtype_83))
+        (all out_MyNewtype_88 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_88) out_MyNewtype_88))
       }
       (lam
-        arg_0_84
+        arg_0_89
         [(con integer) (con 8)]
         (abs
-          out_MyNewtype_85
+          out_MyNewtype_90
           (type)
           (lam
-            case_MyNewtype_86
-            (fun [(con integer) (con 8)] out_MyNewtype_85)
-            [ case_MyNewtype_86 arg_0_84 ]
+            case_MyNewtype_91
+            (fun [(con integer) (con 8)] out_MyNewtype_90)
+            [ case_MyNewtype_91 arg_0_89 ]
           )
         )
       )
     ]
     (lam
-      x_87
-      (all out_MyNewtype_88 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_88) out_MyNewtype_88))
-      x_87
+      x_92
+      (all out_MyNewtype_93 (type) (fun (fun [(con integer) (con 8)] out_MyNewtype_93) out_MyNewtype_93))
+      x_92
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/data/polymorphic/defaultCasePoly.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/polymorphic/defaultCasePoly.plc.golden
@@ -4,69 +4,69 @@
       [
         {
           (abs
-            MyPolyData_89
+            MyPolyData_94
             (fun (type) (fun (type) (type)))
             (lam
-              Poly1_90
-              (all a_91 (type) (all b_92 (type) (fun a_91 (fun b_92 [[MyPolyData_89 a_91] b_92]))))
+              Poly1_95
+              (all a_96 (type) (all b_97 (type) (fun a_96 (fun b_97 [[MyPolyData_94 a_96] b_97]))))
               (lam
-                Poly2_93
-                (all a_94 (type) (all b_95 (type) (fun a_94 [[MyPolyData_89 a_94] b_95])))
+                Poly2_98
+                (all a_99 (type) (all b_100 (type) (fun a_99 [[MyPolyData_94 a_99] b_100])))
                 (lam
-                  MyPolyData_match_96
-                  (all a_97 (type) (all b_98 (type) (fun [[MyPolyData_89 a_97] b_98] [[(lam a_99 (type) (lam b_100 (type) (all out_MyPolyData_101 (type) (fun (fun a_99 (fun b_100 out_MyPolyData_101)) (fun (fun a_99 out_MyPolyData_101) out_MyPolyData_101))))) a_97] b_98])))
+                  MyPolyData_match_101
+                  (all a_102 (type) (all b_103 (type) (fun [[MyPolyData_94 a_102] b_103] [[(lam a_104 (type) (lam b_105 (type) (all out_MyPolyData_106 (type) (fun (fun a_104 (fun b_105 out_MyPolyData_106)) (fun (fun a_104 out_MyPolyData_106) out_MyPolyData_106))))) a_102] b_103])))
                   (lam
-                    ds_102
-                    [[MyPolyData_89 [(con integer) (con 8)]] [(con integer) (con 8)]]
+                    ds_107
+                    [[MyPolyData_94 [(con integer) (con 8)]] [(con integer) (con 8)]]
                     [
                       [
                         {
                           [
                             {
-                              { MyPolyData_match_96 [(con integer) (con 8)] }
+                              { MyPolyData_match_101 [(con integer) (con 8)] }
                               [(con integer) (con 8)]
                             }
-                            ds_102
+                            ds_107
                           ]
                           [(con integer) (con 8)]
                         }
                         (lam
-                          a_103
+                          a_108
                           [(con integer) (con 8)]
-                          (lam ds_104 [(con integer) (con 8)] a_103)
+                          (lam ds_109 [(con integer) (con 8)] a_108)
                         )
                       ]
-                      (lam default_arg0_105 [(con integer) (con 8)] (con 8 ! 2))
+                      (lam default_arg0_110 [(con integer) (con 8)] (con 8 ! 2))
                     ]
                   )
                 )
               )
             )
           )
-          (lam a_106 (type) (lam b_107 (type) (all out_MyPolyData_108 (type) (fun (fun a_106 (fun b_107 out_MyPolyData_108)) (fun (fun a_106 out_MyPolyData_108) out_MyPolyData_108)))))
+          (lam a_111 (type) (lam b_112 (type) (all out_MyPolyData_113 (type) (fun (fun a_111 (fun b_112 out_MyPolyData_113)) (fun (fun a_111 out_MyPolyData_113) out_MyPolyData_113)))))
         }
         (abs
-          a_109
+          a_114
           (type)
           (abs
-            b_110
+            b_115
             (type)
             (lam
-              arg_0_111
-              a_109
+              arg_0_116
+              a_114
               (lam
-                arg_1_112
-                b_110
+                arg_1_117
+                b_115
                 (abs
-                  out_MyPolyData_113
+                  out_MyPolyData_118
                   (type)
                   (lam
-                    case_Poly1_114
-                    (fun a_109 (fun b_110 out_MyPolyData_113))
+                    case_Poly1_119
+                    (fun a_114 (fun b_115 out_MyPolyData_118))
                     (lam
-                      case_Poly2_115
-                      (fun a_109 out_MyPolyData_113)
-                      [ [ case_Poly1_114 arg_0_111 ] arg_1_112 ]
+                      case_Poly2_120
+                      (fun a_114 out_MyPolyData_118)
+                      [ [ case_Poly1_119 arg_0_116 ] arg_1_117 ]
                     )
                   )
                 )
@@ -76,24 +76,24 @@
         )
       ]
       (abs
-        a_116
+        a_121
         (type)
         (abs
-          b_117
+          b_122
           (type)
           (lam
-            arg_0_118
-            a_116
+            arg_0_123
+            a_121
             (abs
-              out_MyPolyData_119
+              out_MyPolyData_124
               (type)
               (lam
-                case_Poly1_120
-                (fun a_116 (fun b_117 out_MyPolyData_119))
+                case_Poly1_125
+                (fun a_121 (fun b_122 out_MyPolyData_124))
                 (lam
-                  case_Poly2_121
-                  (fun a_116 out_MyPolyData_119)
-                  [ case_Poly2_121 arg_0_118 ]
+                  case_Poly2_126
+                  (fun a_121 out_MyPolyData_124)
+                  [ case_Poly2_126 arg_0_123 ]
                 )
               )
             )
@@ -102,15 +102,15 @@
       )
     ]
     (abs
-      a_122
+      a_127
       (type)
       (abs
-        b_123
+        b_128
         (type)
         (lam
-          x_124
-          [[(lam a_125 (type) (lam b_126 (type) (all out_MyPolyData_127 (type) (fun (fun a_125 (fun b_126 out_MyPolyData_127)) (fun (fun a_125 out_MyPolyData_127) out_MyPolyData_127))))) a_122] b_123]
-          x_124
+          x_129
+          [[(lam a_130 (type) (lam b_131 (type) (all out_MyPolyData_132 (type) (fun (fun a_130 (fun b_131 out_MyPolyData_132)) (fun (fun a_130 out_MyPolyData_132) out_MyPolyData_132))))) a_127] b_128]
+          x_129
         )
       )
     )

--- a/plutus-tx-plugin/test/Plugin/data/polymorphic/polyConstructed.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/polymorphic/polyConstructed.plc.golden
@@ -4,21 +4,21 @@
       [
         {
           (abs
-            MyPolyData_84
+            MyPolyData_89
             (fun (type) (fun (type) (type)))
             (lam
-              Poly1_85
-              (all a_86 (type) (all b_87 (type) (fun a_86 (fun b_87 [[MyPolyData_84 a_86] b_87]))))
+              Poly1_90
+              (all a_91 (type) (all b_92 (type) (fun a_91 (fun b_92 [[MyPolyData_89 a_91] b_92]))))
               (lam
-                Poly2_88
-                (all a_89 (type) (all b_90 (type) (fun a_89 [[MyPolyData_84 a_89] b_90])))
+                Poly2_93
+                (all a_94 (type) (all b_95 (type) (fun a_94 [[MyPolyData_89 a_94] b_95])))
                 (lam
-                  MyPolyData_match_91
-                  (all a_92 (type) (all b_93 (type) (fun [[MyPolyData_84 a_92] b_93] [[(lam a_94 (type) (lam b_95 (type) (all out_MyPolyData_96 (type) (fun (fun a_94 (fun b_95 out_MyPolyData_96)) (fun (fun a_94 out_MyPolyData_96) out_MyPolyData_96))))) a_92] b_93])))
+                  MyPolyData_match_96
+                  (all a_97 (type) (all b_98 (type) (fun [[MyPolyData_89 a_97] b_98] [[(lam a_99 (type) (lam b_100 (type) (all out_MyPolyData_101 (type) (fun (fun a_99 (fun b_100 out_MyPolyData_101)) (fun (fun a_99 out_MyPolyData_101) out_MyPolyData_101))))) a_97] b_98])))
                   [
                     [
                       {
-                        { Poly1_85 [(con integer) (con 8)] }
+                        { Poly1_90 [(con integer) (con 8)] }
                         [(con integer) (con 8)]
                       }
                       (con 8 ! 1)
@@ -29,30 +29,30 @@
               )
             )
           )
-          (lam a_97 (type) (lam b_98 (type) (all out_MyPolyData_99 (type) (fun (fun a_97 (fun b_98 out_MyPolyData_99)) (fun (fun a_97 out_MyPolyData_99) out_MyPolyData_99)))))
+          (lam a_102 (type) (lam b_103 (type) (all out_MyPolyData_104 (type) (fun (fun a_102 (fun b_103 out_MyPolyData_104)) (fun (fun a_102 out_MyPolyData_104) out_MyPolyData_104)))))
         }
         (abs
-          a_100
+          a_105
           (type)
           (abs
-            b_101
+            b_106
             (type)
             (lam
-              arg_0_102
-              a_100
+              arg_0_107
+              a_105
               (lam
-                arg_1_103
-                b_101
+                arg_1_108
+                b_106
                 (abs
-                  out_MyPolyData_104
+                  out_MyPolyData_109
                   (type)
                   (lam
-                    case_Poly1_105
-                    (fun a_100 (fun b_101 out_MyPolyData_104))
+                    case_Poly1_110
+                    (fun a_105 (fun b_106 out_MyPolyData_109))
                     (lam
-                      case_Poly2_106
-                      (fun a_100 out_MyPolyData_104)
-                      [ [ case_Poly1_105 arg_0_102 ] arg_1_103 ]
+                      case_Poly2_111
+                      (fun a_105 out_MyPolyData_109)
+                      [ [ case_Poly1_110 arg_0_107 ] arg_1_108 ]
                     )
                   )
                 )
@@ -62,24 +62,24 @@
         )
       ]
       (abs
-        a_107
+        a_112
         (type)
         (abs
-          b_108
+          b_113
           (type)
           (lam
-            arg_0_109
-            a_107
+            arg_0_114
+            a_112
             (abs
-              out_MyPolyData_110
+              out_MyPolyData_115
               (type)
               (lam
-                case_Poly1_111
-                (fun a_107 (fun b_108 out_MyPolyData_110))
+                case_Poly1_116
+                (fun a_112 (fun b_113 out_MyPolyData_115))
                 (lam
-                  case_Poly2_112
-                  (fun a_107 out_MyPolyData_110)
-                  [ case_Poly2_112 arg_0_109 ]
+                  case_Poly2_117
+                  (fun a_112 out_MyPolyData_115)
+                  [ case_Poly2_117 arg_0_114 ]
                 )
               )
             )
@@ -88,15 +88,15 @@
       )
     ]
     (abs
-      a_113
+      a_118
       (type)
       (abs
-        b_114
+        b_119
         (type)
         (lam
-          x_115
-          [[(lam a_116 (type) (lam b_117 (type) (all out_MyPolyData_118 (type) (fun (fun a_116 (fun b_117 out_MyPolyData_118)) (fun (fun a_116 out_MyPolyData_118) out_MyPolyData_118))))) a_113] b_114]
-          x_115
+          x_120
+          [[(lam a_121 (type) (lam b_122 (type) (all out_MyPolyData_123 (type) (fun (fun a_121 (fun b_122 out_MyPolyData_123)) (fun (fun a_121 out_MyPolyData_123) out_MyPolyData_123))))) a_118] b_119]
+          x_120
         )
       )
     )

--- a/plutus-tx-plugin/test/Plugin/data/polymorphic/polyDataType.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/polymorphic/polyDataType.plc.golden
@@ -4,50 +4,50 @@
       [
         {
           (abs
-            MyPolyData_85
+            MyPolyData_90
             (fun (type) (fun (type) (type)))
             (lam
-              Poly1_86
-              (all a_87 (type) (all b_88 (type) (fun a_87 (fun b_88 [[MyPolyData_85 a_87] b_88]))))
+              Poly1_91
+              (all a_92 (type) (all b_93 (type) (fun a_92 (fun b_93 [[MyPolyData_90 a_92] b_93]))))
               (lam
-                Poly2_89
-                (all a_90 (type) (all b_91 (type) (fun a_90 [[MyPolyData_85 a_90] b_91])))
+                Poly2_94
+                (all a_95 (type) (all b_96 (type) (fun a_95 [[MyPolyData_90 a_95] b_96])))
                 (lam
-                  MyPolyData_match_92
-                  (all a_93 (type) (all b_94 (type) (fun [[MyPolyData_85 a_93] b_94] [[(lam a_95 (type) (lam b_96 (type) (all out_MyPolyData_97 (type) (fun (fun a_95 (fun b_96 out_MyPolyData_97)) (fun (fun a_95 out_MyPolyData_97) out_MyPolyData_97))))) a_93] b_94])))
+                  MyPolyData_match_97
+                  (all a_98 (type) (all b_99 (type) (fun [[MyPolyData_90 a_98] b_99] [[(lam a_100 (type) (lam b_101 (type) (all out_MyPolyData_102 (type) (fun (fun a_100 (fun b_101 out_MyPolyData_102)) (fun (fun a_100 out_MyPolyData_102) out_MyPolyData_102))))) a_98] b_99])))
                   (lam
-                    ds_98
-                    [[MyPolyData_85 [(con integer) (con 8)]] [(con integer) (con 8)]]
-                    ds_98
+                    ds_103
+                    [[MyPolyData_90 [(con integer) (con 8)]] [(con integer) (con 8)]]
+                    ds_103
                   )
                 )
               )
             )
           )
-          (lam a_99 (type) (lam b_100 (type) (all out_MyPolyData_101 (type) (fun (fun a_99 (fun b_100 out_MyPolyData_101)) (fun (fun a_99 out_MyPolyData_101) out_MyPolyData_101)))))
+          (lam a_104 (type) (lam b_105 (type) (all out_MyPolyData_106 (type) (fun (fun a_104 (fun b_105 out_MyPolyData_106)) (fun (fun a_104 out_MyPolyData_106) out_MyPolyData_106)))))
         }
         (abs
-          a_102
+          a_107
           (type)
           (abs
-            b_103
+            b_108
             (type)
             (lam
-              arg_0_104
-              a_102
+              arg_0_109
+              a_107
               (lam
-                arg_1_105
-                b_103
+                arg_1_110
+                b_108
                 (abs
-                  out_MyPolyData_106
+                  out_MyPolyData_111
                   (type)
                   (lam
-                    case_Poly1_107
-                    (fun a_102 (fun b_103 out_MyPolyData_106))
+                    case_Poly1_112
+                    (fun a_107 (fun b_108 out_MyPolyData_111))
                     (lam
-                      case_Poly2_108
-                      (fun a_102 out_MyPolyData_106)
-                      [ [ case_Poly1_107 arg_0_104 ] arg_1_105 ]
+                      case_Poly2_113
+                      (fun a_107 out_MyPolyData_111)
+                      [ [ case_Poly1_112 arg_0_109 ] arg_1_110 ]
                     )
                   )
                 )
@@ -57,24 +57,24 @@
         )
       ]
       (abs
-        a_109
+        a_114
         (type)
         (abs
-          b_110
+          b_115
           (type)
           (lam
-            arg_0_111
-            a_109
+            arg_0_116
+            a_114
             (abs
-              out_MyPolyData_112
+              out_MyPolyData_117
               (type)
               (lam
-                case_Poly1_113
-                (fun a_109 (fun b_110 out_MyPolyData_112))
+                case_Poly1_118
+                (fun a_114 (fun b_115 out_MyPolyData_117))
                 (lam
-                  case_Poly2_114
-                  (fun a_109 out_MyPolyData_112)
-                  [ case_Poly2_114 arg_0_111 ]
+                  case_Poly2_119
+                  (fun a_114 out_MyPolyData_117)
+                  [ case_Poly2_119 arg_0_116 ]
                 )
               )
             )
@@ -83,15 +83,15 @@
       )
     ]
     (abs
-      a_115
+      a_120
       (type)
       (abs
-        b_116
+        b_121
         (type)
         (lam
-          x_117
-          [[(lam a_118 (type) (lam b_119 (type) (all out_MyPolyData_120 (type) (fun (fun a_118 (fun b_119 out_MyPolyData_120)) (fun (fun a_118 out_MyPolyData_120) out_MyPolyData_120))))) a_115] b_116]
-          x_117
+          x_122
+          [[(lam a_123 (type) (lam b_124 (type) (all out_MyPolyData_125 (type) (fun (fun a_123 (fun b_124 out_MyPolyData_125)) (fun (fun a_123 out_MyPolyData_125) out_MyPolyData_125))))) a_120] b_121]
+          x_122
         )
       )
     )

--- a/plutus-tx-plugin/test/Plugin/primitives/and.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/and.plc.golden
@@ -3,64 +3,64 @@
     [
       {
         (abs
-          Unit_90
+          Unit_95
           (type)
           (lam
-            Unit_91
-            Unit_90
+            Unit_96
+            Unit_95
             (lam
-              Unit_match_92
-              (fun Unit_90 (all out_Unit_93 (type) (fun out_Unit_93 out_Unit_93)))
+              Unit_match_97
+              (fun Unit_95 (all out_Unit_98 (type) (fun out_Unit_98 out_Unit_98)))
               [
                 [
                   [
                     {
                       (abs
-                        Bool_94
+                        Bool_99
                         (type)
                         (lam
-                          True_95
-                          Bool_94
+                          True_100
+                          Bool_99
                           (lam
-                            False_96
-                            Bool_94
+                            False_101
+                            Bool_99
                             (lam
-                              Bool_match_97
-                              (fun Bool_94 (all out_Bool_98 (type) (fun out_Bool_98 (fun out_Bool_98 out_Bool_98))))
+                              Bool_match_102
+                              (fun Bool_99 (all out_Bool_103 (type) (fun out_Bool_103 (fun out_Bool_103 out_Bool_103))))
                               (lam
-                                ds_99
-                                Bool_94
+                                ds_104
+                                Bool_99
                                 (lam
-                                  ds_100
-                                  Bool_94
+                                  ds_105
+                                  Bool_99
                                   [
                                     [
                                       [
                                         {
-                                          [ Bool_match_97 ds_99 ]
-                                          (fun Unit_90 Bool_94)
+                                          [ Bool_match_102 ds_104 ]
+                                          (fun Unit_95 Bool_99)
                                         }
                                         (lam
-                                          thunk_101
-                                          Unit_90
+                                          thunk_106
+                                          Unit_95
                                           [
                                             [
                                               [
                                                 {
-                                                  [ Bool_match_97 ds_100 ]
-                                                  (fun Unit_90 Bool_94)
+                                                  [ Bool_match_102 ds_105 ]
+                                                  (fun Unit_95 Bool_99)
                                                 }
-                                                (lam thunk_102 Unit_90 True_95)
+                                                (lam thunk_107 Unit_95 True_100)
                                               ]
-                                              (lam thunk_103 Unit_90 False_96)
+                                              (lam thunk_108 Unit_95 False_101)
                                             ]
-                                            Unit_91
+                                            Unit_96
                                           ]
                                         )
                                       ]
-                                      (lam thunk_104 Unit_90 False_96)
+                                      (lam thunk_109 Unit_95 False_101)
                                     ]
-                                    Unit_91
+                                    Unit_96
                                   ]
                                 )
                               )
@@ -68,41 +68,41 @@
                           )
                         )
                       )
-                      (all out_Bool_105 (type) (fun out_Bool_105 (fun out_Bool_105 out_Bool_105)))
+                      (all out_Bool_110 (type) (fun out_Bool_110 (fun out_Bool_110 out_Bool_110)))
                     }
                     (abs
-                      out_Bool_106
+                      out_Bool_111
                       (type)
                       (lam
-                        case_True_107
-                        out_Bool_106
-                        (lam case_False_108 out_Bool_106 case_True_107)
+                        case_True_112
+                        out_Bool_111
+                        (lam case_False_113 out_Bool_111 case_True_112)
                       )
                     )
                   ]
                   (abs
-                    out_Bool_109
+                    out_Bool_114
                     (type)
                     (lam
-                      case_True_110
-                      out_Bool_109
-                      (lam case_False_111 out_Bool_109 case_False_111)
+                      case_True_115
+                      out_Bool_114
+                      (lam case_False_116 out_Bool_114 case_False_116)
                     )
                   )
                 ]
                 (lam
-                  x_112
-                  (all out_Bool_113 (type) (fun out_Bool_113 (fun out_Bool_113 out_Bool_113)))
-                  x_112
+                  x_117
+                  (all out_Bool_118 (type) (fun out_Bool_118 (fun out_Bool_118 out_Bool_118)))
+                  x_117
                 )
               ]
             )
           )
         )
-        (all out_Unit_114 (type) (fun out_Unit_114 out_Unit_114))
+        (all out_Unit_119 (type) (fun out_Unit_119 out_Unit_119))
       }
-      (abs out_Unit_115 (type) (lam case_Unit_116 out_Unit_115 case_Unit_116))
+      (abs out_Unit_120 (type) (lam case_Unit_121 out_Unit_120 case_Unit_121))
     ]
-    (lam x_117 (all out_Unit_118 (type) (fun out_Unit_118 out_Unit_118)) x_117)
+    (lam x_122 (all out_Unit_123 (type) (fun out_Unit_123 out_Unit_123)) x_122)
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/andApply.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/andApply.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_109
+  out_Bool_114
   (type)
   (lam
-    case_True_110 out_Bool_109 (lam case_False_111 out_Bool_109 case_False_111)
+    case_True_115 out_Bool_114 (lam case_False_116 out_Bool_114 case_False_116)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/bool.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/bool.plc.golden
@@ -4,46 +4,46 @@
       [
         {
           (abs
-            Bool_75
+            Bool_80
             (type)
             (lam
-              True_76
-              Bool_75
+              True_81
+              Bool_80
               (lam
-                False_77
-                Bool_75
+                False_82
+                Bool_80
                 (lam
-                  Bool_match_78
-                  (fun Bool_75 (all out_Bool_79 (type) (fun out_Bool_79 (fun out_Bool_79 out_Bool_79))))
-                  True_76
+                  Bool_match_83
+                  (fun Bool_80 (all out_Bool_84 (type) (fun out_Bool_84 (fun out_Bool_84 out_Bool_84))))
+                  True_81
                 )
               )
             )
           )
-          (all out_Bool_80 (type) (fun out_Bool_80 (fun out_Bool_80 out_Bool_80)))
+          (all out_Bool_85 (type) (fun out_Bool_85 (fun out_Bool_85 out_Bool_85)))
         }
         (abs
-          out_Bool_81
+          out_Bool_86
           (type)
           (lam
-            case_True_82
-            out_Bool_81
-            (lam case_False_83 out_Bool_81 case_True_82)
+            case_True_87
+            out_Bool_86
+            (lam case_False_88 out_Bool_86 case_True_87)
           )
         )
       ]
       (abs
-        out_Bool_84
+        out_Bool_89
         (type)
         (lam
-          case_True_85 out_Bool_84 (lam case_False_86 out_Bool_84 case_False_86)
+          case_True_90 out_Bool_89 (lam case_False_91 out_Bool_89 case_False_91)
         )
       )
     ]
     (lam
-      x_87
-      (all out_Bool_88 (type) (fun out_Bool_88 (fun out_Bool_88 out_Bool_88)))
-      x_87
+      x_92
+      (all out_Bool_93 (type) (fun out_Bool_93 (fun out_Bool_93 out_Bool_93)))
+      x_92
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/bytestring.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/bytestring.plc.golden
@@ -1,3 +1,3 @@
 (program 1.0.0
-  (lam ds_68 [(con bytestring) (con 32)] ds_68)
+  (lam ds_73 [(con bytestring) (con 32)] ds_73)
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/error.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/error.plc.golden
@@ -3,29 +3,29 @@
     [
       {
         (abs
-          Unit_71
+          Unit_76
           (type)
           (lam
-            Unit_72
-            Unit_71
+            Unit_77
+            Unit_76
             (lam
-              Unit_match_73
-              (fun Unit_71 (all out_Unit_74 (type) (fun out_Unit_74 out_Unit_74)))
+              Unit_match_78
+              (fun Unit_76 (all out_Unit_79 (type) (fun out_Unit_79 out_Unit_79)))
               [
                 (lam
-                  error_75
-                  (all a_76 (type) (fun Unit_71 a_76))
-                  { error_75 [(con integer) (con 8)] }
+                  error_80
+                  (all a_81 (type) (fun Unit_76 a_81))
+                  { error_80 [(con integer) (con 8)] }
                 )
-                (abs e_77 (type) (lam thunk_78 Unit_71 (error e_77)))
+                (abs e_82 (type) (lam thunk_83 Unit_76 (error e_82)))
               ]
             )
           )
         )
-        (all out_Unit_79 (type) (fun out_Unit_79 out_Unit_79))
+        (all out_Unit_84 (type) (fun out_Unit_84 out_Unit_84))
       }
-      (abs out_Unit_80 (type) (lam case_Unit_81 out_Unit_80 case_Unit_81))
+      (abs out_Unit_85 (type) (lam case_Unit_86 out_Unit_85 case_Unit_86))
     ]
-    (lam x_82 (all out_Unit_83 (type) (fun out_Unit_83 out_Unit_83)) x_82)
+    (lam x_87 (all out_Unit_88 (type) (fun out_Unit_88 out_Unit_88)) x_87)
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/ifThenElse.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/ifThenElse.plc.golden
@@ -3,82 +3,82 @@
     [
       {
         (abs
-          Unit_84
+          Unit_89
           (type)
           (lam
-            Unit_85
-            Unit_84
+            Unit_90
+            Unit_89
             (lam
-              Unit_match_86
-              (fun Unit_84 (all out_Unit_87 (type) (fun out_Unit_87 out_Unit_87)))
+              Unit_match_91
+              (fun Unit_89 (all out_Unit_92 (type) (fun out_Unit_92 out_Unit_92)))
               [
                 [
                   [
                     {
                       (abs
-                        Bool_88
+                        Bool_93
                         (type)
                         (lam
-                          True_89
-                          Bool_88
+                          True_94
+                          Bool_93
                           (lam
-                            False_90
-                            Bool_88
+                            False_95
+                            Bool_93
                             (lam
-                              Bool_match_91
-                              (fun Bool_88 (all out_Bool_92 (type) (fun out_Bool_92 (fun out_Bool_92 out_Bool_92))))
+                              Bool_match_96
+                              (fun Bool_93 (all out_Bool_97 (type) (fun out_Bool_97 (fun out_Bool_97 out_Bool_97))))
                               [
                                 (lam
-                                  equalsInteger_93
-                                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_88))
+                                  equalsInteger_98
+                                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_93))
                                   (lam
-                                    ds_94
+                                    ds_99
                                     [(con integer) (con 8)]
                                     (lam
-                                      ds_95
+                                      ds_100
                                       [(con integer) (con 8)]
                                       [
                                         [
                                           [
                                             {
                                               [
-                                                Bool_match_91
+                                                Bool_match_96
                                                 [
-                                                  [ equalsInteger_93 ds_94 ]
-                                                  ds_95
+                                                  [ equalsInteger_98 ds_99 ]
+                                                  ds_100
                                                 ]
                                               ]
-                                              (fun Unit_84 [(con integer) (con 8)])
+                                              (fun Unit_89 [(con integer) (con 8)])
                                             }
-                                            (lam thunk_96 Unit_84 ds_94)
+                                            (lam thunk_101 Unit_89 ds_99)
                                           ]
-                                          (lam thunk_97 Unit_84 ds_95)
+                                          (lam thunk_102 Unit_89 ds_100)
                                         ]
-                                        Unit_85
+                                        Unit_90
                                       ]
                                     )
                                   )
                                 )
                                 (lam
-                                  arg_98
+                                  arg_103
                                   [(con integer) (con 8)]
                                   (lam
-                                    arg_99
+                                    arg_104
                                     [(con integer) (con 8)]
                                     [
                                       (lam
-                                        b_100
-                                        (all a_101 (type) (fun a_101 (fun a_101 a_101)))
+                                        b_105
+                                        (all a_106 (type) (fun a_106 (fun a_106 a_106)))
                                         [
-                                          [ { b_100 Bool_88 } True_89 ] False_90
+                                          [ { b_105 Bool_93 } True_94 ] False_95
                                         ]
                                       )
                                       [
                                         [
                                           { (builtin equalsInteger) (con 8) }
-                                          arg_98
+                                          arg_103
                                         ]
-                                        arg_99
+                                        arg_104
                                       ]
                                     ]
                                   )
@@ -88,41 +88,41 @@
                           )
                         )
                       )
-                      (all out_Bool_102 (type) (fun out_Bool_102 (fun out_Bool_102 out_Bool_102)))
+                      (all out_Bool_107 (type) (fun out_Bool_107 (fun out_Bool_107 out_Bool_107)))
                     }
                     (abs
-                      out_Bool_103
+                      out_Bool_108
                       (type)
                       (lam
-                        case_True_104
-                        out_Bool_103
-                        (lam case_False_105 out_Bool_103 case_True_104)
+                        case_True_109
+                        out_Bool_108
+                        (lam case_False_110 out_Bool_108 case_True_109)
                       )
                     )
                   ]
                   (abs
-                    out_Bool_106
+                    out_Bool_111
                     (type)
                     (lam
-                      case_True_107
-                      out_Bool_106
-                      (lam case_False_108 out_Bool_106 case_False_108)
+                      case_True_112
+                      out_Bool_111
+                      (lam case_False_113 out_Bool_111 case_False_113)
                     )
                   )
                 ]
                 (lam
-                  x_109
-                  (all out_Bool_110 (type) (fun out_Bool_110 (fun out_Bool_110 out_Bool_110)))
-                  x_109
+                  x_114
+                  (all out_Bool_115 (type) (fun out_Bool_115 (fun out_Bool_115 out_Bool_115)))
+                  x_114
                 )
               ]
             )
           )
         )
-        (all out_Unit_111 (type) (fun out_Unit_111 out_Unit_111))
+        (all out_Unit_116 (type) (fun out_Unit_116 out_Unit_116))
       }
-      (abs out_Unit_112 (type) (lam case_Unit_113 out_Unit_112 case_Unit_113))
+      (abs out_Unit_117 (type) (lam case_Unit_118 out_Unit_117 case_Unit_118))
     ]
-    (lam x_114 (all out_Unit_115 (type) (fun out_Unit_115 out_Unit_115)) x_114)
+    (lam x_119 (all out_Unit_120 (type) (fun out_Unit_120 out_Unit_120)) x_119)
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/intCompare.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/intCompare.plc.golden
@@ -4,46 +4,46 @@
       [
         {
           (abs
-            Bool_77
+            Bool_82
             (type)
             (lam
-              True_78
-              Bool_77
+              True_83
+              Bool_82
               (lam
-                False_79
-                Bool_77
+                False_84
+                Bool_82
                 (lam
-                  Bool_match_80
-                  (fun Bool_77 (all out_Bool_81 (type) (fun out_Bool_81 (fun out_Bool_81 out_Bool_81))))
+                  Bool_match_85
+                  (fun Bool_82 (all out_Bool_86 (type) (fun out_Bool_86 (fun out_Bool_86 out_Bool_86))))
                   [
                     (lam
-                      lessThanInteger_82
-                      (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_77))
+                      lessThanInteger_87
+                      (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_82))
                       (lam
-                        ds_83
+                        ds_88
                         [(con integer) (con 8)]
                         (lam
-                          ds_84
+                          ds_89
                           [(con integer) (con 8)]
-                          [ [ lessThanInteger_82 ds_83 ] ds_84 ]
+                          [ [ lessThanInteger_87 ds_88 ] ds_89 ]
                         )
                       )
                     )
                     (lam
-                      arg_85
+                      arg_90
                       [(con integer) (con 8)]
                       (lam
-                        arg_86
+                        arg_91
                         [(con integer) (con 8)]
                         [
                           (lam
-                            b_87
-                            (all a_88 (type) (fun a_88 (fun a_88 a_88)))
-                            [ [ { b_87 Bool_77 } True_78 ] False_79 ]
+                            b_92
+                            (all a_93 (type) (fun a_93 (fun a_93 a_93)))
+                            [ [ { b_92 Bool_82 } True_83 ] False_84 ]
                           )
                           [
-                            [ { (builtin lessThanInteger) (con 8) } arg_85 ]
-                            arg_86
+                            [ { (builtin lessThanInteger) (con 8) } arg_90 ]
+                            arg_91
                           ]
                         ]
                       )
@@ -53,30 +53,32 @@
               )
             )
           )
-          (all out_Bool_89 (type) (fun out_Bool_89 (fun out_Bool_89 out_Bool_89)))
+          (all out_Bool_94 (type) (fun out_Bool_94 (fun out_Bool_94 out_Bool_94)))
         }
         (abs
-          out_Bool_90
+          out_Bool_95
           (type)
           (lam
-            case_True_91
-            out_Bool_90
-            (lam case_False_92 out_Bool_90 case_True_91)
+            case_True_96
+            out_Bool_95
+            (lam case_False_97 out_Bool_95 case_True_96)
           )
         )
       ]
       (abs
-        out_Bool_93
+        out_Bool_98
         (type)
         (lam
-          case_True_94 out_Bool_93 (lam case_False_95 out_Bool_93 case_False_95)
+          case_True_99
+          out_Bool_98
+          (lam case_False_100 out_Bool_98 case_False_100)
         )
       )
     ]
     (lam
-      x_96
-      (all out_Bool_97 (type) (fun out_Bool_97 (fun out_Bool_97 out_Bool_97)))
-      x_96
+      x_101
+      (all out_Bool_102 (type) (fun out_Bool_102 (fun out_Bool_102 out_Bool_102)))
+      x_101
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/intDiv.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/intDiv.plc.golden
@@ -1,14 +1,14 @@
 (program 1.0.0
   [
     (lam
-      addInteger_74
+      divideInteger_74
       (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] [(con integer) (con 8)]))
       (lam
         ds_75
         [(con integer) (con 8)]
-        (lam ds_76 [(con integer) (con 8)] [ [ addInteger_74 ds_75 ] ds_76 ])
+        (lam ds_76 [(con integer) (con 8)] [ [ divideInteger_74 ds_75 ] ds_76 ])
       )
     )
-    { (builtin addInteger) (con 8) }
+    { (builtin divideInteger) (con 8) }
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/intEq.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/intEq.plc.golden
@@ -4,46 +4,46 @@
       [
         {
           (abs
-            Bool_77
+            Bool_82
             (type)
             (lam
-              True_78
-              Bool_77
+              True_83
+              Bool_82
               (lam
-                False_79
-                Bool_77
+                False_84
+                Bool_82
                 (lam
-                  Bool_match_80
-                  (fun Bool_77 (all out_Bool_81 (type) (fun out_Bool_81 (fun out_Bool_81 out_Bool_81))))
+                  Bool_match_85
+                  (fun Bool_82 (all out_Bool_86 (type) (fun out_Bool_86 (fun out_Bool_86 out_Bool_86))))
                   [
                     (lam
-                      equalsInteger_82
-                      (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_77))
+                      equalsInteger_87
+                      (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_82))
                       (lam
-                        ds_83
+                        ds_88
                         [(con integer) (con 8)]
                         (lam
-                          ds_84
+                          ds_89
                           [(con integer) (con 8)]
-                          [ [ equalsInteger_82 ds_83 ] ds_84 ]
+                          [ [ equalsInteger_87 ds_88 ] ds_89 ]
                         )
                       )
                     )
                     (lam
-                      arg_85
+                      arg_90
                       [(con integer) (con 8)]
                       (lam
-                        arg_86
+                        arg_91
                         [(con integer) (con 8)]
                         [
                           (lam
-                            b_87
-                            (all a_88 (type) (fun a_88 (fun a_88 a_88)))
-                            [ [ { b_87 Bool_77 } True_78 ] False_79 ]
+                            b_92
+                            (all a_93 (type) (fun a_93 (fun a_93 a_93)))
+                            [ [ { b_92 Bool_82 } True_83 ] False_84 ]
                           )
                           [
-                            [ { (builtin equalsInteger) (con 8) } arg_85 ]
-                            arg_86
+                            [ { (builtin equalsInteger) (con 8) } arg_90 ]
+                            arg_91
                           ]
                         ]
                       )
@@ -53,30 +53,32 @@
               )
             )
           )
-          (all out_Bool_89 (type) (fun out_Bool_89 (fun out_Bool_89 out_Bool_89)))
+          (all out_Bool_94 (type) (fun out_Bool_94 (fun out_Bool_94 out_Bool_94)))
         }
         (abs
-          out_Bool_90
+          out_Bool_95
           (type)
           (lam
-            case_True_91
-            out_Bool_90
-            (lam case_False_92 out_Bool_90 case_True_91)
+            case_True_96
+            out_Bool_95
+            (lam case_False_97 out_Bool_95 case_True_96)
           )
         )
       ]
       (abs
-        out_Bool_93
+        out_Bool_98
         (type)
         (lam
-          case_True_94 out_Bool_93 (lam case_False_95 out_Bool_93 case_False_95)
+          case_True_99
+          out_Bool_98
+          (lam case_False_100 out_Bool_98 case_False_100)
         )
       )
     ]
     (lam
-      x_96
-      (all out_Bool_97 (type) (fun out_Bool_97 (fun out_Bool_97 out_Bool_97)))
-      x_96
+      x_101
+      (all out_Bool_102 (type) (fun out_Bool_102 (fun out_Bool_102 out_Bool_102)))
+      x_101
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/intEqApply.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/intEqApply.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  out_Bool_90
+  out_Bool_95
   (type)
-  (lam case_True_91 out_Bool_90 (lam case_False_92 out_Bool_90 case_True_91))
+  (lam case_True_96 out_Bool_95 (lam case_False_97 out_Bool_95 case_True_96))
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/string.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/string.plc.golden
@@ -1,3 +1,99 @@
 (program 1.0.0
-  (con 32 ! #74657374)
+  [
+    [
+      [
+        {
+          (abs
+            List_87
+            (fun (type) (type))
+            (lam
+              Nil_88
+              (all a_89 (type) [List_87 a_89])
+              (lam
+                Cons_90
+                (all a_91 (type) (fun a_91 (fun [List_87 a_91] [List_87 a_91])))
+                (lam
+                  Nil_match_92
+                  (all a_93 (type) (fun [List_87 a_93] [(lam a_94 (type) (all out_List_95 (type) (fun out_List_95 (fun (fun a_94 (fun [List_87 a_94] out_List_95)) out_List_95)))) a_93]))
+                  [
+                    [ { Cons_90 [(con integer) (con 4)] } (con 4 ! 116) ]
+                    [
+                      [ { Cons_90 [(con integer) (con 4)] } (con 4 ! 101) ]
+                      [
+                        [ { Cons_90 [(con integer) (con 4)] } (con 4 ! 115) ]
+                        [
+                          [ { Cons_90 [(con integer) (con 4)] } (con 4 ! 116) ]
+                          { Nil_88 [(con integer) (con 4)] }
+                        ]
+                      ]
+                    ]
+                  ]
+                )
+              )
+            )
+          )
+          (fix List_96 (lam a_97 (type) (all out_List_98 (type) (fun out_List_98 (fun (fun a_97 (fun [List_96 a_97] out_List_98)) out_List_98)))))
+        }
+        (abs
+          a_99
+          (type)
+          (wrap
+            List_100
+            (lam a_101 (type) (all out_List_102 (type) (fun out_List_102 (fun (fun a_101 (fun [List_100 a_101] out_List_102)) out_List_102))))
+            (abs
+              out_List_103
+              (type)
+              (lam
+                case_Nil_104
+                out_List_103
+                (lam
+                  case_Cons_105
+                  (fun a_99 (fun [List_100 a_99] out_List_103))
+                  case_Nil_104
+                )
+              )
+            )
+          )
+        )
+      ]
+      (abs
+        a_106
+        (type)
+        (lam
+          arg_0_107
+          a_106
+          (lam
+            arg_1_108
+            [(fix List_109 (lam a_110 (type) (all out_List_111 (type) (fun out_List_111 (fun (fun a_110 (fun [List_109 a_110] out_List_111)) out_List_111))))) a_106]
+            (wrap
+              List_112
+              (lam a_113 (type) (all out_List_114 (type) (fun out_List_114 (fun (fun a_113 (fun [List_112 a_113] out_List_114)) out_List_114))))
+              (abs
+                out_List_115
+                (type)
+                (lam
+                  case_Nil_116
+                  out_List_115
+                  (lam
+                    case_Cons_117
+                    (fun a_106 (fun [List_112 a_106] out_List_115))
+                    [ [ case_Cons_117 arg_0_107 ] arg_1_108 ]
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    ]
+    (abs
+      a_118
+      (type)
+      (lam
+        x_119
+        [(fix List_120 (lam a_121 (type) (all out_List_122 (type) (fun out_List_122 (fun (fun a_121 (fun [List_120 a_121] out_List_122)) out_List_122))))) a_118]
+        (unwrap x_119)
+      )
+    )
+  ]
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/tuple.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/tuple.plc.golden
@@ -3,18 +3,18 @@
     [
       {
         (abs
-          Tuple2_78
+          Tuple2_83
           (fun (type) (fun (type) (type)))
           (lam
-            Tuple2_79
-            (all a_80 (type) (all b_81 (type) (fun a_80 (fun b_81 [[Tuple2_78 a_80] b_81]))))
+            Tuple2_84
+            (all a_85 (type) (all b_86 (type) (fun a_85 (fun b_86 [[Tuple2_83 a_85] b_86]))))
             (lam
-              Tuple2_match_82
-              (all a_83 (type) (all b_84 (type) (fun [[Tuple2_78 a_83] b_84] [[(lam a_85 (type) (lam b_86 (type) (all out_Tuple2_87 (type) (fun (fun a_85 (fun b_86 out_Tuple2_87)) out_Tuple2_87)))) a_83] b_84])))
+              Tuple2_match_87
+              (all a_88 (type) (all b_89 (type) (fun [[Tuple2_83 a_88] b_89] [[(lam a_90 (type) (lam b_91 (type) (all out_Tuple2_92 (type) (fun (fun a_90 (fun b_91 out_Tuple2_92)) out_Tuple2_92)))) a_88] b_89])))
               [
                 [
                   {
-                    { Tuple2_79 [(con integer) (con 8)] }
+                    { Tuple2_84 [(con integer) (con 8)] }
                     [(con integer) (con 8)]
                   }
                   (con 8 ! 1)
@@ -24,27 +24,27 @@
             )
           )
         )
-        (lam a_88 (type) (lam b_89 (type) (all out_Tuple2_90 (type) (fun (fun a_88 (fun b_89 out_Tuple2_90)) out_Tuple2_90))))
+        (lam a_93 (type) (lam b_94 (type) (all out_Tuple2_95 (type) (fun (fun a_93 (fun b_94 out_Tuple2_95)) out_Tuple2_95))))
       }
       (abs
-        a_91
+        a_96
         (type)
         (abs
-          b_92
+          b_97
           (type)
           (lam
-            arg_0_93
-            a_91
+            arg_0_98
+            a_96
             (lam
-              arg_1_94
-              b_92
+              arg_1_99
+              b_97
               (abs
-                out_Tuple2_95
+                out_Tuple2_100
                 (type)
                 (lam
-                  case_Tuple2_96
-                  (fun a_91 (fun b_92 out_Tuple2_95))
-                  [ [ case_Tuple2_96 arg_0_93 ] arg_1_94 ]
+                  case_Tuple2_101
+                  (fun a_96 (fun b_97 out_Tuple2_100))
+                  [ [ case_Tuple2_101 arg_0_98 ] arg_1_99 ]
                 )
               )
             )
@@ -53,15 +53,15 @@
       )
     ]
     (abs
-      a_97
+      a_102
       (type)
       (abs
-        b_98
+        b_103
         (type)
         (lam
-          x_99
-          [[(lam a_100 (type) (lam b_101 (type) (all out_Tuple2_102 (type) (fun (fun a_100 (fun b_101 out_Tuple2_102)) out_Tuple2_102)))) a_97] b_98]
-          x_99
+          x_104
+          [[(lam a_105 (type) (lam b_106 (type) (all out_Tuple2_107 (type) (fun (fun a_105 (fun b_106 out_Tuple2_107)) out_Tuple2_107)))) a_102] b_103]
+          x_104
         )
       )
     )

--- a/plutus-tx-plugin/test/Plugin/primitives/tupleMatch.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/tupleMatch.plc.golden
@@ -3,59 +3,59 @@
     [
       {
         (abs
-          Tuple2_82
+          Tuple2_87
           (fun (type) (fun (type) (type)))
           (lam
-            Tuple2_83
-            (all a_84 (type) (all b_85 (type) (fun a_84 (fun b_85 [[Tuple2_82 a_84] b_85]))))
+            Tuple2_88
+            (all a_89 (type) (all b_90 (type) (fun a_89 (fun b_90 [[Tuple2_87 a_89] b_90]))))
             (lam
-              Tuple2_match_86
-              (all a_87 (type) (all b_88 (type) (fun [[Tuple2_82 a_87] b_88] [[(lam a_89 (type) (lam b_90 (type) (all out_Tuple2_91 (type) (fun (fun a_89 (fun b_90 out_Tuple2_91)) out_Tuple2_91)))) a_87] b_88])))
+              Tuple2_match_91
+              (all a_92 (type) (all b_93 (type) (fun [[Tuple2_87 a_92] b_93] [[(lam a_94 (type) (lam b_95 (type) (all out_Tuple2_96 (type) (fun (fun a_94 (fun b_95 out_Tuple2_96)) out_Tuple2_96)))) a_92] b_93])))
               (lam
-                ds_92
-                [[Tuple2_82 [(con integer) (con 8)]] [(con integer) (con 8)]]
+                ds_97
+                [[Tuple2_87 [(con integer) (con 8)]] [(con integer) (con 8)]]
                 [
                   {
                     [
                       {
-                        { Tuple2_match_86 [(con integer) (con 8)] }
+                        { Tuple2_match_91 [(con integer) (con 8)] }
                         [(con integer) (con 8)]
                       }
-                      ds_92
+                      ds_97
                     ]
                     [(con integer) (con 8)]
                   }
                   (lam
-                    a_93
+                    a_98
                     [(con integer) (con 8)]
-                    (lam b_94 [(con integer) (con 8)] a_93)
+                    (lam b_99 [(con integer) (con 8)] a_98)
                   )
                 ]
               )
             )
           )
         )
-        (lam a_95 (type) (lam b_96 (type) (all out_Tuple2_97 (type) (fun (fun a_95 (fun b_96 out_Tuple2_97)) out_Tuple2_97))))
+        (lam a_100 (type) (lam b_101 (type) (all out_Tuple2_102 (type) (fun (fun a_100 (fun b_101 out_Tuple2_102)) out_Tuple2_102))))
       }
       (abs
-        a_98
+        a_103
         (type)
         (abs
-          b_99
+          b_104
           (type)
           (lam
-            arg_0_100
-            a_98
+            arg_0_105
+            a_103
             (lam
-              arg_1_101
-              b_99
+              arg_1_106
+              b_104
               (abs
-                out_Tuple2_102
+                out_Tuple2_107
                 (type)
                 (lam
-                  case_Tuple2_103
-                  (fun a_98 (fun b_99 out_Tuple2_102))
-                  [ [ case_Tuple2_103 arg_0_100 ] arg_1_101 ]
+                  case_Tuple2_108
+                  (fun a_103 (fun b_104 out_Tuple2_107))
+                  [ [ case_Tuple2_108 arg_0_105 ] arg_1_106 ]
                 )
               )
             )
@@ -64,15 +64,15 @@
       )
     ]
     (abs
-      a_104
+      a_109
       (type)
       (abs
-        b_105
+        b_110
         (type)
         (lam
-          x_106
-          [[(lam a_107 (type) (lam b_108 (type) (all out_Tuple2_109 (type) (fun (fun a_107 (fun b_108 out_Tuple2_109)) out_Tuple2_109)))) a_104] b_105]
-          x_106
+          x_111
+          [[(lam a_112 (type) (lam b_113 (type) (all out_Tuple2_114 (type) (fun (fun a_112 (fun b_113 out_Tuple2_114)) out_Tuple2_114)))) a_109] b_110]
+          x_111
         )
       )
     )

--- a/plutus-tx-plugin/test/Plugin/primitives/verify.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/verify.plc.golden
@@ -4,49 +4,49 @@
       [
         {
           (abs
-            Bool_78
+            Bool_83
             (type)
             (lam
-              True_79
-              Bool_78
+              True_84
+              Bool_83
               (lam
-                False_80
-                Bool_78
+                False_85
+                Bool_83
                 (lam
-                  Bool_match_81
-                  (fun Bool_78 (all out_Bool_82 (type) (fun out_Bool_82 (fun out_Bool_82 out_Bool_82))))
+                  Bool_match_86
+                  (fun Bool_83 (all out_Bool_87 (type) (fun out_Bool_87 (fun out_Bool_87 out_Bool_87))))
                   [
                     (lam
-                      verifySignature_83
-                      (fun [(con bytestring) (con 32)] (fun [(con bytestring) (con 32)] (fun [(con bytestring) (con 32)] Bool_78)))
+                      verifySignature_88
+                      (fun [(con bytestring) (con 32)] (fun [(con bytestring) (con 32)] (fun [(con bytestring) (con 32)] Bool_83)))
                       (lam
-                        ds_84
+                        ds_89
                         [(con bytestring) (con 32)]
                         (lam
-                          ds_85
+                          ds_90
                           [(con bytestring) (con 32)]
                           (lam
-                            ds_86
+                            ds_91
                             [(con bytestring) (con 32)]
-                            [ [ [ verifySignature_83 ds_84 ] ds_85 ] ds_86 ]
+                            [ [ [ verifySignature_88 ds_89 ] ds_90 ] ds_91 ]
                           )
                         )
                       )
                     )
                     (lam
-                      arg_87
+                      arg_92
                       [(con bytestring) (con 32)]
                       (lam
-                        arg_88
+                        arg_93
                         [(con bytestring) (con 32)]
                         (lam
-                          arg_89
+                          arg_94
                           [(con bytestring) (con 32)]
                           [
                             (lam
-                              b_90
-                              (all a_91 (type) (fun a_91 (fun a_91 a_91)))
-                              [ [ { b_90 Bool_78 } True_79 ] False_80 ]
+                              b_95
+                              (all a_96 (type) (fun a_96 (fun a_96 a_96)))
+                              [ [ { b_95 Bool_83 } True_84 ] False_85 ]
                             )
                             [
                               [
@@ -58,11 +58,11 @@
                                     }
                                     (con 32)
                                   }
-                                  arg_87
+                                  arg_92
                                 ]
-                                arg_88
+                                arg_93
                               ]
-                              arg_89
+                              arg_94
                             ]
                           ]
                         )
@@ -73,30 +73,32 @@
               )
             )
           )
-          (all out_Bool_92 (type) (fun out_Bool_92 (fun out_Bool_92 out_Bool_92)))
+          (all out_Bool_97 (type) (fun out_Bool_97 (fun out_Bool_97 out_Bool_97)))
         }
         (abs
-          out_Bool_93
+          out_Bool_98
           (type)
           (lam
-            case_True_94
-            out_Bool_93
-            (lam case_False_95 out_Bool_93 case_True_94)
+            case_True_99
+            out_Bool_98
+            (lam case_False_100 out_Bool_98 case_True_99)
           )
         )
       ]
       (abs
-        out_Bool_96
+        out_Bool_101
         (type)
         (lam
-          case_True_97 out_Bool_96 (lam case_False_98 out_Bool_96 case_False_98)
+          case_True_102
+          out_Bool_101
+          (lam case_False_103 out_Bool_101 case_False_103)
         )
       )
     ]
     (lam
-      x_99
-      (all out_Bool_100 (type) (fun out_Bool_100 (fun out_Bool_100 out_Bool_100)))
-      x_99
+      x_104
+      (all out_Bool_105 (type) (fun out_Bool_105 (fun out_Bool_105 out_Bool_105)))
+      x_104
     )
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/void.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/void.plc.golden
@@ -3,179 +3,179 @@
     [
       {
         (abs
-          Unit_110
+          Unit_115
           (type)
           (lam
-            Unit_111
-            Unit_110
+            Unit_116
+            Unit_115
             (lam
-              Unit_match_112
-              (fun Unit_110 (all out_Unit_113 (type) (fun out_Unit_113 out_Unit_113)))
+              Unit_match_117
+              (fun Unit_115 (all out_Unit_118 (type) (fun out_Unit_118 out_Unit_118)))
               [
                 [
                   [
                     {
                       (abs
-                        Bool_114
+                        Bool_119
                         (type)
                         (lam
-                          True_115
-                          Bool_114
+                          True_120
+                          Bool_119
                           (lam
-                            False_116
-                            Bool_114
+                            False_121
+                            Bool_119
                             (lam
-                              Bool_match_117
-                              (fun Bool_114 (all out_Bool_118 (type) (fun out_Bool_118 (fun out_Bool_118 out_Bool_118))))
+                              Bool_match_122
+                              (fun Bool_119 (all out_Bool_123 (type) (fun out_Bool_123 (fun out_Bool_123 out_Bool_123))))
                               [
                                 (lam
-                                  equalsInteger_119
-                                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_114))
+                                  equalsInteger_124
+                                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_119))
                                   (lam
-                                    ds_120
+                                    ds_125
                                     [(con integer) (con 8)]
                                     (lam
-                                      ds_121
+                                      ds_126
                                       [(con integer) (con 8)]
                                       [
                                         (lam
-                                          eta_122
-                                          Bool_114
+                                          eta_127
+                                          Bool_119
                                           [
                                             (lam
-                                              eta_123
-                                              Bool_114
+                                              eta_128
+                                              Bool_119
                                               [
                                                 [
                                                   (lam
-                                                    x_124
-                                                    Bool_114
+                                                    x_129
+                                                    Bool_119
                                                     (lam
-                                                      y_125
-                                                      Bool_114
+                                                      y_130
+                                                      Bool_119
                                                       [
                                                         (lam
-                                                          fail_126
-                                                          (fun (all a_127 (type) (fun Unit_110 a_127)) Bool_114)
+                                                          fail_131
+                                                          (fun (all a_132 (type) (fun Unit_115 a_132)) Bool_119)
                                                           [
                                                             [
                                                               [
                                                                 {
                                                                   [
-                                                                    Bool_match_117
-                                                                    x_124
+                                                                    Bool_match_122
+                                                                    x_129
                                                                   ]
-                                                                  (fun Unit_110 Bool_114)
+                                                                  (fun Unit_115 Bool_119)
                                                                 }
                                                                 (lam
-                                                                  thunk_128
-                                                                  Unit_110
+                                                                  thunk_133
+                                                                  Unit_115
                                                                   [
                                                                     [
                                                                       [
                                                                         {
                                                                           [
-                                                                            Bool_match_117
-                                                                            y_125
+                                                                            Bool_match_122
+                                                                            y_130
                                                                           ]
-                                                                          (fun Unit_110 Bool_114)
+                                                                          (fun Unit_115 Bool_119)
                                                                         }
                                                                         (lam
-                                                                          thunk_129
-                                                                          Unit_110
-                                                                          True_115
+                                                                          thunk_134
+                                                                          Unit_115
+                                                                          True_120
                                                                         )
                                                                       ]
                                                                       (lam
-                                                                        thunk_130
-                                                                        Unit_110
+                                                                        thunk_135
+                                                                        Unit_115
                                                                         [
-                                                                          fail_126
+                                                                          fail_131
                                                                           (abs
-                                                                            e_131
+                                                                            e_136
                                                                             (type)
                                                                             (lam
-                                                                              thunk_132
-                                                                              Unit_110
+                                                                              thunk_137
+                                                                              Unit_115
                                                                               (error
-                                                                                e_131
+                                                                                e_136
                                                                               )
                                                                             )
                                                                           )
                                                                         ]
                                                                       )
                                                                     ]
-                                                                    Unit_111
+                                                                    Unit_116
                                                                   ]
                                                                 )
                                                               ]
                                                               (lam
-                                                                thunk_133
-                                                                Unit_110
+                                                                thunk_138
+                                                                Unit_115
                                                                 [
-                                                                  fail_126
+                                                                  fail_131
                                                                   (abs
-                                                                    e_134
+                                                                    e_139
                                                                     (type)
                                                                     (lam
-                                                                      thunk_135
-                                                                      Unit_110
+                                                                      thunk_140
+                                                                      Unit_115
                                                                       (error
-                                                                        e_134
+                                                                        e_139
                                                                       )
                                                                     )
                                                                   )
                                                                 ]
                                                               )
                                                             ]
-                                                            Unit_111
+                                                            Unit_116
                                                           ]
                                                         )
                                                         (lam
-                                                          ds_136
-                                                          (all a_137 (type) (fun Unit_110 a_137))
-                                                          False_116
+                                                          ds_141
+                                                          (all a_142 (type) (fun Unit_115 a_142))
+                                                          False_121
                                                         )
                                                       ]
                                                     )
                                                   )
-                                                  eta_122
+                                                  eta_127
                                                 ]
-                                                eta_123
+                                                eta_128
                                               ]
                                             )
                                             [
-                                              [ equalsInteger_119 ds_121 ]
-                                              ds_120
+                                              [ equalsInteger_124 ds_126 ]
+                                              ds_125
                                             ]
                                           ]
                                         )
-                                        [ [ equalsInteger_119 ds_120 ] ds_121 ]
+                                        [ [ equalsInteger_124 ds_125 ] ds_126 ]
                                       ]
                                     )
                                   )
                                 )
                                 (lam
-                                  arg_138
+                                  arg_143
                                   [(con integer) (con 8)]
                                   (lam
-                                    arg_139
+                                    arg_144
                                     [(con integer) (con 8)]
                                     [
                                       (lam
-                                        b_140
-                                        (all a_141 (type) (fun a_141 (fun a_141 a_141)))
+                                        b_145
+                                        (all a_146 (type) (fun a_146 (fun a_146 a_146)))
                                         [
-                                          [ { b_140 Bool_114 } True_115 ]
-                                          False_116
+                                          [ { b_145 Bool_119 } True_120 ]
+                                          False_121
                                         ]
                                       )
                                       [
                                         [
                                           { (builtin equalsInteger) (con 8) }
-                                          arg_138
+                                          arg_143
                                         ]
-                                        arg_139
+                                        arg_144
                                       ]
                                     ]
                                   )
@@ -185,41 +185,41 @@
                           )
                         )
                       )
-                      (all out_Bool_142 (type) (fun out_Bool_142 (fun out_Bool_142 out_Bool_142)))
+                      (all out_Bool_147 (type) (fun out_Bool_147 (fun out_Bool_147 out_Bool_147)))
                     }
                     (abs
-                      out_Bool_143
+                      out_Bool_148
                       (type)
                       (lam
-                        case_True_144
-                        out_Bool_143
-                        (lam case_False_145 out_Bool_143 case_True_144)
+                        case_True_149
+                        out_Bool_148
+                        (lam case_False_150 out_Bool_148 case_True_149)
                       )
                     )
                   ]
                   (abs
-                    out_Bool_146
+                    out_Bool_151
                     (type)
                     (lam
-                      case_True_147
-                      out_Bool_146
-                      (lam case_False_148 out_Bool_146 case_False_148)
+                      case_True_152
+                      out_Bool_151
+                      (lam case_False_153 out_Bool_151 case_False_153)
                     )
                   )
                 ]
                 (lam
-                  x_149
-                  (all out_Bool_150 (type) (fun out_Bool_150 (fun out_Bool_150 out_Bool_150)))
-                  x_149
+                  x_154
+                  (all out_Bool_155 (type) (fun out_Bool_155 (fun out_Bool_155 out_Bool_155)))
+                  x_154
                 )
               ]
             )
           )
         )
-        (all out_Unit_151 (type) (fun out_Unit_151 out_Unit_151))
+        (all out_Unit_156 (type) (fun out_Unit_156 out_Unit_156))
       }
-      (abs out_Unit_152 (type) (lam case_Unit_153 out_Unit_152 case_Unit_153))
+      (abs out_Unit_157 (type) (lam case_Unit_158 out_Unit_157 case_Unit_158))
     ]
-    (lam x_154 (all out_Unit_155 (type) (fun out_Unit_155 out_Unit_155)) x_154)
+    (lam x_159 (all out_Unit_160 (type) (fun out_Unit_160 out_Unit_160)) x_159)
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/recursiveFunctions/even.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveFunctions/even.plc.golden
@@ -3,87 +3,87 @@
     [
       {
         (abs
-          Unit_185
+          Unit_190
           (type)
           (lam
-            Unit_186
-            Unit_185
+            Unit_191
+            Unit_190
             (lam
-              Unit_match_187
-              (fun Unit_185 (all out_Unit_188 (type) (fun out_Unit_188 out_Unit_188)))
+              Unit_match_192
+              (fun Unit_190 (all out_Unit_193 (type) (fun out_Unit_193 out_Unit_193)))
               [
                 (lam
-                  subtractInteger_189
+                  subtractInteger_194
                   (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] [(con integer) (con 8)]))
                   [
                     [
                       [
                         {
                           (abs
-                            Bool_190
+                            Bool_195
                             (type)
                             (lam
-                              True_191
-                              Bool_190
+                              True_196
+                              Bool_195
                               (lam
-                                False_192
-                                Bool_190
+                                False_197
+                                Bool_195
                                 (lam
-                                  Bool_match_193
-                                  (fun Bool_190 (all out_Bool_194 (type) (fun out_Bool_194 (fun out_Bool_194 out_Bool_194))))
+                                  Bool_match_198
+                                  (fun Bool_195 (all out_Bool_199 (type) (fun out_Bool_199 (fun out_Bool_199 out_Bool_199))))
                                   [
                                     (lam
-                                      equalsInteger_195
-                                      (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_190))
+                                      equalsInteger_200
+                                      (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_195))
                                       [
                                         (lam
-                                          tuple_196
-                                          [[(lam t_0_197 (type) (lam t_1_198 (type) (all r_199 (type) (fun (fun t_0_197 (fun t_1_198 r_199)) r_199)))) (fun [(con integer) (con 8)] Bool_190)] (fun [(con integer) (con 8)] Bool_190)]
+                                          tuple_201
+                                          [[(lam t_0_202 (type) (lam t_1_203 (type) (all r_204 (type) (fun (fun t_0_202 (fun t_1_203 r_204)) r_204)))) (fun [(con integer) (con 8)] Bool_195)] (fun [(con integer) (con 8)] Bool_195)]
                                           [
                                             (lam
-                                              odd_200
-                                              (fun [(con integer) (con 8)] Bool_190)
+                                              odd_205
+                                              (fun [(con integer) (con 8)] Bool_195)
                                               [
                                                 (lam
-                                                  even_201
-                                                  (fun [(con integer) (con 8)] Bool_190)
-                                                  even_201
+                                                  even_206
+                                                  (fun [(con integer) (con 8)] Bool_195)
+                                                  even_206
                                                 )
                                                 [
                                                   {
                                                     {
                                                       (abs
-                                                        t_0_202
+                                                        t_0_207
                                                         (type)
                                                         (abs
-                                                          t_1_203
+                                                          t_1_208
                                                           (type)
                                                           (lam
-                                                            tuple_204
-                                                            [[(lam t_0_205 (type) (lam t_1_206 (type) (all r_207 (type) (fun (fun t_0_205 (fun t_1_206 r_207)) r_207)))) t_0_202] t_1_203]
+                                                            tuple_209
+                                                            [[(lam t_0_210 (type) (lam t_1_211 (type) (all r_212 (type) (fun (fun t_0_210 (fun t_1_211 r_212)) r_212)))) t_0_207] t_1_208]
                                                             [
                                                               {
-                                                                tuple_204
-                                                                t_1_203
+                                                                tuple_209
+                                                                t_1_208
                                                               }
                                                               (lam
-                                                                arg_0_208
-                                                                t_0_202
+                                                                arg_0_213
+                                                                t_0_207
                                                                 (lam
-                                                                  arg_1_209
-                                                                  t_1_203
-                                                                  arg_1_209
+                                                                  arg_1_214
+                                                                  t_1_208
+                                                                  arg_1_214
                                                                 )
                                                               )
                                                             ]
                                                           )
                                                         )
                                                       )
-                                                      (fun [(con integer) (con 8)] Bool_190)
+                                                      (fun [(con integer) (con 8)] Bool_195)
                                                     }
-                                                    (fun [(con integer) (con 8)] Bool_190)
+                                                    (fun [(con integer) (con 8)] Bool_195)
                                                   }
-                                                  tuple_196
+                                                  tuple_201
                                                 ]
                                               ]
                                             )
@@ -91,34 +91,34 @@
                                               {
                                                 {
                                                   (abs
-                                                    t_0_210
+                                                    t_0_215
                                                     (type)
                                                     (abs
-                                                      t_1_211
+                                                      t_1_216
                                                       (type)
                                                       (lam
-                                                        tuple_212
-                                                        [[(lam t_0_213 (type) (lam t_1_214 (type) (all r_215 (type) (fun (fun t_0_213 (fun t_1_214 r_215)) r_215)))) t_0_210] t_1_211]
+                                                        tuple_217
+                                                        [[(lam t_0_218 (type) (lam t_1_219 (type) (all r_220 (type) (fun (fun t_0_218 (fun t_1_219 r_220)) r_220)))) t_0_215] t_1_216]
                                                         [
-                                                          { tuple_212 t_0_210 }
+                                                          { tuple_217 t_0_215 }
                                                           (lam
-                                                            arg_0_216
-                                                            t_0_210
+                                                            arg_0_221
+                                                            t_0_215
                                                             (lam
-                                                              arg_1_217
-                                                              t_1_211
-                                                              arg_0_216
+                                                              arg_1_222
+                                                              t_1_216
+                                                              arg_0_221
                                                             )
                                                           )
                                                         ]
                                                       )
                                                     )
                                                   )
-                                                  (fun [(con integer) (con 8)] Bool_190)
+                                                  (fun [(con integer) (con 8)] Bool_195)
                                                 }
-                                                (fun [(con integer) (con 8)] Bool_190)
+                                                (fun [(con integer) (con 8)] Bool_195)
                                               }
-                                              tuple_196
+                                              tuple_201
                                             ]
                                           ]
                                         )
@@ -128,89 +128,89 @@
                                               {
                                                 {
                                                   (abs
-                                                    a_218
+                                                    a_223
                                                     (type)
                                                     (abs
-                                                      b_219
+                                                      b_224
                                                       (type)
                                                       (abs
-                                                        a_220
+                                                        a_225
                                                         (type)
                                                         (abs
-                                                          b_221
+                                                          b_226
                                                           (type)
                                                           [
                                                             {
                                                               (abs
-                                                                F_222
+                                                                F_227
                                                                 (fun (type) (type))
                                                                 (lam
-                                                                  by_223
-                                                                  (fun (all Q_224 (type) (fun [F_222 Q_224] Q_224)) (all Q_225 (type) (fun [F_222 Q_225] Q_225)))
+                                                                  by_228
+                                                                  (fun (all Q_229 (type) (fun [F_227 Q_229] Q_229)) (all Q_230 (type) (fun [F_227 Q_230] Q_230)))
                                                                   [
                                                                     {
                                                                       {
                                                                         (abs
-                                                                          a_226
+                                                                          a_231
                                                                           (type)
                                                                           (abs
-                                                                            b_227
+                                                                            b_232
                                                                             (type)
                                                                             (lam
-                                                                              f_228
-                                                                              (fun (fun a_226 b_227) (fun a_226 b_227))
+                                                                              f_233
+                                                                              (fun (fun a_231 b_232) (fun a_231 b_232))
                                                                               [
                                                                                 {
                                                                                   (abs
-                                                                                    a_229
+                                                                                    a_234
                                                                                     (type)
                                                                                     (lam
-                                                                                      s_230
-                                                                                      [(lam a_231 (type) (fix self_232 (fun self_232 a_231))) a_229]
+                                                                                      s_235
+                                                                                      [(lam a_236 (type) (fix self_237 (fun self_237 a_236))) a_234]
                                                                                       [
                                                                                         (unwrap
-                                                                                          s_230
+                                                                                          s_235
                                                                                         )
-                                                                                        s_230
+                                                                                        s_235
                                                                                       ]
                                                                                     )
                                                                                   )
-                                                                                  (fun a_226 b_227)
+                                                                                  (fun a_231 b_232)
                                                                                 }
                                                                                 (wrap
-                                                                                  self_233
-                                                                                  [(lam a_234 (type) (fun self_233 a_234)) (fun a_226 b_227)]
+                                                                                  self_238
+                                                                                  [(lam a_239 (type) (fun self_238 a_239)) (fun a_231 b_232)]
                                                                                   (lam
-                                                                                    s_235
-                                                                                    [(lam a_236 (type) (fix self_237 (fun self_237 a_236))) (fun a_226 b_227)]
+                                                                                    s_240
+                                                                                    [(lam a_241 (type) (fix self_242 (fun self_242 a_241))) (fun a_231 b_232)]
                                                                                     (lam
-                                                                                      x_238
-                                                                                      a_226
+                                                                                      x_243
+                                                                                      a_231
                                                                                       [
                                                                                         [
-                                                                                          f_228
+                                                                                          f_233
                                                                                           [
                                                                                             {
                                                                                               (abs
-                                                                                                a_239
+                                                                                                a_244
                                                                                                 (type)
                                                                                                 (lam
-                                                                                                  s_240
-                                                                                                  [(lam a_241 (type) (fix self_242 (fun self_242 a_241))) a_239]
+                                                                                                  s_245
+                                                                                                  [(lam a_246 (type) (fix self_247 (fun self_247 a_246))) a_244]
                                                                                                   [
                                                                                                     (unwrap
-                                                                                                      s_240
+                                                                                                      s_245
                                                                                                     )
-                                                                                                    s_240
+                                                                                                    s_245
                                                                                                   ]
                                                                                                 )
                                                                                               )
-                                                                                              (fun a_226 b_227)
+                                                                                              (fun a_231 b_232)
                                                                                             }
-                                                                                            s_235
+                                                                                            s_240
                                                                                           ]
                                                                                         ]
-                                                                                        x_238
+                                                                                        x_243
                                                                                       ]
                                                                                     )
                                                                                   )
@@ -219,54 +219,54 @@
                                                                             )
                                                                           )
                                                                         )
-                                                                        (all Q_243 (type) (fun [F_222 Q_243] [F_222 Q_243]))
+                                                                        (all Q_248 (type) (fun [F_227 Q_248] [F_227 Q_248]))
                                                                       }
-                                                                      (all Q_244 (type) (fun [F_222 Q_244] Q_244))
+                                                                      (all Q_249 (type) (fun [F_227 Q_249] Q_249))
                                                                     }
                                                                     (lam
-                                                                      rec_245
-                                                                      (fun (all Q_246 (type) (fun [F_222 Q_246] [F_222 Q_246])) (all Q_247 (type) (fun [F_222 Q_247] Q_247)))
+                                                                      rec_250
+                                                                      (fun (all Q_251 (type) (fun [F_227 Q_251] [F_227 Q_251])) (all Q_252 (type) (fun [F_227 Q_252] Q_252)))
                                                                       (lam
-                                                                        h_248
-                                                                        (all Q_249 (type) (fun [F_222 Q_249] [F_222 Q_249]))
+                                                                        h_253
+                                                                        (all Q_254 (type) (fun [F_227 Q_254] [F_227 Q_254]))
                                                                         (abs
-                                                                          R_250
+                                                                          R_255
                                                                           (type)
                                                                           (lam
-                                                                            fr_251
-                                                                            [F_222 R_250]
+                                                                            fr_256
+                                                                            [F_227 R_255]
                                                                             [
                                                                               {
                                                                                 [
-                                                                                  by_223
+                                                                                  by_228
                                                                                   (abs
-                                                                                    Q_252
+                                                                                    Q_257
                                                                                     (type)
                                                                                     (lam
-                                                                                      fq_253
-                                                                                      [F_222 Q_252]
+                                                                                      fq_258
+                                                                                      [F_227 Q_257]
                                                                                       [
                                                                                         {
                                                                                           [
-                                                                                            rec_245
-                                                                                            h_248
+                                                                                            rec_250
+                                                                                            h_253
                                                                                           ]
-                                                                                          Q_252
+                                                                                          Q_257
                                                                                         }
                                                                                         [
                                                                                           {
-                                                                                            h_248
-                                                                                            Q_252
+                                                                                            h_253
+                                                                                            Q_257
                                                                                           }
-                                                                                          fq_253
+                                                                                          fq_258
                                                                                         ]
                                                                                       ]
                                                                                     )
                                                                                   )
                                                                                 ]
-                                                                                R_250
+                                                                                R_255
                                                                               }
-                                                                              fr_251
+                                                                              fr_256
                                                                             ]
                                                                           )
                                                                         )
@@ -275,37 +275,37 @@
                                                                   ]
                                                                 )
                                                               )
-                                                              (lam X_254 (type) (fun (fun a_218 b_219) (fun (fun a_220 b_221) X_254)))
+                                                              (lam X_259 (type) (fun (fun a_223 b_224) (fun (fun a_225 b_226) X_259)))
                                                             }
                                                             (lam
-                                                              k_255
-                                                              (all Q_256 (type) (fun (fun (fun a_218 b_219) (fun (fun a_220 b_221) Q_256)) Q_256))
+                                                              k_260
+                                                              (all Q_261 (type) (fun (fun (fun a_223 b_224) (fun (fun a_225 b_226) Q_261)) Q_261))
                                                               (abs
-                                                                S_257
+                                                                S_262
                                                                 (type)
                                                                 (lam
-                                                                  h_258
-                                                                  (fun (fun a_218 b_219) (fun (fun a_220 b_221) S_257))
+                                                                  h_263
+                                                                  (fun (fun a_223 b_224) (fun (fun a_225 b_226) S_262))
                                                                   [
                                                                     [
-                                                                      h_258
+                                                                      h_263
                                                                       (lam
-                                                                        x_259
-                                                                        a_218
+                                                                        x_264
+                                                                        a_223
                                                                         [
                                                                           {
-                                                                            k_255
-                                                                            b_219
+                                                                            k_260
+                                                                            b_224
                                                                           }
                                                                           (lam
-                                                                            f_260
-                                                                            (fun a_218 b_219)
+                                                                            f_265
+                                                                            (fun a_223 b_224)
                                                                             (lam
-                                                                              f_261
-                                                                              (fun a_220 b_221)
+                                                                              f_266
+                                                                              (fun a_225 b_226)
                                                                               [
-                                                                                f_260
-                                                                                x_259
+                                                                                f_265
+                                                                                x_264
                                                                               ]
                                                                             )
                                                                           )
@@ -313,22 +313,22 @@
                                                                       )
                                                                     ]
                                                                     (lam
-                                                                      x_262
-                                                                      a_220
+                                                                      x_267
+                                                                      a_225
                                                                       [
                                                                         {
-                                                                          k_255
-                                                                          b_221
+                                                                          k_260
+                                                                          b_226
                                                                         }
                                                                         (lam
-                                                                          f_263
-                                                                          (fun a_218 b_219)
+                                                                          f_268
+                                                                          (fun a_223 b_224)
                                                                           (lam
-                                                                            f_264
-                                                                            (fun a_220 b_221)
+                                                                            f_269
+                                                                            (fun a_225 b_226)
                                                                             [
-                                                                              f_264
-                                                                              x_262
+                                                                              f_269
+                                                                              x_267
                                                                             ]
                                                                           )
                                                                         )
@@ -345,112 +345,112 @@
                                                   )
                                                   [(con integer) (con 8)]
                                                 }
-                                                Bool_190
+                                                Bool_195
                                               }
                                               [(con integer) (con 8)]
                                             }
-                                            Bool_190
+                                            Bool_195
                                           }
                                           (abs
-                                            Q_265
+                                            Q_270
                                             (type)
                                             (lam
-                                              choose_266
-                                              (fun (fun [(con integer) (con 8)] Bool_190) (fun (fun [(con integer) (con 8)] Bool_190) Q_265))
+                                              choose_271
+                                              (fun (fun [(con integer) (con 8)] Bool_195) (fun (fun [(con integer) (con 8)] Bool_195) Q_270))
                                               (lam
-                                                odd_267
-                                                (fun [(con integer) (con 8)] Bool_190)
+                                                odd_272
+                                                (fun [(con integer) (con 8)] Bool_195)
                                                 (lam
-                                                  even_268
-                                                  (fun [(con integer) (con 8)] Bool_190)
+                                                  even_273
+                                                  (fun [(con integer) (con 8)] Bool_195)
                                                   [
                                                     [
-                                                      choose_266
+                                                      choose_271
                                                       (lam
-                                                        n_269
+                                                        n_274
                                                         [(con integer) (con 8)]
                                                         [
                                                           [
                                                             [
                                                               {
                                                                 [
-                                                                  Bool_match_193
+                                                                  Bool_match_198
                                                                   [
                                                                     [
-                                                                      equalsInteger_195
-                                                                      n_269
+                                                                      equalsInteger_200
+                                                                      n_274
                                                                     ]
                                                                     (con 8 ! 0)
                                                                   ]
                                                                 ]
-                                                                (fun Unit_185 Bool_190)
+                                                                (fun Unit_190 Bool_195)
                                                               }
                                                               (lam
-                                                                thunk_270
-                                                                Unit_185
-                                                                False_192
+                                                                thunk_275
+                                                                Unit_190
+                                                                False_197
                                                               )
                                                             ]
                                                             (lam
-                                                              thunk_271
-                                                              Unit_185
+                                                              thunk_276
+                                                              Unit_190
                                                               [
-                                                                even_268
+                                                                even_273
                                                                 [
                                                                   [
-                                                                    subtractInteger_189
-                                                                    n_269
+                                                                    subtractInteger_194
+                                                                    n_274
                                                                   ]
                                                                   (con 8 ! 1)
                                                                 ]
                                                               ]
                                                             )
                                                           ]
-                                                          Unit_186
+                                                          Unit_191
                                                         ]
                                                       )
                                                     ]
                                                     (lam
-                                                      n_272
+                                                      n_277
                                                       [(con integer) (con 8)]
                                                       [
                                                         [
                                                           [
                                                             {
                                                               [
-                                                                Bool_match_193
+                                                                Bool_match_198
                                                                 [
                                                                   [
-                                                                    equalsInteger_195
-                                                                    n_272
+                                                                    equalsInteger_200
+                                                                    n_277
                                                                   ]
                                                                   (con 8 ! 0)
                                                                 ]
                                                               ]
-                                                              (fun Unit_185 Bool_190)
+                                                              (fun Unit_190 Bool_195)
                                                             }
                                                             (lam
-                                                              thunk_273
-                                                              Unit_185
-                                                              True_191
+                                                              thunk_278
+                                                              Unit_190
+                                                              True_196
                                                             )
                                                           ]
                                                           (lam
-                                                            thunk_274
-                                                            Unit_185
+                                                            thunk_279
+                                                            Unit_190
                                                             [
-                                                              odd_267
+                                                              odd_272
                                                               [
                                                                 [
-                                                                  subtractInteger_189
-                                                                  n_272
+                                                                  subtractInteger_194
+                                                                  n_277
                                                                 ]
                                                                 (con 8 ! 1)
                                                               ]
                                                             ]
                                                           )
                                                         ]
-                                                        Unit_186
+                                                        Unit_191
                                                       ]
                                                     )
                                                   ]
@@ -462,18 +462,18 @@
                                       ]
                                     )
                                     (lam
-                                      arg_275
+                                      arg_280
                                       [(con integer) (con 8)]
                                       (lam
-                                        arg_276
+                                        arg_281
                                         [(con integer) (con 8)]
                                         [
                                           (lam
-                                            b_277
-                                            (all a_278 (type) (fun a_278 (fun a_278 a_278)))
+                                            b_282
+                                            (all a_283 (type) (fun a_283 (fun a_283 a_283)))
                                             [
-                                              [ { b_277 Bool_190 } True_191 ]
-                                              False_192
+                                              [ { b_282 Bool_195 } True_196 ]
+                                              False_197
                                             ]
                                           )
                                           [
@@ -481,9 +481,9 @@
                                               {
                                                 (builtin equalsInteger) (con 8)
                                               }
-                                              arg_275
+                                              arg_280
                                             ]
-                                            arg_276
+                                            arg_281
                                           ]
                                         ]
                                       )
@@ -493,32 +493,32 @@
                               )
                             )
                           )
-                          (all out_Bool_279 (type) (fun out_Bool_279 (fun out_Bool_279 out_Bool_279)))
+                          (all out_Bool_284 (type) (fun out_Bool_284 (fun out_Bool_284 out_Bool_284)))
                         }
                         (abs
-                          out_Bool_280
+                          out_Bool_285
                           (type)
                           (lam
-                            case_True_281
-                            out_Bool_280
-                            (lam case_False_282 out_Bool_280 case_True_281)
+                            case_True_286
+                            out_Bool_285
+                            (lam case_False_287 out_Bool_285 case_True_286)
                           )
                         )
                       ]
                       (abs
-                        out_Bool_283
+                        out_Bool_288
                         (type)
                         (lam
-                          case_True_284
-                          out_Bool_283
-                          (lam case_False_285 out_Bool_283 case_False_285)
+                          case_True_289
+                          out_Bool_288
+                          (lam case_False_290 out_Bool_288 case_False_290)
                         )
                       )
                     ]
                     (lam
-                      x_286
-                      (all out_Bool_287 (type) (fun out_Bool_287 (fun out_Bool_287 out_Bool_287)))
-                      x_286
+                      x_291
+                      (all out_Bool_292 (type) (fun out_Bool_292 (fun out_Bool_292 out_Bool_292)))
+                      x_291
                     )
                   ]
                 )
@@ -527,10 +527,10 @@
             )
           )
         )
-        (all out_Unit_288 (type) (fun out_Unit_288 out_Unit_288))
+        (all out_Unit_293 (type) (fun out_Unit_293 out_Unit_293))
       }
-      (abs out_Unit_289 (type) (lam case_Unit_290 out_Unit_289 case_Unit_290))
+      (abs out_Unit_294 (type) (lam case_Unit_295 out_Unit_294 case_Unit_295))
     ]
-    (lam x_291 (all out_Unit_292 (type) (fun out_Unit_292 out_Unit_292)) x_291)
+    (lam x_296 (all out_Unit_297 (type) (fun out_Unit_297 out_Unit_297)) x_296)
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/recursiveFunctions/even3.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveFunctions/even3.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_283
+  out_Bool_288
   (type)
   (lam
-    case_True_284 out_Bool_283 (lam case_False_285 out_Bool_283 case_False_285)
+    case_True_289 out_Bool_288 (lam case_False_290 out_Bool_288 case_False_290)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/recursiveFunctions/even4.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveFunctions/even4.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_280
+  out_Bool_285
   (type)
   (lam
-    case_True_281 out_Bool_280 (lam case_False_282 out_Bool_280 case_True_281)
+    case_True_286 out_Bool_285 (lam case_False_287 out_Bool_285 case_True_286)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/recursiveFunctions/fib.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveFunctions/fib.plc.golden
@@ -3,73 +3,73 @@
     [
       {
         (abs
-          Unit_157
+          Unit_162
           (type)
           (lam
-            Unit_158
-            Unit_157
+            Unit_163
+            Unit_162
             (lam
-              Unit_match_159
-              (fun Unit_157 (all out_Unit_160 (type) (fun out_Unit_160 out_Unit_160)))
+              Unit_match_164
+              (fun Unit_162 (all out_Unit_165 (type) (fun out_Unit_165 out_Unit_165)))
               [
                 (lam
-                  addInteger_161
+                  addInteger_166
                   (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] [(con integer) (con 8)]))
                   [
                     (lam
-                      subtractInteger_162
+                      subtractInteger_167
                       (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] [(con integer) (con 8)]))
                       [
                         [
                           [
                             {
                               (abs
-                                Bool_163
+                                Bool_168
                                 (type)
                                 (lam
-                                  True_164
-                                  Bool_163
+                                  True_169
+                                  Bool_168
                                   (lam
-                                    False_165
-                                    Bool_163
+                                    False_170
+                                    Bool_168
                                     (lam
-                                      Bool_match_166
-                                      (fun Bool_163 (all out_Bool_167 (type) (fun out_Bool_167 (fun out_Bool_167 out_Bool_167))))
+                                      Bool_match_171
+                                      (fun Bool_168 (all out_Bool_172 (type) (fun out_Bool_172 (fun out_Bool_172 out_Bool_172))))
                                       [
                                         (lam
-                                          equalsInteger_168
-                                          (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_163))
+                                          equalsInteger_173
+                                          (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_168))
                                           [
                                             (lam
-                                              tuple_169
-                                              [(lam t_0_170 (type) (all r_171 (type) (fun (fun t_0_170 r_171) r_171))) (fun [(con integer) (con 8)] [(con integer) (con 8)])]
+                                              tuple_174
+                                              [(lam t_0_175 (type) (all r_176 (type) (fun (fun t_0_175 r_176) r_176))) (fun [(con integer) (con 8)] [(con integer) (con 8)])]
                                               [
                                                 (lam
-                                                  fib_172
+                                                  fib_177
                                                   (fun [(con integer) (con 8)] [(con integer) (con 8)])
-                                                  fib_172
+                                                  fib_177
                                                 )
                                                 [
                                                   {
                                                     (abs
-                                                      t_0_173
+                                                      t_0_178
                                                       (type)
                                                       (lam
-                                                        tuple_174
-                                                        [(lam t_0_175 (type) (all r_176 (type) (fun (fun t_0_175 r_176) r_176))) t_0_173]
+                                                        tuple_179
+                                                        [(lam t_0_180 (type) (all r_181 (type) (fun (fun t_0_180 r_181) r_181))) t_0_178]
                                                         [
-                                                          { tuple_174 t_0_173 }
+                                                          { tuple_179 t_0_178 }
                                                           (lam
-                                                            arg_0_177
-                                                            t_0_173
-                                                            arg_0_177
+                                                            arg_0_182
+                                                            t_0_178
+                                                            arg_0_182
                                                           )
                                                         ]
                                                       )
                                                     )
                                                     (fun [(con integer) (con 8)] [(con integer) (con 8)])
                                                   }
-                                                  tuple_169
+                                                  tuple_174
                                                 ]
                                               ]
                                             )
@@ -77,83 +77,83 @@
                                               {
                                                 {
                                                   (abs
-                                                    a_178
+                                                    a_183
                                                     (type)
                                                     (abs
-                                                      b_179
+                                                      b_184
                                                       (type)
                                                       [
                                                         {
                                                           (abs
-                                                            F_180
+                                                            F_185
                                                             (fun (type) (type))
                                                             (lam
-                                                              by_181
-                                                              (fun (all Q_182 (type) (fun [F_180 Q_182] Q_182)) (all Q_183 (type) (fun [F_180 Q_183] Q_183)))
+                                                              by_186
+                                                              (fun (all Q_187 (type) (fun [F_185 Q_187] Q_187)) (all Q_188 (type) (fun [F_185 Q_188] Q_188)))
                                                               [
                                                                 {
                                                                   {
                                                                     (abs
-                                                                      a_184
+                                                                      a_189
                                                                       (type)
                                                                       (abs
-                                                                        b_185
+                                                                        b_190
                                                                         (type)
                                                                         (lam
-                                                                          f_186
-                                                                          (fun (fun a_184 b_185) (fun a_184 b_185))
+                                                                          f_191
+                                                                          (fun (fun a_189 b_190) (fun a_189 b_190))
                                                                           [
                                                                             {
                                                                               (abs
-                                                                                a_187
+                                                                                a_192
                                                                                 (type)
                                                                                 (lam
-                                                                                  s_188
-                                                                                  [(lam a_189 (type) (fix self_190 (fun self_190 a_189))) a_187]
+                                                                                  s_193
+                                                                                  [(lam a_194 (type) (fix self_195 (fun self_195 a_194))) a_192]
                                                                                   [
                                                                                     (unwrap
-                                                                                      s_188
+                                                                                      s_193
                                                                                     )
-                                                                                    s_188
+                                                                                    s_193
                                                                                   ]
                                                                                 )
                                                                               )
-                                                                              (fun a_184 b_185)
+                                                                              (fun a_189 b_190)
                                                                             }
                                                                             (wrap
-                                                                              self_191
-                                                                              [(lam a_192 (type) (fun self_191 a_192)) (fun a_184 b_185)]
+                                                                              self_196
+                                                                              [(lam a_197 (type) (fun self_196 a_197)) (fun a_189 b_190)]
                                                                               (lam
-                                                                                s_193
-                                                                                [(lam a_194 (type) (fix self_195 (fun self_195 a_194))) (fun a_184 b_185)]
+                                                                                s_198
+                                                                                [(lam a_199 (type) (fix self_200 (fun self_200 a_199))) (fun a_189 b_190)]
                                                                                 (lam
-                                                                                  x_196
-                                                                                  a_184
+                                                                                  x_201
+                                                                                  a_189
                                                                                   [
                                                                                     [
-                                                                                      f_186
+                                                                                      f_191
                                                                                       [
                                                                                         {
                                                                                           (abs
-                                                                                            a_197
+                                                                                            a_202
                                                                                             (type)
                                                                                             (lam
-                                                                                              s_198
-                                                                                              [(lam a_199 (type) (fix self_200 (fun self_200 a_199))) a_197]
+                                                                                              s_203
+                                                                                              [(lam a_204 (type) (fix self_205 (fun self_205 a_204))) a_202]
                                                                                               [
                                                                                                 (unwrap
-                                                                                                  s_198
+                                                                                                  s_203
                                                                                                 )
-                                                                                                s_198
+                                                                                                s_203
                                                                                               ]
                                                                                             )
                                                                                           )
-                                                                                          (fun a_184 b_185)
+                                                                                          (fun a_189 b_190)
                                                                                         }
-                                                                                        s_193
+                                                                                        s_198
                                                                                       ]
                                                                                     ]
-                                                                                    x_196
+                                                                                    x_201
                                                                                   ]
                                                                                 )
                                                                               )
@@ -162,54 +162,54 @@
                                                                         )
                                                                       )
                                                                     )
-                                                                    (all Q_201 (type) (fun [F_180 Q_201] [F_180 Q_201]))
+                                                                    (all Q_206 (type) (fun [F_185 Q_206] [F_185 Q_206]))
                                                                   }
-                                                                  (all Q_202 (type) (fun [F_180 Q_202] Q_202))
+                                                                  (all Q_207 (type) (fun [F_185 Q_207] Q_207))
                                                                 }
                                                                 (lam
-                                                                  rec_203
-                                                                  (fun (all Q_204 (type) (fun [F_180 Q_204] [F_180 Q_204])) (all Q_205 (type) (fun [F_180 Q_205] Q_205)))
+                                                                  rec_208
+                                                                  (fun (all Q_209 (type) (fun [F_185 Q_209] [F_185 Q_209])) (all Q_210 (type) (fun [F_185 Q_210] Q_210)))
                                                                   (lam
-                                                                    h_206
-                                                                    (all Q_207 (type) (fun [F_180 Q_207] [F_180 Q_207]))
+                                                                    h_211
+                                                                    (all Q_212 (type) (fun [F_185 Q_212] [F_185 Q_212]))
                                                                     (abs
-                                                                      R_208
+                                                                      R_213
                                                                       (type)
                                                                       (lam
-                                                                        fr_209
-                                                                        [F_180 R_208]
+                                                                        fr_214
+                                                                        [F_185 R_213]
                                                                         [
                                                                           {
                                                                             [
-                                                                              by_181
+                                                                              by_186
                                                                               (abs
-                                                                                Q_210
+                                                                                Q_215
                                                                                 (type)
                                                                                 (lam
-                                                                                  fq_211
-                                                                                  [F_180 Q_210]
+                                                                                  fq_216
+                                                                                  [F_185 Q_215]
                                                                                   [
                                                                                     {
                                                                                       [
-                                                                                        rec_203
-                                                                                        h_206
+                                                                                        rec_208
+                                                                                        h_211
                                                                                       ]
-                                                                                      Q_210
+                                                                                      Q_215
                                                                                     }
                                                                                     [
                                                                                       {
-                                                                                        h_206
-                                                                                        Q_210
+                                                                                        h_211
+                                                                                        Q_215
                                                                                       }
-                                                                                      fq_211
+                                                                                      fq_216
                                                                                     ]
                                                                                   ]
                                                                                 )
                                                                               )
                                                                             ]
-                                                                            R_208
+                                                                            R_213
                                                                           }
-                                                                          fr_209
+                                                                          fr_214
                                                                         ]
                                                                       )
                                                                     )
@@ -218,33 +218,33 @@
                                                               ]
                                                             )
                                                           )
-                                                          (lam X_212 (type) (fun (fun a_178 b_179) X_212))
+                                                          (lam X_217 (type) (fun (fun a_183 b_184) X_217))
                                                         }
                                                         (lam
-                                                          k_213
-                                                          (all Q_214 (type) (fun (fun (fun a_178 b_179) Q_214) Q_214))
+                                                          k_218
+                                                          (all Q_219 (type) (fun (fun (fun a_183 b_184) Q_219) Q_219))
                                                           (abs
-                                                            S_215
+                                                            S_220
                                                             (type)
                                                             (lam
-                                                              h_216
-                                                              (fun (fun a_178 b_179) S_215)
+                                                              h_221
+                                                              (fun (fun a_183 b_184) S_220)
                                                               [
-                                                                h_216
+                                                                h_221
                                                                 (lam
-                                                                  x_217
-                                                                  a_178
+                                                                  x_222
+                                                                  a_183
                                                                   [
                                                                     {
-                                                                      k_213
-                                                                      b_179
+                                                                      k_218
+                                                                      b_184
                                                                     }
                                                                     (lam
-                                                                      f_218
-                                                                      (fun a_178 b_179)
+                                                                      f_223
+                                                                      (fun a_183 b_184)
                                                                       [
-                                                                        f_218
-                                                                        x_217
+                                                                        f_223
+                                                                        x_222
                                                                       ]
                                                                     )
                                                                   ]
@@ -261,81 +261,81 @@
                                                 [(con integer) (con 8)]
                                               }
                                               (abs
-                                                Q_219
+                                                Q_224
                                                 (type)
                                                 (lam
-                                                  choose_220
-                                                  (fun (fun [(con integer) (con 8)] [(con integer) (con 8)]) Q_219)
+                                                  choose_225
+                                                  (fun (fun [(con integer) (con 8)] [(con integer) (con 8)]) Q_224)
                                                   (lam
-                                                    fib_221
+                                                    fib_226
                                                     (fun [(con integer) (con 8)] [(con integer) (con 8)])
                                                     [
-                                                      choose_220
+                                                      choose_225
                                                       (lam
-                                                        n_222
+                                                        n_227
                                                         [(con integer) (con 8)]
                                                         [
                                                           [
                                                             [
                                                               {
                                                                 [
-                                                                  Bool_match_166
+                                                                  Bool_match_171
                                                                   [
                                                                     [
-                                                                      equalsInteger_168
-                                                                      n_222
+                                                                      equalsInteger_173
+                                                                      n_227
                                                                     ]
                                                                     (con 8 ! 0)
                                                                   ]
                                                                 ]
-                                                                (fun Unit_157 [(con integer) (con 8)])
+                                                                (fun Unit_162 [(con integer) (con 8)])
                                                               }
                                                               (lam
-                                                                thunk_223
-                                                                Unit_157
+                                                                thunk_228
+                                                                Unit_162
                                                                 (con 8 ! 0)
                                                               )
                                                             ]
                                                             (lam
-                                                              thunk_224
-                                                              Unit_157
+                                                              thunk_229
+                                                              Unit_162
                                                               [
                                                                 [
                                                                   [
                                                                     {
                                                                       [
-                                                                        Bool_match_166
+                                                                        Bool_match_171
                                                                         [
                                                                           [
-                                                                            equalsInteger_168
-                                                                            n_222
+                                                                            equalsInteger_173
+                                                                            n_227
                                                                           ]
                                                                           (con
                                                                             8 ! 1
                                                                           )
                                                                         ]
                                                                       ]
-                                                                      (fun Unit_157 [(con integer) (con 8)])
+                                                                      (fun Unit_162 [(con integer) (con 8)])
                                                                     }
                                                                     (lam
-                                                                      thunk_225
-                                                                      Unit_157
+                                                                      thunk_230
+                                                                      Unit_162
                                                                       (con 8 ! 1
                                                                       )
                                                                     )
                                                                   ]
                                                                   (lam
-                                                                    thunk_226
-                                                                    Unit_157
+                                                                    thunk_231
+                                                                    Unit_162
                                                                     [
                                                                       [
-                                                                        addInteger_161
+                                                                        addInteger_166
                                                                         [
-                                                                          fib_221
+                                                                          fib_226
                                                                           [
                                                                             [
-                                                                              subtractInteger_162
-                                                                              n_222
+                                                                              subtractInteger_167
+                                                                              n_227
                                                                             ]
                                                                             (con
                                                                               8 ! 1
@@ -344,11 +344,11 @@
                                                                         ]
                                                                       ]
                                                                       [
-                                                                        fib_221
+                                                                        fib_226
                                                                         [
                                                                           [
-                                                                            subtractInteger_162
-                                                                            n_222
+                                                                            subtractInteger_167
+                                                                            n_227
                                                                           ]
                                                                           (con
                                                                             8 ! 2
@@ -358,11 +358,11 @@
                                                                     ]
                                                                   )
                                                                 ]
-                                                                Unit_158
+                                                                Unit_163
                                                               ]
                                                             )
                                                           ]
-                                                          Unit_158
+                                                          Unit_163
                                                         ]
                                                       )
                                                     ]
@@ -373,20 +373,20 @@
                                           ]
                                         )
                                         (lam
-                                          arg_227
+                                          arg_232
                                           [(con integer) (con 8)]
                                           (lam
-                                            arg_228
+                                            arg_233
                                             [(con integer) (con 8)]
                                             [
                                               (lam
-                                                b_229
-                                                (all a_230 (type) (fun a_230 (fun a_230 a_230)))
+                                                b_234
+                                                (all a_235 (type) (fun a_235 (fun a_235 a_235)))
                                                 [
                                                   [
-                                                    { b_229 Bool_163 } True_164
+                                                    { b_234 Bool_168 } True_169
                                                   ]
-                                                  False_165
+                                                  False_170
                                                 ]
                                               )
                                               [
@@ -395,9 +395,9 @@
                                                     (builtin equalsInteger)
                                                     (con 8)
                                                   }
-                                                  arg_227
+                                                  arg_232
                                                 ]
-                                                arg_228
+                                                arg_233
                                               ]
                                             ]
                                           )
@@ -407,32 +407,32 @@
                                   )
                                 )
                               )
-                              (all out_Bool_231 (type) (fun out_Bool_231 (fun out_Bool_231 out_Bool_231)))
+                              (all out_Bool_236 (type) (fun out_Bool_236 (fun out_Bool_236 out_Bool_236)))
                             }
                             (abs
-                              out_Bool_232
+                              out_Bool_237
                               (type)
                               (lam
-                                case_True_233
-                                out_Bool_232
-                                (lam case_False_234 out_Bool_232 case_True_233)
+                                case_True_238
+                                out_Bool_237
+                                (lam case_False_239 out_Bool_237 case_True_238)
                               )
                             )
                           ]
                           (abs
-                            out_Bool_235
+                            out_Bool_240
                             (type)
                             (lam
-                              case_True_236
-                              out_Bool_235
-                              (lam case_False_237 out_Bool_235 case_False_237)
+                              case_True_241
+                              out_Bool_240
+                              (lam case_False_242 out_Bool_240 case_False_242)
                             )
                           )
                         ]
                         (lam
-                          x_238
-                          (all out_Bool_239 (type) (fun out_Bool_239 (fun out_Bool_239 out_Bool_239)))
-                          x_238
+                          x_243
+                          (all out_Bool_244 (type) (fun out_Bool_244 (fun out_Bool_244 out_Bool_244)))
+                          x_243
                         )
                       ]
                     )
@@ -444,10 +444,10 @@
             )
           )
         )
-        (all out_Unit_240 (type) (fun out_Unit_240 out_Unit_240))
+        (all out_Unit_245 (type) (fun out_Unit_245 out_Unit_245))
       }
-      (abs out_Unit_241 (type) (lam case_Unit_242 out_Unit_241 case_Unit_242))
+      (abs out_Unit_246 (type) (lam case_Unit_247 out_Unit_246 case_Unit_247))
     ]
-    (lam x_243 (all out_Unit_244 (type) (fun out_Unit_244 out_Unit_244)) x_243)
+    (lam x_248 (all out_Unit_249 (type) (fun out_Unit_249 out_Unit_249)) x_248)
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/recursiveFunctions/sum.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveFunctions/sum.plc.golden
@@ -4,48 +4,48 @@
       [
         {
           (abs
-            List_154
+            List_159
             (fun (type) (type))
             (lam
-              Nil_155
-              (all a_156 (type) [List_154 a_156])
+              Nil_160
+              (all a_161 (type) [List_159 a_161])
               (lam
-                Cons_157
-                (all a_158 (type) (fun a_158 (fun [List_154 a_158] [List_154 a_158])))
+                Cons_162
+                (all a_163 (type) (fun a_163 (fun [List_159 a_163] [List_159 a_163])))
                 (lam
-                  Nil_match_159
-                  (all a_160 (type) (fun [List_154 a_160] [(lam a_161 (type) (all out_List_162 (type) (fun out_List_162 (fun (fun a_161 (fun [List_154 a_161] out_List_162)) out_List_162)))) a_160]))
+                  Nil_match_164
+                  (all a_165 (type) (fun [List_159 a_165] [(lam a_166 (type) (all out_List_167 (type) (fun out_List_167 (fun (fun a_166 (fun [List_159 a_166] out_List_167)) out_List_167)))) a_165]))
                   [
                     (lam
-                      addInteger_163
+                      addInteger_168
                       (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] [(con integer) (con 8)]))
                       [
                         (lam
-                          tuple_164
-                          [(lam t_0_165 (type) (all r_166 (type) (fun (fun t_0_165 r_166) r_166))) (fun [List_154 [(con integer) (con 8)]] [(con integer) (con 8)])]
+                          tuple_169
+                          [(lam t_0_170 (type) (all r_171 (type) (fun (fun t_0_170 r_171) r_171))) (fun [List_159 [(con integer) (con 8)]] [(con integer) (con 8)])]
                           [
                             (lam
-                              sum_167
-                              (fun [List_154 [(con integer) (con 8)]] [(con integer) (con 8)])
-                              sum_167
+                              sum_172
+                              (fun [List_159 [(con integer) (con 8)]] [(con integer) (con 8)])
+                              sum_172
                             )
                             [
                               {
                                 (abs
-                                  t_0_168
+                                  t_0_173
                                   (type)
                                   (lam
-                                    tuple_169
-                                    [(lam t_0_170 (type) (all r_171 (type) (fun (fun t_0_170 r_171) r_171))) t_0_168]
+                                    tuple_174
+                                    [(lam t_0_175 (type) (all r_176 (type) (fun (fun t_0_175 r_176) r_176))) t_0_173]
                                     [
-                                      { tuple_169 t_0_168 }
-                                      (lam arg_0_172 t_0_168 arg_0_172)
+                                      { tuple_174 t_0_173 }
+                                      (lam arg_0_177 t_0_173 arg_0_177)
                                     ]
                                   )
                                 )
-                                (fun [List_154 [(con integer) (con 8)]] [(con integer) (con 8)])
+                                (fun [List_159 [(con integer) (con 8)]] [(con integer) (con 8)])
                               }
-                              tuple_164
+                              tuple_169
                             ]
                           ]
                         )
@@ -53,81 +53,81 @@
                           {
                             {
                               (abs
-                                a_173
+                                a_178
                                 (type)
                                 (abs
-                                  b_174
+                                  b_179
                                   (type)
                                   [
                                     {
                                       (abs
-                                        F_175
+                                        F_180
                                         (fun (type) (type))
                                         (lam
-                                          by_176
-                                          (fun (all Q_177 (type) (fun [F_175 Q_177] Q_177)) (all Q_178 (type) (fun [F_175 Q_178] Q_178)))
+                                          by_181
+                                          (fun (all Q_182 (type) (fun [F_180 Q_182] Q_182)) (all Q_183 (type) (fun [F_180 Q_183] Q_183)))
                                           [
                                             {
                                               {
                                                 (abs
-                                                  a_179
+                                                  a_184
                                                   (type)
                                                   (abs
-                                                    b_180
+                                                    b_185
                                                     (type)
                                                     (lam
-                                                      f_181
-                                                      (fun (fun a_179 b_180) (fun a_179 b_180))
+                                                      f_186
+                                                      (fun (fun a_184 b_185) (fun a_184 b_185))
                                                       [
                                                         {
                                                           (abs
-                                                            a_182
+                                                            a_187
                                                             (type)
                                                             (lam
-                                                              s_183
-                                                              [(lam a_184 (type) (fix self_185 (fun self_185 a_184))) a_182]
+                                                              s_188
+                                                              [(lam a_189 (type) (fix self_190 (fun self_190 a_189))) a_187]
                                                               [
-                                                                (unwrap s_183)
-                                                                s_183
+                                                                (unwrap s_188)
+                                                                s_188
                                                               ]
                                                             )
                                                           )
-                                                          (fun a_179 b_180)
+                                                          (fun a_184 b_185)
                                                         }
                                                         (wrap
-                                                          self_186
-                                                          [(lam a_187 (type) (fun self_186 a_187)) (fun a_179 b_180)]
+                                                          self_191
+                                                          [(lam a_192 (type) (fun self_191 a_192)) (fun a_184 b_185)]
                                                           (lam
-                                                            s_188
-                                                            [(lam a_189 (type) (fix self_190 (fun self_190 a_189))) (fun a_179 b_180)]
+                                                            s_193
+                                                            [(lam a_194 (type) (fix self_195 (fun self_195 a_194))) (fun a_184 b_185)]
                                                             (lam
-                                                              x_191
-                                                              a_179
+                                                              x_196
+                                                              a_184
                                                               [
                                                                 [
-                                                                  f_181
+                                                                  f_186
                                                                   [
                                                                     {
                                                                       (abs
-                                                                        a_192
+                                                                        a_197
                                                                         (type)
                                                                         (lam
-                                                                          s_193
-                                                                          [(lam a_194 (type) (fix self_195 (fun self_195 a_194))) a_192]
+                                                                          s_198
+                                                                          [(lam a_199 (type) (fix self_200 (fun self_200 a_199))) a_197]
                                                                           [
                                                                             (unwrap
-                                                                              s_193
+                                                                              s_198
                                                                             )
-                                                                            s_193
+                                                                            s_198
                                                                           ]
                                                                         )
                                                                       )
-                                                                      (fun a_179 b_180)
+                                                                      (fun a_184 b_185)
                                                                     }
-                                                                    s_188
+                                                                    s_193
                                                                   ]
                                                                 ]
-                                                                x_191
+                                                                x_196
                                                               ]
                                                             )
                                                           )
@@ -136,53 +136,53 @@
                                                     )
                                                   )
                                                 )
-                                                (all Q_196 (type) (fun [F_175 Q_196] [F_175 Q_196]))
+                                                (all Q_201 (type) (fun [F_180 Q_201] [F_180 Q_201]))
                                               }
-                                              (all Q_197 (type) (fun [F_175 Q_197] Q_197))
+                                              (all Q_202 (type) (fun [F_180 Q_202] Q_202))
                                             }
                                             (lam
-                                              rec_198
-                                              (fun (all Q_199 (type) (fun [F_175 Q_199] [F_175 Q_199])) (all Q_200 (type) (fun [F_175 Q_200] Q_200)))
+                                              rec_203
+                                              (fun (all Q_204 (type) (fun [F_180 Q_204] [F_180 Q_204])) (all Q_205 (type) (fun [F_180 Q_205] Q_205)))
                                               (lam
-                                                h_201
-                                                (all Q_202 (type) (fun [F_175 Q_202] [F_175 Q_202]))
+                                                h_206
+                                                (all Q_207 (type) (fun [F_180 Q_207] [F_180 Q_207]))
                                                 (abs
-                                                  R_203
+                                                  R_208
                                                   (type)
                                                   (lam
-                                                    fr_204
-                                                    [F_175 R_203]
+                                                    fr_209
+                                                    [F_180 R_208]
                                                     [
                                                       {
                                                         [
-                                                          by_176
+                                                          by_181
                                                           (abs
-                                                            Q_205
+                                                            Q_210
                                                             (type)
                                                             (lam
-                                                              fq_206
-                                                              [F_175 Q_205]
+                                                              fq_211
+                                                              [F_180 Q_210]
                                                               [
                                                                 {
                                                                   [
-                                                                    rec_198
-                                                                    h_201
+                                                                    rec_203
+                                                                    h_206
                                                                   ]
-                                                                  Q_205
+                                                                  Q_210
                                                                 }
                                                                 [
                                                                   {
-                                                                    h_201 Q_205
+                                                                    h_206 Q_210
                                                                   }
-                                                                  fq_206
+                                                                  fq_211
                                                                 ]
                                                               ]
                                                             )
                                                           )
                                                         ]
-                                                        R_203
+                                                        R_208
                                                       }
-                                                      fr_204
+                                                      fr_209
                                                     ]
                                                   )
                                                 )
@@ -191,28 +191,28 @@
                                           ]
                                         )
                                       )
-                                      (lam X_207 (type) (fun (fun a_173 b_174) X_207))
+                                      (lam X_212 (type) (fun (fun a_178 b_179) X_212))
                                     }
                                     (lam
-                                      k_208
-                                      (all Q_209 (type) (fun (fun (fun a_173 b_174) Q_209) Q_209))
+                                      k_213
+                                      (all Q_214 (type) (fun (fun (fun a_178 b_179) Q_214) Q_214))
                                       (abs
-                                        S_210
+                                        S_215
                                         (type)
                                         (lam
-                                          h_211
-                                          (fun (fun a_173 b_174) S_210)
+                                          h_216
+                                          (fun (fun a_178 b_179) S_215)
                                           [
-                                            h_211
+                                            h_216
                                             (lam
-                                              x_212
-                                              a_173
+                                              x_217
+                                              a_178
                                               [
-                                                { k_208 b_174 }
+                                                { k_213 b_179 }
                                                 (lam
-                                                  f_213
-                                                  (fun a_173 b_174)
-                                                  [ f_213 x_212 ]
+                                                  f_218
+                                                  (fun a_178 b_179)
+                                                  [ f_218 x_217 ]
                                                 )
                                               ]
                                             )
@@ -223,47 +223,47 @@
                                   ]
                                 )
                               )
-                              [List_154 [(con integer) (con 8)]]
+                              [List_159 [(con integer) (con 8)]]
                             }
                             [(con integer) (con 8)]
                           }
                           (abs
-                            Q_214
+                            Q_219
                             (type)
                             (lam
-                              choose_215
-                              (fun (fun [List_154 [(con integer) (con 8)]] [(con integer) (con 8)]) Q_214)
+                              choose_220
+                              (fun (fun [List_159 [(con integer) (con 8)]] [(con integer) (con 8)]) Q_219)
                               (lam
-                                sum_216
-                                (fun [List_154 [(con integer) (con 8)]] [(con integer) (con 8)])
+                                sum_221
+                                (fun [List_159 [(con integer) (con 8)]] [(con integer) (con 8)])
                                 [
-                                  choose_215
+                                  choose_220
                                   (lam
-                                    ds_217
-                                    [List_154 [(con integer) (con 8)]]
+                                    ds_222
+                                    [List_159 [(con integer) (con 8)]]
                                     [
                                       [
                                         {
                                           [
                                             {
-                                              Nil_match_159
+                                              Nil_match_164
                                               [(con integer) (con 8)]
                                             }
-                                            ds_217
+                                            ds_222
                                           ]
                                           [(con integer) (con 8)]
                                         }
                                         (con 8 ! 0)
                                       ]
                                       (lam
-                                        x_218
+                                        x_223
                                         [(con integer) (con 8)]
                                         (lam
-                                          xs_219
-                                          [List_154 [(con integer) (con 8)]]
+                                          xs_224
+                                          [List_159 [(con integer) (con 8)]]
                                           [
-                                            [ addInteger_163 x_218 ]
-                                            [ sum_216 xs_219 ]
+                                            [ addInteger_168 x_223 ]
+                                            [ sum_221 xs_224 ]
                                           ]
                                         )
                                       )
@@ -282,24 +282,24 @@
               )
             )
           )
-          (fix List_220 (lam a_221 (type) (all out_List_222 (type) (fun out_List_222 (fun (fun a_221 (fun [List_220 a_221] out_List_222)) out_List_222)))))
+          (fix List_225 (lam a_226 (type) (all out_List_227 (type) (fun out_List_227 (fun (fun a_226 (fun [List_225 a_226] out_List_227)) out_List_227)))))
         }
         (abs
-          a_223
+          a_228
           (type)
           (wrap
-            List_224
-            (lam a_225 (type) (all out_List_226 (type) (fun out_List_226 (fun (fun a_225 (fun [List_224 a_225] out_List_226)) out_List_226))))
+            List_229
+            (lam a_230 (type) (all out_List_231 (type) (fun out_List_231 (fun (fun a_230 (fun [List_229 a_230] out_List_231)) out_List_231))))
             (abs
-              out_List_227
+              out_List_232
               (type)
               (lam
-                case_Nil_228
-                out_List_227
+                case_Nil_233
+                out_List_232
                 (lam
-                  case_Cons_229
-                  (fun a_223 (fun [List_224 a_223] out_List_227))
-                  case_Nil_228
+                  case_Cons_234
+                  (fun a_228 (fun [List_229 a_228] out_List_232))
+                  case_Nil_233
                 )
               )
             )
@@ -307,27 +307,27 @@
         )
       ]
       (abs
-        a_230
+        a_235
         (type)
         (lam
-          arg_0_231
-          a_230
+          arg_0_236
+          a_235
           (lam
-            arg_1_232
-            [(fix List_233 (lam a_234 (type) (all out_List_235 (type) (fun out_List_235 (fun (fun a_234 (fun [List_233 a_234] out_List_235)) out_List_235))))) a_230]
+            arg_1_237
+            [(fix List_238 (lam a_239 (type) (all out_List_240 (type) (fun out_List_240 (fun (fun a_239 (fun [List_238 a_239] out_List_240)) out_List_240))))) a_235]
             (wrap
-              List_236
-              (lam a_237 (type) (all out_List_238 (type) (fun out_List_238 (fun (fun a_237 (fun [List_236 a_237] out_List_238)) out_List_238))))
+              List_241
+              (lam a_242 (type) (all out_List_243 (type) (fun out_List_243 (fun (fun a_242 (fun [List_241 a_242] out_List_243)) out_List_243))))
               (abs
-                out_List_239
+                out_List_244
                 (type)
                 (lam
-                  case_Nil_240
-                  out_List_239
+                  case_Nil_245
+                  out_List_244
                   (lam
-                    case_Cons_241
-                    (fun a_230 (fun [List_236 a_230] out_List_239))
-                    [ [ case_Cons_241 arg_0_231 ] arg_1_232 ]
+                    case_Cons_246
+                    (fun a_235 (fun [List_241 a_235] out_List_244))
+                    [ [ case_Cons_246 arg_0_236 ] arg_1_237 ]
                   )
                 )
               )
@@ -337,12 +337,12 @@
       )
     ]
     (abs
-      a_242
+      a_247
       (type)
       (lam
-        x_243
-        [(fix List_244 (lam a_245 (type) (all out_List_246 (type) (fun out_List_246 (fun (fun a_245 (fun [List_244 a_245] out_List_246)) out_List_246))))) a_242]
-        (unwrap x_243)
+        x_248
+        [(fix List_249 (lam a_250 (type) (all out_List_251 (type) (fun out_List_251 (fun (fun a_250 (fun [List_249 a_250] out_List_251)) out_List_251))))) a_247]
+        (unwrap x_248)
       )
     )
   ]

--- a/plutus-tx-plugin/test/Plugin/recursiveTypes/listConstruct.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveTypes/listConstruct.plc.golden
@@ -4,40 +4,40 @@
       [
         {
           (abs
-            List_82
+            List_87
             (fun (type) (type))
             (lam
-              Nil_83
-              (all a_84 (type) [List_82 a_84])
+              Nil_88
+              (all a_89 (type) [List_87 a_89])
               (lam
-                Cons_85
-                (all a_86 (type) (fun a_86 (fun [List_82 a_86] [List_82 a_86])))
+                Cons_90
+                (all a_91 (type) (fun a_91 (fun [List_87 a_91] [List_87 a_91])))
                 (lam
-                  Nil_match_87
-                  (all a_88 (type) (fun [List_82 a_88] [(lam a_89 (type) (all out_List_90 (type) (fun out_List_90 (fun (fun a_89 (fun [List_82 a_89] out_List_90)) out_List_90)))) a_88]))
-                  { Nil_83 [(con integer) (con 8)] }
+                  Nil_match_92
+                  (all a_93 (type) (fun [List_87 a_93] [(lam a_94 (type) (all out_List_95 (type) (fun out_List_95 (fun (fun a_94 (fun [List_87 a_94] out_List_95)) out_List_95)))) a_93]))
+                  { Nil_88 [(con integer) (con 8)] }
                 )
               )
             )
           )
-          (fix List_91 (lam a_92 (type) (all out_List_93 (type) (fun out_List_93 (fun (fun a_92 (fun [List_91 a_92] out_List_93)) out_List_93)))))
+          (fix List_96 (lam a_97 (type) (all out_List_98 (type) (fun out_List_98 (fun (fun a_97 (fun [List_96 a_97] out_List_98)) out_List_98)))))
         }
         (abs
-          a_94
+          a_99
           (type)
           (wrap
-            List_95
-            (lam a_96 (type) (all out_List_97 (type) (fun out_List_97 (fun (fun a_96 (fun [List_95 a_96] out_List_97)) out_List_97))))
+            List_100
+            (lam a_101 (type) (all out_List_102 (type) (fun out_List_102 (fun (fun a_101 (fun [List_100 a_101] out_List_102)) out_List_102))))
             (abs
-              out_List_98
+              out_List_103
               (type)
               (lam
-                case_Nil_99
-                out_List_98
+                case_Nil_104
+                out_List_103
                 (lam
-                  case_Cons_100
-                  (fun a_94 (fun [List_95 a_94] out_List_98))
-                  case_Nil_99
+                  case_Cons_105
+                  (fun a_99 (fun [List_100 a_99] out_List_103))
+                  case_Nil_104
                 )
               )
             )
@@ -45,27 +45,27 @@
         )
       ]
       (abs
-        a_101
+        a_106
         (type)
         (lam
-          arg_0_102
-          a_101
+          arg_0_107
+          a_106
           (lam
-            arg_1_103
-            [(fix List_104 (lam a_105 (type) (all out_List_106 (type) (fun out_List_106 (fun (fun a_105 (fun [List_104 a_105] out_List_106)) out_List_106))))) a_101]
+            arg_1_108
+            [(fix List_109 (lam a_110 (type) (all out_List_111 (type) (fun out_List_111 (fun (fun a_110 (fun [List_109 a_110] out_List_111)) out_List_111))))) a_106]
             (wrap
-              List_107
-              (lam a_108 (type) (all out_List_109 (type) (fun out_List_109 (fun (fun a_108 (fun [List_107 a_108] out_List_109)) out_List_109))))
+              List_112
+              (lam a_113 (type) (all out_List_114 (type) (fun out_List_114 (fun (fun a_113 (fun [List_112 a_113] out_List_114)) out_List_114))))
               (abs
-                out_List_110
+                out_List_115
                 (type)
                 (lam
-                  case_Nil_111
-                  out_List_110
+                  case_Nil_116
+                  out_List_115
                   (lam
-                    case_Cons_112
-                    (fun a_101 (fun [List_107 a_101] out_List_110))
-                    [ [ case_Cons_112 arg_0_102 ] arg_1_103 ]
+                    case_Cons_117
+                    (fun a_106 (fun [List_112 a_106] out_List_115))
+                    [ [ case_Cons_117 arg_0_107 ] arg_1_108 ]
                   )
                 )
               )
@@ -75,12 +75,12 @@
       )
     ]
     (abs
-      a_113
+      a_118
       (type)
       (lam
-        x_114
-        [(fix List_115 (lam a_116 (type) (all out_List_117 (type) (fun out_List_117 (fun (fun a_116 (fun [List_115 a_116] out_List_117)) out_List_117))))) a_113]
-        (unwrap x_114)
+        x_119
+        [(fix List_120 (lam a_121 (type) (all out_List_122 (type) (fun out_List_122 (fun (fun a_121 (fun [List_120 a_121] out_List_122)) out_List_122))))) a_118]
+        (unwrap x_119)
       )
     )
   ]

--- a/plutus-tx-plugin/test/Plugin/recursiveTypes/listConstruct2.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveTypes/listConstruct2.plc.golden
@@ -4,43 +4,43 @@
       [
         {
           (abs
-            List_82
+            List_87
             (fun (type) (type))
             (lam
-              Nil_83
-              (all a_84 (type) [List_82 a_84])
+              Nil_88
+              (all a_89 (type) [List_87 a_89])
               (lam
-                Cons_85
-                (all a_86 (type) (fun a_86 (fun [List_82 a_86] [List_82 a_86])))
+                Cons_90
+                (all a_91 (type) (fun a_91 (fun [List_87 a_91] [List_87 a_91])))
                 (lam
-                  Nil_match_87
-                  (all a_88 (type) (fun [List_82 a_88] [(lam a_89 (type) (all out_List_90 (type) (fun out_List_90 (fun (fun a_89 (fun [List_82 a_89] out_List_90)) out_List_90)))) a_88]))
+                  Nil_match_92
+                  (all a_93 (type) (fun [List_87 a_93] [(lam a_94 (type) (all out_List_95 (type) (fun out_List_95 (fun (fun a_94 (fun [List_87 a_94] out_List_95)) out_List_95)))) a_93]))
                   [
-                    [ { Cons_85 [(con integer) (con 8)] } (con 8 ! 1) ]
-                    { Nil_83 [(con integer) (con 8)] }
+                    [ { Cons_90 [(con integer) (con 8)] } (con 8 ! 1) ]
+                    { Nil_88 [(con integer) (con 8)] }
                   ]
                 )
               )
             )
           )
-          (fix List_91 (lam a_92 (type) (all out_List_93 (type) (fun out_List_93 (fun (fun a_92 (fun [List_91 a_92] out_List_93)) out_List_93)))))
+          (fix List_96 (lam a_97 (type) (all out_List_98 (type) (fun out_List_98 (fun (fun a_97 (fun [List_96 a_97] out_List_98)) out_List_98)))))
         }
         (abs
-          a_94
+          a_99
           (type)
           (wrap
-            List_95
-            (lam a_96 (type) (all out_List_97 (type) (fun out_List_97 (fun (fun a_96 (fun [List_95 a_96] out_List_97)) out_List_97))))
+            List_100
+            (lam a_101 (type) (all out_List_102 (type) (fun out_List_102 (fun (fun a_101 (fun [List_100 a_101] out_List_102)) out_List_102))))
             (abs
-              out_List_98
+              out_List_103
               (type)
               (lam
-                case_Nil_99
-                out_List_98
+                case_Nil_104
+                out_List_103
                 (lam
-                  case_Cons_100
-                  (fun a_94 (fun [List_95 a_94] out_List_98))
-                  case_Nil_99
+                  case_Cons_105
+                  (fun a_99 (fun [List_100 a_99] out_List_103))
+                  case_Nil_104
                 )
               )
             )
@@ -48,27 +48,27 @@
         )
       ]
       (abs
-        a_101
+        a_106
         (type)
         (lam
-          arg_0_102
-          a_101
+          arg_0_107
+          a_106
           (lam
-            arg_1_103
-            [(fix List_104 (lam a_105 (type) (all out_List_106 (type) (fun out_List_106 (fun (fun a_105 (fun [List_104 a_105] out_List_106)) out_List_106))))) a_101]
+            arg_1_108
+            [(fix List_109 (lam a_110 (type) (all out_List_111 (type) (fun out_List_111 (fun (fun a_110 (fun [List_109 a_110] out_List_111)) out_List_111))))) a_106]
             (wrap
-              List_107
-              (lam a_108 (type) (all out_List_109 (type) (fun out_List_109 (fun (fun a_108 (fun [List_107 a_108] out_List_109)) out_List_109))))
+              List_112
+              (lam a_113 (type) (all out_List_114 (type) (fun out_List_114 (fun (fun a_113 (fun [List_112 a_113] out_List_114)) out_List_114))))
               (abs
-                out_List_110
+                out_List_115
                 (type)
                 (lam
-                  case_Nil_111
-                  out_List_110
+                  case_Nil_116
+                  out_List_115
                   (lam
-                    case_Cons_112
-                    (fun a_101 (fun [List_107 a_101] out_List_110))
-                    [ [ case_Cons_112 arg_0_102 ] arg_1_103 ]
+                    case_Cons_117
+                    (fun a_106 (fun [List_112 a_106] out_List_115))
+                    [ [ case_Cons_117 arg_0_107 ] arg_1_108 ]
                   )
                 )
               )
@@ -78,12 +78,12 @@
       )
     ]
     (abs
-      a_113
+      a_118
       (type)
       (lam
-        x_114
-        [(fix List_115 (lam a_116 (type) (all out_List_117 (type) (fun out_List_117 (fun (fun a_116 (fun [List_115 a_116] out_List_117)) out_List_117))))) a_113]
-        (unwrap x_114)
+        x_119
+        [(fix List_120 (lam a_121 (type) (all out_List_122 (type) (fun out_List_122 (fun (fun a_121 (fun [List_120 a_121] out_List_122)) out_List_122))))) a_118]
+        (unwrap x_119)
       )
     )
   ]

--- a/plutus-tx-plugin/test/Plugin/recursiveTypes/listConstruct3.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveTypes/listConstruct3.plc.golden
@@ -4,24 +4,24 @@
       [
         {
           (abs
-            List_82
+            List_87
             (fun (type) (type))
             (lam
-              Nil_83
-              (all a_84 (type) [List_82 a_84])
+              Nil_88
+              (all a_89 (type) [List_87 a_89])
               (lam
-                Cons_85
-                (all a_86 (type) (fun a_86 (fun [List_82 a_86] [List_82 a_86])))
+                Cons_90
+                (all a_91 (type) (fun a_91 (fun [List_87 a_91] [List_87 a_91])))
                 (lam
-                  Nil_match_87
-                  (all a_88 (type) (fun [List_82 a_88] [(lam a_89 (type) (all out_List_90 (type) (fun out_List_90 (fun (fun a_89 (fun [List_82 a_89] out_List_90)) out_List_90)))) a_88]))
+                  Nil_match_92
+                  (all a_93 (type) (fun [List_87 a_93] [(lam a_94 (type) (all out_List_95 (type) (fun out_List_95 (fun (fun a_94 (fun [List_87 a_94] out_List_95)) out_List_95)))) a_93]))
                   [
-                    [ { Cons_85 [(con integer) (con 8)] } (con 8 ! 1) ]
+                    [ { Cons_90 [(con integer) (con 8)] } (con 8 ! 1) ]
                     [
-                      [ { Cons_85 [(con integer) (con 8)] } (con 8 ! 2) ]
+                      [ { Cons_90 [(con integer) (con 8)] } (con 8 ! 2) ]
                       [
-                        [ { Cons_85 [(con integer) (con 8)] } (con 8 ! 3) ]
-                        { Nil_83 [(con integer) (con 8)] }
+                        [ { Cons_90 [(con integer) (con 8)] } (con 8 ! 3) ]
+                        { Nil_88 [(con integer) (con 8)] }
                       ]
                     ]
                   ]
@@ -29,24 +29,24 @@
               )
             )
           )
-          (fix List_91 (lam a_92 (type) (all out_List_93 (type) (fun out_List_93 (fun (fun a_92 (fun [List_91 a_92] out_List_93)) out_List_93)))))
+          (fix List_96 (lam a_97 (type) (all out_List_98 (type) (fun out_List_98 (fun (fun a_97 (fun [List_96 a_97] out_List_98)) out_List_98)))))
         }
         (abs
-          a_94
+          a_99
           (type)
           (wrap
-            List_95
-            (lam a_96 (type) (all out_List_97 (type) (fun out_List_97 (fun (fun a_96 (fun [List_95 a_96] out_List_97)) out_List_97))))
+            List_100
+            (lam a_101 (type) (all out_List_102 (type) (fun out_List_102 (fun (fun a_101 (fun [List_100 a_101] out_List_102)) out_List_102))))
             (abs
-              out_List_98
+              out_List_103
               (type)
               (lam
-                case_Nil_99
-                out_List_98
+                case_Nil_104
+                out_List_103
                 (lam
-                  case_Cons_100
-                  (fun a_94 (fun [List_95 a_94] out_List_98))
-                  case_Nil_99
+                  case_Cons_105
+                  (fun a_99 (fun [List_100 a_99] out_List_103))
+                  case_Nil_104
                 )
               )
             )
@@ -54,27 +54,27 @@
         )
       ]
       (abs
-        a_101
+        a_106
         (type)
         (lam
-          arg_0_102
-          a_101
+          arg_0_107
+          a_106
           (lam
-            arg_1_103
-            [(fix List_104 (lam a_105 (type) (all out_List_106 (type) (fun out_List_106 (fun (fun a_105 (fun [List_104 a_105] out_List_106)) out_List_106))))) a_101]
+            arg_1_108
+            [(fix List_109 (lam a_110 (type) (all out_List_111 (type) (fun out_List_111 (fun (fun a_110 (fun [List_109 a_110] out_List_111)) out_List_111))))) a_106]
             (wrap
-              List_107
-              (lam a_108 (type) (all out_List_109 (type) (fun out_List_109 (fun (fun a_108 (fun [List_107 a_108] out_List_109)) out_List_109))))
+              List_112
+              (lam a_113 (type) (all out_List_114 (type) (fun out_List_114 (fun (fun a_113 (fun [List_112 a_113] out_List_114)) out_List_114))))
               (abs
-                out_List_110
+                out_List_115
                 (type)
                 (lam
-                  case_Nil_111
-                  out_List_110
+                  case_Nil_116
+                  out_List_115
                   (lam
-                    case_Cons_112
-                    (fun a_101 (fun [List_107 a_101] out_List_110))
-                    [ [ case_Cons_112 arg_0_102 ] arg_1_103 ]
+                    case_Cons_117
+                    (fun a_106 (fun [List_112 a_106] out_List_115))
+                    [ [ case_Cons_117 arg_0_107 ] arg_1_108 ]
                   )
                 )
               )
@@ -84,12 +84,12 @@
       )
     ]
     (abs
-      a_113
+      a_118
       (type)
       (lam
-        x_114
-        [(fix List_115 (lam a_116 (type) (all out_List_117 (type) (fun out_List_117 (fun (fun a_116 (fun [List_115 a_116] out_List_117)) out_List_117))))) a_113]
-        (unwrap x_114)
+        x_119
+        [(fix List_120 (lam a_121 (type) (all out_List_122 (type) (fun out_List_122 (fun (fun a_121 (fun [List_120 a_121] out_List_122)) out_List_122))))) a_118]
+        (unwrap x_119)
       )
     )
   ]

--- a/plutus-tx-plugin/test/Plugin/recursiveTypes/listMatch.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveTypes/listMatch.plc.golden
@@ -4,32 +4,32 @@
       [
         {
           (abs
-            List_86
+            List_91
             (fun (type) (type))
             (lam
-              Nil_87
-              (all a_88 (type) [List_86 a_88])
+              Nil_92
+              (all a_93 (type) [List_91 a_93])
               (lam
-                Cons_89
-                (all a_90 (type) (fun a_90 (fun [List_86 a_90] [List_86 a_90])))
+                Cons_94
+                (all a_95 (type) (fun a_95 (fun [List_91 a_95] [List_91 a_95])))
                 (lam
-                  Nil_match_91
-                  (all a_92 (type) (fun [List_86 a_92] [(lam a_93 (type) (all out_List_94 (type) (fun out_List_94 (fun (fun a_93 (fun [List_86 a_93] out_List_94)) out_List_94)))) a_92]))
+                  Nil_match_96
+                  (all a_97 (type) (fun [List_91 a_97] [(lam a_98 (type) (all out_List_99 (type) (fun out_List_99 (fun (fun a_98 (fun [List_91 a_98] out_List_99)) out_List_99)))) a_97]))
                   (lam
-                    ds_95
-                    [List_86 [(con integer) (con 8)]]
+                    ds_100
+                    [List_91 [(con integer) (con 8)]]
                     [
                       [
                         {
-                          [ { Nil_match_91 [(con integer) (con 8)] } ds_95 ]
+                          [ { Nil_match_96 [(con integer) (con 8)] } ds_100 ]
                           [(con integer) (con 8)]
                         }
                         (con 8 ! 0)
                       ]
                       (lam
-                        x_96
+                        x_101
                         [(con integer) (con 8)]
-                        (lam ds_97 [List_86 [(con integer) (con 8)]] x_96)
+                        (lam ds_102 [List_91 [(con integer) (con 8)]] x_101)
                       )
                     ]
                   )
@@ -37,24 +37,24 @@
               )
             )
           )
-          (fix List_98 (lam a_99 (type) (all out_List_100 (type) (fun out_List_100 (fun (fun a_99 (fun [List_98 a_99] out_List_100)) out_List_100)))))
+          (fix List_103 (lam a_104 (type) (all out_List_105 (type) (fun out_List_105 (fun (fun a_104 (fun [List_103 a_104] out_List_105)) out_List_105)))))
         }
         (abs
-          a_101
+          a_106
           (type)
           (wrap
-            List_102
-            (lam a_103 (type) (all out_List_104 (type) (fun out_List_104 (fun (fun a_103 (fun [List_102 a_103] out_List_104)) out_List_104))))
+            List_107
+            (lam a_108 (type) (all out_List_109 (type) (fun out_List_109 (fun (fun a_108 (fun [List_107 a_108] out_List_109)) out_List_109))))
             (abs
-              out_List_105
+              out_List_110
               (type)
               (lam
-                case_Nil_106
-                out_List_105
+                case_Nil_111
+                out_List_110
                 (lam
-                  case_Cons_107
-                  (fun a_101 (fun [List_102 a_101] out_List_105))
-                  case_Nil_106
+                  case_Cons_112
+                  (fun a_106 (fun [List_107 a_106] out_List_110))
+                  case_Nil_111
                 )
               )
             )
@@ -62,27 +62,27 @@
         )
       ]
       (abs
-        a_108
+        a_113
         (type)
         (lam
-          arg_0_109
-          a_108
+          arg_0_114
+          a_113
           (lam
-            arg_1_110
-            [(fix List_111 (lam a_112 (type) (all out_List_113 (type) (fun out_List_113 (fun (fun a_112 (fun [List_111 a_112] out_List_113)) out_List_113))))) a_108]
+            arg_1_115
+            [(fix List_116 (lam a_117 (type) (all out_List_118 (type) (fun out_List_118 (fun (fun a_117 (fun [List_116 a_117] out_List_118)) out_List_118))))) a_113]
             (wrap
-              List_114
-              (lam a_115 (type) (all out_List_116 (type) (fun out_List_116 (fun (fun a_115 (fun [List_114 a_115] out_List_116)) out_List_116))))
+              List_119
+              (lam a_120 (type) (all out_List_121 (type) (fun out_List_121 (fun (fun a_120 (fun [List_119 a_120] out_List_121)) out_List_121))))
               (abs
-                out_List_117
+                out_List_122
                 (type)
                 (lam
-                  case_Nil_118
-                  out_List_117
+                  case_Nil_123
+                  out_List_122
                   (lam
-                    case_Cons_119
-                    (fun a_108 (fun [List_114 a_108] out_List_117))
-                    [ [ case_Cons_119 arg_0_109 ] arg_1_110 ]
+                    case_Cons_124
+                    (fun a_113 (fun [List_119 a_113] out_List_122))
+                    [ [ case_Cons_124 arg_0_114 ] arg_1_115 ]
                   )
                 )
               )
@@ -92,12 +92,12 @@
       )
     ]
     (abs
-      a_120
+      a_125
       (type)
       (lam
-        x_121
-        [(fix List_122 (lam a_123 (type) (all out_List_124 (type) (fun out_List_124 (fun (fun a_123 (fun [List_122 a_123] out_List_124)) out_List_124))))) a_120]
-        (unwrap x_121)
+        x_126
+        [(fix List_127 (lam a_128 (type) (all out_List_129 (type) (fun out_List_129 (fun (fun a_128 (fun [List_127 a_128] out_List_129)) out_List_129))))) a_125]
+        (unwrap x_126)
       )
     )
   ]

--- a/plutus-tx-plugin/test/Plugin/recursiveTypes/ptreeConstruct.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveTypes/ptreeConstruct.plc.golden
@@ -3,58 +3,58 @@
     [
       {
         (abs
-          Tuple2_93
+          Tuple2_98
           (fun (type) (fun (type) (type)))
           (lam
-            Tuple2_94
-            (all a_95 (type) (all b_96 (type) (fun a_95 (fun b_96 [[Tuple2_93 a_95] b_96]))))
+            Tuple2_99
+            (all a_100 (type) (all b_101 (type) (fun a_100 (fun b_101 [[Tuple2_98 a_100] b_101]))))
             (lam
-              Tuple2_match_97
-              (all a_98 (type) (all b_99 (type) (fun [[Tuple2_93 a_98] b_99] [[(lam a_100 (type) (lam b_101 (type) (all out_Tuple2_102 (type) (fun (fun a_100 (fun b_101 out_Tuple2_102)) out_Tuple2_102)))) a_98] b_99])))
+              Tuple2_match_102
+              (all a_103 (type) (all b_104 (type) (fun [[Tuple2_98 a_103] b_104] [[(lam a_105 (type) (lam b_106 (type) (all out_Tuple2_107 (type) (fun (fun a_105 (fun b_106 out_Tuple2_107)) out_Tuple2_107)))) a_103] b_104])))
               [
                 [
                   [
                     {
                       (abs
-                        B_103
+                        B_108
                         (fun (type) (type))
                         (lam
-                          One_104
-                          (all a_105 (type) (fun a_105 [B_103 a_105]))
+                          One_109
+                          (all a_110 (type) (fun a_110 [B_108 a_110]))
                           (lam
-                            Two_106
-                            (all a_107 (type) (fun [B_103 [[Tuple2_93 a_107] a_107]] [B_103 a_107]))
+                            Two_111
+                            (all a_112 (type) (fun [B_108 [[Tuple2_98 a_112] a_112]] [B_108 a_112]))
                             (lam
-                              B_match_108
-                              (all a_109 (type) (fun [B_103 a_109] [(lam a_110 (type) (all out_B_111 (type) (fun (fun a_110 out_B_111) (fun (fun [B_103 [[Tuple2_93 a_110] a_110]] out_B_111) out_B_111)))) a_109]))
+                              B_match_113
+                              (all a_114 (type) (fun [B_108 a_114] [(lam a_115 (type) (all out_B_116 (type) (fun (fun a_115 out_B_116) (fun (fun [B_108 [[Tuple2_98 a_115] a_115]] out_B_116) out_B_116)))) a_114]))
                               [
                                 {
-                                  Two_106 [(con integer) (con 8)]
+                                  Two_111 [(con integer) (con 8)]
                                 }
                                 [
                                   {
-                                    Two_106
-                                    [[Tuple2_93 [(con integer) (con 8)]] [(con integer) (con 8)]]
+                                    Two_111
+                                    [[Tuple2_98 [(con integer) (con 8)]] [(con integer) (con 8)]]
                                   }
                                   [
                                     {
-                                      One_104
-                                      [[Tuple2_93 [[Tuple2_93 [(con integer) (con 8)]] [(con integer) (con 8)]]] [[Tuple2_93 [(con integer) (con 8)]] [(con integer) (con 8)]]]
+                                      One_109
+                                      [[Tuple2_98 [[Tuple2_98 [(con integer) (con 8)]] [(con integer) (con 8)]]] [[Tuple2_98 [(con integer) (con 8)]] [(con integer) (con 8)]]]
                                     }
                                     [
                                       [
                                         {
                                           {
-                                            Tuple2_94
-                                            [[Tuple2_93 [(con integer) (con 8)]] [(con integer) (con 8)]]
+                                            Tuple2_99
+                                            [[Tuple2_98 [(con integer) (con 8)]] [(con integer) (con 8)]]
                                           }
-                                          [[Tuple2_93 [(con integer) (con 8)]] [(con integer) (con 8)]]
+                                          [[Tuple2_98 [(con integer) (con 8)]] [(con integer) (con 8)]]
                                         }
                                         [
                                           [
                                             {
                                               {
-                                                Tuple2_94
+                                                Tuple2_99
                                                 [(con integer) (con 8)]
                                               }
                                               [(con integer) (con 8)]
@@ -68,7 +68,7 @@
                                         [
                                           {
                                             {
-                                              Tuple2_94 [(con integer) (con 8)]
+                                              Tuple2_99 [(con integer) (con 8)]
                                             }
                                             [(con integer) (con 8)]
                                           }
@@ -84,27 +84,27 @@
                           )
                         )
                       )
-                      (fix B_112 (lam a_113 (type) (all out_B_114 (type) (fun (fun a_113 out_B_114) (fun (fun [B_112 [[Tuple2_93 a_113] a_113]] out_B_114) out_B_114)))))
+                      (fix B_117 (lam a_118 (type) (all out_B_119 (type) (fun (fun a_118 out_B_119) (fun (fun [B_117 [[Tuple2_98 a_118] a_118]] out_B_119) out_B_119)))))
                     }
                     (abs
-                      a_115
+                      a_120
                       (type)
                       (lam
-                        arg_0_116
-                        a_115
+                        arg_0_121
+                        a_120
                         (wrap
-                          B_117
-                          (lam a_118 (type) (all out_B_119 (type) (fun (fun a_118 out_B_119) (fun (fun [B_117 [[Tuple2_93 a_118] a_118]] out_B_119) out_B_119))))
+                          B_122
+                          (lam a_123 (type) (all out_B_124 (type) (fun (fun a_123 out_B_124) (fun (fun [B_122 [[Tuple2_98 a_123] a_123]] out_B_124) out_B_124))))
                           (abs
-                            out_B_120
+                            out_B_125
                             (type)
                             (lam
-                              case_One_121
-                              (fun a_115 out_B_120)
+                              case_One_126
+                              (fun a_120 out_B_125)
                               (lam
-                                case_Two_122
-                                (fun [B_117 [[Tuple2_93 a_115] a_115]] out_B_120)
-                                [ case_One_121 arg_0_116 ]
+                                case_Two_127
+                                (fun [B_122 [[Tuple2_98 a_120] a_120]] out_B_125)
+                                [ case_One_126 arg_0_121 ]
                               )
                             )
                           )
@@ -113,24 +113,24 @@
                     )
                   ]
                   (abs
-                    a_123
+                    a_128
                     (type)
                     (lam
-                      arg_0_124
-                      [(fix B_125 (lam a_126 (type) (all out_B_127 (type) (fun (fun a_126 out_B_127) (fun (fun [B_125 [[Tuple2_93 a_126] a_126]] out_B_127) out_B_127))))) [[Tuple2_93 a_123] a_123]]
+                      arg_0_129
+                      [(fix B_130 (lam a_131 (type) (all out_B_132 (type) (fun (fun a_131 out_B_132) (fun (fun [B_130 [[Tuple2_98 a_131] a_131]] out_B_132) out_B_132))))) [[Tuple2_98 a_128] a_128]]
                       (wrap
-                        B_128
-                        (lam a_129 (type) (all out_B_130 (type) (fun (fun a_129 out_B_130) (fun (fun [B_128 [[Tuple2_93 a_129] a_129]] out_B_130) out_B_130))))
+                        B_133
+                        (lam a_134 (type) (all out_B_135 (type) (fun (fun a_134 out_B_135) (fun (fun [B_133 [[Tuple2_98 a_134] a_134]] out_B_135) out_B_135))))
                         (abs
-                          out_B_131
+                          out_B_136
                           (type)
                           (lam
-                            case_One_132
-                            (fun a_123 out_B_131)
+                            case_One_137
+                            (fun a_128 out_B_136)
                             (lam
-                              case_Two_133
-                              (fun [B_128 [[Tuple2_93 a_123] a_123]] out_B_131)
-                              [ case_Two_133 arg_0_124 ]
+                              case_Two_138
+                              (fun [B_133 [[Tuple2_98 a_128] a_128]] out_B_136)
+                              [ case_Two_138 arg_0_129 ]
                             )
                           )
                         )
@@ -139,39 +139,39 @@
                   )
                 ]
                 (abs
-                  a_134
+                  a_139
                   (type)
                   (lam
-                    x_135
-                    [(fix B_136 (lam a_137 (type) (all out_B_138 (type) (fun (fun a_137 out_B_138) (fun (fun [B_136 [[Tuple2_93 a_137] a_137]] out_B_138) out_B_138))))) a_134]
-                    (unwrap x_135)
+                    x_140
+                    [(fix B_141 (lam a_142 (type) (all out_B_143 (type) (fun (fun a_142 out_B_143) (fun (fun [B_141 [[Tuple2_98 a_142] a_142]] out_B_143) out_B_143))))) a_139]
+                    (unwrap x_140)
                   )
                 )
               ]
             )
           )
         )
-        (lam a_139 (type) (lam b_140 (type) (all out_Tuple2_141 (type) (fun (fun a_139 (fun b_140 out_Tuple2_141)) out_Tuple2_141))))
+        (lam a_144 (type) (lam b_145 (type) (all out_Tuple2_146 (type) (fun (fun a_144 (fun b_145 out_Tuple2_146)) out_Tuple2_146))))
       }
       (abs
-        a_142
+        a_147
         (type)
         (abs
-          b_143
+          b_148
           (type)
           (lam
-            arg_0_144
-            a_142
+            arg_0_149
+            a_147
             (lam
-              arg_1_145
-              b_143
+              arg_1_150
+              b_148
               (abs
-                out_Tuple2_146
+                out_Tuple2_151
                 (type)
                 (lam
-                  case_Tuple2_147
-                  (fun a_142 (fun b_143 out_Tuple2_146))
-                  [ [ case_Tuple2_147 arg_0_144 ] arg_1_145 ]
+                  case_Tuple2_152
+                  (fun a_147 (fun b_148 out_Tuple2_151))
+                  [ [ case_Tuple2_152 arg_0_149 ] arg_1_150 ]
                 )
               )
             )
@@ -180,15 +180,15 @@
       )
     ]
     (abs
-      a_148
+      a_153
       (type)
       (abs
-        b_149
+        b_154
         (type)
         (lam
-          x_150
-          [[(lam a_151 (type) (lam b_152 (type) (all out_Tuple2_153 (type) (fun (fun a_151 (fun b_152 out_Tuple2_153)) out_Tuple2_153)))) a_148] b_149]
-          x_150
+          x_155
+          [[(lam a_156 (type) (lam b_157 (type) (all out_Tuple2_158 (type) (fun (fun a_156 (fun b_157 out_Tuple2_158)) out_Tuple2_158)))) a_153] b_154]
+          x_155
         )
       )
     )

--- a/plutus-tx-plugin/test/Plugin/recursiveTypes/ptreeMatch.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveTypes/ptreeMatch.plc.golden
@@ -3,47 +3,47 @@
     [
       {
         (abs
-          Tuple2_97
+          Tuple2_102
           (fun (type) (fun (type) (type)))
           (lam
-            Tuple2_98
-            (all a_99 (type) (all b_100 (type) (fun a_99 (fun b_100 [[Tuple2_97 a_99] b_100]))))
+            Tuple2_103
+            (all a_104 (type) (all b_105 (type) (fun a_104 (fun b_105 [[Tuple2_102 a_104] b_105]))))
             (lam
-              Tuple2_match_101
-              (all a_102 (type) (all b_103 (type) (fun [[Tuple2_97 a_102] b_103] [[(lam a_104 (type) (lam b_105 (type) (all out_Tuple2_106 (type) (fun (fun a_104 (fun b_105 out_Tuple2_106)) out_Tuple2_106)))) a_102] b_103])))
+              Tuple2_match_106
+              (all a_107 (type) (all b_108 (type) (fun [[Tuple2_102 a_107] b_108] [[(lam a_109 (type) (lam b_110 (type) (all out_Tuple2_111 (type) (fun (fun a_109 (fun b_110 out_Tuple2_111)) out_Tuple2_111)))) a_107] b_108])))
               [
                 [
                   [
                     {
                       (abs
-                        B_107
+                        B_112
                         (fun (type) (type))
                         (lam
-                          One_108
-                          (all a_109 (type) (fun a_109 [B_107 a_109]))
+                          One_113
+                          (all a_114 (type) (fun a_114 [B_112 a_114]))
                           (lam
-                            Two_110
-                            (all a_111 (type) (fun [B_107 [[Tuple2_97 a_111] a_111]] [B_107 a_111]))
+                            Two_115
+                            (all a_116 (type) (fun [B_112 [[Tuple2_102 a_116] a_116]] [B_112 a_116]))
                             (lam
-                              B_match_112
-                              (all a_113 (type) (fun [B_107 a_113] [(lam a_114 (type) (all out_B_115 (type) (fun (fun a_114 out_B_115) (fun (fun [B_107 [[Tuple2_97 a_114] a_114]] out_B_115) out_B_115)))) a_113]))
+                              B_match_117
+                              (all a_118 (type) (fun [B_112 a_118] [(lam a_119 (type) (all out_B_120 (type) (fun (fun a_119 out_B_120) (fun (fun [B_112 [[Tuple2_102 a_119] a_119]] out_B_120) out_B_120)))) a_118]))
                               (lam
-                                ds_116
-                                [B_107 [(con integer) (con 8)]]
+                                ds_121
+                                [B_112 [(con integer) (con 8)]]
                                 [
                                   [
                                     {
                                       [
-                                        { B_match_112 [(con integer) (con 8)] }
-                                        ds_116
+                                        { B_match_117 [(con integer) (con 8)] }
+                                        ds_121
                                       ]
                                       [(con integer) (con 8)]
                                     }
-                                    (lam a_117 [(con integer) (con 8)] a_117)
+                                    (lam a_122 [(con integer) (con 8)] a_122)
                                   ]
                                   (lam
-                                    ds_118
-                                    [B_107 [[Tuple2_97 [(con integer) (con 8)]] [(con integer) (con 8)]]]
+                                    ds_123
+                                    [B_112 [[Tuple2_102 [(con integer) (con 8)]] [(con integer) (con 8)]]]
                                     (con 8 ! 2)
                                   )
                                 ]
@@ -52,27 +52,27 @@
                           )
                         )
                       )
-                      (fix B_119 (lam a_120 (type) (all out_B_121 (type) (fun (fun a_120 out_B_121) (fun (fun [B_119 [[Tuple2_97 a_120] a_120]] out_B_121) out_B_121)))))
+                      (fix B_124 (lam a_125 (type) (all out_B_126 (type) (fun (fun a_125 out_B_126) (fun (fun [B_124 [[Tuple2_102 a_125] a_125]] out_B_126) out_B_126)))))
                     }
                     (abs
-                      a_122
+                      a_127
                       (type)
                       (lam
-                        arg_0_123
-                        a_122
+                        arg_0_128
+                        a_127
                         (wrap
-                          B_124
-                          (lam a_125 (type) (all out_B_126 (type) (fun (fun a_125 out_B_126) (fun (fun [B_124 [[Tuple2_97 a_125] a_125]] out_B_126) out_B_126))))
+                          B_129
+                          (lam a_130 (type) (all out_B_131 (type) (fun (fun a_130 out_B_131) (fun (fun [B_129 [[Tuple2_102 a_130] a_130]] out_B_131) out_B_131))))
                           (abs
-                            out_B_127
+                            out_B_132
                             (type)
                             (lam
-                              case_One_128
-                              (fun a_122 out_B_127)
+                              case_One_133
+                              (fun a_127 out_B_132)
                               (lam
-                                case_Two_129
-                                (fun [B_124 [[Tuple2_97 a_122] a_122]] out_B_127)
-                                [ case_One_128 arg_0_123 ]
+                                case_Two_134
+                                (fun [B_129 [[Tuple2_102 a_127] a_127]] out_B_132)
+                                [ case_One_133 arg_0_128 ]
                               )
                             )
                           )
@@ -81,24 +81,24 @@
                     )
                   ]
                   (abs
-                    a_130
+                    a_135
                     (type)
                     (lam
-                      arg_0_131
-                      [(fix B_132 (lam a_133 (type) (all out_B_134 (type) (fun (fun a_133 out_B_134) (fun (fun [B_132 [[Tuple2_97 a_133] a_133]] out_B_134) out_B_134))))) [[Tuple2_97 a_130] a_130]]
+                      arg_0_136
+                      [(fix B_137 (lam a_138 (type) (all out_B_139 (type) (fun (fun a_138 out_B_139) (fun (fun [B_137 [[Tuple2_102 a_138] a_138]] out_B_139) out_B_139))))) [[Tuple2_102 a_135] a_135]]
                       (wrap
-                        B_135
-                        (lam a_136 (type) (all out_B_137 (type) (fun (fun a_136 out_B_137) (fun (fun [B_135 [[Tuple2_97 a_136] a_136]] out_B_137) out_B_137))))
+                        B_140
+                        (lam a_141 (type) (all out_B_142 (type) (fun (fun a_141 out_B_142) (fun (fun [B_140 [[Tuple2_102 a_141] a_141]] out_B_142) out_B_142))))
                         (abs
-                          out_B_138
+                          out_B_143
                           (type)
                           (lam
-                            case_One_139
-                            (fun a_130 out_B_138)
+                            case_One_144
+                            (fun a_135 out_B_143)
                             (lam
-                              case_Two_140
-                              (fun [B_135 [[Tuple2_97 a_130] a_130]] out_B_138)
-                              [ case_Two_140 arg_0_131 ]
+                              case_Two_145
+                              (fun [B_140 [[Tuple2_102 a_135] a_135]] out_B_143)
+                              [ case_Two_145 arg_0_136 ]
                             )
                           )
                         )
@@ -107,39 +107,39 @@
                   )
                 ]
                 (abs
-                  a_141
+                  a_146
                   (type)
                   (lam
-                    x_142
-                    [(fix B_143 (lam a_144 (type) (all out_B_145 (type) (fun (fun a_144 out_B_145) (fun (fun [B_143 [[Tuple2_97 a_144] a_144]] out_B_145) out_B_145))))) a_141]
-                    (unwrap x_142)
+                    x_147
+                    [(fix B_148 (lam a_149 (type) (all out_B_150 (type) (fun (fun a_149 out_B_150) (fun (fun [B_148 [[Tuple2_102 a_149] a_149]] out_B_150) out_B_150))))) a_146]
+                    (unwrap x_147)
                   )
                 )
               ]
             )
           )
         )
-        (lam a_146 (type) (lam b_147 (type) (all out_Tuple2_148 (type) (fun (fun a_146 (fun b_147 out_Tuple2_148)) out_Tuple2_148))))
+        (lam a_151 (type) (lam b_152 (type) (all out_Tuple2_153 (type) (fun (fun a_151 (fun b_152 out_Tuple2_153)) out_Tuple2_153))))
       }
       (abs
-        a_149
+        a_154
         (type)
         (abs
-          b_150
+          b_155
           (type)
           (lam
-            arg_0_151
-            a_149
+            arg_0_156
+            a_154
             (lam
-              arg_1_152
-              b_150
+              arg_1_157
+              b_155
               (abs
-                out_Tuple2_153
+                out_Tuple2_158
                 (type)
                 (lam
-                  case_Tuple2_154
-                  (fun a_149 (fun b_150 out_Tuple2_153))
-                  [ [ case_Tuple2_154 arg_0_151 ] arg_1_152 ]
+                  case_Tuple2_159
+                  (fun a_154 (fun b_155 out_Tuple2_158))
+                  [ [ case_Tuple2_159 arg_0_156 ] arg_1_157 ]
                 )
               )
             )
@@ -148,15 +148,15 @@
       )
     ]
     (abs
-      a_155
+      a_160
       (type)
       (abs
-        b_156
+        b_161
         (type)
         (lam
-          x_157
-          [[(lam a_158 (type) (lam b_159 (type) (all out_Tuple2_160 (type) (fun (fun a_158 (fun b_159 out_Tuple2_160)) out_Tuple2_160)))) a_155] b_156]
-          x_157
+          x_162
+          [[(lam a_163 (type) (lam b_164 (type) (all out_Tuple2_165 (type) (fun (fun a_163 (fun b_164 out_Tuple2_165)) out_Tuple2_165)))) a_160] b_161]
+          x_162
         )
       )
     )

--- a/plutus-tx-plugin/test/Plugin/structure/letFun.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/structure/letFun.plc.golden
@@ -4,53 +4,53 @@
       [
         {
           (abs
-            Bool_78
+            Bool_83
             (type)
             (lam
-              True_79
-              Bool_78
+              True_84
+              Bool_83
               (lam
-                False_80
-                Bool_78
+                False_85
+                Bool_83
                 (lam
-                  Bool_match_81
-                  (fun Bool_78 (all out_Bool_82 (type) (fun out_Bool_82 (fun out_Bool_82 out_Bool_82))))
+                  Bool_match_86
+                  (fun Bool_83 (all out_Bool_87 (type) (fun out_Bool_87 (fun out_Bool_87 out_Bool_87))))
                   [
                     (lam
-                      equalsInteger_83
-                      (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_78))
+                      equalsInteger_88
+                      (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_83))
                       (lam
-                        ds_84
+                        ds_89
                         [(con integer) (con 8)]
                         (lam
-                          ds_85
+                          ds_90
                           [(con integer) (con 8)]
                           [
                             (lam
-                              z_86
+                              z_91
                               [(con integer) (con 8)]
-                              [ [ equalsInteger_83 ds_84 ] z_86 ]
+                              [ [ equalsInteger_88 ds_89 ] z_91 ]
                             )
-                            ds_85
+                            ds_90
                           ]
                         )
                       )
                     )
                     (lam
-                      arg_87
+                      arg_92
                       [(con integer) (con 8)]
                       (lam
-                        arg_88
+                        arg_93
                         [(con integer) (con 8)]
                         [
                           (lam
-                            b_89
-                            (all a_90 (type) (fun a_90 (fun a_90 a_90)))
-                            [ [ { b_89 Bool_78 } True_79 ] False_80 ]
+                            b_94
+                            (all a_95 (type) (fun a_95 (fun a_95 a_95)))
+                            [ [ { b_94 Bool_83 } True_84 ] False_85 ]
                           )
                           [
-                            [ { (builtin equalsInteger) (con 8) } arg_87 ]
-                            arg_88
+                            [ { (builtin equalsInteger) (con 8) } arg_92 ]
+                            arg_93
                           ]
                         ]
                       )
@@ -60,30 +60,32 @@
               )
             )
           )
-          (all out_Bool_91 (type) (fun out_Bool_91 (fun out_Bool_91 out_Bool_91)))
+          (all out_Bool_96 (type) (fun out_Bool_96 (fun out_Bool_96 out_Bool_96)))
         }
         (abs
-          out_Bool_92
+          out_Bool_97
           (type)
           (lam
-            case_True_93
-            out_Bool_92
-            (lam case_False_94 out_Bool_92 case_True_93)
+            case_True_98
+            out_Bool_97
+            (lam case_False_99 out_Bool_97 case_True_98)
           )
         )
       ]
       (abs
-        out_Bool_95
+        out_Bool_100
         (type)
         (lam
-          case_True_96 out_Bool_95 (lam case_False_97 out_Bool_95 case_False_97)
+          case_True_101
+          out_Bool_100
+          (lam case_False_102 out_Bool_100 case_False_102)
         )
       )
     ]
     (lam
-      x_98
-      (all out_Bool_99 (type) (fun out_Bool_99 (fun out_Bool_99 out_Bool_99)))
-      x_98
+      x_103
+      (all out_Bool_104 (type) (fun out_Bool_104 (fun out_Bool_104 out_Bool_104)))
+      x_103
     )
   ]
 )

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -20,6 +20,7 @@ source-repository head
 library
     exposed-modules:
         Language.PlutusTx.TH
+        Language.PlutusTx.Prelude
     hs-source-dirs: src
     default-language: Haskell2010
     default-extensions: ExplicitForAll ScopedTypeVariables
@@ -49,8 +50,10 @@ test-suite plutus-tx-tests
     build-depends:
         base >=4.9 && <5,
         language-plutus-core -any,
+        plutus-core-interpreter -any,
         plutus-tx-plugin -any,
         plutus-tx -any,
+        mtl -any,
         template-haskell -any,
         tasty -any
 

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Language.PlutusTx.Prelude where
+
+import qualified Language.PlutusTx.Builtins as Builtins
+
+import Language.Haskell.TH
+
+toPlutusString :: Q (TExp (String -> Builtins.String))
+toPlutusString =
+    [||
+    let f str = case str of
+            [] -> Builtins.emptyString
+            (c:rest) -> Builtins.charToString c `Builtins.appendString` f rest
+    in f
+    ||]

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -1,32 +1,57 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
+{-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:dont-typecheck #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Most tests for this functionality are in the plugin package, this is mainly just checking that the wiring machinery
 -- works.
 module Main (main) where
 
 import           Common
+import           PlcTestUtils
 
 import           TestTH
 
 import           Language.PlutusTx.TH
+import           Language.PlutusTx.Prelude
 
-import qualified Language.PlutusCore.Pretty as PLC
+import           Language.PlutusCore.Interpreter.CekMachine
+import           Language.PlutusCore.Pretty
+import           Language.PlutusCore
+import           Language.PlutusCore.Constant.Dynamic
+import           Language.PlutusCore.Constant
+
+import Control.Monad.Except
+import Control.Exception
 
 import           Test.Tasty
 
 main :: IO ()
 main = defaultMain $ runTestNestedIn ["test"] tests
 
-golden :: String -> PlcCode -> TestNested
-golden name = nestedGoldenVsDoc name . PLC.prettyPlcClassicDebug . getAst
+instance GetProgram PlcCode where
+    getProgram = catchAll . getAst
+
+dynamicBuiltins :: DynamicBuiltinNameMeanings
+dynamicBuiltins =
+    insertDynamicBuiltinNameDefinition dynamicCharToStringDefinition $ insertDynamicBuiltinNameDefinition dynamicAppendDefinition mempty
+
+runPlcCek :: GetProgram a => [a] -> ExceptT SomeException IO EvaluationResult
+runPlcCek values = do
+     ps <- traverse getProgram values
+     let p = foldl1 applyProgram ps
+     catchAll $ runCek dynamicBuiltins p
+
+goldenEvalCek :: GetProgram a => String -> [a] -> TestNested
+goldenEvalCek name values = nestedGoldenVsDocM name $ prettyPlcClassicDebug <$> (rethrow $ runPlcCek values)
 
 tests :: TestNested
 tests = testGroup "plutus-th" <$> sequence [
-    golden "simple" simple
-    , golden "power" powerPlc
-    , golden "and" andPlc
+    goldenPlc "simple" simple
+    , goldenPlc "power" powerPlc
+    , goldenPlc "and" andPlc
+    , goldenEvalCek "convertString" [convertString]
   ]
 
 simple :: PlcCode
@@ -38,3 +63,6 @@ powerPlc = $$(plutus [|| $$(power (4::Int)) ||])
 
 andPlc :: PlcCode
 andPlc = $$(plutus [|| $$(andTH) True False ||])
+
+convertString :: PlcCode
+convertString = $$(plutus [|| $$(toPlutusString) "test" ||])

--- a/plutus-tx/test/and.plc.golden
+++ b/plutus-tx/test/and.plc.golden
@@ -3,89 +3,89 @@
     [
       {
         (abs
-          Unit_83
+          Unit_88
           (type)
           (lam
-            Unit_84
-            Unit_83
+            Unit_89
+            Unit_88
             (lam
-              Unit_match_85
-              (fun Unit_83 (all out_Unit_86 (type) (fun out_Unit_86 out_Unit_86)))
+              Unit_match_90
+              (fun Unit_88 (all out_Unit_91 (type) (fun out_Unit_91 out_Unit_91)))
               [
                 [
                   [
                     {
                       (abs
-                        Bool_87
+                        Bool_92
                         (type)
                         (lam
-                          True_88
-                          Bool_87
+                          True_93
+                          Bool_92
                           (lam
-                            False_89
-                            Bool_87
+                            False_94
+                            Bool_92
                             (lam
-                              Bool_match_90
-                              (fun Bool_87 (all out_Bool_91 (type) (fun out_Bool_91 (fun out_Bool_91 out_Bool_91))))
+                              Bool_match_95
+                              (fun Bool_92 (all out_Bool_96 (type) (fun out_Bool_96 (fun out_Bool_96 out_Bool_96))))
                               [
                                 (lam
-                                  ds_92
-                                  Bool_87
+                                  ds_97
+                                  Bool_92
                                   [
                                     [
                                       [
                                         {
-                                          [ Bool_match_90 ds_92 ]
-                                          (fun Unit_83 Bool_87)
+                                          [ Bool_match_95 ds_97 ]
+                                          (fun Unit_88 Bool_92)
                                         }
-                                        (lam thunk_93 Unit_83 True_88)
+                                        (lam thunk_98 Unit_88 True_93)
                                       ]
-                                      (lam thunk_94 Unit_83 False_89)
+                                      (lam thunk_99 Unit_88 False_94)
                                     ]
-                                    Unit_84
+                                    Unit_89
                                   ]
                                 )
-                                False_89
+                                False_94
                               ]
                             )
                           )
                         )
                       )
-                      (all out_Bool_95 (type) (fun out_Bool_95 (fun out_Bool_95 out_Bool_95)))
+                      (all out_Bool_100 (type) (fun out_Bool_100 (fun out_Bool_100 out_Bool_100)))
                     }
                     (abs
-                      out_Bool_96
+                      out_Bool_101
                       (type)
                       (lam
-                        case_True_97
-                        out_Bool_96
-                        (lam case_False_98 out_Bool_96 case_True_97)
+                        case_True_102
+                        out_Bool_101
+                        (lam case_False_103 out_Bool_101 case_True_102)
                       )
                     )
                   ]
                   (abs
-                    out_Bool_99
+                    out_Bool_104
                     (type)
                     (lam
-                      case_True_100
-                      out_Bool_99
-                      (lam case_False_101 out_Bool_99 case_False_101)
+                      case_True_105
+                      out_Bool_104
+                      (lam case_False_106 out_Bool_104 case_False_106)
                     )
                   )
                 ]
                 (lam
-                  x_102
-                  (all out_Bool_103 (type) (fun out_Bool_103 (fun out_Bool_103 out_Bool_103)))
-                  x_102
+                  x_107
+                  (all out_Bool_108 (type) (fun out_Bool_108 (fun out_Bool_108 out_Bool_108)))
+                  x_107
                 )
               ]
             )
           )
         )
-        (all out_Unit_104 (type) (fun out_Unit_104 out_Unit_104))
+        (all out_Unit_109 (type) (fun out_Unit_109 out_Unit_109))
       }
-      (abs out_Unit_105 (type) (lam case_Unit_106 out_Unit_105 case_Unit_106))
+      (abs out_Unit_110 (type) (lam case_Unit_111 out_Unit_110 case_Unit_111))
     ]
-    (lam x_107 (all out_Unit_108 (type) (fun out_Unit_108 out_Unit_108)) x_107)
+    (lam x_112 (all out_Unit_113 (type) (fun out_Unit_113 out_Unit_113)) x_112)
   ]
 )

--- a/plutus-tx/test/convertString.plc.golden
+++ b/plutus-tx/test/convertString.plc.golden
@@ -1,0 +1,1 @@
+(con test)

--- a/plutus-tx/test/power.plc.golden
+++ b/plutus-tx/test/power.plc.golden
@@ -1,19 +1,19 @@
 (program 1.0.0
   [
     (lam
-      multiplyInteger_70
+      multiplyInteger_75
       (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] [(con integer) (con 8)]))
       (lam
-        ds_71
+        ds_76
         [(con integer) (con 8)]
         [
-          (lam y_72 [(con integer) (con 8)] [ [ multiplyInteger_70 y_72 ] y_72 ]
+          (lam y_77 [(con integer) (con 8)] [ [ multiplyInteger_75 y_77 ] y_77 ]
           )
           [
             (lam
-              y_73 [(con integer) (con 8)] [ [ multiplyInteger_70 y_73 ] y_73 ]
+              y_78 [(con integer) (con 8)] [ [ multiplyInteger_75 y_78 ] y_78 ]
             )
-            [ [ multiplyInteger_70 ds_71 ] (con 8 ! 1) ]
+            [ [ multiplyInteger_75 ds_76 ] (con 8 ! 1) ]
           ]
         ]
       )

--- a/plutus-tx/test/simple.plc.golden
+++ b/plutus-tx/test/simple.plc.golden
@@ -4,23 +4,23 @@
       [
         {
           (abs
-            Bool_77
+            Bool_82
             (type)
             (lam
-              True_78
-              Bool_77
+              True_83
+              Bool_82
               (lam
-                False_79
-                Bool_77
+                False_84
+                Bool_82
                 (lam
-                  Bool_match_80
-                  (fun Bool_77 (all out_Bool_81 (type) (fun out_Bool_81 (fun out_Bool_81 out_Bool_81))))
+                  Bool_match_85
+                  (fun Bool_82 (all out_Bool_86 (type) (fun out_Bool_86 (fun out_Bool_86 out_Bool_86))))
                   (lam
-                    ds_82
-                    Bool_77
+                    ds_87
+                    Bool_82
                     [
                       [
-                        { [ Bool_match_80 ds_82 ] [(con integer) (con 8)] }
+                        { [ Bool_match_85 ds_87 ] [(con integer) (con 8)] }
                         (con 8 ! 1)
                       ]
                       (con 8 ! 2)
@@ -30,30 +30,30 @@
               )
             )
           )
-          (all out_Bool_83 (type) (fun out_Bool_83 (fun out_Bool_83 out_Bool_83)))
+          (all out_Bool_88 (type) (fun out_Bool_88 (fun out_Bool_88 out_Bool_88)))
         }
         (abs
-          out_Bool_84
+          out_Bool_89
           (type)
           (lam
-            case_True_85
-            out_Bool_84
-            (lam case_False_86 out_Bool_84 case_True_85)
+            case_True_90
+            out_Bool_89
+            (lam case_False_91 out_Bool_89 case_True_90)
           )
         )
       ]
       (abs
-        out_Bool_87
+        out_Bool_92
         (type)
         (lam
-          case_True_88 out_Bool_87 (lam case_False_89 out_Bool_87 case_False_89)
+          case_True_93 out_Bool_92 (lam case_False_94 out_Bool_92 case_False_94)
         )
       )
     ]
     (lam
-      x_90
-      (all out_Bool_91 (type) (fun out_Bool_91 (fun out_Bool_91 out_Bool_91)))
-      x_90
+      x_95
+      (all out_Bool_96 (type) (fun out_Bool_96 (fun out_Bool_96 out_Bool_96)))
+      x_95
     )
   ]
 )


### PR DESCRIPTION
- Compile Haskell `String`s into `[Char]` on the PLC side.
- Provide an abstact `String` type corresponding to the PLC `string`.
- Provide a TH function to do the fold converting between the two.

Uniques change, so the usual chaos (really need to do something about that). Interesting tests are 
- The `string` test in `plutus-tx-plugin` which I had apparently got making a bytestring literal before, which was... wrong, and now produces a list of integers.
- The `convertString` test in `plutus-tx` which uses the string converting function to convert a Haskell string literal into a PLC string and evaluate that.

Sadly I now have to mark more stuff as `dont-typecheck` since we still can't typecheck lists.