### PR TITLE
plutus-tx: Improve documentation

### DIFF
--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE TemplateHaskell     #-}
--- this is in the default extensions, but for some reason when loading it during doctests it gets
--- confused if we don't have it
-{-# LANGUAGE ScopedTypeVariables #-}
 module Language.PlutusTx.Prelude (
+    -- $prelude
     -- * String and tracing functions
     toPlutusString,
     trace,
@@ -32,11 +30,24 @@ import qualified Language.PlutusTx.Builtins as Builtins
 
 import           Language.Haskell.TH
 
+-- $prelude
+-- The PlutusTx Prelude is a collection of useful functions that work with 
+-- builtin Haskell data types such as 'Maybe' and @[]@ (list).
+--
+-- Functions from the Prelude can be used with the the typed Template Haskell 
+-- splice operator @$$()@:
+--
+-- @
+--   import qualified Language.PlutusTx.Prelude as P
+--   
+--   [||  $$(P.traceH) "plutus" ... ||]
+-- @
+
 -- | Terminate the evaluation of the script with an error message
 error :: Q (TExp (() -> a))
 error = [|| Builtins.error ||]
 
--- | Convert a Haskell 'String' into a 'Builtins.String'.
+-- | Convert a Haskell 'String' into a PlutusTx 'Builtins.String'.
 toPlutusString :: Q (TExp (String -> Builtins.String))
 toPlutusString =
     [||
@@ -60,37 +71,83 @@ traceH :: Q (TExp (String -> a -> a))
 traceH = [|| \str a -> $$(trace) ($$(toPlutusString) str) a||]
 
 -- | Logical AND
+--
+--   >>> $$([|| $$(and) True False ||])
+--   False
+--
 and :: Q (TExp (Bool -> Bool -> Bool))
 and = [|| \(l :: Bool) (r :: Bool) -> if l then r else False ||]
 
 -- | Logical OR
+--
+--   >>> $$([|| $$(or) True False ||])
+--   True
+--
 or :: Q (TExp (Bool -> Bool -> Bool))
 or = [|| \(l :: Bool) (r :: Bool) -> if l then True else r ||]
 
 -- | Logical negation
+--
+--   >>> $$([|| $$(not) True ||])
+--   False
+--
 not :: Q (TExp (Bool -> Bool))
 not = [|| \(a :: Bool) -> if a then False else True  ||]
 
--- | The smaller of two `Int`s
+-- | The smaller of two 'Int's
+--
+--   >>> $$([|| $$(min) 10 5 ||])
+--   5
+--
 min :: Q (TExp (Int -> Int -> Int))
 min = [|| \(a :: Int) (b :: Int) -> if a < b then a else b ||]
 
--- | The larger of two `Int`s
+-- | The larger of two 'Int's
+--
+--   >>> $$([|| $$(max) 10 5 ||])
+--   10
+--
 max :: Q (TExp (Int -> Int -> Int))
 max = [|| \(a :: Int) (b :: Int) -> if a > b then a else b ||]
 
+-- | Check if a 'Maybe' @a@ is @Just a@
+--
+--   >>> $$([|| $$(isJust) Nothing ||])
+--   False
+--   >>> $$([|| $$(isJust) (Just "plutus") ||])
+--   True
+--
 isJust :: Q (TExp (Maybe a -> Bool))
-isJust = [|| \(m :: Maybe a) -> case m of { Just _ -> True; _ -> False; } ||]
+isJust = [|| \m -> case m of { Just _ -> True; _ -> False; } ||]
 
+-- | Check if a 'Maybe' @a@ is @Nothing@
+--
+--   >>> $$([|| $$(isNothing) Nothing ||])
+--   True
+--   >>> $$([|| $$(isNothing) (Just "plutus") ||])
+--   False
+--
 isNothing :: Q (TExp (Maybe a -> Bool))
-isNothing = [|| \(m :: Maybe a) -> case m of { Just _ -> False; } ||]
+isNothing = [|| \m -> case m of { Just _ -> False; _ -> True; } ||]
 
+-- | PlutusTx version of 'Prelude.maybe'.
+--
+--   >>> $$([|| $$(maybe) "platypus" (\s -> s) (Just "plutus") ||])
+--   "plutus"
+--   >>> $$([|| $$(maybe) "platypus" (\s -> s) Nothing ||])
+--   "platypus"
+--
 maybe :: Q (TExp (b -> (a -> b) -> Maybe a -> b))
 maybe = [|| \b f m ->
     case m of
         Nothing -> b
         Just a  -> f a ||]
 
+-- | PlutusTx version of 'Data.List.map'.
+--
+--   >>> $$([|| $$(map) (\i -> i + 1) [1, 2, 3] ||])
+--   [2,3,4]
+--
 map :: Q (TExp ((a -> b) -> [a] -> [b]))
 map = [||
     \f l ->
@@ -100,6 +157,11 @@ map = [||
         in go l
         ||]
 
+-- | PlutusTx version of 'Data.List.foldr'.
+--
+--   >>> $$([|| $$(foldr) (\i s -> s + i) 0 [1, 2, 3, 4] ||])
+--   10
+--
 foldr :: Q (TExp ((a -> b -> b) -> b -> [a] -> b))
 foldr = [||
     \f b l ->
@@ -109,6 +171,11 @@ foldr = [||
         in go b l
     ||]
 
+-- | 'length' @xs@ is the number of elements in @xs@.
+--
+--   >>> $$([|| $$(length) [1, 2, 3, 4] ||])
+--   4
+--
 length :: Q (TExp ([a] -> Int))
 length = [||
     \l ->
@@ -120,6 +187,11 @@ length = [||
         in go l
     ||]
 
+-- | PlutusTx version of 'Data.List.all'.
+--
+--   >>> $$([|| $$(all) (\i -> i > 5) [6, 8, 12] ||])
+--   True
+-- 
 all :: Q (TExp ((a -> Bool) -> [a] -> Bool))
 all = [||
     \pred l ->

--- a/plutus-tx/tutorial/tutorial-doctests.hs
+++ b/plutus-tx/tutorial/tutorial-doctests.hs
@@ -1,2 +1,2 @@
 import           Test.DocTest
-main = doctest ["-pgmL markdown-unlit", "-isrc", "-itutorial", "tutorial/Tutorial.lhs"]
+main = doctest ["-pgmL markdown-unlit", "-isrc", "-itutorial", "--fast", "-XTemplateHaskell", "-XScopedTypeVariables", "tutorial/Tutorial.lhs", "src/Language/PlutusTx/Prelude.hs"]


### PR DESCRIPTION
* Better haddocks for the PlutusTx prelude, and some doctests
* Note: Some of the doctests for the TH quotes only work if the entire
  expression is wrapped in the splicing operator. For example,
  `$$(isJust) (Just "a")` fails to evaluate, but
  `$$([|| $$(isJust) (Just "a") ]])` works. To make the
  documentation consistent I wrote all of the doctests that way.