### PR TITLE
Various misc nix improvements, mostly to playground expressions

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -66,17 +66,19 @@ with pkgs.lib;
 let
   localLib = import ./lib.nix { inherit config system; } ;
   src = localLib.iohkNix.cleanSourceHaskell ./.;
-  errorOverlay = import ./nix/overlays/force-error.nix {
-    inherit pkgs;
-    filter = localLib.isPlutus;
-  };
-  customOverlays = optional forceError errorOverlay;
+
   packages = self: (rec {
     inherit pkgs localLib;
 
     # This is the stackage LTS plus overrides, plus the plutus
     # packages.
-    haskellPackages = self.callPackage localLib.iohkNix.haskellPackages {
+    haskellPackages = let 
+      errorOverlay = import ./nix/overlays/force-error.nix {
+        inherit pkgs;
+        filter = localLib.isPlutus;
+      };
+      customOverlays = optional forceError errorOverlay;
+    in self.callPackage localLib.iohkNix.haskellPackages {
       inherit forceDontCheck enableProfiling enablePhaseMetrics
       enableHaddockHydra enableBenchmarks fasterBuild enableDebugging
       enableSplitCheck customOverlays;

--- a/default.nix
+++ b/default.nix
@@ -71,7 +71,6 @@ let
     filter = localLib.isPlutus;
   };
   customOverlays = optional forceError errorOverlay;
-  purescriptNixpkgs = import (localLib.iohkNix.fetchNixpkgs ./plutus-playground/plutus-playground-client/nixpkgs-src.json) {};
   packages = self: (rec {
     inherit pkgs localLib;
 
@@ -99,16 +98,10 @@ let
       requiredOverlay = ./nix/overlays/required.nix;
     };
 
-    # the playground uses ghc at runtime so it needs one packaged up with the dependencies it needs in one place
-    playgroundGhc = haskellPackages.ghcWithPackages (ps: [
-      haskellPackages.plutus-playground-server
-      haskellPackages.plutus-playground-lib
-      haskellPackages.plutus-use-cases
-    ]);
-
     localPackages = localLib.getPackages {
       inherit (self) haskellPackages; filter = localLib.isPlutus;
     };
+
     tests = {
       shellcheck = pkgs.callPackage localLib.iohkNix.tests.shellcheck { inherit src; };
       hlint = pkgs.callPackage localLib.iohkNix.tests.hlint {
@@ -124,36 +117,40 @@ let
         inherit src;
       };
     };
-    plutus-server-invoker = pkgs.stdenv.mkDerivation {
-      name = "plutus-server-invoker";
-      unpackPhase = "true";
-      buildInputs = [ playgroundGhc haskellPackages.plutus-playground-server pkgs.makeWrapper ];
-      buildPhase = ''
-        # We need to provide the ghc interpreter (hint) with the location of the ghc lib dir and the package db
-        mkdir -p $out/bin
-        ln -s ${haskellPackages.plutus-playground-server}/bin/plutus-playground-server $out/bin/plutus-playground-server
-        wrapProgram $out/bin/plutus-playground-server --set GHC_LIB_DIR "${playgroundGhc}/lib/ghc-8.4.3" --set GHC_PACKAGE_PATH "${playgroundGhc}/lib/ghc-8.4.3/package.conf.d"
-      '';
-      installPhase = "echo nothing to install";
-    };
-    plutus-playground-purescript = pkgs.stdenv.mkDerivation {
-        name = "plutus-playground-purescript";
-        unpackPhase = "true";
-        buildInputs = [ haskellPackages.plutus-playground-server ];
-        buildPhase = ''
-        mkdir $out
-        ${haskellPackages.plutus-playground-server}/bin/plutus-playground-server psgenerator $out
-        '';
-        installPhase = "echo nothing to install";
-    };
-    inherit (pkgs.callPackage ./plutus-playground/plutus-playground-client {
-         pkgs = purescriptNixpkgs;
-         psSrc = plutus-playground-purescript;
-    }) plutus-playground-client;
+
     docs = {
       plutus-core-spec = pkgs.callPackage ./plutus-core-spec {};
       lazy-machine = pkgs.callPackage ./docs/fomega/lazy-machine {};
     };
+
+    plutus-server-invoker = let 
+      # the playground uses ghc at runtime so it needs one packaged up with the dependencies it needs in one place
+      runtimeGhc = haskellPackages.ghcWithPackages (ps: [
+        haskellPackages.plutus-playground-server
+        haskellPackages.plutus-playground-lib
+        haskellPackages.plutus-use-cases
+      ]);
+    in pkgs.runCommand "plutus-server-invoker" { buildInputs = [pkgs.makeWrapper]; } ''
+      # We need to provide the ghc interpreter (hint) with the location of the ghc lib dir and the package db
+      mkdir -p $out/bin
+      ln -s ${haskellPackages.plutus-playground-server}/bin/plutus-playground-server $out/bin/plutus-playground-server
+      wrapProgram $out/bin/plutus-playground-server --set GHC_LIB_DIR "${runtimeGhc}/lib/ghc-${runtimeGhc.version}" --set GHC_PACKAGE_PATH "${runtimeGhc}/lib/ghc-${runtimeGhc.version}/package.conf.d"
+    '';
+
+    plutus-playground-client = let 
+      plutus-playground-purescript = pkgs.runCommand "plutus-playground-purescript" {} ''
+        mkdir $out
+        ${haskellPackages.plutus-playground-server}/bin/plutus-playground-server psgenerator $out
+      '';
+      # We have to use purescript 0.11.7 (why?), but our pinned nixpkgs has 0.12, and overriding
+      # doesn't work easily because we can't built 0.11.7 with the default compiler either.
+      purescriptNixpkgs = import (localLib.iohkNix.fetchNixpkgs ./plutus-playground/plutus-playground-client/nixpkgs-src.json) {};
+      in
+      pkgs.callPackage ./plutus-playground/plutus-playground-client {
+        pkgs = purescriptNixpkgs;
+        psSrc = plutus-playground-purescript;
+      };
+
     plutus-playground-docker = pkgs.dockerTools.buildImage {
       name = "plutus-playgrounds";
       contents = [ plutus-playground-client plutus-server-invoker ];
@@ -161,6 +158,7 @@ let
         Cmd = ["${plutus-server-invoker}/bin/plutus-playground-server" "webserver" "-b" "0.0.0.0" "-p" "8080" "${plutus-playground-client}"];
       };
     };
+
     inherit (pkgs) stack2nix;
   });
 

--- a/default.nix
+++ b/default.nix
@@ -160,8 +160,6 @@ let
         Cmd = ["${plutus-server-invoker}/bin/plutus-playground-server" "webserver" "-b" "0.0.0.0" "-p" "8080" "${plutus-playground-client}"];
       };
     };
