### PR TITLE
Fix persistent error in machine descriptions (lazy evaluation document)

### DIFF
--- a/docs/fomega/lazy-machine/cekmachine.tex
+++ b/docs/fomega/lazy-machine/cekmachine.tex
@@ -50,7 +50,7 @@
       s; \rho &\compute \unwrap{M}               &{}\mapsto{}& s,\inUnwrapFrame{};\rho  \compute M\\
       s; \rho &\compute \lam{x}{A}{M}            &{}\mapsto{}& s;\rho \return \lam{x}{A}{M}\\
       s; \rho &\compute \app{M}{N}               &{}\mapsto{}& s,\inAppLeftFrame{(N,\rho)};\rho \compute M\\
-      s; \rho &\compute \builtin{bn}{\repetition{A}}{} &{}\mapsto{}& U \quad (\textit{$bn$ computes on $\repetition{A}$ to $U$})\\
+      s; \rho &\compute \builtin{bn}{\repetition{A}}{} &{}\mapsto{}& s;\rho \return U \quad (\textit{$bn$ computes on $\repetition{A}$ to $U$})\\
       s; \rho &\compute \builtin{bn}{\repetition{A}}{M \repetition{M}} &{}\mapsto{}& s,\inBuiltin{bn}{\repetition{A}}{}{\_}{\repetition{M}};\rho \compute M\\
       s; \rho &\compute \error{A} &{}\mapsto{}& \ckerror{}\\
       \cdot; \rho &\return V &{}\mapsto{}& \square (V, \rho)\\
@@ -61,7 +61,7 @@
       \blue{s,\inAppRightFrame{(\lam{x}{A}{M}, \rho^{\prime})}; \rho} &\breturn V &{}\bmapsto{}& \blue{s;\rho^{\prime}[x\mapsto (V,\rho)] \compute M}\\  %% Modified
       s,  \inBuiltin{bn}{\repetition{A}}{\repetition{V}}{\_}{M \repetition{M}}{}; \rho&\return V &{}\mapsto{}& s, \inBuiltin{bn}{\repetition{A}}{\repetition{V} V}{\_}{\repetition{M}};\rho \compute M\\
       s,\inBuiltin {bn} {\repetition{A}} {\repetition{V}}{\_}{}; \rho &\return V 
-                                                &{}\mapsto{}& s;\rho \compute W \quad (\textit{$bn$ computes on $\repetition{A}$ and $\repetition{V}V$ to $W$})\\
+                                                &{}\mapsto{}& s;\rho \return W \quad (\textit{$bn$ computes on $\repetition{A}$ and $\repetition{V}V$ to $W$})\\
 \end{alignat*}
 }
 \end{subfigure}

--- a/docs/fomega/lazy-machine/ckmachine.tex
+++ b/docs/fomega/lazy-machine/ckmachine.tex
@@ -52,9 +52,9 @@
       s &\compute \lam{x}{A}{M}            &{}\mapsto{}& s \return \lam{x}{A}{M}\\
       s &\compute \app{M}{N}               &{}\mapsto{}& s,\inAppLeftFrame{N} \compute M\\
       s &\compute \builtin{bn}{\repetition{A}}{} &{}\mapsto{}& 
-                                      U \quad (\textit{$bn$ computes on $\repetition{A}$ to $U$})\\
+                                      s \return U \quad (\textit{$bn$ computes on $\repetition{A}$ to $U$})\\
       s &\compute \builtin{bn}{\repetition{A}}{M \repetition{M}} &{}\mapsto{}& 
-                                      s, \inBuiltin{bn}{\repetition{A}}{}{\_}{\repetition{M}} \compute {M}\\
+                                      s,\inBuiltin{bn}{\repetition{A}}{}{\_}{\repetition{M}} \compute {M}\\
       s &\compute \error{A} &{}\mapsto{}& \ckerror{}\\
       \cdot &\return V &{}\mapsto{}& \square V\\
       s,\inInstLeftFrame{A} &\return \abs{\alpha}{K}{M} &{}\mapsto{}& s \compute{M} \\
@@ -63,7 +63,7 @@
       s,\inAppLeftFrame{N} &\return V                   &{}\mapsto{}& s, \inAppRightFrame{V} \compute N\\
       s,\inAppRightFrame{\lam{x}{A}{M}} &\return V      &{}\mapsto{}& s \compute \subst{V}{x}{M}\\
       s,  \inBuiltin{bn}{\repetition{A}}{\repetition{V}}{\_}{M \repetition{M}} &\return V &{}\mapsto{}& s, \inBuiltin{bn}{\repetition{A}}{\repetition{V} V}{\_}{\repetition{M}} \compute M\\
-      s,\inBuiltin{bn}{\repetition{A}}{\repetition{V}}{\_}{} &\return V &{}\mapsto{}& s \compute W \quad (\textit{$bn$ computes on $\repetition{A}$ and $\repetition{V}V$ to $W$})\\
+      s,\inBuiltin{bn}{\repetition{A}}{\repetition{V}}{\_}{} &\return V &{}\mapsto{}& s \return W \quad (\textit{$bn$ computes on $\repetition{A}$ and $\repetition{V}V$ to $W$})\\
     \end{alignat*}
 }
 \end{subfigure}

--- a/docs/fomega/lazy-machine/lmachine.tex
+++ b/docs/fomega/lazy-machine/lmachine.tex
@@ -56,7 +56,7 @@
       s;h &\compute (\lam{x}{A}{M}, \rho)           &{}\mapsto{}& s;h \return (\lam{x}{A}{M}, \rho)\\
       s;h &\compute (\app{M}{N}, \rho)              &{}\mapsto{}& s,\inAppLeftFrame{(N, \rho)};h \compute (M,\rho)\\
       s;h &\compute (\builtin{bn}{\repetition{A}}{}, \rho) 
-                                                    &{}\mapsto{}& (U,\rho) \quad (\textit{$bn$ computes on $\repetition{A}$ to $U$})\\
+                                                    &{}\mapsto{}& s;h \return (U,\rho) \quad (\textit{$bn$ computes on $\repetition{A}$ to $U$})\\
       s;h &\compute (\builtin{bn}{\repetition{A}}{M \repetition{M}}, \rho) 
                                                     &{}\mapsto{}& s,\inBuiltin{bn}{\repetition{A}}{}{\_}{\repetition{M}; \rho};h \compute (M, \rho)\\
       s;h &\compute (\error{A}, \rho) &{}\mapsto{}& \ckerror{}\\
@@ -73,7 +73,7 @@
       s, \inBuiltin{bn}{\repetition{A}}{\repetition{V}}{\_}{M \repetition{M}; \rho}{}; h &\return (V , \rho^{\prime})
                                                     &{}\mapsto{}& s, \inBuiltin{bn}{\repetition{A}}{\repetition{V} V}{\_}{\repetition{M}; \rho};h \compute (M, \rho)\\
       s,\inBuiltin {bn} {\repetition{A}} {\repetition{V}}{\_}{; \rho}; h &\return (V, \rho^{\prime}) 
-                                                    &{}\mapsto{}& s;h \compute (W, \rho) \quad 
+                                                    &{}\mapsto{}& s;h \return (W, \rho) \quad 
                                                     (\textit{$bn$ computes on $\repetition{A}$ and $\repetition{V}V$ to $W$})\\
 \end{alignat*}
 }


### PR DESCRIPTION
There's a minor error that's propagated from the spec to the lazy evaluation document.  I'm just going to fix it directly since no-one cares much about this particular document.