### PR TITLE
[Test] Added 'FsTree'

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -48,6 +48,7 @@ library
         Language.PlutusCore.Subst
         Language.PlutusCore.Name
         Language.PlutusCore.Check.Uniques
+        Language.PlutusCore.FsTree
         Language.PlutusCore.StdLib.Data.Bool
         Language.PlutusCore.StdLib.Data.ChurchNat
         Language.PlutusCore.StdLib.Data.Function

--- a/language-plutus-core/src/Language/PlutusCore/FsTree.hs
+++ b/language-plutus-core/src/Language/PlutusCore/FsTree.hs
@@ -1,0 +1,89 @@
+-- | Machinery defined in this module allows to export mulptiple Plutus Core definitions
+-- (types and terms) as a single value which enables convenient testing of various procedures
+-- (pretty-printing, type checking, etc): each time a function / data type is added to that value,
+-- none of the tests is required to be adapted, instead all the tests see the new definition
+-- automatically.
+
+module Language.PlutusCore.FsTree
+    ( FsTree (..)
+    , FolderContents (..)
+    , PlcEntity (..)
+    , PlcFsTree
+    , PlcFolderContents
+    , treeFolderContents
+    , plcTypeFile
+    , plcTermFile
+    , foldFsTree
+    , foldPlcFsTree
+    , foldPlcFolderContents
+    ) where
+
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Quote
+import           Language.PlutusCore.Type
+
+-- We use 'String's for names, because 'FilePath's are 'String's.
+-- | An 'FsTree' is either a file or a folder with a list of 'FsTree's inside.
+data FsTree a
+    = FsFolder String (FolderContents a)
+    | FsFile String a
+
+-- | The contents of a folder. A wrapper around @[FsTree a]@.
+-- Exists because of its 'Semigroup' instance which allows to concatenate two 'FolderContents's
+-- without placing them into the same folder immediately, so we can have various PLC "modules"
+-- (@stdlib@, @examples@, etc), define compound modules (e.g. @stdlib <> examples@) and run various
+-- tests (pretty-printing, type synthesis, etc) against simple and compound modules uniformly.
+newtype FolderContents a = FolderContents
+    { unFolderContents :: [FsTree a]
+    } deriving (Semigroup, Monoid)
+
+-- | A 'PlcEntity' is either a 'Type' or a 'Term'.
+data PlcEntity
+    = PlcType (Quote (Type TyName ()))
+    | PlcTerm (Quote (Term TyName Name ()))
+
+type PlcFsTree         = FsTree         PlcEntity
+type PlcFolderContents = FolderContents PlcEntity
+
+-- | Construct an 'FsTree' out of the name of a folder and a list of 'FsTree's.
+treeFolderContents :: String -> [FsTree a] -> FsTree a
+treeFolderContents name = FsFolder name . FolderContents
+
+-- | Construct a single-file 'PlcFsTree' out of a type.
+plcTypeFile :: String -> Quote (Type TyName ()) -> PlcFsTree
+plcTypeFile name = FsFile name . PlcType
+
+-- | Construct a single-file 'PlcFsTree' out of a term.
+plcTermFile :: String -> Quote (Term TyName Name ()) -> PlcFsTree
+plcTermFile name = FsFile name . PlcTerm
+
+-- | Fold a 'FsTree'.
+foldFsTree
+    :: (String -> [b] -> b)  -- ^ What to do on a folder.
+    -> (String -> a -> b)    -- ^ What to do on a single file in a folder.
+    -> FsTree a
+    -> b
+foldFsTree onFolder onFile = go where
+    go (FsFolder name (FolderContents trees)) = onFolder name $ map go trees
+    go (FsFile name x)                        = onFile name x
+
+-- | Fold a 'PlcFsTree'.
+foldPlcFsTree
+    :: (String -> [b] -> b)                          -- ^ What to do on a folder.
+    -> (String -> Quote (Type TyName ())      -> b)  -- ^ What to do on a type.
+    -> (String -> Quote (Term TyName Name ()) -> b)  -- ^ What to do on a term.
+    -> PlcFsTree
+    -> b
+foldPlcFsTree onFolder onType onTerm = foldFsTree onFolder onFile where
+    onFile name (PlcType getTy)   = onType name getTy
+    onFile name (PlcTerm getTerm) = onTerm name getTerm
+
+-- | Fold the contents of a PLC folder.
+foldPlcFolderContents
+    :: (String -> [b] -> b)                          -- ^ What to do on a folder.
+    -> (String -> Quote (Type TyName ())      -> b)  -- ^ What to do on a type.
+    -> (String -> Quote (Term TyName Name ()) -> b)  -- ^ What to do on a term.
+    -> PlcFolderContents
+    -> [b]
+foldPlcFolderContents onFolder onType onTerm (FolderContents trees) =
+    map (foldPlcFsTree onFolder onType onTerm) trees

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Everything.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Everything.hs
@@ -7,10 +7,11 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Language.PlutusCore.StdLib.Everything
-    ( foldStdLib
+    ( stdLib
     ) where
 
-import           Language.PlutusCore
+import           Language.PlutusCore.FsTree
+
 import           Language.PlutusCore.StdLib.Data.Bool
 import           Language.PlutusCore.StdLib.Data.ChurchNat
 import           Language.PlutusCore.StdLib.Data.Function
@@ -20,115 +21,62 @@ import           Language.PlutusCore.StdLib.Data.Nat
 import           Language.PlutusCore.StdLib.Data.Unit
 import           Language.PlutusCore.StdLib.Meta.Data.Tuple
 
--- We use 'String's for names, because this module exists for tests right now and
--- there we have 'FilePath's which are 'String's.
-
-data Named a = Named String a
-
--- | A PLC entity in the standard library.
-data AnonStdLibPlcEntity
-    = AnonStdLibType (Quote (Type TyName ()))       -- ^ A type.
-    | AnonStdLibTerm (Quote (Term TyName Name ()))  -- ^ A term.
-
-type StdLibPlcEntity = Named AnonStdLibPlcEntity
-
--- | The contents of a file system entity in the standard library.
-data AnonStdLibFsEntity
-    = AnonStdLibFolder [StdLibFsEntity]   -- ^ A subfolder.
-    | AnonStdLibFile   [StdLibPlcEntity]  -- ^ A file in the folder.
-
--- | A folder in the standard library.
-type StdLibFsEntity = Named AnonStdLibFsEntity
-
--- | Fold a 'StdLibPlcEntity'.
-foldStdLibPlcEntity
-    :: (String -> Quote (Type TyName ())      -> a)  -- ^ What to do on a type.
-    -> (String -> Quote (Term TyName Name ()) -> a)  -- ^ What to do on a term.
-    -> StdLibPlcEntity
-    -> a
-foldStdLibPlcEntity onType onTerm (Named plcName anonStdLibPlcEntity) =
-    case anonStdLibPlcEntity of
-        AnonStdLibType ty   -> onType plcName ty
-        AnonStdLibTerm term -> onTerm plcName term
-
--- | Fold a 'StdLibFsEntity'.
-foldStdLibFsEntity
-    :: (String -> [a] -> a)                          -- ^ What to do on a folder or a file.
-    -> (String -> Quote (Type TyName ())      -> a)  -- ^ What to do on a type.
-    -> (String -> Quote (Term TyName Name ()) -> a)  -- ^ What to do on a term.
-    -> StdLibFsEntity
-    -> a
-foldStdLibFsEntity onFs onType onTerm = go where
-    go (Named fsName anonStdLibFsEntity) = onFs fsName $ case anonStdLibFsEntity of
-        AnonStdLibFolder fsEntities  -> map go fsEntities
-        AnonStdLibFile   plcEntities -> map (foldStdLibPlcEntity onType onTerm) plcEntities
-
--- | Fold the entire stdlib.
-foldStdLib
-    :: (String -> [a] -> a)                          -- ^ What to do on a folder or a file.
-    -> (String -> Quote (Type TyName ())      -> a)  -- ^ What to do on a type.
-    -> (String -> Quote (Term TyName Name ()) -> a)  -- ^ What to do on a term.
-    -> a
-foldStdLib onFs onType onTerm = foldStdLibFsEntity onFs onType onTerm stdLib
-
 -- | The entire stdlib exported as a single value.
-stdLib :: StdLibFsEntity
-stdLib
-    = Named "StdLib" $ AnonStdLibFolder
-        [ Named "Data" $ AnonStdLibFolder
-            [ Named "Bool" $ AnonStdLibFile
-                [ Named "Bool"  $ AnonStdLibType getBuiltinBool
-                , Named "True"  $ AnonStdLibTerm getBuiltinTrue
-                , Named "False" $ AnonStdLibTerm getBuiltinFalse
-                , Named "If"    $ AnonStdLibTerm getBuiltinIf
-                ]
-            , Named "ChurchNat" $ AnonStdLibFile
-                [ Named "ChurchNat"  $ AnonStdLibType getBuiltinChurchNat
-                , Named "ChurchZero" $ AnonStdLibTerm getBuiltinChurchZero
-                , Named "ChurchSucc" $ AnonStdLibTerm getBuiltinChurchSucc
-                ]
-            , Named "Function" $ AnonStdLibFile
-                [ Named "Const"  $ AnonStdLibTerm getBuiltinConst
-                -- , Named "Self"   $ AnonStdLibType getBuiltinSelf
-                , Named "Unroll" $ AnonStdLibTerm getBuiltinUnroll
-                , Named "Fix"    $ AnonStdLibTerm getBuiltinFix
-                , Named "Fix2"   $ AnonStdLibTerm (getBuiltinFixN 2)
-                ]
-            , Named "Integer" $ AnonStdLibFile
-                [ Named "SuccInteger" $ AnonStdLibTerm getBuiltinSuccInteger
-                ]
-            , Named "List" $ AnonStdLibFile
-                [ -- Named "List"       $ AnonStdLibType getBuiltinList
-                  Named "Nil"        $ AnonStdLibTerm getBuiltinNil
-                , Named "Cons"       $ AnonStdLibTerm getBuiltinCons
-                , Named "FoldrList"  $ AnonStdLibTerm getBuiltinFoldrList
-                , Named "FoldList"   $ AnonStdLibTerm getBuiltinFoldList
-                , Named "EnumFromTo" $ AnonStdLibTerm getBuiltinEnumFromTo
-                , Named "Sum"        $ AnonStdLibTerm getBuiltinSum
-                , Named "Product"    $ AnonStdLibTerm getBuiltinProduct
-                ]
-            , Named "Nat" $ AnonStdLibFile
-                [ -- Named "Nat"          $ AnonStdLibType getBuiltinNat
-                  Named "Zero"         $ AnonStdLibTerm getBuiltinZero
-                , Named "Succ"         $ AnonStdLibTerm getBuiltinSucc
-                , Named "FoldrNat"     $ AnonStdLibTerm getBuiltinFoldrNat
-                , Named "FoldNat"      $ AnonStdLibTerm getBuiltinFoldNat
-                , Named "NatToInteger" $ AnonStdLibTerm getBuiltinNatToInteger
-                ]
-            , Named "Unit" $ AnonStdLibFile
-                [ Named "Unit"    $ AnonStdLibType getBuiltinUnit
-                , Named "Unitval" $ AnonStdLibTerm getBuiltinUnitval
-                ]
-            ]
-        , Named "Meta" $ AnonStdLibFolder
-            [ Named "Data" $ AnonStdLibFolder
-                [ Named "Tuple" $ AnonStdLibFile
-                    [ Named "Tuple2"       $ AnonStdLibType $ getBuiltinTuple 2
-                    , Named "Tuple2_0"     $ AnonStdLibTerm $ getBuiltinTupleAccessor 2 0
-                    , Named "Tuple2_1"     $ AnonStdLibTerm $ getBuiltinTupleAccessor 2 1
-                    , Named "MkTuple2"     $ AnonStdLibTerm $ getBuiltinTupleConstructor 2
-                    ]
-                ]
-            ]
-        ]
--- Commented out types are of the 'HoledType' form which will vanish in future.
+stdLib :: PlcFolderContents
+stdLib =
+    FolderContents
+      [ treeFolderContents "StdLib"
+          [ treeFolderContents "Data"
+              [ treeFolderContents "Bool"
+                  [ plcTypeFile "Bool"  getBuiltinBool
+                  , plcTermFile "True"  getBuiltinTrue
+                  , plcTermFile "False" getBuiltinFalse
+                  , plcTermFile "If"    getBuiltinIf
+                  ]
+              , treeFolderContents "ChurchNat"
+                  [ plcTypeFile "ChurchNat"  getBuiltinChurchNat
+                  , plcTermFile "ChurchZero" getBuiltinChurchZero
+                  , plcTermFile "ChurchSucc" getBuiltinChurchSucc
+                  ]
+              , treeFolderContents "Function"
+                  [ plcTermFile "Const"  getBuiltinConst
+                  , plcTermFile "Unroll" getBuiltinUnroll
+                  , plcTermFile "Fix"    getBuiltinFix
+                  , plcTermFile "Fix2"   $ getBuiltinFixN 2
+                  ]
+              , treeFolderContents "Integer"
+                  [ plcTermFile "SuccInteger" getBuiltinSuccInteger
+                  ]
+              , treeFolderContents "List"
+                  [ plcTermFile "Nil"        getBuiltinNil
+                  , plcTermFile "Cons"       getBuiltinCons
+                  , plcTermFile "FoldrList"  getBuiltinFoldrList
+                  , plcTermFile "FoldList"   getBuiltinFoldList
+                  , plcTermFile "EnumFromTo" getBuiltinEnumFromTo
+                  , plcTermFile "Sum"        getBuiltinSum
+                  , plcTermFile "Product"    getBuiltinProduct
+                  ]
+              , treeFolderContents "Nat"
+                  [ plcTermFile "Zero"         getBuiltinZero
+                  , plcTermFile "Succ"         getBuiltinSucc
+                  , plcTermFile "FoldrNat"     getBuiltinFoldrNat
+                  , plcTermFile "FoldNat"      getBuiltinFoldNat
+                  , plcTermFile "NatToInteger" getBuiltinNatToInteger
+                  ]
+              , treeFolderContents "Unit"
+                  [ plcTypeFile "Unit"    getBuiltinUnit
+                  , plcTermFile "Unitval" getBuiltinUnitval
+                  ]
+              ]
+          , treeFolderContents "Meta"
+              [ treeFolderContents "Data"
+                  [ treeFolderContents "Tuple"
+                      [ plcTypeFile "Tuple2"   $ getBuiltinTuple 2
+                      , plcTermFile "Tuple2_0" $ getBuiltinTupleAccessor 2 0
+                      , plcTermFile "Tuple2_1" $ getBuiltinTupleAccessor 2 1
+                      , plcTermFile "MkTuple2" $ getBuiltinTupleConstructor 2
+                      ]
+                  ]
+              ]
+          ]
+      ]

--- a/language-plutus-core/test/Pretty/Readable.hs
+++ b/language-plutus-core/test/Pretty/Readable.hs
@@ -1,8 +1,10 @@
-module Pretty.Readable (test_PrettyReadable) where
+module Pretty.Readable (test_Pretty) where
 
+import           Language.PlutusCore.FsTree            (foldPlcFolderContents)
 import           Language.PlutusCore.Pretty
 import           Language.PlutusCore.Quote
-import           Language.PlutusCore.StdLib.Everything
+
+import           Language.PlutusCore.StdLib.Everything (stdLib)
 
 import           Common
 
@@ -18,6 +20,14 @@ testReadable :: PrettyPlc a => TestName -> Quote a -> TestNested
 testReadable name = nestedGoldenVsDoc name . prettyBy prettyConfigReadable . runQuote
 
 test_PrettyReadable :: TestTree
-test_PrettyReadable =
-    runTestNestedIn ["test", "Pretty", "Golden", "Readable"] $
-        foldStdLib testNested testReadable testReadable
+test_PrettyReadable
+    = runTestNestedIn ["test", "Pretty", "Golden"]
+    . testNested "Readable"
+    . foldPlcFolderContents testNested testReadable testReadable
+    $ stdLib
+
+test_Pretty :: TestTree
+test_Pretty =
+    testGroup "pretty"
+        [ test_PrettyReadable
+        ]

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -105,7 +105,7 @@ allTests plcFiles rwFiles typeFiles typeNormalizeFiles typeErrorFiles = testGrou
     , testsType typeFiles
     , testsNormalizeType typeNormalizeFiles
     , testsType typeErrorFiles
-    , test_PrettyReadable
+    , test_Pretty
     , test_typeNormalization
     , test_typecheck
     , test_constant

--- a/language-plutus-core/test/TypeSynthesis/Spec.hs
+++ b/language-plutus-core/test/TypeSynthesis/Spec.hs
@@ -6,8 +6,10 @@ module TypeSynthesis.Spec
 
 import           Language.PlutusCore
 import           Language.PlutusCore.Constant          (typeOfBuiltinName)
+import           Language.PlutusCore.FsTree            (foldPlcFolderContents)
 import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.StdLib.Everything
+
+import           Language.PlutusCore.StdLib.Everything (stdLib)
 
 import           Common
 
@@ -50,12 +52,14 @@ assertIllTyped getTerm = case runExcept . runQuoteT $ typecheckQuoted getTerm of
     Right term -> assertFailure $ "Well-typed: " ++ prettyPlcCondensedErrorClassicString term
     Left  _    -> return ()
 
-test_typecheckStdLib :: TestTree
-test_typecheckStdLib =
-    foldStdLib
-        testGroup
-        (\name -> testCase name . assertWellKinded)
-        (\name -> testCase name . assertWellTyped)
+test_typecheckAvailable :: TestTree
+test_typecheckAvailable =
+    testGroup "Available" $
+        foldPlcFolderContents
+            testGroup
+            (\name -> testCase name . assertWellKinded)
+            (\name -> testCase name . assertWellTyped)
+            stdLib
 
 -- | Self-application. An example of ill-typed term.
 --
@@ -91,6 +95,6 @@ test_typecheck :: TestTree
 test_typecheck =
     testGroup "typecheck"
         [ test_typecheckBuiltinNames
-        , test_typecheckStdLib
+        , test_typecheckAvailable
         , test_typecheckIllTyped
         ]


### PR DESCRIPTION
Golden tests refactoring. Needed, because the `ifix` PR adds `examples` in addition to `stdlib`, so hardcoding "automatic" golden testing to `stdlib` no longer works.