### PR TITLE
playground: Add test for mkFunction

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -55696,6 +55696,7 @@ license = stdenv.lib.licenses.bsd3;
 , base64-bytestring
 , bytestring
 , containers
+, hedgehog
 , hint
 , http-media
 , insert-ordered-containers
@@ -55709,6 +55710,8 @@ license = stdenv.lib.licenses.bsd3;
 , servant
 , stdenv
 , swagger2
+, tasty
+, tasty-hunit
 , template-haskell
 , text
 , transformers
@@ -55740,6 +55743,18 @@ swagger2
 template-haskell
 text
 transformers
+wallet-api
+];
+testHaskellDepends = [
+aeson
+base
+containers
+hedgehog
+swagger2
+tasty
+tasty-hunit
+template-haskell
+text
 wallet-api
 ];
 doHaddock = false;

--- a/plutus-playground/plutus-playground-lib/plutus-playground-lib.cabal
+++ b/plutus-playground/plutus-playground-lib/plutus-playground-lib.cabal
@@ -56,3 +56,25 @@ library
     , text
     , wallet-api
   default-language: Haskell2010
+
+test-suite playground-lib-test
+    default-language: Haskell2010
+    hs-source-dirs: tests
+    type: exitcode-stdio-1.0
+    main-is: Spec.hs
+    build-depends:
+        base >=4.9 && <5,
+        containers -any,
+        hedgehog -any,
+        swagger2 -any,
+        tasty -any,
+        tasty-hunit -any,
+        text -any,
+        template-haskell -any,
+        plutus-playground-lib -any,
+        wallet-api -any,
+        aeson -any
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances
+    -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wredundant-constraints -Widentities

--- a/plutus-playground/plutus-playground-lib/src/Playground/API.hs
+++ b/plutus-playground/plutus-playground-lib/src/Playground/API.hs
@@ -47,7 +47,7 @@ newtype SourceCode = SourceCode Text
   deriving anyclass (Newtype)
 
 newtype Fn = Fn Text
-  deriving stock (Show, Generic, TH.Lift)
+  deriving stock (Eq, Show, Generic, TH.Lift)
   deriving newtype (ToJSON, FromJSON)
 
 data Expression
@@ -83,7 +83,7 @@ data EvaluationResult = EvaluationResult
 data FunctionSchema a = FunctionSchema
   { functionName   :: Fn
   , argumentSchema :: [a]
-  } deriving (Show, Generic, ToJSON, Functor)
+  } deriving (Eq, Show, Generic, ToJSON, Functor)
 
 data SimpleArgumentSchema
   = SimpleIntArgument

--- a/plutus-playground/plutus-playground-lib/src/Playground/TH.hs
+++ b/plutus-playground/plutus-playground-lib/src/Playground/TH.hs
@@ -42,6 +42,7 @@ toSchemas fn ts = do
 
 args :: Type -> [Type]
 args (AppT (AppT ArrowT t1) as) = t1 : args as
+args (AppT (ConT _) _)          = []
 args (ForallT _ _ as)           = args as
 args (ConT _)                   = []
 args (TupleT _)                 = []

--- a/plutus-playground/plutus-playground-lib/tests/Spec.hs
+++ b/plutus-playground/plutus-playground-lib/tests/Spec.hs
@@ -1,0 +1,60 @@
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
+module Main where
+
+import           Data.Aeson            (FromJSON (..), ToJSON (..))
+import           Data.Proxy            (Proxy (..))
+import           Data.Swagger          (Schema, ToSchema (..), toSchema)
+import           Data.Text             (Text)
+import           GHC.Generics          (Generic)
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import           Playground.API
+import           Playground.TH
+import           Wallet.Emulator.Types (MockWallet)
+
+-- f1..fn are functions that we should be able to generate schemas
+-- for, using `mkFunction`. The schemas will be called f1Schema etc.
+
+f1 :: MockWallet ()
+f1 = pure ()
+
+f2 :: String -> MockWallet ()
+f2 _ = pure ()
+
+f3 :: String -> Value -> MockWallet ()
+f3 _ _ = pure ()
+
+f4 :: Text -> Text -> (Int, Int) -> [Text] -> MockWallet ()
+f4 _ _ _ _ = pure ()
+
+data Value = Value Int Int
+    deriving (Generic, FromJSON, ToJSON, ToSchema)
+
+$(mkFunction 'f1)
+$(mkFunction 'f2)
+$(mkFunction 'f3)
+$(mkFunction 'f4)
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "TH" [
+    testCase "f1" (f1Schema @?= FunctionSchema @Schema (Fn "f1") []),
+    testCase "f2" (f2Schema @?= FunctionSchema (Fn "f2") [
+        toSchema (Proxy @String)]),
+    testCase "f3" (f3Schema @?= FunctionSchema (Fn "f3") [
+        toSchema (Proxy @String),
+        toSchema (Proxy @Value)]),
+    testCase "f4" (f4Schema @?= FunctionSchema (Fn "f4") [
+        toSchema (Proxy @Text),
+        toSchema (Proxy @Text),
+        toSchema (Proxy @(Int, Int)),
+        toSchema (Proxy @[Text]) ])
+    ]


### PR DESCRIPTION
* Add a test for `mkFunction` with some of the signatures that we expect to work. In particular we would like to use the concrete `MockWallet` monad instead of the `WalletAPI m` constraints.
* Change `Playground.TH.args` to support functions that end in `MockWallet ()`