### PR TITLE
wallet-api: Int instead Integer for value

### DIFF
--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/CrowdFunding.hs
@@ -75,10 +75,7 @@ contribute cmp value = do
     _ <- if value <= 0 then otherError "Must contribute a positive value" else pure ()
     ds <- DataScript . UTXO.lifted . pubKey <$> myKeyPair
 
-    -- TODO: Remove duplicate definition of Value
-    --       (Value = Integer in Haskell land but Value = Int in PLC land)
-    let v' = UTXO.Value $ fromIntegral value
-    tx <- payToScript (campaignAddress cmp) v' ds
+    tx <- payToScript (campaignAddress cmp) value ds
     logMsg "Submitted contribution"
 
     register (refundTrigger cmp) (refund (UTXO.hashTx tx) cmp)
@@ -192,7 +189,7 @@ refundTrigger c = andT
 -- | An event trigger that fires when the funds for a campaign can be collected
 collectFundsTrigger :: Campaign -> EventTrigger
 collectFundsTrigger c = andT
-    (fundsAtAddressT (campaignAddress c) $ GEQ $ UTXO.Value $ fromIntegral $ campaignTarget c)
+    (fundsAtAddressT (campaignAddress c) $ GEQ $ campaignTarget c)
     (blockHeightT $ fromIntegral . getHeight <$> Interval (campaignDeadline c) (campaignCollectionDeadline c))
 
 -- | Claim a refund of our campaign contribution

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Future.hs
@@ -85,11 +85,10 @@ initialise :: (
 initialise long short f = do
     let
         im = futureInitialMargin f
-        vl = fromIntegral im
-        o = scriptTxOut vl (validatorScript f) ds
+        o = scriptTxOut im (validatorScript f) ds
         ds = DataScript $ UTXO.lifted $ FutureData long short im im
 
-    (payment, change) <- createPaymentWithChange vl
+    (payment, change) <- createPaymentWithChange im
     void $ signAndSubmit payment [o, change]
 
 -- | Close the position by extracting the payment
@@ -106,8 +105,8 @@ settle refs ft fd ov = do
         forwardPrice = futureUnitPrice ft
         OracleValue (Signed (_, (_, spotPrice))) = ov
         delta = (Value $ futureUnits ft) * (spotPrice - forwardPrice)
-        longOut = fromIntegral $ futureDataMarginLong fd + delta
-        shortOut = fromIntegral $ futureDataMarginShort fd - delta
+        longOut = futureDataMarginLong fd + delta
+        shortOut = futureDataMarginShort fd - delta
         red = UTXO.Redeemer $ UTXO.lifted $ Settle ov
         outs = [
             UTXO.pubKeyTxOut longOut (futureDataLong fd),
@@ -126,7 +125,7 @@ settleEarly :: (
     -> OracleValue Value
     -> m ()
 settleEarly refs ft fd ov = do
-    let totalVal = fromIntegral $ futureDataMarginLong fd + futureDataMarginShort fd
+    let totalVal = futureDataMarginLong fd + futureDataMarginShort fd
         outs = [UTXO.pubKeyTxOut totalVal (futureDataLong fd)]
         inp = (\r -> scriptTxIn r (validatorScript ft) red) <$> refs
         red = UTXO.Redeemer $ UTXO.lifted $ Settle ov
@@ -144,15 +143,15 @@ adjustMargin refs ft fd vl = do
     pk <- pubKey <$> myKeyPair
     (payment, change) <- createPaymentWithChange vl
     fd' <- let fd''
-                | pk == futureDataLong fd = pure $ fd { futureDataMarginLong  = fromIntegral vl + futureDataMarginLong fd  }
-                | pk == futureDataShort fd = pure $ fd { futureDataMarginShort = fromIntegral vl + futureDataMarginShort fd }
+                | pk == futureDataLong fd = pure $ fd { futureDataMarginLong  = vl + futureDataMarginLong fd  }
+                | pk == futureDataShort fd = pure $ fd { futureDataMarginShort = vl + futureDataMarginShort fd }
                 | otherwise = otherError "Private key is not part of futures contrat"
             in fd''
     let
         red = UTXO.Redeemer $ UTXO.lifted AdjustMargin
         ds  = DataScript $ UTXO.lifted fd'
         o = scriptTxOut outVal (validatorScript ft) ds
-        outVal = vl + fromIntegral (futureDataMarginLong fd + futureDataMarginShort fd)
+        outVal = vl + (futureDataMarginLong fd + futureDataMarginShort fd)
         inp = Set.fromList $ (\r -> scriptTxIn r (validatorScript ft) red) <$> refs
     void $ signAndSubmit (Set.union payment inp) [o, change]
 

--- a/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/Plutus/Coordination/Contracts/Vesting.hs
@@ -73,10 +73,9 @@ vestFunds :: (
     -> m VestingData
 vestFunds vst value = do
     _ <- if value < totalAmount vst then otherError "Value must not be smaller than vested amount" else pure ()
-    let v' = UTXO.Value $ fromIntegral value
-    (payment, change) <- createPaymentWithChange v'
+    (payment, change) <- createPaymentWithChange value
     let vs = validatorScript vst
-        o = scriptTxOut v' vs (DataScript $ UTXO.lifted vd)
+        o = scriptTxOut value vs (DataScript $ UTXO.lifted vd)
         vd =  VestingData (validatorScriptHash vst) 0
     _ <- signAndSubmit payment [o, change]
     pure vd
@@ -94,8 +93,8 @@ retrieveFunds vs vd r vnow = do
     oo <- ownPubKeyTxOut vnow
     let val = validatorScript vs
         o   = scriptTxOut remaining val (DataScript $ UTXO.lifted vd')
-        remaining = (fromIntegral $ totalAmount vs) - vnow
-        vd' = vd {vestingDataPaidOut = fromIntegral vnow + vestingDataPaidOut vd }
+        remaining = totalAmount vs - vnow
+        vd' = vd {vestingDataPaidOut = vnow + vestingDataPaidOut vd }
         inp = scriptTxIn r val UTXO.unitRedeemer
     _ <- signAndSubmit (Set.singleton inp) [oo, o]
     pure vd'

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -61,10 +61,10 @@ settle :: Property
 settle = checkTrace $ do
     ins <- initBoth
     let
-        im = fromIntegral initMargin
+        im = initMargin
         cur = FutureData (PubKey 1) (PubKey 2) im im
         spotPrice = 1124
-        delta = fromIntegral $ units * (Runtime.getValue $ spotPrice - forwardPrice)
+        delta = fromIntegral units * (spotPrice - forwardPrice)
         ov  = OracleValue (Signed (oracle, (Runtime.Height 10, spotPrice)))
 
     -- advance the clock to block height 10
@@ -79,7 +79,7 @@ settleEarly :: Property
 settleEarly = checkTrace $ do
     ins <- initBoth
     let
-        im = fromIntegral initMargin
+        im = initMargin
         cur = FutureData (PubKey 1) (PubKey 2) im im
 
         -- In this example, the price moves up (in favour of the long position)
@@ -103,7 +103,7 @@ increaseMargin :: Property
 increaseMargin = checkTrace $ do
     ins <- initBoth
     let
-        im = fromIntegral initMargin
+        im = initMargin
         cur = FutureData (PubKey 1) (PubKey 2) im im
         increase = fromIntegral units * 5
 
@@ -120,7 +120,7 @@ increaseMargin = checkTrace $ do
     -- Now the contract has ended successfully and wallet 2 gets some of its
     -- margin back.
     let
-        im' = fromIntegral $ initMargin + increase
+        im' = initMargin + increase
         cur' = cur { futureDataMarginShort = im' }
 
         (_, upper) = marginRange
@@ -129,7 +129,7 @@ increaseMargin = checkTrace $ do
         -- settleEarly above)
         spotPrice = upper + 1
 
-        delta = fromIntegral $ units * (Runtime.getValue $ spotPrice - forwardPrice)
+        delta = fromIntegral units * (spotPrice - forwardPrice)
         ov  = OracleValue (Signed (oracle, (Runtime.Height 10, spotPrice)))
 
     void $ walletAction w2 (F.settle [ins'] contract cur' ov)
@@ -188,7 +188,7 @@ oracle :: PubKey
 oracle = PubKey 17
 
 initMargin :: UTXO.Value
-initMargin = fromIntegral $ futureInitialMargin contract
+initMargin = futureInitialMargin contract
 
 -- | Funds available to wallets at the beginning.
 startingBalance :: UTXO.Value

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -118,7 +118,7 @@ canRetrieveFundsAtEnd = checkVestingTrace scen1 $ do
 
     -- Wallet 1 now has control of all the funds that were locked in the
     -- vesting scheme.
-    traverse_ (uncurry assertOwnFundsEq) [(w2, w2Funds), (w1, startingBalance + fromIntegral total)]
+    traverse_ (uncurry assertOwnFundsEq) [(w2, w2Funds), (w1, startingBalance + total)]
 
 -- | Vesting scenario with test parameters
 data VestingScenario = VestingScenario {
@@ -136,7 +136,7 @@ startingBalance = 1000
 -- | Amount of money left in wallet `Wallet 2` after committing funds to the
 --   vesting scheme
 w2Funds :: UTXO.Value
-w2Funds = startingBalance - fromIntegral total
+w2Funds = startingBalance - total
 
 -- | Total amount of money vested in the scheme `scen1`
 total :: Runtime.Value

--- a/wallet-api/src/Wallet/UTXO/Index.hs
+++ b/wallet-api/src/Wallet/UTXO/Index.hs
@@ -208,15 +208,15 @@ validationData h tx = rump <$> ins where
     rump inputs = PendingTx
         { pendingTxInputs = inputs
         , pendingTxOutputs = mkOut <$> txOutputs tx
-        , pendingTxForge = fromIntegral $ txForge tx
-        , pendingTxFee = fromIntegral $ txFee tx
+        , pendingTxForge = txForge tx
+        , pendingTxFee = txFee tx
         , pendingTxBlockHeight = Runtime.Height $ fromIntegral h
         , pendingTxSignatures = txSignatures tx
         , pendingTxOwnHash    = ()
         }
 
 mkOut :: TxOut' -> Runtime.PendingTxOut
-mkOut t = Runtime.PendingTxOut (fromIntegral $ txOutValue t) d tp where
+mkOut t = Runtime.PendingTxOut (txOutValue t) d tp where
     (d, tp) = case txOutType t of
         UTXO.PayToScript scrpt ->
             let
@@ -239,7 +239,7 @@ mkIn i = Runtime.PendingTxIn <$> ref <*> pure red <*> vl where
             Just (Runtime.plcValidatorDigest h, Runtime.plcRedeemerHash r)
         UTXO.ConsumePublicKeyAddress _ ->
             Nothing
-    vl = fromIntegral <$> valueOf i
+    vl = valueOf i
 
 valueOf :: ValidationMonad m => UTXO.TxIn' -> m Value
 valueOf = lkpValue . txInRef

--- a/wallet-api/src/Wallet/UTXO/Runtime.hs
+++ b/wallet-api/src/Wallet/UTXO/Runtime.hs
@@ -38,7 +38,7 @@ import qualified Data.ByteArray         as BA
 import qualified Data.ByteString.Lazy   as BSL
 import           GHC.Generics           (Generic)
 import           Language.PlutusTx.Lift (makeLift)
-import           Wallet.UTXO.Types      (PubKey (..), Signature (..))
+import           Wallet.UTXO.Types      (PubKey (..), Signature (..), Value (..))
 import qualified Wallet.UTXO.Types      as UTXO
 
 -- Ignore newtype warnings related to `Oracle` and `Signed` because it causes
@@ -90,31 +90,6 @@ data OracleValue a = OracleValue (Signed (Height, a))
 
 data Signed a = Signed (PubKey, a)
     deriving Generic
-
--- | Ada value
---
--- TODO: Use [[Wallet.UTXO.Types.Value]] when Integer is supported
-data Value = Value { getValue ::  Int }
-    deriving (Eq, Ord, Show, Generic)
-
-instance Enum Value where
-    toEnum = Value
-    fromEnum = getValue
-
-instance Num Value where
-    (Value l) + (Value r) = Value (l + r)
-    (Value l) * (Value r) = Value (l * r)
-    abs (Value v)         = Value (abs v)
-    signum (Value v)      = Value (signum v)
-    fromInteger           = Value . fromInteger
-    negate (Value v)      = Value (negate v)
-
-instance Real Value where
-    toRational (Value v) = toRational v
-
-instance Integral Value where
-    quotRem (Value l) (Value r) = let (l', r') = quotRem l r in (Value l', Value r')
-    toInteger (Value i) = toInteger i
 
 {- Note [Hashes in validator scripts]
 
@@ -185,7 +160,6 @@ makeLift ''PendingTxIn
 makeLift ''PendingTx
 makeLift ''OracleValue
 makeLift ''Signed
-makeLift ''Value
 makeLift ''ValidatorHash
 makeLift ''DataScriptHash
 makeLift ''RedeemerHash

--- a/wallet-api/src/Wallet/UTXO/Types.hs
+++ b/wallet-api/src/Wallet/UTXO/Types.hs
@@ -174,10 +174,12 @@ signedBy (Signature k) (PubKey s) = k == s
 
 -- | Cryptocurrency value
 --
-newtype Value = Value { getValue :: Integer }
+newtype Value = Value { getValue :: Int }
     deriving (Eq, Ord, Show, Enum)
     deriving stock (Generic)
     deriving newtype (Num, Integral, Real, Serialise, ToJSON, FromJSON)
+
+makeLift ''Value
 
 -- | Transaction ID (double SHA256 hash of the transaction)
 newtype TxId h = TxId { getTxId :: h }
@@ -329,7 +331,7 @@ newtype Height = Height { getHeight :: Int }
 
 -- | The height of a blockchain
 height :: Blockchain -> Height
-height = Height . fromIntegral . length
+height = Height . length
 
 -- | Transaction including witnesses for its inputs
 data Tx = Tx {


### PR DESCRIPTION
* `newtype Value = Value Int` means we can use the same type for ada
  values PLC and Haskell, which allows us to get rid of a few
  `fromIntegral`s