### PR TITLE
plutus-tx-plugin: use a phantom type parameter for CompiledCode

### DIFF
--- a/plutus-tx-plugin/test/Plugin/IllTyped.hs
+++ b/plutus-tx-plugin/test/Plugin/IllTyped.hs
@@ -14,33 +14,33 @@ import           Language.PlutusTx.Plugin
 -- this module does lots of weird stuff deliberately
 {-# ANN module "HLint: ignore" #-}
 
-string :: CompiledCode
+string :: CompiledCode String
 string = plc @"string" "test"
 
-listConstruct :: CompiledCode
+listConstruct :: CompiledCode [Int]
 listConstruct = plc @"listConstruct" ([]::[Int])
 
-listConstruct2 :: CompiledCode
+listConstruct2 :: CompiledCode [Int]
 listConstruct2 = plc @"listConstruct2" ([1]::[Int])
 
 -- It is very difficult to get GHC to make a non-polymorphic redex if you use
 -- list literal syntax with integers. But this works.
-listConstruct3 :: CompiledCode
+listConstruct3 :: CompiledCode [Int]
 listConstruct3 = plc @"listConstruct3" ((1::Int):(2::Int):(3::Int):[])
 
-listMatch :: CompiledCode
+listMatch :: CompiledCode ([Int] -> Int)
 listMatch = plc @"listMatch" (\(l::[Int]) -> case l of { (x:_) -> x ; [] -> 0; })
 
 data B a = One a | Two (B (a, a))
 
-ptreeConstruct :: CompiledCode
+ptreeConstruct :: CompiledCode (B Int)
 ptreeConstruct = plc @"ptreeConstruct" (Two (Two (One ((1,2),(3,4)))) :: B Int)
 
 -- TODO: replace this with 'first' when we have working recursive functions
-ptreeMatch :: CompiledCode
+ptreeMatch :: CompiledCode (B Int -> Int)
 ptreeMatch = plc @"ptreeMatch" (\(t::B Int) -> case t of { One a -> a; Two _ -> 2; })
 
-sumDirect :: CompiledCode
+sumDirect :: CompiledCode ([Int] -> Int)
 sumDirect = plc @"sumDirect" (
     let sum :: [Int] -> Int
         sum []     = 0

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -29,10 +29,10 @@ import           GHC.Generics
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}
 
-instance GetProgram CompiledCode where
+instance GetProgram (CompiledCode a) where
     getProgram = catchAll . getPlc
 
-goldenPir :: String -> CompiledCode -> TestNested
+goldenPir :: String -> CompiledCode a -> TestNested
 goldenPir name value = nestedGoldenVsDoc name $ PIR.prettyDef $ getPir value
 
 tests :: TestNested
@@ -52,10 +52,10 @@ basic = testNested "basic" [
   , goldenPlc "monoK" monoK
   ]
 
-monoId :: CompiledCode
+monoId :: CompiledCode (Int -> Int)
 monoId = plc @"monoId" (\(x :: Int) -> x)
 
-monoK :: CompiledCode
+monoK :: CompiledCode (Int -> Int -> Int)
 monoK = plc @"monoK" (\(i :: Int) -> \(j :: Int) -> i)
 
 primitives :: TestNested
@@ -65,20 +65,20 @@ primitives = testNested "primitives" [
   , goldenPir "int2" int
   , goldenPir "bool" bool
   , goldenPir "and" andPlc
-  , goldenEval "andApply" [ andPlc, plc @"T" True, plc @"F" False ]
+  , goldenEval "andApply" [ getProgram $ andPlc, getProgram $ plc @"T" True, getProgram $ plc @"F" False ]
   , goldenPir "tuple" tuple
   , goldenPir "tupleMatch" tupleMatch
-  , goldenEval "tupleConstDest" [ tupleMatch, tuple ]
+  , goldenEval "tupleConstDest" [ getProgram $ tupleMatch, getProgram $ tuple ]
   , goldenPir "intCompare" intCompare
   , goldenPir "intEq" intEq
-  , goldenEval "intEqApply" [ intEq, int, int ]
+  , goldenEval "intEqApply" [ getProgram $ intEq, getProgram $ int, getProgram $ int ]
   , goldenPir "void" void
   , goldenPir "intPlus" intPlus
   , goldenPir "intDiv" intDiv
-  , goldenEval "intPlusApply" [ intPlus, int, int2 ]
+  , goldenEval "intPlusApply" [ getProgram $ intPlus, getProgram $ int, getProgram $ int2 ]
   , goldenPir "error" errorPlc
   , goldenPir "ifThenElse" ifThenElse
-  , goldenEval "ifThenElseApply" [ ifThenElse, int, int2 ]
+  , goldenEval "ifThenElseApply" [ getProgram $ ifThenElse, getProgram $ int, getProgram $ int2 ]
   --, goldenPlc "blocknum" blocknumPlc
   , goldenPir "bytestring" bytestring
   , goldenEval "bytestringApply" [ getPlc bytestring, unsafeLiftProgram ("hello"::ByteString) ]
@@ -87,59 +87,59 @@ primitives = testNested "primitives" [
   , goldenPir "verify" verify
   ]
 
-int :: CompiledCode
+int :: CompiledCode Int
 int = plc @"int" (1::Int)
 
-int2 :: CompiledCode
+int2 :: CompiledCode Int
 int2 = plc @"int2" (2::Int)
 
-bool :: CompiledCode
+bool :: CompiledCode Bool
 bool = plc @"bool" True
 
-andPlc :: CompiledCode
+andPlc :: CompiledCode (Bool -> Bool -> Bool)
 andPlc = plc @"andPlc" (\(x::Bool) (y::Bool) -> if x then (if y then True else False) else False)
 
-tuple :: CompiledCode
+tuple :: CompiledCode (Int, Int)
 tuple = plc @"tuple" ((1::Int), (2::Int))
 
-tupleMatch :: CompiledCode
+tupleMatch :: CompiledCode ((Int, Int) -> Int)
 tupleMatch = plc @"tupleMatch" (\(x:: (Int, Int)) -> let (a, b) = x in a)
 
-intCompare :: CompiledCode
+intCompare :: CompiledCode (Int -> Int -> Bool)
 intCompare = plc @"intCompare" (\(x::Int) (y::Int) -> x < y)
 
-intEq :: CompiledCode
+intEq :: CompiledCode (Int -> Int -> Bool)
 intEq = plc @"intEq" (\(x::Int) (y::Int) -> x == y)
 
 -- Has a Void in it
-void :: CompiledCode
+void :: CompiledCode (Int -> Int -> Bool)
 void = plc @"void" (\(x::Int) (y::Int) -> let a x' y' = case (x', y') of { (True, True) -> True; _ -> False; } in (x == y) `a` (y == x))
 
-intPlus :: CompiledCode
+intPlus :: CompiledCode (Int -> Int -> Int)
 intPlus = plc @"intPlus" (\(x::Int) (y::Int) -> x + y)
 
-intDiv :: CompiledCode
+intDiv :: CompiledCode (Int -> Int -> Int)
 intDiv = plc @"intDiv" (\(x::Int) (y::Int) -> x `div` y)
 
-errorPlc :: CompiledCode
+errorPlc :: CompiledCode (() -> Int)
 errorPlc = plc @"errorPlc" (Builtins.error @Int)
 
-ifThenElse :: CompiledCode
+ifThenElse :: CompiledCode (Int -> Int -> Int)
 ifThenElse = plc @"ifThenElse" (\(x::Int) (y::Int) -> if x == y then x else y)
 
 --blocknumPlc :: CompiledCode
 --blocknumPlc = plc @"blocknumPlc" Builtins.blocknum
 
-bytestring :: CompiledCode
+bytestring :: CompiledCode (ByteString -> ByteString)
 bytestring = plc @"bytestring" (\(x::ByteString) -> x)
 
-sha2 :: CompiledCode
+sha2 :: CompiledCode (ByteString -> ByteString)
 sha2 = plc @"sha2" (\(x :: ByteString) -> Builtins.sha2_256 x)
 
-bsEquals :: CompiledCode
+bsEquals :: CompiledCode (ByteString -> ByteString -> Bool)
 bsEquals = plc @"bsEquals" (\(x :: ByteString) (y :: ByteString) -> Builtins.equalsByteString x y)
 
-verify :: CompiledCode
+verify :: CompiledCode (ByteString -> ByteString -> ByteString -> Bool)
 verify = plc @"verify" (\(x::ByteString) (y::ByteString) (z::ByteString) -> Builtins.verifySignature x y z)
 
 structure :: TestNested
@@ -148,7 +148,7 @@ structure = testNested "structure" [
   ]
 
 -- GHC acutually turns this into a lambda for us, try and make one that stays a let
-letFun :: CompiledCode
+letFun :: CompiledCode (Int -> Int -> Bool)
 letFun = plc @"lefFun" (\(x::Int) (y::Int) -> let f z = x == z in f y)
 
 datat :: TestNested
@@ -165,11 +165,11 @@ monoData = testNested "monomorphic" [
   , goldenPir "monoConstructor" monoConstructor
   , goldenPir "monoConstructed" monoConstructed
   , goldenPir "monoCase" monoCase
-  , goldenEval "monoConstDest" [ monoCase, monoConstructed ]
+  , goldenEval "monoConstDest" [ getProgram $ monoCase, getProgram $ monoConstructed ]
   , goldenPir "defaultCase" defaultCase
   , goldenPir "irrefutableMatch" irrefutableMatch
   , goldenPir "atPattern" atPattern
-  , goldenEval "monoConstDestDefault" [ monoCase, monoConstructed ]
+  , goldenEval "monoConstDestDefault" [ getProgram $ monoCase, getProgram $ monoConstructed ]
   , goldenPir "monoRecord" monoRecord
   , goldenPir "nonValueCase" nonValueCase
   , goldenPir "synonym" synonym
@@ -177,44 +177,44 @@ monoData = testNested "monomorphic" [
 
 data MyEnum = Enum1 | Enum2
 
-basicEnum :: CompiledCode
+basicEnum :: CompiledCode MyEnum
 basicEnum = plc @"basicEnum" (Enum1)
 
 data MyMonoData = Mono1 Int Int | Mono2 Int | Mono3 Int deriving (Generic)
 
-monoDataType :: CompiledCode
+monoDataType :: CompiledCode (MyMonoData -> MyMonoData)
 monoDataType = plc @"monoDataType" (\(x :: MyMonoData) -> x)
 
-monoConstructor :: CompiledCode
+monoConstructor :: CompiledCode (Int -> Int -> MyMonoData)
 monoConstructor = plc @"monConstructor" (Mono1)
 
-monoConstructed :: CompiledCode
+monoConstructed :: CompiledCode MyMonoData
 monoConstructed = plc @"monoConstructed" (Mono2 1)
 
-monoCase :: CompiledCode
+monoCase :: CompiledCode (MyMonoData -> Int)
 monoCase = plc @"monoCase" (\(x :: MyMonoData) -> case x of { Mono1 _ b -> b;  Mono2 a -> a; Mono3 a -> a })
 
-defaultCase :: CompiledCode
+defaultCase :: CompiledCode (MyMonoData -> Int)
 defaultCase = plc @"defaultCase" (\(x :: MyMonoData) -> case x of { Mono3 a -> a ; _ -> 2; })
 
-irrefutableMatch :: CompiledCode
+irrefutableMatch :: CompiledCode (MyMonoData -> Int)
 irrefutableMatch = plc @"irrefutableMatch" (\(x :: MyMonoData) -> case x of { Mono2 a -> a })
 
-atPattern :: CompiledCode
+atPattern :: CompiledCode ((Int, Int) -> Int)
 atPattern = plc @"atPattern" (\t@(x::Int, y::Int) -> let fst (a, b) = a in y + fst t)
 
 data MyMonoRecord = MyMonoRecord { mrA :: Int , mrB :: Int} deriving Generic
 
-monoRecord :: CompiledCode
+monoRecord :: CompiledCode (MyMonoRecord -> MyMonoRecord)
 monoRecord = plc @"monoRecord" (\(x :: MyMonoRecord) -> x)
 
 -- must be compiled with a lazy case
-nonValueCase :: CompiledCode
+nonValueCase :: CompiledCode (MyEnum -> Int)
 nonValueCase = plc @"nonValueCase" (\(x :: MyEnum) -> case x of { Enum1 -> 1::Int ; Enum2 -> Builtins.error (); })
 
 type Synonym = Int
 
-synonym :: CompiledCode
+synonym :: CompiledCode Int
 synonym = plc @"synonym" (1::Synonym)
 
 polyData :: TestNested
@@ -226,13 +226,13 @@ polyData = testNested "polymorphic" [
 
 data MyPolyData a b = Poly1 a b | Poly2 a
 
-polyDataType :: CompiledCode
+polyDataType :: CompiledCode (MyPolyData Int Int -> MyPolyData Int Int)
 polyDataType = plc @"polyDataType" (\(x:: MyPolyData Int Int) -> x)
 
-polyConstructed :: CompiledCode
+polyConstructed :: CompiledCode (MyPolyData Int Int)
 polyConstructed = plc @"polyConstructed" (Poly1 (1::Int) (2::Int))
 
-defaultCasePoly :: CompiledCode
+defaultCasePoly :: CompiledCode (MyPolyData Int Int -> Int)
 defaultCasePoly = plc @"defaultCasePoly" (\(x :: MyPolyData Int Int) -> case x of { Poly1 a _ -> a ; _ -> 2; })
 
 newtypes :: TestNested
@@ -242,26 +242,26 @@ newtypes = testNested "newtypes" [
    , goldenPir "newtypeCreate" newtypeCreate
    , goldenPir "newtypeCreate2" newtypeCreate2
    , goldenPir "nestedNewtypeMatch" nestedNewtypeMatch
-   , goldenEval "newtypeCreatDest" [ newtypeMatch, newtypeCreate2 ]
+   , goldenEval "newtypeCreatDest" [ getProgram $ newtypeMatch, getProgram $ newtypeCreate2 ]
    ]
 
 newtype MyNewtype = MyNewtype Int
 
 newtype MyNewtype2 = MyNewtype2 MyNewtype
 
-basicNewtype :: CompiledCode
+basicNewtype :: CompiledCode (MyNewtype -> MyNewtype)
 basicNewtype = plc @"basicNewtype" (\(x::MyNewtype) -> x)
 
-newtypeMatch :: CompiledCode
+newtypeMatch :: CompiledCode (MyNewtype -> Int)
 newtypeMatch = plc @"newtypeMatch" (\(MyNewtype x) -> x)
 
-newtypeCreate :: CompiledCode
+newtypeCreate :: CompiledCode (Int -> MyNewtype)
 newtypeCreate = plc @"newtypeCreate" (\(x::Int) -> MyNewtype x)
 
-newtypeCreate2 :: CompiledCode
+newtypeCreate2 :: CompiledCode MyNewtype
 newtypeCreate2 = plc @"newtypeCreate2" (MyNewtype 1)
 
-nestedNewtypeMatch :: CompiledCode
+nestedNewtypeMatch :: CompiledCode (MyNewtype2 -> Int)
 nestedNewtypeMatch = plc @"nestedNewtypeMatch" (\(MyNewtype2 (MyNewtype x)) -> x)
 
 recursiveTypes :: TestNested
@@ -270,35 +270,35 @@ recursiveTypes = testNested "recursiveTypes" [
     , goldenPir "listConstruct2" listConstruct2
     , goldenPir "listConstruct3" listConstruct3
     , goldenPir "listMatch" listMatch
-    , goldenEval "listConstDest" [ listMatch, listConstruct ]
-    , goldenEval "listConstDest2" [ listMatch, listConstruct2 ]
+    , goldenEval "listConstDest" [ getProgram $ listMatch, getProgram $ listConstruct ]
+    , goldenEval "listConstDest2" [ getProgram $ listMatch, getProgram $ listConstruct2 ]
     , goldenPir "ptreeConstruct" ptreeConstruct
     , goldenPir "ptreeMatch" ptreeMatch
-    , goldenEval "ptreeConstDest" [ ptreeMatch, ptreeConstruct ]
+    , goldenEval "ptreeConstDest" [ getProgram $ ptreeMatch, getProgram $ ptreeConstruct ]
   ]
 
 recursion :: TestNested
 recursion = testNested "recursiveFunctions" [
     -- currently broken, will come back to this later
     goldenPir "fib" fib
-    , goldenEval "fib4" [ fib, plc @"4" (4::Int) ]
+    , goldenEval "fib4" [ getProgram $ fib, getProgram $ plc @"4" (4::Int) ]
     , goldenPir "sum" sumDirect
-    , goldenEval "sumList" [ sumDirect, listConstruct3 ]
+    , goldenEval "sumList" [ getProgram $ sumDirect, getProgram $ listConstruct3 ]
     --, golden "sumFold" sumViaFold
     --, goldenEval "sumFoldList" [ sumViaFold, listConstruct3 ]
     , goldenPir "even" evenMutual
-    , goldenEval "even3" [ evenMutual, plc @"3" (3::Int) ]
-    , goldenEval "even4" [ evenMutual, plc @"4" (4::Int) ]
+    , goldenEval "even3" [ getProgram $ evenMutual, getProgram $ plc @"3" (3::Int) ]
+    , goldenEval "even4" [ getProgram $ evenMutual, getProgram $ plc @"4" (4::Int) ]
   ]
 
-fib :: CompiledCode
+fib :: CompiledCode (Int -> Int)
 -- not using case to avoid literal cases
 fib = plc @"fib" (
     let fib :: Int -> Int
         fib n = if n == 0 then 0 else if n == 1 then 1 else fib(n-1) + fib(n-2)
     in fib)
 
-evenMutual :: CompiledCode
+evenMutual :: CompiledCode (Int -> Bool)
 evenMutual = plc @"evenMutual" (
     let even :: Int -> Bool
         even n = if n == 0 then True else odd (n-1)
@@ -314,16 +314,16 @@ errors = testNested "errors" [
     , goldenPlcCatch "recordSelector" recordSelector
   ]
 
-integer :: CompiledCode
+integer :: CompiledCode Integer
 integer = plc @"integer" (1::Integer)
 
-free :: CompiledCode
+free :: CompiledCode Bool
 free = plc @"free" (True && False)
 
 -- It's little tricky to get something that GHC actually turns into a polymorphic computation! We use our value twice
 -- at different types to prevent the obvious specialization.
-valueRestriction :: CompiledCode
+valueRestriction :: CompiledCode (Bool, Int)
 valueRestriction = plc @"valueRestriction" (let { f :: forall a . a; f = Builtins.error (); } in (f @Bool, f @Int))
 
-recordSelector :: CompiledCode
+recordSelector :: CompiledCode (MyMonoRecord -> Int)
 recordSelector = plc @"recordSelector" (\(x :: MyMonoRecord) -> mrA x)

--- a/plutus-tx/src/Language/PlutusTx/TH.hs
+++ b/plutus-tx/src/Language/PlutusTx/TH.hs
@@ -16,7 +16,7 @@ import qualified Language.Haskell.TH        as TH
 import qualified Language.Haskell.TH.Syntax as TH
 
 -- | Compile a quoted Haskell expression into a corresponding Plutus Core program.
-compile :: TH.Q (TH.TExp a) -> TH.Q (TH.TExp CompiledCode)
+compile :: TH.Q (TH.TExp a) -> TH.Q (TH.TExp (CompiledCode a))
 -- See note [Typed TH]
 compile e = TH.unsafeTExpCoerce $ compileUntyped $ TH.unType <$> e
 

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -32,10 +32,10 @@ import           Test.Tasty
 main :: IO ()
 main = defaultMain $ runTestNestedIn ["test"] tests
 
-instance GetProgram CompiledCode where
+instance GetProgram (CompiledCode a) where
     getProgram = catchAll . getPlc
 
-goldenPir :: String -> CompiledCode -> TestNested
+goldenPir :: String -> (CompiledCode a) -> TestNested
 goldenPir name value = nestedGoldenVsDoc name $ PIR.prettyDef $ getPir value
 
 runPlcCek :: GetProgram a => [a] -> ExceptT SomeException IO EvaluationResult
@@ -67,26 +67,26 @@ tests = testGroup "plutus-th" <$> sequence [
     , goldenEvalCekLog "traceRepeatedly" [traceRepeatedly]
   ]
 
-simple :: CompiledCode
+simple :: CompiledCode (Bool -> Int)
 simple = $$(compile [|| \(x::Bool) -> if x then (1::Int) else (2::Int) ||])
 
 -- similar to the power example for Feldspar - should be completely unrolled at compile time
-powerPlc :: CompiledCode
+powerPlc :: CompiledCode (Int -> Int)
 powerPlc = $$(compile [|| $$(power (4::Int)) ||])
 
-andPlc :: CompiledCode
+andPlc :: CompiledCode Bool
 andPlc = $$(compile [|| $$(andTH) True False ||])
 
-convertString :: CompiledCode
+convertString :: CompiledCode Builtins.String
 convertString = $$(compile [|| $$(toPlutusString) "test" ||])
 
-traceDirect :: CompiledCode
+traceDirect :: CompiledCode ()
 traceDirect = $$(compile [|| Builtins.trace ($$(toPlutusString) "test") ||])
 
-tracePrelude :: CompiledCode
+tracePrelude :: CompiledCode Int
 tracePrelude = $$(compile [|| $$(trace) ($$(toPlutusString) "test") (1::Int) ||])
 
-traceRepeatedly :: CompiledCode
+traceRepeatedly :: CompiledCode Int
 traceRepeatedly = $$(compile
      [||
                -- This will in fact print the third log first, and then the others, but this

--- a/plutus-tx/tutorial/Tutorial.md
+++ b/plutus-tx/tutorial/Tutorial.md
@@ -17,9 +17,9 @@ import Language.PlutusCore.Evaluation.CkMachine
 
 ## Writing basic PlutusTx programs
 
-The `CompiledCode` type is an opaque type which contains the serialized Plutus Core code
-corresponding to a Haskell expression. The `compile` function takes a typed Template Haskell
-`Q (TExp a)`, for any a, and produces a `Q (TExp CompiledCode)`, which we then
+The `CompiledCode a` type is an opaque type which contains the serialized Plutus Core code
+corresponding to a Haskell expression of type `a`. The `compile` function takes a typed Template Haskell
+`Q (TExp a)`, for any a, and produces a `Q (TExp (CompiledCode a))`, which we then
 have to splice into our program.
 
 The fact that `compile` takes a TH quote means that what you write inside the quote
@@ -34,7 +34,7 @@ Here's the most basic program we can write: one that just evaluates to the integ
 -- (program 1.0.0
 --   (con 8 ! 1)
 -- )
-integerOne :: CompiledCode
+integerOne :: CompiledCode Int
 -- We don't like unbounded integers in Plutus Core, so we have to pin
 -- down that numeric literal to an `Int` not an `Integer`.
 integerOne = $$(compile [|| (1 :: Int) ||])
@@ -59,7 +59,7 @@ Here's a slightly more complex program, namely the identity function on integers
 -- (program 1.0.0
 --   (lam ds [(con integer) (con 8)] ds)
 -- )
-integerIdentity :: CompiledCode
+integerIdentity :: CompiledCode (Int -> Int)
 integerIdentity = $$(compile [|| \(x:: Int) -> x ||])
 ```
 
@@ -74,7 +74,7 @@ some reusable components.
 plusOne :: Int -> Int
 plusOne x = x + 1
 
-functions :: CompiledCode
+functions :: CompiledCode Int
 functions = $$(compile [||
     let
         plusOneLocal :: Int -> Int
@@ -100,7 +100,7 @@ TODO: when we store the PIR, start showing PIR at this stage (or earlier).
 We can use normal Haskell datatypes and pattern matching freely:
 
 ```haskell
-matchMaybe :: CompiledCode
+matchMaybe :: CompiledCode (Maybe Int -> Int)
 matchMaybe = $$(compile [|| \(x:: Maybe Int) -> case x of
     Just n -> n
     Nothing -> 0
@@ -116,7 +116,7 @@ end date.
 ```haskell
 data EndDate = Fixed Int | Never
 
-shouldEnd :: CompiledCode
+shouldEnd :: CompiledCode (EndDate -> Int -> Bool)
 shouldEnd = $$(compile [|| \(end::EndDate) (current::Int) -> case end of
     Fixed n -> n <= current
     Never -> False

--- a/wallet-api/src/Ledger/Types.hs
+++ b/wallet-api/src/Ledger/Types.hs
@@ -241,7 +241,7 @@ newtype Script = Script { getSerialized :: BSL.ByteString }
   deriving newtype (Serialise, Eq, Ord)
 
 -- TODO: possibly this belongs with CompiledCode
-fromCompiledCode :: CompiledCode -> Script
+fromCompiledCode :: CompiledCode a -> Script
 fromCompiledCode = Script . getSerializedPlc
 
 getPlc :: Script -> PLC.Program PLC.TyName PLC.Name ()


### PR DESCRIPTION
This tracks the type of the Haskell that was compiled, and hence
implicitly (insofar as we believe that the compiation is
type-preserving) the type of the compiled code. This can be used to
ensure that application of compiled programs is well-typed - however in
our primary setting in `wallet-api` we simply have programs as
unknown serialized blobs, and so we cannot make use of this facility.

I considered using existentials in `wallet-api` so we could at least
enforce the *shape* of a validator script as a function of the
appropriate arity, but this makes things quite a bit more complicated,
and would give users confusing error messages, so I've decided not to do
that for now.
