### PR TITLE
[plutus-exe] Added examples

### DIFF
--- a/plutus-exe/plutus-exe.cabal
+++ b/plutus-exe/plutus-exe.cabal
@@ -33,8 +33,10 @@ executable plc
         base <5,
         language-plutus-core -any,
         plutus-core-interpreter -any,
+        transformers -any,
         bytestring -any,
         text -any,
+        prettyprinter -any,
         optparse-applicative -any
 
     if (flag(development) && impl(ghc <8.4))

--- a/plutus-exe/src/Main.hs
+++ b/plutus-exe/src/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main (main) where
 
@@ -7,13 +8,20 @@ import qualified Language.PlutusCore.Evaluation.CkMachine   as PLC
 import qualified Language.PlutusCore.Interpreter.CekMachine as PLC
 import qualified Language.PlutusCore.Interpreter.LMachine   as PLC
 import qualified Language.PlutusCore.Pretty                 as PLC
+import qualified Language.PlutusCore.StdLib.Data.Bool       as PLC
+import qualified Language.PlutusCore.StdLib.Data.ChurchNat  as PLC
+import qualified Language.PlutusCore.StdLib.Data.Integer    as PLC
+import qualified Language.PlutusCore.StdLib.Data.Unit       as PLC
 
 import           Control.Monad
+import           Control.Monad.Trans.Except                 (runExceptT)
+import           Data.Foldable                              (traverse_)
 
 import qualified Data.ByteString.Lazy                       as BSL
 import qualified Data.Text                                  as T
 import           Data.Text.Encoding                         (encodeUtf8)
 import qualified Data.Text.IO                               as T
+import           Data.Text.Prettyprint.Doc
 
 import           System.Exit
 
@@ -44,7 +52,10 @@ data NormalizationMode = Required | NotRequired deriving (Show, Read)
 data TypecheckOptions = TypecheckOptions Input NormalizationMode
 data EvalMode = CK | CEK | L deriving (Show, Read)
 data EvalOptions = EvalOptions Input EvalMode
-data Command = Typecheck TypecheckOptions | Eval EvalOptions
+type ExampleName = T.Text
+data ExampleMode = ExampleSingle ExampleName | ExampleAvailable
+newtype ExampleOptions = ExampleOptions ExampleMode
+data Command = Typecheck TypecheckOptions | Eval EvalOptions | Example ExampleOptions
 
 plutus :: ParserInfo Command
 plutus = info (plutusOpts <**> helper) (progDesc "Plutus Core tool")
@@ -53,6 +64,7 @@ plutusOpts :: Parser Command
 plutusOpts = hsubparser (
     command "typecheck" (info (Typecheck <$> typecheckOpts) (progDesc "Typecheck a Plutus Core program"))
     <> command "evaluate" (info (Eval <$> evalOpts) (progDesc "Evaluate a Plutus Core program"))
+    <> command "example" (info (Example <$> exampleOpts) (progDesc "Show a Plutus Core program example"))
   )
 
 normalizationMode :: Parser NormalizationMode
@@ -77,6 +89,28 @@ evalMode = option auto
 
 evalOpts :: Parser EvalOptions
 evalOpts = EvalOptions <$> input <*> evalMode
+
+exampleMode :: Parser ExampleMode
+exampleMode = exampleAvailable <|> exampleSingle
+
+exampleAvailable :: Parser ExampleMode
+exampleAvailable = flag' ExampleAvailable
+  (  long "available"
+  <> short 'a'
+  <> help "Show available examples")
+
+exampleName :: Parser ExampleName
+exampleName = strOption
+  (  long "single"
+  <> metavar "NAME"
+  <> short 's'
+  <> help "Show a single example")
+
+exampleSingle :: Parser ExampleMode
+exampleSingle = ExampleSingle <$> exampleName
+
+exampleOpts :: Parser ExampleOptions
+exampleOpts = ExampleOptions <$> exampleMode
 
 runTypecheck :: TypecheckOptions -> IO ()
 runTypecheck (TypecheckOptions inp mode) = do
@@ -107,9 +141,58 @@ runEval (EvalOptions inp mode) = do
             T.putStrLn $ PLC.prettyPlcDefText v
             exitSuccess
 
