### PR TITLE
Add support for de Bruijn indices

### DIFF
--- a/language-plutus-core/examples/Language/PlutusCore/Examples/Data/InterList.hs
+++ b/language-plutus-core/examples/Language/PlutusCore/Examples/Data/InterList.hs
@@ -7,8 +7,11 @@ module Language.PlutusCore.Examples.Data.InterList
     , getBuiltinFoldrInterList
     ) where
 
-import           Language.PlutusCore
 import           Language.PlutusCore.MkPlc
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Quote
+import           Language.PlutusCore.Renamer
+import           Language.PlutusCore.Type
 
 import           Language.PlutusCore.StdLib.Data.Function
 import           Language.PlutusCore.StdLib.Data.Unit

--- a/language-plutus-core/examples/Language/PlutusCore/Examples/Data/TreeForest.hs
+++ b/language-plutus-core/examples/Language/PlutusCore/Examples/Data/TreeForest.hs
@@ -11,9 +11,12 @@ module Language.PlutusCore.Examples.Data.TreeForest
     , getBuiltinForestCons
     ) where
 
-import           Language.PlutusCore
 import           Language.PlutusCore.MkPlc
+import           Language.PlutusCore.Name
 import           Language.PlutusCore.Normalize
+import           Language.PlutusCore.Quote
+import           Language.PlutusCore.Renamer
+import           Language.PlutusCore.Type
 
 import           Language.PlutusCore.StdLib.Type
 

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -47,6 +47,7 @@ library
         Language.PlutusCore.View
         Language.PlutusCore.Subst
         Language.PlutusCore.Name
+        Language.PlutusCore.DeBruijn
         Language.PlutusCore.Check.Uniques
         Language.PlutusCore.FsTree
         Language.PlutusCore.StdLib.Data.Bool
@@ -122,6 +123,7 @@ library
         bytestring -any,
         cryptonite -any,
         containers -any,
+        bimap -any,
         array -any,
         mtl -any,
         transformers -any,

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -10,6 +10,7 @@ import           Codec.CBOR.Encoding
 import           Codec.Serialise
 import qualified Data.ByteString.Lazy           as BSL
 import           Data.Functor.Foldable          hiding (fold)
+import           Language.PlutusCore.DeBruijn
 import           Language.PlutusCore.Lexer      (AlexPosn)
 import           Language.PlutusCore.Lexer.Type hiding (name)
 import           Language.PlutusCore.MkPlc      (TyVarDecl (..), VarDecl (..))
@@ -226,3 +227,13 @@ instance (Serialise a, Serialise (tyname a), Serialise (name a)) => Serialise (P
     decode = Program <$> decode <*> decode <*> decode
 
 instance Serialise AlexPosn
+
+deriving instance Serialise Ix
+
+instance Serialise a => Serialise (DeBruijn a) where
+    encode (DeBruijn x txt i) = encode x <> encode txt <> encode i
+    decode = DeBruijn <$> decode <*> decode <*> decode
+
+instance Serialise a => Serialise (TyDeBruijn a) where
+    encode (TyDeBruijn n) = encode n
+    decode = TyDeBruijn <$> decode

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -228,7 +228,7 @@ instance (Serialise a, Serialise (tyname a), Serialise (name a)) => Serialise (P
 
 instance Serialise AlexPosn
 
-deriving instance Serialise Ix
+deriving instance Serialise Index
 
 instance Serialise a => Serialise (DeBruijn a) where
     encode (DeBruijn x txt i) = encode x <> encode txt <> encode i

--- a/language-plutus-core/src/Language/PlutusCore/DeBruijn.hs
+++ b/language-plutus-core/src/Language/PlutusCore/DeBruijn.hs
@@ -1,0 +1,266 @@
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+-- | Support for using de Bruijn indices for term and type names.
+module Language.PlutusCore.DeBruijn (
+                                Ix (..)
+                                , DeBruijn (..)
+                                , TyDeBruijn (..)
+                                , FreeVariableError (..)
+                                , deBruijnTy
+                                , deBruijnTerm
+                                , deBruijnProgram
+                                , unDeBruijnTy
+                                , unDeBruijnTerm
+                                , unDeBruijnProgram
+                                ) where
+
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Pretty
+import           Language.PlutusCore.Quote
+import           Language.PlutusCore.Type
+
+import           Control.Exception
+import           Control.Lens               hiding (Level, index, ix)
+import           Control.Monad.Except
+import           Control.Monad.Reader
+
+import qualified Data.Bimap                 as BM
+import qualified Data.Text                  as T
+import           Data.Typeable
+
+import           Numeric.Natural
+
+import           GHC.Generics
+
+-- | A relative index used for de Bruijn identifiers.
+newtype Ix = Ix Natural
+    deriving stock Generic
+    deriving newtype (Show, Num, Eq, Ord)
+
+-- | A term name as a de Bruijn index.
+data DeBruijn a = DeBruijn { dbnAttribute :: a, dbnString :: T.Text, dbnIndex :: Ix }
+    deriving (Show, Functor, Generic)
+
+-- | A type name as a de Bruijn index.
+newtype TyDeBruijn a = TyDeBruijn (DeBruijn a)
+    deriving (Show, Functor, Generic)
+instance Wrapped (TyDeBruijn a)
+
+instance HasPrettyConfigName config => PrettyBy config (DeBruijn a) where
+    prettyBy config (DeBruijn _ txt (Ix ix))
+        | showsUnique = pretty txt <> "_i" <> pretty ix
+        | otherwise   = pretty txt
+        where PrettyConfigName showsUnique _ = toPrettyConfigName config
+
+deriving newtype instance HasPrettyConfigName config => PrettyBy config (TyDeBruijn a)
+
+class HasIx a where
+    index :: Lens' a Ix
+
+instance HasIx (DeBruijn a) where
+    index = lens g s where
+        g = dbnIndex
+        s n i = n{dbnIndex=i}
+
+instance HasIx (TyDeBruijn a) where
+    index = _Wrapped' . index
+
+-- Converting from normal names to DeBruijn indices, and vice versa
+
+{- Note [Levels and indices]
+The indices that we use for de Bruijn identifiers are *relative*. However,
+when doing conversions it is easier to work with *absolute* levels, since  that
+way we don't have to adjust them all when we go under a binder.
+
+However, this means that we *do* need to adjust them when we use them or record them.
+The adjustment is fairly straightforward:
+- An index `i` points to a binder `i` levels above (smaller than) the current level, so the level
+  of `i` is `current - i`.
+- A level `l` which is `i` levels above (smaller than) the current level has an index of `i`, so it
+  is also calculated as `current - l`.
+
+We use a newtype to keep these separate, since getting it wrong will leads to annoying bugs.
+-}
+
+-- | An absolute level in the program.
+newtype Level = Level Ix deriving newtype (Eq, Ord, Num)
+data Levels = Levels Level (BM.Bimap Unique Level)
+
+-- | Compute the absolute 'Level' of a relative 'Ix' relative to the current 'Level'.
+ixToLevel :: Level -> Ix -> Level
+ixToLevel (Level current) ix = Level (current - ix)
+
+-- | Compute the relative 'Ix' of a absolute 'Level' relative to the current 'Level'.
+levelToIx :: Level -> Level -> Ix
+levelToIx (Level current) (Level l) = current - l
+
+-- | Declare a name with a unique, recording the mapping to a 'Level'.
+declareUnique :: (MonadReader Levels m, HasUnique name unique) => name -> m a -> m a
+declareUnique n = local $ \(Levels current ls) -> Levels current $ BM.insert (n ^. unique . coerced) current ls
+
+-- | Declare a name with an index, recording the mapping from the corresponding 'Level' to a fresh unique.
+declareIx :: (MonadReader Levels m, MonadQuote m, HasIx name) => name -> m a -> m a
+declareIx n act = do
+    newU <- freshUnique
+    local (\(Levels current ls) -> Levels current $ BM.insert newU (ixToLevel current (n ^. index)) ls) act
+
+-- | Enter a scope, incrementing the current 'Level' by one
+withScope :: (MonadReader Levels m) => m a -> m a
+withScope = local $ \(Levels current ls) -> Levels (current+1) ls
+
+-- | We cannot do a correct translation to or from de Bruijn indices if the program is not well-scoped.
+-- So we throw an error in such a case.
+data FreeVariableError = FreeUnique Unique | FreeIndex Ix deriving (Show, Typeable, Eq, Ord)
+instance Exception FreeVariableError
+
+-- | Get the 'Ix' corresponding to a given 'Unique'.
+getIndex :: (MonadReader Levels m, MonadError FreeVariableError m) => Unique -> m Ix
+getIndex u = do
+    Levels current ls <- ask
+    case BM.lookup u ls of
+        Just ix -> pure $ levelToIx current ix
+        Nothing -> throwError $ FreeUnique u
+
+-- | Get the 'Unique' corresponding to a given 'Ix'.
+getUnique :: (MonadReader Levels m, MonadError FreeVariableError m) => Ix -> m Unique
+getUnique ix = do
+    Levels current ls <- ask
+    case BM.lookupR (ixToLevel current ix) ls of
+        Just u  -> pure u
+        Nothing -> throwError $ FreeIndex ix
+
+nameToDeBruijn :: (MonadReader Levels m, MonadError FreeVariableError m) => Name a -> m (DeBruijn a)
+nameToDeBruijn (Name x str u) = DeBruijn x str <$> getIndex u
+
+tyNameToDeBruijn :: (MonadReader Levels m, MonadError FreeVariableError m) => TyName a -> m (TyDeBruijn a)
+tyNameToDeBruijn (TyName n) = TyDeBruijn <$> nameToDeBruijn n
+
+deBruijnToName :: (MonadReader Levels m, MonadError FreeVariableError m) => DeBruijn a -> m (Name a)
+deBruijnToName (DeBruijn x str ix) = Name x str <$> getUnique ix
+
+deBruijnToTyName :: (MonadReader Levels m, MonadError FreeVariableError m) => TyDeBruijn a -> m (TyName a)
+deBruijnToTyName (TyDeBruijn n) = TyName <$> deBruijnToName n
+
+-- | Convert a 'Type' with 'TyName's into a 'Type' with 'TyDeBruijn's.
+deBruijnTy :: (MonadError FreeVariableError m) => Type TyName a -> m (Type TyDeBruijn a)
+deBruijnTy = flip runReaderT (Levels 0 BM.empty) . deBruijnTyM
+
+-- | Convert a 'Term' with 'TyName's and 'Name's into a 'Term' with 'TyDeBruijn's and 'DeBruijn's.
+deBruijnTerm :: (MonadError FreeVariableError m) => Term TyName Name a -> m (Term TyDeBruijn DeBruijn a)
+deBruijnTerm = flip runReaderT (Levels 0 BM.empty) . deBruijnTermM
+
+-- | Convert a 'Program' with 'TyName's and 'Name's into a 'Program' with 'TyDeBruijn's and 'DeBruijn's.
+deBruijnProgram :: (MonadError FreeVariableError m) => Program TyName Name a -> m (Program TyDeBruijn DeBruijn a)
+deBruijnProgram (Program x v t) = Program x v <$> deBruijnTerm t
+
+{- Note [De Bruijn conversion and recursion schemes]
+These are quite repetitive, but we can't use a catamorphism for this, because
+we are not only altering the recursive type, but also the name type parameters.
+These are normally constant in a catamorphic application.
+-}
+deBruijnTyM
+    :: (MonadReader Levels m, MonadError FreeVariableError m)
+    => Type TyName a
+    -> m (Type TyDeBruijn a)
+deBruijnTyM = \case
+    -- variable case
+    TyVar x n -> TyVar x <$> tyNameToDeBruijn n
+    -- binder cases
+    TyForall x tn k ty -> declareUnique tn $ do
+        tn' <- tyNameToDeBruijn tn
+        withScope $ TyForall x tn' k <$> deBruijnTyM ty
+    TyLam x tn k ty -> declareUnique tn $ do
+        tn' <- tyNameToDeBruijn tn
+        withScope $ TyLam x tn' k <$> deBruijnTyM ty
+    -- boring recursive cases
+    TyFun x i o -> TyFun x <$> deBruijnTyM i <*> deBruijnTyM o
+    TyApp x fun arg -> TyApp x <$> deBruijnTyM fun <*> deBruijnTyM arg
+    TyIFix x pat arg -> TyIFix x <$> deBruijnTyM pat <*> deBruijnTyM arg
+    -- boring non-recursive cases
+    TyBuiltin x bn -> pure $ TyBuiltin x bn
+    TyInt x nat -> pure $ TyInt x nat
+
+deBruijnTermM
+    :: (MonadReader Levels m, MonadError FreeVariableError m)
+    => Term TyName Name a
+    -> m (Term TyDeBruijn DeBruijn a)
+deBruijnTermM = \case
+    -- variable case
+    Var x n -> Var x <$> nameToDeBruijn n
+    -- binder cases
+    TyAbs x tn k t -> declareUnique tn $ do
+        tn' <- tyNameToDeBruijn tn
+        withScope $ TyAbs x tn' k <$> deBruijnTermM t
+    LamAbs x n ty t -> declareUnique n $ do
+        n' <- nameToDeBruijn n
+        withScope $ LamAbs x n' <$> deBruijnTyM ty <*> deBruijnTermM t
+    -- boring recursive cases
+    Apply x t1 t2 -> Apply x <$> deBruijnTermM t1 <*> deBruijnTermM t2
+    TyInst x t ty -> TyInst x <$> deBruijnTermM t <*> deBruijnTyM ty
+    Unwrap x t -> Unwrap x <$> deBruijnTermM t
+    IWrap x pat arg t -> IWrap x <$> deBruijnTyM pat <*> deBruijnTyM arg <*> deBruijnTermM t
+    Error x ty -> Error x <$> deBruijnTyM ty
+    -- boring non-recursive cases
+    Constant x con -> pure $ Constant x con
+    Builtin x bn -> pure $ Builtin x bn
+
+-- | Convert a 'Type' with 'TyDeBruijn's into a 'Type' with 'TyName's.
+unDeBruijnTy :: (MonadQuote m, MonadError FreeVariableError m) => Type TyDeBruijn a -> m (Type TyName a)
+unDeBruijnTy = flip runReaderT (Levels 0 BM.empty) . unDeBruijnTyM
+
+-- | Convert a 'Term' with 'TyDeBruijn's and 'DeBruijn's into a 'Term' with 'TyName's and 'Name's.
+unDeBruijnTerm :: (MonadQuote m, MonadError FreeVariableError m) => Term TyDeBruijn DeBruijn a -> m (Term TyName Name a)
+unDeBruijnTerm = flip runReaderT (Levels 0 BM.empty) . unDeBruijnTermM
+
+-- | Convert a 'Program' with 'TyDeBruijn's and 'DeBruijn's into a 'Program' with 'TyName's and 'Name's.
+unDeBruijnProgram :: (MonadQuote m, MonadError FreeVariableError m) => Program TyDeBruijn DeBruijn a -> m (Program TyName Name a)
+unDeBruijnProgram (Program x v t) = Program x v <$> unDeBruijnTerm t
+
+unDeBruijnTyM
+    :: (MonadReader Levels m, MonadQuote m, MonadError FreeVariableError m)
+    => Type TyDeBruijn a
+    -> m (Type TyName a)
+unDeBruijnTyM = \case
+    -- variable case
+    TyVar x n -> TyVar x <$> deBruijnToTyName n
+    -- binder cases
+    TyForall x tn k ty -> declareIx tn $ do
+        tn' <- deBruijnToTyName tn
+        withScope $ TyForall x tn' k <$> unDeBruijnTyM ty
+    TyLam x tn k ty -> declareIx tn $ do
+        tn' <- deBruijnToTyName tn
+        withScope $ TyLam x tn' k <$> unDeBruijnTyM ty
+    -- boring recursive cases
+    TyFun x i o -> TyFun x <$> unDeBruijnTyM i <*> unDeBruijnTyM o
+    TyApp x fun arg -> TyApp x <$> unDeBruijnTyM fun <*> unDeBruijnTyM arg
+    TyIFix x pat arg -> TyIFix x <$> unDeBruijnTyM pat <*> unDeBruijnTyM arg
+    -- boring non-recursive cases
+    TyBuiltin x bn -> pure $ TyBuiltin x bn
+    TyInt x nat -> pure $ TyInt x nat
+
+unDeBruijnTermM
+    :: (MonadReader Levels m, MonadQuote m, MonadError FreeVariableError m)
+    => Term TyDeBruijn DeBruijn a
+    -> m (Term TyName Name a)
+unDeBruijnTermM = \case
+    -- variable case
+    Var x n -> Var x <$> deBruijnToName n
+    -- binder cases
+    TyAbs x tn k t -> declareIx tn $ do
+        tn' <- deBruijnToTyName tn
+        withScope $ TyAbs x tn' k <$> unDeBruijnTermM t
+    LamAbs x n ty t -> declareIx n $ do
+        n' <- deBruijnToName n
+        withScope $ LamAbs x n' <$> unDeBruijnTyM ty <*> unDeBruijnTermM t
+    -- boring recursive cases
+    Apply x t1 t2 -> Apply x <$> unDeBruijnTermM t1 <*> unDeBruijnTermM t2
+    TyInst x t ty -> TyInst x <$> unDeBruijnTermM t <*> unDeBruijnTyM ty
+    Unwrap x t -> Unwrap x <$> unDeBruijnTermM t
+    IWrap x pat arg t -> IWrap x <$> unDeBruijnTyM pat <*> unDeBruijnTyM arg <*> unDeBruijnTermM t
+    Error x ty -> Error x <$> unDeBruijnTyM ty
+    -- boring non-recursive cases
+    Constant x con -> pure $ Constant x con
+    Builtin x bn -> pure $ Builtin x bn

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -43089,6 +43089,7 @@ license = stdenv.lib.licenses.bsd3;
 , alex
 , array
 , base
+, bimap
 , bytestring
 , cborg
 , composition-prelude
@@ -43129,6 +43130,7 @@ isExecutable = true;
 libraryHaskellDepends = [
 array
 base
+bimap
 bytestring
 cborg
 composition-prelude

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -139,7 +139,7 @@ recursion :: TestNested
 recursion = testNested "recursion" [
     goldenPlc "even3" evenOdd,
     goldenEval "even3Eval" [evenOdd],
-    goldenPlcCatch "mutuallyRecursiveValues" mutuallyRecursiveValues
+    goldenPlc "mutuallyRecursiveValues" mutuallyRecursiveValues
     ]
 
 natToBool :: Quote (Type TyName ())

--- a/plutus-ir/test/datatypes/listMatch.plc.golden
+++ b/plutus-ir/test/datatypes/listMatch.plc.golden
@@ -4,35 +4,35 @@
       [
         {
           (abs
-            List_31
+            List_i0
             (fun (type) (type))
             (lam
-              Nil_32
-              (all a_33 (type) [List_31 a_33])
+              Nil_i0
+              (all a_i0 (type) [List_i3 a_i1])
               (lam
-                Cons_34
-                (all a_35 (type) (fun a_35 (fun [List_31 a_35] [List_31 a_35])))
+                Cons_i0
+                (all a_i0 (type) (fun a_i1 (fun [List_i4 a_i1] [List_i4 a_i1])))
                 (lam
-                  match_List_36
-                  (all a_37 (type) (fun [List_31 a_37] (all out_List_38 (type) (fun out_List_38 (fun (fun a_37 (fun [List_31 a_37] out_List_38)) out_List_38)))))
+                  match_List_i0
+                  (all a_i0 (type) (fun [List_i5 a_i1] (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i6 a_i2] out_List_i1)) out_List_i1)))))
                   [
                     [
                       {
                         [
-                          { match_List_36 (all a_39 (type) (fun a_39 a_39)) }
-                          { Nil_32 (all a_40 (type) (fun a_40 a_40)) }
+                          { match_List_i1 (all a_i0 (type) (fun a_i1 a_i1)) }
+                          { Nil_i3 (all a_i0 (type) (fun a_i1 a_i1)) }
                         ]
-                        (all a_41 (type) (fun a_41 a_41))
+                        (all a_i0 (type) (fun a_i1 a_i1))
                       }
-                      (abs a_42 (type) (lam x_43 a_42 x_43))
+                      (abs a_i0 (type) (lam x_i0 a_i2 x_i1))
                     ]
                     (lam
-                      head_44
-                      (all a_45 (type) (fun a_45 a_45))
+                      head_i0
+                      (all a_i0 (type) (fun a_i1 a_i1))
                       (lam
-                        tail_46
-                        [List_31 (all a_47 (type) (fun a_47 a_47))]
-                        head_44
+                        tail_i0
+                        [List_i6 (all a_i0 (type) (fun a_i1 a_i1))]
+                        head_i2
                       )
                     )
                   ]
@@ -40,24 +40,24 @@
               )
             )
           )
-          (lam a_48 (type) (ifix (lam rec_49 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_50 (fun (fun (type) (type)) (type)) [spine_50 [(lam List_51 (fun (type) (type)) (lam a_52 (type) (all out_List_53 (type) (fun out_List_53 (fun (fun a_52 (fun [List_51 a_52] out_List_53)) out_List_53))))) (lam a_54 (type) [rec_49 (lam dat_55 (fun (type) (type)) [dat_55 a_54])])]])) (lam dat_56 (fun (type) (type)) [dat_56 a_48])))
+          (lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])))
         }
         (abs
-          a_57
+          a_i0
           (type)
           (iwrap
-            (lam rec_58 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_59 (fun (fun (type) (type)) (type)) [spine_59 [(lam List_60 (fun (type) (type)) (lam a_61 (type) (all out_List_62 (type) (fun out_List_62 (fun (fun a_61 (fun [List_60 a_61] out_List_62)) out_List_62))))) (lam a_63 (type) [rec_58 (lam dat_64 (fun (type) (type)) [dat_64 a_63])])]]))
-            (lam dat_65 (fun (type) (type)) [dat_65 a_57])
+            (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]]))
+            (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])
             (abs
-              out_List_66
+              out_List_i0
               (type)
               (lam
-                case_Nil_67
-                out_List_66
+                case_Nil_i0
+                out_List_i2
                 (lam
-                  case_Cons_68
-                  (fun a_57 (fun [(lam a_69 (type) (ifix (lam rec_70 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_71 (fun (fun (type) (type)) (type)) [spine_71 [(lam List_72 (fun (type) (type)) (lam a_73 (type) (all out_List_74 (type) (fun out_List_74 (fun (fun a_73 (fun [List_72 a_73] out_List_74)) out_List_74))))) (lam a_75 (type) [rec_70 (lam dat_76 (fun (type) (type)) [dat_76 a_75])])]])) (lam dat_77 (fun (type) (type)) [dat_77 a_69]))) a_57] out_List_66))
-                  case_Nil_67
+                  case_Cons_i0
+                  (fun a_i4 (fun [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i4] out_List_i3))
+                  case_Nil_i2
                 )
               )
             )
