### PR TITLE
language-plutus-core/plutus-ir: add default Pretty instances

### DIFF
--- a/language-plutus-core/prelude/PlutusPrelude.hs
+++ b/language-plutus-core/prelude/PlutusPrelude.hs
@@ -86,6 +86,8 @@ module PlutusPrelude ( -- * Reëxports from base
                      , iasqrt
                      , ilogFloor
                      , ilogRound
+                     -- * GHCi
+                     , printPretty
                      ) where
 
 import           Control.Applicative                     (Alternative (..))
@@ -275,3 +277,9 @@ ilogRound b x
     | b ^ p == x = p
     | otherwise  = p + 1
     where p = ilogFloor b x
+
+-- For GHCi to use this properly it needs to be in a registered package, hence
+-- why we're naming such a trivial thing.
+-- | A command suitable for use in GHCi as an interactive printer.
+printPretty :: Pretty a => a -> IO ()
+printPretty = print . pretty

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/Result.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/Result.hs
@@ -13,8 +13,8 @@ module Language.PlutusCore.Evaluation.Result
     ) where
 
 import           Language.PlutusCore.Name
+import           Language.PlutusCore.Pretty
 import           Language.PlutusCore.Type
-import           PlutusPrelude
 
 -- | The parameterized type of results various evaluation engines return.
 data EvaluationResultF a
@@ -38,6 +38,9 @@ type EvaluationResult = EvaluationResultF (Value TyName Name ())
 instance PrettyBy config (Value TyName Name ()) => PrettyBy config EvaluationResult where
     prettyBy config (EvaluationSuccess value) = prettyBy config value
     prettyBy _      EvaluationFailure         = "Failure"
+
+instance Pretty EvaluationResult where
+    pretty = prettyPlcDef
 
 -- | Map 'EvaluationSuccess' to 'Just' and 'EvaluationFailure' to 'Nothing'.
 evaluationResultToMaybe :: EvaluationResult -> Maybe (Value TyName Name ())

--- a/language-plutus-core/src/Language/PlutusCore/Pretty.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE UndecidableInstances #-}
+-- There is really no way to avoid these being orphans without a cycle
+-- between the pretty printing and AST modules.
+{-# OPTIONS_GHC -Wno-orphans -Wno-simplifiable-class-constraints #-}
 module Language.PlutusCore.Pretty
     (
     -- * Basic types and functions
@@ -47,14 +51,13 @@ module Language.PlutusCore.Pretty
     , PrettyReadableBy
     , topPrettyConfigReadable
     , botPrettyConfigReadable
-    -- * GHCi
-    , interactivePrint
     ) where
 
 import           Language.PlutusCore.Name            as Export
 import           Language.PlutusCore.Pretty.Classic  as Export
 import           Language.PlutusCore.Pretty.Plc      as Export
 import           Language.PlutusCore.Pretty.Readable as Export
+import           Language.PlutusCore.Type
 import           PlutusPrelude
 
 import           Data.Text                           (Text)
@@ -76,6 +79,20 @@ prettyPlcCondensedErrorClassicString :: PrettyPlc a => a -> String
 prettyPlcCondensedErrorClassicString =
     docString . prettyPlcCondensedErrorBy defPrettyConfigPlcClassic
 
--- | A command suitable for use in GHCi as an interactive printer.
-interactivePrint :: PrettyPlc a => a -> IO ()
-interactivePrint = print . prettyPlcDef
+{- Note [Default pretty instances for PLC]
+While the flexible pretty-printing infrastructure is useful when you want it,
+it's helpful to have an implementation of the default Pretty typeclass that
+does the default thing.
+-}
+instance Pretty (Kind a) where
+    pretty = prettyPlcDef
+instance Pretty (Constant a) where
+    pretty = prettyPlcDef
+instance Pretty (Builtin a) where
+    pretty = prettyPlcDef
+instance PrettyPlc (Type tyname a) => Pretty (Type tyname a) where
+    pretty = prettyPlcDef
+instance PrettyPlc (Term tyname name a) => Pretty (Term tyname name a) where
+    pretty = prettyPlcDef
+instance PrettyPlc (Program tyname name a) => Pretty (Program tyname name a) where
+    pretty = prettyPlcDef

--- a/language-plutus-core/src/Language/PlutusCore/Pretty.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty.hs
@@ -45,10 +45,13 @@ module Language.PlutusCore.Pretty
     -- * Classic view
     , PrettyConfigClassic (..)
     , PrettyClassicBy
+    , PrettyClassic
+    , prettyClassicDef
     -- * Readable view
     , RenderContext (..)
     , PrettyConfigReadable (..)
     , PrettyReadableBy
+    , PrettyReadable
     , topPrettyConfigReadable
     , botPrettyConfigReadable
     ) where
