### PR TITLE
[Uniques] Added renaming of types of variables during type checking

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -183,11 +183,11 @@ printNormalizeType norm bs = runQuoteT $ prettyPlcDefText <$> do
 -- | Parse and rewrite so that names are globally unique, not just unique within
 -- their scope.
 parseScoped
-    :: (AsParseError e AlexPosn, AsUniqueError e AlexPosn, MonadError e m)
+    :: (AsParseError e AlexPosn, AsUniqueError e AlexPosn, MonadError e m, MonadQuote m)
     => BSL.ByteString
     -> m (Program TyName Name AlexPosn)
 -- don't require there to be no free variables at this point, we might be parsing an open term
-parseScoped = runQuoteT . (through (Uniques.checkProgram (const True)) <=< rename <=< parseProgram)
+parseScoped = through (Uniques.checkProgram (const True)) <=< rename <=< parseProgram
 
 -- | Parse a program and typecheck it.
 parseTypecheck

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -20,7 +20,7 @@ import           Language.PlutusCore.Lexer.Type hiding (name)
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Normalize
 import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Renamer    (annotateType)
+import           Language.PlutusCore.Renamer    (annotateType, rename)
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
@@ -241,7 +241,10 @@ typeOf :: Term TyNameWithKind NameWithType a -> TypeCheckM a (NormalizedType TyN
 typeOf (Var _ (NameWithType (Name (_, ty) _ _))) =
     -- Since we kind check types at lambdas, we can normalize types here without kind checking.
     -- Type normalization at each variable is inefficient and we may consider something else later.
-    normalizeTypeOpt $ void ty
+    -- We 'rename' the type of a variable here before normalizing it. Otherwise we would get duplicate
+    -- names, because the annotation machinery takes the type at a lambda and duplicates it for each
+    -- usage of the variable the lambda binds.
+    rename ty >>= normalizeTypeOpt . void
 
 -- [check| dom :: *]    dom ~>? vDom    [infer| body : vCod]
 -- ---------------------------------------------------------

--- a/plutus-exe/src/Main.hs
+++ b/plutus-exe/src/Main.hs
@@ -99,7 +99,7 @@ runEval (EvalOptions inp mode) = do
             CK  -> PLC.runCk
             CEK -> PLC.runCek mempty
             L   -> PLC.runL mempty
-    case evalFn .void <$> PLC.parseScoped bsContents of
+    case evalFn . void <$> PLC.runQuoteT (PLC.parseScoped bsContents) of
         Left (e :: PLC.Error PLC.AlexPosn) -> do
             T.putStrLn $ PLC.prettyPlcDefText e
             exitFailure


### PR DESCRIPTION
This fixes the following bug:

> We duplicate things during the annotation step, annotate each term-level variable with its type and then simply return that type while type checking instead of renaming it

Which reveals another bug: we `runQuoteT` right after parsing a program which is way too early. This is fixed too.