### PR TITLE
[NormalizeType] 'NormalizeTypeM' -> 'NormalizeTypeT'

### DIFF
--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
@@ -77,7 +77,7 @@ typeEvalCheckBy
     -> TermOf (TypedBuiltinValue Size a)
     -> TypeEvalCheckM (TermOf TypeEvalCheckResult)
 typeEvalCheckBy eval (TermOf term tbv) = TermOf term <$> do
-    let typecheck = annotateTerm >=> typecheckTerm (TypeConfig True mempty (Just 1000))
+    let typecheck = annotateTerm >=> typecheckTerm (TypeConfig True mempty defaultTypecheckerGas)
     termTy <- typecheck term
     resExpected <- liftQuote $ maybeToEvaluationResult <$> makeBuiltin tbv
     fmap (TypeEvalCheckResult termTy) $

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -42,6 +42,7 @@ library
         Language.PlutusCore.CBOR
         Language.PlutusCore.Constant
         Language.PlutusCore.Constant.Dynamic
+        Language.PlutusCore.Normalize
         Language.PlutusCore.Pretty
         Language.PlutusCore.View
         Language.PlutusCore.Subst
@@ -90,7 +91,6 @@ library
         Language.PlutusCore.Renamer
         Language.PlutusCore.Error
         Language.PlutusCore.TypeSynthesis
-        Language.PlutusCore.Normalize
         Language.PlutusCore.Analysis.Definitions
         Language.PlutusCore.Generators.Internal.Denotation
         Language.PlutusCore.Generators.Internal.Entity
@@ -178,6 +178,7 @@ test-suite language-plutus-core-test
         Evaluation.Constant.Failure
         Evaluation.Constant.Resize
         Generators
+        Normalization.Type
         Pretty.Readable
         Check.Spec
         TypeSynthesis.Spec

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -44,6 +44,7 @@ module Language.PlutusCore
     , format
     , formatDoc
     -- * Processing
+    , Gas (..)
     , annotateProgram
     , annotateTerm
     , annotateType
@@ -81,7 +82,6 @@ module Language.PlutusCore
     , TypeCheckM
     , parseTypecheck
     -- for testing
-    , normalizeType
     , runTypeCheckM
     , typecheckPipeline
     , defaultTypecheckerGas
@@ -177,7 +177,7 @@ printNormalizeType
 printNormalizeType norm bs = runQuoteT $ prettyPlcDefText <$> do
     scoped <- parseScoped bs
     annotated <- annotateProgram scoped
-    typecheckProgram (TypeConfig norm mempty (Just 1000)) annotated
+    typecheckProgram (TypeConfig norm mempty defaultTypecheckerGas) annotated
 
 -- | Parse and rewrite so that names are globally unique, not just unique within
 -- their scope.
@@ -228,8 +228,8 @@ defaultVersion :: a -> Version a
 defaultVersion a = Version a 1 0 0
 
 -- | The default amount of gas to run the typechecker with.
-defaultTypecheckerGas :: Maybe Natural
-defaultTypecheckerGas = Just 1000
+defaultTypecheckerGas :: Maybe Gas
+defaultTypecheckerGas = Just $ Gas 1000
 
 defaultTypecheckerCfg :: TypeConfig
 defaultTypecheckerCfg = TypeConfig False mempty defaultTypecheckerGas

--- a/language-plutus-core/src/Language/PlutusCore/Normalize.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Normalize.hs
@@ -1,12 +1,23 @@
 -- | Normalization of PLC entities.
 
