### PR TITLE
PIR: variables are values

### DIFF
--- a/plutus-ir/src/Language/PlutusIR/Value.hs
+++ b/plutus-ir/src/Language/PlutusIR/Value.hs
@@ -16,8 +16,12 @@ isTermValue = \case
     -- Type abstractions and wraps are values if their bodies are
     TyAbs _ _ _ t -> isTermValue t
     Wrap _ _ _ t -> isTermValue t
+    x -> isBuiltinValue x
+
+-- Builtins or applications of builtins are also values
+isBuiltinValue :: Term tyname name a -> Bool
+isBuiltinValue = \case
+    Builtin {} -> True
+    Apply _ fun _ -> isBuiltinValue fun
     -- All other PLC terms are not values
-    Apply {} -> False
-    TyInst {} -> False
-    Error {} -> False
-    Unwrap {} -> False
+    _ -> False

--- a/plutus-ir/src/Language/PlutusIR/Value.hs
+++ b/plutus-ir/src/Language/PlutusIR/Value.hs
@@ -8,15 +8,15 @@ isTermValue :: Term tyname name a -> Bool
 isTermValue = \case
     -- Let is not a value (will compile into applications and/or type instantiations)
     Let {} -> False
-    -- Lambdas and constants are always values
+    -- Lambdas, variables, constants, and builtins are always values
     LamAbs {} -> True
+    Var {} -> True
     Constant {} -> True
     Builtin {} -> True
     -- Type abstractions and wraps are values if their bodies are
     TyAbs _ _ _ t -> isTermValue t
     Wrap _ _ _ t -> isTermValue t
     -- All other PLC terms are not values
-    Var {} -> False
     Apply {} -> False
     TyInst {} -> False
     Error {} -> False

--- a/plutus-tx-plugin/test/Lift/boolInterop.plc.golden
+++ b/plutus-tx-plugin/test/Lift/boolInterop.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_112
+  out_Bool_106
   (type)
   (lam
-    case_True_113 out_Bool_112 (lam case_False_114 out_Bool_112 case_True_113)
+    case_True_107 out_Bool_106 (lam case_False_108 out_Bool_106 case_True_107)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/and.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/and.plc.golden
@@ -24,20 +24,7 @@
             [
               [
                 { [ Bool_match ds ] (fun Unit Bool) }
-                (lam
-                  thunk
-                  Unit
-                  [
-                    [
-                      [
-                        { [ Bool_match ds ] (fun Unit Bool) }
-                        (lam thunk Unit True)
-                      ]
-                      (lam thunk Unit False)
-                    ]
-                    Unit
-                  ]
-                )
+                (lam thunk Unit [ [ { [ Bool_match ds ] Bool } True ] False ])
               ]
               (lam thunk Unit False)
             ]

--- a/plutus-tx-plugin/test/Plugin/primitives/andApply.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/andApply.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_115
+  out_Bool_109
   (type)
   (lam
-    case_True_116 out_Bool_115 (lam case_False_117 out_Bool_115 case_False_117)
+    case_True_110 out_Bool_109 (lam case_False_111 out_Bool_109 case_False_111)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/ifThenElse.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/ifThenElse.plc.golden
@@ -2,62 +2,51 @@
   (let
     (nonrec)
     (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+      (datatype
+        (tyvardecl Bool (type))
+        
+        Bool_match
+        (vardecl True Bool) (vardecl False Bool)
+      )
     )
     (let
       (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Bool (type))
-          
-          Bool_match
-          (vardecl True Bool) (vardecl False Bool)
+      (termbind
+        (vardecl
+          equalsInteger
+          (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool))
         )
-      )
-      (let
-        (nonrec)
-        (termbind
-          (vardecl
-            equalsInteger
-            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool))
-          )
+        (lam
+          arg
+          [(con integer) (con 8)]
           (lam
             arg
             [(con integer) (con 8)]
-            (lam
-              arg
-              [(con integer) (con 8)]
-              [
-                (lam
-                  b
-                  (all a (type) (fun a (fun a a)))
-                  [ [ { b Bool } True ] False ]
-                )
-                [ [ { (builtin equalsInteger) (con 8) } arg ] arg ]
-              ]
-            )
+            [
+              (lam
+                b (all a (type) (fun a (fun a a))) [ [ { b Bool } True ] False ]
+              )
+              [ [ { (builtin equalsInteger) (con 8) } arg ] arg ]
+            ]
           )
         )
+      )
+      (lam
+        ds
+        [(con integer) (con 8)]
         (lam
           ds
           [(con integer) (con 8)]
-          (lam
-            ds
-            [(con integer) (con 8)]
+          [
             [
-              [
-                [
-                  {
-                    [ Bool_match [ [ equalsInteger ds ] ds ] ]
-                    (fun Unit [(con integer) (con 8)])
-                  }
-                  (lam thunk Unit ds)
-                ]
-                (lam thunk Unit ds)
-              ]
-              Unit
+              {
+                [ Bool_match [ [ equalsInteger ds ] ds ] ]
+                [(con integer) (con 8)]
+              }
+              ds
             ]
-          )
+            ds
+          ]
         )
       )
     )

--- a/plutus-tx/test/and.plc.golden
+++ b/plutus-tx/test/and.plc.golden
@@ -2,32 +2,13 @@
   (let
     (nonrec)
     (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-    )
-    (let
-      (nonrec)
-      (datatypebind
-        (datatype
-          (tyvardecl Bool (type))
-          
-          Bool_match
-          (vardecl True Bool) (vardecl False Bool)
-        )
+      (datatype
+        (tyvardecl Bool (type))
+        
+        Bool_match
+        (vardecl True Bool) (vardecl False Bool)
       )
-      [
-        (lam
-          ds
-          Bool
-          [
-            [
-              [ { [ Bool_match ds ] (fun Unit Bool) } (lam thunk Unit True) ]
-              (lam thunk Unit False)
-            ]
-            Unit
-          ]
-        )
-        False
-      ]
     )
+    [ (lam ds Bool [ [ { [ Bool_match ds ] Bool } True ] False ]) False ]
   )
 )


### PR DESCRIPTION
As in PLC. The place where this matters is deciding whether we need to
do a lazy match, so this removes a few of those.