@@ -65,27 +65,27 @@
         )
       ]
       (abs
-        a_78
+        a_i0
         (type)
         (lam
-          arg_0_79
-          a_78
+          arg_0_i0
+          a_i2
           (lam
-            arg_1_80
-            [(lam a_81 (type) (ifix (lam rec_82 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_83 (fun (fun (type) (type)) (type)) [spine_83 [(lam List_84 (fun (type) (type)) (lam a_85 (type) (all out_List_86 (type) (fun out_List_86 (fun (fun a_85 (fun [List_84 a_85] out_List_86)) out_List_86))))) (lam a_87 (type) [rec_82 (lam dat_88 (fun (type) (type)) [dat_88 a_87])])]])) (lam dat_89 (fun (type) (type)) [dat_89 a_81]))) a_78]
+            arg_1_i0
+            [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i3]
             (iwrap
-              (lam rec_90 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_91 (fun (fun (type) (type)) (type)) [spine_91 [(lam List_92 (fun (type) (type)) (lam a_93 (type) (all out_List_94 (type) (fun out_List_94 (fun (fun a_93 (fun [List_92 a_93] out_List_94)) out_List_94))))) (lam a_95 (type) [rec_90 (lam dat_96 (fun (type) (type)) [dat_96 a_95])])]]))
-              (lam dat_97 (fun (type) (type)) [dat_97 a_78])
+              (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]]))
+              (lam dat_i0 (fun (type) (type)) [dat_i1 a_i4])
               (abs
-                out_List_98
+                out_List_i0
                 (type)
                 (lam
-                  case_Nil_99
-                  out_List_98
+                  case_Nil_i0
+                  out_List_i2
                   (lam
-                    case_Cons_100
-                    (fun a_78 (fun [(lam a_101 (type) (ifix (lam rec_102 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_103 (fun (fun (type) (type)) (type)) [spine_103 [(lam List_104 (fun (type) (type)) (lam a_105 (type) (all out_List_106 (type) (fun out_List_106 (fun (fun a_105 (fun [List_104 a_105] out_List_106)) out_List_106))))) (lam a_107 (type) [rec_102 (lam dat_108 (fun (type) (type)) [dat_108 a_107])])]])) (lam dat_109 (fun (type) (type)) [dat_109 a_101]))) a_78] out_List_98))
-                    [ [ case_Cons_100 arg_0_79 ] arg_1_80 ]
+                    case_Cons_i0
+                    (fun a_i6 (fun [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i6] out_List_i3))
+                    [ [ case_Cons_i1 arg_0_i5 ] arg_1_i4 ]
                   )
                 )
               )
@@ -95,12 +95,12 @@
       )
     ]
     (abs
-      a_110
+      a_i0
       (type)
       (lam
-        x_111
-        [(lam a_112 (type) (ifix (lam rec_113 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_114 (fun (fun (type) (type)) (type)) [spine_114 [(lam List_115 (fun (type) (type)) (lam a_116 (type) (all out_List_117 (type) (fun out_List_117 (fun (fun a_116 (fun [List_115 a_116] out_List_117)) out_List_117))))) (lam a_118 (type) [rec_113 (lam dat_119 (fun (type) (type)) [dat_119 a_118])])]])) (lam dat_120 (fun (type) (type)) [dat_120 a_112]))) a_110]
-        (unwrap x_111)
+        x_i0
+        [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i2]
+        (unwrap x_i1)
       )
     )
   ]

--- a/plutus-ir/test/datatypes/maybe.plc.golden
+++ b/plutus-ir/test/datatypes/maybe.plc.golden
@@ -4,55 +4,55 @@
       [
         {
           (abs
-            Maybe_20
+            Maybe_i0
             (fun (type) (type))
             (lam
-              Nothing_21
-              (all a_22 (type) [Maybe_20 a_22])
+              Nothing_i0
+              (all a_i0 (type) [Maybe_i3 a_i1])
               (lam
-                Just_23
-                (all a_24 (type) (fun a_24 [Maybe_20 a_24]))
+                Just_i0
+                (all a_i0 (type) (fun a_i1 [Maybe_i4 a_i1]))
                 (lam
-                  match_Maybe_25
-                  (all a_26 (type) (fun [Maybe_20 a_26] (all out_Maybe_27 (type) (fun out_Maybe_27 (fun (fun a_26 out_Maybe_27) out_Maybe_27)))))
+                  match_Maybe_i0
+                  (all a_i0 (type) (fun [Maybe_i5 a_i1] (all out_Maybe_i0 (type) (fun out_Maybe_i1 (fun (fun a_i2 out_Maybe_i1) out_Maybe_i1)))))
                   [
-                    { Just_23 (all a_28 (type) (fun a_28 a_28)) }
-                    (abs a_29 (type) (lam x_30 a_29 x_30))
+                    { Just_i2 (all a_i0 (type) (fun a_i1 a_i1)) }
+                    (abs a_i0 (type) (lam x_i0 a_i2 x_i1))
                   ]
                 )
               )
             )
           )
-          (lam a_31 (type) (all out_Maybe_32 (type) (fun out_Maybe_32 (fun (fun a_31 out_Maybe_32) out_Maybe_32))))
+          (lam a_i0 (type) (all out_Maybe_i0 (type) (fun out_Maybe_i1 (fun (fun a_i2 out_Maybe_i1) out_Maybe_i1))))
         }
         (abs
-          a_33
+          a_i0
           (type)
           (abs
-            out_Maybe_34
+            out_Maybe_i0
             (type)
             (lam
-              case_Nothing_35
-              out_Maybe_34
-              (lam case_Just_36 (fun a_33 out_Maybe_34) case_Nothing_35)
+              case_Nothing_i0
+              out_Maybe_i2
+              (lam case_Just_i0 (fun a_i4 out_Maybe_i3) case_Nothing_i2)
             )
           )
         )
       ]
       (abs
-        a_37
+        a_i0
         (type)
         (lam
-          arg_0_38
-          a_37
+          arg_0_i0
+          a_i2
           (abs
-            out_Maybe_39
+            out_Maybe_i0
             (type)
             (lam
-              case_Nothing_40
-              out_Maybe_39
+              case_Nothing_i0
+              out_Maybe_i2
               (lam
-                case_Just_41 (fun a_37 out_Maybe_39) [ case_Just_41 arg_0_38 ]
+                case_Just_i0 (fun a_i5 out_Maybe_i3) [ case_Just_i1 arg_0_i4 ]
               )
             )
           )
@@ -60,12 +60,12 @@
       )
     ]
     (abs
-      a_42
+      a_i0
       (type)
       (lam
-        x_43
-        [(lam a_44 (type) (all out_Maybe_45 (type) (fun out_Maybe_45 (fun (fun a_44 out_Maybe_45) out_Maybe_45)))) a_42]
-        x_43
+        x_i0
+        [(lam a_i0 (type) (all out_Maybe_i0 (type) (fun out_Maybe_i1 (fun (fun a_i2 out_Maybe_i1) out_Maybe_i1)))) a_i2]
+        x_i1
       )
     )
   ]

--- a/plutus-ir/test/recursion/even3.plc.golden
+++ b/plutus-ir/test/recursion/even3.plc.golden
@@ -1,34 +1,34 @@
 (program 1.0.0
   [
     (lam
-      arg_316
-      (ifix (lam rec_317 (fun (fun (type) (type)) (type)) (lam spine_318 (fun (type) (type)) [spine_318 [(lam nat_319 (type) (all r_320 (type) (fun r_320 (fun (fun nat_319 r_320) r_320)))) [rec_317 (lam dat_321 (type) dat_321)]]])) (lam dat_322 (type) dat_322))
+      arg_i0
+      (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))
       [
         (lam
-          tup_323
-          (all r_324 (type) (fun (fun (fun (ifix (lam rec_325 (fun (fun (type) (type)) (type)) (lam spine_326 (fun (type) (type)) [spine_326 [(lam nat_327 (type) (all r_328 (type) (fun r_328 (fun (fun nat_327 r_328) r_328)))) [rec_325 (lam dat_329 (type) dat_329)]]])) (lam dat_330 (type) dat_330)) (all a_331 (type) (fun a_331 (fun a_331 a_331)))) (fun (fun (ifix (lam rec_332 (fun (fun (type) (type)) (type)) (lam spine_333 (fun (type) (type)) [spine_333 [(lam nat_334 (type) (all r_335 (type) (fun r_335 (fun (fun nat_334 r_335) r_335)))) [rec_332 (lam dat_336 (type) dat_336)]]])) (lam dat_337 (type) dat_337)) (all a_338 (type) (fun a_338 (fun a_338 a_338)))) r_324)) r_324))
+          tup_i0
+          (all r_i0 (type) (fun (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1)))) (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1)))) r_i1)) r_i1))
           [
             (lam
-              even_339
-              (fun (ifix (lam rec_340 (fun (fun (type) (type)) (type)) (lam spine_341 (fun (type) (type)) [spine_341 [(lam nat_342 (type) (all r_343 (type) (fun r_343 (fun (fun nat_342 r_343) r_343)))) [rec_340 (lam dat_344 (type) dat_344)]]])) (lam dat_345 (type) dat_345)) (all a_346 (type) (fun a_346 (fun a_346 a_346))))
+              even_i0
+              (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1))))
               [
                 (lam
-                  odd_347
-                  (fun (ifix (lam rec_348 (fun (fun (type) (type)) (type)) (lam spine_349 (fun (type) (type)) [spine_349 [(lam nat_350 (type) (all r_351 (type) (fun r_351 (fun (fun nat_350 r_351) r_351)))) [rec_348 (lam dat_352 (type) dat_352)]]])) (lam dat_353 (type) dat_353)) (all a_354 (type) (fun a_354 (fun a_354 a_354))))
-                  [ even_339 arg_316 ]
+                  odd_i0
+                  (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1))))
+                  [ even_i2 arg_i4 ]
                 )
                 [
                   {
-                    tup_323
-                    (fun (ifix (lam rec_355 (fun (fun (type) (type)) (type)) (lam spine_356 (fun (type) (type)) [spine_356 [(lam nat_357 (type) (all r_358 (type) (fun r_358 (fun (fun nat_357 r_358) r_358)))) [rec_355 (lam dat_359 (type) dat_359)]]])) (lam dat_360 (type) dat_360)) (all a_361 (type) (fun a_361 (fun a_361 a_361))))
+                    tup_i2
+                    (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1))))
                   }
                   (lam
-                    arg_0_362
-                    (fun (ifix (lam rec_363 (fun (fun (type) (type)) (type)) (lam spine_364 (fun (type) (type)) [spine_364 [(lam nat_365 (type) (all r_366 (type) (fun r_366 (fun (fun nat_365 r_366) r_366)))) [rec_363 (lam dat_367 (type) dat_367)]]])) (lam dat_368 (type) dat_368)) (all a_369 (type) (fun a_369 (fun a_369 a_369))))
+                    arg_0_i0
+                    (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1))))
                     (lam
-                      arg_1_370
-                      (fun (ifix (lam rec_371 (fun (fun (type) (type)) (type)) (lam spine_372 (fun (type) (type)) [spine_372 [(lam nat_373 (type) (all r_374 (type) (fun r_374 (fun (fun nat_373 r_374) r_374)))) [rec_371 (lam dat_375 (type) dat_375)]]])) (lam dat_376 (type) dat_376)) (all a_377 (type) (fun a_377 (fun a_377 a_377))))
-                      arg_1_370
+                      arg_1_i0
+                      (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1))))
+                      arg_1_i1
                     )
                   )
                 ]
@@ -36,16 +36,16 @@
             )
             [
               {
-                tup_323
-                (fun (ifix (lam rec_378 (fun (fun (type) (type)) (type)) (lam spine_379 (fun (type) (type)) [spine_379 [(lam nat_380 (type) (all r_381 (type) (fun r_381 (fun (fun nat_380 r_381) r_381)))) [rec_378 (lam dat_382 (type) dat_382)]]])) (lam dat_383 (type) dat_383)) (all a_384 (type) (fun a_384 (fun a_384 a_384))))
+                tup_i1
+                (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1))))
               }
               (lam
-                arg_0_385
-                (fun (ifix (lam rec_386 (fun (fun (type) (type)) (type)) (lam spine_387 (fun (type) (type)) [spine_387 [(lam nat_388 (type) (all r_389 (type) (fun r_389 (fun (fun nat_388 r_389) r_389)))) [rec_386 (lam dat_390 (type) dat_390)]]])) (lam dat_391 (type) dat_391)) (all a_392 (type) (fun a_392 (fun a_392 a_392))))
+                arg_0_i0
+                (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1))))
                 (lam
-                  arg_1_393
-                  (fun (ifix (lam rec_394 (fun (fun (type) (type)) (type)) (lam spine_395 (fun (type) (type)) [spine_395 [(lam nat_396 (type) (all r_397 (type) (fun r_397 (fun (fun nat_396 r_397) r_397)))) [rec_394 (lam dat_398 (type) dat_398)]]])) (lam dat_399 (type) dat_399)) (all a_400 (type) (fun a_400 (fun a_400 a_400))))
-                  arg_0_385
+                  arg_1_i0
+                  (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1))))
+                  arg_0_i2
                 )
               )
             ]
