### PR TITLE
wallet-api/plutus-use-cases: more module shuffling

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -68,11 +68,7 @@ let
   src = localLib.iohkNix.cleanSourceHaskell ./.;
   errorOverlay = import ./nix/overlays/force-error.nix {
     inherit pkgs;
-    # TODO: fix plutus-use-cases and plutus-exe warnings
-    #filter = localLib.isPlutus;
-    filter = let
-      pkgList = pkgs.lib.remove "plutus-use-cases" localLib.plutusPkgList;
-      in name: builtins.elem name pkgList;
+    filter = localLib.isPlutus;
   };
   customOverlays = optional forceError errorOverlay;
   packages = self: ({
@@ -85,7 +81,7 @@ let
       enableHaddockHydra enableBenchmarks fasterBuild enableDebugging
       enableSplitCheck customOverlays;
       pkgsGenerated = ./pkgs;
-      filter = name: builtins.elem name localLib.plutusPkgList; 
+      filter = localLib.isPlutus;
       filterOverrides = {
         # split check is broken for things with test tool dependencies
         splitCheck = let

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -6,9 +6,25 @@ module Language.PlutusTx.Prelude (
     traceH,
     -- error is the only builtin that people are likely to want to use directly
     -- * Re-exported builtins
-    error) where
+    error,
+    -- * Boolean operators
+    and,
+    or,
+    not,
+    -- * Numbers
+    min,
+    max,
+    -- * Maybe
+    isJust,
+    isNothing,
+    maybe,
+    -- * Lists
+    map,
+    foldr,
+    length,
+    all) where
 
-import           Prelude                    hiding (error)
+import           Prelude                    (Bool (..), Int, Maybe (..), String, (<), (>), (+))
 
 import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Builtins (error)
@@ -37,3 +53,75 @@ trace = [||
 -- | A version of 'trace' that takes a Haskell 'String'.
 traceH :: Q (TExp (String -> a -> a))
 traceH = [|| \str a -> $$(trace) ($$(toPlutusString) str) a||]
+
+-- | Logical AND
+and :: Q (TExp (Bool -> Bool -> Bool))
+and = [|| \(l :: Bool) (r :: Bool) -> if l then r else False ||]
+
+-- | Logical OR
+or :: Q (TExp (Bool -> Bool -> Bool))
+or = [|| \(l :: Bool) (r :: Bool) -> if l then True else r ||]
+
+-- | Logical negation
+not :: Q (TExp (Bool -> Bool))
+not = [|| \(a :: Bool) -> if a then False else True  ||]
+
+-- | The smaller of two `Int`s
+min :: Q (TExp (Int -> Int -> Int))
+min = [|| \(a :: Int) (b :: Int) -> if a < b then a else b ||]
+
+-- | The larger of two `Int`s
+max :: Q (TExp (Int -> Int -> Int))
+max = [|| \(a :: Int) (b :: Int) -> if a > b then a else b ||]
+
+isJust :: Q (TExp (Maybe a -> Bool))
+isJust = [|| \(m :: Maybe a) -> case m of { Just _ -> True; _ -> False; } ||]
+
+isNothing :: Q (TExp (Maybe a -> Bool))
+isNothing = [|| \(m :: Maybe a) -> case m of { Just _ -> False; } ||]
+
+maybe :: Q (TExp (b -> (a -> b) -> Maybe a -> b))
+maybe = [|| \b f m ->
+    case m of
+        Nothing -> b
+        Just a  -> f a ||]
+
+map :: Q (TExp ((a -> b) -> [a] -> [b]))
+map = [||
+    \f l ->
+        let go ls = case ls of
+                x:xs -> f x : go xs
+                _    -> []
+        in go l
+        ||]
+
+foldr :: Q (TExp ((a -> b -> b) -> b -> [a] -> b))
+foldr = [||
+    \f b l ->
+        let go cur as = case as of
+                []    -> cur
+                a:as' -> go (f a cur) as'
+        in go b l
+    ||]
+
+length :: Q (TExp ([a] -> Int))
+length = [||
+    \l ->
+        -- it would be nice to define length in terms of foldr,
+        -- but we can't, due to staging restrictions.
+        let go lst = case lst of
+                []   -> 0::Int
+                _:xs -> 1 + go xs
+        in go l
+    ||]
+
+all :: Q (TExp ((a -> Bool) -> [a] -> Bool))
+all = [||
+    \pred l ->
+        let and' a b = if a then b else False
+            go lst = case lst of
+                []   -> True
+                x:xs -> pred x `and'` go xs
+        in go l
+    ||]
+

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -36,13 +36,14 @@ library
                       GeneralizedNewtypeDeriving DeriveFunctor DeriveFoldable
                       DeriveTraversable
   exposed-modules:
-    Language.Plutus.Coordination.Contracts
-    Language.Plutus.Coordination.Contracts.CrowdFunding
-    Language.Plutus.Coordination.Contracts.Future
-    Language.Plutus.Coordination.Contracts.Vesting
-    Language.Plutus.Coordination.Contracts.Swap
-    Language.Plutus.Runtime
-    Language.Plutus.Runtime.TH
+    Language.PlutusTx.Coordination.Contracts
+    Language.PlutusTx.Coordination.Contracts.CrowdFunding
+    Language.PlutusTx.Coordination.Contracts.Future
+    Language.PlutusTx.Coordination.Contracts.Vesting
+    Language.PlutusTx.Coordination.Contracts.Swap
+    Language.PlutusTx.Validation
+  other-modules:
+    Language.PlutusTx.Validation.TH
   ghc-options:
     -Wall -Wnoncanonical-monad-instances
     -Wincomplete-uni-patterns -Wincomplete-record-updates

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts.hs
@@ -1,13 +1,13 @@
-module Language.Plutus.Coordination.Contracts(
+module Language.PlutusTx.Coordination.Contracts(
   -- * Example contracts
   module CrowdFunding,
   module Swap,
   module Vesting
   ) where
 
-import           Language.Plutus.Coordination.Contracts.CrowdFunding as CrowdFunding
-import           Language.Plutus.Coordination.Contracts.Swap         as Swap
-import           Language.Plutus.Coordination.Contracts.Vesting      as Vesting
+import           Language.PlutusTx.Coordination.Contracts.CrowdFunding as CrowdFunding
+import           Language.PlutusTx.Coordination.Contracts.Swap         as Swap
+import           Language.PlutusTx.Coordination.Contracts.Vesting      as Vesting
 
 {- Note [Contracts and Validator Scripts]
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -12,7 +12,7 @@
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS -fplugin=Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:dont-typecheck #-}
-module Language.Plutus.Coordination.Contracts.CrowdFunding (
+module Language.PlutusTx.Coordination.Contracts.CrowdFunding (
     -- * Campaign parameters
     Campaign(..)
     , CampaignActor
@@ -23,26 +23,25 @@ module Language.Plutus.Coordination.Contracts.CrowdFunding (
     , campaignAddress
     ) where
 
-import           Control.Applicative        (Applicative (..))
+import           Control.Applicative          (Applicative (..))
 import           Control.Lens
-import           Control.Monad              (void)
-import           Data.Foldable              (foldMap)
-import qualified Data.Map                   as Map
-import           Data.Maybe                 (fromMaybe)
-import           Data.Monoid                (Sum (..))
-import qualified Data.Set                   as Set
-import           GHC.Generics               (Generic)
+import           Control.Monad                (void)
+import           Data.Foldable                (foldMap)
+import qualified Data.Map                     as Map
+import           Data.Maybe                   (fromMaybe)
+import           Data.Monoid                  (Sum (..))
+import qualified Data.Set                     as Set
+import           GHC.Generics                 (Generic)
 
-import           Language.Plutus.Runtime    (Height (..), PendingTx (..), PendingTxIn (..), PendingTxOut, PubKey (..),
-                                             ValidatorHash, Value (..))
-import qualified Language.PlutusTx          as PlutusTx
-import           Wallet.API                 (EventHandler (..), EventTrigger, Range (..), WalletAPI (..),
-                                             WalletDiagnostics (..), andT, blockHeightT, fundsAtAddressT, otherError,
-                                             ownPubKeyTxOut, payToScript, pubKey, signAndSubmit)
-import           Wallet.UTXO                (DataScript (..), TxId', Validator (..), scriptTxIn)
-import qualified Wallet.UTXO                as UTXO
+import qualified Language.PlutusTx            as PlutusTx
+import qualified Language.PlutusTx.Validation as PlutusTx
+import           Ledger                       (DataScript (..), PubKey (..), TxId', Validator (..), Value (..), scriptTxIn)
+import qualified Ledger                       as Ledger
+import           Ledger.Validation            (Height (..), PendingTx (..), PendingTxIn (..), PendingTxOut, ValidatorHash)
+import           Wallet                       (EventHandler (..), EventTrigger, Range (..), WalletAPI (..),
+                                               WalletDiagnostics (..), andT, blockHeightT, fundsAtAddressT, otherError,
+                                               ownPubKeyTxOut, payToScript, pubKey, signAndSubmit)
 
-import qualified Language.Plutus.Runtime.TH as TH
 import           Prelude                    (Bool (..), Int, Num (..), Ord (..), fromIntegral, fst, snd, succ, ($), (.),
                                              (<$>), (==))
 
@@ -71,12 +70,12 @@ contribute :: (WalletAPI m, WalletDiagnostics m)
     -> m ()
 contribute cmp value = do
     _ <- if value <= 0 then otherError "Must contribute a positive value" else pure ()
-    ds <- DataScript . UTXO.lifted . pubKey <$> myKeyPair
+    ds <- DataScript . Ledger.lifted . pubKey <$> myKeyPair
 
     tx <- payToScript (campaignAddress cmp) value ds
     logMsg "Submitted contribution"
 
-    register (refundTrigger cmp) (refund (UTXO.hashTx tx) cmp)
+    register (refundTrigger cmp) (refund (Ledger.hashTx tx) cmp)
     logMsg "Registered refund trigger"
 
 -- | Register a [[EventHandler]] to collect all the funds of a campaign
@@ -87,7 +86,7 @@ collect cmp = register (collectFundsTrigger cmp) $ EventHandler $ \_ -> do
         am <- watchedAddresses
         let scr        = contributionScript cmp
             contributions = am ^. at (campaignAddress cmp) . to (Map.toList . fromMaybe Map.empty)
-            red        = UTXO.Redeemer $ UTXO.lifted Collect
+            red        = Ledger.Redeemer $ Ledger.lifted Collect
             con (r, _) = scriptTxIn r scr red
             ins        = con <$> contributions
             value = getSum $ foldMap (Sum . snd) contributions
@@ -97,8 +96,8 @@ collect cmp = register (collectFundsTrigger cmp) $ EventHandler $ \_ -> do
 
 
 -- | The address of a [[Campaign]]
-campaignAddress :: Campaign -> UTXO.Address'
-campaignAddress = UTXO.scriptAddress . contributionScript
+campaignAddress :: Campaign -> Ledger.Address'
+campaignAddress = Ledger.scriptAddress . contributionScript
 
 -- | The validator script that determines whether the campaign owner can
 --   retrieve the funds or the contributors can claim a refund.
@@ -119,21 +118,21 @@ campaignAddress = UTXO.scriptAddress . contributionScript
 --      covered by the `refundable` branch.
 contributionScript :: Campaign -> Validator
 contributionScript cmp  = Validator val where
-    val = UTXO.applyScript inner (UTXO.lifted cmp)
+    val = Ledger.applyScript inner (Ledger.lifted cmp)
 
     --   See note [Contracts and Validator Scripts] in
     --       Language.Plutus.Coordination.Contracts
-    inner = UTXO.fromPlcCode $$(PlutusTx.plutus [|| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx ValidatorHash) ->
+    inner = Ledger.fromPlcCode $$(PlutusTx.plutus [|| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx ValidatorHash) ->
         let
 
             infixr 3 &&
             (&&) :: Bool -> Bool -> Bool
-            (&&) = $$(TH.and)
+            (&&) = $$(PlutusTx.and)
 
             -- | Check that a pending transaction is signed by the private key
             --   of the given public key.
             signedByT :: PendingTx ValidatorHash -> CampaignActor -> Bool
-            signedByT = $$(TH.txSignedBy)
+            signedByT = $$(PlutusTx.txSignedBy)
 
             PendingTx ps outs _ _ (Height h) _ _ = p
 
@@ -150,7 +149,7 @@ contributionScript cmp  = Validator val where
             totalInputs :: Int
             totalInputs =
                 let v (PendingTxIn _ _ (Value vl)) = vl in
-                $$(TH.foldr) (\i total -> total + v i) 0 ps
+                $$(PlutusTx.foldr) (\i total -> total + v i) 0 ps
 
             isValid = case act of
                 Refund -> -- the "refund" branch
@@ -159,9 +158,9 @@ contributionScript cmp  = Validator val where
                         -- of the contributor (that is, to the `a` argument of the data script)
 
                         contributorTxOut :: PendingTxOut -> Bool
-                        contributorTxOut o = $$(TH.maybe) False (\pk -> $$(TH.eqPubKey) pk a) ($$(TH.pubKeyOutput) o)
+                        contributorTxOut o = $$(PlutusTx.maybe) False (\pk -> $$(PlutusTx.eqPubKey) pk a) ($$(PlutusTx.pubKeyOutput) o)
 
-                        contributorOnly = $$(TH.all) contributorTxOut outs
+                        contributorOnly = $$(PlutusTx.all) contributorTxOut outs
 
                         refundable   = h > collectionDeadline &&
                                                     contributorOnly &&
@@ -197,9 +196,9 @@ refund txid cmp = EventHandler $ \_ -> do
     am <- watchedAddresses
     let adr     = campaignAddress cmp
         utxo    = fromMaybe Map.empty $ am ^. at adr
-        ourUtxo = Map.toList $ Map.filterWithKey (\k _ -> txid == UTXO.txOutRefId k) utxo
+        ourUtxo = Map.toList $ Map.filterWithKey (\k _ -> txid == Ledger.txOutRefId k) utxo
         scr   = contributionScript cmp
-        red   = UTXO.Redeemer $ UTXO.lifted Refund
+        red   = Ledger.Redeemer $ Ledger.lifted Refund
         i ref = scriptTxIn ref scr red
         inputs = Set.fromList $ i . fst <$> ourUtxo
         value  = getSum $ foldMap (Sum . snd) ourUtxo

--- a/plutus-use-cases/src/Language/PlutusTx/Validation.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Validation.hs
@@ -1,11 +1,8 @@
--- | A model of the types involved in transactions. These types are intented to
---   be used in PLC scripts.
-module Language.Plutus.Runtime (
-    -- * Pending transactions
-    module Types
+module Language.PlutusTx.Validation (
+    module TH
     ) where
 
-import           Wallet.UTXO.Runtime as Types
+import           Language.PlutusTx.Validation.TH as TH
 
 {- Note [Script types in pending transactions]
 

--- a/plutus-use-cases/src/Language/PlutusTx/Validation/TH.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Validation/TH.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 -- | Useful functions for validator scripts, in the form of quoted expressions
-module Language.Plutus.Runtime.TH(
+module Language.PlutusTx.Validation.TH(
     -- * Boolean operators
     and,
     or,
@@ -34,7 +34,8 @@ module Language.Plutus.Runtime.TH(
 
 import           Language.Haskell.TH        (Q, TExp)
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Wallet.UTXO.Runtime
+import           Ledger
+import           Ledger.Validation
 
 import           Prelude                    (Bool (..), Eq (..), Int, Maybe (..), (<), (>), (+))
 

--- a/plutus-use-cases/src/Language/PlutusTx/Validation/TH.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Validation/TH.hs
@@ -3,22 +3,6 @@
 {-# LANGUAGE TemplateHaskell     #-}
 -- | Useful functions for validator scripts, in the form of quoted expressions
 module Language.PlutusTx.Validation.TH(
-    -- * Boolean operators
-    and,
-    or,
-    not,
-    -- * Numbers
-    min,
-    max,
-    -- * Maybe
-    isJust,
-    isNothing,
-    maybe,
-    -- * Lists
-    map,
-    foldr,
-    length,
-    all,
     -- * Signatures
     txSignedBy,
     txInSignedBy,
@@ -38,26 +22,6 @@ import           Ledger
 import           Ledger.Validation
 
 import           Prelude                    (Bool (..), Eq (..), Int, Maybe (..), (<), (>), (+))
-
--- | Logical AND
-and :: Q (TExp (Bool -> Bool -> Bool))
-and = [|| \(l :: Bool) (r :: Bool) -> if l then r else False ||]
-
--- | Logical OR
-or :: Q (TExp (Bool -> Bool -> Bool))
-or = [|| \(l :: Bool) (r :: Bool) -> if l then True else r ||]
-
--- | Logical negation
-not :: Q (TExp (Bool -> Bool))
-not = [|| \(a :: Bool) -> if a then False else True  ||]
-
--- | The smaller of two `Int`s
-min :: Q (TExp (Int -> Int -> Int))
-min = [|| \(a :: Int) (b :: Int) -> if a < b then a else b ||]
-
--- | The larger of two `Int`s
-max :: Q (TExp (Int -> Int -> Int))
-max = [|| \(a :: Int) (b :: Int) -> if a > b then a else b ||]
 
 -- | Check if a transaction was signed by a public key
 txSignedBy :: Q (TExp (PendingTx ValidatorHash -> PubKey -> Bool))
@@ -94,57 +58,6 @@ txInSignedBy = [||
                         []  -> False
         in go sigs
 
-    ||]
-
-isJust :: Q (TExp (Maybe a -> Bool))
-isJust = [|| \(m :: Maybe a) -> case m of { Just _ -> True; _ -> False; } ||]
-
-isNothing :: Q (TExp (Maybe a -> Bool))
-isNothing = [|| \(m :: Maybe a) -> case m of { Just _ -> False; } ||]
-
-maybe :: Q (TExp (b -> (a -> b) -> Maybe a -> b))
-maybe = [|| \b f m ->
-    case m of
-        Nothing -> b
-        Just a  -> f a ||]
-
-map :: Q (TExp ((a -> b) -> [a] -> [b]))
-map = [||
-    \f l ->
-        let go ls = case ls of
-                x:xs -> f x : go xs
-                _    -> []
-        in go l
-        ||]
-
-foldr :: Q (TExp ((a -> b -> b) -> b -> [a] -> b))
-foldr = [||
-    \f b l ->
-        let go cur as = case as of
-                []    -> cur
-                a:as' -> go (f a cur) as'
-        in go b l
-    ||]
-
-length :: Q (TExp ([a] -> Int))
-length = [||
-    \l ->
-        -- it would be nice to define length in terms of foldr,
-        -- but we can't, due to staging restrictions.
-        let go lst = case lst of
-                []   -> 0::Int
-                _:xs -> 1 + go xs
-        in go l
-    ||]
-
-all :: Q (TExp ((a -> Bool) -> [a] -> Bool))
-all = [||
-    \pred l ->
-        let and a b = if a then b else False
-            go lst = case lst of
-                []   -> True
-                x:xs -> pred x `and` go xs
-        in go l
     ||]
 
 -- | Returns the public key that locks the transaction output

--- a/plutus-use-cases/src/Language/PlutusTx/Validation/TH.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Validation/TH.hs
@@ -21,7 +21,7 @@ import qualified Language.PlutusTx.Builtins as Builtins
 import           Ledger
 import           Ledger.Validation
 
-import           Prelude                    (Bool (..), Eq (..), Int, Maybe (..), (<), (>), (+))
+import           Prelude                    (Bool (..), Eq (..), Maybe (..))
 
 -- | Check if a transaction was signed by a public key
 txSignedBy :: Q (TExp (PendingTx ValidatorHash -> PubKey -> Bool))
@@ -30,12 +30,12 @@ txSignedBy = [||
         let
             PendingTx _ _ _ _ _ sigs _ = p
 
-            signedBy :: Signature -> Bool
-            signedBy (Signature s) = s == k
+            signedBy' :: Signature -> Bool
+            signedBy' (Signature s) = s == k
 
             go :: [Signature] -> Bool
             go l = case l of
-                        s:r -> if signedBy s then True else go r
+                        s:r -> if signedBy' s then True else go r
                         []  -> False
         in
             go sigs
@@ -49,12 +49,12 @@ txInSignedBy = [||
             PendingTxIn ref _ _      = i
             PendingTxOutRef _ _ sigs = ref
 
-            signedBy :: Signature -> Bool
-            signedBy (Signature i') = i' == k
+            signedBy' :: Signature -> Bool
+            signedBy' (Signature i') = i' == k
 
             go :: [Signature] -> Bool
             go l = case l of
-                        s:r -> if signedBy s then True else go r
+                        s:r -> if signedBy' s then True else go r
                         []  -> False
         in go sigs
 

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -21,7 +21,7 @@ import qualified Wallet.Generators                                     as Gen
 
 import           Language.PlutusTx.Coordination.Contracts.CrowdFunding (Campaign (..), contribute)
 import qualified Language.PlutusTx.Coordination.Contracts.CrowdFunding as CF
-import qualified Ledger                                                as Ledger
+import qualified Ledger
 import qualified Ledger.Validation                                     as Validation
 
 tests :: TestTree

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -6,23 +6,23 @@
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns -fno-warn-unused-do-bind #-}
 module Spec.Crowdfunding(tests) where
 
-import           Control.Monad                                       (void)
-import           Data.Either                                         (isRight)
-import           Data.Foldable                                       (traverse_)
-import qualified Data.Map                                            as Map
-import           Hedgehog                                            (Property, forAll, property)
+import           Control.Monad                                         (void)
+import           Data.Either                                           (isRight)
+import           Data.Foldable                                         (traverse_)
+import qualified Data.Map                                              as Map
+import           Hedgehog                                              (Property, forAll, property)
 import qualified Hedgehog
 import           Test.Tasty
-import           Test.Tasty.Hedgehog                                 (testProperty)
+import           Test.Tasty.Hedgehog                                   (testProperty)
 
-import           Wallet.API                                          (PubKey (..))
-import           Wallet.Emulator                                     hiding (Value)
-import qualified Wallet.Generators                                   as Gen
+import           Wallet                                                (PubKey (..))
+import           Wallet.Emulator
+import qualified Wallet.Generators                                     as Gen
 
-import           Language.Plutus.Coordination.Contracts.CrowdFunding (Campaign (..), contribute)
-import qualified Language.Plutus.Coordination.Contracts.CrowdFunding as CF
-import qualified Language.Plutus.Runtime                             as Runtime
-import qualified Wallet.UTXO                                         as UTXO
+import           Language.PlutusTx.Coordination.Contracts.CrowdFunding (Campaign (..), contribute)
+import qualified Language.PlutusTx.Coordination.Contracts.CrowdFunding as CF
+import qualified Ledger                                                as Ledger
+import qualified Ledger.Validation                                     as Validation
 
 tests :: TestTree
 tests = testGroup "crowdfunding" [
@@ -37,16 +37,16 @@ tests = testGroup "crowdfunding" [
 -- | Make a contribution to the campaign from a wallet. Returns the reference
 --   to the transaction output that is locked by the campaign's validator
 --   script (and can be collected by the campaign owner)
-contrib :: Wallet -> Runtime.Value -> Trace MockWallet ()
+contrib :: Wallet -> Ledger.Value -> Trace MockWallet ()
 contrib w v = void $ walletAction w (contribute cmp v) where
     cmp = cfCampaign scenario1
 
 -- | Make a contribution from wallet 2
-contrib2 :: Runtime.Value -> Trace MockWallet ()
+contrib2 :: Ledger.Value -> Trace MockWallet ()
 contrib2 = contrib (Wallet 2)
 
 -- | Make a contribution from wallet 3
-contrib3 :: Runtime.Value -> Trace MockWallet ()
+contrib3 :: Ledger.Value -> Trace MockWallet ()
 contrib3 = contrib (Wallet 3)
 
 -- | Collect the contributions of a crowdfunding campaign
@@ -59,9 +59,9 @@ collect w = void $ walletAction w $ CF.collect $ cfCampaign scenario1
 scenario1 :: CFScenario
 scenario1 = CFScenario{..} where
     cfCampaign = Campaign {
-        campaignDeadline = Runtime.Height 10,
+        campaignDeadline = Validation.Height 10,
         campaignTarget   = 1000,
-        campaignCollectionDeadline = Runtime.Height 15,
+        campaignCollectionDeadline = Validation.Height 15,
         campaignOwner              = PubKey 1
         }
     cfWallets = [w1, w2, w3]
@@ -200,11 +200,11 @@ canRefund = checkCFTrace scenario1 $ do
 data CFScenario = CFScenario {
     cfCampaign        :: Campaign,
     cfWallets         :: [Wallet],
-    cfInitialBalances :: Map.Map PubKey UTXO.Value
+    cfInitialBalances :: Map.Map PubKey Ledger.Value
     }
 
 -- | Funds available to wallets `Wallet 2` and `Wallet 3`
-startingBalance :: UTXO.Value
+startingBalance :: Ledger.Value
 startingBalance = 1000
 
 -- | Run a trace with the given scenario and check that the emulator finished
@@ -217,9 +217,9 @@ checkCFTrace CFScenario{cfInitialBalances} t = property $ do
     Hedgehog.assert ([] == _txPool st)
 
 -- | Notify all wallets in the campaign of the new blocks.
-notifyBlocks :: [Block] -> Trace MockWallet ()
+notifyBlocks :: [Ledger.Block] -> Trace MockWallet ()
 notifyBlocks = traverse_ notifyBlock
 
 -- | Notify all wallets in the campaign of a new block
-notifyBlock :: Block -> Trace MockWallet ()
+notifyBlock :: Ledger.Block -> Trace MockWallet ()
 notifyBlock = void . walletsNotifyBlock [w1, w2, w3]

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -11,7 +11,7 @@ import qualified Hedgehog
 import           Test.Tasty
 import           Test.Tasty.Hedgehog                             (testProperty)
 
-import qualified Ledger                                          as Ledger
+import qualified Ledger
 import           Ledger.Validation                               (OracleValue (..), Signed (..))
 import qualified Ledger.Validation                               as Validation
 import           Prelude                                         hiding (init)

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -19,7 +19,7 @@ import           Test.Tasty.Hedgehog                              (testProperty)
 import           Language.PlutusTx.Coordination.Contracts.Vesting (Vesting (..), VestingData (..), VestingTranche (..),
                                                                    retrieveFunds, totalAmount, validatorScriptHash,
                                                                    vestFunds)
-import qualified Ledger                                           as Ledger
+import qualified Ledger
 import qualified Ledger.Validation                                as Validation
 import           Wallet                                           (PubKey (..))
 import           Wallet.Emulator

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -7,23 +7,23 @@
 {-# OPTIONS -fplugin=Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:dont-typecheck #-}
 module Spec.Vesting(tests) where
 
-import           Control.Monad                                  (void)
-import           Data.Either                                    (isRight)
-import           Data.Foldable                                  (traverse_)
-import qualified Data.Map                                       as Map
-import           Hedgehog                                       (Property, forAll, property)
+import           Control.Monad                                    (void)
+import           Data.Either                                      (isRight)
+import           Data.Foldable                                    (traverse_)
+import qualified Data.Map                                         as Map
+import           Hedgehog                                         (Property, forAll, property)
 import qualified Hedgehog
 import           Test.Tasty
-import           Test.Tasty.Hedgehog                            (testProperty)
+import           Test.Tasty.Hedgehog                              (testProperty)
 
-import           Language.Plutus.Coordination.Contracts.Vesting (Vesting (..), VestingData (..), VestingTranche (..),
-                                                                 retrieveFunds, totalAmount, validatorScriptHash,
-                                                                 vestFunds)
-import qualified Language.Plutus.Runtime                        as Runtime
-import           Wallet.API                                     (PubKey (..))
-import           Wallet.Emulator                                hiding (Value)
-import qualified Wallet.Generators                              as Gen
-import qualified Wallet.UTXO                                    as UTXO
+import           Language.PlutusTx.Coordination.Contracts.Vesting (Vesting (..), VestingData (..), VestingTranche (..),
+                                                                   retrieveFunds, totalAmount, validatorScriptHash,
+                                                                   vestFunds)
+import qualified Ledger                                           as Ledger
+import qualified Ledger.Validation                                as Validation
+import           Wallet                                           (PubKey (..))
+import           Wallet.Emulator
+import qualified Wallet.Generators                                as Gen
 
 tests :: TestTree
 tests = testGroup "vesting" [
@@ -39,8 +39,8 @@ tests = testGroup "vesting" [
 scen1 :: VestingScenario
 scen1 = VestingScenario{..} where
     vsVestingScheme = Vesting {
-        vestingTranche1 = VestingTranche (Runtime.Height 10) 200,
-        vestingTranche2 = VestingTranche (Runtime.Height 20) 400,
+        vestingTranche1 = VestingTranche (Validation.Height 10) 200,
+        vestingTranche2 = VestingTranche (Validation.Height 20) 400,
         vestingOwner    = PubKey 1 }
     vsWallets = Wallet <$> [1, 2]
     vsInitialBalances = Map.fromList [
@@ -51,9 +51,9 @@ scen1 = VestingScenario{..} where
 -- | Commit some funds from a wallet to a vesting scheme. Returns the reference
 --   to the transaction output that is locked by the schemes's validator
 --   script (and can be collected by the scheme's owner)
-commit :: Wallet -> Vesting -> Runtime.Value -> Trace MockWallet  TxOutRef'
+commit :: Wallet -> Vesting -> Ledger.Value -> Trace MockWallet Ledger.TxOutRef'
 commit w vv vl = exScriptOut <$> walletAction w (void $ vestFunds vv vl) where
-    exScriptOut = snd . head . filter (isPayToScriptOut . fst) . txOutRefs . head
+    exScriptOut = snd . head . filter (Ledger.isPayToScriptOut . fst) . Ledger.txOutRefs . head
 
 secureFunds :: Property
 secureFunds = checkVestingTrace scen1 $ do
@@ -124,22 +124,22 @@ canRetrieveFundsAtEnd = checkVestingTrace scen1 $ do
 data VestingScenario = VestingScenario {
     vsVestingScheme   :: Vesting,
     vsWallets         :: [Wallet],
-    vsInitialBalances :: Map.Map PubKey UTXO.Value,
-    vsScriptHash      :: Runtime.ValidatorHash -- Hash of validator script for this scenario
+    vsInitialBalances :: Map.Map PubKey Ledger.Value,
+    vsScriptHash      :: Validation.ValidatorHash -- Hash of validator script for this scenario
     }
 
 -- | Funds available to each wallet after the initial transaction on the
 --   mockchain
-startingBalance :: UTXO.Value
+startingBalance :: Ledger.Value
 startingBalance = 1000
 
 -- | Amount of money left in wallet `Wallet 2` after committing funds to the
 --   vesting scheme
-w2Funds :: UTXO.Value
+w2Funds :: Ledger.Value
 w2Funds = startingBalance - total
 
 -- | Total amount of money vested in the scheme `scen1`
-total :: Runtime.Value
+total :: Ledger.Value
 total = totalAmount $ vsVestingScheme scen1
 
 -- | Run a trace with the given scenario and check that the emulator finished
@@ -152,6 +152,6 @@ checkVestingTrace VestingScenario{vsInitialBalances} t = property $ do
     Hedgehog.assert ([] == _txPool st)
 
 -- | Validate all pending transactions and notify the wallets
-updateAll :: VestingScenario -> Trace MockWallet [Tx]
+updateAll :: VestingScenario -> Trace MockWallet [Ledger.Tx]
 updateAll VestingScenario{vsWallets} =
     processPending >>= walletsNotifyBlock vsWallets

--- a/wallet-api/src/Ledger.hs
+++ b/wallet-api/src/Ledger.hs
@@ -1,0 +1,8 @@
+module Ledger (
+    module Types,
+    module Index
+    ) where
+
+import           Ledger.Index as Index
+import           Ledger.Types as Types
+

--- a/wallet-api/src/Ledger/Types.hs
+++ b/wallet-api/src/Ledger/Types.hs
@@ -13,7 +13,7 @@
 {-# LANGUAGE ViewPatterns       #-}
 {-# OPTIONS -fplugin=Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:dont-typecheck #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Wallet.UTXO.Types(
+module Ledger.Types(
     -- * Basic types
     Value(..),
     Height(..),

--- a/wallet-api/src/Ledger/Validation.hs
+++ b/wallet-api/src/Ledger/Validation.hs
@@ -5,14 +5,11 @@
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
--- | A model of the types involved in transactions. These types are intented to
+-- | A model of the types involved in validating transactions. These types are intented to
 --   be used in PLC scripts.
-module Wallet.UTXO.Runtime (-- * Transactions and related types
-                PubKey(..)
-              , Value(..)
-              , Height(..)
+module Ledger.Validation (-- * Transactions and related types
+                Height(..)
               , PendingTxOutRef(..)
-              , Signature(..)
               -- ** Hashes (see note [Hashes in validator scripts])
               , DataScriptHash(..)
               , RedeemerHash(..)
@@ -38,8 +35,8 @@ import qualified Data.ByteArray         as BA
 import qualified Data.ByteString.Lazy   as BSL
 import           GHC.Generics           (Generic)
 import           Language.PlutusTx.Lift (makeLift)
-import           Wallet.UTXO.Types      (PubKey (..), Signature (..), Value (..))
-import qualified Wallet.UTXO.Types      as UTXO
+import           Ledger.Types           (PubKey (..), Signature (..), Value (..))
+import qualified Ledger.Types           as Ledger
 
 -- Ignore newtype warnings related to `Oracle` and `Signed` because it causes
 -- problems with the plugin
@@ -100,8 +97,8 @@ We need to deal with hashes of four different things in a validator script:
 3. Data scripts
 4. Redeemer scripts
 
-The mockchain code in [[Wallet.UTXO.Types]] only deals with the hashes of(1)
-and (2), and uses the [[Wallet.UTXO.Types.TxId']] and `Digest SHA256` types for
+The mockchain code in [[Ledger.Types]] only deals with the hashes of(1)
+and (2), and uses the [[Ledger.TxId']] and `Digest SHA256` types for
 them.
 
 In PLC validator scripts the situation is different: First, they need to work
@@ -128,17 +125,17 @@ newtype RedeemerHash = RedeemerHash BSL.ByteString
 newtype TxHash = TxHash BSL.ByteString
     deriving (Eq, Generic)
 
-plcDataScriptHash :: UTXO.DataScript -> DataScriptHash
+plcDataScriptHash :: Ledger.DataScript -> DataScriptHash
 plcDataScriptHash = DataScriptHash . plcHash
 
 plcValidatorDigest :: Digest SHA256 -> ValidatorHash
 plcValidatorDigest = ValidatorHash . plcDigest
 
-plcRedeemerHash :: UTXO.Redeemer -> RedeemerHash
+plcRedeemerHash :: Ledger.Redeemer -> RedeemerHash
 plcRedeemerHash = RedeemerHash . plcHash
 
-plcTxHash :: UTXO.TxId' -> TxHash
-plcTxHash = TxHash . plcDigest . UTXO.getTxId
+plcTxHash :: Ledger.TxId' -> TxHash
+plcTxHash = TxHash . plcDigest . Ledger.getTxId
 
 -- | PLC-compatible hash of a hashable value
 plcHash :: BA.ByteArrayAccess a => a -> BSL.ByteString
@@ -149,7 +146,7 @@ plcDigest :: Digest SHA256 -> BSL.ByteString
 plcDigest = serialise
 
 -- | Blockchain height
---   TODO: Use [[Wallet.UTXO.Height]] when Integer is supported
+--   TODO: Use [[Ledger.Height]] when Integer is supported
 data Height = Height { getHeight :: Int }
     deriving (Eq, Ord, Show, Generic)
 

--- a/wallet-api/src/Wallet.hs
+++ b/wallet-api/src/Wallet.hs
@@ -1,0 +1,5 @@
+module Wallet (
+    module API
+    ) where
+
+import           Wallet.API as API

--- a/wallet-api/src/Wallet/API.hs
+++ b/wallet-api/src/Wallet/API.hs
@@ -55,10 +55,10 @@ import           Data.Ord.Deriving          (deriveOrd1)
 import qualified Data.Set                   as Set
 import           Data.Text                  (Text)
 import           GHC.Generics               (Generic)
+import           Ledger                     (Address', DataScript, Height, PubKey (..), Signature (..), Tx (..), TxIn',
+                                             TxOut (..), TxOut', TxOutType (..), Value, pubKeyTxOut)
 import           Text.Show.Deriving         (deriveShow1)
 import           Wallet.Emulator.AddressMap (AddressMap)
-import           Wallet.UTXO                (Address', DataScript, Height, PubKey (..), Signature (..), Tx (..), TxIn',
-                                             TxOut (..), TxOut', TxOutType (..), Value, pubKeyTxOut)
 
 import           Prelude                    hiding (Ordering (..))
 

--- a/wallet-api/src/Wallet/Emulator.hs
+++ b/wallet-api/src/Wallet/Emulator.hs
@@ -1,9 +1,5 @@
 module Wallet.Emulator(
-    module API,
-    module Types,
-    module UTXO
+    module Types
     ) where
 
-import           Wallet.API            as API
 import           Wallet.Emulator.Types as Types
-import           Wallet.UTXO           as UTXO

--- a/wallet-api/src/Wallet/Emulator/AddressMap.hs
+++ b/wallet-api/src/Wallet/Emulator/AddressMap.hs
@@ -31,7 +31,7 @@ import qualified Data.Set               as Set
 import qualified Data.Text.Encoding     as TE
 import           GHC.Generics           (Generic)
 
-import           Wallet.UTXO            (Address', Tx (..), TxIn (..), TxIn', TxOut (..), TxOutRef (..), TxOutRef',
+import           Ledger                 (Address', Tx (..), TxIn (..), TxIn', TxOut (..), TxOutRef (..), TxOutRef',
                                          Value, hashTx)
 
 -- | A map of [[Address']]es and their unspent outputs

--- a/wallet-api/src/Wallet/Emulator/Client.hs
+++ b/wallet-api/src/Wallet/Emulator/Client.hs
@@ -25,6 +25,7 @@ import           Control.Monad.Writer       (MonadWriter, WriterT, runWriterT, t
 import           Data.Foldable              (fold)
 import           Data.Proxy                 (Proxy (Proxy))
 import           Data.Set                   (Set)
+import           Ledger                     (Block, Height, Tx, TxIn', TxOut', Value)
 import           Servant.API                ((:<|>) ((:<|>)), NoContent)
 import           Servant.Client             (ClientEnv, ClientM, ServantError, client, runClientM)
 import           Wallet.API                 (KeyPair, WalletAPI (..))
@@ -32,7 +33,6 @@ import           Wallet.Emulator.AddressMap (AddressMap)
 import           Wallet.Emulator.Http       (API)
 import           Wallet.Emulator.Types      (Assertion (IsValidated, OwnFundsEqual), Event (..),
                                              Notification (BlockHeight, BlockValidated), Trace, Wallet)
-import           Wallet.UTXO                (Block, Height, Tx, TxIn', TxOut', Value)
 
 api :: Proxy API
 api = Proxy

--- a/wallet-api/src/Wallet/Emulator/Http.hs
+++ b/wallet-api/src/Wallet/Emulator/Http.hs
@@ -39,8 +39,8 @@ import           Wallet.Emulator.Types      (Assertion (IsValidated, OwnFundsEqu
                                              chainNewestFirst, emptyEmulatorState, emptyWalletState, liftMockWallet,
                                              txPool, walletStates)
 
+import           Ledger                     (Block, Height, Tx, TxIn', TxOut', Value)
 import qualified Wallet.Emulator.Types      as Types
-import           Wallet.UTXO                (Block, Height, Tx, TxIn', TxOut', Value)
 
 type WalletAPI
    = "wallets" :> Get '[ JSON] [Wallet]

--- a/wallet-api/src/Wallet/Emulator/Types.hs
+++ b/wallet-api/src/Wallet/Emulator/Types.hs
@@ -77,13 +77,13 @@ import           Prelude                    as P
 import           Servant.API                (FromHttpApiData, ToHttpApiData)
 
 import           Data.Hashable              (Hashable)
+import           Ledger                     (Address', Block, Blockchain, Height, Tx (..), TxId', TxOutRef', Value,
+                                             hashTx, height, pubKeyAddress, pubKeyTxIn, pubKeyTxOut, txOutAddress)
+import qualified Ledger.Index               as Index
 import           Wallet.API                 (EventHandler (..), EventTrigger, KeyPair (..), WalletAPI (..),
                                              WalletAPIError (..), WalletDiagnostics (..), WalletLog (..), addresses,
                                              annTruthValue, getAnnot, keyPair, pubKey, signature)
 import qualified Wallet.Emulator.AddressMap as AM
-import           Wallet.UTXO                (Address', Block, Blockchain, Height, Tx (..), TxId', TxOutRef', Value,
-                                             hashTx, height, pubKeyAddress, pubKeyTxIn, pubKeyTxOut, txOutAddress)
-import qualified Wallet.UTXO.Index          as Index
 
 -- agents/wallets
 newtype Wallet = Wallet { getWallet :: Int }

--- a/wallet-api/src/Wallet/Generators.hs
+++ b/wallet-api/src/Wallet/Generators.hs
@@ -35,8 +35,8 @@ import           Hedgehog
 import qualified Hedgehog.Gen    as Gen
 import qualified Hedgehog.Range  as Range
 
+import           Ledger
 import           Wallet.Emulator as Emulator
-import           Wallet.UTXO     (unitValidationData)
 
 data GeneratorModel = GeneratorModel {
     gmInitialBalance :: Map PubKey Value,
@@ -62,7 +62,7 @@ constantFee = FeeEstimator . const . const
 -- | Blockchain for testing the emulator implementation and traces.
 --
 --   To avoid having to rely on functions from the implementation of
---   wallet-api (in particular, `Wallet.UTXO.Types.unspentOutputs`) we note the
+--   wallet-api (in particular, `Ledger.Types.unspentOutputs`) we note the
 --   unspent outputs of the chain when it is first created.
 data Mockchain = Mockchain {
     mockchainInitialBlock :: Block,

--- a/wallet-api/src/Wallet/UTXO.hs
+++ b/wallet-api/src/Wallet/UTXO.hs
@@ -1,8 +1,0 @@
-module Wallet.UTXO (
-    module Types,
-    module Index
-    ) where
-
-import           Wallet.UTXO.Index as Index
-import           Wallet.UTXO.Types as Types
-

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -19,7 +19,7 @@ import           Test.Tasty
 import           Test.Tasty.Hedgehog        (testProperty)
 import           Language.PlutusTx.TH       (plutus)
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Prelude
+import qualified Language.PlutusTx.Prelude  as PlutusTx
 
 import           Wallet
 import           Wallet.Emulator
@@ -144,7 +144,7 @@ invalidScript = property $ do
 
     where
         failValidator :: Validator
-        failValidator = Validator $ fromPlcCode $$(plutus [|| \() () () -> $$(traceH) "I always fail everything" (Builtins.error @()) ||])
+        failValidator = Validator $ fromPlcCode $$(plutus [|| \() () () -> $$(PlutusTx.traceH) "I always fail everything" (Builtins.error @()) ||])
 
 splitVal :: Property
 splitVal = property $ do

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -21,10 +21,12 @@ import           Language.PlutusTx.TH       (plutus)
 import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Prelude
 
+import           Wallet
 import           Wallet.Emulator
 import           Wallet.Generators          (Mockchain (..))
 import qualified Wallet.Generators          as Gen
-import qualified Wallet.UTXO.Index          as Index
+import           Ledger
+import qualified Ledger.Index          as Index
 
 main :: IO ()
 main = defaultMain tests

--- a/wallet-api/wallet-api.cabal
+++ b/wallet-api/wallet-api.cabal
@@ -25,6 +25,7 @@ flag development
 
 library
     exposed-modules:
+        Wallet
         Wallet.API
         Wallet.Emulator
         Wallet.Emulator.AddressMap
@@ -32,10 +33,10 @@ library
         Wallet.Emulator.Http
         Wallet.Emulator.Types
         Wallet.Generators
-        Wallet.UTXO
-        Wallet.UTXO.Types
-        Wallet.UTXO.Runtime
-        Wallet.UTXO.Index
+        Ledger 
+        Ledger.Types
+        Ledger.Validation
+        Ledger.Index
     hs-source-dirs: src
     default-language: Haskell2010
     default-extensions: ExplicitForAll ScopedTypeVariables


### PR DESCRIPTION
wallet-api:
- `Wallet.UTXO` -> `Ledger`
- `Wallet.UTXO.Runtime` -> `Ledger.Validation`
- Trimmed some export lists to not re-export too much.

plutus-use-cases:
- `Language.Plutus` -> `Language.PlutusTx`
- `Language.Plutus.Runtime` -> `Language.PlutusTx.Validation`
    - I also moved a bunch of the general functions from here to the PlutusTx Prelude, so this now only contains functions that work on the validation types.
    - Possibly this should also move to `wallet-api`.

At this point you need the following imports to write a contract:
- `Language.PlutusTx` (PlutusTx functions)
- `Wallet` (wallet API types and functions)
- `Ledger` (transaction types and functions)
- `Ledger.Validation` (runtime validation types and functions)
- `Language.PlutusTx.Validation` (PlutusTx functions for working with the validation types)

The first three all seem good, the latter two are a little annoying, but I think helpful if we want to keep ourselves clear about what happens at validation time vs off-chain.