### PR TITLE
[Plutus Core] Keep annotations in 'mkIterForall' and 'mkIterTyLam'

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -63,7 +63,7 @@ mkTermLet
     -> TermDef tyname name a
     -> Term tyname name a -- ^ The body of the let, possibly referencing the name.
     -> Term tyname name a
-mkTermLet x (Def (VarDecl _ name ty) bind) body = Apply x (LamAbs x name ty body) bind
+mkTermLet x1 (Def (VarDecl x2 name ty) bind) body = Apply x1 (LamAbs x2 name ty body) bind
 
 -- | Make a "let-binding" for a type. Note: the body must be a value.
 mkTypeLet
@@ -71,7 +71,7 @@ mkTypeLet
     -> TypeDef tyname a
     -> Term tyname name a -- ^ The body of the let, possibly referencing the name.
     -> Term tyname name a
-mkTypeLet x (Def (TyVarDecl _ name k) bind) body = TyInst x (TyAbs x name k body) bind
+mkTypeLet x1 (Def (TyVarDecl x2 name k) bind) body = TyInst x1 (TyAbs x2 name k body) bind
 
 -- | Make an iterated application.
 mkIterApp
@@ -91,19 +91,17 @@ mkIterInst x = foldl' (TyInst x)
 
 -- | Lambda abstract a list of names.
 mkIterLamAbs
-    :: a
-    -> [VarDecl tyname name a]
+    :: [VarDecl tyname name a]
     -> Term tyname name a
     -> Term tyname name a
-mkIterLamAbs x args body = foldr (\(VarDecl _ n ty) acc -> LamAbs x n ty acc) body args
+mkIterLamAbs args body = foldr (\(VarDecl x n ty) acc -> LamAbs x n ty acc) body args
 
 -- | Type abstract a list of names.
 mkIterTyAbs
-    :: a
-    -> [TyVarDecl tyname a]
+    :: [TyVarDecl tyname a]
     -> Term tyname name a
     -> Term tyname name a
-mkIterTyAbs x args body = foldr (\(TyVarDecl _ n k) acc -> TyAbs x n k acc) body args
+mkIterTyAbs args body = foldr (\(TyVarDecl x n k) acc -> TyAbs x n k acc) body args
 
 -- | Make an iterated type application.
 mkIterTyApp
@@ -123,20 +121,19 @@ mkIterTyFun x tys target = foldr (\ty acc -> TyFun x ty acc) target tys
 
 -- | Universally quantify a list of names.
 mkIterTyForall
-    :: a
-    -> [TyVarDecl tyname a]
+    :: [TyVarDecl tyname a]
     -> Type tyname a
     -> Type tyname a
-mkIterTyForall x args body = foldr (\(TyVarDecl _ n k) acc -> TyForall x n k acc) body args
+mkIterTyForall args body = foldr (\(TyVarDecl x n k) acc -> TyForall x n k acc) body args
 
 -- | Lambda abstract a list of names.
 mkIterTyLam
-    :: a
-    -> [TyVarDecl tyname a]
+    :: [TyVarDecl tyname a]
     -> Type tyname a
     -> Type tyname a
-mkIterTyLam x args body = foldr (\(TyVarDecl _ n k) acc -> TyLam x n k acc) body args
+mkIterTyLam args body = foldr (\(TyVarDecl x n k) acc -> TyLam x n k acc) body args
 
+-- | Make an iterated function kind.
 mkIterKindArrow
     :: a
     -> [Kind a]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Bool.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Bool.hs
@@ -38,7 +38,7 @@ getBuiltinTrue = rename =<< do
     y <- freshName () "y"
     return
        . TyAbs () a (Type ())