@@ -57,84 +57,83 @@
               {
                 {
                   (abs
-                    a_401
+                    a_i0
                     (type)
                     (abs
-                      b_402
+                      b_i0
                       (type)
                       (abs
-                        a_403
+                        a_i0
                         (type)
                         (abs
-                          b_404
+                          b_i0
                           (type)
                           [
                             {
                               (abs
-                                F_405
+                                F_i0
                                 (fun (type) (type))
                                 (lam
-                                  by_406
-                                  (fun (all Q_407 (type) (fun [F_405 Q_407] Q_407)) (all Q_408 (type) (fun [F_405 Q_408] Q_408)))
+                                  by_i0
+                                  (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
                                   [
                                     {
                                       {
                                         (abs
-                                          a_409
+                                          a_i0
                                           (type)
                                           (abs
-                                            b_410
+                                            b_i0
                                             (type)
                                             (lam
-                                              f_411
-                                              (fun (fun a_409 b_410) (fun a_409 b_410))
+                                              f_i0
+                                              (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
                                               [
                                                 {
                                                   (abs
-                                                    a_412
+                                                    a_i0
                                                     (type)
                                                     (lam
-                                                      s_413
-                                                      [(lam a_414 (type) (ifix (lam rec_415 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_416 (fun (fun (type) (type)) (type)) [spine_416 [(lam self_417 (fun (type) (type)) (lam a_418 (type) (fun [self_417 a_418] a_418))) (lam a_419 (type) [rec_415 (lam dat_420 (fun (type) (type)) [dat_420 a_419])])]])) (lam dat_421 (fun (type) (type)) [dat_421 a_414]))) a_412]
-                                                      [ (unwrap s_413) s_413 ]
+                                                      s_i0
+                                                      [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i2]
+                                                      [ (unwrap s_i1) s_i1 ]
                                                     )
                                                   )
-                                                  (fun a_409 b_410)
+                                                  (fun a_i3 b_i2)
                                                 }
                                                 (iwrap
-                                                  (lam rec_422 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_423 (fun (fun (type) (type)) (type)) [spine_423 [(lam self_424 (fun (type) (type)) (lam a_425 (type) (fun [self_424 a_425] a_425))) (lam a_426 (type) [rec_422 (lam dat_427 (fun (type) (type)) [dat_427 a_426])])]]))
-                                                  (lam dat_428 (fun (type) (type)) [dat_428 (fun a_409 b_410)])
+                                                  (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]]))
+                                                  (lam dat_i0 (fun (type) (type)) [dat_i1 (fun a_i4 b_i3)])
                                                   (lam
-                                                    s_429
-                                                    [(lam a_430 (type) (ifix (lam rec_431 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_432 (fun (fun (type) (type)) (type)) [spine_432 [(lam self_433 (fun (type) (type)) (lam a_434 (type) (fun [self_433 a_434] a_434))) (lam a_435 (type) [rec_431 (lam dat_436 (fun (type) (type)) [dat_436 a_435])])]])) (lam dat_437 (fun (type) (type)) [dat_437 a_430]))) (fun a_409 b_410)]
+                                                    s_i0
+                                                    [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) (fun a_i4 b_i3)]
                                                     (lam
-                                                      x_438
-                                                      a_409
+                                                      x_i0
+                                                      a_i5
                                                       [
                                                         [
-                                                          f_411
+                                                          f_i3
                                                           [
                                                             {
                                                               (abs
-                                                                a_439
+                                                                a_i0
                                                                 (type)
                                                                 (lam
-                                                                  s_440
-                                                                  [(lam a_441 (type) (ifix (lam rec_442 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_443 (fun (fun (type) (type)) (type)) [spine_443 [(lam self_444 (fun (type) (type)) (lam a_445 (type) (fun [self_444 a_445] a_445))) (lam a_446 (type) [rec_442 (lam dat_447 (fun (type) (type)) [dat_447 a_446])])]])) (lam dat_448 (fun (type) (type)) [dat_448 a_441]))) a_439]
+                                                                  s_i0
+                                                                  [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i2]
                                                                   [
-                                                                    (unwrap
-                                                                      s_440
+                                                                    (unwrap s_i1
                                                                     )
-                                                                    s_440
+                                                                    s_i1
                                                                   ]
                                                                 )
                                                               )
-                                                              (fun a_409 b_410)
+                                                              (fun a_i5 b_i4)
                                                             }
-                                                            s_429
+                                                            s_i2
                                                           ]
                                                         ]
-                                                        x_438
+                                                        x_i1
                                                       ]
                                                     )
                                                   )
@@ -143,47 +142,42 @@
                                             )
                                           )
                                         )
-                                        (all Q_449 (type) (fun [F_405 Q_449] [F_405 Q_449]))
+                                        (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
                                       }
-                                      (all Q_450 (type) (fun [F_405 Q_450] Q_450))
+                                      (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
                                     }
                                     (lam
-                                      rec_451
-                                      (fun (all Q_452 (type) (fun [F_405 Q_452] [F_405 Q_452])) (all Q_453 (type) (fun [F_405 Q_453] Q_453)))
+                                      rec_i0
+                                      (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
                                       (lam
-                                        h_454
-                                        (all Q_455 (type) (fun [F_405 Q_455] [F_405 Q_455]))
+                                        h_i0
+                                        (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
                                         (abs
-                                          R_456
+                                          R_i0
                                           (type)
                                           (lam
-                                            fr_457
-                                            [F_405 R_456]
+                                            fr_i0
+                                            [F_i6 R_i2]
                                             [
                                               {
                                                 [
-                                                  by_406
+                                                  by_i5
                                                   (abs
-                                                    Q_458
+                                                    Q_i0
                                                     (type)
                                                     (lam
-                                                      fq_459
-                                                      [F_405 Q_458]
+                                                      fq_i0
+                                                      [F_i8 Q_i2]
                                                       [
-                                                        {
-                                                          [ rec_451 h_454 ]
-                                                          Q_458
-                                                        }
-                                                        [
-                                                          { h_454 Q_458 } fq_459
-                                                        ]
+                                                        { [ rec_i6 h_i5 ] Q_i2 }
+                                                        [ { h_i5 Q_i2 } fq_i1 ]
                                                       ]
                                                     )
                                                   )
                                                 ]
-                                                R_456
+                                                R_i2
                                               }
-                                              fr_457
+                                              fr_i1
                                             ]
                                           )
                                         )
@@ -192,49 +186,45 @@
                                   ]
                                 )
                               )
-                              (lam X_460 (type) (fun (fun a_401 b_402) (fun (fun a_403 b_404) X_460)))
+                              (lam X_i0 (type) (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) X_i1)))
                             }
                             (lam
-                              k_461
-                              (all Q_462 (type) (fun (fun (fun a_401 b_402) (fun (fun a_403 b_404) Q_462)) Q_462))
+                              k_i0
+                              (all Q_i0 (type) (fun (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1)) Q_i1))
                               (abs
-                                S_463
+                                S_i0
                                 (type)
                                 (lam
-                                  h_464
-                                  (fun (fun a_401 b_402) (fun (fun a_403 b_404) S_463))
+                                  h_i0
+                                  (fun (fun a_i7 b_i6) (fun (fun a_i5 b_i4) S_i2))
                                   [
                                     [
-                                      h_464
+                                      h_i1
                                       (lam
-                                        x_465
-                                        a_401
+                                        x_i0
+                                        a_i8
                                         [
-                                          { k_461 b_402 }
+                                          { k_i4 b_i7 }
                                           (lam
-                                            f_466
-                                            (fun a_401 b_402)
+                                            f_i0
+                                            (fun a_i9 b_i8)
                                             (lam
-                                              f_467
-                                              (fun a_403 b_404)
-                                              [ f_466 x_465 ]
+                                              f_i0 (fun a_i8 b_i7) [ f_i2 x_i3 ]
                                             )
                                           )
                                         ]
                                       )
                                     ]
                                     (lam
-                                      x_468
-                                      a_403
+                                      x_i0
+                                      a_i6
                                       [
-                                        { k_461 b_404 }
+                                        { k_i4 b_i5 }
                                         (lam
-                                          f_469
-                                          (fun a_401 b_402)
+                                          f_i0
+                                          (fun a_i9 b_i8)
                                           (lam
-                                            f_470
-                                            (fun a_403 b_404)
-                                            [ f_470 x_468 ]
+                                            f_i0 (fun a_i8 b_i7) [ f_i1 x_i3 ]
                                           )
                                         )
                                       ]
@@ -248,64 +238,58 @@
                       )
                     )
                   )
-                  (ifix (lam rec_471 (fun (fun (type) (type)) (type)) (lam spine_472 (fun (type) (type)) [spine_472 [(lam nat_473 (type) (all r_474 (type) (fun r_474 (fun (fun nat_473 r_474) r_474)))) [rec_471 (lam dat_475 (type) dat_475)]]])) (lam dat_476 (type) dat_476))
+                  (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))
                 }
-                (all a_477 (type) (fun a_477 (fun a_477 a_477)))
+                (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1)))
               }
-              (ifix (lam rec_478 (fun (fun (type) (type)) (type)) (lam spine_479 (fun (type) (type)) [spine_479 [(lam nat_480 (type) (all r_481 (type) (fun r_481 (fun (fun nat_480 r_481) r_481)))) [rec_478 (lam dat_482 (type) dat_482)]]])) (lam dat_483 (type) dat_483))
+              (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))
             }
-            (all a_484 (type) (fun a_484 (fun a_484 a_484)))
+            (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1)))
           }
           (abs
-            Q_485
+            Q_i0
             (type)
             (lam
-              choose_486
-              (fun (fun (ifix (lam rec_487 (fun (fun (type) (type)) (type)) (lam spine_488 (fun (type) (type)) [spine_488 [(lam nat_489 (type) (all r_490 (type) (fun r_490 (fun (fun nat_489 r_490) r_490)))) [rec_487 (lam dat_491 (type) dat_491)]]])) (lam dat_492 (type) dat_492)) (all a_493 (type) (fun a_493 (fun a_493 a_493)))) (fun (fun (ifix (lam rec_494 (fun (fun (type) (type)) (type)) (lam spine_495 (fun (type) (type)) [spine_495 [(lam nat_496 (type) (all r_497 (type) (fun r_497 (fun (fun nat_496 r_497) r_497)))) [rec_494 (lam dat_498 (type) dat_498)]]])) (lam dat_499 (type) dat_499)) (all a_500 (type) (fun a_500 (fun a_500 a_500)))) Q_485))
+              choose_i0
+              (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1)))) (fun (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1)))) Q_i2))
               (lam
-                even_501
-                (fun (ifix (lam rec_502 (fun (fun (type) (type)) (type)) (lam spine_503 (fun (type) (type)) [spine_503 [(lam nat_504 (type) (all r_505 (type) (fun r_505 (fun (fun nat_504 r_505) r_505)))) [rec_502 (lam dat_506 (type) dat_506)]]])) (lam dat_507 (type) dat_507)) (all a_508 (type) (fun a_508 (fun a_508 a_508))))
+                even_i0
+                (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1))))
                 (lam
-                  odd_509
-                  (fun (ifix (lam rec_510 (fun (fun (type) (type)) (type)) (lam spine_511 (fun (type) (type)) [spine_511 [(lam nat_512 (type) (all r_513 (type) (fun r_513 (fun (fun nat_512 r_513) r_513)))) [rec_510 (lam dat_514 (type) dat_514)]]])) (lam dat_515 (type) dat_515)) (all a_516 (type) (fun a_516 (fun a_516 a_516))))
+                  odd_i0
+                  (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1))))
                   [
                     [
-                      choose_486
+                      choose_i3
                       (lam
-                        n_517
-                        (ifix (lam rec_518 (fun (fun (type) (type)) (type)) (lam spine_519 (fun (type) (type)) [spine_519 [(lam nat_520 (type) (all r_521 (type) (fun r_521 (fun (fun nat_520 r_521) r_521)))) [rec_518 (lam dat_522 (type) dat_522)]]])) (lam dat_523 (type) dat_523))
+                        n_i0
+                        (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))
                         [
                           [
                             {
-                              (unwrap n_517)
-                              (all a_524 (type) (fun a_524 (fun a_524 a_524)))
+                              (unwrap n_i1)
+                              (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1)))
                             }
                             (abs
-                              a_525
-                              (type)
-                              (lam x_526 a_525 (lam y_527 a_525 x_526))
+                              a_i0 (type) (lam x_i0 a_i2 (lam y_i0 a_i3 x_i2))
                             )
                           ]
-                          odd_509
+                          odd_i2
                         ]
                       )
                     ]
                     (lam
-                      n_528
-                      (ifix (lam rec_529 (fun (fun (type) (type)) (type)) (lam spine_530 (fun (type) (type)) [spine_530 [(lam nat_531 (type) (all r_532 (type) (fun r_532 (fun (fun nat_531 r_532) r_532)))) [rec_529 (lam dat_533 (type) dat_533)]]])) (lam dat_534 (type) dat_534))
+                      n_i0
+                      (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))
                       [
                         [
                           {
-                            (unwrap n_528)
-                            (all a_535 (type) (fun a_535 (fun a_535 a_535)))
+                            (unwrap n_i1)
+                            (all a_i0 (type) (fun a_i1 (fun a_i1 a_i1)))
                           }
-                          (abs
-                            a_536
-                            (type)
-                            (lam x_537 a_536 (lam y_538 a_536 y_538))
-                          )
+                          (abs a_i0 (type) (lam x_i0 a_i2 (lam y_i0 a_i3 y_i1)))
                         ]
-                        even_501
+                        even_i3
                       ]
                     )
                   ]
@@ -318,21 +302,21 @@
     )
     [
       (lam
-        n_539
-        (ifix (lam rec_540 (fun (fun (type) (type)) (type)) (lam spine_541 (fun (type) (type)) [spine_541 [(lam nat_542 (type) (all r_543 (type) (fun r_543 (fun (fun nat_542 r_543) r_543)))) [rec_540 (lam dat_544 (type) dat_544)]]])) (lam dat_545 (type) dat_545))
+        n_i0
+        (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))
         (iwrap
-          (lam rec_546 (fun (fun (type) (type)) (type)) (lam spine_547 (fun (type) (type)) [spine_547 [(lam nat_548 (type) (all r_549 (type) (fun r_549 (fun (fun nat_548 r_549) r_549)))) [rec_546 (lam dat_550 (type) dat_550)]]]))
-          (lam dat_551 (type) dat_551)
+          (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]]))
+          (lam dat_i0 (type) dat_i1)
           (abs
-            r_552
+            r_i0
             (type)
             (lam
-              z_553
-              r_552
+              z_i0
+              r_i2
               (lam
-                f_554
-                (fun (ifix (lam rec_555 (fun (fun (type) (type)) (type)) (lam spine_556 (fun (type) (type)) [spine_556 [(lam nat_557 (type) (all r_558 (type) (fun r_558 (fun (fun nat_557 r_558) r_558)))) [rec_555 (lam dat_559 (type) dat_559)]]])) (lam dat_560 (type) dat_560)) r_552)
-                [ f_554 n_539 ]
+                f_i0
+                (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) r_i3)
+                [ f_i1 n_i4 ]
               )
             )
           )
@@ -340,21 +324,21 @@
       )
       [
         (lam
-          n_561
-          (ifix (lam rec_562 (fun (fun (type) (type)) (type)) (lam spine_563 (fun (type) (type)) [spine_563 [(lam nat_564 (type) (all r_565 (type) (fun r_565 (fun (fun nat_564 r_565) r_565)))) [rec_562 (lam dat_566 (type) dat_566)]]])) (lam dat_567 (type) dat_567))
+          n_i0
+          (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))
           (iwrap
-            (lam rec_568 (fun (fun (type) (type)) (type)) (lam spine_569 (fun (type) (type)) [spine_569 [(lam nat_570 (type) (all r_571 (type) (fun r_571 (fun (fun nat_570 r_571) r_571)))) [rec_568 (lam dat_572 (type) dat_572)]]]))
-            (lam dat_573 (type) dat_573)
+            (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]]))
+            (lam dat_i0 (type) dat_i1)
             (abs
-              r_574
+              r_i0
               (type)
               (lam
-                z_575
-                r_574
+                z_i0
+                r_i2
                 (lam
-                  f_576
-                  (fun (ifix (lam rec_577 (fun (fun (type) (type)) (type)) (lam spine_578 (fun (type) (type)) [spine_578 [(lam nat_579 (type) (all r_580 (type) (fun r_580 (fun (fun nat_579 r_580) r_580)))) [rec_577 (lam dat_581 (type) dat_581)]]])) (lam dat_582 (type) dat_582)) r_574)
-                  [ f_576 n_561 ]
+                  f_i0
+                  (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) r_i3)
+                  [ f_i1 n_i4 ]
                 )
               )
             )
@@ -362,39 +346,39 @@
         )
         [
           (lam
-            n_583
-            (ifix (lam rec_584 (fun (fun (type) (type)) (type)) (lam spine_585 (fun (type) (type)) [spine_585 [(lam nat_586 (type) (all r_587 (type) (fun r_587 (fun (fun nat_586 r_587) r_587)))) [rec_584 (lam dat_588 (type) dat_588)]]])) (lam dat_589 (type) dat_589))
+            n_i0
+            (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))
             (iwrap
-              (lam rec_590 (fun (fun (type) (type)) (type)) (lam spine_591 (fun (type) (type)) [spine_591 [(lam nat_592 (type) (all r_593 (type) (fun r_593 (fun (fun nat_592 r_593) r_593)))) [rec_590 (lam dat_594 (type) dat_594)]]]))
-              (lam dat_595 (type) dat_595)
+              (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]]))
+              (lam dat_i0 (type) dat_i1)
               (abs
-                r_596
+                r_i0
                 (type)
                 (lam
-                  z_597
-                  r_596
+                  z_i0
+                  r_i2
                   (lam
-                    f_598
-                    (fun (ifix (lam rec_599 (fun (fun (type) (type)) (type)) (lam spine_600 (fun (type) (type)) [spine_600 [(lam nat_601 (type) (all r_602 (type) (fun r_602 (fun (fun nat_601 r_602) r_602)))) [rec_599 (lam dat_603 (type) dat_603)]]])) (lam dat_604 (type) dat_604)) r_596)
-                    [ f_598 n_583 ]
+                    f_i0
+                    (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) r_i3)
+                    [ f_i1 n_i4 ]
                   )
                 )
               )
             )
           )
           (iwrap
-            (lam rec_605 (fun (fun (type) (type)) (type)) (lam spine_606 (fun (type) (type)) [spine_606 [(lam nat_607 (type) (all r_608 (type) (fun r_608 (fun (fun nat_607 r_608) r_608)))) [rec_605 (lam dat_609 (type) dat_609)]]]))
-            (lam dat_610 (type) dat_610)
+            (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]]))
+            (lam dat_i0 (type) dat_i1)
             (abs
-              r_611
+              r_i0
               (type)
               (lam
-                z_612
-                r_611
+                z_i0
+                r_i2
                 (lam
-                  f_613
-                  (fun (ifix (lam rec_614 (fun (fun (type) (type)) (type)) (lam spine_615 (fun (type) (type)) [spine_615 [(lam nat_616 (type) (all r_617 (type) (fun r_617 (fun (fun nat_616 r_617) r_617)))) [rec_614 (lam dat_618 (type) dat_618)]]])) (lam dat_619 (type) dat_619)) r_611)
-                  z_612
+                  f_i0
+                  (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam nat_i0 (type) (all r_i0 (type) (fun r_i1 (fun (fun nat_i2 r_i1) r_i1)))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1)) r_i3)
+                  z_i2
                 )
               )
             )

