### PR TITLE
wallet-api: Improvements

### DIFF
--- a/plutus-playground/plutus-playground-lib/src/Playground/Interpreter/Util.hs
+++ b/plutus-playground/plutus-playground-lib/src/Playground/Interpreter/Util.hs
@@ -11,7 +11,7 @@ import qualified Data.Map                   as Map
 import           Data.Monoid                (Sum (Sum), getSum)
 import qualified Data.Set                   as Set
 import qualified Data.Typeable              as T
-import           Ledger.Types               (Blockchain, PubKey (PubKey), Tx, Value (Value))
+import           Ledger.Types               (Blockchain, PubKey (PubKey), Tx, TxOut(txOutValue), Value (Value))
 import           Playground.API             (PlaygroundError (OtherError))
 import           Wallet.Emulator.Types      (EmulatorEvent, EmulatorState (_chainNewestFirst, _emulatorLog), MockWallet,
                                              Trace, Wallet (Wallet), ownFunds, processPending, runTraceTxPool,
@@ -43,7 +43,7 @@ runTrace wallets actions =
               blockchain = _chainNewestFirst newState
               emulatorLog = _emulatorLog newState
               fundsDistribution =
-                Map.map (getSum . foldMap Sum . view ownFunds) .
+                Map.map (getSum . foldMap (Sum . txOutValue) . view ownFunds) .
                 view walletStates $
                 newState
            in case eRes of

--- a/plutus-playground/plutus-playground-lib/src/Playground/Interpreter/Util.hs
+++ b/plutus-playground/plutus-playground-lib/src/Playground/Interpreter/Util.hs
@@ -11,7 +11,7 @@ import qualified Data.Map                   as Map
 import           Data.Monoid                (Sum (Sum), getSum)
 import qualified Data.Set                   as Set
 import qualified Data.Typeable              as T
-import           Ledger.Types               (Blockchain, PubKey (PubKey), Tx, TxOut(txOutValue), Value (Value))
+import           Ledger.Types               (Blockchain, PubKey (PubKey), Tx, TxOut (txOutValue), Value (Value))
 import           Playground.API             (PlaygroundError (OtherError))
 import           Wallet.Emulator.Types      (EmulatorEvent, EmulatorState (_chainNewestFirst, _emulatorLog), MockWallet,
                                              Trace, Wallet (Wallet), ownFunds, processPending, runTraceTxPool,

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -89,7 +89,7 @@ collect cmp = register (collectFundsTrigger cmp) $ EventHandler $ \_ -> do
             red        = Ledger.RedeemerScript $ Ledger.lifted Collect
             con (r, _) = scriptTxIn r scr red
             ins        = con <$> contributions
-            value = getSum $ foldMap (Sum . snd) contributions
+            value = getSum $ foldMap (Sum . Ledger.txOutValue . snd) contributions
 
         oo <- ownPubKeyTxOut value
         void $ signAndSubmit (Set.fromList ins) [oo]
@@ -201,7 +201,7 @@ refund txid cmp = EventHandler $ \_ -> do
         red   = Ledger.RedeemerScript $ Ledger.lifted Refund
         i ref = scriptTxIn ref scr red
         inputs = Set.fromList $ i . fst <$> ourUtxo
-        value  = getSum $ foldMap (Sum . snd) ourUtxo
+        value  = getSum $ foldMap (Sum . Ledger.txOutValue . snd) ourUtxo
 
     out <- ownPubKeyTxOut value
     void $ signAndSubmit inputs [out]

--- a/wallet-api/src/Wallet/API.hs
+++ b/wallet-api/src/Wallet/API.hs
@@ -296,7 +296,7 @@ collectFromScript scr red = do
         outputs = am ^. at addr . to (Map.toList . fromMaybe Map.empty)
         con (r, _) = scriptTxIn r scr red
         ins        = con <$> outputs
-        value = getSum $ foldMap (Sum . snd) outputs
+        value = getSum $ foldMap (Sum . txOutValue . snd) outputs
 
     oo <- ownPubKeyTxOut value
     void $ signAndSubmit (Set.fromList ins) [oo]
@@ -312,7 +312,7 @@ collectFromScriptTxn vls red txid = do
         ourUtxo = Map.toList $ Map.filterWithKey (\k _ -> txid == Ledger.txOutRefId k) utxo
         i ref = scriptTxIn ref vls red
         inputs = Set.fromList $ i . fst <$> ourUtxo
-        value  = getSum $ foldMap (Sum . snd) ourUtxo
+        value  = getSum $ foldMap (Sum . txOutValue . snd) ourUtxo
 
     out <- ownPubKeyTxOut value
     void $ signAndSubmit inputs [out]

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -188,7 +188,7 @@ notifyWallet = property $ do
         $ Gen.runTraceOn Gen.generatorModel
         $ processPending >>= walletNotifyBlock w
     let ttl = Map.lookup w st
-    Hedgehog.assert $ (getSum . foldMap Sum . view ownFunds <$> ttl) == Just initialBalance
+    Hedgehog.assert $ (getSum . foldMap (Sum . txOutValue) . view ownFunds <$> ttl) == Just initialBalance
 
 eventTrace :: Property
 eventTrace = property $ do
@@ -212,7 +212,7 @@ eventTrace = property $ do
     let ttl = Map.lookup w st
 
     -- if `mkPayment` was run then the funds of wallet 1 should be reduced by 100
-    Hedgehog.assert $ (getSum . foldMap Sum . view ownFunds <$> ttl) == Just (initialBalance - 100)
+    Hedgehog.assert $ (getSum . foldMap (Sum . txOutValue) . view ownFunds <$> ttl) == Just (initialBalance - 100)
 
 payToPubKeyScript2 :: Property
 payToPubKeyScript2 = property $ do
@@ -279,7 +279,7 @@ watchFundsAtAddress = property $ do
             addBlocks 3 >>= traverse_ (walletNotifyBlock w)
             void (processPending >>= walletNotifyBlock w)
     let ttl = Map.lookup w st
-    Hedgehog.assert $ (getSum . foldMap Sum . view ownFunds <$> ttl) == Just (initialBalance - 200)
+    Hedgehog.assert $ (getSum . foldMap (Sum . txOutValue) . view ownFunds <$> ttl) == Just (initialBalance - 200)
 
 genChainTxn :: Hedgehog.MonadGen m => m (Mockchain, Tx)
 genChainTxn = do


### PR DESCRIPTION
* `AddressMap` keeps track of `TxOut` instead of `TxOutRef`. This means we get the data script of the output as well
* Add a `payToScripts` function in `Wallet.API` that lets us pay to multiple script addresses using our own funds