### PR TITLE
Generate more sensible constants

### DIFF
--- a/language-plutus-core/test/Generators.hs
+++ b/language-plutus-core/test/Generators.hs
@@ -40,9 +40,11 @@ genConstant = Gen.choice [genInt, genSize, genBS]
     where int' = Gen.integral_ (Range.linear (-10000000) 10000000)
           size' = Gen.integral_ (Range.linear 1 10)
           string' = BSL.fromStrict <$> Gen.utf8 (Range.linear 0 40) Gen.unicode
-          genInt = BuiltinInt () <$> size' <*> int'
+          genInt = Gen.filter (not . badInt) $ BuiltinInt () <$> size' <*> int'
           genSize = BuiltinSize () <$> size'
           genBS = BuiltinBS () <$> size' <*> string'
+          badInt (BuiltinInt _ sz i) = (2 ^ (sz - 1)) <= i || -(2 ^ (sz - 1)) > i
+          badInt _                   = False
 
 genType :: MonadGen m => m (Type TyName ())
 genType = simpleRecursive nonRecursive recursive

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -85,8 +85,8 @@ propParser = property $ do
     prog <- forAll genProgram
     let reprint = BSL.fromStrict . encodeUtf8 . prettyPlcDefText
         proc = void <$> parse (reprint prog)
-        compared = and (compareProgram (void prog) <$> proc)
-    Hedgehog.assert compared
+        compared = compareProgram (void prog) <$> proc
+    Hedgehog.assert (fromRight False compared)
 
 propRename :: Property
 propRename = property $ do


### PR DESCRIPTION
This fixes https://github.com/input-output-hk/plutus/issues/438

Before, we generated bad data for constants sometimes. This filters out that bad data (viz., integers which are out of range), which means that we no longer have to allow errors in the parser roundtrip tests.