### PR TITLE
[PlutusCore] [TypeCheck] Removed the annotation machinery

### DIFF
--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
@@ -45,15 +45,12 @@ makeClassyPrisms ''TypeEvalCheckError
 instance AsError TypeEvalCheckError () where
     _Error = _TypeEvalCheckErrorIllFormed . _Error
 
-instance AsRenameError TypeEvalCheckError () where
-    _RenameError = _TypeEvalCheckErrorIllFormed . _RenameError
-
 instance AsTypeError TypeEvalCheckError () where
     _TypeError = _TypeEvalCheckErrorIllFormed . _TypeError
 
 -- | Type-eval checking of a term results in a value of this type.
 data TypeEvalCheckResult = TypeEvalCheckResult
-    { _termCheckResultType  :: NormalizedType TyNameWithKind ()
+    { _termCheckResultType  :: NormalizedType TyName ()
       -- ^ The type of the term.
     , _termCheckResultValue :: EvaluationResult
       -- ^ The result of evaluation of the term.
@@ -77,7 +74,7 @@ typeEvalCheckBy
     -> TermOf (TypedBuiltinValue Size a)
     -> TypeEvalCheckM (TermOf TypeEvalCheckResult)
 typeEvalCheckBy eval (TermOf term tbv) = TermOf term <$> do
-    let typecheck = annotateTerm >=> typecheckTerm (TypeConfig True mempty defaultTypecheckerGas)
+    let typecheck = typecheckTerm (TypeConfig True mempty mempty mempty defaultTypecheckerGas)
     termTy <- typecheck term
     resExpected <- liftQuote $ maybeToEvaluationResult <$> makeBuiltin tbv
     fmap (TypeEvalCheckResult termTy) $

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Emit.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Emit.hs
@@ -34,8 +34,6 @@ globalUniqueVar = unsafePerformIO $ newIORef 0
 nextGlobalUnique :: IO Int
 nextGlobalUnique = atomicModifyIORef' globalUniqueVar $ \i -> (i, succ i)
 
--- We do not type check terms here, because type checking of nested dynamic built-in types simply
--- does not work. The type checker can't be quickly repaired, so we keep it like this for now.
 withEmitEvaluateBy
     :: Evaluator Term m
     -> (forall size. TypedBuiltin size a)

--- a/language-plutus-core/src/Language/PlutusCore/Renamer.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Renamer.hs
@@ -5,112 +5,16 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 module Language.PlutusCore.Renamer ( Rename (..)
-                                   , annotateProgram
-                                   , annotateTerm
-                                   , annotateType
-                                   , TypeState (..)
-                                   , RenameError (..)
                                    ) where
 
-import           Language.PlutusCore.Error
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
 import           Control.Lens.TH
-import           Control.Monad.Except
 import           Control.Monad.Reader
-import           Control.Monad.State.Lazy
 import qualified Data.IntMap               as IM
-
-data TypeState a = TypeState { _terms :: IM.IntMap (RenamedType a), _types :: IM.IntMap (Kind a) }
-
-terms :: Lens' (TypeState a) (IM.IntMap (RenamedType a))
-terms f s = fmap (\x -> s { _terms = x }) (f (_terms s))
-
-types :: Lens' (TypeState a) (IM.IntMap (Kind a))
-types f s = fmap (\x -> s { _types = x }) (f (_types s))
-
-instance Semigroup (TypeState a) where
-    (<>) (TypeState x x') (TypeState y y') = TypeState (x <> y) (x' <> y')
-
-instance Monoid (TypeState a) where
-    mempty = TypeState mempty mempty
-    mappend = (<>)
-
-type TypeM a = StateT (TypeState a) (Either (RenameError a))
-
--- | Annotate a PLC program, so that all names are annotated with their types/kinds.
-annotateProgram :: (AsRenameError e a, MonadError e m) => Program TyName Name a -> m (Program TyNameWithKind NameWithType a)
-annotateProgram (Program a v t) = Program a v <$> annotateTerm t
-
--- | Annotate a PLC term, so that all names are annotated with their types/kinds.
-annotateTerm :: (AsRenameError e a, MonadError e m) => Term TyName Name a -> m (Term TyNameWithKind NameWithType a)
-annotateTerm t = fmap fst $ throwingEither _RenameError $ runStateT (annotateT t) mempty
-
--- | Annotate a PLC type, so that all names are annotated with their types/kinds.
-annotateType :: (AsRenameError e a, MonadError e m) => Type TyName a -> m (Type TyNameWithKind a)
-annotateType t = fmap fst $ throwingEither _RenameError $ runStateT (annotateTy t) mempty
-
-insertType :: Int -> Type TyNameWithKind a -> TypeM a ()
-insertType = modify .* over terms .* IM.insert
-
-insertKind :: Int -> Kind a -> TypeM a ()
-insertKind = modify .* over types .* IM.insert
-
-annotateT :: Term TyName Name a -> TypeM a (RenamedTerm a)
-annotateT (Var x (Name x' b (Unique u))) = do
-    st <- gets _terms
-    case IM.lookup u st of
-        Just ty -> pure $ Var x (NameWithType (Name (x', ty) b (Unique u)))
-        Nothing -> throwError $ UnboundVar (Name x' b (Unique u))
-annotateT (LamAbs x (Name x' s u@(Unique i)) ty t) = do
-    aty <- annotateTy ty
-    let nwt = NameWithType (Name (x', aty) s u)
-    insertType i aty
-    LamAbs x nwt aty <$> annotateT t
-annotateT (TyAbs x (TyName (Name x' b u@(Unique i))) k t) = do
-    insertKind i k
-    let nwty = TyNameWithKind (TyName (Name (x', k) b u))
-    TyAbs x nwty k <$> annotateT t
-annotateT (Unwrap x t) =
-    Unwrap x <$> annotateT t
-annotateT (Error x ty) =
-    Error x <$> annotateTy ty
-annotateT (Apply x t t') =
-    Apply x <$> annotateT t <*> annotateT t'
-annotateT (Constant x c) =
-    pure (Constant x c)
-annotateT (Builtin x bi) =
-    pure (Builtin x bi)
-annotateT (TyInst x t ty) =
-    TyInst x <$> annotateT t <*> annotateTy ty
-annotateT (IWrap x pat arg t) =
-    IWrap x <$> annotateTy pat <*> annotateTy arg <*> annotateT t
-
-annotateTy :: Type TyName a -> TypeM a (RenamedType a)
-annotateTy (TyVar x (TyName (Name x' b (Unique u)))) = do
-    st <- gets _types
-    case IM.lookup u st of
-        Just ty -> pure $ TyVar x (TyNameWithKind (TyName (Name (x', ty) b (Unique u))))
-        Nothing -> throwError $ UnboundTyVar (TyName (Name x' b (Unique u)))
-annotateTy (TyLam x (TyName (Name x' s u@(Unique i))) k ty) = do
-    insertKind i k
-    let nwty = TyNameWithKind (TyName (Name (x', k) s u))
-    TyLam x nwty k <$> annotateTy ty
-annotateTy (TyForall x (TyName (Name x' s u@(Unique i))) k ty) = do
-    insertKind i k
-    let nwty = TyNameWithKind (TyName (Name (x', k) s u))
-    TyForall x nwty k <$> annotateTy ty
-annotateTy (TyIFix x pat arg) =
-    TyIFix x <$> annotateTy pat <*> annotateTy arg
-annotateTy (TyFun x ty ty') =
-    TyFun x <$> annotateTy ty <*> annotateTy ty'
-annotateTy (TyApp x ty ty') =
-    TyApp x <$> annotateTy ty <*> annotateTy ty'
-annotateTy (TyBuiltin x tyb) = pure (TyBuiltin x tyb)
-annotateTy (TyInt x n) = pure (TyInt x n)
 
 newtype UniquesRenaming unique = UniquesRenaming
     { unUniquesRenaming :: IM.IntMap unique
@@ -158,6 +62,9 @@ instance (HasUnique (tyname a) TypeUnique, HasUnique (name a) TermUnique) =>
 instance (HasUnique (tyname a) TypeUnique, HasUnique (name a) TermUnique) =>
         Rename (Program tyname name a) where
     rename = runScopedRenameM . renameProgramM
+
+instance HasUnique (tyname a) TypeUnique => Rename (NormalizedType tyname a) where
+    rename = traverse rename
 
 -- | The monad the renamer runs in.
 type RenameM renaming = ReaderT renaming Quote

--- a/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeSynthesis.hs
@@ -1,6 +1,10 @@
+-- 'makeLenses' produces unused lenses.
+{-# OPTIONS_GHC -fno-warn-unused-binds #-}
+
 {-# LANGUAGE MonadComprehensions #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE TemplateHaskell     #-}
 
 module Language.PlutusCore.TypeSynthesis ( typecheckProgram
                                          , typecheckTerm
@@ -20,43 +24,62 @@ import           Language.PlutusCore.Lexer.Type hiding (name)
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Normalize
 import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Renamer    (annotateType, rename)
+import           Language.PlutusCore.Renamer    (rename)
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
+import           Control.Lens                   (coerced)
+import           Control.Lens.TH                (makeLenses)
 import           Control.Monad.Error.Lens
 import           Control.Monad.Except
 import           Control.Monad.Reader
+import qualified Data.IntMap                    as IM
 import           Data.Map                       (Map)
 import qualified Data.Map                       as Map
 
 {- Note [Costs]
-Typechecking costs are relatively simple: it costs 1 gas to perform
-a reduction. Substitution does not in general cost anything.
+Typechecking costs are relatively simple: it costs 1 gas to perform a reduction.
+Substitution does not in general cost anything.
 
 Costs are reset every time we enter 'NormalizeTypeT'.
 
-In unlimited mode, gas is not tracked and we do not fail even on large numbers
-of reductions.
+In unlimited mode, gas is not tracked and we do not fail even on large numbers of reductions.
 -}
 
 -- | Mapping from 'DynamicBuiltinName's to their 'Type's.
 newtype DynamicBuiltinNameTypes = DynamicBuiltinNameTypes
-    { unDynamicBuiltinNameTypes :: Map DynamicBuiltinName (Quote (Type TyName ()))
+    { unDynamicBuiltinNameTypes :: Map DynamicBuiltinName (NormalizedType TyName ())
     } deriving (Semigroup, Monoid)
+
+-- TODO: define @UniqueMap@ already.
+
+newtype TyVarKinds = TyVarKinds
+    { unTyVarKinds :: IM.IntMap (Kind ())
+    } deriving (Semigroup, Monoid)
+
+newtype VarTypes = VarTypes
+    { unVarTypes :: IM.IntMap (NormalizedType TyName ())
+    } deriving (Semigroup, Monoid)  -- This is just to be able to say 'mempty'.
+                                    -- TODO: Remove this once this is not visible to the user.
+
+-- TODO: split 'TypeConfig' to 'TypeEnv' and 'TypeConfig'.
 
 -- | Configuration of the type checker.
 data TypeConfig = TypeConfig
     { _typeConfigNormalize           :: Bool
       -- ^ Whether to normalize type annotations.
     , _typeConfigDynBuiltinNameTypes :: DynamicBuiltinNameTypes
+    , _typeConfigTyVarKinds          :: TyVarKinds
+    , _typeConfigVarTypes            :: VarTypes
     , _typeConfigGas                 :: Maybe Gas
        -- ^ The upper limit on the length of type reductions.
        -- If set to 'Nothing', type reductions will be unbounded.
     }
 
--- | The type checking monad contains the 'BuiltinTable' and it lets us throw 'TypeError's.
+-- | The type checking monad contains the 'TypeConfig' and it lets us throw 'TypeError's.
 type TypeCheckM ann = ReaderT TypeConfig (ExceptT (TypeError ann) Quote)
+
+makeLenses ''TypeConfig
 
 -- | Run a 'NormalizeTypeT' computation in the 'TypeCheckM' context.
 -- Depending on whether gas is finite or infinite, calls either
@@ -73,21 +96,29 @@ runInTypeCheckM a = do
                 Nothing -> throwing _TypeError OutOfGas
                 Just x  -> pure x
 
+withTyVar :: TyName ann -> Kind () -> TypeCheckM ann a -> TypeCheckM ann a
+withTyVar name =
+    local . over typeConfigTyVarKinds . coerce . IM.insert (name ^. unique . coerced)
+
+withVar :: Name ann -> NormalizedType TyName () -> TypeCheckM ann a -> TypeCheckM ann a
+withVar name =
+    local . over typeConfigVarTypes . coerce . IM.insert (name ^. unique . coerced)
+
 -- | Normalize a 'Type'.
-normalizeTypeTcm :: Type TyNameWithKind () -> TypeCheckM a (NormalizedType TyNameWithKind ())
+normalizeTypeTcm :: Type TyName () -> TypeCheckM a (NormalizedType TyName ())
 normalizeTypeTcm ty = runInTypeCheckM $ normalizeTypeM ty
 
 -- | Substitute a type for a variable in a type and normalize the result.
 substituteNormalizeTypeTcm
-    :: NormalizedType TyNameWithKind ()                 -- ^ @ty@
-    -> TyNameWithKind ()                                -- ^ @name@
-    -> Type TyNameWithKind ()                           -- ^ @body@
-    -> TypeCheckM a (NormalizedType TyNameWithKind ())
+    :: NormalizedType TyName ()                 -- ^ @ty@
+    -> TyName ()                                -- ^ @name@
+    -> Type TyName ()                           -- ^ @body@
+    -> TypeCheckM a (NormalizedType TyName ())
 substituteNormalizeTypeTcm ty name body = runInTypeCheckM $ substituteNormalizeTypeM ty name body
 
 -- | Normalize a 'Type' or simply wrap it in the 'NormalizedType' constructor
 -- if we are working with normalized type annotations.
-normalizeTypeOptTcm :: Type TyNameWithKind () -> TypeCheckM a (NormalizedType TyNameWithKind ())
+normalizeTypeOptTcm :: Type TyName () -> TypeCheckM a (NormalizedType TyName ())
 normalizeTypeOptTcm ty = do
     normalize <- asks _typeConfigNormalize
     if normalize
@@ -104,48 +135,37 @@ kindOfTypeBuiltin TyByteString = sizeToType
 kindOfTypeBuiltin TySize       = sizeToType
 kindOfTypeBuiltin TyString     = Type ()
 
--- | Annotate a 'Type'. Invariant: the type must be in normal form. The invariant is not checked.
--- In case a type is open, an 'OpenTypeOfBuiltin' is returned.
--- We use this for annotating types of built-ins (both static and dynamic).
-annotateNormalizeType
-    :: a -> Builtin () -> Type TyName () -> TypeCheckM a (NormalizedType TyNameWithKind ())
-annotateNormalizeType ann con ty = case annotateType ty of
-    Left  (_::RenameError ()) -> throwing _TypeError $ InternalTypeErrorE ann $ OpenTypeOfBuiltin ty con
-    -- That's quite inefficient, but is there anything we can do about that?
-    Right annTyOfName         -> normalizeTypeTcm annTyOfName
-
--- | Annotate the type of a 'BuiltinName' and return it wrapped in 'NormalizedType'.
-normalizedAnnotatedTypeOfBuiltinName
-    :: a -> BuiltinName -> TypeCheckM a (NormalizedType TyNameWithKind ())
-normalizedAnnotatedTypeOfBuiltinName ann name = do
-    tyOfName <- liftQuote $ typeOfBuiltinName name
-    -- Types of built-in names are already normalized.
-    annotateNormalizeType ann (BuiltinName () name) tyOfName
-
+-- TODO: move me to a separate API module once it's there.
 -- | Extract the 'TypeScheme' from a 'DynamicBuiltinNameMeaning' and convert it to the
 -- corresponding @Type TyName@ for each row of a 'DynamicBuiltinNameMeanings'.
 dynamicBuiltinNameMeaningsToTypes :: DynamicBuiltinNameMeanings -> DynamicBuiltinNameTypes
 dynamicBuiltinNameMeaningsToTypes (DynamicBuiltinNameMeanings means) =
-    DynamicBuiltinNameTypes $ fmap dynamicBuiltinNameMeaningToType means
+    DynamicBuiltinNameTypes $ fmap toType means where
+        -- TODO: kind check the types before normalizing them. We can't do that right now
+        -- in a nice way, because 'kindCheck' infers the kind of a type rather than checks a type
+        -- against a kind.
+        -- We call 'runQuote' here in order to prevent renormalization at each look-up.
+        -- It's fine to do so, because we rename types in 'lookupDynamicBuiltinName'.
+        toType mean = runQuote $ dynamicBuiltinNameMeaningToType mean >>= rename >>= normalizeTypeDown
 
 -- | Type-check a program, returning a normalized type.
 typecheckProgram :: (AsTypeError e a, MonadError e m, MonadQuote m)
                  => TypeConfig
-                 -> Program TyNameWithKind NameWithType a
-                 -> m (NormalizedType TyNameWithKind ())
+                 -> Program TyName Name a
+                 -> m (NormalizedType TyName ())
 typecheckProgram cfg (Program _ _ t) = typecheckTerm cfg t
 
 -- | Type-check a term, returning a normalized type.
 typecheckTerm :: (AsTypeError e a, MonadError e m, MonadQuote m)
               => TypeConfig
-              -> Term TyNameWithKind NameWithType a
-              -> m (NormalizedType TyNameWithKind ())
+              -> Term TyName Name a
+              -> m (NormalizedType TyName ())
 typecheckTerm cfg t = throwingEither _TypeError =<< (liftQuote $ runExceptT $ runTypeCheckM cfg (typeOf t))
 
 -- | Kind-check a PLC type.
 kindCheck :: (AsTypeError e a, MonadError e m, MonadQuote m)
           => TypeConfig
-          -> Type TyNameWithKind a
+          -> Type TyName a
           -> m (Kind ())
 kindCheck cfg t = throwingEither _TypeError =<< (liftQuote $ runExceptT $ runTypeCheckM cfg (kindOf t))
 
@@ -153,35 +173,75 @@ kindCheck cfg t = throwingEither _TypeError =<< (liftQuote $ runExceptT $ runTyp
 runTypeCheckM :: TypeConfig
               -> TypeCheckM a b
               -> ExceptT (TypeError a) Quote b
-runTypeCheckM typeConfig tc =
-    runReaderT tc typeConfig
+runTypeCheckM typeConfig tc = runReaderT tc typeConfig
 
--- | Extract kind information from a type.
-kindOf :: Type TyNameWithKind a -> TypeCheckM a (Kind ())
-kindOf TyInt{} = pure (Size ())
-kindOf (TyFun x dom cod) = do
+-- | Infer the kind of a type variable by looking it up in the current context.
+kindOfTyVar :: TyName a -> TypeCheckM a (Kind ())
+kindOfTyVar name = do
+    mayKind <- asks $ IM.lookup (name ^. unique . coerced) . unTyVarKinds . _typeConfigTyVarKinds
+    case mayKind of
+        Nothing   -> throwError $ FreeTypeVariableE name
+        Just kind -> pure kind
+
+-- | Infer the type of a variable by looking it up in the current context.
+typeOfVar :: Name a -> TypeCheckM a (NormalizedType TyName ())
+typeOfVar name = do
+    mayTy <- asks $ IM.lookup (name ^. unique . coerced) . unVarTypes . _typeConfigVarTypes
+    case mayTy of
+        Nothing -> throwError $ FreeVariableE name
+        Just ty -> rename ty
+
+-- | Infer the kind of a type.
+kindOf :: Type TyName a -> TypeCheckM a (Kind ())
+
+-- ---------------------------
+-- [infer| G !- con i :: size]
+kindOf TyInt{}               = pure (Size ())
+
+-- [check| G !- a :: *]    [check| G !- b :: *]
+-- --------------------------------------------
+-- [infer| G !- a -> b :: *]
+kindOf (TyFun x dom cod)     = do
     kindCheckM x dom $ Type ()
     kindCheckM x cod $ Type ()
     pure $ Type ()
-kindOf (TyForall x _ _ ty) = do
-    kindCheckM x ty $ Type ()
-    pure $ Type ()
-kindOf (TyLam _ _ argK body) = KindArrow () (void argK) <$> kindOf body
-kindOf (TyVar _ (TyNameWithKind (TyName (Name (_, k) _ _)))) = pure (void k)
-kindOf (TyBuiltin _ b) = pure $ kindOfTypeBuiltin b
 
--- [infer| arg :: k]    [check| pat :: (k -> *) -> k -> *]
--- -------------------------------------------------------
--- [infer| ifix pat arg :: *]
-kindOf (TyIFix x pat arg) = do
+-- [check| G , n :: k !- body :: *]
+-- ---------------------------------------
+-- [infer| G !- (all (n :: k). body) :: *]
+kindOf (TyForall x n k body) = do
+    withTyVar n (void k) $ kindCheckM x body (Type ())
+    pure $ Type ()
+
+-- [infer| G , n :: dom !- body :: cod]
+-- -------------------------------------------------
+-- [infer| G !- (\(n :: dom) -> body) :: dom -> cod]
+kindOf (TyLam _ n dom body)  = do
+    let dom_ = void dom
+    withTyVar n dom_ $ KindArrow () dom_ <$> kindOf body
+
+-- [infer| G !- v :: k]
+-- ------------------------
+-- [infer| G !- var v :: k]
+kindOf (TyVar _ v)           = kindOfTyVar v
+
+-- [infer| G !- b :: k]
+-- ------------------------
+-- [infer| G !- con b :: k]
+kindOf (TyBuiltin _ b)       = pure $ kindOfTypeBuiltin b
+
+-- [infer| G !- arg :: k]    [check| G !- pat :: (k -> *) -> k -> *]
+-- -----------------------------------------------------------------
+-- [infer| G !- ifix pat arg :: *]
+kindOf (TyIFix x pat arg)    = do
     k <- kindOf arg
     kindCheckPatternFunctorM x pat k
     pure $ Type ()
 
--- [infer| fun :: dom -> cod]    [check | arg :: dom]
--- --------------------------------------------------
--- [infer| fun arg :: cod]
-kindOf (TyApp x fun arg) = do
+-- [infer| G !- fun :: dom -> cod]    [check| G !- arg :: dom]
+-- -----------------------------------------------------------
+-- [infer| G !- fun arg :: cod]
+kindOf (TyApp x fun arg)     = do
     funKind <- kindOf fun
     case funKind of
         KindArrow _ dom cod -> do
@@ -189,20 +249,24 @@ kindOf (TyApp x fun arg) = do
             pure cod
         _ -> throwError $ KindMismatch x (void fun) (KindArrow () dummyKind dummyKind) funKind
 
--- | Check that the kind of a pattern functor is @(k -> *) -> k -> *@.
-kindCheckPatternFunctorM
-    :: ann
-    -> Type TyNameWithKind ann  -- ^ A pattern functor.
-    -> Kind ()                  -- ^ @k@.
-    -> TypeCheckM ann ()
-kindCheckPatternFunctorM ann pat k =
-    kindCheckM ann pat $ KindArrow () (KindArrow () k (Type ())) (KindArrow () k (Type ()))
-
 -- | Check a 'Type' against a 'Kind'.
-kindCheckM :: a -> Type TyNameWithKind a -> Kind () -> TypeCheckM a ()
+kindCheckM :: a -> Type TyName a -> Kind () -> TypeCheckM a ()
+
+-- [infer| G !- ty : tyK]    tyK ~ k
+-- ---------------------------------
+-- [check| G !- ty : k]
 kindCheckM x ty k = do
     tyK <- kindOf ty
     when (tyK /= k) $ throwError (KindMismatch x (void ty) k tyK)
+
+-- | Check that the kind of a pattern functor is @(k -> *) -> k -> *@.
+kindCheckPatternFunctorM
+    :: ann
+    -> Type TyName ann  -- ^ A pattern functor.
+    -> Kind ()          -- ^ @k@.
+    -> TypeCheckM ann ()
+kindCheckPatternFunctorM ann pat k =
+    kindCheckM ann pat $ KindArrow () (KindArrow () k (Type ())) (KindArrow () k (Type ()))
 
 -- | Apply a 'TypeBuiltin' to a 'Size' and wrap in 'NormalizedType'.
 applySizedNormalized :: TypeBuiltin -> Size -> NormalizedType tyname ()
@@ -211,104 +275,115 @@ applySizedNormalized tb = NormalizedType . TyApp () (TyBuiltin () tb) . TyInt ()
 dummyUnique :: Unique
 dummyUnique = Unique 0
 
-dummyTyName :: TyNameWithKind ()
-dummyTyName = TyNameWithKind (TyName (Name ((), Type ()) "*" dummyUnique))
+dummyTyName :: TyName ()
+dummyTyName = TyName (Name () "*" dummyUnique)
 
 dummyKind :: Kind ()
 dummyKind = Type ()
 
-dummyType :: Type TyNameWithKind ()
+dummyType :: Type TyName ()
 dummyType = TyVar () dummyTyName
 
 -- | Look up a 'DynamicBuiltinName' in the 'DynBuiltinNameTypes' environment.
-lookupDynamicBuiltinName :: a -> DynamicBuiltinName -> TypeCheckM a (NormalizedType TyNameWithKind ())
+lookupDynamicBuiltinName :: a -> DynamicBuiltinName -> TypeCheckM a (NormalizedType TyName ())
 lookupDynamicBuiltinName ann name = do
     dbnts <- asks $ unDynamicBuiltinNameTypes . _typeConfigDynBuiltinNameTypes
     case Map.lookup name dbnts of
-        Nothing    ->
+        Nothing ->
             throwError $ UnknownDynamicBuiltinName ann (UnknownDynamicBuiltinNameErrorE name)
-        Just quoTy -> do
-            ty <- liftQuote quoTy
-            annotateNormalizeType ann (DynBuiltinName () name) ty
+        Just ty -> rename ty
 
 -- | Get the 'Type' of a 'Constant' wrapped in 'NormalizedType'.
-typeOfConstant :: Constant a -> NormalizedType TyNameWithKind ()
+typeOfConstant :: Constant a -> NormalizedType TyName ()
 typeOfConstant (BuiltinInt  _ size _) = applySizedNormalized TyInteger    size
 typeOfConstant (BuiltinBS   _ size _) = applySizedNormalized TyByteString size
 typeOfConstant (BuiltinSize _ size)   = applySizedNormalized TySize       size
 typeOfConstant (BuiltinStr _ _)       = NormalizedType $ TyBuiltin () TyString
 
-typeOfBuiltin :: Builtin a -> TypeCheckM a (NormalizedType TyNameWithKind ())
-typeOfBuiltin (BuiltinName    ann name) = normalizedAnnotatedTypeOfBuiltinName ann name
+typeOfBuiltin :: Builtin a -> TypeCheckM a (NormalizedType TyName ())
+-- We have a weird corner case here: the type of a 'BuiltinName' can contain 'TypedBuiltinDyn', i.e.
+-- a static built-in name is allowed to depend on a dynamic built-in type which are not required
+-- to be normalized. For dynamic built-in names we store a map from them to their *normalized types*,
+-- with the normalization happening in this module, but what should we do for static built-in names?
+-- Right now we just renormalize the type of a static built-in name each time we encounter that name.
+typeOfBuiltin (BuiltinName    _   name) =
+    liftQuote (typeOfBuiltinName name) >>= rename >>= normalizeTypeDown
 typeOfBuiltin (DynBuiltinName ann name) = lookupDynamicBuiltinName ann name
 
 {- Note [Type rules]
 We write type rules in the bidirectional style.
-[infer| x : a] -- means that the inferred type of 'x' is 'a'. 'a' is not necessary a varible, e.g.
-[infer| fun : dom -> cod] is fine too. It reads as follows: "infer the type of 'fun', check that its
-functional and bind the 'dom' variable to the domain and the 'cod' variable to the codomain of this type".
 
-Analogously, [infer| t :: k] means that the inferred kind of 't' is 'k'.
-The [infer| x : a] judgement appears in conclusions in the clauses of the 'typeOf' function.
-[check| x : a] -- check that the type of 'x' is 'a'. Since Plutus Core is fully elaborated language,
-this amounts to inferring the type of 'x' and checking that it's equal to 'a'.
+[infer| G !- x : a] -- means that the inferred type of 'x' in the context 'G' is 'a'.
+'a' is not necessary a varible, e.g. [infer| G !- fun : dom -> cod] is fine too.
+It reads as follows: "infer the type of 'fun' in the context 'G', check that it's functional and
+bind the 'dom' variable to the domain and the 'cod' variable to the codomain of this type".
+
+Analogously, [infer| G !- t :: k] means that the inferred kind of 't' in the context 'G' is 'k'.
+The [infer| G !- x : a] judgement appears in conclusions in the clauses of the 'typeOf' function.
+
+[check| G !- x : a] -- check that the type of 'x' in the context 'G' is 'a'.
+Since Plutus Core is a fully elaborated language, this amounts to inferring the type of 'x' and
+checking that it's equal to 'a'.
+
+Analogously, [check| G !- t :: k] means "check that the kind of 't' in the context 'G' is 'k'".
+The [check| G !- x : a] judgement appears in the conclusion in the sole clause of
+the 'typeCheckM' function.
+
 The equality check is denoted as "a ~ b".
 
-Analogously, [check| t :: k] means "check that the kind of 't' is 'k'".
-The [check| x : a] judgement appears in the conclusion in the sole clause of the 'typeCheckM' function.
+We use unified contexts, i.e. a context can carry type variables as well as term variables.
+
 The "NORM a" notation reads as "normalize 'a'".
+
 The "a ~>? b" notations reads as "optionally normalize 'a' to 'b'". The "optionally" part is due to the
 fact that we allow non-normalized types during development, but do not allow to submit them on a chain.
 -}
 
 -- See the [Type rules] and [Type environments] notes.
 -- | Synthesize the type of a term, returning a normalized type.
-typeOf :: Term TyNameWithKind NameWithType a -> TypeCheckM a (NormalizedType TyNameWithKind ())
+typeOf :: Term TyName Name a -> TypeCheckM a (NormalizedType TyName ())
 
--- v : ty    ty ~>? vTy
--- --------------------
--- [infer| var v : vTy]
-typeOf (Var _ (NameWithType (Name (_, ty) _ _))) =
-    -- Since we kind check types at lambdas, we can normalize types here without kind checking.
-    -- Type normalization at each variable is inefficient and we may consider something else later.
-    -- We 'rename' the type of a variable here before normalizing it. Otherwise we would get duplicate
-    -- names, because the annotation machinery takes the type at a lambda and duplicates it for each
-    -- usage of the variable the lambda binds.
-    rename ty >>= normalizeTypeOptTcm . void
+-- [infer| G !- v : ty]    ty ~>? vTy
+-- ----------------------------------
+-- [infer| G !- var v : vTy]
+typeOf (Var _ name)                              = typeOfVar name
 
--- [check| dom :: *]    dom ~>? vDom    [infer| body : vCod]
--- ---------------------------------------------------------
--- [infer| lam n dom body : vDom -> vCod]
-typeOf (LamAbs x _ dom body)                     = do
+-- [check| G !- dom :: *]    dom ~>? vDom    [infer| G , n : dom !- body : vCod]
+-- -----------------------------------------------------------------------------
+-- [infer| G !- lam n dom body : vDom -> vCod]
+typeOf (LamAbs x n dom body)                     = do
     kindCheckM x dom $ Type ()
-    TyFun () <<$>> normalizeTypeOptTcm (void dom) <<*>> typeOf body
+    vDom <- normalizeTypeOptTcm $ void dom
+    TyFun () <<$>> pure vDom <<*>> withVar n vDom (typeOf body)
 
--- [check| ty :: *]    ty ~>? vTy
--- ------------------------------
--- [infer| error ty : vTy]
+-- [check| G !- ty :: *]    ty ~>? vTy
+-- -----------------------------------
+-- [infer| G !- error ty : vTy]
 typeOf (Error x ty)                              = do
     kindCheckM x ty $ Type ()
     normalizeTypeOptTcm $ void ty
 
--- [infer| body : vBodyTy]
--- ----------------------------------------------
--- [infer| abs n nK body : all (n :: nK) vBodyTy]
-typeOf (TyAbs _ n nK body)                       = TyForall () (void n) (void nK) <<$>> typeOf body
+-- [infer| G , n :: nK !- body : vBodyTy]
+-- ---------------------------------------------------
+-- [infer| G !- abs n nK body : all (n :: nK) vBodyTy]
+typeOf (TyAbs _ n nK body)                       = do
+    let nK_ = void nK
+    TyForall () (void n) nK_ <<$>> withTyVar n nK_ (typeOf body)
 
--- c : vTy
--- --------------------
--- [infer| con c : vTy]
+-- [infer| G !- c : vTy]
+-- -------------------------
+-- [infer| G !- con c : vTy]
 typeOf (Constant _ con)                          = pure (typeOfConstant con)
 
--- bi : vTy
--- -------------------------
--- [infer| builtin by : vTy]
+-- [infer| G !- bi : vTy]
+-- ------------------------------
+-- [infer| G !- builtin bi : vTy]
 typeOf (Builtin _ bi)                            = typeOfBuiltin bi
 
--- [infer| fun : vDom -> vCod]    [check| arg : vDom]
--- --------------------------------------------------
--- [infer| fun arg : vCod]
-typeOf (Apply x fun arg) = do
+-- [infer| G !- fun : vDom -> vCod]    [check| G !- arg : vDom]
+-- ------------------------------------------------------------
+-- [infer| G !- fun arg : vCod]
+typeOf (Apply x fun arg)                         = do
     vFunTy <- typeOf fun
     case getNormalizedType vFunTy of
         TyFun _ vDom vCod -> do
@@ -316,10 +391,10 @@ typeOf (Apply x fun arg) = do
             pure $ NormalizedType vCod              -- Subpart of a normalized type, so normalized.
         _ -> throwError (TypeMismatch x (void fun) (TyFun () dummyType dummyType) vFunTy)
 
--- [infer| body : all (n :: nK) vCod]    [check| ty :: tyK]    ty ~>? vTy
--- ----------------------------------------------------------------------
--- [infer| body {ty} : NORM ([vTy / n] vCod)]
-typeOf (TyInst x body ty) = do
+-- [infer| G !- body : all (n :: nK) vCod]    [check| G !- ty :: tyK]    ty ~>? vTy
+-- --------------------------------------------------------------------------------
+-- [infer| G !- body {ty} : NORM ([vTy / n] vCod)]
+typeOf (TyInst x body ty)                        = do
     vBodyTy <- typeOf body
     case getNormalizedType vBodyTy of
         TyForall _ n nK vCod -> do
@@ -328,21 +403,22 @@ typeOf (TyInst x body ty) = do
             substituteNormalizeTypeTcm vTy n vCod
         _ -> throwError (TypeMismatch x (void body) (TyForall () dummyTyName dummyKind dummyType) vBodyTy)
 
--- [infer| term : ifix vPat vArg]    [infer| vArg :: k]
--- ------------------------------------------------------------------
--- [infer| unwrap term : NORM (vPat (\(a :: k) -> ifix vPat a) vArg)]
-typeOf (Unwrap x term) = do
+-- [infer| G !- term : ifix vPat vArg]    [infer| G !- vArg :: k]
+-- -----------------------------------------------------------------------
+-- [infer| G !- unwrap term : NORM (vPat (\(a :: k) -> ifix vPat a) vArg)]
+typeOf (Unwrap x term)                           = do
     vTermTy <- typeOf term
     case getNormalizedType vTermTy of
         TyIFix _ vPat vArg -> do
             k <- kindOf $ x <$ vArg
+            -- Subparts of a normalized type, so normalized.
             unfoldFixOf (NormalizedType vPat) (NormalizedType vArg) k
         _                  -> throwError (TypeMismatch x (void term) (TyIFix () dummyType dummyType) vTermTy)
 
--- [infer| arg :: k]    [check| pat :: (k -> *) -> k -> *]    pat ~>? vPat    arg ~>? vArg
--- [check| term : NORM (vPat (\(a :: k) -> ifix vPat a) vArg)]
--- ---------------------------------------------------------------------------------------
--- [infer| iwrap pat arg term : ifix vPat vArg]
+-- [infer| G !- arg :: k]    [check| G !- pat :: (k -> *) -> k -> *]    pat ~>? vPat    arg ~>? vArg
+-- [check| G !- term : NORM (vPat (\(a :: k) -> ifix vPat a) vArg)]
+-- -------------------------------------------------------------------------------------------------
+-- [infer| G !- iwrap pat arg term : ifix vPat vArg]
 typeOf (IWrap x pat arg term) = do
     k <- kindOf arg
     kindCheckPatternFunctorM x pat k
@@ -352,28 +428,25 @@ typeOf (IWrap x pat arg term) = do
     return $ TyIFix () <$> vPat <*> vArg
 
 -- | Check a 'Term' against a 'NormalizedType'.
-typeCheckM :: a
-           -> Term TyNameWithKind NameWithType a
-           -> NormalizedType TyNameWithKind ()
-           -> TypeCheckM a ()
+typeCheckM :: a -> Term TyName Name a -> NormalizedType TyName () -> TypeCheckM a ()
 
--- [infer| term : vTermTy]    vTermTy ~ vTy
--- ----------------------------------------
--- [check| term : vTy]
+-- [infer| G !- term : vTermTy]    vTermTy ~ vTy
+-- ---------------------------------------------
+-- [check| G !- term : vTy]
 typeCheckM x term vTy = do
     vTermTy <- typeOf term
     when (vTermTy /= vTy) $ throwError (TypeMismatch x (void term) (getNormalizedType vTermTy) vTy)
 
 -- | @unfoldFixOf pat arg k = NORM (vPat (\(a :: k) -> ifix vPat a) arg)@
 unfoldFixOf
-    :: NormalizedType TyNameWithKind ()  -- ^ @vPat@
-    -> NormalizedType TyNameWithKind ()  -- ^ @vArg@
-    -> Kind ()                           -- ^ @k@
-    -> TypeCheckM a (NormalizedType TyNameWithKind ())
+    :: NormalizedType TyName ()  -- ^ @vPat@
+    -> NormalizedType TyName ()  -- ^ @vArg@
+    -> Kind ()                   -- ^ @k@
+    -> TypeCheckM a (NormalizedType TyName ())
 unfoldFixOf pat arg k = do
     let vPat = getNormalizedType pat
         vArg = getNormalizedType arg
-    a <- liftQuote $ TyNameWithKind <$> freshTyName ((), k) "a"
+    a <- liftQuote $ freshTyName () "a"
     normalizeTypeTcm $
         foldl' (TyApp ()) vPat
             [ TyLam () a k . TyIFix () vPat $ TyVar () a

--- a/language-plutus-core/test/TypeSynthesis/Spec.hs
+++ b/language-plutus-core/test/TypeSynthesis/Spec.hs
@@ -24,7 +24,7 @@ kindcheckQuoted
     => Quote (Type TyName ()) -> m (Type TyName ())
 kindcheckQuoted getType = do
     ty <- liftQuote getType
-    _ <- annotateType ty >>= kindCheck (TypeConfig True mempty Nothing)
+    _ <- kindCheck (TypeConfig True mempty mempty mempty Nothing) ty
     return ty
 
 typecheckQuoted
@@ -32,7 +32,7 @@ typecheckQuoted
     => Quote (Term TyName Name ()) -> m (Term TyName Name ())
 typecheckQuoted getTerm = do
     term <- liftQuote getTerm
-    _ <- annotateTerm term >>= typecheckTerm (TypeConfig True mempty Nothing)
+    _ <- typecheckTerm (TypeConfig True mempty mempty mempty Nothing) term
     return term
 
 -- | Assert a 'Type' is well-kinded.

--- a/plutus-core-interpreter/test/DynamicBuiltins/Common.hs
+++ b/plutus-core-interpreter/test/DynamicBuiltins/Common.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 module DynamicBuiltins.Common
-    ( typecheckEvaluate
+    ( typecheckEvaluateCek
     ) where
 
 import           Language.PlutusCore
@@ -12,16 +12,16 @@ import           Language.PlutusCore.Interpreter.CekMachine
 import           Control.Monad.Except
 
 -- | Type check and evaluate a term that can contain dynamic built-ins.
--- Does not support nested dynamic built-in types, so do not use it for terms
--- that may contain such types.
-typecheckEvaluate
-    :: (MonadError (Error ()) m, MonadQuote m)
+typecheckEvaluateCek
+    :: MonadError (Error ()) m
     => DynamicBuiltinNameMeanings -> Term TyName Name () -> m EvaluationResult
-typecheckEvaluate meanings term = do
+typecheckEvaluateCek meanings term = do
     let types = dynamicBuiltinNameMeaningsToTypes meanings
-        typecheckConfig = TypeConfig True types Nothing
-        typecheck = rename >=> annotateTerm >=> typecheckTerm typecheckConfig
-    _ <- typecheck term
+        typecheckConfig = TypeConfig True types mempty mempty Nothing
+        typecheck = rename >=> typecheckTerm typecheckConfig
+    _ <- runQuoteT $ typecheck term
     -- We do not rename terms before evaluating them, because the evaluator must work correctly over
     -- terms with duplicate names, because it produces such terms during evaluation.
-    return $ evaluateCek meanings term
+    -- The bang is important in order to force the effects of a computation regardless of whether
+    -- the result of the computation is forced or not.
+    return $! evaluateCek meanings term

--- a/plutus-core-interpreter/test/DynamicBuiltins/Factorial.hs
+++ b/plutus-core-interpreter/test/DynamicBuiltins/Factorial.hs
@@ -39,8 +39,8 @@ dynamicFactorial = dynamicBuiltinNameAsTerm dynamicFactorialName
 -- a factorial defined in PLC itself.
 test_dynamicFactorial :: TestTree
 test_dynamicFactorial = testCase "dynamicFactorial" $
-        runQuoteT (typecheckEvaluate
+        typecheckEvaluateCek
             (insertDynamicBuiltinNameDefinition dynamicFactorialDefinition mempty)
-            (applyFactorial dynamicFactorial 3 10))
+            (applyFactorial dynamicFactorial 3 10)
     @?=
         Right (evaluateCek mempty $ applyFactorial (runQuote getBuiltinFactorial) 3 10)

--- a/plutus-core-interpreter/test/DynamicBuiltins/String.hs
+++ b/plutus-core-interpreter/test/DynamicBuiltins/String.hs
@@ -14,6 +14,8 @@ import           Language.PlutusCore.StdLib.Data.Unit
 
 import           Language.PlutusCore.Interpreter.CekMachine
 
+import           DynamicBuiltins.Common
+
 import           Control.Monad.IO.Class                     (liftIO)
 import           Hedgehog                                   hiding (Size, Var)
 import qualified Hedgehog.Gen                               as Gen
@@ -44,7 +46,7 @@ test_plcListOfStringsRoundtrip = testProperty "listOfStringsRoundtrip" . propert
 test_collectChars :: TestTree
 test_collectChars = testProperty "collectChars" . property $ do
     str <- forAll $ Gen.string (Range.linear 0 20) Gen.unicode
-    (str', errOrRes) <- liftIO . withEmitEvaluateBy evaluateCekCatch TypedBuiltinDyn $ \emit ->
+    (str', errOrRes) <- liftIO . withEmitEvaluateBy typecheckEvaluateCek TypedBuiltinDyn $ \emit ->
         runQuote $ do
             unit        <- getBuiltinUnit
             unitval     <- getBuiltinUnitval

--- a/plutus-exe/src/Main.hs
+++ b/plutus-exe/src/Main.hs
@@ -116,7 +116,7 @@ runTypecheck :: TypecheckOptions -> IO ()
 runTypecheck (TypecheckOptions inp mode) = do
     contents <- getInput inp
     let bsContents = (BSL.fromStrict . encodeUtf8 . T.pack) contents
-    let cfg = PLC.TypeConfig (case mode of {NotRequired -> True; Required -> False}) mempty PLC.defaultTypecheckerGas
+    let cfg = PLC.TypeConfig (case mode of {NotRequired -> True; Required -> False}) mempty mempty mempty PLC.defaultTypecheckerGas
     case (PLC.runQuoteT . PLC.parseTypecheck cfg) bsContents of
         Left (e :: PLC.Error PLC.AlexPosn) -> do
             T.putStrLn $ PLC.prettyPlcDefText e
@@ -142,7 +142,7 @@ runEval (EvalOptions inp mode) = do
             exitSuccess
 
 data TypeExample = TypeExample (PLC.Kind ()) (PLC.Type PLC.TyName ())
-data TermExample = TermExample (PLC.Type PLC.TyNameWithKind ()) (PLC.Term PLC.TyName PLC.Name ())
+data TermExample = TermExample (PLC.Type PLC.TyName ()) (PLC.Term PLC.TyName PLC.Name ())
 data SomeExample = SomeTypeExample TypeExample | SomeTermExample TermExample
 
 prettySignature :: ExampleName -> SomeExample -> Doc ann
@@ -160,7 +160,7 @@ toTermExample :: PLC.Quote (PLC.Term PLC.TyName PLC.Name ()) -> TermExample
 toTermExample getTerm = TermExample ty term where
     term = PLC.runQuote getTerm
     program = PLC.Program () (PLC.defaultVersion ()) term
-    config = PLC.TypeConfig True mempty Nothing
+    config = PLC.TypeConfig True mempty mempty mempty Nothing
     ty = case PLC.runQuote . runExceptT $ PLC.typecheckPipeline config program of
         Left (err :: PLC.Error ()) -> error $ PLC.prettyPlcDefString err
         Right vTy                  -> PLC.getNormalizedType vTy

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
@@ -26,9 +26,6 @@ makeClassyPrisms ''Error
 instance PLC.AsTypeError (Error a) a where
     _TypeError = _PLCError . PLC._TypeError
 
-instance PLC.AsRenameError (Error a) a where
-    _RenameError = _PLCError . PLC._RenameError
-
 instance (PP.Pretty a) => Show (Error a) where
     show e = show $ PLC.prettyPlcClassicDebug e
 

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -54,10 +54,9 @@ compileAndMaybeTypecheck doTypecheck pir = flip runReaderT NoProvenance $ runQuo
     -- it is important we run the two computations in the same Quote together, otherwise we might make
     -- names during compilation that are not fresh
     compiled <- compileTerm =<< liftQuote pir
-    when doTypecheck $ void $ do
-        annotated <- PLC.annotateTerm compiled
+    when doTypecheck $ void $
         -- need our own typechecker pipeline to allow normalized types
-        PLC.typecheckTerm (PLC.TypeConfig True mempty Nothing) annotated
+        PLC.typecheckTerm (PLC.TypeConfig True mempty mempty mempty Nothing) compiled
     pure compiled
 
 tests :: TestNested

--- a/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Error.hs
@@ -69,9 +69,6 @@ makeClassyPrisms ''Error
 instance (PP.Pretty a) => PP.Pretty (Error a) where
     pretty = PLC.prettyPlcClassicDebug
 
-instance PLC.AsRenameError ConvError () where
-    _RenameError = _NoContext . _PLCError . PLC._RenameError
-
 instance PLC.AsTypeError ConvError () where
     _TypeError = _NoContext . _PLCError . PLC._TypeError
 


### PR DESCRIPTION
This removes the annotation machinery and all the `TyNameWithKind`, `NameWithType`, `RenameError`, `AsRenameError`, etc business.

Pros:

 - Terms with types involving dynamic builtin types type check just fine. Previously they did not type check and instead we were getting errors from the annotation machinery for whatever reasons.
 - Type rules contain contexts and finally look sensible and the way one would expect.
 - No need to renormalize the type of a variable at each usage of this variable like this was previously.
 - Less code.

Cons:

 - You tell me.