### PR TITLE
playground: Better sample contracts

### DIFF
--- a/plutus-playground/plutus-playground-lib/src/Playground/Contract.hs
+++ b/plutus-playground/plutus-playground-lib/src/Playground/Contract.hs
@@ -6,17 +6,21 @@ module Playground.Contract
     , ToJSON
     , FromJSON
     , FunctionSchema
+    , Generic
     , payToPublicKey
+    , MockWallet
     ) where
 
-import           Control.Monad  (void)
-import           Data.Aeson     (FromJSON, ToJSON)
-import           Data.Swagger   (Schema, ToSchema)
-import           Ledger.Types   (PubKey, Value)
-import           Playground.API (FunctionSchema)
-import           Playground.TH  (mkFunction)
-import           Wallet.API     (WalletAPI)
-import qualified Wallet.API     as WAPI
+import           Control.Monad         (void)
+import           Data.Aeson            (FromJSON, ToJSON)
+import           Data.Swagger          (Schema, ToSchema)
+import           GHC.Generics          (Generic)
+import           Ledger.Types          (PubKey, Value)
+import           Playground.API        (FunctionSchema)
+import           Playground.TH         (mkFunction)
+import           Wallet.API            (WalletAPI)
+import qualified Wallet.API            as WAPI
+import           Wallet.Emulator.Types (MockWallet)
 
 payToPublicKey :: (Monad m, WalletAPI m) => Value -> PubKey -> m ()
 payToPublicKey v = void . WAPI.payToPubKey v

--- a/plutus-playground/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Game.hs
@@ -1,24 +1,12 @@
 module Language.PlutusTx.Coordination.Contracts.Game where
 
-import           Control.Applicative          (Applicative (..))
-import           Control.Lens
-import           Control.Monad                (void)
-import           Data.Foldable                (foldMap)
-import qualified Data.Map                     as Map
-import           Data.Maybe                   (fromMaybe)
-import           Data.Monoid                  (Sum (..))
-import qualified Data.Set                     as Set
-import           GHC.Generics                 (Generic)
-import           Playground.Contract
-import           Data.Text
-import           Control.Monad.Error (MonadError(..))
-
 import qualified Language.PlutusTx            as PlutusTx
-import           Ledger as Ledger
+import           Ledger
 import           Ledger.Validation
-import Wallet hiding (payToPubKey)
+import           Wallet
+import           Playground.Contract
 
-logAMessage :: (WalletAPI m, WalletDiagnostics m) => m ()
+logAMessage :: MockWallet ()
 logAMessage = logMsg "wallet log"
 
 data ANumber = ANumber Int

--- a/plutus-playground/plutus-playground-server/usecases/Messages.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Messages.hs
@@ -4,29 +4,18 @@
 -- throwWalletAPIError throws an error from a wallet (client)
 module Language.PlutusTx.Coordination.Contracts.Messages where
 
-import           Control.Applicative          (Applicative (..))
-import           Control.Lens
-import           Control.Monad                (void)
-import           Control.Monad.Error          (MonadError (..))
-import           Data.Foldable                (foldMap)
-import qualified Data.Map                     as Map
-import           Data.Maybe                   (fromMaybe)
-import           Data.Monoid                  (Sum (..))
 import qualified Data.Set                     as Set
-import           Data.Text
-import           GHC.Generics                 (Generic)
-import           Playground.Contract
+import           Data.Text                    (Text)
 
-import qualified Language.PlutusTx            as PlutusTx
 import           Ledger
 import           Ledger.Validation
-import qualified Ledger.Validation            as Validation
 import           Wallet
+import           Playground.Contract
 
-logAMessage :: (WalletAPI m, WalletDiagnostics m) => m ()
+logAMessage :: MockWallet ()
 logAMessage = logMsg "wallet log"
 
-submitInvalidTxn :: (WalletAPI m, WalletDiagnostics m) => m ()
+submitInvalidTxn :: MockWallet ()
 submitInvalidTxn = do
     logMsg "Preparing to submit an invalid transaction"
     let tx = Tx