--- a/plutus-ir/test/recursion/mutuallyRecursiveValues.plc.golden
+++ b/plutus-ir/test/recursion/mutuallyRecursiveValues.plc.golden
@@ -1,40 +1,40 @@
 (program 1.0.0
   [
     (lam
-      tup_122
-      (all r_123 (type) (fun (fun (fun (all a_124 (type) (fun a_124 a_124)) (all a_125 (type) (fun a_125 a_125))) (fun (fun (all a_126 (type) (fun a_126 a_126)) (all a_127 (type) (fun a_127 a_127))) r_123)) r_123))
+      tup_i0
+      (all r_i0 (type) (fun (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) r_i1)) r_i1))
       [
         (lam
-          x_thunked_128
-          (fun (all a_129 (type) (fun a_129 a_129)) (all a_130 (type) (fun a_130 a_130)))
+          x_thunked_i0
+          (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
           [
             (lam
-              y_thunked_131
-              (fun (all a_132 (type) (fun a_132 a_132)) (all a_133 (type) (fun a_133 a_133)))
+              y_thunked_i0
+              (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
               [
                 (lam
-                  y_134
-                  (all a_135 (type) (fun a_135 a_135))
+                  y_i0
+                  (all a_i0 (type) (fun a_i1 a_i1))
                   [
-                    (lam x_136 (all a_137 (type) (fun a_137 a_137)) x_136)
-                    [ x_thunked_128 (abs a_138 (type) (lam x_139 a_138 x_139)) ]
+                    (lam x_i0 (all a_i0 (type) (fun a_i1 a_i1)) x_i1)
+                    [ x_thunked_i3 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
                   ]
                 )
-                [ y_thunked_131 (abs a_140 (type) (lam x_141 a_140 x_141)) ]
+                [ y_thunked_i1 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
               ]
             )
             [
               {
-                tup_122
-                (fun (all a_142 (type) (fun a_142 a_142)) (all a_143 (type) (fun a_143 a_143)))
+                tup_i2
+                (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
               }
               (lam
-                arg_0_144
-                (fun (all a_145 (type) (fun a_145 a_145)) (all a_146 (type) (fun a_146 a_146)))
+                arg_0_i0
+                (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
                 (lam
-                  arg_1_147
-                  (fun (all a_148 (type) (fun a_148 a_148)) (all a_149 (type) (fun a_149 a_149)))
-                  arg_1_147
+                  arg_1_i0
+                  (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                  arg_1_i1
                 )
               )
             ]
@@ -42,16 +42,16 @@
         )
         [
           {
-            tup_122
-            (fun (all a_150 (type) (fun a_150 a_150)) (all a_151 (type) (fun a_151 a_151)))
+            tup_i1
+            (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
           }
           (lam
-            arg_0_152
-            (fun (all a_153 (type) (fun a_153 a_153)) (all a_154 (type) (fun a_154 a_154)))
+            arg_0_i0
+            (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
             (lam
-              arg_1_155
-              (fun (all a_156 (type) (fun a_156 a_156)) (all a_157 (type) (fun a_157 a_157)))
-              arg_0_152
+              arg_1_i0
+              (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+              arg_0_i2
             )
           )
         ]
@@ -63,82 +63,82 @@
           {
             {
               (abs
-                a_158
+                a_i0
                 (type)
                 (abs
-                  b_159
+                  b_i0
                   (type)
                   (abs
-                    a_160
+                    a_i0
                     (type)
                     (abs
-                      b_161
+                      b_i0
                       (type)
                       [
                         {
                           (abs
-                            F_162
+                            F_i0
                             (fun (type) (type))
                             (lam
-                              by_163
-                              (fun (all Q_164 (type) (fun [F_162 Q_164] Q_164)) (all Q_165 (type) (fun [F_162 Q_165] Q_165)))
+                              by_i0
+                              (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
                               [
                                 {
                                   {
                                     (abs
-                                      a_166
+                                      a_i0
                                       (type)
                                       (abs
-                                        b_167
+                                        b_i0
                                         (type)
                                         (lam
-                                          f_168
-                                          (fun (fun a_166 b_167) (fun a_166 b_167))
+                                          f_i0
+                                          (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
                                           [
                                             {
                                               (abs
-                                                a_169
+                                                a_i0
                                                 (type)
                                                 (lam
-                                                  s_170
-                                                  [(lam a_171 (type) (ifix (lam rec_172 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_173 (fun (fun (type) (type)) (type)) [spine_173 [(lam self_174 (fun (type) (type)) (lam a_175 (type) (fun [self_174 a_175] a_175))) (lam a_176 (type) [rec_172 (lam dat_177 (fun (type) (type)) [dat_177 a_176])])]])) (lam dat_178 (fun (type) (type)) [dat_178 a_171]))) a_169]
-                                                  [ (unwrap s_170) s_170 ]
+                                                  s_i0
+                                                  [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i2]
+                                                  [ (unwrap s_i1) s_i1 ]
                                                 )
                                               )
-                                              (fun a_166 b_167)
+                                              (fun a_i3 b_i2)
                                             }
                                             (iwrap
-                                              (lam rec_179 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_180 (fun (fun (type) (type)) (type)) [spine_180 [(lam self_181 (fun (type) (type)) (lam a_182 (type) (fun [self_181 a_182] a_182))) (lam a_183 (type) [rec_179 (lam dat_184 (fun (type) (type)) [dat_184 a_183])])]]))
-                                              (lam dat_185 (fun (type) (type)) [dat_185 (fun a_166 b_167)])
+                                              (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]]))
+                                              (lam dat_i0 (fun (type) (type)) [dat_i1 (fun a_i4 b_i3)])
                                               (lam
-                                                s_186
-                                                [(lam a_187 (type) (ifix (lam rec_188 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_189 (fun (fun (type) (type)) (type)) [spine_189 [(lam self_190 (fun (type) (type)) (lam a_191 (type) (fun [self_190 a_191] a_191))) (lam a_192 (type) [rec_188 (lam dat_193 (fun (type) (type)) [dat_193 a_192])])]])) (lam dat_194 (fun (type) (type)) [dat_194 a_187]))) (fun a_166 b_167)]
+                                                s_i0
+                                                [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) (fun a_i4 b_i3)]
                                                 (lam
-                                                  x_195
-                                                  a_166
+                                                  x_i0
+                                                  a_i5
                                                   [
                                                     [
-                                                      f_168
+                                                      f_i3
                                                       [
                                                         {
                                                           (abs
-                                                            a_196
+                                                            a_i0
                                                             (type)
                                                             (lam
-                                                              s_197
-                                                              [(lam a_198 (type) (ifix (lam rec_199 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_200 (fun (fun (type) (type)) (type)) [spine_200 [(lam self_201 (fun (type) (type)) (lam a_202 (type) (fun [self_201 a_202] a_202))) (lam a_203 (type) [rec_199 (lam dat_204 (fun (type) (type)) [dat_204 a_203])])]])) (lam dat_205 (fun (type) (type)) [dat_205 a_198]))) a_196]
+                                                              s_i0
+                                                              [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i2]
                                                               [
-                                                                (unwrap s_197)
-                                                                s_197
+                                                                (unwrap s_i1)
+                                                                s_i1
                                                               ]
                                                             )
                                                           )
-                                                          (fun a_166 b_167)
+                                                          (fun a_i5 b_i4)
                                                         }
-                                                        s_186
+                                                        s_i2
                                                       ]
                                                     ]
-                                                    x_195
+                                                    x_i1
                                                   ]
                                                 )
                                               )
@@ -147,42 +147,42 @@
                                         )
                                       )
                                     )
-                                    (all Q_206 (type) (fun [F_162 Q_206] [F_162 Q_206]))
+                                    (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
                                   }
-                                  (all Q_207 (type) (fun [F_162 Q_207] Q_207))
+                                  (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
                                 }
                                 (lam
-                                  rec_208
-                                  (fun (all Q_209 (type) (fun [F_162 Q_209] [F_162 Q_209])) (all Q_210 (type) (fun [F_162 Q_210] Q_210)))
+                                  rec_i0
+                                  (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
                                   (lam
-                                    h_211
-                                    (all Q_212 (type) (fun [F_162 Q_212] [F_162 Q_212]))
+                                    h_i0
+                                    (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
                                     (abs
-                                      R_213
+                                      R_i0
                                       (type)
                                       (lam
-                                        fr_214
-                                        [F_162 R_213]
+                                        fr_i0
+                                        [F_i6 R_i2]
                                         [
                                           {
                                             [
-                                              by_163
+                                              by_i5
                                               (abs
-                                                Q_215
+                                                Q_i0
                                                 (type)
                                                 (lam
-                                                  fq_216
-                                                  [F_162 Q_215]
+                                                  fq_i0
+                                                  [F_i8 Q_i2]
                                                   [
-                                                    { [ rec_208 h_211 ] Q_215 }
-                                                    [ { h_211 Q_215 } fq_216 ]
+                                                    { [ rec_i6 h_i5 ] Q_i2 }
+                                                    [ { h_i5 Q_i2 } fq_i1 ]
                                                   ]
                                                 )
                                               )
                                             ]
-                                            R_213
+                                            R_i2
                                           }
-                                          fr_214
+                                          fr_i1
                                         ]
                                       )
                                     )
@@ -191,48 +191,42 @@
                               ]
                             )
                           )
-                          (lam X_217 (type) (fun (fun a_158 b_159) (fun (fun a_160 b_161) X_217)))
+                          (lam X_i0 (type) (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) X_i1)))
                         }
                         (lam
-                          k_218
-                          (all Q_219 (type) (fun (fun (fun a_158 b_159) (fun (fun a_160 b_161) Q_219)) Q_219))
+                          k_i0
+                          (all Q_i0 (type) (fun (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1)) Q_i1))
                           (abs
-                            S_220
+                            S_i0
                             (type)
                             (lam
-                              h_221
-                              (fun (fun a_158 b_159) (fun (fun a_160 b_161) S_220))
+                              h_i0
+                              (fun (fun a_i7 b_i6) (fun (fun a_i5 b_i4) S_i2))
                               [
                                 [
-                                  h_221
+                                  h_i1
                                   (lam
-                                    x_222
-                                    a_158
+                                    x_i0
+                                    a_i8
                                     [
-                                      { k_218 b_159 }
+                                      { k_i4 b_i7 }
                                       (lam
-                                        f_223
-                                        (fun a_158 b_159)
-                                        (lam
-                                          f_224
-                                          (fun a_160 b_161)
-                                          [ f_223 x_222 ]
-                                        )
+                                        f_i0
+                                        (fun a_i9 b_i8)
+                                        (lam f_i0 (fun a_i8 b_i7) [ f_i2 x_i3 ])
                                       )
                                     ]
                                   )
                                 ]
                                 (lam
-                                  x_225
-                                  a_160
+                                  x_i0
+                                  a_i6
                                   [
-                                    { k_218 b_161 }
+                                    { k_i4 b_i5 }
                                     (lam
-                                      f_226
-                                      (fun a_158 b_159)
-                                      (lam
-                                        f_227 (fun a_160 b_161) [ f_227 x_225 ]
-                                      )
+                                      f_i0
+                                      (fun a_i9 b_i8)
+                                      (lam f_i0 (fun a_i8 b_i7) [ f_i1 x_i3 ])
                                     )
                                   ]
                                 )
@@ -245,39 +239,39 @@
                   )
                 )
               )
-              (all a_228 (type) (fun a_228 a_228))
+              (all a_i0 (type) (fun a_i1 a_i1))
             }
-            (all a_229 (type) (fun a_229 a_229))
+            (all a_i0 (type) (fun a_i1 a_i1))
           }
-          (all a_230 (type) (fun a_230 a_230))
+          (all a_i0 (type) (fun a_i1 a_i1))
         }
-        (all a_231 (type) (fun a_231 a_231))
+        (all a_i0 (type) (fun a_i1 a_i1))
       }
       (abs
-        Q_232
+        Q_i0
         (type)
         (lam
-          choose_233
-          (fun (fun (all a_234 (type) (fun a_234 a_234)) (all a_235 (type) (fun a_235 a_235))) (fun (fun (all a_236 (type) (fun a_236 a_236)) (all a_237 (type) (fun a_237 a_237))) Q_232))
+          choose_i0
+          (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) Q_i2))
           (lam
-            x_thunked_238
-            (fun (all a_239 (type) (fun a_239 a_239)) (all a_240 (type) (fun a_240 a_240)))
+            x_thunked_i0
+            (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
             (lam
-              y_thunked_241
-              (fun (all a_242 (type) (fun a_242 a_242)) (all a_243 (type) (fun a_243 a_243)))
+              y_thunked_i0
+              (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
               [
                 [
-                  choose_233
+                  choose_i3
                   (lam
-                    arg_244
-                    (all a_245 (type) (fun a_245 a_245))
-                    [ y_thunked_241 (abs a_246 (type) (lam x_247 a_246 x_247)) ]
+                    arg_i0
+                    (all a_i0 (type) (fun a_i1 a_i1))
+                    [ y_thunked_i2 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
                   )
                 ]
                 (lam
-                  arg_248
-                  (all a_249 (type) (fun a_249 a_249))
-                  (abs a_250 (type) (lam x_251 a_250 x_251))
+                  arg_i0
+                  (all a_i0 (type) (fun a_i1 a_i1))
+                  (abs a_i0 (type) (lam x_i0 a_i2 x_i1))
                 )
               ]
             )

--- a/plutus-tx-plugin/test/Lift/list.plc.golden
+++ b/plutus-tx-plugin/test/Lift/list.plc.golden
@@ -4,45 +4,45 @@
       [
         {
           (abs
-            GHC_Types_List_23
+            GHC_Types_List_i0
             (fun (type) (type))
             (lam
-              GHC_Types_Nil_24
-              (all a_25 (type) [GHC_Types_List_23 a_25])
+              GHC_Types_Nil_i0
+              (all a_i0 (type) [GHC_Types_List_i3 a_i1])
               (lam
-                GHC_Types_Cons_26
-                (all a_27 (type) (fun a_27 (fun [GHC_Types_List_23 a_27] [GHC_Types_List_23 a_27])))
+                GHC_Types_Cons_i0
+                (all a_i0 (type) (fun a_i1 (fun [GHC_Types_List_i4 a_i1] [GHC_Types_List_i4 a_i1])))
                 (lam
-                  match_GHC_Types_Nil_28
-                  (all a_29 (type) (fun [GHC_Types_List_23 a_29] (all out_GHC_Types_List_30 (type) (fun out_GHC_Types_List_30 (fun (fun a_29 (fun [GHC_Types_List_23 a_29] out_GHC_Types_List_30)) out_GHC_Types_List_30)))))
+                  match_GHC_Types_Nil_i0
+                  (all a_i0 (type) (fun [GHC_Types_List_i5 a_i1] (all out_GHC_Types_List_i0 (type) (fun out_GHC_Types_List_i1 (fun (fun a_i2 (fun [GHC_Types_List_i6 a_i2] out_GHC_Types_List_i1)) out_GHC_Types_List_i1)))))
                   [
                     [
-                      { GHC_Types_Cons_26 [(con integer) (con 8)] } (con 8 ! 1)
+                      { GHC_Types_Cons_i2 [(con integer) (con 8)] } (con 8 ! 1)
                     ]
-                    { GHC_Types_Nil_24 [(con integer) (con 8)] }
+                    { GHC_Types_Nil_i3 [(con integer) (con 8)] }
                   ]
                 )
               )
             )
           )
-          (lam a_31 (type) (ifix (lam rec_32 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_33 (fun (fun (type) (type)) (type)) [spine_33 [(lam GHC_Types_List_34 (fun (type) (type)) (lam a_35 (type) (all out_GHC_Types_List_36 (type) (fun out_GHC_Types_List_36 (fun (fun a_35 (fun [GHC_Types_List_34 a_35] out_GHC_Types_List_36)) out_GHC_Types_List_36))))) (lam a_37 (type) [rec_32 (lam dat_38 (fun (type) (type)) [dat_38 a_37])])]])) (lam dat_39 (fun (type) (type)) [dat_39 a_31])))
+          (lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam GHC_Types_List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_GHC_Types_List_i0 (type) (fun out_GHC_Types_List_i1 (fun (fun a_i2 (fun [GHC_Types_List_i3 a_i2] out_GHC_Types_List_i1)) out_GHC_Types_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])))
         }
         (abs
-          a_40
+          a_i0
           (type)
           (iwrap
-            (lam rec_41 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_42 (fun (fun (type) (type)) (type)) [spine_42 [(lam GHC_Types_List_43 (fun (type) (type)) (lam a_44 (type) (all out_GHC_Types_List_45 (type) (fun out_GHC_Types_List_45 (fun (fun a_44 (fun [GHC_Types_List_43 a_44] out_GHC_Types_List_45)) out_GHC_Types_List_45))))) (lam a_46 (type) [rec_41 (lam dat_47 (fun (type) (type)) [dat_47 a_46])])]]))
-            (lam dat_48 (fun (type) (type)) [dat_48 a_40])
+            (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam GHC_Types_List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_GHC_Types_List_i0 (type) (fun out_GHC_Types_List_i1 (fun (fun a_i2 (fun [GHC_Types_List_i3 a_i2] out_GHC_Types_List_i1)) out_GHC_Types_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]]))
+            (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])
             (abs
-              out_GHC_Types_List_49
+              out_GHC_Types_List_i0
               (type)
               (lam
-                case_GHC_Types_Nil_50
-                out_GHC_Types_List_49
+                case_GHC_Types_Nil_i0
+                out_GHC_Types_List_i2
                 (lam
-                  case_GHC_Types_Cons_51
-                  (fun a_40 (fun [(lam a_52 (type) (ifix (lam rec_53 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_54 (fun (fun (type) (type)) (type)) [spine_54 [(lam GHC_Types_List_55 (fun (type) (type)) (lam a_56 (type) (all out_GHC_Types_List_57 (type) (fun out_GHC_Types_List_57 (fun (fun a_56 (fun [GHC_Types_List_55 a_56] out_GHC_Types_List_57)) out_GHC_Types_List_57))))) (lam a_58 (type) [rec_53 (lam dat_59 (fun (type) (type)) [dat_59 a_58])])]])) (lam dat_60 (fun (type) (type)) [dat_60 a_52]))) a_40] out_GHC_Types_List_49))
-                  case_GHC_Types_Nil_50
+                  case_GHC_Types_Cons_i0
+                  (fun a_i4 (fun [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam GHC_Types_List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_GHC_Types_List_i0 (type) (fun out_GHC_Types_List_i1 (fun (fun a_i2 (fun [GHC_Types_List_i3 a_i2] out_GHC_Types_List_i1)) out_GHC_Types_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i4] out_GHC_Types_List_i3))
+                  case_GHC_Types_Nil_i2
                 )
               )
             )
@@ -50,27 +50,27 @@
         )
       ]
       (abs
-        a_61
+        a_i0
         (type)
         (lam
-          arg_0_62
-          a_61
+          arg_0_i0
+          a_i2
           (lam
-            arg_1_63
-            [(lam a_64 (type) (ifix (lam rec_65 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_66 (fun (fun (type) (type)) (type)) [spine_66 [(lam GHC_Types_List_67 (fun (type) (type)) (lam a_68 (type) (all out_GHC_Types_List_69 (type) (fun out_GHC_Types_List_69 (fun (fun a_68 (fun [GHC_Types_List_67 a_68] out_GHC_Types_List_69)) out_GHC_Types_List_69))))) (lam a_70 (type) [rec_65 (lam dat_71 (fun (type) (type)) [dat_71 a_70])])]])) (lam dat_72 (fun (type) (type)) [dat_72 a_64]))) a_61]
+            arg_1_i0
+            [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam GHC_Types_List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_GHC_Types_List_i0 (type) (fun out_GHC_Types_List_i1 (fun (fun a_i2 (fun [GHC_Types_List_i3 a_i2] out_GHC_Types_List_i1)) out_GHC_Types_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i3]
             (iwrap
-              (lam rec_73 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_74 (fun (fun (type) (type)) (type)) [spine_74 [(lam GHC_Types_List_75 (fun (type) (type)) (lam a_76 (type) (all out_GHC_Types_List_77 (type) (fun out_GHC_Types_List_77 (fun (fun a_76 (fun [GHC_Types_List_75 a_76] out_GHC_Types_List_77)) out_GHC_Types_List_77))))) (lam a_78 (type) [rec_73 (lam dat_79 (fun (type) (type)) [dat_79 a_78])])]]))
-              (lam dat_80 (fun (type) (type)) [dat_80 a_61])
+              (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam GHC_Types_List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_GHC_Types_List_i0 (type) (fun out_GHC_Types_List_i1 (fun (fun a_i2 (fun [GHC_Types_List_i3 a_i2] out_GHC_Types_List_i1)) out_GHC_Types_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]]))
+              (lam dat_i0 (fun (type) (type)) [dat_i1 a_i4])
               (abs
-                out_GHC_Types_List_81
+                out_GHC_Types_List_i0
                 (type)
                 (lam
-                  case_GHC_Types_Nil_82
-                  out_GHC_Types_List_81
+                  case_GHC_Types_Nil_i0
+                  out_GHC_Types_List_i2
                   (lam
-                    case_GHC_Types_Cons_83
-                    (fun a_61 (fun [(lam a_84 (type) (ifix (lam rec_85 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_86 (fun (fun (type) (type)) (type)) [spine_86 [(lam GHC_Types_List_87 (fun (type) (type)) (lam a_88 (type) (all out_GHC_Types_List_89 (type) (fun out_GHC_Types_List_89 (fun (fun a_88 (fun [GHC_Types_List_87 a_88] out_GHC_Types_List_89)) out_GHC_Types_List_89))))) (lam a_90 (type) [rec_85 (lam dat_91 (fun (type) (type)) [dat_91 a_90])])]])) (lam dat_92 (fun (type) (type)) [dat_92 a_84]))) a_61] out_GHC_Types_List_81))
-                    [ [ case_GHC_Types_Cons_83 arg_0_62 ] arg_1_63 ]
+                    case_GHC_Types_Cons_i0
+                    (fun a_i6 (fun [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam GHC_Types_List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_GHC_Types_List_i0 (type) (fun out_GHC_Types_List_i1 (fun (fun a_i2 (fun [GHC_Types_List_i3 a_i2] out_GHC_Types_List_i1)) out_GHC_Types_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i6] out_GHC_Types_List_i3))
+                    [ [ case_GHC_Types_Cons_i1 arg_0_i5 ] arg_1_i4 ]
                   )
                 )
               )
@@ -80,12 +80,12 @@
       )
     ]
     (abs
-      a_93
+      a_i0
       (type)
       (lam
-        x_94
-        [(lam a_95 (type) (ifix (lam rec_96 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_97 (fun (fun (type) (type)) (type)) [spine_97 [(lam GHC_Types_List_98 (fun (type) (type)) (lam a_99 (type) (all out_GHC_Types_List_100 (type) (fun out_GHC_Types_List_100 (fun (fun a_99 (fun [GHC_Types_List_98 a_99] out_GHC_Types_List_100)) out_GHC_Types_List_100))))) (lam a_101 (type) [rec_96 (lam dat_102 (fun (type) (type)) [dat_102 a_101])])]])) (lam dat_103 (fun (type) (type)) [dat_103 a_95]))) a_93]
-        (unwrap x_94)
+        x_i0
+        [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam GHC_Types_List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_GHC_Types_List_i0 (type) (fun out_GHC_Types_List_i1 (fun (fun a_i2 (fun [GHC_Types_List_i3 a_i2] out_GHC_Types_List_i1)) out_GHC_Types_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i2]
+        (unwrap x_i1)
       )
     )
   ]

--- a/plutus-tx-plugin/test/Lift/mono.plc.golden
+++ b/plutus-tx-plugin/test/Lift/mono.plc.golden
@@ -5,47 +5,47 @@
         [
           {
             (abs
-              Plugin_Spec_MyMonoData_23
+              Plugin_Spec_MyMonoData_i0
               (type)
               (lam
-                Plugin_Spec_Mono1_24
-                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Plugin_Spec_MyMonoData_23))
+                Plugin_Spec_Mono1_i0
+                (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Plugin_Spec_MyMonoData_i2))
                 (lam
-                  Plugin_Spec_Mono2_25
-                  (fun [(con integer) (con 8)] Plugin_Spec_MyMonoData_23)
+                  Plugin_Spec_Mono2_i0
+                  (fun [(con integer) (con 8)] Plugin_Spec_MyMonoData_i3)
                   (lam
-                    Plugin_Spec_Mono3_26
-                    (fun [(con integer) (con 8)] Plugin_Spec_MyMonoData_23)
+                    Plugin_Spec_Mono3_i0
+                    (fun [(con integer) (con 8)] Plugin_Spec_MyMonoData_i4)
                     (lam
-                      match_Plugin_Spec_MyMonoData_27
-                      (fun Plugin_Spec_MyMonoData_23 (all out_Plugin_Spec_MyMonoData_28 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_28)) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_28) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_28) out_Plugin_Spec_MyMonoData_28)))))
-                      [ Plugin_Spec_Mono2_25 (con 8 ! 2) ]
+                      match_Plugin_Spec_MyMonoData_i0
+                      (fun Plugin_Spec_MyMonoData_i5 (all out_Plugin_Spec_MyMonoData_i0 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i1)) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i1) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i1) out_Plugin_Spec_MyMonoData_i1)))))
+                      [ Plugin_Spec_Mono2_i3 (con 8 ! 2) ]
                     )
                   )
                 )
               )
             )
-            (all out_Plugin_Spec_MyMonoData_29 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_29)) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_29) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_29) out_Plugin_Spec_MyMonoData_29))))
+            (all out_Plugin_Spec_MyMonoData_i0 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i1)) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i1) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i1) out_Plugin_Spec_MyMonoData_i1))))
           }
           (lam
-            arg_0_30
+            arg_0_i0
             [(con integer) (con 8)]
             (lam
-              arg_1_31
+              arg_1_i0
               [(con integer) (con 8)]
               (abs
-                out_Plugin_Spec_MyMonoData_32
+                out_Plugin_Spec_MyMonoData_i0
                 (type)
                 (lam
-                  case_Plugin_Spec_Mono1_33
-                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_32))
+                  case_Plugin_Spec_Mono1_i0
+                  (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i2))
                   (lam
-                    case_Plugin_Spec_Mono2_34
-                    (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_32)
+                    case_Plugin_Spec_Mono2_i0
+                    (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i3)
                     (lam
-                      case_Plugin_Spec_Mono3_35
-                      (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_32)
-                      [ [ case_Plugin_Spec_Mono1_33 arg_0_30 ] arg_1_31 ]
+                      case_Plugin_Spec_Mono3_i0
+                      (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i4)
+                      [ [ case_Plugin_Spec_Mono1_i3 arg_0_i6 ] arg_1_i5 ]
                     )
                   )
                 )