+data TypeExample = TypeExample (PLC.Kind ()) (PLC.Type PLC.TyName ())
+data TermExample = TermExample (PLC.Type PLC.TyNameWithKind ()) (PLC.Term PLC.TyName PLC.Name ())
+data SomeExample = SomeTypeExample TypeExample | SomeTermExample TermExample
+
+prettySignature :: ExampleName -> SomeExample -> Doc ann
+prettySignature name (SomeTypeExample (TypeExample kind _)) =
+    pretty name <+> "::" <+> PLC.prettyPlcDef kind
+prettySignature name (SomeTermExample (TermExample ty _)) =
+    pretty name <+> ":"  <+> PLC.prettyPlcDef ty
+
+prettyExample :: SomeExample -> Doc ann
+prettyExample (SomeTypeExample (TypeExample _ ty))   = PLC.prettyPlcDef ty
+prettyExample (SomeTermExample (TermExample _ term)) =
+    PLC.prettyPlcDef $ PLC.Program () (PLC.defaultVersion ()) term
+
+toTermExample :: PLC.Quote (PLC.Term PLC.TyName PLC.Name ()) -> TermExample
+toTermExample getTerm = TermExample ty term where
+    term = PLC.runQuote getTerm
+    program = PLC.Program () (PLC.defaultVersion ()) term
+    config = PLC.TypeConfig True mempty Nothing
+    ty = case PLC.runQuote . runExceptT $ PLC.typecheckPipeline config program of
+        Left (err :: PLC.Error ()) -> error $ PLC.prettyPlcDefString err
+        Right vTy                  -> PLC.getNormalizedType vTy
+
+avalaibleExamples :: [(ExampleName, SomeExample)]
+avalaibleExamples =
+    [ ("succInteger", SomeTermExample $ toTermExample PLC.getBuiltinSuccInteger)
+    , ("unit"       , SomeTypeExample $ TypeExample (PLC.Type ()) unit)
+    , ("unitval"    , SomeTermExample $ toTermExample PLC.getBuiltinUnitval)
+    , ("bool"       , SomeTypeExample $ TypeExample (PLC.Type ()) bool)
+    , ("true"       , SomeTermExample $ toTermExample PLC.getBuiltinTrue)
+    , ("false"      , SomeTermExample $ toTermExample PLC.getBuiltinFalse)
+    , ("churchNat"  , SomeTypeExample $ TypeExample (PLC.Type ()) churchNat)
+    , ("churchZero" , SomeTermExample $ toTermExample PLC.getBuiltinChurchZero)
+    , ("churchSucc" , SomeTermExample $ toTermExample PLC.getBuiltinChurchSucc)
+    ] where
+        unit = PLC.runQuote PLC.getBuiltinUnit
+        bool = PLC.runQuote PLC.getBuiltinBool
+        churchNat = PLC.runQuote PLC.getBuiltinChurchNat
+
+runExample :: ExampleOptions -> IO ()
+runExample (ExampleOptions ExampleAvailable)     =
+    traverse_ (T.putStrLn . PLC.docText . uncurry prettySignature) avalaibleExamples
+runExample (ExampleOptions (ExampleSingle name)) =
+    T.putStrLn $ case lookup name avalaibleExamples of
+        Nothing -> "Unknown name: " <> name
+        Just ex -> PLC.docText $ prettyExample ex
+
 main :: IO ()
 main = do
     options <- customExecParser (prefs showHelpOnEmpty) plutus
     case options of
         Typecheck tos -> runTypecheck tos
         Eval eos      -> runEval eos
+        Example eos   -> runExample eos


### PR DESCRIPTION
Adds example types and programs to `plutus-exe`. There are two commands

```
~/code/iohk/plutus$ plc example --available
succInteger : (all s (size) (fun [(con integer) s] [(con integer) s]))
unit :: (type)
unitval : (all a (type) (fun a a))
bool :: (type)
true : (all a (type) (fun a (fun a a)))
false : (all a (type) (fun a (fun a a)))
churchNat :: (type)
churchZero : (all r (type) (fun r (fun (fun r r) r)))
churchSucc : (all r (type) (fun r (fun (fun r r) r)))
```

and

```
~/code/iohk/plutus$ plc example --single unitval
(program 1.0.0
  (abs a (type) (lam x a x))
)
```

(where `unitval` can be any "available" name). There are intentionally no available tests with recursive types inside, because the RV team got confused (and rightfully so) about our partial implementation of elimination contexts in the spec and my advise was "just ignore recursive types for now".

It is nice to package example programs together with type checking and evaluation machineries, because we change syntax from time to time, so it's nice to have a "show me the current syntax" command, and because we can play with things like this now:

```
plc example -s unitval | plc typecheck --stdin
```

Maybe it's even worth to add this to our CI ("whatever `plc example` returns must be type checkable").