### PR TITLE
PlutusTx: two final renames

### DIFF
--- a/plutus-playground/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground/plutus-playground-server/usecases/CrowdFunding.hs
@@ -73,7 +73,7 @@ campaignAddress = Ledger.scriptAddress . contributionScript
 contributionScript :: Campaign -> ValidatorScript
 contributionScript cmp  = ValidatorScript val where
     val = Ledger.applyScript mkValidator (Ledger.lifted cmp)
-    mkValidator = Ledger.fromPlcCode $$(PlutusTx.plutus [|| (\Campaign{..} (act :: CampaignAction) (con :: CampaignActor) (p :: PendingTx ValidatorHash) ->
+    mkValidator = Ledger.fromCompiledCode $$(PlutusTx.compile [|| (\Campaign{..} (act :: CampaignAction) (con :: CampaignActor) (p :: PendingTx ValidatorHash) ->
         let
 
             infixr 3 &&

--- a/plutus-playground/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Game.hs
@@ -32,7 +32,7 @@ mkRedeemerScript word =
     in RedeemerScript (Ledger.lifted (ClearString clearWord))
 
 gameValidator :: ValidatorScript
-gameValidator = ValidatorScript (Ledger.fromPlcCode $$(PlutusTx.plutus [||
+gameValidator = ValidatorScript (Ledger.fromCompiledCode $$(PlutusTx.compile [||
     \(ClearString guess) (HashedString actual) (p :: PendingTx ValidatorHash) ->
 
     if $$(P.equalsByteString) actual ($$(P.sha2_256) guess)

--- a/plutus-playground/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Vesting.hs
@@ -85,7 +85,7 @@ validatorScriptHash =
 validatorScript :: Vesting -> ValidatorScript
 validatorScript v = ValidatorScript val where
     val = Ledger.applyScript inner (Ledger.lifted v)
-    inner = Ledger.fromPlcCode $$(PlutusTx.plutus [|| \Vesting{..} () VestingData{..} (p :: PendingTx ValidatorHash) ->
+    inner = Ledger.fromCompiledCode $$(PlutusTx.compile [|| \Vesting{..} () VestingData{..} (p :: PendingTx ValidatorHash) ->
         let
 
             eqPk :: PubKey -> PubKey -> Bool

--- a/plutus-tx-plugin/test/Plugin/IllTyped.hs
+++ b/plutus-tx-plugin/test/Plugin/IllTyped.hs
@@ -14,33 +14,33 @@ import           Language.PlutusTx.Plugin
 -- this module does lots of weird stuff deliberately
 {-# ANN module "HLint: ignore" #-}
 
-string :: PlcCode
+string :: CompiledCode
 string = plc @"string" "test"
 
-listConstruct :: PlcCode
+listConstruct :: CompiledCode
 listConstruct = plc @"listConstruct" ([]::[Int])
 
-listConstruct2 :: PlcCode
+listConstruct2 :: CompiledCode
 listConstruct2 = plc @"listConstruct2" ([1]::[Int])
 
 -- It is very difficult to get GHC to make a non-polymorphic redex if you use
 -- list literal syntax with integers. But this works.
-listConstruct3 :: PlcCode
+listConstruct3 :: CompiledCode
 listConstruct3 = plc @"listConstruct3" ((1::Int):(2::Int):(3::Int):[])
 
-listMatch :: PlcCode
+listMatch :: CompiledCode
 listMatch = plc @"listMatch" (\(l::[Int]) -> case l of { (x:_) -> x ; [] -> 0; })
 
 data B a = One a | Two (B (a, a))
 
-ptreeConstruct :: PlcCode
+ptreeConstruct :: CompiledCode
 ptreeConstruct = plc @"ptreeConstruct" (Two (Two (One ((1,2),(3,4)))) :: B Int)
 
 -- TODO: replace this with 'first' when we have working recursive functions
-ptreeMatch :: PlcCode
+ptreeMatch :: CompiledCode
 ptreeMatch = plc @"ptreeMatch" (\(t::B Int) -> case t of { One a -> a; Two _ -> 2; })
 
-sumDirect :: PlcCode
+sumDirect :: CompiledCode
 sumDirect = plc @"sumDirect" (
     let sum :: [Int] -> Int
         sum []     = 0
@@ -50,7 +50,7 @@ sumDirect = plc @"sumDirect" (
 -- This doesn't work: we can't handle things that aren't of plain function type, and fold
 -- is a universally quantified function type
 {-
-sumViaFold :: PlcCode
+sumViaFold :: CompiledCode
 sumViaFold = plc (let fold :: (a -> b -> a) -> a -> [b] -> a
                       fold f base l = case l of
                           [] -> base

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -29,10 +29,10 @@ import           GHC.Generics
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}
 
-instance GetProgram PlcCode where
+instance GetProgram CompiledCode where
     getProgram = catchAll . getPlc
 
-goldenPir :: String -> PlcCode -> TestNested
+goldenPir :: String -> CompiledCode -> TestNested
 goldenPir name value = nestedGoldenVsDoc name $ PIR.prettyDef $ getPir value
 
 tests :: TestNested
@@ -52,10 +52,10 @@ basic = testNested "basic" [
   , goldenPlc "monoK" monoK
   ]
 
-monoId :: PlcCode
+monoId :: CompiledCode
 monoId = plc @"monoId" (\(x :: Int) -> x)
 
-monoK :: PlcCode
+monoK :: CompiledCode
 monoK = plc @"monoK" (\(i :: Int) -> \(j :: Int) -> i)
 
 primitives :: TestNested
@@ -85,53 +85,53 @@ primitives = testNested "primitives" [
   , goldenPir "verify" verify
   ]
 
-int :: PlcCode
+int :: CompiledCode
 int = plc @"int" (1::Int)
 
-int2 :: PlcCode
+int2 :: CompiledCode
 int2 = plc @"int2" (2::Int)
 
-bool :: PlcCode
+bool :: CompiledCode
 bool = plc @"bool" True
 
-andPlc :: PlcCode
+andPlc :: CompiledCode
 andPlc = plc @"andPlc" (\(x::Bool) (y::Bool) -> if x then (if y then True else False) else False)
 
-tuple :: PlcCode
+tuple :: CompiledCode
 tuple = plc @"tuple" ((1::Int), (2::Int))
 
-tupleMatch :: PlcCode
+tupleMatch :: CompiledCode
 tupleMatch = plc @"tupleMatch" (\(x:: (Int, Int)) -> let (a, b) = x in a)
 
-intCompare :: PlcCode
+intCompare :: CompiledCode
 intCompare = plc @"intCompare" (\(x::Int) (y::Int) -> x < y)
 
-intEq :: PlcCode
+intEq :: CompiledCode
 intEq = plc @"intEq" (\(x::Int) (y::Int) -> x == y)
 
 -- Has a Void in it
-void :: PlcCode
+void :: CompiledCode
 void = plc @"void" (\(x::Int) (y::Int) -> let a x' y' = case (x', y') of { (True, True) -> True; _ -> False; } in (x == y) `a` (y == x))
 
-intPlus :: PlcCode
+intPlus :: CompiledCode
 intPlus = plc @"intPlus" (\(x::Int) (y::Int) -> x + y)
 
-intDiv :: PlcCode
+intDiv :: CompiledCode
 intDiv = plc @"intDiv" (\(x::Int) (y::Int) -> x `div` y)
 
-errorPlc :: PlcCode
+errorPlc :: CompiledCode
 errorPlc = plc @"errorPlc" (Builtins.error @Int)
 
-ifThenElse :: PlcCode
+ifThenElse :: CompiledCode
 ifThenElse = plc @"ifThenElse" (\(x::Int) (y::Int) -> if x == y then x else y)
 
---blocknumPlc :: PlcCode
+--blocknumPlc :: CompiledCode
 --blocknumPlc = plc @"blocknumPlc" Builtins.blocknum
 
-bytestring :: PlcCode
+bytestring :: CompiledCode
 bytestring = plc @"bytestring" (\(x::ByteString) -> x)
 
-verify :: PlcCode
+verify :: CompiledCode
 verify = plc @"verify" (\(x::ByteString) (y::ByteString) (z::ByteString) -> Builtins.verifySignature x y z)
 
 structure :: TestNested
@@ -140,7 +140,7 @@ structure = testNested "structure" [
   ]
 
 -- GHC acutually turns this into a lambda for us, try and make one that stays a let
-letFun :: PlcCode
+letFun :: CompiledCode
 letFun = plc @"lefFun" (\(x::Int) (y::Int) -> let f z = x == z in f y)
 
 datat :: TestNested
@@ -169,44 +169,44 @@ monoData = testNested "monomorphic" [
 
 data MyEnum = Enum1 | Enum2
 
-basicEnum :: PlcCode
+basicEnum :: CompiledCode
 basicEnum = plc @"basicEnum" (Enum1)
 
 data MyMonoData = Mono1 Int Int | Mono2 Int | Mono3 Int deriving (Generic)
 
-monoDataType :: PlcCode
+monoDataType :: CompiledCode
 monoDataType = plc @"monoDataType" (\(x :: MyMonoData) -> x)
 
-monoConstructor :: PlcCode
+monoConstructor :: CompiledCode
 monoConstructor = plc @"monConstructor" (Mono1)
 
-monoConstructed :: PlcCode
+monoConstructed :: CompiledCode
 monoConstructed = plc @"monoConstructed" (Mono2 1)
 
-monoCase :: PlcCode
+monoCase :: CompiledCode
 monoCase = plc @"monoCase" (\(x :: MyMonoData) -> case x of { Mono1 _ b -> b;  Mono2 a -> a; Mono3 a -> a })
 
-defaultCase :: PlcCode
+defaultCase :: CompiledCode
 defaultCase = plc @"defaultCase" (\(x :: MyMonoData) -> case x of { Mono3 a -> a ; _ -> 2; })
 
-irrefutableMatch :: PlcCode
+irrefutableMatch :: CompiledCode
 irrefutableMatch = plc @"irrefutableMatch" (\(x :: MyMonoData) -> case x of { Mono2 a -> a })
 
-atPattern :: PlcCode
+atPattern :: CompiledCode
 atPattern = plc @"atPattern" (\t@(x::Int, y::Int) -> let fst (a, b) = a in y + fst t)
 
 data MyMonoRecord = MyMonoRecord { mrA :: Int , mrB :: Int} deriving Generic
 
-monoRecord :: PlcCode
+monoRecord :: CompiledCode
 monoRecord = plc @"monoRecord" (\(x :: MyMonoRecord) -> x)
 
 -- must be compiled with a lazy case
-nonValueCase :: PlcCode
+nonValueCase :: CompiledCode
 nonValueCase = plc @"nonValueCase" (\(x :: MyEnum) -> case x of { Enum1 -> 1::Int ; Enum2 -> Builtins.error (); })
 
 type Synonym = Int
 
-synonym :: PlcCode
+synonym :: CompiledCode
 synonym = plc @"synonym" (1::Synonym)
 
 polyData :: TestNested
@@ -218,13 +218,13 @@ polyData = testNested "polymorphic" [
 
 data MyPolyData a b = Poly1 a b | Poly2 a
 
-polyDataType :: PlcCode
+polyDataType :: CompiledCode
 polyDataType = plc @"polyDataType" (\(x:: MyPolyData Int Int) -> x)
 
-polyConstructed :: PlcCode
+polyConstructed :: CompiledCode
 polyConstructed = plc @"polyConstructed" (Poly1 (1::Int) (2::Int))
 
-defaultCasePoly :: PlcCode
+defaultCasePoly :: CompiledCode
 defaultCasePoly = plc @"defaultCasePoly" (\(x :: MyPolyData Int Int) -> case x of { Poly1 a _ -> a ; _ -> 2; })
 
 newtypes :: TestNested
@@ -241,19 +241,19 @@ newtype MyNewtype = MyNewtype Int
 
 newtype MyNewtype2 = MyNewtype2 MyNewtype
 
-basicNewtype :: PlcCode
+basicNewtype :: CompiledCode
 basicNewtype = plc @"basicNewtype" (\(x::MyNewtype) -> x)
 
-newtypeMatch :: PlcCode
+newtypeMatch :: CompiledCode
 newtypeMatch = plc @"newtypeMatch" (\(MyNewtype x) -> x)
 
-newtypeCreate :: PlcCode
+newtypeCreate :: CompiledCode
 newtypeCreate = plc @"newtypeCreate" (\(x::Int) -> MyNewtype x)
 
-newtypeCreate2 :: PlcCode
+newtypeCreate2 :: CompiledCode
 newtypeCreate2 = plc @"newtypeCreate2" (MyNewtype 1)
 
-nestedNewtypeMatch :: PlcCode
+nestedNewtypeMatch :: CompiledCode
 nestedNewtypeMatch = plc @"nestedNewtypeMatch" (\(MyNewtype2 (MyNewtype x)) -> x)
 
 recursiveTypes :: TestNested
@@ -283,14 +283,14 @@ recursion = testNested "recursiveFunctions" [
     , goldenEval "even4" [ evenMutual, plc @"4" (4::Int) ]
   ]
 
-fib :: PlcCode
+fib :: CompiledCode
 -- not using case to avoid literal cases
 fib = plc @"fib" (
     let fib :: Int -> Int
         fib n = if n == 0 then 0 else if n == 1 then 1 else fib(n-1) + fib(n-2)
     in fib)
 
-evenMutual :: PlcCode
+evenMutual :: CompiledCode
 evenMutual = plc @"evenMutual" (
     let even :: Int -> Bool
         even n = if n == 0 then True else odd (n-1)
@@ -306,16 +306,16 @@ errors = testNested "errors" [
     , goldenPlcCatch "recordSelector" recordSelector
   ]
 
-integer :: PlcCode
+integer :: CompiledCode
 integer = plc @"integer" (1::Integer)
 
-free :: PlcCode
+free :: CompiledCode
 free = plc @"free" (True && False)
 
 -- It's little tricky to get something that GHC actually turns into a polymorphic computation! We use our value twice
 -- at different types to prevent the obvious specialization.
-valueRestriction :: PlcCode
+valueRestriction :: CompiledCode
 valueRestriction = plc @"valueRestriction" (let { f :: forall a . a; f = Builtins.error (); } in (f @Bool, f @Int))
 
-recordSelector :: PlcCode
+recordSelector :: CompiledCode
 recordSelector = plc @"recordSelector" (\(x :: MyMonoRecord) -> mrA x)

--- a/plutus-tx/src/Language/PlutusTx/TH.hs
+++ b/plutus-tx/src/Language/PlutusTx/TH.hs
@@ -4,7 +4,7 @@
 module Language.PlutusTx.TH (
     plutus,
     plutusUntyped,
-    PlcCode,
+    CompiledCode,
     getSerializedPlc,
     getSerializedPir,
     getPlc,
@@ -16,7 +16,7 @@ import qualified Language.Haskell.TH        as TH
 import qualified Language.Haskell.TH.Syntax as TH
 
 -- | Covert a quoted Haskell expression into a corresponding Plutus Core program.
-plutus :: TH.Q (TH.TExp a) -> TH.Q (TH.TExp PlcCode)
+plutus :: TH.Q (TH.TExp a) -> TH.Q (TH.TExp CompiledCode)
 -- See note [Typed TH]
 plutus e = TH.unsafeTExpCoerce $ plutusUntyped $ TH.unType <$> e
 
@@ -29,7 +29,7 @@ so we can't isolate the badness much. So we pretty much just have to use unsafeT
 and assert that we know what we're doing.
 
 This isn't so bad, since our plc function accepts an argument of any type, so that's always
-going to typecheck, and the result is always a PlcCode, so that's also fine.
+going to typecheck, and the result is always a CompiledCode, so that's also fine.
 -}
 
 -- | Covert a quoted Haskell expression into a corresponding Plutus Core program.

--- a/plutus-tx/src/Language/PlutusTx/TH.hs
+++ b/plutus-tx/src/Language/PlutusTx/TH.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE TemplateHaskell  #-}
 {-# LANGUAGE TypeApplications #-}
 module Language.PlutusTx.TH (
-    plutus,
-    plutusUntyped,
+    compile,
+    compileUntyped,
     CompiledCode,
     getSerializedPlc,
     getSerializedPir,
@@ -15,10 +15,10 @@ import           Language.PlutusTx.Plugin
 import qualified Language.Haskell.TH        as TH
 import qualified Language.Haskell.TH.Syntax as TH
 
--- | Covert a quoted Haskell expression into a corresponding Plutus Core program.
-plutus :: TH.Q (TH.TExp a) -> TH.Q (TH.TExp CompiledCode)
+-- | Compile a quoted Haskell expression into a corresponding Plutus Core program.
+compile :: TH.Q (TH.TExp a) -> TH.Q (TH.TExp CompiledCode)
 -- See note [Typed TH]
-plutus e = TH.unsafeTExpCoerce $ plutusUntyped $ TH.unType <$> e
+compile e = TH.unsafeTExpCoerce $ compileUntyped $ TH.unType <$> e
 
 {- Note [Typed TH]
 It's nice to use typed TH! However, we sadly can't *quite* use it thoroughly, because we
@@ -32,9 +32,9 @@ This isn't so bad, since our plc function accepts an argument of any type, so th
 going to typecheck, and the result is always a CompiledCode, so that's also fine.
 -}
 
--- | Covert a quoted Haskell expression into a corresponding Plutus Core program.
-plutusUntyped :: TH.Q TH.Exp -> TH.Q TH.Exp
-plutusUntyped e = do
+-- | Compile a quoted Haskell expression into a corresponding Plutus Core program.
+compileUntyped :: TH.Q TH.Exp -> TH.Q TH.Exp
+compileUntyped e = do
     TH.addCorePlugin "Language.PlutusTx.Plugin"
     loc <- TH.location
     let locStr = TH.pprint loc

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -68,26 +68,26 @@ tests = testGroup "plutus-th" <$> sequence [
   ]
 
 simple :: CompiledCode
-simple = $$(plutus [|| \(x::Bool) -> if x then (1::Int) else (2::Int) ||])
+simple = $$(compile [|| \(x::Bool) -> if x then (1::Int) else (2::Int) ||])
 
 -- similar to the power example for Feldspar - should be completely unrolled at compile time
 powerPlc :: CompiledCode
-powerPlc = $$(plutus [|| $$(power (4::Int)) ||])
+powerPlc = $$(compile [|| $$(power (4::Int)) ||])
 
 andPlc :: CompiledCode
-andPlc = $$(plutus [|| $$(andTH) True False ||])
+andPlc = $$(compile [|| $$(andTH) True False ||])
 
 convertString :: CompiledCode
-convertString = $$(plutus [|| $$(toPlutusString) "test" ||])
+convertString = $$(compile [|| $$(toPlutusString) "test" ||])
 
 traceDirect :: CompiledCode
-traceDirect = $$(plutus [|| Builtins.trace ($$(toPlutusString) "test") ||])
+traceDirect = $$(compile [|| Builtins.trace ($$(toPlutusString) "test") ||])
 
 tracePrelude :: CompiledCode
-tracePrelude = $$(plutus [|| $$(trace) ($$(toPlutusString) "test") (1::Int) ||])
+tracePrelude = $$(compile [|| $$(trace) ($$(toPlutusString) "test") (1::Int) ||])
 
 traceRepeatedly :: CompiledCode
-traceRepeatedly = $$(plutus
+traceRepeatedly = $$(compile
      [||
                -- This will in fact print the third log first, and then the others, but this
                -- is the same behaviour as Debug.trace

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -32,10 +32,10 @@ import           Test.Tasty
 main :: IO ()
 main = defaultMain $ runTestNestedIn ["test"] tests
 
-instance GetProgram PlcCode where
+instance GetProgram CompiledCode where
     getProgram = catchAll . getPlc
 
-goldenPir :: String -> PlcCode -> TestNested
+goldenPir :: String -> CompiledCode -> TestNested
 goldenPir name value = nestedGoldenVsDoc name $ PIR.prettyDef $ getPir value
 
 runPlcCek :: GetProgram a => [a] -> ExceptT SomeException IO EvaluationResult
@@ -67,26 +67,26 @@ tests = testGroup "plutus-th" <$> sequence [
     , goldenEvalCekLog "traceRepeatedly" [traceRepeatedly]
   ]
 
-simple :: PlcCode
+simple :: CompiledCode
 simple = $$(plutus [|| \(x::Bool) -> if x then (1::Int) else (2::Int) ||])
 
 -- similar to the power example for Feldspar - should be completely unrolled at compile time
-powerPlc :: PlcCode
+powerPlc :: CompiledCode
 powerPlc = $$(plutus [|| $$(power (4::Int)) ||])
 
-andPlc :: PlcCode
+andPlc :: CompiledCode
 andPlc = $$(plutus [|| $$(andTH) True False ||])
 
-convertString :: PlcCode
+convertString :: CompiledCode
 convertString = $$(plutus [|| $$(toPlutusString) "test" ||])
 
-traceDirect :: PlcCode
+traceDirect :: CompiledCode
 traceDirect = $$(plutus [|| Builtins.trace ($$(toPlutusString) "test") ||])
 
-tracePrelude :: PlcCode
+tracePrelude :: CompiledCode
 tracePrelude = $$(plutus [|| $$(trace) ($$(toPlutusString) "test") (1::Int) ||])
 
-traceRepeatedly :: PlcCode
+traceRepeatedly :: CompiledCode
 traceRepeatedly = $$(plutus
      [||
                -- This will in fact print the third log first, and then the others, but this

--- a/plutus-tx/tutorial/Tutorial.md
+++ b/plutus-tx/tutorial/Tutorial.md
@@ -17,9 +17,9 @@ import Language.PlutusCore.Evaluation.CkMachine
 
 ## Writing basic PlutusTx programs
 
-The `PlcCode` type is an opaque type which contains the serialized Plutus Core code
+The `CompiledCode` type is an opaque type which contains the serialized Plutus Core code
 corresponding to a Haskell expression. The `plutus` function takes a typed Template Haskell
-`Q (TExp a)`, for any a, and produces a `Q (TExp PlcCode)`, which we then
+`Q (TExp a)`, for any a, and produces a `Q (TExp CompiledCode)`, which we then
 have to splice into our program.
 
 The fact that `plutus` takes a TH quote means that what you write inside the quote
@@ -34,7 +34,7 @@ Here's the most basic program we can write: one that just evaluates to the integ
 -- (program 1.0.0
 --   (con 8 ! 1)
 -- )
-integerOne :: PlcCode
+integerOne :: CompiledCode
 -- We don't like unbounded integers in Plutus Core, so we have to pin
 -- down that numeric literal to an `Int` not an `Integer`.
 integerOne = $$(plutus [|| (1 :: Int) ||])
@@ -59,7 +59,7 @@ Here's a slightly more complex program, namely the identity function on integers
 -- (program 1.0.0
 --   (lam ds [(con integer) (con 8)] ds)
 -- )
-integerIdentity :: PlcCode
+integerIdentity :: CompiledCode
 integerIdentity = $$(plutus [|| \(x:: Int) -> x ||])
 ```
 
@@ -74,7 +74,7 @@ some reusable components.
 plusOne :: Int -> Int
 plusOne x = x + 1
 
-functions :: PlcCode
+functions :: CompiledCode
 functions = $$(plutus [||
     let
         plusOneLocal :: Int -> Int
@@ -100,7 +100,7 @@ TODO: when we store the PIR, start showing PIR at this stage (or earlier).
 We can use normal Haskell datatypes and pattern matching freely:
 
 ```haskell
-matchMaybe :: PlcCode
+matchMaybe :: CompiledCode
 matchMaybe = $$(plutus [|| \(x:: Maybe Int) -> case x of
     Just n -> n
     Nothing -> 0
@@ -116,7 +116,7 @@ end date.
 ```haskell
 data EndDate = Fixed Int | Never
 
-shouldEnd :: PlcCode
+shouldEnd :: CompiledCode
 shouldEnd = $$(plutus [|| \(end::EndDate) (current::Int) -> case end of
     Fixed n -> n <= current
     Never -> False

--- a/plutus-tx/tutorial/Tutorial.md
+++ b/plutus-tx/tutorial/Tutorial.md
@@ -18,11 +18,11 @@ import Language.PlutusCore.Evaluation.CkMachine
 ## Writing basic PlutusTx programs
 
 The `CompiledCode` type is an opaque type which contains the serialized Plutus Core code
-corresponding to a Haskell expression. The `plutus` function takes a typed Template Haskell
+corresponding to a Haskell expression. The `compile` function takes a typed Template Haskell
 `Q (TExp a)`, for any a, and produces a `Q (TExp CompiledCode)`, which we then
 have to splice into our program.
 
-The fact that `plutus` takes a TH quote means that what you write inside the quote
+The fact that `compile` takes a TH quote means that what you write inside the quote
 is *just normal Haskell* - there is no PlutusTx-specific syntax, and the PlutusTx compiler will
 tell you if you use any Haskell features which are not supported.
 
@@ -37,7 +37,7 @@ Here's the most basic program we can write: one that just evaluates to the integ
 integerOne :: CompiledCode
 -- We don't like unbounded integers in Plutus Core, so we have to pin
 -- down that numeric literal to an `Int` not an `Integer`.
-integerOne = $$(plutus [|| (1 :: Int) ||])
+integerOne = $$(compile [|| (1 :: Int) ||])
 ```
 
 The Plutus Core program will look incomprehensible, which is fine, since you
@@ -60,7 +60,7 @@ Here's a slightly more complex program, namely the identity function on integers
 --   (lam ds [(con integer) (con 8)] ds)
 -- )
 integerIdentity :: CompiledCode
-integerIdentity = $$(plutus [|| \(x:: Int) -> x ||])
+integerIdentity = $$(compile [|| \(x:: Int) -> x ||])
 ```
 
 So far, so familiar: we compiled a lambda into a lambda.
@@ -75,7 +75,7 @@ plusOne :: Int -> Int
 plusOne x = x + 1
 
 functions :: CompiledCode
-functions = $$(plutus [||
+functions = $$(compile [||
     let
         plusOneLocal :: Int -> Int
         plusOneLocal x = x + 1
@@ -101,7 +101,7 @@ We can use normal Haskell datatypes and pattern matching freely:
 
 ```haskell
 matchMaybe :: CompiledCode
-matchMaybe = $$(plutus [|| \(x:: Maybe Int) -> case x of
+matchMaybe = $$(compile [|| \(x:: Maybe Int) -> case x of
     Just n -> n
     Nothing -> 0
    ||])
@@ -117,7 +117,7 @@ end date.
 data EndDate = Fixed Int | Never
 
 shouldEnd :: CompiledCode
-shouldEnd = $$(plutus [|| \(end::EndDate) (current::Int) -> case end of
+shouldEnd = $$(compile [|| \(end::EndDate) (current::Int) -> case end of
     Fixed n -> n <= current
     Never -> False
    ||])
@@ -171,7 +171,7 @@ very simple example, let's write an add-one function.
 -- (con 8 ! 5)
 addOneToN :: Int -> Program TyName Name ()
 addOneToN n =
-    let addOne = $$(plutus [|| \(x:: Int) -> x + 1 ||])
+    let addOne = $$(compile [|| \(x:: Int) -> x + 1 ||])
     in (getPlc addOne) `applyProgram` unsafeLiftProgram n
 ```
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -122,7 +122,7 @@ contributionScript cmp  = ValidatorScript val where
 
     --   See note [Contracts and Validator Scripts] in
     --       Language.Plutus.Coordination.Contracts
-    inner = Ledger.fromPlcCode $$(PlutusTx.plutus [|| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx ValidatorHash) ->
+    inner = Ledger.fromCompiledCode $$(PlutusTx.plutus [|| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx ValidatorHash) ->
         let
 
             infixr 3 &&

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -122,7 +122,7 @@ contributionScript cmp  = ValidatorScript val where
 
     --   See note [Contracts and Validator Scripts] in
     --       Language.Plutus.Coordination.Contracts
-    inner = Ledger.fromCompiledCode $$(PlutusTx.plutus [|| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx ValidatorHash) ->
+    inner = Ledger.fromCompiledCode $$(PlutusTx.compile [|| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx ValidatorHash) ->
         let
 
             infixr 3 &&

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -194,7 +194,7 @@ data FutureRedeemer =
 validatorScript :: Future -> ValidatorScript
 validatorScript ft = ValidatorScript val where
     val = Ledger.applyScript inner (Ledger.lifted ft)
-    inner = Ledger.fromPlcCode $$(PlutusTx.plutus [||
+    inner = Ledger.fromCompiledCode $$(PlutusTx.plutus [||
         \Future{..} (r :: FutureRedeemer) FutureData{..} (p :: (PendingTx ValidatorHash)) ->
 
             let

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -194,7 +194,7 @@ data FutureRedeemer =
 validatorScript :: Future -> ValidatorScript
 validatorScript ft = ValidatorScript val where
     val = Ledger.applyScript inner (Ledger.lifted ft)
-    inner = Ledger.fromCompiledCode $$(PlutusTx.plutus [||
+    inner = Ledger.fromCompiledCode $$(PlutusTx.compile [||
         \Future{..} (r :: FutureRedeemer) FutureData{..} (p :: (PendingTx ValidatorHash)) ->
 
             let

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
@@ -58,7 +58,7 @@ type SwapOracle = OracleValue (Ratio Int)
 --       Language.Plutus.Coordination.Contracts
 swapValidator :: Swap -> ValidatorScript
 swapValidator _ = ValidatorScript result where
-    result = Ledger.fromCompiledCode $$(PlutusTx.plutus [|| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx ValidatorHash) Swap{..} ->
+    result = Ledger.fromCompiledCode $$(PlutusTx.compile [|| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx ValidatorHash) Swap{..} ->
         let
             infixr 3 &&
             (&&) :: Bool -> Bool -> Bool

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
@@ -58,7 +58,7 @@ type SwapOracle = OracleValue (Ratio Int)
 --       Language.Plutus.Coordination.Contracts
 swapValidator :: Swap -> ValidatorScript
 swapValidator _ = ValidatorScript result where
-    result = Ledger.fromPlcCode $$(PlutusTx.plutus [|| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx ValidatorHash) Swap{..} ->
+    result = Ledger.fromCompiledCode $$(PlutusTx.plutus [|| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx ValidatorHash) Swap{..} ->
         let
             infixr 3 &&
             (&&) :: Bool -> Bool -> Bool

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -107,7 +107,7 @@ validatorScriptHash =
 validatorScript :: Vesting -> ValidatorScript
 validatorScript v = ValidatorScript val where
     val = Ledger.applyScript inner (Ledger.lifted v)
-    inner = Ledger.fromCompiledCode $$(PlutusTx.plutus [|| \Vesting{..} () VestingData{..} (p :: PendingTx ValidatorHash) ->
+    inner = Ledger.fromCompiledCode $$(PlutusTx.compile [|| \Vesting{..} () VestingData{..} (p :: PendingTx ValidatorHash) ->
         let
 
             eqBs :: ValidatorHash -> ValidatorHash -> Bool

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -107,7 +107,7 @@ validatorScriptHash =
 validatorScript :: Vesting -> ValidatorScript
 validatorScript v = ValidatorScript val where
     val = Ledger.applyScript inner (Ledger.lifted v)
-    inner = Ledger.fromPlcCode $$(PlutusTx.plutus [|| \Vesting{..} () VestingData{..} (p :: PendingTx ValidatorHash) ->
+    inner = Ledger.fromCompiledCode $$(PlutusTx.plutus [|| \Vesting{..} () VestingData{..} (p :: PendingTx ValidatorHash) ->
         let
 
             eqBs :: ValidatorHash -> ValidatorHash -> Bool

--- a/wallet-api/src/Ledger/Types.hs
+++ b/wallet-api/src/Ledger/Types.hs
@@ -130,7 +130,7 @@ import           Language.PlutusCore.Evaluation.Result
 import           Language.PlutusTx.Lift                   (makeLift, unsafeLiftProgram)
 import           Language.PlutusTx.Lift.Class             (Lift)
 import           Language.PlutusTx.Plugin                 (CompiledCode, getSerializedPlc)
-import           Language.PlutusTx.TH                     (plutus)
+import           Language.PlutusTx.TH                     (compile)
 
 {- Note [Serialisation and hashing]
 
@@ -698,7 +698,7 @@ runScript (ValidationData valData) (ValidatorScript validator) (RedeemerScript r
 
 -- | () as a data script
 unitData :: DataScript
-unitData = DataScript $ fromCompiledCode $$(plutus [|| () ||])
+unitData = DataScript $ fromCompiledCode $$(compile [|| () ||])
 
 -- | \() () () -> () as a validator
 --
@@ -711,15 +711,15 @@ unitData = DataScript $ fromCompiledCode $$(plutus [|| () ||])
 --       you need to provide `unitData`, `unitRedeemer` and
 --       `unitValidationData` to consume it.
 emptyValidator :: ValidatorScript
-emptyValidator = ValidatorScript $ fromCompiledCode $$(plutus [|| \() () () -> () ||])
+emptyValidator = ValidatorScript $ fromCompiledCode $$(compile [|| \() () () -> () ||])
 
 -- | () as a redeemer
 unitRedeemer :: RedeemerScript
-unitRedeemer = RedeemerScript $ fromCompiledCode $$(plutus [|| () ||])
+unitRedeemer = RedeemerScript $ fromCompiledCode $$(compile [|| () ||])
 
 -- | () as validation data
 unitValidationData :: ValidationData
-unitValidationData = ValidationData $ fromCompiledCode $$(plutus [|| () ||])
+unitValidationData = ValidationData $ fromCompiledCode $$(compile [|| () ||])
 
 -- | Transaction output locked by the empty validator and unit data scripts.
 simpleOutput :: Value -> TxOut'

--- a/wallet-api/src/Ledger/Types.hs
+++ b/wallet-api/src/Ledger/Types.hs
@@ -30,7 +30,7 @@ module Ledger.Types(
     scriptAddress,
     -- ** Scripts
     Script, -- abstract
-    fromPlcCode,
+    fromCompiledCode,
     lifted,
     applyScript,
     evaluateScript,
@@ -129,7 +129,7 @@ import           Language.PlutusTx.Evaluation             (evaluateCekTrace)
 import           Language.PlutusCore.Evaluation.Result
 import           Language.PlutusTx.Lift                   (makeLift, unsafeLiftProgram)
 import           Language.PlutusTx.Lift.Class             (Lift)
-import           Language.PlutusTx.Plugin                 (PlcCode, getSerializedPlc)
+import           Language.PlutusTx.Plugin                 (CompiledCode, getSerializedPlc)
 import           Language.PlutusTx.TH                     (plutus)
 
 {- Note [Serialisation and hashing]
@@ -240,9 +240,9 @@ deriving anyclass instance FromJSON Address'
 newtype Script = Script { getSerialized :: BSL.ByteString }
   deriving newtype (Serialise, Eq, Ord)
 
--- TODO: possibly this belongs with PlcCode
-fromPlcCode :: PlcCode -> Script
-fromPlcCode = Script . getSerializedPlc
+-- TODO: possibly this belongs with CompiledCode
+fromCompiledCode :: CompiledCode -> Script
+fromCompiledCode = Script . getSerializedPlc
 
 getPlc :: Script -> PLC.Program PLC.TyName PLC.Name ()
 getPlc = deserialise . getSerialized
@@ -698,7 +698,7 @@ runScript (ValidationData valData) (ValidatorScript validator) (RedeemerScript r
 
 -- | () as a data script
 unitData :: DataScript
-unitData = DataScript $ fromPlcCode $$(plutus [|| () ||])
+unitData = DataScript $ fromCompiledCode $$(plutus [|| () ||])
 
 -- | \() () () -> () as a validator
 --
@@ -711,15 +711,15 @@ unitData = DataScript $ fromPlcCode $$(plutus [|| () ||])
 --       you need to provide `unitData`, `unitRedeemer` and
 --       `unitValidationData` to consume it.
 emptyValidator :: ValidatorScript
-emptyValidator = ValidatorScript $ fromPlcCode $$(plutus [|| \() () () -> () ||])
+emptyValidator = ValidatorScript $ fromCompiledCode $$(plutus [|| \() () () -> () ||])
 
 -- | () as a redeemer
 unitRedeemer :: RedeemerScript
-unitRedeemer = RedeemerScript $ fromPlcCode $$(plutus [|| () ||])
+unitRedeemer = RedeemerScript $ fromCompiledCode $$(plutus [|| () ||])
 
 -- | () as validation data
 unitValidationData :: ValidationData
-unitValidationData = ValidationData $ fromPlcCode $$(plutus [|| () ||])
+unitValidationData = ValidationData $ fromCompiledCode $$(plutus [|| () ||])
 
 -- | Transaction output locked by the empty validator and unit data scripts.
 simpleOutput :: Value -> TxOut'

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -145,7 +145,7 @@ invalidScript = property $ do
 
     where
         failValidator :: ValidatorScript
-        failValidator = ValidatorScript $ fromPlcCode $$(plutus [|| \() () () -> $$(PlutusTx.traceH) "I always fail everything" (Builtins.error @()) ||])
+        failValidator = ValidatorScript $ fromCompiledCode $$(plutus [|| \() () () -> $$(PlutusTx.traceH) "I always fail everything" (Builtins.error @()) ||])
 
 splitVal :: Property
 splitVal = property $ do

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -17,7 +17,7 @@ import qualified Hedgehog.Gen               as Gen
 import qualified Hedgehog.Range             as Range
 import           Test.Tasty
 import           Test.Tasty.Hedgehog        (testProperty)
-import           Language.PlutusTx.TH       (plutus)
+import           Language.PlutusTx.TH       (compile)
 import qualified Language.PlutusTx.Builtins as Builtins
 import qualified Language.PlutusTx.Prelude  as PlutusTx
 
@@ -145,7 +145,7 @@ invalidScript = property $ do
 
     where
         failValidator :: ValidatorScript
-        failValidator = ValidatorScript $ fromCompiledCode $$(plutus [|| \() () () -> $$(PlutusTx.traceH) "I always fail everything" (Builtins.error @()) ||])
+        failValidator = ValidatorScript $ fromCompiledCode $$(compile [|| \() () () -> $$(PlutusTx.traceH) "I always fail everything" (Builtins.error @()) ||])
 
 splitVal :: Property
 splitVal = property $ do

--- a/wallet-api/tutorial/Tutorial.md
+++ b/wallet-api/tutorial/Tutorial.md
@@ -86,7 +86,7 @@ mkValidatorScript :: Campaign -> ValidatorScript
 mkValidatorScript campaign = ValidatorScript val where
   val = applyScript mkValidator (lifted campaign)
   -- ^ val is the obtained by applying `mkValidator` to the lifted `campaign` value
-  mkValidator = fromCompiledCode $$(PlutusTx.plutus [|| 
+  mkValidator = fromCompiledCode $$(PlutusTx.compile [|| 
 ```
 
 Anything between the `[||` and `||]` quotes is going to be _on-chain code_ and anything outside the quotes is _off-chain code_. We can now implement a lambda function that looks like `mkValidator`, starting with its parameters:

--- a/wallet-api/tutorial/Tutorial.md
+++ b/wallet-api/tutorial/Tutorial.md
@@ -86,7 +86,7 @@ mkValidatorScript :: Campaign -> ValidatorScript
 mkValidatorScript campaign = ValidatorScript val where
   val = applyScript mkValidator (lifted campaign)
   -- ^ val is the obtained by applying `mkValidator` to the lifted `campaign` value
-  mkValidator = fromPlcCode $$(PlutusTx.plutus [|| 
+  mkValidator = fromCompiledCode $$(PlutusTx.plutus [|| 
 ```
 
 Anything between the `[||` and `||]` quotes is going to be _on-chain code_ and anything outside the quotes is _off-chain code_. We can now implement a lambda function that looks like `mkValidator`, starting with its parameters:


### PR DESCRIPTION
These are I think the last things I want to rename before the conference.

- `PlcCode` -> `CompiledCode`
    - I want to avoid mentioning PLC as much as possible.
    - The more "opaque" the name here the better, since in future we may end up stuffing even more things in here (like additional debug information).
    - Alternatives:
        - `Code` (too generic IMO)
        - `StagedCode`
- `plutus` -> `compile`
    - This makes it much clearer what is actually happening, IMO.
    - Fits nicely with `CompiledCode`: `compile :: TH.TExp a -> CompiledCode`
    - Alternatives:
       - `plutusTx` (I was originally going to use this, but then I thought of `compile`)

The `plutus` rename is the most user-facing one, so I'd like some opinions on that.