@@ -54,21 +54,21 @@
           )
         ]
         (lam
-          arg_0_36
+          arg_0_i0
           [(con integer) (con 8)]
           (abs
-            out_Plugin_Spec_MyMonoData_37
+            out_Plugin_Spec_MyMonoData_i0
             (type)
             (lam
-              case_Plugin_Spec_Mono1_38
-              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_37))
+              case_Plugin_Spec_Mono1_i0
+              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i2))
               (lam
-                case_Plugin_Spec_Mono2_39
-                (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_37)
+                case_Plugin_Spec_Mono2_i0
+                (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i3)
                 (lam
-                  case_Plugin_Spec_Mono3_40
-                  (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_37)
-                  [ case_Plugin_Spec_Mono2_39 arg_0_36 ]
+                  case_Plugin_Spec_Mono3_i0
+                  (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i4)
+                  [ case_Plugin_Spec_Mono2_i2 arg_0_i5 ]
                 )
               )
             )
@@ -76,21 +76,21 @@
         )
       ]
       (lam
-        arg_0_41
+        arg_0_i0
         [(con integer) (con 8)]
         (abs
-          out_Plugin_Spec_MyMonoData_42
+          out_Plugin_Spec_MyMonoData_i0
           (type)
           (lam
-            case_Plugin_Spec_Mono1_43
-            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_42))
+            case_Plugin_Spec_Mono1_i0
+            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i2))
             (lam
-              case_Plugin_Spec_Mono2_44
-              (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_42)
+              case_Plugin_Spec_Mono2_i0
+              (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i3)
               (lam
-                case_Plugin_Spec_Mono3_45
-                (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_42)
-                [ case_Plugin_Spec_Mono3_45 arg_0_41 ]
+                case_Plugin_Spec_Mono3_i0
+                (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i4)
+                [ case_Plugin_Spec_Mono3_i1 arg_0_i5 ]
               )
             )
           )
@@ -98,9 +98,9 @@
       )
     ]
     (lam
-      x_46
-      (all out_Plugin_Spec_MyMonoData_47 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_47)) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_47) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_47) out_Plugin_Spec_MyMonoData_47))))
-      x_46
+      x_i0
+      (all out_Plugin_Spec_MyMonoData_i0 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i1)) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i1) (fun (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoData_i1) out_Plugin_Spec_MyMonoData_i1))))
+      x_i1
     )
   ]
 )

--- a/plutus-tx-plugin/test/Lift/nested.plc.golden
+++ b/plutus-tx-plugin/test/Lift/nested.plc.golden
@@ -3,54 +3,54 @@
     [
       {
         (abs
-          GHC_Tuple_Tuple2_33
+          GHC_Tuple_Tuple2_i0
           (fun (type) (fun (type) (type)))
           (lam
-            GHC_Tuple_Tuple2_34
-            (all a_35 (type) (all b_36 (type) (fun a_35 (fun b_36 [[GHC_Tuple_Tuple2_33 a_35] b_36]))))
+            GHC_Tuple_Tuple2_i0
+            (all a_i0 (type) (all b_i0 (type) (fun a_i2 (fun b_i1 [[GHC_Tuple_Tuple2_i4 a_i2] b_i1]))))
             (lam
-              match_GHC_Tuple_Tuple2_37
-              (all a_38 (type) (all b_39 (type) (fun [[GHC_Tuple_Tuple2_33 a_38] b_39] (all out_GHC_Tuple_Tuple2_40 (type) (fun (fun a_38 (fun b_39 out_GHC_Tuple_Tuple2_40)) out_GHC_Tuple_Tuple2_40)))))
+              match_GHC_Tuple_Tuple2_i0
+              (all a_i0 (type) (all b_i0 (type) (fun [[GHC_Tuple_Tuple2_i5 a_i2] b_i1] (all out_GHC_Tuple_Tuple2_i0 (type) (fun (fun a_i3 (fun b_i2 out_GHC_Tuple_Tuple2_i1)) out_GHC_Tuple_Tuple2_i1)))))
               [
                 [
                   [
                     {
                       (abs
-                        GHC_Base_Maybe_41
+                        GHC_Base_Maybe_i0
                         (fun (type) (type))
                         (lam
-                          GHC_Base_Just_42
-                          (all a_43 (type) (fun a_43 [GHC_Base_Maybe_41 a_43]))
+                          GHC_Base_Just_i0
+                          (all a_i0 (type) (fun a_i1 [GHC_Base_Maybe_i3 a_i1]))
                           (lam
-                            GHC_Base_Nothing_44
-                            (all a_45 (type) [GHC_Base_Maybe_41 a_45])
+                            GHC_Base_Nothing_i0
+                            (all a_i0 (type) [GHC_Base_Maybe_i4 a_i1])
                             (lam
-                              match_GHC_Base_Maybe_46
-                              (all a_47 (type) (fun [GHC_Base_Maybe_41 a_47] (all out_GHC_Base_Maybe_48 (type) (fun (fun a_47 out_GHC_Base_Maybe_48) (fun out_GHC_Base_Maybe_48 out_GHC_Base_Maybe_48)))))
+                              match_GHC_Base_Maybe_i0
+                              (all a_i0 (type) (fun [GHC_Base_Maybe_i5 a_i1] (all out_GHC_Base_Maybe_i0 (type) (fun (fun a_i2 out_GHC_Base_Maybe_i1) (fun out_GHC_Base_Maybe_i1 out_GHC_Base_Maybe_i1)))))
                               [
                                 [
                                   {
                                     (abs
-                                      Lift_Spec_NestedRecord_49
+                                      Lift_Spec_NestedRecord_i0
                                       (type)
                                       (lam
-                                        Lift_Spec_NestedRecord_50
-                                        (fun [GHC_Base_Maybe_41 [[GHC_Tuple_Tuple2_33 [(con integer) (con 8)]] [(con integer) (con 8)]]] Lift_Spec_NestedRecord_49)
+                                        Lift_Spec_NestedRecord_i0
+                                        (fun [GHC_Base_Maybe_i6 [[GHC_Tuple_Tuple2_i9 [(con integer) (con 8)]] [(con integer) (con 8)]]] Lift_Spec_NestedRecord_i2)
                                         (lam
-                                          match_Lift_Spec_NestedRecord_51
-                                          (fun Lift_Spec_NestedRecord_49 (all out_Lift_Spec_NestedRecord_52 (type) (fun (fun [GHC_Base_Maybe_41 [[GHC_Tuple_Tuple2_33 [(con integer) (con 8)]] [(con integer) (con 8)]]] out_Lift_Spec_NestedRecord_52) out_Lift_Spec_NestedRecord_52)))
+                                          match_Lift_Spec_NestedRecord_i0
+                                          (fun Lift_Spec_NestedRecord_i3 (all out_Lift_Spec_NestedRecord_i0 (type) (fun (fun [GHC_Base_Maybe_i8 [[GHC_Tuple_Tuple2_i11 [(con integer) (con 8)]] [(con integer) (con 8)]]] out_Lift_Spec_NestedRecord_i1) out_Lift_Spec_NestedRecord_i1)))
                                           [
-                                            Lift_Spec_NestedRecord_50
+                                            Lift_Spec_NestedRecord_i2
                                             [
                                               {
-                                                GHC_Base_Just_42
-                                                [[GHC_Tuple_Tuple2_33 [(con integer) (con 8)]] [(con integer) (con 8)]]
+                                                GHC_Base_Just_i6
+                                                [[GHC_Tuple_Tuple2_i10 [(con integer) (con 8)]] [(con integer) (con 8)]]
                                               }
                                               [
                                                 [
                                                   {
                                                     {
-                                                      GHC_Tuple_Tuple2_34
+                                                      GHC_Tuple_Tuple2_i9
                                                       [(con integer) (con 8)]
                                                     }
                                                     [(con integer) (con 8)]
@@ -64,53 +64,53 @@
                                         )
                                       )
                                     )
-                                    (all out_Lift_Spec_NestedRecord_53 (type) (fun (fun [GHC_Base_Maybe_41 [[GHC_Tuple_Tuple2_33 [(con integer) (con 8)]] [(con integer) (con 8)]]] out_Lift_Spec_NestedRecord_53) out_Lift_Spec_NestedRecord_53))
+                                    (all out_Lift_Spec_NestedRecord_i0 (type) (fun (fun [GHC_Base_Maybe_i5 [[GHC_Tuple_Tuple2_i8 [(con integer) (con 8)]] [(con integer) (con 8)]]] out_Lift_Spec_NestedRecord_i1) out_Lift_Spec_NestedRecord_i1))
                                   }
                                   (lam
-                                    arg_0_54
-                                    [GHC_Base_Maybe_41 [[GHC_Tuple_Tuple2_33 [(con integer) (con 8)]] [(con integer) (con 8)]]]
+                                    arg_0_i0
+                                    [GHC_Base_Maybe_i5 [[GHC_Tuple_Tuple2_i8 [(con integer) (con 8)]] [(con integer) (con 8)]]]
                                     (abs
-                                      out_Lift_Spec_NestedRecord_55
+                                      out_Lift_Spec_NestedRecord_i0
                                       (type)
                                       (lam
-                                        case_Lift_Spec_NestedRecord_56
-                                        (fun [GHC_Base_Maybe_41 [[GHC_Tuple_Tuple2_33 [(con integer) (con 8)]] [(con integer) (con 8)]]] out_Lift_Spec_NestedRecord_55)
+                                        case_Lift_Spec_NestedRecord_i0
+                                        (fun [GHC_Base_Maybe_i7 [[GHC_Tuple_Tuple2_i10 [(con integer) (con 8)]] [(con integer) (con 8)]]] out_Lift_Spec_NestedRecord_i2)
                                         [
-                                          case_Lift_Spec_NestedRecord_56
-                                          arg_0_54
+                                          case_Lift_Spec_NestedRecord_i1
+                                          arg_0_i3
                                         ]
                                       )
                                     )
                                   )
                                 ]
                                 (lam
-                                  x_57
-                                  (all out_Lift_Spec_NestedRecord_58 (type) (fun (fun [GHC_Base_Maybe_41 [[GHC_Tuple_Tuple2_33 [(con integer) (con 8)]] [(con integer) (con 8)]]] out_Lift_Spec_NestedRecord_58) out_Lift_Spec_NestedRecord_58))
-                                  x_57
+                                  x_i0
+                                  (all out_Lift_Spec_NestedRecord_i0 (type) (fun (fun [GHC_Base_Maybe_i6 [[GHC_Tuple_Tuple2_i9 [(con integer) (con 8)]] [(con integer) (con 8)]]] out_Lift_Spec_NestedRecord_i1) out_Lift_Spec_NestedRecord_i1))
+                                  x_i1
                                 )
                               ]
                             )
                           )
                         )
                       )
-                      (lam a_59 (type) (all out_GHC_Base_Maybe_60 (type) (fun (fun a_59 out_GHC_Base_Maybe_60) (fun out_GHC_Base_Maybe_60 out_GHC_Base_Maybe_60))))
+                      (lam a_i0 (type) (all out_GHC_Base_Maybe_i0 (type) (fun (fun a_i2 out_GHC_Base_Maybe_i1) (fun out_GHC_Base_Maybe_i1 out_GHC_Base_Maybe_i1))))
                     }
                     (abs
-                      a_61
+                      a_i0
                       (type)
                       (lam
-                        arg_0_62
-                        a_61
+                        arg_0_i0
+                        a_i2
                         (abs
-                          out_GHC_Base_Maybe_63
+                          out_GHC_Base_Maybe_i0
                           (type)
                           (lam
-                            case_GHC_Base_Just_64
-                            (fun a_61 out_GHC_Base_Maybe_63)
+                            case_GHC_Base_Just_i0
+                            (fun a_i4 out_GHC_Base_Maybe_i2)
                             (lam
-                              case_GHC_Base_Nothing_65
-                              out_GHC_Base_Maybe_63
-                              [ case_GHC_Base_Just_64 arg_0_62 ]
+                              case_GHC_Base_Nothing_i0
+                              out_GHC_Base_Maybe_i3
+                              [ case_GHC_Base_Just_i2 arg_0_i4 ]
                             )
                           )
                         )
@@ -118,57 +118,57 @@
                     )
                   ]
                   (abs
-                    a_66
+                    a_i0
                     (type)
                     (abs
-                      out_GHC_Base_Maybe_67
+                      out_GHC_Base_Maybe_i0
                       (type)
                       (lam
-                        case_GHC_Base_Just_68
-                        (fun a_66 out_GHC_Base_Maybe_67)
+                        case_GHC_Base_Just_i0
+                        (fun a_i3 out_GHC_Base_Maybe_i2)
                         (lam
-                          case_GHC_Base_Nothing_69
-                          out_GHC_Base_Maybe_67
-                          case_GHC_Base_Nothing_69
+                          case_GHC_Base_Nothing_i0
+                          out_GHC_Base_Maybe_i3
+                          case_GHC_Base_Nothing_i1
                         )
                       )
                     )
                   )
                 ]
                 (abs
-                  a_70
+                  a_i0
                   (type)
                   (lam
-                    x_71
-                    [(lam a_72 (type) (all out_GHC_Base_Maybe_73 (type) (fun (fun a_72 out_GHC_Base_Maybe_73) (fun out_GHC_Base_Maybe_73 out_GHC_Base_Maybe_73)))) a_70]
-                    x_71
+                    x_i0
+                    [(lam a_i0 (type) (all out_GHC_Base_Maybe_i0 (type) (fun (fun a_i2 out_GHC_Base_Maybe_i1) (fun out_GHC_Base_Maybe_i1 out_GHC_Base_Maybe_i1)))) a_i2]
+                    x_i1
                   )
                 )
               ]
             )
           )
         )
-        (lam a_74 (type) (lam b_75 (type) (all out_GHC_Tuple_Tuple2_76 (type) (fun (fun a_74 (fun b_75 out_GHC_Tuple_Tuple2_76)) out_GHC_Tuple_Tuple2_76))))
+        (lam a_i0 (type) (lam b_i0 (type) (all out_GHC_Tuple_Tuple2_i0 (type) (fun (fun a_i3 (fun b_i2 out_GHC_Tuple_Tuple2_i1)) out_GHC_Tuple_Tuple2_i1))))
       }
       (abs
-        a_77
+        a_i0
         (type)
         (abs
-          b_78
+          b_i0
           (type)
           (lam
-            arg_0_79
-            a_77
+            arg_0_i0
+            a_i3
             (lam
-              arg_1_80
-              b_78
+              arg_1_i0
+              b_i3
               (abs
-                out_GHC_Tuple_Tuple2_81
+                out_GHC_Tuple_Tuple2_i0
                 (type)
                 (lam
-                  case_GHC_Tuple_Tuple2_82
-                  (fun a_77 (fun b_78 out_GHC_Tuple_Tuple2_81))
-                  [ [ case_GHC_Tuple_Tuple2_82 arg_0_79 ] arg_1_80 ]
+                  case_GHC_Tuple_Tuple2_i0
+                  (fun a_i6 (fun b_i5 out_GHC_Tuple_Tuple2_i2))
+                  [ [ case_GHC_Tuple_Tuple2_i1 arg_0_i4 ] arg_1_i3 ]
                 )
               )
             )
@@ -177,15 +177,15 @@
       )
     ]
     (abs
-      a_83
+      a_i0
       (type)
       (abs
-        b_84
+        b_i0
         (type)
         (lam
-          x_85
-          [[(lam a_86 (type) (lam b_87 (type) (all out_GHC_Tuple_Tuple2_88 (type) (fun (fun a_86 (fun b_87 out_GHC_Tuple_Tuple2_88)) out_GHC_Tuple_Tuple2_88)))) a_83] b_84]
-          x_85
+          x_i0
+          [[(lam a_i0 (type) (lam b_i0 (type) (all out_GHC_Tuple_Tuple2_i0 (type) (fun (fun a_i3 (fun b_i2 out_GHC_Tuple_Tuple2_i1)) out_GHC_Tuple_Tuple2_i1)))) a_i3] b_i2]
+          x_i1
         )
       )
     )

--- a/plutus-tx-plugin/test/Lift/poly.plc.golden
+++ b/plutus-tx-plugin/test/Lift/poly.plc.golden
@@ -4,21 +4,21 @@
       [
         {
           (abs
-            Plugin_Spec_MyPolyData_17
+            Plugin_Spec_MyPolyData_i0
             (fun (type) (fun (type) (type)))
             (lam
-              Plugin_Spec_Poly1_18
-              (all a_19 (type) (all b_20 (type) (fun a_19 (fun b_20 [[Plugin_Spec_MyPolyData_17 a_19] b_20]))))
+              Plugin_Spec_Poly1_i0
+              (all a_i0 (type) (all b_i0 (type) (fun a_i2 (fun b_i1 [[Plugin_Spec_MyPolyData_i4 a_i2] b_i1]))))
               (lam
-                Plugin_Spec_Poly2_21
-                (all a_22 (type) (all b_23 (type) (fun a_22 [[Plugin_Spec_MyPolyData_17 a_22] b_23])))
+                Plugin_Spec_Poly2_i0
+                (all a_i0 (type) (all b_i0 (type) (fun a_i2 [[Plugin_Spec_MyPolyData_i5 a_i2] b_i1])))
                 (lam
-                  match_Plugin_Spec_MyPolyData_24
-                  (all a_25 (type) (all b_26 (type) (fun [[Plugin_Spec_MyPolyData_17 a_25] b_26] (all out_Plugin_Spec_MyPolyData_27 (type) (fun (fun a_25 (fun b_26 out_Plugin_Spec_MyPolyData_27)) (fun (fun a_25 out_Plugin_Spec_MyPolyData_27) out_Plugin_Spec_MyPolyData_27))))))
+                  match_Plugin_Spec_MyPolyData_i0
+                  (all a_i0 (type) (all b_i0 (type) (fun [[Plugin_Spec_MyPolyData_i6 a_i2] b_i1] (all out_Plugin_Spec_MyPolyData_i0 (type) (fun (fun a_i3 (fun b_i2 out_Plugin_Spec_MyPolyData_i1)) (fun (fun a_i3 out_Plugin_Spec_MyPolyData_i1) out_Plugin_Spec_MyPolyData_i1))))))
                   [
                     [
                       {
-                        { Plugin_Spec_Poly1_18 [(con integer) (con 8)] }
+                        { Plugin_Spec_Poly1_i3 [(con integer) (con 8)] }
                         [(con integer) (con 8)]
                       }
                       (con 8 ! 1)
@@ -29,30 +29,30 @@
               )
             )
           )
-          (lam a_28 (type) (lam b_29 (type) (all out_Plugin_Spec_MyPolyData_30 (type) (fun (fun a_28 (fun b_29 out_Plugin_Spec_MyPolyData_30)) (fun (fun a_28 out_Plugin_Spec_MyPolyData_30) out_Plugin_Spec_MyPolyData_30)))))
+          (lam a_i0 (type) (lam b_i0 (type) (all out_Plugin_Spec_MyPolyData_i0 (type) (fun (fun a_i3 (fun b_i2 out_Plugin_Spec_MyPolyData_i1)) (fun (fun a_i3 out_Plugin_Spec_MyPolyData_i1) out_Plugin_Spec_MyPolyData_i1)))))
         }
         (abs
-          a_31
+          a_i0
           (type)
           (abs
-            b_32
+            b_i0
             (type)
             (lam
-              arg_0_33
-              a_31
+              arg_0_i0
+              a_i3
               (lam
-                arg_1_34
-                b_32
+                arg_1_i0
+                b_i3
                 (abs
-                  out_Plugin_Spec_MyPolyData_35
+                  out_Plugin_Spec_MyPolyData_i0
                   (type)
                   (lam
-                    case_Plugin_Spec_Poly1_36
-                    (fun a_31 (fun b_32 out_Plugin_Spec_MyPolyData_35))
+                    case_Plugin_Spec_Poly1_i0
+                    (fun a_i6 (fun b_i5 out_Plugin_Spec_MyPolyData_i2))
                     (lam
-                      case_Plugin_Spec_Poly2_37
-                      (fun a_31 out_Plugin_Spec_MyPolyData_35)
-                      [ [ case_Plugin_Spec_Poly1_36 arg_0_33 ] arg_1_34 ]
+                      case_Plugin_Spec_Poly2_i0
+                      (fun a_i7 out_Plugin_Spec_MyPolyData_i3)
+                      [ [ case_Plugin_Spec_Poly1_i2 arg_0_i5 ] arg_1_i4 ]
                     )
                   )
                 )
@@ -62,24 +62,24 @@
         )
       ]
       (abs
-        a_38
+        a_i0
         (type)
         (abs
-          b_39
+          b_i0
           (type)
           (lam
-            arg_0_40
-            a_38
+            arg_0_i0
+            a_i3
             (abs
-              out_Plugin_Spec_MyPolyData_41
+              out_Plugin_Spec_MyPolyData_i0
               (type)
               (lam
-                case_Plugin_Spec_Poly1_42
-                (fun a_38 (fun b_39 out_Plugin_Spec_MyPolyData_41))
+                case_Plugin_Spec_Poly1_i0
+                (fun a_i5 (fun b_i4 out_Plugin_Spec_MyPolyData_i2))
                 (lam
-                  case_Plugin_Spec_Poly2_43
-                  (fun a_38 out_Plugin_Spec_MyPolyData_41)
-                  [ case_Plugin_Spec_Poly2_43 arg_0_40 ]
+                  case_Plugin_Spec_Poly2_i0
+                  (fun a_i6 out_Plugin_Spec_MyPolyData_i3)
+                  [ case_Plugin_Spec_Poly2_i1 arg_0_i4 ]
                 )
               )
             )
@@ -88,15 +88,15 @@
       )
     ]
     (abs
-      a_44
+      a_i0
       (type)
       (abs
-        b_45
+        b_i0
         (type)
         (lam
-          x_46
-          [[(lam a_47 (type) (lam b_48 (type) (all out_Plugin_Spec_MyPolyData_49 (type) (fun (fun a_47 (fun b_48 out_Plugin_Spec_MyPolyData_49)) (fun (fun a_47 out_Plugin_Spec_MyPolyData_49) out_Plugin_Spec_MyPolyData_49))))) a_44] b_45]
-          x_46
+          x_i0
+          [[(lam a_i0 (type) (lam b_i0 (type) (all out_Plugin_Spec_MyPolyData_i0 (type) (fun (fun a_i3 (fun b_i2 out_Plugin_Spec_MyPolyData_i1)) (fun (fun a_i3 out_Plugin_Spec_MyPolyData_i1) out_Plugin_Spec_MyPolyData_i1))))) a_i3] b_i2]
+          x_i1
         )
       )
     )

--- a/plutus-tx-plugin/test/Lift/record.plc.golden
+++ b/plutus-tx-plugin/test/Lift/record.plc.golden
@@ -3,42 +3,42 @@
     [
       {
         (abs
-          Plugin_Spec_MyMonoRecord_9
+          Plugin_Spec_MyMonoRecord_i0
           (type)
           (lam
-            Plugin_Spec_MyMonoRecord_10
-            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Plugin_Spec_MyMonoRecord_9))
+            Plugin_Spec_MyMonoRecord_i0
+            (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Plugin_Spec_MyMonoRecord_i2))
             (lam
-              match_Plugin_Spec_MyMonoRecord_11
-              (fun Plugin_Spec_MyMonoRecord_9 (all out_Plugin_Spec_MyMonoRecord_12 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoRecord_12)) out_Plugin_Spec_MyMonoRecord_12)))
-              [ [ Plugin_Spec_MyMonoRecord_10 (con 8 ! 1) ] (con 8 ! 2) ]
+              match_Plugin_Spec_MyMonoRecord_i0
+              (fun Plugin_Spec_MyMonoRecord_i3 (all out_Plugin_Spec_MyMonoRecord_i0 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoRecord_i1)) out_Plugin_Spec_MyMonoRecord_i1)))
+              [ [ Plugin_Spec_MyMonoRecord_i2 (con 8 ! 1) ] (con 8 ! 2) ]
             )
           )
         )
-        (all out_Plugin_Spec_MyMonoRecord_13 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoRecord_13)) out_Plugin_Spec_MyMonoRecord_13))
+        (all out_Plugin_Spec_MyMonoRecord_i0 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoRecord_i1)) out_Plugin_Spec_MyMonoRecord_i1))
       }
       (lam
-        arg_0_14
+        arg_0_i0
         [(con integer) (con 8)]
         (lam
-          arg_1_15
+          arg_1_i0
           [(con integer) (con 8)]
           (abs
-            out_Plugin_Spec_MyMonoRecord_16
+            out_Plugin_Spec_MyMonoRecord_i0
             (type)
             (lam
-              case_Plugin_Spec_MyMonoRecord_17
-              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoRecord_16))
-              [ [ case_Plugin_Spec_MyMonoRecord_17 arg_0_14 ] arg_1_15 ]
+              case_Plugin_Spec_MyMonoRecord_i0
+              (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoRecord_i2))
+              [ [ case_Plugin_Spec_MyMonoRecord_i1 arg_0_i4 ] arg_1_i3 ]
             )
           )
         )
       )
     ]
     (lam
-      x_18
-      (all out_Plugin_Spec_MyMonoRecord_19 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoRecord_19)) out_Plugin_Spec_MyMonoRecord_19))
-      x_18
+      x_i0
+      (all out_Plugin_Spec_MyMonoRecord_i0 (type) (fun (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] out_Plugin_Spec_MyMonoRecord_i1)) out_Plugin_Spec_MyMonoRecord_i1))
+      x_i1
     )
   ]
 )

