### PR TITLE
plutus-ir: datatype vars have dependencies on each other

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -40,7 +40,7 @@ mkTyVar :: a -> TyVarDecl tyname a -> Type tyname a
 mkTyVar x = TyVar x . tyVarDeclName
 
 -- | A definition. Pretty much just a pair with more descriptive names.
-data Def var val = Def { defVar::var, defVal::val}
+data Def var val = Def { defVar::var, defVal::val} deriving (Show, Eq, Ord, Generic)
 
 -- | A term definition as a variable.
 type TermDef tyname name a = Def (VarDecl tyname name a) (Term tyname name a)

--- a/plutus-ir/test/optimizer/deadCode/nestedBindingsIndirect.plc.golden
+++ b/plutus-ir/test/optimizer/deadCode/nestedBindingsIndirect.plc.golden
@@ -1,0 +1,16 @@
+(let
+  (nonrec)
+  (typebind (tyvardecl unit (type)) (all a (type) (fun a a)))
+  (let
+    (nonrec)
+    (datatypebind
+      (datatype
+        (tyvardecl SomeType (type))
+        
+        match_SomeType
+        (vardecl Constr (fun unit SomeType))
+      )
+    )
+    (lam arg SomeType arg)
+  )
+)

--- a/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Type.hs
@@ -122,7 +122,7 @@ splitNewtypeCoercion coerce = case GHC.coercionKind coerce of
 getUsedTcs :: (Converting m) => GHC.TyCon -> m [GHC.TyCon]
 getUsedTcs tc = do
     dcs <- getDataCons tc
-    let usedTcs = GHC.unionManyUniqSets $ (\dc -> GHC.unionManyUniqSets $ GHC.tyConsOfType <$> GHC.dataConRepArgTys dc) <$> dcs
+    let usedTcs = GHC.unionManyUniqSets $ (\dc -> GHC.unionManyUniqSets $ GHC.tyConsOfType <$> GHC.dataConOrigArgTys dc) <$> dcs
     pure $ GHC.nonDetEltsUniqSet usedTcs
 
 {- Note [Case expressions and laziness]
@@ -198,7 +198,7 @@ getDataCons tc' = sortConstructors tc' <$> extractDcs tc'
 -- | Makes the type of the constructor corresponding to the given 'DataCon', with the type variables free.
 mkConstructorType :: Converting m => GHC.DataCon -> m PIRType
 mkConstructorType dc =
-    let argTys = GHC.dataConRepArgTys dc
+    let argTys = GHC.dataConOrigArgTys dc
     in
         -- See Note [Scott encoding of datatypes]
         withContextM (sdToTxt $ "Converting data constructor type:" GHC.<+> GHC.ppr dc) $ do

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -172,6 +172,7 @@ monoData = testNested "monomorphic" [
   , goldenPir "atPattern" atPattern
   , goldenEval "monoConstDestDefault" [ getProgram $ monoCase, getProgram $ monoConstructed ]
   , goldenPir "monoRecord" monoRecord
+  , goldenPir "recordNewtype" recordNewtype
   , goldenPir "nonValueCase" nonValueCase
   , goldenPir "synonym" synonym
   ]
@@ -181,7 +182,7 @@ data MyEnum = Enum1 | Enum2
 basicEnum :: CompiledCode MyEnum
 basicEnum = plc @"basicEnum" (Enum1)
 
-data MyMonoData = Mono1 Int Int | Mono2 Int | Mono3 Int deriving (Generic)
+data MyMonoData = Mono1 Int Int | Mono2 Int | Mono3 Int
 
 monoDataType :: CompiledCode (MyMonoData -> MyMonoData)
 monoDataType = plc @"monoDataType" (\(x :: MyMonoData) -> x)
@@ -204,10 +205,15 @@ irrefutableMatch = plc @"irrefutableMatch" (\(x :: MyMonoData) -> case x of { Mo
 atPattern :: CompiledCode ((Int, Int) -> Int)
 atPattern = plc @"atPattern" (\t@(x::Int, y::Int) -> let fst (a, b) = a in y + fst t)
 
-data MyMonoRecord = MyMonoRecord { mrA :: Int , mrB :: Int} deriving Generic
+data MyMonoRecord = MyMonoRecord { mrA :: Int , mrB :: Int}
 
 monoRecord :: CompiledCode (MyMonoRecord -> MyMonoRecord)
 monoRecord = plc @"monoRecord" (\(x :: MyMonoRecord) -> x)
+
+data RecordNewtype = RecordNewtype { newtypeField :: MyNewtype }
+
+recordNewtype :: CompiledCode (RecordNewtype -> RecordNewtype)
+recordNewtype = plc @"recordNewtype" (\(x :: RecordNewtype) -> x)
 
 -- must be compiled with a lazy case
 nonValueCase :: CompiledCode (MyEnum -> Int)

--- a/plutus-tx-plugin/test/Plugin/data/monomorphic/recordNewtype.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/data/monomorphic/recordNewtype.plc.golden
@@ -1,0 +1,25 @@
+(program
+  (let
+    (nonrec)
+    (datatypebind
+      (datatype
+        (tyvardecl MyNewtype (type))
+        
+        MyNewtype_match
+        (vardecl MyNewtype (fun [(con integer) (con 8)] MyNewtype))
+      )
+    )
+    (let
+      (nonrec)
+      (datatypebind
+        (datatype
+          (tyvardecl RecordNewtype (type))
+          
+          RecordNewtype_match
+          (vardecl RecordNewtype (fun MyNewtype RecordNewtype))
+        )
+      )
+      (lam ds RecordNewtype ds)
+    )
+  )
+)


### PR DESCRIPTION
This is slightly subtle. Naively, we might think that the datatype
variable `A` does not depend on the constructor `MkA`. However, this is
not true: we cannot remove the latter from the program without removing
the former, because they are defined in the same binding. Hence there
*is* a dependency.

Missing this causes us to miss that the dependencies of `MkA` are also
live in this instance, causing us to erroneously remove them.

Also a drive-by fix for using the right GHC method for getting datatype args,
although that turned out not to be the problem.

Fixes one of the type errors on the ifix branch.