@@ -85,14 +88,14 @@ it's helpful to have an implementation of the default Pretty typeclass that
 does the default thing.
 -}
 instance Pretty (Kind a) where
-    pretty = prettyPlcDef
+    pretty = prettyClassicDef
 instance Pretty (Constant a) where
-    pretty = prettyPlcDef
+    pretty = prettyClassicDef
 instance Pretty (Builtin a) where
-    pretty = prettyPlcDef
-instance PrettyPlc (Type tyname a) => Pretty (Type tyname a) where
-    pretty = prettyPlcDef
-instance PrettyPlc (Term tyname name a) => Pretty (Term tyname name a) where
-    pretty = prettyPlcDef
-instance PrettyPlc (Program tyname name a) => Pretty (Program tyname name a) where
-    pretty = prettyPlcDef
+    pretty = prettyClassicDef
+instance PrettyClassic (Type tyname a) => Pretty (Type tyname a) where
+    pretty = prettyClassicDef
+instance PrettyClassic (Term tyname name a) => Pretty (Term tyname name a) where
+    pretty = prettyClassicDef
+instance PrettyClassic (Program tyname name a) => Pretty (Program tyname name a) where
+    pretty = prettyClassicDef

--- a/language-plutus-core/src/Language/PlutusCore/Pretty/Classic.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty/Classic.hs
@@ -9,10 +9,12 @@
 module Language.PlutusCore.Pretty.Classic
     ( PrettyConfigClassic (..)
     , PrettyClassicBy
+    , PrettyClassic
+    , prettyClassicDef
     ) where
 
 import           Language.PlutusCore.Lexer.Type
-import           Language.PlutusCore.Name       (HasPrettyConfigName (..), PrettyConfigName)
+import           Language.PlutusCore.Name       (HasPrettyConfigName (..), PrettyConfigName, defPrettyConfigName)
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
@@ -25,6 +27,8 @@ newtype PrettyConfigClassic configName = PrettyConfigClassic
 
 -- | The "classically pretty-printable" constraint.
 type PrettyClassicBy configName = PrettyBy (PrettyConfigClassic configName)
+
+type PrettyClassic = PrettyClassicBy PrettyConfigName
 
 instance configName ~ PrettyConfigName => HasPrettyConfigName (PrettyConfigClassic configName) where
     toPrettyConfigName = _pccConfigName
@@ -81,3 +85,7 @@ instance PrettyClassicBy configName (Term tyname name a) =>
         PrettyBy (PrettyConfigClassic configName) (Program tyname name a) where
     prettyBy config (Program _ version term) =
         parens' $ "program" <+> pretty version <//> prettyBy config term
+
+-- | Pretty-print a value in the default mode using the classic view.
+prettyClassicDef :: PrettyClassic a => a -> Doc ann
+prettyClassicDef = prettyBy $ PrettyConfigClassic defPrettyConfigName

--- a/language-plutus-core/src/Language/PlutusCore/Pretty/Plc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty/Plc.hs
@@ -27,6 +27,7 @@ module Language.PlutusCore.Pretty.Plc
     , prettyPlcCondensedErrorBy
     ) where
 
+import           Data.Text.Prettyprint.Doc
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Pretty.Classic
 import           Language.PlutusCore.Pretty.Readable

--- a/language-plutus-core/src/Language/PlutusCore/Pretty/Plc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty/Plc.hs
@@ -55,8 +55,8 @@ type PrettyPlc = PrettyBy PrettyConfigPlc
 
 -- | A constraint that allows to derive @PrettyBy PrettyConfigPlc@ instances, see below.
 type DefaultPrettyPlcStrategy a =
