### PR TITLE
Strip suffixes from the Lift class

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2,7 +2,7 @@
 - functions:
   - {name: unsafePerformIO, within: [PlutusPrelude, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Constant.Dynamic.Call, Language.PlutusCore.Constant.Dynamic.Emit, Language.PlutusCore.Constant.Dynamic.Instances, Language.PlutusTx.Plugin, Language.PlutusTx.Evaluation]}
   - {name: error, within: [Main, PlutusPrelude, Language.PlutusCore.StdLib.Meta, Evaluation.Constant.Success, Language.PlutusCore.Constant.Apply, Language.PlutusCore.Constant.Typed, Language.PlutusCore.Evaluation.CkMachine, Language.PlutusCore.TypeSynthesis, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Generators.Internal.Utils, Language.PlutusCore.Constant.Make, Language.PlutusCore.TH, Language.PlutusTx.Utils, Language.PlutusIR.Compiler.Datatype]}
-  - {name: undefined, within: [Language.PlutusCore.Constant.Apply, Language.PlutusTx.Lift.LiftPir, Language.PlutusTx.Lift.Instances]}
+  - {name: undefined, within: [Language.PlutusCore.Constant.Apply, Language.PlutusTx.Lift.Class, Language.PlutusTx.Lift.Instances]}
   - {name: fromJust, within: [Language.PlutusTx.Lift]}
   - {name: foldl, within: []}
   - {name: traceShowId, within: []} # for debugging only, should not be merged to master

--- a/plutus-tx-plugin/plutus-tx-plugin.cabal
+++ b/plutus-tx-plugin/plutus-tx-plugin.cabal
@@ -26,6 +26,7 @@ flag development
 library
     exposed-modules:
         Language.PlutusTx.Lift
+        Language.PlutusTx.Lift.Class
         Language.PlutusTx.Plugin
         Language.PlutusTx.Builtins
         Language.PlutusTx.Compiler.Error
@@ -34,7 +35,6 @@ library
         Language.PlutusTx.PLCTypes
         Language.PlutusTx.PIRTypes
         Language.PlutusTx.Utils
-        Language.PlutusTx.Lift.LiftPir
         Language.PlutusTx.Lift.THUtils
         Language.PlutusTx.Lift.Instances
         Language.PlutusTx.Compiler.Binders

--- a/plutus-tx-plugin/src/Language/PlutusTx/Lift.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Lift.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE FlexibleContexts #-}
+-- Note that we don't export the Lift class itself, most consumers shouldn't need that.
 module Language.PlutusTx.Lift (
-    module Lift,
     makeLift,
-    liftPlc,
-    liftPlcProgram,
-    unsafeLiftPlc,
-    unsafeLiftPlcProgram) where
+    lift,
+    liftProgram,
+    unsafeLift,
+    unsafeLiftProgram) where
 
+import           Language.PlutusTx.Lift.Class           (makeLift)
+import qualified Language.PlutusTx.Lift.Class           as Lift
 import           Language.PlutusTx.Lift.Instances       ()
-import           Language.PlutusTx.Lift.LiftPir         as Lift
 
 import           Language.PlutusIR
 import           Language.PlutusIR.Compiler
@@ -18,34 +19,28 @@ import qualified Language.PlutusCore                    as PLC
 import           Language.PlutusCore.Quote
 
 import           Control.Exception
-import           Control.Monad.Except
-import           Control.Monad.Reader
-
-import qualified Language.Haskell.TH                    as TH
+import           Control.Monad.Except                   hiding (lift)
+import           Control.Monad.Reader                   hiding (lift)
 
 -- | Get a Plutus Core term corresponding to the given value.
-liftPlc :: (LiftPir a, AsError e (Provenance ()), MonadError e m, MonadQuote m) => a -> m (PLC.Term TyName Name ())
-liftPlc x = do
+lift :: (Lift.Lift a, AsError e (Provenance ()), MonadError e m, MonadQuote m) => a -> m (PLC.Term TyName Name ())
+lift x = do
     lifted <- runDefT () $ Lift.lift x
     compiled <- flip runReaderT NoProvenance $ compileTerm lifted
     pure $ void compiled
 
 -- | Get a Plutus Core program corresponding to the given value.
