### PR TITLE
wallet-api: Do not return zero change

### DIFF
--- a/plutus-playground/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Vesting.hs
@@ -4,6 +4,7 @@ module Language.PlutusTx.Coordination.Contracts.Vesting  where
 import           Control.Monad.Error.Class    (MonadError (..))
 import           Control.Monad                (void)
 import           Data.Aeson                   (FromJSON, ToJSON)
+import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
 import           GHC.Generics                 (Generic)
 import           Ledger.Validation            (Height (..), PendingTx (..), PendingTxOut (..), PendingTxOutType (..),
@@ -61,7 +62,7 @@ vestFunds vst value = do
     let vs = validatorScript vst
         o = scriptTxOut value vs (DataScript $ Ledger.lifted vd)
         vd =  VestingData (validatorScriptHash vst) 0
-    void $ signAndSubmit payment [o, change]
+    void $ signAndSubmit payment (o : maybeToList change)
 
 -- | Retrieve some of the vested funds.
 retrieveFunds :: (

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -26,6 +26,7 @@ module Language.PlutusTx.Coordination.Contracts.Future(
 
 import           Control.Monad                (void)
 import           Control.Monad.Error.Class    (MonadError (..))
+import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
 import           GHC.Generics                 (Generic)
 import qualified Language.PlutusTx            as PlutusTx 
@@ -86,7 +87,7 @@ initialise long short f = do
         ds = DataScript $ Ledger.lifted $ FutureData long short im im
 
     (payment, change) <- createPaymentWithChange im
-    void $ signAndSubmit payment [o, change]
+    void $ signAndSubmit payment (o : maybeToList change)
 
 -- | Close the position by extracting the payment
 settle :: (
@@ -150,7 +151,7 @@ adjustMargin refs ft fd vl = do
         o = scriptTxOut outVal (validatorScript ft) ds
         outVal = vl + (futureDataMarginLong fd + futureDataMarginShort fd)
         inp = Set.fromList $ (\r -> scriptTxIn r (validatorScript ft) red) <$> refs
-    void $ signAndSubmit (Set.union payment inp) [o, change]
+    void $ signAndSubmit (Set.union payment inp) (o : maybeToList change)
 
 
 -- | Basic data of a futures contract. `Future` contains all values that do not

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -18,6 +18,7 @@ module Language.PlutusTx.Coordination.Contracts.Vesting (
     ) where
 
 import           Control.Monad.Error.Class    (MonadError (..))
+import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
 import           GHC.Generics                 (Generic)
 import           Ledger.Validation            (Height (..), PendingTx (..), PendingTxOut (..), PendingTxOutType (..),
@@ -74,7 +75,7 @@ vestFunds vst value = do
     let vs = validatorScript vst
         o = scriptTxOut value vs (DataScript $ Ledger.lifted vd)
         vd =  VestingData (validatorScriptHash vst) 0
-    _ <- signAndSubmit payment [o, change]
+    _ <- signAndSubmit payment (o : maybeToList change)
     pure vd
 
 -- | Retrieve some of the vested funds.

--- a/wallet-api/src/Wallet/Emulator/Client.hs
+++ b/wallet-api/src/Wallet/Emulator/Client.hs
@@ -41,7 +41,7 @@ wallets :: ClientM [Wallet]
 fetchWallet :: Wallet -> ClientM Wallet
 createWallet :: Wallet -> ClientM NoContent
 myKeyPair' :: Wallet -> ClientM KeyPair
-createPaymentWithChange' :: Wallet -> Value -> ClientM (Set TxIn', TxOut')
+createPaymentWithChange' :: Wallet -> Value -> ClientM (Set TxIn', Maybe TxOut')
 submitTxn' :: Wallet -> Tx -> ClientM [Tx]
 getTransactions :: ClientM [Tx]
 processPending :: ClientM [Tx]

--- a/wallet-api/src/Wallet/Emulator/Http.hs
+++ b/wallet-api/src/Wallet/Emulator/Http.hs
@@ -47,7 +47,7 @@ type WalletAPI
      :<|> "wallets" :> Capture "walletid" Wallet :> Get '[ JSON] Wallet
      :<|> "wallets" :> ReqBody '[ JSON] Wallet :> Post '[ JSON] NoContent
      :<|> "wallets" :> Capture "walletid" Wallet :> "my-key-pair" :> Get '[ JSON] KeyPair
-     :<|> "wallets" :> Capture "walletid" Wallet :> "payments" :> ReqBody '[ JSON] Value :> Post '[ JSON] (Set TxIn', TxOut')
+     :<|> "wallets" :> Capture "walletid" Wallet :> "payments" :> ReqBody '[ JSON] Value :> Post '[ JSON] (Set TxIn', Maybe TxOut')
 -- This is where the line between wallet API and control API is crossed
 -- Returning the [Tx] only makes sense when running a WalletAPI m => m () inside a Trace, but not on the wallet API on its own,
 --   otherwise the signature of submitTxn would be submitTxn :: Tx -> m [Tx]
@@ -115,7 +115,7 @@ createPaymentWithChange ::
      (MonadReader ServerState m, MonadIO m, MonadError ServantErr m)
   => Wallet
   -> Value
-  -> m (Set.Set TxIn', TxOut')
+  -> m (Set.Set TxIn', Maybe TxOut')
 createPaymentWithChange wallet =
   runWalletAction wallet . WAPI.createPaymentWithChange
 

--- a/wallet-api/src/Wallet/Emulator/Types.hs
+++ b/wallet-api/src/Wallet/Emulator/Types.hs
@@ -81,7 +81,8 @@ import           Servant.API                (FromHttpApiData, ToHttpApiData)
 
 import           Data.Hashable              (Hashable)
 import           Ledger                     (Address', Block, Blockchain, Height, Tx (..), TxId', TxOutRef', Value,
-                                             hashTx, height, pubKeyAddress, pubKeyTxIn, pubKeyTxOut, txOutAddress)
+                                             hashTx, height, pubKeyAddress, pubKeyTxIn, pubKeyTxOut, txOutAddress,
+                                             txOutValue)
 import qualified Ledger.Index               as Index
 import           Wallet.API                 (EventHandler (..), EventTrigger, KeyPair (..), WalletAPI (..),
                                              WalletAPIError (..), WalletDiagnostics (..), WalletLog (..), addresses,
@@ -219,7 +220,8 @@ instance WalletAPI MockWallet where
                         totalSpent     = P.last (snd <$> fundsToSpend)-- can use `last` because `fundsToSpend` is not empty
                         change         = totalSpent - vl -- `change` is the value that we pay back to a public-key address owned by us
                         txOutput       = pubKeyTxOut change (pubKey kp)
-                    in pure (txIns, txOutput)
+                        txOutput'      = if txOutValue txOutput == 0 then Nothing else Just txOutput
+                    in pure (txIns, txOutput')
 
     register tr action =
         modify (over triggers (Map.insertWith (<>) tr action))


### PR DESCRIPTION
* Currently when we call `createPaymentWithChange` and happen to have
  the exact amount, we get a transaction output containing the change of
  zero. This is not incorrect - there are no fees in the
  emulator, so even for the zero-cost output the cost of spending it is
  not higher than its value. (That is, we can't have "dust" in the
  mockchain).
* However, this might cause some problems in the playground, so it's
  best to get rid of this behaviour.