-       ( PrettyBy (PrettyConfigClassic PrettyConfigName) a
-       , PrettyBy (PrettyConfigReadable PrettyConfigName) a
+       ( PrettyClassic a
+       , PrettyReadable a
        )
 
 instance HasPrettyConfigName PrettyConfigPlcStrategy where

--- a/language-plutus-core/src/Language/PlutusCore/Pretty/Readable.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty/Readable.hs
@@ -13,6 +13,7 @@ module Language.PlutusCore.Pretty.Readable
     ( RenderContext (..)
     , PrettyConfigReadable (..)
     , PrettyReadableBy
+    , PrettyReadable
     , topPrettyConfigReadable
     , botPrettyConfigReadable
     ) where
@@ -132,6 +133,8 @@ encloseInContext (RenderContext (Fixity precOut assocOut) dir) (Fixity precIn as
 
 -- | The "readably pretty-printable" constraint.
 type PrettyReadableBy configName = PrettyBy (PrettyConfigReadable configName)
+
+type PrettyReadable = PrettyReadableBy PrettyConfigName
 
 -- | Adjust a 'PrettyConfigReadable' by setting new 'Fixity' and 'Direction' and call 'prettyBy'.
 prettyInBy

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55684,6 +55684,7 @@ base
 language-plutus-core
 mmorph
 mtl
+prettyprinter
 serialise
 tasty
 ];
@@ -55950,6 +55951,7 @@ license = stdenv.lib.licenses.bsd3;
 , plutus-core-interpreter
 , plutus-ir
 , plutus-tx-plugin
+, prettyprinter
 , stdenv
 , tasty
 , template-haskell
@@ -55974,6 +55976,7 @@ language-plutus-core
 mtl
 plutus-ir
 plutus-tx-plugin
+prettyprinter
 tasty
 template-haskell
 ];

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -56036,6 +56036,7 @@ base
 bytestring
 language-plutus-core
 plutus-ir
+prettyprinter
 tasty
 ];
 doHaddock = false;

--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -85,5 +85,6 @@ test-suite plutus-ir-test
         language-plutus-core -any,
         mtl -any,
         mmorph -any,
+        prettyprinter -any,
         serialise -any,
         tasty -any

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-# OPTIONS_GHC -Wno-orphans       #-}
 module Language.PlutusIR (
     TyName (..),
@@ -184,5 +185,40 @@ instance (PLC.PrettyClassicBy configName (tyname a), PLC.PrettyClassicBy configN
         PrettyBy (PLC.PrettyConfigClassic configName) (Program tyname name a) where
     prettyBy config (Program _ t) = parens' ("program" </> prettyBy config t)
 
-prettyDef :: (PLC.PrettyBy (PLC.PrettyConfigClassic PLC.PrettyConfigName) a) => a -> Doc ann
+prettyDef :: (PLC.PrettyClassicBy PLC.PrettyConfigName a) => a -> Doc ann
 prettyDef = prettyBy $ PLC.PrettyConfigClassic PLC.defPrettyConfigName
+
+-- See note [Default pretty instances for PLC]
+instance (PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)) =>
+    Pretty (TyVarDecl tyname a) where
+    pretty = prettyDef
+
+instance
+    ( PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)
+    , PLC.PrettyClassicBy PLC.PrettyConfigName (name a)) =>
+    Pretty (VarDecl tyname name a) where
+    pretty = prettyDef
+
+instance
+    ( PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)
+    , PLC.PrettyClassicBy PLC.PrettyConfigName (name a)) =>
+    Pretty (Datatype tyname name a) where
+    pretty = prettyDef
+
+instance
+    ( PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)
+    , PLC.PrettyClassicBy PLC.PrettyConfigName (name a)) =>
+    Pretty (Binding tyname name a) where
+    pretty = prettyDef
+
+instance
+    ( PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)
+    , PLC.PrettyClassicBy PLC.PrettyConfigName (name a)) =>
+    Pretty (Term tyname name a) where
+    pretty = prettyDef
+
+instance
+    ( PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)
+    , PLC.PrettyClassicBy PLC.PrettyConfigName (name a)) =>
+    Pretty (Program tyname name a) where
+    pretty = prettyDef

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -20,7 +20,6 @@ module Language.PlutusIR (
     Binding (..),
     Term (..),
     Program (..),
-    prettyDef,
     embedIntoIR
     ) where
 