-liftPlcProgram :: (LiftPir a, AsError e (Provenance ()), MonadError e m, MonadQuote m) => a -> m (PLC.Program TyName Name ())
-liftPlcProgram x = PLC.Program () (PLC.defaultVersion ()) <$> liftPlc x
+liftProgram :: (Lift.Lift a, AsError e (Provenance ()), MonadError e m, MonadQuote m) => a -> m (PLC.Program TyName Name ())
+liftProgram x = PLC.Program () (PLC.defaultVersion ()) <$> lift x
 
 -- | Get a Plutus Core term corresponding to the given value, throwing any errors that occur as exceptions and ignoring fresh names.
-unsafeLiftPlc :: LiftPir a => a -> PLC.Term TyName Name ()
-unsafeLiftPlc a = runQuote $ do
-    run <- runExceptT $ liftPlc a
+unsafeLift :: Lift.Lift a => a -> PLC.Term TyName Name ()
+unsafeLift a = runQuote $ do
+    run <- runExceptT $ lift a
     case run of
         Left (e::Error (Provenance ())) -> throw e
         Right t                         -> pure t
 
 -- | Get a Plutus Core program corresponding to the given value, throwing any errors that occur as exceptions and ignoring fresh names.
-unsafeLiftPlcProgram :: LiftPir a => a -> PLC.Program TyName Name ()
-unsafeLiftPlcProgram x = PLC.Program () (PLC.defaultVersion ()) $ unsafeLiftPlc x
-
--- | Make lift typeclass instances for the given type constructor name.
-makeLift :: TH.Name -> TH.Q [TH.Dec]
-makeLift = makeLiftPir
+unsafeLiftProgram :: Lift.Lift a => a -> PLC.Program TyName Name ()
+unsafeLiftProgram x = PLC.Program () (PLC.defaultVersion ()) $ unsafeLift x

--- a/plutus-tx-plugin/src/Language/PlutusTx/Lift/Instances.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Lift/Instances.hs
@@ -7,49 +7,49 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Language.PlutusTx.Lift.Instances () where
 
-import qualified Language.PlutusCore            as PLC
+import qualified Language.PlutusCore          as PLC
 
-import           Language.PlutusTx.Lift.LiftPir
+import           Language.PlutusTx.Lift.Class
 import           Language.PlutusTx.Utils
 
 import           Language.PlutusIR
 
-import qualified Data.ByteString.Lazy           as BSL
+import qualified Data.ByteString.Lazy         as BSL
 import           Data.Proxy
 
 -- Derived instances
 
 -- This instance ensures that we can apply typeable type constructors to typeable arguments and get a typeable
 -- type. We need the kind variable, so that partial application of type constructors works.
-instance (TypeablePir (f :: * -> k), TypeablePir (a :: *)) => TypeablePir (f a) where
+instance (Typeable (f :: * -> k), Typeable (a :: *)) => Typeable (f a) where
     typeRep _ = TyApp () <$> typeRep (undefined :: Proxy f) <*> typeRep (undefined :: Proxy a)
 
-instance (TypeablePir (a :: *), TypeablePir (b :: *)) => TypeablePir (a -> b) where
+instance (Typeable (a :: *), Typeable (b :: *)) => Typeable (a -> b) where
     typeRep _ = TyFun () <$> typeRep (undefined :: Proxy a) <*> typeRep (undefined :: Proxy b)
 
 -- Primitives
 
-instance TypeablePir Int where
+instance Typeable Int where
     typeRep _ = pure $ appSize haskellIntSize (TyBuiltin () PLC.TyInteger)
 
-instance LiftPir Int where
+instance Lift Int where
     lift i = pure $ Constant () $ PLC.BuiltinInt () haskellIntSize $ fromIntegral i
 
-instance TypeablePir BSL.ByteString where
+instance Typeable BSL.ByteString where
     typeRep _ = pure $ appSize haskellBSSize (TyBuiltin () PLC.TyByteString)
 