--- a/plutus-tx-plugin/test/Lift/tuple.plc.golden
+++ b/plutus-tx-plugin/test/Lift/tuple.plc.golden
@@ -3,18 +3,18 @@
     [
       {
         (abs
-          GHC_Tuple_Tuple2_11
+          GHC_Tuple_Tuple2_i0
           (fun (type) (fun (type) (type)))
           (lam
-            GHC_Tuple_Tuple2_12
-            (all a_13 (type) (all b_14 (type) (fun a_13 (fun b_14 [[GHC_Tuple_Tuple2_11 a_13] b_14]))))
+            GHC_Tuple_Tuple2_i0
+            (all a_i0 (type) (all b_i0 (type) (fun a_i2 (fun b_i1 [[GHC_Tuple_Tuple2_i4 a_i2] b_i1]))))
             (lam
-              match_GHC_Tuple_Tuple2_15
-              (all a_16 (type) (all b_17 (type) (fun [[GHC_Tuple_Tuple2_11 a_16] b_17] (all out_GHC_Tuple_Tuple2_18 (type) (fun (fun a_16 (fun b_17 out_GHC_Tuple_Tuple2_18)) out_GHC_Tuple_Tuple2_18)))))
+              match_GHC_Tuple_Tuple2_i0
+              (all a_i0 (type) (all b_i0 (type) (fun [[GHC_Tuple_Tuple2_i5 a_i2] b_i1] (all out_GHC_Tuple_Tuple2_i0 (type) (fun (fun a_i3 (fun b_i2 out_GHC_Tuple_Tuple2_i1)) out_GHC_Tuple_Tuple2_i1)))))
               [
                 [
                   {
-                    { GHC_Tuple_Tuple2_12 [(con integer) (con 8)] }
+                    { GHC_Tuple_Tuple2_i2 [(con integer) (con 8)] }
                     [(con integer) (con 8)]
                   }
                   (con 8 ! 1)
@@ -24,27 +24,27 @@
             )
           )
         )
-        (lam a_19 (type) (lam b_20 (type) (all out_GHC_Tuple_Tuple2_21 (type) (fun (fun a_19 (fun b_20 out_GHC_Tuple_Tuple2_21)) out_GHC_Tuple_Tuple2_21))))
+        (lam a_i0 (type) (lam b_i0 (type) (all out_GHC_Tuple_Tuple2_i0 (type) (fun (fun a_i3 (fun b_i2 out_GHC_Tuple_Tuple2_i1)) out_GHC_Tuple_Tuple2_i1))))
       }
       (abs
-        a_22
+        a_i0
         (type)
         (abs
-          b_23
+          b_i0
           (type)
           (lam
-            arg_0_24
-            a_22
+            arg_0_i0
+            a_i3
             (lam
-              arg_1_25
-              b_23
+              arg_1_i0
+              b_i3
               (abs
-                out_GHC_Tuple_Tuple2_26
+                out_GHC_Tuple_Tuple2_i0
                 (type)
                 (lam
-                  case_GHC_Tuple_Tuple2_27
-                  (fun a_22 (fun b_23 out_GHC_Tuple_Tuple2_26))
-                  [ [ case_GHC_Tuple_Tuple2_27 arg_0_24 ] arg_1_25 ]
+                  case_GHC_Tuple_Tuple2_i0
+                  (fun a_i6 (fun b_i5 out_GHC_Tuple_Tuple2_i2))
+                  [ [ case_GHC_Tuple_Tuple2_i1 arg_0_i4 ] arg_1_i3 ]
                 )
               )
             )
@@ -53,15 +53,15 @@
       )
     ]
     (abs
-      a_28
+      a_i0
       (type)
       (abs
-        b_29
+        b_i0
         (type)
         (lam
-          x_30
-          [[(lam a_31 (type) (lam b_32 (type) (all out_GHC_Tuple_Tuple2_33 (type) (fun (fun a_31 (fun b_32 out_GHC_Tuple_Tuple2_33)) out_GHC_Tuple_Tuple2_33)))) a_28] b_29]
-          x_30
+          x_i0
+          [[(lam a_i0 (type) (lam b_i0 (type) (all out_GHC_Tuple_Tuple2_i0 (type) (fun (fun a_i3 (fun b_i2 out_GHC_Tuple_Tuple2_i1)) out_GHC_Tuple_Tuple2_i1)))) a_i3] b_i2]
+          x_i1
         )
       )
     )

--- a/plutus-tx-plugin/test/Plugin/Spec.hs
+++ b/plutus-tx-plugin/test/Plugin/Spec.hs
@@ -48,8 +48,8 @@ tests = testNested "Plugin" [
 
 basic :: TestNested
 basic = testNested "basic" [
-    goldenPlc "monoId" monoId
-  , goldenPlc "monoK" monoK
+    goldenPir "monoId" monoId
+  , goldenPir "monoK" monoK
   ]
 
 monoId :: CompiledCode (Int -> Int)
@@ -151,7 +151,7 @@ trace = plc @"trace" (\(x :: Builtins.String) -> Builtins.trace x)
 
 structure :: TestNested
 structure = testNested "structure" [
-    goldenPlc "letFun" letFun
+    goldenPir "letFun" letFun
   ]
 
 -- GHC acutually turns this into a lambda for us, try and make one that stays a let

--- a/plutus-tx-plugin/test/Plugin/basic/monoId.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/basic/monoId.plc.golden
@@ -1,3 +1,1 @@
-(program 1.0.0
-  (lam ds_78 [(con integer) (con 8)] ds_78)
-)
+(program (lam ds [(con integer) (con 8)] ds))

--- a/plutus-tx-plugin/test/Plugin/basic/monoK.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/basic/monoK.plc.golden
@@ -1,3 +1,1 @@
-(program 1.0.0
-  (lam ds_79 [(con integer) (con 8)] (lam ds_80 [(con integer) (con 8)] ds_79))
-)
+(program (lam ds [(con integer) (con 8)] (lam ds [(con integer) (con 8)] ds)))

--- a/plutus-tx-plugin/test/Plugin/recursiveTypes/sameEmptyRose.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/recursiveTypes/sameEmptyRose.plc.golden
@@ -3,69 +3,69 @@
     [
       {
         (abs
-          Unit_324
+          Unit_i0
           (type)
           (lam
-            Unit_325
-            Unit_324
+            Unit_i0
+            Unit_i2
             (lam
-              Unit_match_326
-              (fun Unit_324 (all out_Unit_327 (type) (fun out_Unit_327 out_Unit_327)))
+              Unit_match_i0
+              (fun Unit_i3 (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1)))
               [
                 [
                   [
                     {
                       (abs
-                        List_328
+                        List_i0
                         (fun (type) (type))
                         (lam
-                          Nil_329
-                          (all a_330 (type) [List_328 a_330])
+                          Nil_i0
+                          (all a_i0 (type) [List_i3 a_i1])
                           (lam
-                            Cons_331
-                            (all a_332 (type) (fun a_332 (fun [List_328 a_332] [List_328 a_332])))
+                            Cons_i0
+                            (all a_i0 (type) (fun a_i1 (fun [List_i4 a_i1] [List_i4 a_i1])))
                             (lam
-                              Nil_match_333
-                              (all a_334 (type) (fun [List_328 a_334] (all out_List_335 (type) (fun out_List_335 (fun (fun a_334 (fun [List_328 a_334] out_List_335)) out_List_335)))))
+                              Nil_match_i0
+                              (all a_i0 (type) (fun [List_i5 a_i1] (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i6 a_i2] out_List_i1)) out_List_i1)))))
                               [
                                 [
                                   {
                                     (abs
-                                      EmptyRose_336
+                                      EmptyRose_i0
                                       (type)
                                       (lam
-                                        EmptyRose_337
-                                        (fun [List_328 EmptyRose_336] EmptyRose_336)
+                                        EmptyRose_i0
+                                        (fun [List_i6 EmptyRose_i2] EmptyRose_i2)
                                         (lam
-                                          EmptyRose_match_338
-                                          (fun EmptyRose_336 (all out_EmptyRose_339 (type) (fun (fun [List_328 EmptyRose_336] out_EmptyRose_339) out_EmptyRose_339)))
+                                          EmptyRose_match_i0
+                                          (fun EmptyRose_i3 (all out_EmptyRose_i0 (type) (fun (fun [List_i8 EmptyRose_i4] out_EmptyRose_i1) out_EmptyRose_i1)))
                                           [
                                             (lam
-                                              tup_340
-                                              (all r_341 (type) (fun (fun (fun (fun EmptyRose_336 EmptyRose_336) (fun [List_328 EmptyRose_336] [List_328 EmptyRose_336])) r_341) r_341))
+                                              tup_i0
+                                              (all r_i0 (type) (fun (fun (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5])) r_i1) r_i1))
                                               [
                                                 (lam
-                                                  map_342
-                                                  (fun (fun EmptyRose_336 EmptyRose_336) (fun [List_328 EmptyRose_336] [List_328 EmptyRose_336]))
+                                                  map_i0
+                                                  (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5]))
                                                   [
                                                     (lam
-                                                      tup_343
-                                                      (all r_344 (type) (fun (fun (fun EmptyRose_336 EmptyRose_336) r_344) r_344))
+                                                      tup_i0
+                                                      (all r_i0 (type) (fun (fun (fun EmptyRose_i7 EmptyRose_i7) r_i1) r_i1))
                                                       [
                                                         (lam
-                                                          go_345
-                                                          (fun EmptyRose_336 EmptyRose_336)
-                                                          go_345
+                                                          go_i0
+                                                          (fun EmptyRose_i7 EmptyRose_i7)
+                                                          go_i1
                                                         )
                                                         [
                                                           {
-                                                            tup_343
-                                                            (fun EmptyRose_336 EmptyRose_336)
+                                                            tup_i1
+                                                            (fun EmptyRose_i6 EmptyRose_i6)
                                                           }
                                                           (lam
-                                                            arg_0_346
-                                                            (fun EmptyRose_336 EmptyRose_336)
-                                                            arg_0_346
+                                                            arg_0_i0
+                                                            (fun EmptyRose_i7 EmptyRose_i7)
+                                                            arg_0_i1
                                                           )
                                                         ]
                                                       ]
@@ -74,83 +74,83 @@
                                                       {
                                                         {
                                                           (abs
-                                                            a_347
+                                                            a_i0
                                                             (type)
                                                             (abs
-                                                              b_348
+                                                              b_i0
                                                               (type)
                                                               [
                                                                 {
                                                                   (abs
-                                                                    F_349
+                                                                    F_i0
                                                                     (fun (type) (type))
                                                                     (lam
-                                                                      by_350
-                                                                      (fun (all Q_351 (type) (fun [F_349 Q_351] Q_351)) (all Q_352 (type) (fun [F_349 Q_352] Q_352)))
+                                                                      by_i0
+                                                                      (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
                                                                       [
                                                                         {
                                                                           {
                                                                             (abs
-                                                                              a_353
+                                                                              a_i0
                                                                               (type)
                                                                               (abs
-                                                                                b_354
+                                                                                b_i0
                                                                                 (type)
                                                                                 (lam
-                                                                                  f_355
-                                                                                  (fun (fun a_353 b_354) (fun a_353 b_354))
+                                                                                  f_i0
+                                                                                  (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
                                                                                   [
                                                                                     {
                                                                                       (abs
-                                                                                        a_356
+                                                                                        a_i0
                                                                                         (type)
                                                                                         (lam
-                                                                                          s_357
-                                                                                          [(lam a_358 (type) (ifix (lam rec_359 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_360 (fun (fun (type) (type)) (type)) [spine_360 [(lam self_361 (fun (type) (type)) (lam a_362 (type) (fun [self_361 a_362] a_362))) (lam a_363 (type) [rec_359 (lam dat_364 (fun (type) (type)) [dat_364 a_363])])]])) (lam dat_365 (fun (type) (type)) [dat_365 a_358]))) a_356]
+                                                                                          s_i0
+                                                                                          [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i2]
                                                                                           [
                                                                                             (unwrap
-                                                                                              s_357
+                                                                                              s_i1
                                                                                             )
-                                                                                            s_357
+                                                                                            s_i1
                                                                                           ]
                                                                                         )
                                                                                       )
-                                                                                      (fun a_353 b_354)
+                                                                                      (fun a_i3 b_i2)
                                                                                     }
                                                                                     (iwrap
-                                                                                      (lam rec_366 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_367 (fun (fun (type) (type)) (type)) [spine_367 [(lam self_368 (fun (type) (type)) (lam a_369 (type) (fun [self_368 a_369] a_369))) (lam a_370 (type) [rec_366 (lam dat_371 (fun (type) (type)) [dat_371 a_370])])]]))
-                                                                                      (lam dat_372 (fun (type) (type)) [dat_372 (fun a_353 b_354)])
+                                                                                      (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]]))
+                                                                                      (lam dat_i0 (fun (type) (type)) [dat_i1 (fun a_i4 b_i3)])
                                                                                       (lam
-                                                                                        s_373
-                                                                                        [(lam a_374 (type) (ifix (lam rec_375 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_376 (fun (fun (type) (type)) (type)) [spine_376 [(lam self_377 (fun (type) (type)) (lam a_378 (type) (fun [self_377 a_378] a_378))) (lam a_379 (type) [rec_375 (lam dat_380 (fun (type) (type)) [dat_380 a_379])])]])) (lam dat_381 (fun (type) (type)) [dat_381 a_374]))) (fun a_353 b_354)]
+                                                                                        s_i0
+                                                                                        [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) (fun a_i4 b_i3)]
                                                                                         (lam
-                                                                                          x_382
-                                                                                          a_353
+                                                                                          x_i0
+                                                                                          a_i5
                                                                                           [
                                                                                             [
-                                                                                              f_355
+                                                                                              f_i3
                                                                                               [
                                                                                                 {
                                                                                                   (abs
-                                                                                                    a_383
+                                                                                                    a_i0
                                                                                                     (type)
                                                                                                     (lam
-                                                                                                      s_384
-                                                                                                      [(lam a_385 (type) (ifix (lam rec_386 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_387 (fun (fun (type) (type)) (type)) [spine_387 [(lam self_388 (fun (type) (type)) (lam a_389 (type) (fun [self_388 a_389] a_389))) (lam a_390 (type) [rec_386 (lam dat_391 (fun (type) (type)) [dat_391 a_390])])]])) (lam dat_392 (fun (type) (type)) [dat_392 a_385]))) a_383]
+                                                                                                      s_i0
+                                                                                                      [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i2]
                                                                                                       [
                                                                                                         (unwrap
-                                                                                                          s_384
+                                                                                                          s_i1
                                                                                                         )
-                                                                                                        s_384
+                                                                                                        s_i1
                                                                                                       ]
                                                                                                     )
                                                                                                   )
-                                                                                                  (fun a_353 b_354)
+                                                                                                  (fun a_i5 b_i4)
                                                                                                 }
-                                                                                                s_373
+                                                                                                s_i2
                                                                                               ]
                                                                                             ]
-                                                                                            x_382
+                                                                                            x_i1
                                                                                           ]
                                                                                         )
                                                                                       )
@@ -159,54 +159,54 @@
                                                                                 )
                                                                               )
                                                                             )
-                                                                            (all Q_393 (type) (fun [F_349 Q_393] [F_349 Q_393]))
+                                                                            (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
                                                                           }
-                                                                          (all Q_394 (type) (fun [F_349 Q_394] Q_394))
+                                                                          (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
                                                                         }
                                                                         (lam
-                                                                          rec_395
-                                                                          (fun (all Q_396 (type) (fun [F_349 Q_396] [F_349 Q_396])) (all Q_397 (type) (fun [F_349 Q_397] Q_397)))
+                                                                          rec_i0
+                                                                          (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
                                                                           (lam
-                                                                            h_398
-                                                                            (all Q_399 (type) (fun [F_349 Q_399] [F_349 Q_399]))
+                                                                            h_i0
+                                                                            (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
                                                                             (abs
-                                                                              R_400
+                                                                              R_i0
                                                                               (type)
                                                                               (lam
-                                                                                fr_401
-                                                                                [F_349 R_400]
+                                                                                fr_i0
+                                                                                [F_i6 R_i2]
                                                                                 [
                                                                                   {
                                                                                     [
-                                                                                      by_350
+                                                                                      by_i5
                                                                                       (abs
-                                                                                        Q_402
+                                                                                        Q_i0
                                                                                         (type)
                                                                                         (lam
-                                                                                          fq_403
-                                                                                          [F_349 Q_402]
+                                                                                          fq_i0
+                                                                                          [F_i8 Q_i2]
                                                                                           [
                                                                                             {
                                                                                               [
-                                                                                                rec_395
-                                                                                                h_398
+                                                                                                rec_i6
+                                                                                                h_i5
                                                                                               ]
-                                                                                              Q_402
+                                                                                              Q_i2
                                                                                             }
                                                                                             [
                                                                                               {
-                                                                                                h_398
-                                                                                                Q_402
+                                                                                                h_i5
+                                                                                                Q_i2
                                                                                               }
-                                                                                              fq_403
+                                                                                              fq_i1
                                                                                             ]
                                                                                           ]
                                                                                         )
                                                                                       )
                                                                                     ]
-                                                                                    R_400
+                                                                                    R_i2
                                                                                   }
-                                                                                  fr_401
+                                                                                  fr_i1
                                                                                 ]
                                                                               )
                                                                             )
@@ -215,33 +215,33 @@
                                                                       ]
                                                                     )
                                                                   )
-                                                                  (lam X_404 (type) (fun (fun a_347 b_348) X_404))
+                                                                  (lam X_i0 (type) (fun (fun a_i3 b_i2) X_i1))
                                                                 }
                                                                 (lam
-                                                                  k_405
-                                                                  (all Q_406 (type) (fun (fun (fun a_347 b_348) Q_406) Q_406))
+                                                                  k_i0
+                                                                  (all Q_i0 (type) (fun (fun (fun a_i4 b_i3) Q_i1) Q_i1))
                                                                   (abs
-                                                                    S_407
+                                                                    S_i0
                                                                     (type)
                                                                     (lam
-                                                                      h_408
-                                                                      (fun (fun a_347 b_348) S_407)
+                                                                      h_i0
+                                                                      (fun (fun a_i5 b_i4) S_i2)
                                                                       [
-                                                                        h_408
+                                                                        h_i1
                                                                         (lam
-                                                                          x_409
-                                                                          a_347
+                                                                          x_i0
+                                                                          a_i6
                                                                           [
                                                                             {
-                                                                              k_405
-                                                                              b_348
+                                                                              k_i4
+                                                                              b_i5
                                                                             }
                                                                             (lam
-                                                                              f_410
-                                                                              (fun a_347 b_348)
+                                                                              f_i0
+                                                                              (fun a_i7 b_i6)
                                                                               [
-                                                                                f_410
-                                                                                x_409
+                                                                                f_i1
+                                                                                x_i2
                                                                               ]
                                                                             )
                                                                           ]
@@ -253,51 +253,51 @@
                                                               ]
                                                             )
                                                           )
-                                                          EmptyRose_336
+                                                          EmptyRose_i5
                                                         }
-                                                        EmptyRose_336
+                                                        EmptyRose_i5
                                                       }
                                                       (abs
-                                                        Q_411
+                                                        Q_i0
                                                         (type)
                                                         (lam
-                                                          choose_412
-                                                          (fun (fun EmptyRose_336 EmptyRose_336) Q_411)
+                                                          choose_i0
+                                                          (fun (fun EmptyRose_i7 EmptyRose_i7) Q_i2)
                                                           (lam
-                                                            go_413
-                                                            (fun EmptyRose_336 EmptyRose_336)
+                                                            go_i0
+                                                            (fun EmptyRose_i8 EmptyRose_i8)
                                                             [
-                                                              choose_412
+                                                              choose_i2
                                                               (lam
-                                                                x_414
-                                                                EmptyRose_336
+                                                                x_i0
+                                                                EmptyRose_i9
                                                                 [
-                                                                  EmptyRose_337
+                                                                  EmptyRose_i8
                                                                   [
                                                                     [
-                                                                      map_342
-                                                                      go_413
+                                                                      map_i5
+                                                                      go_i2
                                                                     ]
                                                                     [
                                                                       (lam
-                                                                        ds_415
-                                                                        EmptyRose_336
+                                                                        ds_i0
+                                                                        EmptyRose_i10
                                                                         [
                                                                           {
                                                                             [
-                                                                              EmptyRose_match_338
-                                                                              ds_415
+                                                                              EmptyRose_match_i8
+                                                                              ds_i1
                                                                             ]
-                                                                            [List_328 EmptyRose_336]
+                                                                            [List_i14 EmptyRose_i10]
                                                                           }
                                                                           (lam
-                                                                            inner_416
-                                                                            [List_328 EmptyRose_336]
-                                                                            inner_416
+                                                                            inner_i0
+                                                                            [List_i15 EmptyRose_i11]
+                                                                            inner_i1
                                                                           )
                                                                         ]
                                                                       )
-                                                                      x_414
+                                                                      x_i1
                                                                     ]
                                                                   ]
                                                                 ]
@@ -311,13 +311,13 @@
                                                 )
                                                 [
                                                   {
-                                                    tup_340
-                                                    (fun (fun EmptyRose_336 EmptyRose_336) (fun [List_328 EmptyRose_336] [List_328 EmptyRose_336]))
+                                                    tup_i1
+                                                    (fun (fun EmptyRose_i4 EmptyRose_i4) (fun [List_i8 EmptyRose_i4] [List_i8 EmptyRose_i4]))
                                                   }
                                                   (lam
-                                                    arg_0_417
-                                                    (fun (fun EmptyRose_336 EmptyRose_336) (fun [List_328 EmptyRose_336] [List_328 EmptyRose_336]))
-                                                    arg_0_417
+                                                    arg_0_i0
+                                                    (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5]))
+                                                    arg_0_i1
                                                   )
                                                 ]
                                               ]
@@ -326,83 +326,83 @@
                                               {
                                                 {
                                                   (abs
-                                                    a_418
+                                                    a_i0
                                                     (type)
                                                     (abs
-                                                      b_419
+                                                      b_i0
                                                       (type)
                                                       [
                                                         {
                                                           (abs
-                                                            F_420
+                                                            F_i0
                                                             (fun (type) (type))
                                                             (lam
-                                                              by_421
-                                                              (fun (all Q_422 (type) (fun [F_420 Q_422] Q_422)) (all Q_423 (type) (fun [F_420 Q_423] Q_423)))
+                                                              by_i0
+                                                              (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
                                                               [
                                                                 {
                                                                   {
                                                                     (abs
-                                                                      a_424
+                                                                      a_i0
                                                                       (type)
                                                                       (abs
-                                                                        b_425
+                                                                        b_i0
                                                                         (type)
                                                                         (lam
-                                                                          f_426
-                                                                          (fun (fun a_424 b_425) (fun a_424 b_425))
+                                                                          f_i0
+                                                                          (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
                                                                           [
                                                                             {
                                                                               (abs
-                                                                                a_427
+                                                                                a_i0
                                                                                 (type)
                                                                                 (lam
-                                                                                  s_428
-                                                                                  [(lam a_429 (type) (ifix (lam rec_430 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_431 (fun (fun (type) (type)) (type)) [spine_431 [(lam self_432 (fun (type) (type)) (lam a_433 (type) (fun [self_432 a_433] a_433))) (lam a_434 (type) [rec_430 (lam dat_435 (fun (type) (type)) [dat_435 a_434])])]])) (lam dat_436 (fun (type) (type)) [dat_436 a_429]))) a_427]
+                                                                                  s_i0
+                                                                                  [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i2]
                                                                                   [
                                                                                     (unwrap
-                                                                                      s_428
+                                                                                      s_i1
                                                                                     )
-                                                                                    s_428
+                                                                                    s_i1
                                                                                   ]
                                                                                 )
                                                                               )
-                                                                              (fun a_424 b_425)
+                                                                              (fun a_i3 b_i2)
                                                                             }
                                                                             (iwrap
-                                                                              (lam rec_437 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_438 (fun (fun (type) (type)) (type)) [spine_438 [(lam self_439 (fun (type) (type)) (lam a_440 (type) (fun [self_439 a_440] a_440))) (lam a_441 (type) [rec_437 (lam dat_442 (fun (type) (type)) [dat_442 a_441])])]]))
-                                                                              (lam dat_443 (fun (type) (type)) [dat_443 (fun a_424 b_425)])
+                                                                              (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]]))
+                                                                              (lam dat_i0 (fun (type) (type)) [dat_i1 (fun a_i4 b_i3)])
                                                                               (lam
-                                                                                s_444
-                                                                                [(lam a_445 (type) (ifix (lam rec_446 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_447 (fun (fun (type) (type)) (type)) [spine_447 [(lam self_448 (fun (type) (type)) (lam a_449 (type) (fun [self_448 a_449] a_449))) (lam a_450 (type) [rec_446 (lam dat_451 (fun (type) (type)) [dat_451 a_450])])]])) (lam dat_452 (fun (type) (type)) [dat_452 a_445]))) (fun a_424 b_425)]
+                                                                                s_i0
+                                                                                [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) (fun a_i4 b_i3)]
                                                                                 (lam
-                                                                                  x_453
-                                                                                  a_424
+                                                                                  x_i0
+                                                                                  a_i5
                                                                                   [
                                                                                     [
-                                                                                      f_426
+                                                                                      f_i3
                                                                                       [
                                                                                         {
                                                                                           (abs
-                                                                                            a_454
+                                                                                            a_i0
                                                                                             (type)
                                                                                             (lam
-                                                                                              s_455
-                                                                                              [(lam a_456 (type) (ifix (lam rec_457 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_458 (fun (fun (type) (type)) (type)) [spine_458 [(lam self_459 (fun (type) (type)) (lam a_460 (type) (fun [self_459 a_460] a_460))) (lam a_461 (type) [rec_457 (lam dat_462 (fun (type) (type)) [dat_462 a_461])])]])) (lam dat_463 (fun (type) (type)) [dat_463 a_456]))) a_454]
+                                                                                              s_i0
+                                                                                              [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i2]
                                                                                               [
                                                                                                 (unwrap
-                                                                                                  s_455
+                                                                                                  s_i1
                                                                                                 )
-                                                                                                s_455
+                                                                                                s_i1
                                                                                               ]
                                                                                             )
                                                                                           )
-                                                                                          (fun a_424 b_425)
+                                                                                          (fun a_i5 b_i4)
                                                                                         }
-                                                                                        s_444
+                                                                                        s_i2
                                                                                       ]
                                                                                     ]
-                                                                                    x_453
+                                                                                    x_i1
                                                                                   ]
                                                                                 )
                                                                               )
@@ -411,54 +411,54 @@
                                                                         )
                                                                       )
                                                                     )
-                                                                    (all Q_464 (type) (fun [F_420 Q_464] [F_420 Q_464]))
+                                                                    (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
                                                                   }
-                                                                  (all Q_465 (type) (fun [F_420 Q_465] Q_465))
+                                                                  (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
                                                                 }
                                                                 (lam
-                                                                  rec_466
-                                                                  (fun (all Q_467 (type) (fun [F_420 Q_467] [F_420 Q_467])) (all Q_468 (type) (fun [F_420 Q_468] Q_468)))
+                                                                  rec_i0
+                                                                  (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
                                                                   (lam
-                                                                    h_469
-                                                                    (all Q_470 (type) (fun [F_420 Q_470] [F_420 Q_470]))
+                                                                    h_i0
+                                                                    (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
                                                                     (abs
-                                                                      R_471
+                                                                      R_i0
                                                                       (type)
                                                                       (lam
-                                                                        fr_472
-                                                                        [F_420 R_471]
+                                                                        fr_i0
+                                                                        [F_i6 R_i2]
                                                                         [
                                                                           {
                                                                             [
-                                                                              by_421
+                                                                              by_i5
                                                                               (abs
-                                                                                Q_473
+                                                                                Q_i0
                                                                                 (type)
                                                                                 (lam
-                                                                                  fq_474
-                                                                                  [F_420 Q_473]
+                                                                                  fq_i0
+                                                                                  [F_i8 Q_i2]
                                                                                   [
                                                                                     {
                                                                                       [
-                                                                                        rec_466
-                                                                                        h_469
+                                                                                        rec_i6
+                                                                                        h_i5
                                                                                       ]
-                                                                                      Q_473
+                                                                                      Q_i2
                                                                                     }
                                                                                     [
                                                                                       {
-                                                                                        h_469
-                                                                                        Q_473
+                                                                                        h_i5
+                                                                                        Q_i2
                                                                                       }
-                                                                                      fq_474
+                                                                                      fq_i1
                                                                                     ]
                                                                                   ]
                                                                                 )
                                                                               )
                                                                             ]
-                                                                            R_471
+                                                                            R_i2
                                                                           }
-                                                                          fr_472
+                                                                          fr_i1
                                                                         ]
                                                                       )
                                                                     )
@@ -467,33 +467,32 @@
                                                               ]
                                                             )
                                                           )
-                                                          (lam X_475 (type) (fun (fun a_418 b_419) X_475))
+                                                          (lam X_i0 (type) (fun (fun a_i3 b_i2) X_i1))
                                                         }
                                                         (lam
-                                                          k_476
-                                                          (all Q_477 (type) (fun (fun (fun a_418 b_419) Q_477) Q_477))
+                                                          k_i0
+                                                          (all Q_i0 (type) (fun (fun (fun a_i4 b_i3) Q_i1) Q_i1))
                                                           (abs
-                                                            S_478
+                                                            S_i0
                                                             (type)
                                                             (lam
-                                                              h_479
-                                                              (fun (fun a_418 b_419) S_478)
+                                                              h_i0
+                                                              (fun (fun a_i5 b_i4) S_i2)
                                                               [
-                                                                h_479
+                                                                h_i1
                                                                 (lam
-                                                                  x_480
-                                                                  a_418
+                                                                  x_i0
+                                                                  a_i6
                                                                   [
                                                                     {
-                                                                      k_476
-                                                                      b_419
+                                                                      k_i4 b_i5
                                                                     }
                                                                     (lam
-                                                                      f_481
-                                                                      (fun a_418 b_419)
+                                                                      f_i0
+                                                                      (fun a_i7 b_i6)
                                                                       [
-                                                                        f_481
-                                                                        x_480
+                                                                        f_i1
+                                                                        x_i2
                                                                       ]
                                                                     )
                                                                   ]
@@ -505,82 +504,82 @@
                                                       ]
                                                     )
                                                   )
-                                                  (fun EmptyRose_336 EmptyRose_336)
+                                                  (fun EmptyRose_i3 EmptyRose_i3)
                                                 }
-                                                (fun [List_328 EmptyRose_336] [List_328 EmptyRose_336])
+                                                (fun [List_i7 EmptyRose_i3] [List_i7 EmptyRose_i3])
                                               }
                                               (abs
-                                                Q_482
+                                                Q_i0
                                                 (type)
                                                 (lam
-                                                  choose_483
-                                                  (fun (fun (fun EmptyRose_336 EmptyRose_336) (fun [List_328 EmptyRose_336] [List_328 EmptyRose_336])) Q_482)
+                                                  choose_i0
+                                                  (fun (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5])) Q_i2)
                                                   (lam
-                                                    map_484
-                                                    (fun (fun EmptyRose_336 EmptyRose_336) (fun [List_328 EmptyRose_336] [List_328 EmptyRose_336]))
+                                                    map_i0
+                                                    (fun (fun EmptyRose_i6 EmptyRose_i6) (fun [List_i10 EmptyRose_i6] [List_i10 EmptyRose_i6]))
                                                     [
-                                                      choose_483
+                                                      choose_i2
                                                       (lam
-                                                        ds_485
-                                                        (fun EmptyRose_336 EmptyRose_336)
+                                                        ds_i0
+                                                        (fun EmptyRose_i7 EmptyRose_i7)
                                                         (lam
-                                                          ds_486
-                                                          [List_328 EmptyRose_336]
+                                                          ds_i0
+                                                          [List_i12 EmptyRose_i8]
                                                           [
                                                             [
                                                               [
                                                                 {
                                                                   [
                                                                     {
-                                                                      Nil_match_333
-                                                                      EmptyRose_336
+                                                                      Nil_match_i9
+                                                                      EmptyRose_i8
                                                                     }
-                                                                    ds_486
+                                                                    ds_i1
                                                                   ]
-                                                                  (fun Unit_324 [List_328 EmptyRose_336])
+                                                                  (fun Unit_i15 [List_i12 EmptyRose_i8])
                                                                 }
                                                                 (lam
-                                                                  thunk_487
-                                                                  Unit_324
+                                                                  thunk_i0
+                                                                  Unit_i16
                                                                   {
-                                                                    Nil_329
-                                                                    EmptyRose_336
+                                                                    Nil_i12
+                                                                    EmptyRose_i9
                                                                   }
                                                                 )
                                                               ]
                                                               (lam
-                                                                x_488
-                                                                EmptyRose_336
+                                                                x_i0
+                                                                EmptyRose_i9
                                                                 (lam
-                                                                  xs_489
-                                                                  [List_328 EmptyRose_336]
+                                                                  xs_i0
+                                                                  [List_i14 EmptyRose_i10]
                                                                   (lam
-                                                                    thunk_490
-                                                                    Unit_324
+                                                                    thunk_i0
+                                                                    Unit_i18
                                                                     [
                                                                       [
                                                                         {
-                                                                          Cons_331
-                                                                          EmptyRose_336
+                                                                          Cons_i13
+                                                                          EmptyRose_i11
                                                                         }
                                                                         [
-                                                                          ds_485
-                                                                          x_488
+                                                                          ds_i5
+                                                                          x_i3
                                                                         ]
                                                                       ]
                                                                       [
                                                                         [
-                                                                          map_484
-                                                                          ds_485
+                                                                          map_i6
+                                                                          ds_i5
                                                                         ]
-                                                                        xs_489
+                                                                        xs_i2
                                                                       ]
                                                                     ]
                                                                   )
                                                                 )
                                                               )
                                                             ]
-                                                            Unit_325
+                                                            Unit_i14
                                                           ]
                                                         )
                                                       )
@@ -593,54 +592,54 @@
                                         )
                                       )
                                     )
-                                    (ifix (lam rec_491 (fun (fun (type) (type)) (type)) (lam spine_492 (fun (type) (type)) [spine_492 [(lam EmptyRose_493 (type) (all out_EmptyRose_494 (type) (fun (fun [List_328 EmptyRose_493] out_EmptyRose_494) out_EmptyRose_494))) [rec_491 (lam dat_495 (type) dat_495)]]])) (lam dat_496 (type) dat_496))
+                                    (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i8 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))
                                   }
                                   (lam
-                                    arg_0_497
-                                    [List_328 (ifix (lam rec_498 (fun (fun (type) (type)) (type)) (lam spine_499 (fun (type) (type)) [spine_499 [(lam EmptyRose_500 (type) (all out_EmptyRose_501 (type) (fun (fun [List_328 EmptyRose_500] out_EmptyRose_501) out_EmptyRose_501))) [rec_498 (lam dat_502 (type) dat_502)]]])) (lam dat_503 (type) dat_503))]
+                                    arg_0_i0
+                                    [List_i5 (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i9 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))]
                                     (iwrap
-                                      (lam rec_504 (fun (fun (type) (type)) (type)) (lam spine_505 (fun (type) (type)) [spine_505 [(lam EmptyRose_506 (type) (all out_EmptyRose_507 (type) (fun (fun [List_328 EmptyRose_506] out_EmptyRose_507) out_EmptyRose_507))) [rec_504 (lam dat_508 (type) dat_508)]]]))
-                                      (lam dat_509 (type) dat_509)
+                                      (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i9 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))) [rec_i2 (lam dat_i0 (type) dat_i1)]]]))
+                                      (lam dat_i0 (type) dat_i1)
                                       (abs
-                                        out_EmptyRose_510
+                                        out_EmptyRose_i0
                                         (type)
                                         (lam
-                                          case_EmptyRose_511
-                                          (fun [List_328 (ifix (lam rec_512 (fun (fun (type) (type)) (type)) (lam spine_513 (fun (type) (type)) [spine_513 [(lam EmptyRose_514 (type) (all out_EmptyRose_515 (type) (fun (fun [List_328 EmptyRose_514] out_EmptyRose_515) out_EmptyRose_515))) [rec_512 (lam dat_516 (type) dat_516)]]])) (lam dat_517 (type) dat_517))] out_EmptyRose_510)
-                                          [ case_EmptyRose_511 arg_0_497 ]
+                                          case_EmptyRose_i0
+                                          (fun [List_i7 (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i11 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))] out_EmptyRose_i2)
+                                          [ case_EmptyRose_i1 arg_0_i3 ]
                                         )
                                       )
                                     )
                                   )
                                 ]
                                 (lam
-                                  x_518
-                                  (ifix (lam rec_519 (fun (fun (type) (type)) (type)) (lam spine_520 (fun (type) (type)) [spine_520 [(lam EmptyRose_521 (type) (all out_EmptyRose_522 (type) (fun (fun [List_328 EmptyRose_521] out_EmptyRose_522) out_EmptyRose_522))) [rec_519 (lam dat_523 (type) dat_523)]]])) (lam dat_524 (type) dat_524))
-                                  (unwrap x_518)
+                                  x_i0
+                                  (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam spine_i0 (fun (type) (type)) [spine_i1 [(lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i9 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))) [rec_i2 (lam dat_i0 (type) dat_i1)]]])) (lam dat_i0 (type) dat_i1))
+                                  (unwrap x_i1)
                                 )
                               ]
                             )
                           )
                         )
                       )
-                      (lam a_525 (type) (ifix (lam rec_526 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_527 (fun (fun (type) (type)) (type)) [spine_527 [(lam List_528 (fun (type) (type)) (lam a_529 (type) (all out_List_530 (type) (fun out_List_530 (fun (fun a_529 (fun [List_528 a_529] out_List_530)) out_List_530))))) (lam a_531 (type) [rec_526 (lam dat_532 (fun (type) (type)) [dat_532 a_531])])]])) (lam dat_533 (fun (type) (type)) [dat_533 a_525])))
+                      (lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])))
                     }
                     (abs
-                      a_534
+                      a_i0
                       (type)
                       (iwrap
-                        (lam rec_535 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_536 (fun (fun (type) (type)) (type)) [spine_536 [(lam List_537 (fun (type) (type)) (lam a_538 (type) (all out_List_539 (type) (fun out_List_539 (fun (fun a_538 (fun [List_537 a_538] out_List_539)) out_List_539))))) (lam a_540 (type) [rec_535 (lam dat_541 (fun (type) (type)) [dat_541 a_540])])]]))
-                        (lam dat_542 (fun (type) (type)) [dat_542 a_534])
+                        (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]]))
+                        (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])
                         (abs
-                          out_List_543
+                          out_List_i0
                           (type)
                           (lam
-                            case_Nil_544
-                            out_List_543
+                            case_Nil_i0
+                            out_List_i2
                             (lam
-                              case_Cons_545
-                              (fun a_534 (fun [(lam a_546 (type) (ifix (lam rec_547 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_548 (fun (fun (type) (type)) (type)) [spine_548 [(lam List_549 (fun (type) (type)) (lam a_550 (type) (all out_List_551 (type) (fun out_List_551 (fun (fun a_550 (fun [List_549 a_550] out_List_551)) out_List_551))))) (lam a_552 (type) [rec_547 (lam dat_553 (fun (type) (type)) [dat_553 a_552])])]])) (lam dat_554 (fun (type) (type)) [dat_554 a_546]))) a_534] out_List_543))
-                              case_Nil_544
+                              case_Cons_i0
+                              (fun a_i4 (fun [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i4] out_List_i3))
+                              case_Nil_i2
                             )
                           )
                         )
@@ -648,27 +647,27 @@
                     )
                   ]
                   (abs
-                    a_555
+                    a_i0
                     (type)
                     (lam
-                      arg_0_556
-                      a_555
+                      arg_0_i0
+                      a_i2
                       (lam
-                        arg_1_557
-                        [(lam a_558 (type) (ifix (lam rec_559 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_560 (fun (fun (type) (type)) (type)) [spine_560 [(lam List_561 (fun (type) (type)) (lam a_562 (type) (all out_List_563 (type) (fun out_List_563 (fun (fun a_562 (fun [List_561 a_562] out_List_563)) out_List_563))))) (lam a_564 (type) [rec_559 (lam dat_565 (fun (type) (type)) [dat_565 a_564])])]])) (lam dat_566 (fun (type) (type)) [dat_566 a_558]))) a_555]
+                        arg_1_i0
+                        [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i3]
                         (iwrap
-                          (lam rec_567 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_568 (fun (fun (type) (type)) (type)) [spine_568 [(lam List_569 (fun (type) (type)) (lam a_570 (type) (all out_List_571 (type) (fun out_List_571 (fun (fun a_570 (fun [List_569 a_570] out_List_571)) out_List_571))))) (lam a_572 (type) [rec_567 (lam dat_573 (fun (type) (type)) [dat_573 a_572])])]]))
-                          (lam dat_574 (fun (type) (type)) [dat_574 a_555])
+                          (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]]))
+                          (lam dat_i0 (fun (type) (type)) [dat_i1 a_i4])
                           (abs
-                            out_List_575
+                            out_List_i0
                             (type)
                             (lam
-                              case_Nil_576
-                              out_List_575
+                              case_Nil_i0
+                              out_List_i2
                               (lam
-                                case_Cons_577
-                                (fun a_555 (fun [(lam a_578 (type) (ifix (lam rec_579 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_580 (fun (fun (type) (type)) (type)) [spine_580 [(lam List_581 (fun (type) (type)) (lam a_582 (type) (all out_List_583 (type) (fun out_List_583 (fun (fun a_582 (fun [List_581 a_582] out_List_583)) out_List_583))))) (lam a_584 (type) [rec_579 (lam dat_585 (fun (type) (type)) [dat_585 a_584])])]])) (lam dat_586 (fun (type) (type)) [dat_586 a_578]))) a_555] out_List_575))
-                                [ [ case_Cons_577 arg_0_556 ] arg_1_557 ]
+                                case_Cons_i0
+                                (fun a_i6 (fun [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i6] out_List_i3))
+                                [ [ case_Cons_i1 arg_0_i5 ] arg_1_i4 ]
                               )
                             )
                           )
@@ -678,22 +677,22 @@
                   )
                 ]
                 (abs
-                  a_587
+                  a_i0
                   (type)
                   (lam
-                    x_588
-                    [(lam a_589 (type) (ifix (lam rec_590 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_591 (fun (fun (type) (type)) (type)) [spine_591 [(lam List_592 (fun (type) (type)) (lam a_593 (type) (all out_List_594 (type) (fun out_List_594 (fun (fun a_593 (fun [List_592 a_593] out_List_594)) out_List_594))))) (lam a_595 (type) [rec_590 (lam dat_596 (fun (type) (type)) [dat_596 a_595])])]])) (lam dat_597 (fun (type) (type)) [dat_597 a_589]))) a_587]
-                    (unwrap x_588)
+                    x_i0
+                    [(lam a_i0 (type) (ifix (lam rec_i0 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_i0 (fun (fun (type) (type)) (type)) [spine_i1 [(lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) (lam a_i0 (type) [rec_i3 (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2])])]])) (lam dat_i0 (fun (type) (type)) [dat_i1 a_i2]))) a_i2]
+                    (unwrap x_i1)
                   )
                 )
               ]
             )
           )
         )
