### PR TITLE
CI: use the main derivation as the test derivation for things that aren't split check

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -30,9 +30,11 @@ let
   mapped = mapTestOn platforms;
   makePlutusTestRuns = system:
     let
-      pred = name: value: fixedLib.isPlutus name && value ? testdata;
+      pred = name: value: fixedLib.isPlutus name;
       plutusPkgs = import ./. { inherit system; };
-      f = name: value: value.testrun;
+      # for things which are split-check then take the test run, otherwise
+      # use the main derivation which will have the tests as part of it
+      f = name: value: if value ? testdata then value.testrun else value;
     in pkgs.lib.mapAttrs f (lib.filterAttrs pred plutusPkgs.haskellPackages);
 in pkgs.lib.fix (jobsets:  mapped // {
   inherit (plutusPkgs) tests docs;


### PR DESCRIPTION
For derivations where the check phase isn't split, we don't put anything
into the required jobset for them. This is okay if they're depended on,
but is a bit sketchy.
    
What we should do is include the main derivation in (at least) this
case, as it will include the tests.
    
I think I would prefer to just include all the main derivation to be
sure, but I can't figure out how to do that.