+-- Due to the generated 'normalizeEnvCountStep' below which is not used.
+{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TemplateHaskell    #-}
+
 module Language.PlutusCore.Normalize
-    ( normalizeType
-    , substituteNormalizeType
-    , GasInit
+    ( NormalizeTypeT
+    , runNormalizeTypeM
+    , runNormalizeTypeDownM
+    , runNormalizeTypeGasM
+    , withExtendedTypeVarEnv
+    , normalizeTypeM
+    , normalizeTypeDown
+    , substituteNormalizeTypeM
+    , normalizeTypesIn
     ) where
 
-import           Language.PlutusCore.Error
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Renamer
@@ -14,45 +25,119 @@ import           Language.PlutusCore.Type
 import           PlutusPrelude
 
 import           Control.Lens
-import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Control.Monad.State
+import           Control.Monad.Trans.Maybe
 import           Data.IntMap                 (IntMap)
 import qualified Data.IntMap                 as IntMap
 
--- | Type environments contain
-newtype TypeEnv tyname = TypeEnv
-    { unTypeEnv :: IntMap (NormalizedType tyname ())
+-- | Mapping from variables to what they stand for (each row represents a substitution).
+-- Needed for efficiency reasons, otherwise we could just use substitutions.
+newtype TypeVarEnv tyname ann = TypeVarEnv
+    { unTypeVarEnv :: IntMap (NormalizedType tyname ann)
     }
 
-type NormalizeTypeM tyname a = StateT GasInit (ReaderT (TypeEnv tyname) (ExceptT (TypeError a) Quote))
+-- | The environments that type normalization runs in.
+data NormalizeTypeEnv m tyname ann = NormalizeTypeEnv
+    { _normalizeTypeEnvTypeVarEnv :: TypeVarEnv tyname ann
+    , _normalizeTypeEnvCountStep  :: m ()
+      -- ^ How to count a type normalization step.
+    }
 
-type GasInit = Maybe Natural
+makeLenses ''NormalizeTypeEnv
 
-normalizeTypeStep :: NormalizeTypeM tyname a ()
-normalizeTypeStep = do
-    st <- get
-    case st of
-        Just 0  -> throwError OutOfGas
-        Just _  -> modify (fmap (subtract 1))
-        Nothing -> pure ()
+{- Note [NormalizeTypeT]
+Type normalization requires 'Quote' (because we need to be able to generate fresh names), but we
+do not put 'Quote' into 'NormalizeTypeT'. The reason for this is that it makes type signatures of
+various runners much nicer and also more generic. For example, we have
+
+    runNormalizeTypeDownM :: MonadQuote m => NormalizeTypeT m tyname ann a -> m a
+
+If 'NormalizeTypeT' contained 'Quote', it would be
+
+    runNormalizeTypeDownM :: NormalizeTypeT m tyname ann a -> QuoteT m a
+
+which hardcodes 'QuoteT' to be the outermost transformer.
+
+Type normalization can run in any @m@ (as long as it's a 'MonadQuote') as witnessed by
+the following type signature:
+
+    normalizeTypeM
+        :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
+        => Type tyname ann -> NormalizeTypeT m tyname ann (NormalizedType tyname ann)
+
+so it's natural to have runners that do not break this genericity.
+-}
+
+{- Note [Normalization API]
+Normalization is split in two parts:
+
+1. functions returning computations that perform reductions and run in defined in this module
+   monad transformers (e.g. 'NormalizeTypeT')
+2. runners of those computations
+
+The reason for splitting the API is that this way the type-theoretic notion of normalization is
+separated from implementation-specific details like how to count gas (we hardcode *where* to count
+gas, but this can be generalized in case we need it). And this is important, because gas counting
+requires access to different monads in different scenarios, so in the end we have a fine-grained API
+instead of a single function that reflects all possible effects from distinct scenarios in its type
+signature.
+-}
+
+-- See Note [NormalizedTypeT].
+-- | The monad transformer that type normalization runs in.
+newtype NormalizeTypeT m tyname ann a = NormalizeTypeT
+    { unNormalizeTypeT :: ReaderT (NormalizeTypeEnv m tyname ann) m a
+    } deriving newtype
+        ( Functor, Applicative, Alternative, Monad, MonadPlus
+        , MonadReader (NormalizeTypeEnv m tyname ann), MonadState s
+        , MonadQuote
+        )
+
+type CountSubstT m = StateT Gas (MaybeT m)
 
 -- | Run a 'NormalizeTypeM' computation.
-runNormalizeTypeM :: (MonadQuote m, AsTypeError e a, MonadError e m) => GasInit -> NormalizeTypeM tyname a b -> m b
-runNormalizeTypeM mn a = throwingEither _TypeError =<< (liftQuote $ runExceptT $ runReaderT (evalStateT a mn) (TypeEnv mempty))
+runNormalizeTypeM :: m () -> NormalizeTypeT m tyname ann a -> m a
+runNormalizeTypeM countStep (NormalizeTypeT a) =
+    runReaderT a $ NormalizeTypeEnv (TypeVarEnv mempty) countStep
 
--- | Locally extend a 'TypeEnv' in a 'NormalizeTypeM' computation.
-withExtendedTypeEnv
-    :: HasUnique (tyname ()) TypeUnique
-    => tyname () -> NormalizedType tyname () -> NormalizeTypeM tyname ann a -> NormalizeTypeM tyname ann a
-withExtendedTypeEnv name ty =
-    local (TypeEnv . IntMap.insert (name ^. unique . coerced) ty . unTypeEnv)
+-- | Run a 'NormalizeTypeM' computation without dealing with gas.
+runNormalizeTypeDownM
+    :: MonadQuote m => NormalizeTypeT m tyname ann a -> m a
+runNormalizeTypeDownM = runNormalizeTypeM $ pure ()
 
--- | Look up a @tyname@ in a 'TypeEnv'.
+-- | Run a gas-consuming 'NormalizeTypeM' computation.
+-- Count a single substitution step by subtracting @1@ from available gas or
+-- fail when there is no available gas.
+runNormalizeTypeGasM
+    :: MonadQuote m => Gas -> NormalizeTypeT (CountSubstT m) tyname ann a -> m (Maybe a)
+runNormalizeTypeGasM gas a = runMaybeT $ evalStateT (runNormalizeTypeM countSubst a) gas where
+    countSubst = do
+        Gas gas' <- get
+        if gas' == 0
+            then mzero
+            else put . Gas $ gas' - 1
+
+countTypeNormalizationStep :: NormalizeTypeT m tyname ann ()
+countTypeNormalizationStep = NormalizeTypeT . ReaderT $ _normalizeTypeEnvCountStep
+
+-- | Locally extend a 'TypeVarEnv' in a 'NormalizeTypeM' computation.
+withExtendedTypeVarEnv
+    :: (HasUnique (tyname ann) TypeUnique, Monad m)
+    => tyname ann
+    -> NormalizedType tyname ann
+    -> NormalizeTypeT m tyname ann a
+    -> NormalizeTypeT m tyname ann a
+withExtendedTypeVarEnv name ty =
+    local . over (normalizeTypeEnvTypeVarEnv . coerced) $
+        IntMap.insert (name ^. unique . coerced) ty
+
+-- | Look up a @tyname@ in a 'TypeVarEnv'.
 lookupTyName
-    :: HasUnique (tyname ()) TypeUnique
-    => tyname () -> NormalizeTypeM tyname a (Maybe (NormalizedType tyname ()))
-lookupTyName name = asks $ IntMap.lookup (name ^. unique . coerced) . unTypeEnv
+    :: (HasUnique (tyname ann) TypeUnique, Monad m)
+    => tyname ann -> NormalizeTypeT m tyname ann (Maybe (NormalizedType tyname ann))
+lookupTyName name =
+    asks $ IntMap.lookup (name ^. unique . coerced) . unTypeVarEnv . _normalizeTypeEnvTypeVarEnv
 
 {- Note [Normalization]
 Normalization works under the assumption that variables are globally unique.
@@ -63,27 +148,17 @@ interesting cases: function application and a variable usage. In the function ap
 normalize a function and its argument, add the normalized argument to the environment and continue
 normalization. In the variable case we look up the variable in the current environment: if it's not
 found, we leave the variable untouched. If the variable is found, then what this variable stands for
-was previously added to an environment (while handling the function application case), so we pick this
-value and rename all bound variables in it to preserve the global uniqueness condition. It is safe to
-do so, because picked values cannot contain uninstantiated variables as only normalized types are
-added to environments and normalization instantiates all variables presented in an environment.
--}
-
-{- Note [Costs]
-Typechecking costs are relatively simple: it costs 1 gas to perform
-a reduction. Substitution does not in general cost anything.
-
-Costs are reset every time we enter 'NormalizeTypeM'.
-
-In unlimited mode, gas is not tracked and we do not fail even on large numbers
-of reductions.
+was previously added to an environment (while handling the function application case), so we pick
+this value and rename all bound variables in it to preserve the global uniqueness condition. It is
+safe to do so, because picked values cannot contain uninstantiated variables as only normalized types
+are added to environments and normalization instantiates all variables presented in an environment.
 -}
 
 -- See Note [Normalization].
 -- | Normalize a 'Type' in the 'NormalizeTypeM' monad.
 normalizeTypeM
-    :: HasUnique (tyname ()) TypeUnique
-    => Type tyname () -> NormalizeTypeM tyname a (NormalizedType tyname ())
+    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
+    => Type tyname ann -> NormalizeTypeT m tyname ann (NormalizedType tyname ann)
 normalizeTypeM (TyForall ann name kind body) =
     TyForall ann name kind <<$>> normalizeTypeM body
 normalizeTypeM (TyFix ann name pat)          =
@@ -96,15 +171,19 @@ normalizeTypeM (TyApp ann fun arg)           = do
     vFun <- normalizeTypeM fun
     vArg <- normalizeTypeM arg
     case getNormalizedType vFun of
-        TyLam _ nArg _ body -> normalizeTypeStep *> substituteNormalizeTypeM vArg nArg body
+        TyLam _ nArg _ body -> do
+            countTypeNormalizationStep
+            substituteNormalizeTypeM vArg nArg body
         _                   -> pure $ TyApp ann <$> vFun <*> vArg
 normalizeTypeM var@(TyVar _ name)            = do
     mayTy <- lookupTyName name
     case mayTy of
         Nothing -> pure $ NormalizedType var
         Just ty -> traverse rename ty
-normalizeTypeM size@TyInt{}                  = pure $ NormalizedType size
-normalizeTypeM builtin@TyBuiltin{}           = pure $ NormalizedType builtin
+normalizeTypeM size@TyInt{}                  =
+    pure $ NormalizedType size
+normalizeTypeM builtin@TyBuiltin{}           =
+    pure $ NormalizedType builtin
 
 {- Note [Normalizing substitution]
 @substituteNormalize[M]@ is only ever used as normalizing substitution that receives two already
@@ -116,27 +195,42 @@ normalized types. However we do not enforce this in the type signature, because
 -- See Note [Normalizing substitution].
 -- | Substitute a type for a variable in a type and normalize in the 'NormalizeTypeM' monad.
 substituteNormalizeTypeM
-    :: HasUnique (tyname ()) TypeUnique
-    => NormalizedType tyname ()                            -- ^ @ty@
-    -> tyname ()                                           -- ^ @name@
-    -> Type tyname ()                                      -- ^ @body@
-    -> NormalizeTypeM tyname a (NormalizedType tyname ())  -- ^ @NORM ([ty / name] body)@
-substituteNormalizeTypeM ty name = withExtendedTypeEnv name ty . normalizeTypeM
+    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
+    => NormalizedType tyname ann                                -- ^ @ty@
+    -> tyname ann                                               -- ^ @name@
+    -> Type tyname ann                                          -- ^ @body@
+    -> NormalizeTypeT m tyname ann (NormalizedType tyname ann)  -- ^ @NORM ([ty / name] body)@
+substituteNormalizeTypeM ty name = withExtendedTypeVarEnv name ty . normalizeTypeM
 
 -- See Note [Normalization].
 -- | Normalize a 'Type'.
 normalizeType
-    :: (HasUnique (tyname ()) TypeUnique, MonadQuote m, AsTypeError e a, MonadError e m)
-    => GasInit -> Type tyname () -> m (NormalizedType tyname ())
-normalizeType n = runNormalizeTypeM n . normalizeTypeM
+    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
+    => m () -> Type tyname ann -> m (NormalizedType tyname ann)
+normalizeType countStep = runNormalizeTypeM countStep . normalizeTypeM
 
--- See Note [Normalizing substitution].
--- | Substitute a type for a variable in a type and normalize.
-substituteNormalizeType
-    :: (HasUnique (tyname ()) TypeUnique, MonadQuote m, AsTypeError e a, MonadError e m)
-    => GasInit
-    -> NormalizedType tyname ()      -- ^ @ty@
-    -> tyname ()                     -- ^ @name@
-    -> Type tyname ()                -- ^ @body@
-    -> m (NormalizedType tyname ())  -- ^ @NORM ([ty / name] body)@
-substituteNormalizeType gas ty name = runNormalizeTypeM gas . substituteNormalizeTypeM ty name
+-- See Note [Normalization].
+--- | Normalize a 'Type' without dealing with gas.
+normalizeTypeDown
+    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
+    => Type tyname ann -> m (NormalizedType tyname ann)
+normalizeTypeDown = normalizeType $ pure ()
+
+-- | Normalize every 'Type' in a 'Term'.
+normalizeTypesIn
+    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
+    => Term tyname name ann -> NormalizeTypeT m tyname ann (Term tyname name ann)
+normalizeTypesIn = go where
+    -- | Normalize a 'Type' and return the result as a 'Type' (as opposed to 'NormalizedType').
+    normalizeReturnType = fmap getNormalizedType . normalizeTypeM
+
+    go (LamAbs ann name ty body)  = LamAbs ann name <$> normalizeReturnType ty <*> go body
+    go (TyAbs ann name kind body) = TyAbs ann name kind <$> go body
+    go (Wrap ann name pat term)   = Wrap ann name <$> normalizeReturnType pat <*> go term
+    go (Apply ann fun arg)        = Apply ann <$> go fun <*> go arg
+    go (Unwrap ann term)          = Unwrap ann <$> go term
+    go (Error ann ty)             = Error ann <$> normalizeReturnType ty
+    go (TyInst ann body ty)       = TyInst ann <$> go body <*> normalizeReturnType ty
+    go (Var ann name)             = return $ Var ann name
+    go con@Constant{}             = pure con
+    go bi@Builtin{}               = pure bi

--- a/language-plutus-core/src/Language/PlutusCore/Quote.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Quote.hs
@@ -24,17 +24,18 @@ module Language.PlutusCore.Quote (
             , liftQuote
             ) where
 
-import           Control.Lens             (coerced)
+import           Control.Lens              (coerced)
 import           Control.Monad.Except
-import           Control.Monad.Morph      as MM
+import           Control.Monad.Morph       as MM
 import           Control.Monad.Reader
 import           Control.Monad.State
+import           Control.Monad.Trans.Maybe
 
-import qualified Data.ByteString.Lazy     as BSL
+import qualified Data.ByteString.Lazy      as BSL
 import           Data.Functor.Foldable
 import           Data.Functor.Identity
-import qualified Data.Set                 as Set
-import           Hedgehog                 (GenT)
+import qualified Data.Set                  as Set
+import           Hedgehog                  (GenT, PropertyT)
 
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Type
@@ -63,9 +64,11 @@ instance (Monad m) => MonadQuote (QuoteT m) where
     liftQuote = MM.hoist (pure . runIdentity)
 
 instance MonadQuote m => MonadQuote (StateT s m)
+instance MonadQuote m => MonadQuote (MaybeT m)
 instance MonadQuote m => MonadQuote (ExceptT e m)
 instance MonadQuote m => MonadQuote (ReaderT r m)
 instance MonadQuote m => MonadQuote (GenT m)
+instance MonadQuote m => MonadQuote (PropertyT m)
 
 -- | Run a quote from an empty identifier state. Note that the resulting term cannot necessarily
 -- be safely combined with other terms - that should happen inside 'QuoteT'.

--- a/language-plutus-core/src/Language/PlutusCore/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Type.hs
@@ -19,6 +19,7 @@ module Language.PlutusCore.Type ( Term (..)
                                 , StagedBuiltinName (..)
                                 , TypeBuiltin (..)
                                 , Size
+                                , Gas (..)
                                 -- * Base functors
                                 , TermF (..)
                                 , TypeF (..)
@@ -51,6 +52,10 @@ import           Language.PlutusCore.Name
 import           PlutusPrelude
 
 type Size = Natural
+
+newtype Gas = Gas
+    { unGas :: Natural
+    }
 
 -- | A 'Type' assigned to expressions.
 data Type tyname a = TyVar a (tyname a)

--- a/language-plutus-core/test/Generators.hs
+++ b/language-plutus-core/test/Generators.hs
@@ -1,4 +1,5 @@
-module Generators ( genProgram
+module Generators ( genTerm
+                  , genProgram
                   ) where
 
 import qualified Data.ByteString.Lazy as BSL

--- a/language-plutus-core/test/Normalization/Type.hs
+++ b/language-plutus-core/test/Normalization/Type.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Normalization.Type
+    ( test_typeNormalization
+    ) where
+
+import           Language.PlutusCore
+import           Language.PlutusCore.MkPlc
+import           Language.PlutusCore.Normalize
+
+import           Generators
+
+import           Control.Monad.Morph           (hoist)
+
+import           Hedgehog
+import           Test.Tasty
+import           Test.Tasty.Hedgehog
+import           Test.Tasty.HUnit
+
+test_appAppLamLam :: IO ()
+test_appAppLamLam = do
+    let integer2 = TyApp () (TyBuiltin () TyInteger) $ TyInt () 2
+        Normalized integer2' = runQuote $ do
+            x <- freshTyName () "x"
+            y <- freshTyName () "y"
+            normalizeTypeDown $ mkIterTyApp ()
+                (TyLam () x (Type ()) (TyLam () y (Type ()) $ TyVar () y))
+                [integer2, integer2]
+    integer2 @?= integer2'
+
+test_normalizeTypesInIdempotent :: Property
+test_normalizeTypesInIdempotent = property . hoist (pure . runQuote) $ do
+    term <- forAll genTerm
+    mayTermNormTypes <- liftQuote . runNormalizeTypeGasM (Gas 100) $ normalizeTypesIn term
+    case mayTermNormTypes of
+        Nothing            -> return ()
+        Just termNormTypes -> do
+            termNormTypes' <- liftQuote . runNormalizeTypeDownM $ normalizeTypesIn termNormTypes
+            termNormTypes === termNormTypes'
+
+test_typeNormalization :: TestTree
+test_typeNormalization =
+    testGroup "typeNormalization"
+        [ testCase     "appAppLamLam"               test_appAppLamLam
+        , testProperty "normalizeTypesInIdempotent" test_normalizeTypesInIdempotent
+        ]

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -6,8 +6,6 @@ module Main ( main
 import qualified Check.Spec                   as Check
 import           Codec.Serialise
 import           Control.Monad.Except
-import           Control.Monad.Reader         (ask)
-import           Control.Monad.Trans.Except   (runExceptT)
 import qualified Data.ByteString.Lazy         as BSL
 import qualified Data.Text                    as T
 import           Data.Text.Encoding           (encodeUtf8)
@@ -20,6 +18,7 @@ import qualified Hedgehog.Range               as Range
 import           Language.PlutusCore
 import           Language.PlutusCore.Constant
 import           Language.PlutusCore.Pretty
+import           Normalization.Type
 import           PlutusPrelude
 import           Pretty.Readable
 import qualified Quotation.Spec               as Quotation
@@ -107,6 +106,7 @@ allTests plcFiles rwFiles typeFiles typeNormalizeFiles typeErrorFiles = testGrou
     , testsNormalizeType typeNormalizeFiles
     , testsType typeErrorFiles
     , test_PrettyReadable
+    , test_typeNormalization
     , test_typecheck
     , test_constant
     , test_evaluateCk
@@ -162,22 +162,6 @@ testsRewrite :: [FilePath] -> TestTree
 testsRewrite
     = testGroup "golden rewrite tests"
     . fmap (asGolden (format $ debugPrettyConfigPlcClassic defPrettyConfigPlcOptions))
-
-appAppLamLam :: MonadQuote m => m (Type TyNameWithKind ())
-appAppLamLam = do
-    x <- liftQuote (TyNameWithKind <$> freshTyName ((), Type ()) "x")
-    y <- liftQuote (TyNameWithKind <$> freshTyName ((), Type ()) "y")
-    pure $
-        TyApp ()
-            (TyApp ()
-                 (TyLam () x (Type ()) (TyLam () y (Type ()) $ TyVar () y))
-                 (TyBuiltin () TyInteger))
-            (TyBuiltin () TyInteger)
-
-testLam :: Either (TypeError ()) String
-testLam = fmap prettyPlcDefString . runQuote . runExceptT $ runTypeCheckM (TypeConfig True mempty Nothing) $ do
-    (TypeConfig _ _ gas) <- ask
-    normalizeType gas =<< appAppLamLam
 
 testEqTerm :: Bool
 testEqTerm =
@@ -259,7 +243,6 @@ tests = testCase "example programs" $ fold
     [ fmt "(program 0.1.0 [(builtin addInteger) x y])" @?= Right "(program 0.1.0\n  [ [ (builtin addInteger) x ] y ]\n)"
     , fmt "(program 0.1.0 doesn't)" @?= Right "(program 0.1.0\n  doesn't\n)"
     , fmt "{- program " @?= Left (ParseErrorE (LexErr "Error in nested comment at line 1, column 12"))
-    , testLam @?= Right "(con integer)"
     , testRebindShadowedVariable @?= True
     , testRebindCapturedVariable @?= True
     , testEqTerm @?= True


### PR DESCRIPTION
Changes:

1. type normalization runs in a monad transformer now
2. in the finite gas case a `TypeError` is no longer returned (because type normalization is unrelated to type checking and it's type checking that can return `TypeError`s), instead we just use `MaybeT`
3. in the infinite gas case type normalization runs without `StateT` and `MaybeT`, hence no need for the user to handle the impossible case of running out of infinite gas (which was the case before)
4. type normalization no longer throws away annotations
5. added `normalizeTypesIn` which allows to normalize all types in a term
6. `Gas` is a `newtype` around `Natural` now (we need to do the same for `Size` later)
7. some cosmetic changes in the type checking algorithm to ease migration to `ifix`