@@ -185,40 +184,27 @@ instance (PLC.PrettyClassicBy configName (tyname a), PLC.PrettyClassicBy configN
         PrettyBy (PLC.PrettyConfigClassic configName) (Program tyname name a) where
     prettyBy config (Program _ t) = parens' ("program" </> prettyBy config t)
 
-prettyDef :: (PLC.PrettyClassicBy PLC.PrettyConfigName a) => a -> Doc ann
-prettyDef = prettyBy $ PLC.PrettyConfigClassic PLC.defPrettyConfigName
-
 -- See note [Default pretty instances for PLC]
-instance (PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)) =>
+instance (PLC.PrettyClassic (tyname a)) =>
     Pretty (TyVarDecl tyname a) where
-    pretty = prettyDef
+    pretty = PLC.prettyClassicDef
 
-instance
-    ( PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)
-    , PLC.PrettyClassicBy PLC.PrettyConfigName (name a)) =>
+instance (PLC.PrettyClassic (tyname a), PLC.PrettyClassic (name a)) =>
     Pretty (VarDecl tyname name a) where
-    pretty = prettyDef
+    pretty = PLC.prettyClassicDef
 
-instance
-    ( PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)
-    , PLC.PrettyClassicBy PLC.PrettyConfigName (name a)) =>
+instance (PLC.PrettyClassic (tyname a), PLC.PrettyClassic (name a)) =>
     Pretty (Datatype tyname name a) where
-    pretty = prettyDef
+    pretty = PLC.prettyClassicDef
 
-instance
-    ( PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)
-    , PLC.PrettyClassicBy PLC.PrettyConfigName (name a)) =>
+instance (PLC.PrettyClassic (tyname a), PLC.PrettyClassic (name a)) =>
     Pretty (Binding tyname name a) where
-    pretty = prettyDef
+    pretty = PLC.prettyClassicDef
 
-instance
-    ( PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)
-    , PLC.PrettyClassicBy PLC.PrettyConfigName (name a)) =>
+instance (PLC.PrettyClassic (tyname a), PLC.PrettyClassic (name a)) =>
     Pretty (Term tyname name a) where
-    pretty = prettyDef
+    pretty = PLC.prettyClassicDef
 
-instance
-    ( PLC.PrettyClassicBy PLC.PrettyConfigName (tyname a)
-    , PLC.PrettyClassicBy PLC.PrettyConfigName (name a)) =>
+instance (PLC.PrettyClassic (tyname a), PLC.PrettyClassic (name a)) =>
     Pretty (Program tyname name a) where
-    pretty = prettyDef
+    pretty = PLC.prettyClassicDef

--- a/plutus-ir/test/TestLib.hs
+++ b/plutus-ir/test/TestLib.hs
@@ -6,8 +6,10 @@ import           Common
 import           Language.PlutusCore.Quote
 import           Language.PlutusIR
 
+import           Data.Text.Prettyprint.Doc
+
 goldenPir :: String -> Term TyName Name a -> TestNested
-goldenPir name value = nestedGoldenVsDoc name $ prettyDef value
+goldenPir name value = nestedGoldenVsDoc name $ pretty value
 
 maybeDatatype :: Quote (Datatype TyName Name ())
 maybeDatatype = do

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -94,6 +94,7 @@ test-suite plutus-tx-plugin-tests
         base >=4.9 && <5,
         plutus-tx-plugin -any,
         plutus-ir -any,
+        prettyprinter -any,
         language-plutus-core -any,
         bytestring -any,
         tasty -any

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -24,6 +24,7 @@ import           Language.PlutusTx.Plugin
 import qualified Language.PlutusIR          as PIR
 
 import           Data.ByteString.Lazy
+import           Data.Text.Prettyprint.Doc
 import           GHC.Generics
 
 -- this module does lots of weird stuff deliberately
@@ -33,7 +34,7 @@ instance GetProgram (CompiledCode a) where
     getProgram = catchAll . getPlc
 
 goldenPir :: String -> CompiledCode a -> TestNested