-
-    inherit (pkgs) stack2nix;
   });
 
 in

--- a/default.nix
+++ b/default.nix
@@ -125,39 +125,41 @@ let
       lazy-machine = pkgs.callPackage ./docs/fomega/lazy-machine {};
     };
 
-    plutus-server-invoker = let 
-      # the playground uses ghc at runtime so it needs one packaged up with the dependencies it needs in one place
-      runtimeGhc = haskellPackages.ghcWithPackages (ps: [
-        haskellPackages.plutus-playground-server
-        haskellPackages.plutus-playground-lib
-        haskellPackages.plutus-use-cases
-      ]);
-    in pkgs.runCommand "plutus-server-invoker" { buildInputs = [pkgs.makeWrapper]; } ''
-      # We need to provide the ghc interpreter (hint) with the location of the ghc lib dir and the package db
-      mkdir -p $out/bin
-      ln -s ${haskellPackages.plutus-playground-server}/bin/plutus-playground-server $out/bin/plutus-playground-server
-      wrapProgram $out/bin/plutus-playground-server --set GHC_LIB_DIR "${runtimeGhc}/lib/ghc-${runtimeGhc.version}" --set GHC_PACKAGE_PATH "${runtimeGhc}/lib/ghc-${runtimeGhc.version}/package.conf.d"
-    '';
-
-    plutus-playground-client = let 
-      plutus-playground-purescript = pkgs.runCommand "plutus-playground-purescript" {} ''
-        mkdir $out
-        ${haskellPackages.plutus-playground-server}/bin/plutus-playground-server psgenerator $out
+    plutus-playground = rec {
+      server-invoker = let 
+        # the playground uses ghc at runtime so it needs one packaged up with the dependencies it needs in one place
+        runtimeGhc = haskellPackages.ghcWithPackages (ps: [
+          haskellPackages.plutus-playground-server
+          haskellPackages.plutus-playground-lib
+          haskellPackages.plutus-use-cases
+        ]);
+      in pkgs.runCommand "plutus-server-invoker" { buildInputs = [pkgs.makeWrapper]; } ''
+        # We need to provide the ghc interpreter (hint) with the location of the ghc lib dir and the package db
+        mkdir -p $out/bin
+        ln -s ${haskellPackages.plutus-playground-server}/bin/plutus-playground-server $out/bin/plutus-playground-server
+        wrapProgram $out/bin/plutus-playground-server --set GHC_LIB_DIR "${runtimeGhc}/lib/ghc-${runtimeGhc.version}" --set GHC_PACKAGE_PATH "${runtimeGhc}/lib/ghc-${runtimeGhc.version}/package.conf.d"
       '';
-      # We have to use purescript 0.11.7 (why?), but our pinned nixpkgs has 0.12, and overriding
-      # doesn't work easily because we can't built 0.11.7 with the default compiler either.
-      purescriptNixpkgs = import (localLib.iohkNix.fetchNixpkgs ./plutus-playground/plutus-playground-client/nixpkgs-src.json) {};
-      in
-      pkgs.callPackage ./plutus-playground/plutus-playground-client {
-        pkgs = purescriptNixpkgs;
-        psSrc = plutus-playground-purescript;
-      };
 
-    plutus-playground-docker = pkgs.dockerTools.buildImage {
-      name = "plutus-playgrounds";
-      contents = [ plutus-playground-client plutus-server-invoker ];
-      config = {
-        Cmd = ["${plutus-server-invoker}/bin/plutus-playground-server" "webserver" "-b" "0.0.0.0" "-p" "8080" "${plutus-playground-client}"];
+      client = let 
+        generated-purescript = pkgs.runCommand "plutus-playground-purescript" {} ''
+          mkdir $out
+          ${haskellPackages.plutus-playground-server}/bin/plutus-playground-server psgenerator $out
+        '';
+        # We have to use purescript 0.11.7 (why?), but our pinned nixpkgs has 0.12, and overriding
+        # doesn't work easily because we can't built 0.11.7 with the default compiler either.
+        purescriptNixpkgs = import (localLib.iohkNix.fetchNixpkgs ./plutus-playground/plutus-playground-client/nixpkgs-src.json) {};
+        in
+        pkgs.callPackage ./plutus-playground/plutus-playground-client {
+          pkgs = purescriptNixpkgs;
+          psSrc = generated-purescript;
+        };
+
+      docker = pkgs.dockerTools.buildImage {
+        name = "plutus-playgrounds";
+        contents = [ client server-invoker ];
+        config = {
+          Cmd = ["${server-invoker}/bin/plutus-playground-server" "webserver" "-b" "0.0.0.0" "-p" "8080" "${client}"];
+        };
       };
     };
   });

