### PR TITLE
plutus-tx: Prelude exports quoted Builtins.error

### DIFF
--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -7,8 +7,7 @@ module Language.PlutusTx.Prelude (
     toPlutusString,
     trace,
     traceH,
-    -- error is the only builtin that people are likely to want to use directly
-    -- * Re-exported builtins
+    -- * Error
     error,
     -- * Boolean operators
     and,
@@ -30,9 +29,12 @@ module Language.PlutusTx.Prelude (
 import           Prelude                    (Bool (..), Int, Maybe (..), String, (<), (>), (+))
 
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Builtins (error)
 
 import           Language.Haskell.TH
+
+-- | Terminate the evaluation of the script with an error message
+error :: Q (TExp (() -> a))
+error = [|| Builtins.error ||]
 
 -- | Convert a Haskell 'String' into a 'Builtins.String'.
 toPlutusString :: Q (TExp (String -> Builtins.String))

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -175,7 +175,7 @@ contributionScript cmp  = ValidatorScript val where
                                     signedByT p campaignOwner
                     in payToOwner
         in
-        if isValid then () else PlutusTx.error ()) ||])
+        if isValid then () else $$(PlutusTx.error) ()) ||])
 
 -- | An event trigger that fires when a refund of campaign contributions can be claimed
 refundTrigger :: Campaign -> EventTrigger

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -245,7 +245,7 @@ validatorScript ft = ValidatorScript val where
 
                 verifyOracle :: OracleValue a -> (Height, a)
                 verifyOracle (OracleValue (Signed (pk, t))) =
-                    if pk `eqPk` futurePriceOracle then t else PlutusTx.error ()
+                    if pk `eqPk` futurePriceOracle then t else $$(PlutusTx.error) ()
 
                 isValid =
                     case r of
@@ -305,7 +305,7 @@ validatorScript ft = ValidatorScript val where
 
                                 _ -> False
             in
-                if isValid then () else PlutusTx.error ()
+                if isValid then () else $$(PlutusTx.error) ()
             ||])
 
 PlutusTx.makeLift ''Future

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
@@ -80,14 +80,14 @@ swapValidator _ = ValidatorScript result where
             minusR (x :% y) (x' :% y') = (x*y' - x'*y) :% (y*y')
 
             extractVerifyAt :: OracleValue (Ratio Int) -> PubKey -> Ratio Int -> Height -> Ratio Int
-            extractVerifyAt = PlutusTx.error ()
+            extractVerifyAt = $$(PlutusTx.error) ()
 
             round :: Ratio Int -> Int
-            round = PlutusTx.error ()
+            round = $$(PlutusTx.error) ()
 
             -- | Convert an [[Int]] to a [[Ratio Int]]
             fromInt :: Int -> Ratio Int
-            fromInt = PlutusTx.error ()
+            fromInt = $$(PlutusTx.error) ()
 
             signedBy :: PendingTxIn -> PubKey -> Bool
             signedBy = $$(Validation.txInSignedBy)
@@ -173,7 +173,7 @@ swapValidator _ = ValidatorScript result where
 
 
         in
-        if inConditions && outConditions then () else PlutusTx.error ()
+        if inConditions && outConditions then () else $$(PlutusTx.error) ()
         ) ||])
 
 {- Note [Swap Transactions]

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -129,7 +129,7 @@ validatorScript v = ValidatorScript val where
             amountSpent = case os of
                 PendingTxOut (Value v') _ (PubKeyTxOut pk):_
                     | pk `eqPk` vestingOwner -> v'
-                _ -> PlutusTx.error ()
+                _ -> $$(PlutusTx.error) ()
 
             -- Value that has been released so far under the scheme
             currentThreshold =
@@ -155,8 +155,8 @@ validatorScript v = ValidatorScript val where
             txnOutputsValid = case os of
                 _:PendingTxOut _ (Just (vl', _)) DataTxOut:_ ->
                     vl' `eqBs` vestingDataHash
-                _ -> PlutusTx.error ()
+                _ -> $$(PlutusTx.error) ()
 
             isValid = amountsValid && txnOutputsValid
         in
-        if isValid then () else PlutusTx.error () ||])
+        if isValid then () else $$(PlutusTx.error) () ||])

--- a/wallet-api/tutorial/Tutorial.md
+++ b/wallet-api/tutorial/Tutorial.md
@@ -190,7 +190,7 @@ In the `Collect` case, the current blockchain height must be between `deadline` 
 Finally, we can return the unit value `()` if `isValid` is true, or fail with an error otherwise.
 
 ```haskell
-              if isValid then () else (PlutusTx.error ())
+              if isValid then () else ($$(PlutusTx.error) ())
                   ||])
 ```
 


### PR DESCRIPTION
* By exporting `Builtins.error` as a quoted expression we ensure that it
  is used in exactly the same way as everything else that is exported from
  that module