-goldenPir name value = nestedGoldenVsDoc name $ PIR.prettyDef $ getPir value
+goldenPir name value = nestedGoldenVsDoc name $ pretty $ getPir value
 
 tests :: TestNested
 tests = testNested "Plugin" [

--- a/plutus-tx/.ghci
+++ b/plutus-tx/.ghci
@@ -1,3 +1,3 @@
 :set -XFlexibleContexts
-:m +Language.PlutusCore.Pretty
-:set -interactive-print interactivePrint
+:m +PlutusPrelude Data.Text.Prettyprint.Doc
+:set -interactive-print printPretty

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -58,6 +58,7 @@ test-suite plutus-tx-tests
         plutus-tx-plugin -any,
         plutus-tx -any,
         plutus-ir -any,
+        prettyprinter -any,
         mtl -any,
         template-haskell -any,
         tasty -any

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -76,4 +76,5 @@ test-suite plutus-tx-tutorial-doctests
         plutus-tx -any,
         plutus-tx-plugin -any,
         language-plutus-core -any,
+        prettyprinter -any,
         doctest -any

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -27,6 +27,7 @@ import           Language.PlutusCore
 import           Control.Monad.Except
 import           Control.Exception
 
+import Data.Text.Prettyprint.Doc
 import           Test.Tasty
 
 main :: IO ()
@@ -35,8 +36,8 @@ main = defaultMain $ runTestNestedIn ["test"] tests
 instance GetProgram (CompiledCode a) where
     getProgram = catchAll . getPlc
 
-goldenPir :: String -> (CompiledCode a) -> TestNested
-goldenPir name value = nestedGoldenVsDoc name $ PIR.prettyDef $ getPir value
+goldenPir :: String -> CompiledCode a -> TestNested
+goldenPir name value = nestedGoldenVsDoc name $ pretty $ getPir value
 
 runPlcCek :: GetProgram a => [a] -> ExceptT SomeException IO EvaluationResult
 runPlcCek values = do

--- a/plutus-tx/tutorial/Tutorial.md
+++ b/plutus-tx/tutorial/Tutorial.md
@@ -30,7 +30,7 @@ Here's the most basic program we can write: one that just evaluates to the integ
 
 ```haskell
 -- |
--- >>> prettyPlcDef $ getPlc integerOne
+-- >>> pretty $ getPlc integerOne
 -- (program 1.0.0
 --   (con 8 ! 1)
 -- )
@@ -55,7 +55,7 @@ Here's a slightly more complex program, namely the identity function on integers
 
 ```haskell
 -- |
--- >>> prettyPlcDef $ getPlc integerIdentity
+-- >>> pretty $ getPlc integerIdentity
 -- (program 1.0.0
 --   (lam ds [(con integer) (con 8)] ds)
 -- )
@@ -152,7 +152,7 @@ very simple example, let's write an add-one function.
 -- TODO: show PIR here too
 
 -- |
--- >>> prettyPlcDef $ addOneToN 4
+-- >>> pretty $ addOneToN 4
 -- (program 1.0.0
 --   [
 --     [
@@ -167,7 +167,7 @@ very simple example, let's write an add-one function.
 --   ]
 -- )
 
--- >>> prettyPlcDef $ runCk program
+-- >>> pretty $ runCk program
 -- (con 8 ! 5)
 addOneToN :: Int -> Program TyName Name ()
 addOneToN n =
@@ -196,7 +196,7 @@ makeLift ''EndDate
 
 -- |
 -- >>> let program = shouldEndAt Never 5
--- >>> prettyPlcDef $ runCk program
+-- >>> pretty $ runCk program
 -- (abs
 --   out_Bool (type) (lam case_True out_Bool (lam case_False out_Bool case_False))
 -- )


### PR DESCRIPTION
While the full-on pretty-printing machinery is useful, and we do want it
for PIR (so we can e.g. get debug printing of uniques), it's nice to
have a default implementation of plain `Pretty` for "boring" usage.

As a side benefit, this lets me define a printing function that works
for both PLC and PIR, which will be helpful for my demo. (Possibly we
can do this already but I am unable to figure out how to.)