-instance LiftPir BSL.ByteString where
+instance Lift BSL.ByteString where
     lift bs = pure $ Constant () $ PLC.BuiltinBS () haskellBSSize bs
 
 -- Standard types
 -- These need to be in a separate file for TH staging reasons
 
-makeLiftPir ''Bool
-makeLiftPir ''Maybe
-makeLiftPir ''Either
-makeLiftPir ''[]
+makeLift ''Bool
+makeLift ''Maybe
+makeLift ''Either
+makeLift ''[]
 -- include a few tuple instances for convenience
-makeLiftPir ''(,)
-makeLiftPir ''(,,)
-makeLiftPir ''(,,,)
-makeLiftPir ''(,,,,)
+makeLift ''(,)
+makeLift ''(,,)
+makeLift ''(,,,)
+makeLift ''(,,,,)

--- a/plutus-tx-plugin/src/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Plugin.hs
@@ -23,7 +23,7 @@ import           Language.PlutusTx.Compiler.Error
 import           Language.PlutusTx.Compiler.Expr
 import           Language.PlutusTx.Compiler.Types
 import           Language.PlutusTx.Compiler.Utils
-import           Language.PlutusTx.Lift
+import qualified Language.PlutusTx.Lift.Class           as Lift
 import           Language.PlutusTx.PIRTypes
 import           Language.PlutusTx.PLCTypes
 import           Language.PlutusTx.Utils
