### PR TITLE
Remove [Signature] from UtxoIndex and PendingTx API.

### DIFF
--- a/plutus-playground/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground/plutus-playground-server/usecases/CrowdFunding.hs
@@ -2,7 +2,7 @@
 -- This is the fully parallel version that collects all contributions
 -- in a single transaction.
 --
--- Note [Transactions in the crowdfunding campaign] explains the structure of 
+-- Note [Transactions in the crowdfunding campaign] explains the structure of
 -- this contract on the blockchain.
 module Language.PlutusTx.Coordination.Contracts.CrowdFunding where
 
@@ -22,17 +22,17 @@ data Campaign = Campaign
     , campaignCollectionDeadline :: Slot
     -- ^ The date by which the campaign owner has to collect the funds
     , campaignOwner              :: PubKey
-    -- ^ Public key of the campaign owner. This key is entitled to retrieve the 
+    -- ^ Public key of the campaign owner. This key is entitled to retrieve the
     --   funds if the campaign is successful.
     } deriving (Generic, ToJSON, FromJSON, ToSchema)
 
 PlutusTx.makeLift ''Campaign
 
 -- | Action that can be taken by the participants in this contract. A value of
---   `CampaignAction` is provided as the redeemer. The validator script then 
---   checks if the conditions for performing this action are met. 
---   
-data CampaignAction = Collect | Refund
+--   `CampaignAction` is provided as the redeemer. The validator script then
+--   checks if the conditions for performing this action are met.
+--
+data CampaignAction = Collect Signature | Refund Signature
     deriving (Generic, ToJSON, FromJSON, ToSchema)
 
 PlutusTx.makeLift ''CampaignAction
@@ -43,7 +43,7 @@ PlutusTx.makeLift ''CampaignAction
 contributionScript :: Campaign -> ValidatorScript
 contributionScript cmp  = ValidatorScript val where
     val = Ledger.applyScript mkValidator (Ledger.lifted cmp)
