### PR TITLE
Remove redundant library dependencies identified by weeder

### DIFF
--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -57,7 +57,6 @@ library
                  -Wredundant-constraints -Widentities
     build-depends:
         base >=4.9 && <5,
-        bytestring -any,
         containers -any,
         language-plutus-core -any,
         lens -any,
@@ -86,9 +85,5 @@ test-suite plutus-ir-test
         language-plutus-core -any,
         mtl -any,
         mmorph -any,
-        prettyprinter -any,
         serialise -any,
-        tasty -any,
-        tasty-hunit -any,
-        tasty-golden -any,
-        text -any
+        tasty -any

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -54,7 +54,6 @@ test-suite plutus-tx-tests
     build-depends:
         base >=4.9 && <5,
         language-plutus-core -any,
-        plutus-core-interpreter -any,
         plutus-tx-plugin -any,
         plutus-tx -any,
         plutus-ir -any,
@@ -65,16 +64,15 @@ test-suite plutus-tx-tests
 test-suite plutus-tx-tutorial-doctests
     type: exitcode-stdio-1.0
     main-is: tutorial-doctests.hs
+    build-tool-depends: markdown-unlit:markdown-unlit -any
     hs-source-dirs: tutorial
     other-modules:
         Tutorial
     default-language: Haskell2010
+    ghc-options: -pgmL markdown-unlit -threaded
     build-depends:
         base >=4.9 && <5,
         plutus-tx -any,
         plutus-tx-plugin -any,
         language-plutus-core -any,
-        markdown-unlit -any,
         doctest -any
-    build-tool-depends: markdown-unlit:markdown-unlit
-    ghc-options: -pgmL markdown-unlit -threaded


### PR DESCRIPTION
I used `weeder` to identify redundant library depends and removed them. I also used `cabal format` on a couple files to standardize things. 