### PR TITLE
wallet-api: Be explicit about block order

### DIFF
--- a/wallet-api/src/Wallet/Emulator/Http.hs
+++ b/wallet-api/src/Wallet/Emulator/Http.hs
@@ -36,8 +36,8 @@ import           Wallet.Emulator.AddressMap (AddressMap)
 import           Wallet.Emulator.Types      (Assertion (IsValidated, OwnFundsEqual), EmulatedWalletApi,
                                              EmulatorState (_txPool, _walletStates),
                                              Notification (BlockHeight, BlockValidated), Wallet, WalletState, assert,
-                                             chain, emptyEmulatorState, emptyWalletState, liftEmulatedWallet, txPool,
-                                             walletStates)
+                                             chainNewestFirst, emptyEmulatorState, emptyWalletState, liftEmulatedWallet,
+                                             txPool, walletStates)
 
 import qualified Wallet.Emulator.Types      as Types
 import           Wallet.UTXO                (Block, Height, Tx, TxIn', TxOut', Value)
@@ -255,7 +255,7 @@ processPendingSTM var = do
   writeTVar var newState
   pure block
   where
-    addBlock block = over chain ((:) block)
+    addBlock block = over chainNewestFirst ((:) block)
     emptyPool = set txPool []
 
 api :: Proxy API

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -72,7 +72,7 @@ txnIndex :: Property
 txnIndex = property $ do
     (m, txn) <- forAll genChainTxn
     let (result, st) = Gen.runTrace m $ processPending >> simpleTrace txn
-    Hedgehog.assert (Index.initialise (_chain st) == _index st)
+    Hedgehog.assert (Index.initialise (_chainNewestFirst st) == _index st)
 
 txnIndexValid :: Property
 txnIndexValid = property $ do


### PR DESCRIPTION
* Field name indicates the order of blocks in the blockchain