-    mkValidator = Ledger.fromCompiledCode $$(PlutusTx.compile [|| 
+    mkValidator = Ledger.fromCompiledCode $$(PlutusTx.compile [||
 
         -- The validator script is a function of four arguments:
         -- 1. The 'Campaign' definition. This argument is provided by the Plutus client, using 'Ledger.applyScript'.
@@ -62,38 +62,41 @@ contributionScript cmp  = ValidatorScript val where
 
                 -- In Haskell we can define new operators. We import
                 -- `PlutusTx.and` from the Prelude here so that we can use it
-                -- in infix position rather than prefix (which would require a 
+                -- in infix position rather than prefix (which would require a
                 -- lot of additional brackets)
                 infixr 3 &&
                 (&&) :: Bool -> Bool -> Bool
                 (&&) = $$(PlutusTx.and)
-                
-                -- We pattern match on the pending transaction `p` to get the 
+
+                signedBy :: PubKey -> Signature -> Bool
+                signedBy (PubKey pk) (Signature s) = pk == s
+
+                -- We pattern match on the pending transaction `p` to get the
                 -- information we need:
                 -- `ps` is the list of inputs of the transaction
                 -- `outs` is the list of outputs
                 -- `h` is the current slot number
-                PendingTx ps outs _ _ (Slot h) _ _ = p
+                PendingTx ps outs _ _ (Slot h) _ = p
 
-                -- `deadline` is the campaign deadline, but we need it as an 
+                -- `deadline` is the campaign deadline, but we need it as an
                 -- `Int` so that we can compare it with other integers.
                 deadline :: Int
                 deadline = let Slot h' = campaignDeadline in h'
 
 
-                -- `collectionDeadline` is the campaign collection deadline as 
+                -- `collectionDeadline` is the campaign collection deadline as
                 -- an `Int`
                 collectionDeadline :: Int
                 collectionDeadline = let Slot h' = campaignCollectionDeadline in h'
 
-                -- `target` is the campaign target as 
+                -- `target` is the campaign target as
                 -- an `Int`
                 target :: Int
                 target = let Value v = campaignTarget in v
 
-                
-                -- `totalInputs` is the sum of the values of all transation 
-                -- inputs. We ise `foldr` from the Prelude to go through the 
+
+                -- `totalInputs` is the sum of the values of all transation
+                -- inputs. We ise `foldr` from the Prelude to go through the
                 -- list and sum up the values.
                 totalInputs :: Int
                 totalInputs =
@@ -101,7 +104,7 @@ contributionScript cmp  = ValidatorScript val where
                     $$(P.foldr) (\i total -> total + v i) 0 ps
 
                 isValid = case act of
-                    Refund -> -- the "refund" branch
+                    Refund sig -> -- the "refund" branch
                         let
 
                             contributorTxOut :: PendingTxOut -> Bool
@@ -113,12 +116,15 @@ contributionScript cmp  = ValidatorScript val where
                             -- of the contributor (this key is provided as the data script `con`)
                             contributorOnly = $$(P.all) contributorTxOut outs
 
-                            refundable = h >= collectionDeadline && contributorOnly && $$(txSignedBy) p con
+                            refundable = h >= collectionDeadline && contributorOnly && con `signedBy` sig
 
                         in refundable
-                    Collect -> -- the "successful campaign" branch
+                    Collect sig -> -- the "successful campaign" branch
                         let
-                            payToOwner = h >= deadline && h < collectionDeadline && totalInputs >= target && $$(txSignedBy) p campaignOwner
+                            payToOwner = h >= deadline
+                                && h < collectionDeadline
+                                && totalInputs >= target
+                                && campaignOwner `signedBy` sig
                         in payToOwner
             in
             if isValid then () else $$(P.error) () ||])
@@ -132,25 +138,27 @@ campaignAddress = Ledger.scriptAddress . contributionScript
 contribute :: Campaign -> Value -> MockWallet ()
 contribute cmp value = do
     _ <- if value <= 0 then throwOtherError "Must contribute a positive value" else pure ()
+    keyPair <- myKeyPair
     ownPK <- ownPubKey
+    let sig = signature keyPair
     let ds = DataScript (Ledger.lifted ownPK)
 
-    -- `payToScript` is a function of the wallet API. It takes a campaign 
-    -- address, value, and data script, and generates a transaction that 
+    -- `payToScript` is a function of the wallet API. It takes a campaign
+    -- address, value, and data script, and generates a transaction that
     -- pays the value to the script. `tx` is bound to this transaction. We need
     -- to hold on to it because we are going to use it in the refund handler.
-    -- If we were not interested in the transaction produced by `payToScript` 
-    -- we could have used `payeToScript_`, which has the same effect but 
+    -- If we were not interested in the transaction produced by `payToScript`
+    -- we could have used `payeToScript_`, which has the same effect but
     -- discards the result.
     tx <- payToScript (campaignAddress cmp) value ds
-    
+
     logMsg "Submitted contribution"
 
-    -- `register` adds a blockchain event handler on the `refundTrigger` 
+    -- `register` adds a blockchain event handler on the `refundTrigger`
     -- event. It instructs the wallet to start watching the addresses mentioned
     -- in the trigger definition and run the handler when the refund condition
     -- is true.
-    register (refundTrigger cmp) (refundHandler (Ledger.hashTx tx) cmp)
+    register (refundTrigger cmp) (refundHandler (Ledger.hashTx tx) sig cmp)
 
 
     logMsg "Registered refund trigger"
@@ -158,9 +166,12 @@ contribute cmp value = do
 -- | Register a [[EventHandler]] to collect all the funds of a campaign
 --
 scheduleCollection :: Campaign -> MockWallet ()
-scheduleCollection cmp = register (collectFundsTrigger cmp) (EventHandler (\_ -> do
+scheduleCollection cmp = do
+    keyPair <- myKeyPair
+    let sig = signature keyPair
+    register (collectFundsTrigger cmp) (EventHandler (\_ -> do
         logMsg "Collecting funds"
-        let redeemerScript = Ledger.RedeemerScript (Ledger.lifted Collect)
+        let redeemerScript = Ledger.RedeemerScript (Ledger.lifted $ Collect sig)
         collectFromScript (contributionScript cmp) redeemerScript))
 
 -- | An event trigger that fires when a refund of campaign contributions can be claimed
@@ -176,17 +187,17 @@ collectFundsTrigger c = andT
     (slotRangeT (Interval (campaignDeadline c) (campaignCollectionDeadline c)))
 
 -- | Claim a refund of our campaign contribution
-refundHandler :: TxId' -> Campaign -> EventHandler MockWallet
-refundHandler txid cmp = EventHandler (\_ -> do
+refundHandler :: TxId' -> Signature -> Campaign -> EventHandler MockWallet
+refundHandler txid signature cmp = EventHandler (\_ -> do
     logMsg "Claiming refund"
     let validatorScript = contributionScript cmp
-        redeemerScript  = Ledger.RedeemerScript (Ledger.lifted Refund)
-        
+        redeemerScript  = Ledger.RedeemerScript (Ledger.lifted $ Refund signature)
+
     -- `collectFromScriptTxn` generates a transaction that spends the unspent
     -- transaction outputs at the address of the validator scripts, *but* only
-    -- those outputs that were produced by the transaction `txid`. We use it 
-    -- here to ensure that we don't attempt to claim back other contributors' 
-    -- funds (if we did that, the validator script would fail and the entire 
+    -- those outputs that were produced by the transaction `txid`. We use it
+    -- here to ensure that we don't attempt to claim back other contributors'
+    -- funds (if we did that, the validator script would fail and the entire
     -- transaction would be invalid).
     collectFromScriptTxn validatorScript redeemerScript txid)
 
@@ -219,7 +230,7 @@ In both cases, the validator script is run twice. In the first case there is a s
 
 {- note [RecordWildCards]
 
-We can use the syntax "Campaign{..}" here because the 'RecordWildCards' 
+We can use the syntax "Campaign{..}" here because the 'RecordWildCards'
 extension is enabled automatically by the Playground backend.
 
 The extension is documented here:

--- a/plutus-playground/plutus-playground-server/usecases/Messages.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Messages.hs
@@ -23,7 +23,6 @@ submitInvalidTxn = do
             , txOutputs = []
             , txForge = 2
             , txFee = 0
-            , txSignatures = []
             }
     submitTxn tx
 

--- a/plutus-playground/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Vesting.hs
@@ -53,18 +53,18 @@ vestFunds vst value = do
     payToScript_ contractAddress value dataScript
 
 -- | Register this wallet as the owner of the vesting scheme. At each of the
---   two dates (tranche 1, tranche 2) we take out the funds that have been 
+--   two dates (tranche 1, tranche 2) we take out the funds that have been
 --   released so far.
---   This function has to be called before the funds are vested, so that the 
+--   This function has to be called before the funds are vested, so that the
 --   wallet can start watching the contract address for changes.
 registerVestingOwner :: Vesting -> MockWallet ()
 registerVestingOwner v = do
     ourPubKey <- ownPubKey
-    let 
+    let
         o = vestingOwner v
         addr = Ledger.scriptAddress (validatorScript v)
-    _ <- if o /= ourPubKey 
-         then throwOtherError "Vesting scheme is not owned by this wallet" 
+    _ <- if o /= ourPubKey
+         then throwOtherError "Vesting scheme is not owned by this wallet"
          else startWatching addr
 
     register (tranche2Trigger v) (tranche2Handler v)
@@ -73,7 +73,7 @@ registerVestingOwner v = do
     --   (as explained in the script code, below) but doing so requires some
     --   low-level code dealing with the transaction outputs, because we don't
     --   have a nice interface for this in 'Wallet.API' yet.
-    
+
 
 validatorScriptHash :: Vesting -> ValidatorHash
 validatorScriptHash =
@@ -95,7 +95,7 @@ validatorScript v = ValidatorScript val where
             (&&) :: Bool -> Bool -> Bool
             (&&) = $$(P.and)
 
-            PendingTx _ os _ _ (Slot h) _ _ = p
+            PendingTx _ os _ _ (Slot h) _ = p
             VestingTranche (Slot d1) (Value a1) = vestingTranche1
             VestingTranche (Slot d2) (Value a2) = vestingTranche2
 
@@ -141,7 +141,7 @@ validatorScript v = ValidatorScript val where
         if isValid then () else $$(P.error) () ||])
 
 tranche1Trigger :: Vesting -> EventTrigger
-tranche1Trigger v = 
+tranche1Trigger v =
     let VestingTranche dt1 _ = vestingTranche1 v in
     (slotRangeT (Interval dt1 (succ dt1)))
 
@@ -154,7 +154,7 @@ tranche2Handler vesting = EventHandler (\_ -> do
     collectFromScript vlscript redeemerScript)
 
 tranche2Trigger :: Vesting -> EventTrigger
-tranche2Trigger v = 
+tranche2Trigger v =
     let VestingTranche dt2 _ = vestingTranche2 v in
     (slotRangeT (Interval dt2 (succ dt2)))
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -33,13 +33,14 @@ import qualified Data.Set                     as Set
 import           GHC.Generics                 (Generic)
 
 import qualified Language.PlutusTx            as PlutusTx
-import           Ledger                       (DataScript (..), PubKey (..), TxId', ValidatorScript (..), Value (..), scriptTxIn, Slot(..))
+import           Ledger                       (DataScript (..), Signature(..), PubKey (..),
+                                               TxId', ValidatorScript (..), Value (..), scriptTxIn, Slot(..))
 import qualified Ledger                       as Ledger
 import           Ledger.Validation            (PendingTx (..), PendingTxIn (..), PendingTxOut, ValidatorHash)
 import qualified Ledger.Validation            as Validation
 import           Wallet                       (EventHandler (..), EventTrigger, Range (..), WalletAPI (..),
                                                WalletDiagnostics (..), andT, slotRangeT, fundsAtAddressT, throwOtherError,
-                                               ownPubKeyTxOut, payToScript, pubKey, signAndSubmit)
+                                               ownPubKeyTxOut, payToScript, pubKey, createTxAndSubmit, signature)
 
 import           Prelude                    (Bool (..), Int, Num (..), Ord (..), fst, snd, succ, ($), (.),
                                              (<$>), (==))
@@ -56,7 +57,7 @@ type CampaignActor = PubKey
 
 PlutusTx.makeLift ''Campaign
 
-data CampaignAction = Collect | Refund
+data CampaignAction = Collect Signature | Refund Signature
     deriving Generic
 
 PlutusTx.makeLift ''CampaignAction
@@ -83,15 +84,17 @@ collect :: (WalletAPI m, WalletDiagnostics m) => Campaign -> m ()
 collect cmp = register (collectFundsTrigger cmp) $ EventHandler $ \_ -> do
         logMsg "Collecting funds"
         am <- watchedAddresses
+        keyPair <- myKeyPair
+        let sig = signature keyPair
         let scr        = contributionScript cmp
             contributions = am ^. at (campaignAddress cmp) . to (Map.toList . fromMaybe Map.empty)
-            red        = Ledger.RedeemerScript $ Ledger.lifted Collect
+            red        = Ledger.RedeemerScript $ Ledger.lifted $ Collect sig
             con (r, _) = scriptTxIn r scr red
             ins        = con <$> contributions
             value = getSum $ foldMap (Sum . Ledger.txOutValue . snd) contributions
 
         oo <- ownPubKeyTxOut value
-        void $ signAndSubmit (Set.fromList ins) [oo]
+        void $ createTxAndSubmit (Set.fromList ins) [oo]
 
 
 -- | The address of a [[Campaign]]
@@ -130,10 +133,10 @@ contributionScript cmp  = ValidatorScript val where
 
             -- | Check that a pending transaction is signed by the private key
             --   of the given public key.
-            signedByT :: PendingTx ValidatorHash -> CampaignActor -> Bool
-            signedByT = $$(Validation.txSignedBy)
+            signedBy :: PubKey -> Signature -> Bool
+            signedBy (PubKey pk) (Signature s) = pk == s
 
-            PendingTx ps outs _ _ (Slot h) _ _ = p
+            PendingTx ps outs _ _ (Slot h) _ = p
 
             deadline :: Int
             deadline = let Slot h' = campaignDeadline in h'
@@ -151,7 +154,7 @@ contributionScript cmp  = ValidatorScript val where
                 $$(PlutusTx.foldr) (\i total -> total + v i) 0 ps
 
             isValid = case act of
-                Refund -> -- the "refund" branch
+                Refund sig -> -- the "refund" branch
                     let
                         -- Check that all outputs are paid to the public key
                         -- of the contributor (that is, to the `a` argument of the data script)
@@ -163,15 +166,15 @@ contributionScript cmp  = ValidatorScript val where
 
                         refundable   = h > collectionDeadline &&
                                                     contributorOnly &&
-                                                    signedByT p a
+                                                    a `signedBy` sig
 
                     in refundable
-                Collect -> -- the "successful campaign" branch
+                Collect sig -> -- the "successful campaign" branch
                     let
                         payToOwner = h > deadline &&
                                     h <= collectionDeadline &&
                                     totalInputs >= target &&
-                                    signedByT p campaignOwner
+                                    campaignOwner `signedBy` sig
                     in payToOwner
         in
         if isValid then () else $$(PlutusTx.error) ()) ||])
@@ -193,14 +196,16 @@ refund :: (WalletAPI m, WalletDiagnostics m) => TxId' -> Campaign -> EventHandle
 refund txid cmp = EventHandler $ \_ -> do
     logMsg "Claiming refund"
     am <- watchedAddresses
+    keyPair <- myKeyPair
+    let sig = signature keyPair
     let adr     = campaignAddress cmp
         utxo    = fromMaybe Map.empty $ am ^. at adr
         ourUtxo = Map.toList $ Map.filterWithKey (\k _ -> txid == Ledger.txOutRefId k) utxo
         scr   = contributionScript cmp
-        red   = Ledger.RedeemerScript $ Ledger.lifted Refund
+        red   = Ledger.RedeemerScript $ Ledger.lifted $ Refund sig
         i ref = scriptTxIn ref scr red
         inputs = Set.fromList $ i . fst <$> ourUtxo
         value  = getSum $ foldMap (Sum . Ledger.txOutValue . snd) ourUtxo
 
     out <- ownPubKeyTxOut value
-    void $ signAndSubmit inputs [out]
+    void $ createTxAndSubmit inputs [out]

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -34,7 +34,7 @@ import qualified Ledger                       as Ledger
 import           Ledger.Validation            (OracleValue (..), PendingTx (..), PendingTxOut (..),
                                               PendingTxOutType (..), ValidatorHash)
 import qualified Ledger.Validation            as Validation
-import           Wallet                       (WalletAPI (..), WalletAPIError, throwOtherError, pubKey, signAndSubmit)
+import           Wallet                       (WalletAPI (..), WalletAPIError, throwOtherError, pubKey, createTxAndSubmit)
 
 import           Prelude                      hiding ((&&), (||))
 
@@ -86,7 +86,7 @@ initialise long short f = do
         ds = DataScript $ Ledger.lifted $ FutureData long short im im
 
     (payment, change) <- createPaymentWithChange im
-    void $ signAndSubmit payment (o : maybeToList change)
+    void $ createTxAndSubmit payment (o : maybeToList change)
 
 -- | Close the position by extracting the payment
 settle :: (
@@ -110,7 +110,7 @@ settle refs ft fd ov = do
             Ledger.pubKeyTxOut shortOut (futureDataShort fd)
             ]
         inp = (\r -> scriptTxIn r (validatorScript ft) red) <$> refs
-    void $ signAndSubmit (Set.fromList inp) outs
+    void $ createTxAndSubmit (Set.fromList inp) outs
 
 -- | Settle the position early if a margin payment has been missed.
 settleEarly :: (
@@ -126,7 +126,7 @@ settleEarly refs ft fd ov = do
         outs = [Ledger.pubKeyTxOut totalVal (futureDataLong fd)]
         inp = (\r -> scriptTxIn r (validatorScript ft) red) <$> refs
         red = Ledger.RedeemerScript $ Ledger.lifted $ Settle ov
-    void $ signAndSubmit (Set.fromList inp) outs
+    void $ createTxAndSubmit (Set.fromList inp) outs
 
 adjustMargin :: (
     MonadError WalletAPIError m,
@@ -150,7 +150,7 @@ adjustMargin refs ft fd vl = do
         o = scriptTxOut outVal (validatorScript ft) ds
         outVal = vl + (futureDataMarginLong fd + futureDataMarginShort fd)
         inp = Set.fromList $ (\r -> scriptTxIn r (validatorScript ft) red) <$> refs
-    void $ signAndSubmit (Set.union payment inp) (o : maybeToList change)
+    void $ createTxAndSubmit (Set.union payment inp) (o : maybeToList change)
 
 
 -- | Basic data of a futures contract. `Future` contains all values that do not
@@ -197,7 +197,7 @@ validatorScript ft = ValidatorScript val where
         \Future{..} (r :: FutureRedeemer) FutureData{..} (p :: (PendingTx ValidatorHash)) ->
 
             let
-                PendingTx _ outs _ _ (Slot sl) _ ownHash = p
+                PendingTx _ outs _ _ (Slot sl) ownHash = p
 
                 eqPk :: PubKey -> PubKey -> Bool
                 eqPk = $$(Validation.eqPubKey)

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
@@ -134,7 +134,7 @@ swapValidator _ = ValidatorScript result where
             -- NOTE: Partial match is OK because if it fails then the PLC script
             --       terminates with `error` and the validation fails (which is
             --       what we want when the number of inputs and outputs is /= 2)
-            PendingTx [t1, t2] [o1, o2] _ _ _ _ _ = p
+            PendingTx [t1, t2] [o1, o2] _ _ _ _ = p
 
             -- Each participant must deposit the margin. But we don't know
             -- which of the two participant's deposit we are currently

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -27,7 +27,7 @@ import           Ledger                       (DataScript (..), Slot(..), PubKey
 import qualified Ledger                       as Ledger
 import qualified Ledger.Validation            as Validation
 import           Prelude                      hiding ((&&))
-import           Wallet                       (WalletAPI (..), WalletAPIError, throwOtherError, ownPubKeyTxOut, signAndSubmit)
+import           Wallet                       (WalletAPI (..), WalletAPIError, throwOtherError, ownPubKeyTxOut, createTxAndSubmit)
 
 -- | Tranche of a vesting scheme.
 data VestingTranche = VestingTranche {
@@ -74,7 +74,7 @@ vestFunds vst value = do
     let vs = validatorScript vst
         o = scriptTxOut value vs (DataScript $ Ledger.lifted vd)
         vd =  VestingData (validatorScriptHash vst) 0
-    _ <- signAndSubmit payment (o : maybeToList change)
+    _ <- createTxAndSubmit payment (o : maybeToList change)
     pure vd
 
 -- | Retrieve some of the vested funds.
@@ -93,7 +93,7 @@ retrieveFunds vs vd r vnow = do
         remaining = totalAmount vs - vnow
         vd' = vd {vestingDataPaidOut = vnow + vestingDataPaidOut vd }
         inp = scriptTxIn r val Ledger.unitRedeemer
-    _ <- signAndSubmit (Set.singleton inp) [oo, o]
+    _ <- createTxAndSubmit (Set.singleton inp) [oo, o]
     pure vd'
 
 validatorScriptHash :: Vesting -> ValidatorHash
@@ -119,7 +119,7 @@ validatorScript v = ValidatorScript val where
             (&&) :: Bool -> Bool -> Bool
             (&&) = $$(PlutusTx.and)
 
-            PendingTx _ os _ _ (Slot h) _ _ = p
+            PendingTx _ os _ _ (Slot h) _ = p
             VestingTranche (Slot d1) (Value a1) = vestingTranche1
             VestingTranche (Slot d2) (Value a2) = vestingTranche2
 

--- a/wallet-api/src/Wallet/Generators.hs
+++ b/wallet-api/src/Wallet/Generators.hs
@@ -106,8 +106,7 @@ genInitialTransaction GeneratorModel{..} =
         txInputs = Set.empty,
         txOutputs = o,
         txForge = t,
-        txFee = 0,
-        txSignatures = []
+        txFee = 0
         }, o)
 
 -- | Generate a valid transaction, using the unspent outputs provided.
@@ -163,8 +162,7 @@ genValidTransactionSpending' g f ins totalVal = do
                     txInputs = ins,
                     txOutputs = uncurry pubKeyTxOut <$> zip outVals (Set.toList $ gmPubKeys g),
                     txForge = 0,
-                    txFee = fee,
-                    txSignatures = [] }
+                    txFee = fee }
         else Gen.discard
 
 genValue :: MonadGen m => m Value

--- a/wallet-api/tutorial/Tutorial.md
+++ b/wallet-api/tutorial/Tutorial.md
@@ -23,7 +23,7 @@ import           Prelude                      hiding ((&&))
 import           GHC.Generics                 (Generic)
 ```
 
-The module imported as `Validation` contains types and functions that can be used in on-chain code. `PlutusTx` lets us translate code between Haskell and Plutus Core (see the [PlutusTx tutorial](https://github.com/input-output-hk/plutus/blob/master/plutus-tx/tutorial/Tutorial.md)). `Wallet.Emulator` covers interactions with the wallet, for example generating the transactions that actually get the crowdfunding contract onto the blockchain. 
+The module imported as `Validation` contains types and functions that can be used in on-chain code. `PlutusTx` lets us translate code between Haskell and Plutus Core (see the [PlutusTx tutorial](https://github.com/input-output-hk/plutus/blob/master/plutus-tx/tutorial/Tutorial.md)). `Wallet.Emulator` covers interactions with the wallet, for example generating the transactions that actually get the crowdfunding contract onto the blockchain.
 
 The campaign has the following parameters:
 
@@ -53,18 +53,18 @@ One of the strengths of PlutusTx is the ability to use the same definitions for 
 PlutusTx.makeLift ''Campaign
 ```
 
-Now we need to figure out what the campaign will look like on the blockchain. Which transactions are involved, who submits them, and in what order? 
+Now we need to figure out what the campaign will look like on the blockchain. Which transactions are involved, who submits them, and in what order?
 
 Each contributor pays their contribution to the address of the campaign script. When the slot `endDate` is reached, the campaign owner submits a single transaction, spending all inputs from the campaign address and paying them to a pubkey address. If the funding target isn't reached, or the campaign owner fails to collect the funds, then each contributor can claim a refund, in the form of a transaction that spends their own contribution. This means that the validator script is going to be run once per contribution, and we need to tell it which of the two cases outcomes it should check.
 
 We can encode the two possible actions in a data type:
 
 ```haskell
-data CampaignAction = Collect | Refund
+data CampaignAction = Collect Signature | Refund Signature
 PlutusTx.makeLift ''CampaignAction
 ```
 
-The `CampaignAction` will be submitted as the redeemer script. Now we need one final bit of information, namely the identity (public key) of each contributor, so that we know the recipient of the refund. This data can't be part of the redeemer script because then a reclaim could be made by anyone, not just the original contributor. Therefore the public key is going to be stored in the data script of the contribution. 
+The `CampaignAction` will be submitted as the redeemer script. Now we need one final bit of information, namely the identity (public key) of each contributor, so that we know the recipient of the refund. This data can't be part of the redeemer script because then a reclaim could be made by anyone, not just the original contributor. Therefore the public key is going to be stored in the data script of the contribution.
 
 ```haskell
 data Contributor = Contributor PubKey
@@ -86,7 +86,7 @@ mkValidatorScript :: Campaign -> ValidatorScript
 mkValidatorScript campaign = ValidatorScript val where
   val = applyScript mkValidator (lifted campaign)
   -- ^ val is the obtained by applying `mkValidator` to the lifted `campaign` value
-  mkValidator = fromCompiledCode $$(PlutusTx.compile [|| 
+  mkValidator = fromCompiledCode $$(PlutusTx.compile [||
 ```
 
 Anything between the `[||` and `||]` quotes is going to be _on-chain code_ and anything outside the quotes is _off-chain code_. We can now implement a lambda function that looks like `mkValidator`, starting with its parameters:
@@ -102,6 +102,9 @@ Before we check whether `act` is permitted, we define a number of intermediate v
                   infixr 3 &&
                   (&&) :: Bool -> Bool -> Bool
                   (&&) = $$(PlutusTx.and)
+
+                  signedBy :: PubKey -> Signature -> Bool
+                  signedBy (PubKey pk) (Signature s) = pk == s
 ```
 
 There is no standard library of functions that are automatically in scope for on-chain code, so we need to import the ones that we want to use from the `Validation` module using the `\$\$()` splicing operator.
@@ -109,7 +112,7 @@ There is no standard library of functions that are automatically in scope for on
 Next, we pattern match on the structure of the `PendingTx'` value `p` to get the Validation information we care about:
 
 ```haskell
-                  PendingTx ins outs _ _ (Slot currentSlot) _ _ = p
+                  PendingTx ins outs _ _ (Slot currentSlot) _ = p
 ```
 
 This binds `ins` to the list of all inputs of the current transaction, `outs` to the list of all its outputs, and `currentSlot` to the current slot (that is, to the current date).
@@ -133,7 +136,7 @@ We now have all the information we need to check whether the action `act` is all
 
 ```haskell
                   isValid = case act of
-                      Refund -> 
+                      Refund sig ->
                           let
                               Contributor pkCon = con
 ```
@@ -142,7 +145,7 @@ In the `Refund` branch we check that the outputs of this transaction all go to t
 
 ```haskell
                               contributorTxOut :: PendingTxOut -> Bool
-                              contributorTxOut o = 
+                              contributorTxOut o =
                                 case $$(Validation.pubKeyOutput) o of
                                   Nothing -> False
                                   Just pk -> $$(Validation.eqPubKey) pk pkCon
@@ -161,7 +164,7 @@ For the contribution to be refundable, three conditions must hold. The collectio
 ```haskell
                               refundable   = currentSlot > collectionDeadline &&
                                       contributorOnly &&
-                                      $$(Validation.txSignedBy) p pkCon
+                                      pkCon `signedBy` sig
 ```
 
 The overall result of this branch is the `refundable` value:
@@ -170,10 +173,10 @@ The overall result of this branch is the `refundable` value:
                           in refundable
 ```
 
-The second branch represents a successful campaign. 
+The second branch represents a successful campaign.
 
 ```haskell
-                      Collect -> 
+                      Collect sig ->
 ```
 
 In the `Collect` case, the current slot must be between `deadline` and `collectionDeadline`, the target must have been met, and and transaction has to be signed by the campaign owner.
@@ -182,7 +185,7 @@ In the `Collect` case, the current slot must be between `deadline` and `collecti
                           currentSlot > deadline &&
                           currentSlot <= collectionDeadline &&
                           totalInputs >= target &&
-                          $$(Validation.txSignedBy) p campaignOwner
+                          campaignOwner `signedBy` sig
 
               in
 ```
@@ -223,7 +226,7 @@ Contributing to a campaign is easy: We need to pay the value `amount` to a scrip
       tx <- payToScript (campaignAddress cmp) amount dataScript
 ```
 
-`tx` is a transaction that pays `amount` to the address of the campaign validator script, using our own public key as the data script. 
+`tx` is a transaction that pays `amount` to the address of the campaign validator script, using our own public key as the data script.
 
 ```haskell
       -- TODO: In the original contract we now register a refund trigger for our own contribution, using the hash of `tx`.
@@ -237,13 +240,13 @@ mkRedeemer :: CampaignAction -> RedeemerScript
 mkRedeemer action = RedeemerScript (lifted (action))
 ```
 
-To collect the funds we use `collectFromScript`, which expects a validator script and a redeemer script. 
+To collect the funds we use `collectFromScript`, which expects a validator script and a redeemer script.
 
 ```haskell
-collect :: Campaign -> MockWallet ()
-collect cmp = 
+collect :: Signature -> Campaign -> MockWallet ()
+collect sig cmp =
       let validatorScript = mkValidatorScript cmp
-          redeemer = mkRedeemer Collect
+          redeemer = mkRedeemer $ Collect sig
       in
           collectFromScript validatorScript redeemer
 ```


### PR DESCRIPTION
Currently we have a bit misleading API with regards to `Signatures` in `PendingTx` API, and `UtxoIndex`.

    newtype UtxoIndex = UtxoIndex { getIndex :: Map.Map TxOutRef' (TxOut', [Signature]) }

`UtxoIndex` contains `Signature`s of unspent `TxOut` which is inconsistent with current Cardano SL, because those are witnesses of actual spending of the transaction input.

This Pull Request aims to fix the inconsistency.