-       $ mkIterLamAbs () [
+       $ mkIterLamAbs [
           VarDecl () x (TyVar () a),
           VarDecl () y (TyVar () a)
           ]
@@ -54,7 +54,7 @@ getBuiltinFalse = rename =<< do
     y <- freshName () "y"
     return
        . TyAbs () a (Type ())
-       $ mkIterLamAbs () [
+       $ mkIterLamAbs [
           VarDecl () x (TyVar () a),
           VarDecl () y (TyVar () a)
           ]
@@ -75,7 +75,7 @@ getBuiltinIf = rename =<< do
     let unitFunA = TyFun () unit (TyVar () a)
     return
        . TyAbs () a (Type ())
-      $ mkIterLamAbs () [
+      $ mkIterLamAbs [
           VarDecl () b builtinBool,
           VarDecl () x unitFunA,
           VarDecl () y unitFunA

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
@@ -230,7 +230,7 @@ getBuiltinFixN n = do
             pure $
                 LamAbs () x (TyVar () a) $
                 Apply () (TyInst () (Var () k) (TyVar () b)) $
-                mkIterLamAbs () fs $
+                mkIterLamAbs fs $
                 -- this is an ugly but straightforward way of getting the right fi
                 Apply () (mkVar () (fs !! i)) (Var () x)
 
@@ -241,7 +241,7 @@ getBuiltinFixN n = do
     let allAsBs = foldMap (\(a, b) -> [a, b]) asbs
     pure $
         -- abstract out all the As and Bs
-        mkIterTyAbs () (fmap (\tn -> TyVarDecl () tn (Type ())) allAsBs) $
+        mkIterTyAbs (fmap (\tn -> TyVarDecl () tn (Type ())) allAsBs) $
         Apply () instantiatedFix $
         LamAbs () k kTy $
         TyAbs () s (Type ()) $

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Tuple.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Tuple.hs
@@ -31,7 +31,7 @@ getBuiltinTuple arity = do
     let caseType = mkIterTyFun () (fmap (mkTyVar ()) tyVars) (TyVar () resultType)
     pure $
         -- \T_1 .. T_n
-        mkIterTyLam () tyVars $
+        mkIterTyLam tyVars $
         -- all R
         TyForall () resultType (Type ()) $
         -- (T_1 -> .. -> T_n -> r) -> r
@@ -61,9 +61,9 @@ getBuiltinTupleConstructor arity = do
     let caseTy = mkIterTyFun () (fmap (mkTyVar ()) tyVars) (TyVar () resultType)
     pure $
         -- /\T_1 .. T_n
-        mkIterTyAbs () tyVars $
+        mkIterTyAbs tyVars $
         -- \arg_1 .. arg_n
-        mkIterLamAbs () args $
+        mkIterLamAbs args $
         -- /\R
         TyAbs () resultType (Type ()) $
         -- \case
@@ -97,10 +97,10 @@ getBuiltinTupleAccessor arity index = rename =<< do
     tupleArg <- liftQuote $ freshName () "tuple"
     pure $
         -- /\T_1 .. T_n
-        mkIterTyAbs () tyVars $
+        mkIterTyAbs tyVars $
         -- \tuple :: (tupleN T_1 .. T_n)
         LamAbs () tupleArg tupleTy $
         -- tuple {T_i}
         Apply () (TyInst () (Var () tupleArg) selectedTy) $
         -- \arg_1 .. arg_n . arg_i
-        mkIterLamAbs () args selectedArg
+        mkIterLamAbs args selectedArg

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Type.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Type.hs
@@ -582,7 +582,7 @@ getWithSpine
     -> Quote ((Type TyName ann -> Type TyName ann) -> Type TyName ann)
 getWithSpine ann argVars = do
     spine <- getSpine ann $ map tyDeclVar argVars
-    return $ \k -> mkIterTyLam ann argVars $ k spine
+    return $ \k -> mkIterTyLam argVars $ k spine
 
 -- See Note [Spiney API].
 type FromDataPieces ann a
@@ -616,7 +616,7 @@ packPatternFunctorBodyN ann dataName argVars patBodyN = do
         spineKind = dataKindToSpineKind ann dataKind
         recKind   = spineKindToRecKind  ann spineKind
         vDat = TyVarDecl ann dataName dataKind
-        patN = mkIterTyLam ann (vDat : argVars) patBodyN
+        patN = mkIterTyLam (vDat : argVars) patBodyN
 
     withSpine <- getWithSpine ann argVars
 

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Recursion.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Recursion.hs
@@ -85,7 +85,7 @@ mkFixpoint bs = do
     bsLam <- do
           rhss <- traverse (compileTerm . PLC.defVal) bs
           let chosen =  PLC.mkIterApp p (PLC.Var p choose) rhss
-              abstracted = PLC.mkIterLamAbs p (fmap PLC.defVar bs) chosen
+              abstracted = PLC.mkIterLamAbs (fmap PLC.defVar bs) chosen
           pure abstracted
 
     -- abstract out Q and choose


### PR DESCRIPTION
As per an old discussion with @michaelpj.