### PR TITLE
Playground: Enabling purescript bundling for an improved compilation artifact size.

### DIFF
--- a/plutus-playground/plutus-playground-client/webpack.config.js
+++ b/plutus-playground/plutus-playground-client/webpack.config.js
@@ -56,7 +56,7 @@ module.exports = {
                                 'src/**/*.purs',
                                 'generated/**/*.purs'
                             ],
-                            bundle: false,
+                            bundle: true,
                             psc: 'psa',
                             watch: isWebpackDevServer || isWatch,
                             pscIde: true


### PR DESCRIPTION
It's still too big, but this does make it more reasonable.