--- a/plutus-playground/README.md
+++ b/plutus-playground/README.md
@@ -14,8 +14,8 @@ stack exec -- plutus-playground-server webserver -p 8080 ../plutus-playground-cl
 ### nix
 
 ```sh
-nix-build -A plutus-server-invoker --option substituters https://hydra.iohk.io --option require-sigs false
-/nix/store/***-plutus-server-invoker webserver -p 4000 ./plutus-playground/plutus-playground-client/dist
+nix build -f default.nix plutus-playground.server-invoker 
+result/bin/plutus-server-invoker webserver -p 4000 ./plutus-playground/plutus-playground-client/dist
 ```
 
 ## Client
@@ -34,20 +34,19 @@ Then run: `yarn run webpack` for a production build on http://localhost:8080
 nix is not really suitable for development with purescript but if you want to check everything works correctly:
 
 ```sh
-nix-build -A plutus-playground-purescript --option substituters https://hydra.iohk.io --option require-sigs false
-nix-build -A plutus-playground-client  --option substituters https://hydra.iohk.io --option require-sigs false
+nix build -f default.nix plutus-playground.client
 ```
 
 ## Docker image
 
 ```sh
-nix-build -A plutus-playground-docker --option substituters https://hydra.iohk.io --option require-sigs false
-docker load < /nix/store/***docker-image-plutus-playground-docker.tar.gz
+nix build -f default.nix plutus-playground.docker
+docker load < result
 # You can see the image name and tag as a result of the previous command and use it below
 docker run -p 8080:8080 plutus-playground-docker:somecrazytag
 ```
 
-# TroubleShooting
+# Troubleshooting
 
 On a Mac, you may see this when compiling a contract:
 

--- a/plutus-playground/deployment/nixops/playground.nix
+++ b/plutus-playground/deployment/nixops/playground.nix
@@ -4,7 +4,7 @@
       before = [ "nginx.service" ];
       enable = true;
       path = [
-        "${playground.plutus-server-invoker}"
+        "${playground.plutus-playground.server-invoker}"
       ];
 
       serviceConfig = {
@@ -14,7 +14,7 @@
         PrivateTmp = true;
       };
 
-      script = "plutus-playground-server webserver -b 127.0.0.1 -p ${port} ${playground.plutus-playground-client}";
+      script = "plutus-playground-server webserver -b 127.0.0.1 -p ${port} ${playground.plutus-playground.client}";
   };
   in
   {

--- a/plutus-playground/plutus-playground-client/default.nix
+++ b/plutus-playground/plutus-playground-client/default.nix
@@ -24,48 +24,46 @@ let
     url = "https://github.com/sass/node-sass/releases/download/v4.11.0/darwin-x64-48_binding.node";
     sha256 = "11jik9r379dxnx5v9h79sirqlk7ixdspnccfibzd4pgm6s2mw4vn";
   };
