### PR TITLE
[WIP] Build `plutus-playground-client` on Hydra

### DIFF
--- a/plutus-playground/plutus-playground-client/default.nix
+++ b/plutus-playground/plutus-playground-client/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, psSrc }:
+{ stdenv, pkgs, fetchurl, psSrc }:
 
 with pkgs;
 
@@ -15,6 +15,15 @@ let
         -e 's@#!/.*/coffee@#!'"$coffee"'@' || true
   '';
 
+  # node-sass is terrible and we have to get it its binaries otherwise it will try to build them
+  nodeSassBinLinux = fetchurl {
+    url = "https://github.com/sass/node-sass/releases/download/v4.11.0/linux-x64-48_binding.node";
+    sha256 = "0by4hp7wxdzl8dq5svs2c11i93zsdkmn1v2009lqcrw3jyg6fxym";
+  };
+  nodeSassBinDarwin = fetchurl {
+    url = "https://github.com/sass/node-sass/releases/download/v4.11.0/darwin-x64-48_binding.node";
+    sha256 = "11jik9r379dxnx5v9h79sirqlk7ixdspnccfibzd4pgm6s2mw4vn";
+  };
 in {
   plutus-playground-client = stdenv.mkDerivation {
     src = ./.;
@@ -31,6 +40,7 @@ in {
 
     configurePhase = ''
       export HOME="$NIX_BUILD_TOP"
+      export SASS_BINARY_PATH=${if stdenv.isDarwin then nodeSassBinDarwin else nodeSassBinLinux}
 
       sed -i -E 's|^(\s*resolved\s*")https?://.*/|\1|' yarn.lock
       yarn --offline config set yarn-offline-mirror ${yarnDeps.offline_cache}

--- a/release.nix
+++ b/release.nix
@@ -37,7 +37,7 @@ let
       f = name: value: if value ? testdata then value.testrun else value;
     in pkgs.lib.mapAttrs f (lib.filterAttrs pred plutusPkgs.haskellPackages);
 in pkgs.lib.fix (jobsets:  mapped // {
-  inherit (plutusPkgs) tests docs;
+  inherit (plutusPkgs) tests docs plutus-playground-client;
   all-plutus-tests = builtins.listToAttrs (map (arch: { name = arch; value = makePlutusTestRuns arch; }) supportedSystems);
   required = pkgs.lib.hydraJob (pkgs.releaseTools.aggregate {
     name = "plutus-required-checks";
@@ -48,6 +48,6 @@ in pkgs.lib.fix (jobsets:  mapped // {
       in
     [
       (builtins.concatLists (map lib.attrValues (all jobsets.all-plutus-tests)))
-    ] ++ (builtins.attrValues jobsets.tests) ++ (builtins.attrValues jobsets.docs);
+    ] ++ (builtins.attrValues jobsets.tests) ++ (builtins.attrValues jobsets.docs) ++ [jobsets.plutus-playground-client];
   });
 })


### PR DESCRIPTION
We're not building it or running the tests, which is bad.

I think this adds it to `release.nix`, but in the process I discovered it doesn't build. Probably sandboxing issues.

I've fixed one (missing `python2` dep), but now I'm getting networking errors.