@@ -38,8 +27,8 @@ submitInvalidTxn = do
             }
     submitTxn tx
 
-throwWalletAPIError :: (WalletAPI m, WalletDiagnostics m) => Text -> m ()
-throwWalletAPIError = throwError . OtherError
+throwWalletAPIError :: Text -> MockWallet ()
+throwWalletAPIError = otherError
 
 $(mkFunction 'logAMessage)
 $(mkFunction 'submitInvalidTxn)

--- a/plutus-playground/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Vesting.hs
@@ -4,6 +4,7 @@ module Language.PlutusTx.Coordination.Contracts.Vesting  where
 import           Control.Monad.Error.Class    (MonadError (..))
 import           Control.Monad                (void)
 import           Data.Aeson                   (FromJSON, ToJSON)
+import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
 import           GHC.Generics                 (Generic)
 import           Ledger.Validation            (Height (..), PendingTx (..), PendingTxOut (..), PendingTxOutType (..),
@@ -61,7 +62,7 @@ vestFunds vst value = do
     let vs = validatorScript vst
         o = scriptTxOut value vs (DataScript $ Ledger.lifted vd)
         vd =  VestingData (validatorScriptHash vst) 0
-    void $ signAndSubmit payment [o, change]
+    void $ signAndSubmit payment (o : maybeToList change)
 
 -- | Retrieve some of the vested funds.
 retrieveFunds :: (

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -34,15 +34,15 @@ import qualified Data.Set                     as Set
 import           GHC.Generics                 (Generic)
 
 import qualified Language.PlutusTx            as PlutusTx
-import           Ledger                       (DataScript (..), PubKey (..), TxId', ValidatorScript (..), Value (..), scriptTxIn)
+import           Ledger                       (DataScript (..), PubKey (..), TxId', ValidatorScript (..), Value (..), scriptTxIn, Height(..))
 import qualified Ledger                       as Ledger
-import           Ledger.Validation            (Height (..), PendingTx (..), PendingTxIn (..), PendingTxOut, ValidatorHash)
+import           Ledger.Validation            (PendingTx (..), PendingTxIn (..), PendingTxOut, ValidatorHash)
 import qualified Ledger.Validation            as Validation
 import           Wallet                       (EventHandler (..), EventTrigger, Range (..), WalletAPI (..),
                                                WalletDiagnostics (..), andT, blockHeightT, fundsAtAddressT, otherError,
                                                ownPubKeyTxOut, payToScript, pubKey, signAndSubmit)
 
-import           Prelude                    (Bool (..), Int, Num (..), Ord (..), fromIntegral, fst, snd, succ, ($), (.),
+import           Prelude                    (Bool (..), Int, Num (..), Ord (..), fst, snd, succ, ($), (.),
                                              (<$>), (==))
 
 -- | A crowdfunding campaign.
@@ -181,13 +181,13 @@ contributionScript cmp  = ValidatorScript val where
 refundTrigger :: Campaign -> EventTrigger
 refundTrigger c = andT
     (fundsAtAddressT (campaignAddress c) $ GEQ 1)
-    (blockHeightT (GEQ $ fromIntegral $ succ $ getHeight $ campaignCollectionDeadline c))
+    (blockHeightT (GEQ $ succ $ campaignCollectionDeadline c))
 
 -- | An event trigger that fires when the funds for a campaign can be collected
 collectFundsTrigger :: Campaign -> EventTrigger
 collectFundsTrigger c = andT
     (fundsAtAddressT (campaignAddress c) $ GEQ $ campaignTarget c)
-    (blockHeightT $ fromIntegral . getHeight <$> Interval (campaignDeadline c) (campaignCollectionDeadline c))
+    (blockHeightT $ Interval (campaignDeadline c) (campaignCollectionDeadline c))
 
 -- | Claim a refund of our campaign contribution
 refund :: (WalletAPI m, WalletDiagnostics m) => TxId' -> Campaign -> EventHandler m

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -26,6 +26,7 @@ module Language.PlutusTx.Coordination.Contracts.Future(
 
 import           Control.Monad                (void)
 import           Control.Monad.Error.Class    (MonadError (..))
+import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
 import           GHC.Generics                 (Generic)
 import qualified Language.PlutusTx            as PlutusTx 
@@ -86,7 +87,7 @@ initialise long short f = do
         ds = DataScript $ Ledger.lifted $ FutureData long short im im
 
     (payment, change) <- createPaymentWithChange im
-    void $ signAndSubmit payment [o, change]
+    void $ signAndSubmit payment (o : maybeToList change)
 
 -- | Close the position by extracting the payment
 settle :: (
@@ -150,7 +151,7 @@ adjustMargin refs ft fd vl = do
         o = scriptTxOut outVal (validatorScript ft) ds
         outVal = vl + (futureDataMarginLong fd + futureDataMarginShort fd)
         inp = Set.fromList $ (\r -> scriptTxIn r (validatorScript ft) red) <$> refs
-    void $ signAndSubmit (Set.union payment inp) [o, change]
+    void $ signAndSubmit (Set.union payment inp) (o : maybeToList change)
 
 
 -- | Basic data of a futures contract. `Future` contains all values that do not

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -21,10 +21,10 @@ import           Control.Monad.Error.Class    (MonadError (..))
 import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
 import           GHC.Generics                 (Generic)
-import           Ledger.Validation            (Height (..), PendingTx (..), PendingTxOut (..), PendingTxOutType (..),
+import           Ledger.Validation            (PendingTx (..), PendingTxOut (..), PendingTxOutType (..),
                                               ValidatorHash)
 import qualified Language.PlutusTx            as PlutusTx
-import           Ledger                       (DataScript (..), PubKey (..), TxOutRef', ValidatorScript (..), Value (..), scriptTxIn, scriptTxOut)
+import           Ledger                       (DataScript (..), Height(..), PubKey (..), TxOutRef', ValidatorScript (..), Value (..), scriptTxIn, scriptTxOut)
 import qualified Ledger                       as Ledger
 import qualified Ledger.Validation            as Validation
 import           Prelude                      hiding ((&&))

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -18,6 +18,7 @@ module Language.PlutusTx.Coordination.Contracts.Vesting (
     ) where
 
 import           Control.Monad.Error.Class    (MonadError (..))
+import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
 import           GHC.Generics                 (Generic)
 import           Ledger.Validation            (Height (..), PendingTx (..), PendingTxOut (..), PendingTxOutType (..),
@@ -74,7 +75,7 @@ vestFunds vst value = do
     let vs = validatorScript vst
         o = scriptTxOut value vs (DataScript $ Ledger.lifted vd)
         vd =  VestingData (validatorScriptHash vst) 0
-    _ <- signAndSubmit payment [o, change]
+    _ <- signAndSubmit payment (o : maybeToList change)
     pure vd
 
 -- | Retrieve some of the vested funds.

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -22,7 +22,6 @@ import qualified Wallet.Generators                                     as Gen
 import           Language.PlutusTx.Coordination.Contracts.CrowdFunding (Campaign (..), contribute)
 import qualified Language.PlutusTx.Coordination.Contracts.CrowdFunding as CF
 import qualified Ledger
-import qualified Ledger.Validation                                     as Validation
 
 tests :: TestTree
 tests = testGroup "crowdfunding" [
@@ -59,9 +58,9 @@ collect w = void $ walletAction w $ CF.collect $ cfCampaign scenario1
 scenario1 :: CFScenario
 scenario1 = CFScenario{..} where
     cfCampaign = Campaign {
-        campaignDeadline = Validation.Height 10,
+        campaignDeadline = 10,
         campaignTarget   = 1000,
-        campaignCollectionDeadline = Validation.Height 15,
+        campaignCollectionDeadline = 15,
         campaignOwner              = PubKey 1
         }
     cfWallets = [w1, w2, w3]

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -12,8 +12,7 @@ import           Test.Tasty
 import           Test.Tasty.Hedgehog                             (testProperty)
 
 import qualified Ledger
-import           Ledger.Validation                               (OracleValue (..), Signed (..))
-import qualified Ledger.Validation                               as Validation
+import           Ledger.Validation                               (OracleValue (..))
 import           Prelude                                         hiding (init)
 import           Wallet.API                                      (PubKey (..))
 import           Wallet.Emulator
@@ -65,7 +64,7 @@ settle = checkTrace $ do
         cur = FutureData (PubKey 1) (PubKey 2) im im
         spotPrice = 1124
         delta = fromIntegral units * (spotPrice - forwardPrice)
-        ov  = OracleValue (Signed (oracle, (Validation.Height 10, spotPrice)))
+        ov  = OracleValue oracle (Ledger.Height 10) spotPrice
 
     -- advance the clock to block height 10
     void $ addBlocks 8
@@ -89,7 +88,7 @@ settleEarly = checkTrace $ do
         -- up with the variation margin.
         (_, upper) = marginRange
         spotPrice = upper + 1
-        ov  = OracleValue (Signed (oracle, (Validation.Height 8, spotPrice)))
+        ov  = OracleValue oracle (Ledger.Height 8) spotPrice
 
     -- advance the clock to block height 8
     void $ addBlocks 6
@@ -130,7 +129,7 @@ increaseMargin = checkTrace $ do
         spotPrice = upper + 1
 
         delta = fromIntegral units * (spotPrice - forwardPrice)
-        ov  = OracleValue (Signed (oracle, (Validation.Height 10, spotPrice)))
+        ov  = OracleValue oracle (Ledger.Height 10) spotPrice
 
     void $ walletAction w2 (F.settle [ins'] contract cur' ov)
     updateAll
@@ -147,7 +146,7 @@ increaseMargin = checkTrace $ do
 --   10 blocks.
 contract :: Future
 contract = Future {
-    futureDeliveryDate  = Validation.Height 10,
+    futureDeliveryDate  = Ledger.Height 10,
     futureUnits         = units,
     futureUnitPrice     = forwardPrice,
     futureInitialMargin = im,

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -39,8 +39,8 @@ tests = testGroup "vesting" [
 scen1 :: VestingScenario
 scen1 = VestingScenario{..} where
     vsVestingScheme = Vesting {
-        vestingTranche1 = VestingTranche (Validation.Height 10) 200,
-        vestingTranche2 = VestingTranche (Validation.Height 20) 400,
+        vestingTranche1 = VestingTranche (Ledger.Height 10) 200,
+        vestingTranche2 = VestingTranche (Ledger.Height 20) 400,
         vestingOwner    = PubKey 1 }
     vsWallets = Wallet <$> [1, 2]
     vsInitialBalances = Map.fromList [

--- a/wallet-api/src/Ledger/Index.hs
+++ b/wallet-api/src/Ledger/Index.hs
@@ -34,8 +34,9 @@ import qualified Data.Map             as Map
 import           Data.Semigroup       (Semigroup, Sum (..))
 import qualified Data.Set             as Set
 import           GHC.Generics         (Generic)
-import           Ledger.Types         (Blockchain, DataScript, PubKey, Signature, Tx (..), TxIn (..), TxIn', TxOut (..),
-                                       TxOut', TxOutRef', ValidationData (..), Value, lifted, updateUtxo, validValuesTx)
+import           Ledger.Types         (Blockchain, DataScript, Height (..), PubKey, Signature, Tx (..), TxIn (..),
+                                       TxIn', TxOut (..), TxOut', TxOutRef', ValidationData (..), Value, lifted,
+                                       updateUtxo, validValuesTx)
 import qualified Ledger.Types         as Ledger
 import           Ledger.Validation    (PendingTx (..))
 import qualified Ledger.Validation    as Validation
@@ -201,7 +202,7 @@ checkPositiveValues t =
 
 -- | Encode the current transaction and blockchain height
 --   in PLC.
-validationData :: ValidationMonad m => Ledger.Height -> Tx -> m (PendingTx ())
+validationData :: ValidationMonad m => Height -> Tx -> m (PendingTx ())
 validationData h tx = rump <$> ins where
     ins = traverse mkIn $ Set.toList $ txInputs tx
 
@@ -210,7 +211,7 @@ validationData h tx = rump <$> ins where
         , pendingTxOutputs = mkOut <$> txOutputs tx
         , pendingTxForge = txForge tx
         , pendingTxFee = txFee tx
-        , pendingTxBlockHeight = Validation.Height $ fromIntegral h
+        , pendingTxBlockHeight = h
         , pendingTxSignatures = txSignatures tx
         , pendingTxOwnHash    = ()
         }

--- a/wallet-api/src/Ledger/Types.hs
+++ b/wallet-api/src/Ledger/Types.hs
@@ -345,6 +345,8 @@ newtype Height = Height { getHeight :: Int }
     deriving anyclass (ToSchema, FromJSON, ToJSON)
     deriving newtype (Num, Real, Integral, Serialise)
 
+makeLift ''Height
+
 -- | The height of a blockchain
 height :: Blockchain -> Height
 height = Height . length

--- a/wallet-api/src/Wallet/API.hs
+++ b/wallet-api/src/Wallet/API.hs
@@ -21,6 +21,7 @@ module Wallet.API(
     payToScript,
     payToPubKey,
     collectFromScript,
+    collectFromScriptTxn,
     ownPubKeyTxOut,
     ownPubKey,
     -- * Triggers
@@ -62,7 +63,7 @@ import qualified Data.Set                   as Set
 import           Data.Text                  (Text)
 import           GHC.Generics               (Generic)
 import           Ledger                     (Address', DataScript, Height, PubKey (..), RedeemerScript, Signature (..),
-                                             Tx (..), TxIn', TxOut (..), TxOut', TxOutType (..), ValidatorScript, Value,
+                                             Tx (..), TxIn', TxId', txOutRefId, TxOut (..), TxOut', TxOutType (..), ValidatorScript, Value,
                                              pubKeyTxOut, scriptAddress, scriptTxIn)
 import           Text.Show.Deriving         (deriveShow1)
 import           Wallet.Emulator.AddressMap (AddressMap)
@@ -292,6 +293,22 @@ collectFromScript scr red = do
 
     oo <- ownPubKeyTxOut value
     void $ signAndSubmit (Set.fromList ins) [oo]
+
+-- | Given the pay to script address of the 'ValidatorScript', collect from it
+--   all the inputs that were produced by a specific transaction, using the
+--   'RedeemerScript'.
+collectFromScriptTxn :: (Monad m, WalletAPI m) => ValidatorScript -> RedeemerScript -> TxId' -> m ()
+collectFromScriptTxn vls red txid = do
+    am <- watchedAddresses
+    let adr     = Ledger.scriptAddress vls
+        utxo    = fromMaybe Map.empty $ am ^. at adr
+        ourUtxo = Map.toList $ Map.filterWithKey (\k _ -> txid == Ledger.txOutRefId k) utxo
+        i ref = scriptTxIn ref vls red
+        inputs = Set.fromList $ i . fst <$> ourUtxo
+        value  = getSum $ foldMap (Sum . snd) ourUtxo
+
+    out <- ownPubKeyTxOut value
+    void $ signAndSubmit inputs [out]
 
 -- | Get the public key for this wallet
 ownPubKey :: (Functor m, WalletAPI m) => m PubKey

--- a/wallet-api/src/Wallet/Emulator/Client.hs
+++ b/wallet-api/src/Wallet/Emulator/Client.hs
@@ -41,7 +41,7 @@ wallets :: ClientM [Wallet]
 fetchWallet :: Wallet -> ClientM Wallet
 createWallet :: Wallet -> ClientM NoContent
 myKeyPair' :: Wallet -> ClientM KeyPair
-createPaymentWithChange' :: Wallet -> Value -> ClientM (Set TxIn', TxOut')
+createPaymentWithChange' :: Wallet -> Value -> ClientM (Set TxIn', Maybe TxOut')
 submitTxn' :: Wallet -> Tx -> ClientM [Tx]
 getTransactions :: ClientM [Tx]
 processPending :: ClientM [Tx]

--- a/wallet-api/src/Wallet/Emulator/Http.hs
+++ b/wallet-api/src/Wallet/Emulator/Http.hs
@@ -47,7 +47,7 @@ type WalletAPI
      :<|> "wallets" :> Capture "walletid" Wallet :> Get '[ JSON] Wallet
      :<|> "wallets" :> ReqBody '[ JSON] Wallet :> Post '[ JSON] NoContent
      :<|> "wallets" :> Capture "walletid" Wallet :> "my-key-pair" :> Get '[ JSON] KeyPair
-     :<|> "wallets" :> Capture "walletid" Wallet :> "payments" :> ReqBody '[ JSON] Value :> Post '[ JSON] (Set TxIn', TxOut')
+     :<|> "wallets" :> Capture "walletid" Wallet :> "payments" :> ReqBody '[ JSON] Value :> Post '[ JSON] (Set TxIn', Maybe TxOut')
 -- This is where the line between wallet API and control API is crossed
 -- Returning the [Tx] only makes sense when running a WalletAPI m => m () inside a Trace, but not on the wallet API on its own,
 --   otherwise the signature of submitTxn would be submitTxn :: Tx -> m [Tx]
@@ -115,7 +115,7 @@ createPaymentWithChange ::
      (MonadReader ServerState m, MonadIO m, MonadError ServantErr m)
   => Wallet
   -> Value
-  -> m (Set.Set TxIn', TxOut')
+  -> m (Set.Set TxIn', Maybe TxOut')
 createPaymentWithChange wallet =
   runWalletAction wallet . WAPI.createPaymentWithChange
 

--- a/wallet-api/src/Wallet/Emulator/Types.hs
+++ b/wallet-api/src/Wallet/Emulator/Types.hs
@@ -81,7 +81,8 @@ import           Servant.API                (FromHttpApiData, ToHttpApiData)
 
 import           Data.Hashable              (Hashable)
 import           Ledger                     (Address', Block, Blockchain, Height, Tx (..), TxId', TxOutRef', Value,
-                                             hashTx, height, pubKeyAddress, pubKeyTxIn, pubKeyTxOut, txOutAddress)
+                                             hashTx, height, pubKeyAddress, pubKeyTxIn, pubKeyTxOut, txOutAddress,
+                                             txOutValue)
 import qualified Ledger.Index               as Index
 import           Wallet.API                 (EventHandler (..), EventTrigger, KeyPair (..), WalletAPI (..),
                                              WalletAPIError (..), WalletDiagnostics (..), WalletLog (..), addresses,
@@ -219,7 +220,8 @@ instance WalletAPI MockWallet where
                         totalSpent     = P.last (snd <$> fundsToSpend)-- can use `last` because `fundsToSpend` is not empty
                         change         = totalSpent - vl -- `change` is the value that we pay back to a public-key address owned by us
                         txOutput       = pubKeyTxOut change (pubKey kp)
-                    in pure (txIns, txOutput)
+                        txOutput'      = if txOutValue txOutput == 0 then Nothing else Just txOutput
+                    in pure (txIns, txOutput')
 
     register tr action =
         modify (over triggers (Map.insertWith (<>) tr action))


### PR DESCRIPTION
* Clean up imports
* Remove `WalletAPI m` contraints
* Change `OracleValue` to be a proper data type. This means we can get
  rid of the two `Height`s we used to have (one newtype for
  Haskell-land, one data for PLC-land) and just use the newtype Height
  everywhere
* Remove all operators except the TH splicing one

(this depdends on #389)