### PR TITLE
wallet-api: don't re-export Wallet from Wallet.Emulator

### DIFF
--- a/plutus-use-cases/tutorial/Tutorial.md
+++ b/plutus-use-cases/tutorial/Tutorial.md
@@ -18,6 +18,7 @@ import qualified Language.PlutusTx            as PlutusTx
 import           Language.PlutusTx.Validation as Validation
 import           Ledger                       hiding (Height)
 import           Ledger.Validation
+import           Wallet
 import           Wallet.Emulator
 import           Prelude                      hiding ((&&))
 import           GHC.Generics                 (Generic)

--- a/wallet-api/src/Wallet/Emulator.hs
+++ b/wallet-api/src/Wallet/Emulator.hs
@@ -1,7 +1,5 @@
 module Wallet.Emulator(
-    module Types,
-    module WalletAPI
+    module Types
     ) where
 
-import           Wallet.API            as WalletAPI
 import           Wallet.Emulator.Types as Types


### PR DESCRIPTION
It's generally bad hygiene to re-export your dependencies, and I think
we want to emphasise that the wallet bits and the emulator bits come
from different places.