### PR TITLE
Hack together combined Haddock output

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -123,6 +123,13 @@ let
     docs = {
       plutus-core-spec = pkgs.callPackage ./plutus-core-spec {};
       lazy-machine = pkgs.callPackage ./docs/fomega/lazy-machine {};
+      combined-haddock = (pkgs.callPackage ./nix/haddock-combine.nix {}) {
+        hspkgs = builtins.attrValues localPackages;
+        prologue = pkgs.writeTextFile { 
+          name = "prologue"; 
+          text = "Combined documentation for all the Plutus libraries."; 
+        };
+      };
     };
 
     plutus-playground = rec {
@@ -169,4 +176,4 @@ let
 
 in
   # The top-level package set
-  pkgs.lib.makeScope pkgs.newScope packages
+  pkgs.lib.makeScope pkgs.newScope packages 

--- a/nix/haddock-combine.nix
+++ b/nix/haddock-combine.nix
@@ -1,0 +1,59 @@
+{ runCommand, lib, haskellPackages }:
+{ hspkgs # Haskell packages to make documentation for. Only those with a "doc" output will be used.
+  # Note: we do not provide arbitrary additional Haddock options, as these would not be 
+  # applied consistently, since we're reusing the already built Haddock for the packages.
+, prologue ? null # Optionally, a file to be used for the Haddock "--prologue" option.
+}: 
+let 
+  hsdocs = builtins.map (x: x.doc) (builtins.filter (x: x ? doc) hspkgs); 
+in runCommand "haddock-join" { buildInputs = [ hsdocs ]; } ''
+  # Merge all the docs from the packages. We don't use symlinkJoin because:
+  # - We are going to want to redistribute this, so we don't want any symlinks.
+  # - We want to be selective about what we copy (we don't need the hydra 
+  #   tarballs from the other packages, for example.
+  mkdir -p "$out/share/doc"
+  for pkg in ${lib.concatStringsSep " " hsdocs}; do
+    cp -R $pkg/share/doc/* "$out/share/doc"
+  done
+  # We're going to sed all the files so they'd better be writable!
+  chmod -R +w $out/share/doc
+
+  # We're now going to rewrite all the pre-generated Haddock HTML output
+  # so that links point to the appropriate place within our combined output,
+  # rather than into the store.
+  root=$out/share/doc
+  for f in $(find $out -name "*.html"); do
+    # Replace all links to the docs we're processing with relative links 
+    # to the root of the doc directory we're creating - the rest of the link is
+    # the same.
+    # Also, it's not a a file:// link now because it's a relative URL instead
+    # of an absolute one.
+    relpath=$(realpath --relative-to=$(dirname $f) --no-symlinks $root)
+    pkgsRegex="${"file://(" + (lib.concatStringsSep "|" hsdocs) + ")/share/doc"}"
+    sed -i -r "s,$pkgsRegex,$relpath,g" "$f"
+    # Now also replace the index/contents links so they point to (what will be) 
+    # the combined ones instead.
+    # Match the enclosing quotes to make sure the regex for index.html doesn't also match
+    # the trailing part of doc-index.html
+    sed -i -r "s,\"index\.html\",\"$relpath/share/doc/index.html\",g" "$f"
+    sed -i -r "s,\"doc-index\.html\",\"$relpath/share/doc/doc-index.html\",g" "$f"
+  done
+
+  # Move to the docdir. We do this so that we can give relative docpaths to
+  # Haddock so it will generate relative (relocatable) links in the index.
+  cd $out/share/doc
+  # Collect all the interface files and their docpaths (in this case
+  # we can just use the enclosing directory).
+  interfaceOpts=()
+  for interfaceFile in $(find . -name "*.haddock"); do
+    docdir=$(dirname $interfaceFile)
+    interfaceOpts+=("--read-interface=$docdir,$interfaceFile")
+  done
+
+  # Generate the contents and index
+  ${haskellPackages.ghc}/bin/haddock \
+    --gen-contents \
+    --gen-index \
+    ${lib.optionalString (prologue != null) "--prologue ${prologue}"} \
+    "''${interfaceOpts[@]}"
+''


### PR DESCRIPTION
This glues together the Haddock generated for the various packages.
- There is an index and contents
    - Links to the index/contents from component packages will go to
      the combined index.
- All the links that go to component are relativized, so the result
  is relocatable.
    - Links to other packages will still be broken.
- You can provide a prologue that goes on the main page.
- No symlinks.

We still need to serve this somewhere, but this is a start.

Also, some of our modules are missing, but that's because we're not
generating Haddock for them properly, which is a separate problem.