### PR TITLE
plutus-tx-plugin: wrap trace

### DIFF
--- a/plutus-tx-plugin/test/Lift/boolInterop.plc.golden
+++ b/plutus-tx-plugin/test/Lift/boolInterop.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_106
+  out_Bool_110
   (type)
   (lam
-    case_True_107 out_Bool_106 (lam case_False_108 out_Bool_106 case_True_107)
+    case_True_111 out_Bool_110 (lam case_False_112 out_Bool_110 case_True_111)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -86,6 +86,7 @@ primitives = testNested "primitives" [
   , goldenEval "sha2_256" [ getPlc sha2, unsafeLiftProgram ("hello" :: ByteString)]
   , goldenEval "equalsByteString" [ getPlc bsEquals, unsafeLiftProgram ("hello" :: ByteString), unsafeLiftProgram ("hello" :: ByteString)]
   , goldenPir "verify" verify
+  , goldenPir "trace" trace
   ]
 
 int :: CompiledCode Int
@@ -142,6 +143,9 @@ bsEquals = plc @"bsEquals" (\(x :: ByteString) (y :: ByteString) -> Builtins.equ
 
 verify :: CompiledCode (ByteString -> ByteString -> ByteString -> Bool)
 verify = plc @"verify" (\(x::ByteString) (y::ByteString) (z::ByteString) -> Builtins.verifySignature x y z)
+
+trace :: CompiledCode (Builtins.String -> ())
+trace = plc @"trace" (\(x :: Builtins.String) -> Builtins.trace x)
 
 structure :: TestNested
 structure = testNested "structure" [

--- a/plutus-tx-plugin/test/Plugin/basic/monoId.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/basic/monoId.plc.golden
@@ -1,3 +1,3 @@
 (program 1.0.0
-  (lam ds_74 [(con integer) (con 8)] ds_74)
+  (lam ds_78 [(con integer) (con 8)] ds_78)
 )

--- a/plutus-tx-plugin/test/Plugin/basic/monoK.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/basic/monoK.plc.golden
@@ -1,3 +1,3 @@
 (program 1.0.0
-  (lam ds_75 [(con integer) (con 8)] (lam ds_76 [(con integer) (con 8)] ds_75))
+  (lam ds_79 [(con integer) (con 8)] (lam ds_80 [(con integer) (con 8)] ds_79))
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/andApply.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/andApply.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_109
+  out_Bool_113
   (type)
   (lam
-    case_True_110 out_Bool_109 (lam case_False_111 out_Bool_109 case_False_111)
+    case_True_114 out_Bool_113 (lam case_False_115 out_Bool_113 case_False_115)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/equalsByteString.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/equalsByteString.plc.golden
@@ -1,5 +1,7 @@
 (abs
-  out_Bool_96
+  out_Bool_100
   (type)
-  (lam case_True_97 out_Bool_96 (lam case_False_98 out_Bool_96 case_True_97))
+  (lam
+    case_True_101 out_Bool_100 (lam case_False_102 out_Bool_100 case_True_101)
+  )
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/intEqApply.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/intEqApply.plc.golden
@@ -1,5 +1,7 @@
 (abs
-  out_Bool_96
+  out_Bool_100
   (type)
-  (lam case_True_97 out_Bool_96 (lam case_False_98 out_Bool_96 case_True_97))
+  (lam
+    case_True_101 out_Bool_100 (lam case_False_102 out_Bool_100 case_True_101)
+  )
 )

--- a/plutus-tx-plugin/test/Plugin/primitives/trace.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/primitives/trace.plc.golden
@@ -1,0 +1,20 @@
+(program
+  (let
+    (nonrec)
+    (datatypebind
+      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+    )
+    (let
+      (nonrec)
+      (termbind
+        (vardecl trace (fun (con string) Unit))
+        (lam
+          arg
+          (con string)
+          [ (lam b (all a (type) (fun a a)) Unit) [ (builtin trace) arg ] ]
+        )
+      )
+      (lam ds (con string) [ trace ds ])
+    )
+  )
+)

--- a/plutus-tx-plugin/test/Plugin/recursiveFunctions/even3.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveFunctions/even3.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_289
+  out_Bool_293
   (type)
   (lam
-    case_True_290 out_Bool_289 (lam case_False_291 out_Bool_289 case_False_291)
+    case_True_294 out_Bool_293 (lam case_False_295 out_Bool_293 case_False_295)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/recursiveFunctions/even4.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveFunctions/even4.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_286
+  out_Bool_290
   (type)
   (lam
-    case_True_287 out_Bool_286 (lam case_False_288 out_Bool_286 case_True_287)
+    case_True_291 out_Bool_290 (lam case_False_292 out_Bool_290 case_True_291)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/structure/letFun.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/structure/letFun.plc.golden
@@ -4,53 +4,53 @@
       [
         {
           (abs
-            Bool_84
+            Bool_88
             (type)
             (lam
-              True_85
-              Bool_84
+              True_89
+              Bool_88
               (lam
-                False_86
-                Bool_84
+                False_90
+                Bool_88
                 (lam
-                  Bool_match_87
-                  (fun Bool_84 (all out_Bool_88 (type) (fun out_Bool_88 (fun out_Bool_88 out_Bool_88))))
+                  Bool_match_91
+                  (fun Bool_88 (all out_Bool_92 (type) (fun out_Bool_92 (fun out_Bool_92 out_Bool_92))))
                   [
                     (lam
-                      equalsInteger_89
-                      (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_84))
+                      equalsInteger_93
+                      (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_88))
                       (lam
-                        ds_90
+                        ds_94
                         [(con integer) (con 8)]
                         (lam
-                          ds_91
+                          ds_95
                           [(con integer) (con 8)]
                           [
                             (lam
-                              z_92
+                              z_96
                               [(con integer) (con 8)]
-                              [ [ equalsInteger_89 ds_90 ] z_92 ]
+                              [ [ equalsInteger_93 ds_94 ] z_96 ]
                             )
-                            ds_91
+                            ds_95
                           ]
                         )
                       )
                     )
                     (lam
-                      arg_93
+                      arg_97
                       [(con integer) (con 8)]
                       (lam
-                        arg_94
+                        arg_98
                         [(con integer) (con 8)]
                         [
                           (lam
-                            b_95
-                            (all a_96 (type) (fun a_96 (fun a_96 a_96)))
-                            [ [ { b_95 Bool_84 } True_85 ] False_86 ]
+                            b_99
+                            (all a_100 (type) (fun a_100 (fun a_100 a_100)))
+                            [ [ { b_99 Bool_88 } True_89 ] False_90 ]
                           )
                           [
-                            [ { (builtin equalsInteger) (con 8) } arg_93 ]
-                            arg_94
+                            [ { (builtin equalsInteger) (con 8) } arg_97 ]
+                            arg_98
                           ]
                         ]
                       )
@@ -60,32 +60,32 @@
               )
             )
           )
-          (all out_Bool_97 (type) (fun out_Bool_97 (fun out_Bool_97 out_Bool_97)))
+          (all out_Bool_101 (type) (fun out_Bool_101 (fun out_Bool_101 out_Bool_101)))
         }
         (abs
-          out_Bool_98
+          out_Bool_102
           (type)
           (lam
-            case_True_99
-            out_Bool_98
-            (lam case_False_100 out_Bool_98 case_True_99)
+            case_True_103
+            out_Bool_102
+            (lam case_False_104 out_Bool_102 case_True_103)
           )
         )
       ]
       (abs
-        out_Bool_101
+        out_Bool_105
         (type)
         (lam
-          case_True_102
-          out_Bool_101
-          (lam case_False_103 out_Bool_101 case_False_103)
+          case_True_106
+          out_Bool_105
+          (lam case_False_107 out_Bool_105 case_False_107)
         )
       )
     ]
     (lam
-      x_104
-      (all out_Bool_105 (type) (fun out_Bool_105 (fun out_Bool_105 out_Bool_105)))
-      x_104
+      x_108
+      (all out_Bool_109 (type) (fun out_Bool_109 (fun out_Bool_109 out_Bool_109)))
+      x_108
     )
   ]
 )


### PR DESCRIPTION
`trace` returns unit, but a Scott-encoded unit, so we need to do the
same wrapping trick that we do for builtins that return a bool and add
an adapter that converts the result to a Haskell unit.

This should fix another one of the typechecking errors with ifix.