### PR TITLE
Docs: add a script to deploy the combined Haddock to GH pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ result*
 
 .terraform
 *.tfvars
+
+gh-pages

--- a/README.md
+++ b/README.md
@@ -30,8 +30,18 @@ https://hydra.iohk.io/job/serokell/plutus/language-plutus-core.x86_64-linux/late
 
 You can also build the docs yourself locally. For example:
 ```
+# Haddock for language-plutus-core
 nix build -f default.nix localPackages.language-plutus-core.doc
+# Combined Haddock for all our packages
+nix build -f default.nix localPackages.combined-haddock
 ```
+
+### Deploying the docs
+
+The combined Haddocks are deployed to the [Github Pages page](https://input-output-hk.github.io/plutus/).
+
+Deploying the docs means committing to the `gh-pages` branch. You can do this automatically
+by running `./deploy-docs.sh`, and pushing the result if it looks good.
 
 ## Glossary
 

--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+cd "$GIT_ROOT"
+
+if [ -n "$(git status --porcelain)" ]
+then
+  echo "The working directory is dirty. Please commit any pending changes."
+  exit 1
+fi
+
+# We use a (gitignored!) worktree to store the generated output. This is a convenient way to
+# have the GH Pages branch checked out while still having the main branch checked
+# out to generate docs etc. The alternative would be to generate to something
+# like /tmp, change branch, and then copy it over.
+BRANCH=gh-pages
+UPSTREAM=upstream
+WORKTREE_NAME=$BRANCH
+
+echo "Clearing worktree"
+rm -rf $WORKTREE_NAME
+git worktree prune
+rm -rf .git/worktrees/$WORKTREE_NAME/
+mkdir $WORKTREE_NAME
+
+echo "Checking out $BRANCH into $WORKTREE_NAME"
+git fetch $UPSTREAM $BRANCH
+git worktree add -B $BRANCH $WORKTREE_NAME $UPSTREAM/$BRANCH
+
+echo "Generating"
+nix build -f default.nix docs.combined-haddock
+cp -ar result/share/doc/* $WORKTREE_NAME
+# The results are copied from the store so have read-only permissions, which
+# will upset git. We will own the files, so we can change the perms.
+chmod -R +w $WORKTREE_NAME
+
+echo "Committing to $BRANCH"
+cd $WORKTREE_NAME && git add --all && git commit -m "Automated publish"
+
+echo "If you are happy with the output in $WORKTREE_NAME, then change into that directory and push it to $UPSTREAM/$BRANCH"
+


### PR DESCRIPTION
At the moment the only place we really have to host our docs is the GH pages site associated with this repo.

Automatically deploying to this site is a bit of a pain, so I've written a script to make at least the actual deployment part automated. We still need to run this script manually whenever we want to deploy the docs. (When do we do that? Who knows, we don't exactly have releases or anything.)