-        (all out_Unit_598 (type) (fun out_Unit_598 out_Unit_598))
+        (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1))
       }
-      (abs out_Unit_599 (type) (lam case_Unit_600 out_Unit_599 case_Unit_600))
+      (abs out_Unit_i0 (type) (lam case_Unit_i0 out_Unit_i2 case_Unit_i1))
     ]
-    (lam x_601 (all out_Unit_602 (type) (fun out_Unit_602 out_Unit_602)) x_601)
+    (lam x_i0 (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1)) x_i1)
   ]
 )

--- a/plutus-tx-plugin/test/Plugin/structure/letFun.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/structure/letFun.plc.golden
@@ -1,91 +1,45 @@
-(program 1.0.0
-  [
-    [
-      [
-        {
-          (abs
-            Bool_88
-            (type)
-            (lam
-              True_89
-              Bool_88
-              (lam
-                False_90
-                Bool_88
-                (lam
-                  Bool_match_91
-                  (fun Bool_88 (all out_Bool_92 (type) (fun out_Bool_92 (fun out_Bool_92 out_Bool_92))))
-                  [
-                    (lam
-                      equalsInteger_93
-                      (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool_88))
-                      (lam
-                        ds_94
-                        [(con integer) (con 8)]
-                        (lam
-                          ds_95
-                          [(con integer) (con 8)]
-                          [
-                            (lam
-                              z_96
-                              [(con integer) (con 8)]
-                              [ [ equalsInteger_93 ds_94 ] z_96 ]
-                            )
-                            ds_95
-                          ]
-                        )
-                      )
-                    )
-                    (lam
-                      arg_97
-                      [(con integer) (con 8)]
-                      (lam
-                        arg_98
-                        [(con integer) (con 8)]
-                        [
-                          (lam
-                            b_99
-                            (all a_100 (type) (fun a_100 (fun a_100 a_100)))
-                            [ [ { b_99 Bool_88 } True_89 ] False_90 ]
-                          )
-                          [
-                            [ { (builtin equalsInteger) (con 8) } arg_97 ]
-                            arg_98
-                          ]
-                        ]
-                      )
-                    )
-                  ]
-                )
-              )
-            )
-          )
-          (all out_Bool_101 (type) (fun out_Bool_101 (fun out_Bool_101 out_Bool_101)))
-        }
-        (abs
-          out_Bool_102
-          (type)
-          (lam
-            case_True_103
-            out_Bool_102
-            (lam case_False_104 out_Bool_102 case_True_103)
-          )
+(program
+  (let
+    (nonrec)
+    (datatypebind
+      (datatype
+        (tyvardecl Bool (type))
+        
+        Bool_match
+        (vardecl True Bool) (vardecl False Bool)
+      )
+    )
+    (let
+      (nonrec)
+      (termbind
+        (vardecl
+          equalsInteger
+          (fun [(con integer) (con 8)] (fun [(con integer) (con 8)] Bool))
         )
-      ]
-      (abs
-        out_Bool_105
-        (type)
         (lam
-          case_True_106
-          out_Bool_105
-          (lam case_False_107 out_Bool_105 case_False_107)
+          arg
+          [(con integer) (con 8)]
+          (lam
+            arg
+            [(con integer) (con 8)]
+            [
+              (lam
+                b (all a (type) (fun a (fun a a))) [ [ { b Bool } True ] False ]
+              )
+              [ [ { (builtin equalsInteger) (con 8) } arg ] arg ]
+            ]
+          )
         )
       )
-    ]
-    (lam
-      x_108
-      (all out_Bool_109 (type) (fun out_Bool_109 (fun out_Bool_109 out_Bool_109)))
-      x_108
+      (lam
+        ds
+        [(con integer) (con 8)]
+        (lam
+          ds
+          [(con integer) (con 8)]
+          [ (lam z [(con integer) (con 8)] [ [ equalsInteger ds ] z ]) ds ]
+        )
+      )
     )
-  ]
+  )
 )


### PR DESCRIPTION
This seems useful to have, for tests if nothing else. I haven't implemented using it for serialization, as suggested in https://github.com/input-output-hk/plutus/issues/471, but it's there if we want it.

- Add de Bruijn indices as kinds of name.
- Adds transformations between terms with uniques and terms with de Bruijn indices.
    - Also check that these round-trip. (We have to use the "interesting" term generator, since we need the terms to be well-scoped, so we can't use the simple term generator.)
- Debruijnify terms before printing them in tests, making them more robust to changes.
    - I noticed that the PIR-producing tests aren't producing debug output, which they should be, will fix later. Although maybe I'll need to write another debruijnifier for PIR...