@@ -66,7 +66,7 @@ data PlcCode = PlcCode {
 
 -- Note that we do *not* have a TypeablePlc instance, since we don't know what the type is. We could in principle store it after the plugin
 -- typechecks the code, but we don't currently.
-instance LiftPir PlcCode where
+instance Lift.Lift PlcCode where
     lift (getPlc -> (PLC.Program () _ body)) = PIR.embedIntoIR <$> PLC.rename body
 
 getSerializedPlc :: PlcCode -> BSL.ByteString

--- a/plutus-tx-plugin/test/Lift/Spec.hs
+++ b/plutus-tx-plugin/test/Lift/Spec.hs
@@ -22,15 +22,15 @@ Lift.makeLift ''NestedRecord
 
 tests :: TestNested
 tests = testNested "Lift" [
-    goldenPlc "int" (Lift.unsafeLiftPlcProgram (1::Int))
-    , goldenPlc "tuple" (Lift.unsafeLiftPlcProgram (1::Int, 2::Int))
-    , goldenPlc "mono" (Lift.unsafeLiftPlcProgram (Mono2 2))
-    , goldenEval "monoInterop" [ getPlc monoCase, Lift.unsafeLiftPlcProgram (Mono1 1 2) ]
-    , goldenPlc "poly" (Lift.unsafeLiftPlcProgram (Poly1 (1::Int) (2::Int)))
-    , goldenEval "polyInterop" [ getPlc defaultCasePoly, Lift.unsafeLiftPlcProgram (Poly1 (1::Int) (2::Int)) ]
-    , goldenPlc "record" (Lift.unsafeLiftPlcProgram (MyMonoRecord 1 2))
-    , goldenEval "boolInterop" [ getPlc andPlc, Lift.unsafeLiftPlcProgram True, Lift.unsafeLiftPlcProgram True ]
-    , goldenPlc "list" (Lift.unsafeLiftPlcProgram ([1]::[Int]))
-    , goldenEval "listInterop" [ getPlc listMatch, Lift.unsafeLiftPlcProgram ([1]::[Int]) ]
-    , goldenPlc "nested" (Lift.unsafeLiftPlcProgram (NestedRecord (Just (1, 2))))
+    goldenPlc "int" (Lift.unsafeLiftProgram (1::Int))
+    , goldenPlc "tuple" (Lift.unsafeLiftProgram (1::Int, 2::Int))
+    , goldenPlc "mono" (Lift.unsafeLiftProgram (Mono2 2))
+    , goldenEval "monoInterop" [ getPlc monoCase, Lift.unsafeLiftProgram (Mono1 1 2) ]
+    , goldenPlc "poly" (Lift.unsafeLiftProgram (Poly1 (1::Int) (2::Int)))
+    , goldenEval "polyInterop" [ getPlc defaultCasePoly, Lift.unsafeLiftProgram (Poly1 (1::Int) (2::Int)) ]
+    , goldenPlc "record" (Lift.unsafeLiftProgram (MyMonoRecord 1 2))
+    , goldenEval "boolInterop" [ getPlc andPlc, Lift.unsafeLiftProgram True, Lift.unsafeLiftProgram True ]
+    , goldenPlc "list" (Lift.unsafeLiftProgram ([1]::[Int]))
+    , goldenEval "listInterop" [ getPlc listMatch, Lift.unsafeLiftProgram ([1]::[Int]) ]
+    , goldenPlc "nested" (Lift.unsafeLiftProgram (NestedRecord (Just (1, 2))))
  ]

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -81,7 +81,7 @@ primitives = testNested "primitives" [
   , goldenEval "ifThenElseApply" [ ifThenElse, int, int2 ]
   --, goldenPlc "blocknum" blocknumPlc
   , goldenPir "bytestring" bytestring
-  , goldenEval "bytestringApply" [ getPlc bytestring, unsafeLiftPlcProgram ("hello"::ByteString) ]
+  , goldenEval "bytestringApply" [ getPlc bytestring, unsafeLiftProgram ("hello"::ByteString) ]
   , goldenPir "verify" verify
   ]
 

--- a/plutus-tx/tutorial/Tutorial.md
+++ b/plutus-tx/tutorial/Tutorial.md
@@ -172,7 +172,7 @@ very simple example, let's write an add-one function.
 addOneToN :: Int -> Program TyName Name ()
 addOneToN n =
     let addOne = $$(plutus [|| \(x:: Int) -> x + 1 ||])
-    in (getPlc addOne) `applyProgram` unsafeLiftPlcProgram n
+    in (getPlc addOne) `applyProgram` unsafeLiftProgram n
 ```
 
 Here we have lifted the Haskell value `4` into a Plutus Core term at runtime.
@@ -204,9 +204,9 @@ shouldEndAt :: EndDate -> Int -> Program TyName Name ()
 shouldEndAt end current =
     (getPlc shouldEnd)
     `applyProgram`
-    unsafeLiftPlcProgram end
+    unsafeLiftProgram end
     `applyProgram`
-    unsafeLiftPlcProgram current
+    unsafeLiftProgram current
 ```
 
 This is more or less all you need to get started - from here on it should mostly

--- a/wallet-api/src/Ledger/Types.hs
+++ b/wallet-api/src/Ledger/Types.hs
@@ -127,7 +127,8 @@ import           Data.Swagger.Internal.Schema             (ToSchema(declareNamed
 import qualified Language.PlutusCore                      as PLC
 import           Language.PlutusTx.Evaluation             (evaluateCekTrace)
 import           Language.PlutusCore.Evaluation.Result
-import           Language.PlutusTx.Lift                   (LiftPir, makeLift, unsafeLiftPlcProgram)
+import           Language.PlutusTx.Lift                   (makeLift, unsafeLiftProgram)
+import           Language.PlutusTx.Lift.Class             (Lift)
 import           Language.PlutusTx.Plugin                 (PlcCode, getSerializedPlc)
 import           Language.PlutusTx.TH                     (plutus)
 
@@ -265,8 +266,8 @@ instance FromJSON Script where
       Left e  -> fail e
       Right v -> pure v
 
-lifted :: LiftPir a => a -> Script
-lifted = Script . serialise . unsafeLiftPlcProgram
+lifted :: Lift a => a -> Script
+lifted = Script . serialise . unsafeLiftProgram
 
 -- | A validator is a PLC script.
 newtype ValidatorScript = ValidatorScript { getValidator :: Script }


### PR DESCRIPTION
It's better not to try and indicate what we're lifting "to" in the
names, as TH does.

Just pushing through a few final renames for friendliness.