-in {
-  plutus-playground-client = stdenv.mkDerivation {
+in stdenv.mkDerivation {
+  src = ./.;
+
+  name = "plutus-playground-client";
+
+  buildInputs = [ nodejs yarn git cacert purescript yarnDeps.offline_cache python2 ];
+
+  bowerComponents = pkgs.buildBowerComponents {
+    name = "my-web-app";
+    generated = ./bower-packages.nix;
     src = ./.;
-
-    name = "plutus-playground-client";
-
-    buildInputs = [ nodejs yarn git cacert purescript yarnDeps.offline_cache python2 ];
-
-    bowerComponents = pkgs.buildBowerComponents {
-      name = "my-web-app";
-      generated = ./bower-packages.nix;
-      src = ./.;
-    };
-
-    configurePhase = ''
-      export HOME="$NIX_BUILD_TOP"
-      export SASS_BINARY_PATH=${if stdenv.isDarwin then nodeSassBinDarwin else nodeSassBinLinux}
-
-      sed -i -E 's|^(\s*resolved\s*")https?://.*/|\1|' yarn.lock
-      yarn --offline config set yarn-offline-mirror ${yarnDeps.offline_cache}
-      yarn --offline config set yarn-offline-mirror-pruning true
-      yarn --offline install
-
-      ${patchShebangs "node_modules/.bin/"}
-
-      mkdir generated
-      cp -R ${psSrc}/* generated/
-      cp --reflink=auto --no-preserve=mode -R $bowerComponents/bower_components .
-    '';
-
-    buildPhase = ''
-      yarn --offline run webpack
-    '';
-
-    doCheck = true;
-
-    checkPhase = ''
-      yarn test
-    '';
-
-    installPhase = ''
-      mv dist $out
-    '';
   };
+
+  configurePhase = ''
+    export HOME="$NIX_BUILD_TOP"
+    export SASS_BINARY_PATH=${if stdenv.isDarwin then nodeSassBinDarwin else nodeSassBinLinux}
+
+    sed -i -E 's|^(\s*resolved\s*")https?://.*/|\1|' yarn.lock
+    yarn --offline config set yarn-offline-mirror ${yarnDeps.offline_cache}
+    yarn --offline config set yarn-offline-mirror-pruning true
+    yarn --offline install
+
+    ${patchShebangs "node_modules/.bin/"}
+
+    mkdir generated
+    cp -R ${psSrc}/* generated/
+    cp --reflink=auto --no-preserve=mode -R $bowerComponents/bower_components .
+  '';
+
+  buildPhase = ''
+    yarn --offline run webpack
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    yarn test
+  '';
+
+  installPhase = ''
+    mv dist $out
+  '';
 }

--- a/release.nix
+++ b/release.nix
@@ -37,7 +37,7 @@ let
       f = name: value: if value ? testdata then value.testrun else value;
     in pkgs.lib.mapAttrs f (lib.filterAttrs pred plutusPkgs.haskellPackages);
 in pkgs.lib.fix (jobsets:  mapped // {
-  inherit (plutusPkgs) tests docs plutus-playground-client;
+  inherit (plutusPkgs) tests docs plutus-playground;
   all-plutus-tests = builtins.listToAttrs (map (arch: { name = arch; value = makePlutusTestRuns arch; }) supportedSystems);
   required = pkgs.lib.hydraJob (pkgs.releaseTools.aggregate {
     name = "plutus-required-checks";
@@ -48,6 +48,6 @@ in pkgs.lib.fix (jobsets:  mapped // {
       in
     [
       (builtins.concatLists (map lib.attrValues (all jobsets.all-plutus-tests)))
-    ] ++ (builtins.attrValues jobsets.tests) ++ (builtins.attrValues jobsets.docs) ++ [jobsets.plutus-playground-client];
+    ] ++ (builtins.attrValues jobsets.tests) ++ (builtins.attrValues jobsets.docs) ++ [jobsets.plutus-playground.client];
   });
 })


### PR DESCRIPTION
Commit-by-commit should be clear.

Most controversial thing is probably moving the non-haskell playground expressions to a sub-attr-set, but I think this is a bit clearer.

I tried to override the version of purescript in the main package to the version David said we needed, but it doesn't build with the default GHC in that package set (8.4), and I couldn't be bothered to try overriding that too. So we're still stuck with the additional pinned nixpkgs for now, but I'd like to try and understand what we need to do to get rid of it.