### PR TITLE
plutus-tx-plugin: use source spans from -g

### DIFF
--- a/plutus-tx-plugin/README.md
+++ b/plutus-tx-plugin/README.md
@@ -2,4 +2,12 @@
 
 This package is a library which allows converting GHC Core into Plutus Core, with the aim of allowing people to write Plutus contracts in surface Haskell.
 
-The package also contains a compiler plugin which looks for specially tagged expressions and applies the converter. This should not usually be used directly, but rather via a Template Haskell frontend that handles the details.
+The package also contains a compiler plugin which looks for specially tagged expressions and applies the converter. This should not usually be used directly, 
+but rather via [plutus-tx](../plutus-tx/README.md).
+
+## Debugging
+
+The plugin can produce somewhat intimidating errors. In particular it can be hard to work out which expression
+is responsible for an error. To improve this you can compile the file in question with the `-g` GHC option. This
+will result in additional source spans being put into the program which will appear in errors.
+

--- a/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Expr.hs
@@ -253,7 +253,11 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
                 -- See Note [At patterns]
                 let binds = [ PIR.TermBind () v scrutinee' ]
                 pure $ PIR.Let () PIR.NonRec binds mainCase
-        -- ignore annotation
+        -- we can use source notes to get a better context for the inner expression
+        -- these are put in when you compile with -g
+        GHC.Tick GHC.SourceNote{GHC.sourceSpan=src} body ->
+            withContextM (sdToTxt $ "Converting expr at:" GHC.<+> GHC.ppr src) $ convExpr body
+        -- ignore other annotations
         GHC.Tick _ body -> convExpr body
         GHC.Cast body coerce -> do
             body' <- convExpr body

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -9,6 +9,8 @@
 -- the simplifier messes with things otherwise
 {-# OPTIONS_GHC   -O0 #-}
 {-# OPTIONS_GHC   -Wno-orphans #-}
+-- this adds source notes which helps the plugin give better errors
+{-# OPTIONS_GHC   -g #-}
 
 module Plugin.Spec where
 
@@ -20,8 +22,6 @@ import           PlcTestUtils
 import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Lift
 import           Language.PlutusTx.Plugin
-
-import qualified Language.PlutusIR          as PIR
 
 import           Data.ByteString.Lazy
 import           Data.Text.Prettyprint.Doc


### PR DESCRIPTION
If you pass `-g` you get source spans in Core `Tick`s. We can hoist
these out and use them in error contexts. They also get printed in the
Core, which is a nice bonus too.

No test changes, because I'm still stripping context from the errors in
the tests. Possibly I should change it to by default only strip out the
detailed printing of all the expressions.

(Thanks go to Simon PJ for the tip-off!)