### PR TITLE
Spec modifications 2018 11 26

### DIFF
--- a/plutus-core-spec/CHANGELOG.md
+++ b/plutus-core-spec/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+This will record all the major changes to the spec for Plutus Core
+
+At the present time, versioning is of the form `RCn` for Release Candidate #n.
+
+
+
+
+
+## RC7 - 2019-01-20
+
+	
+
+### Added
+
+- Add CHANGELOG.md to track changes.
+
+
+
+### Changed
+
+- Changes the lexical syntax for sizes to include the `bytes` suffixe so that
+  one can write, e.g., `10bytes` instead of just `10` for sizes.
+
+- Replaces the old definition of fixed points with the new canonical indexed
+  fixed point definition of fixed point types.
+
+- Replaces the reduction based type equality with declarative equality of types
+  that includes standard properties for equality (i.e. symmetry, transitivity,
+  and congruence).
+
+
+
+### Fixed
+
+- Fix typos in the definition of the CK machine that used just a return value
+  instead of a machine state.
+
+- Fix a bug in the definition of bounded type reduction that made not sense,
+  wherein it was somehow return the *term* `(error A)` instead of simply being
+  impossible to reduce. This obviously is nonsensical because types don't reduce
+  to terms.
+
+- Fix typo in the list of abbreviations that left `builtinT` in place instead of
+  changing it to `conT`.
+
+- Fix inconsistency between type frames and term frames, where type frames were
+  not named as such, and required the hole to be explicitly written, while the
+  term frames were named as such and did not require the hole to be explicity\
+  written. The new form is that all are explicitly named as frames and the holes
+  need not be written.

--- a/plutus-core-spec/figures/PlutusCoreBuiltins.tex
+++ b/plutus-core-spec/figures/PlutusCoreBuiltins.tex
@@ -24,17 +24,17 @@
         \hline
         $\forall \alpha :: K.\ B$ & \(\allT{\alpha}{K}{B}\) \rule{0mm}{4mm} \\[\sep]
 
-        $\forall \alpha, \beta, \ldots :: K, \ldots.\ C$ & \(\forall \alpha :: K.\ \forall \beta :: K.\ \ldots.\ C\)\\[\sep]
+        $integer_s$ & \(\conT{\conIntegerType{}}{s}\)\\\\
 
-        $A \to B$ & \(\funT{A}{B}\)\\[\sep]
+        $bytestring_s$ & \(\conT{\conBytestringType{}}{s}\)\\\\
 
-        $err(A)$ & \(\error{A}\)\\[\sep]
+        $size_s$ & \(\conT{\conSizeType{}}{s}\)\\\\
 
-        $integer_s$ & \(\builtinT{\conIntegerType{}}{s}\)\\[\sep]
+        $integer_s$ & \(\conT{\conIntegerType{}}{s}\)\\[\sep]
 
-        $bytestring_s$ & \(\builtinT{\conBytestringType{}}{s}\)\\[\sep]
+        $bytestring_s$ & \(\conT{\conBytestringType{}}{s}\)\\[\sep]
 
-        $size_s$ & \(\builtinT{\conSizeType{}}{s}\)\\[\sep]
+        $size_s$ & \(\conT{\conSizeType{}}{s}\)\\[\sep]
 
         $\star$ & \(\typeK{}\)\\[\sep]
 

--- a/plutus-core-spec/figures/PlutusCoreBuiltins.tex
+++ b/plutus-core-spec/figures/PlutusCoreBuiltins.tex
@@ -23,15 +23,8 @@
         \textrm{Abbreviation} & \textrm{Expanded}\\
         \hline
         $\forall \alpha :: K.\ B$ & \(\allT{\alpha}{K}{B}\) \rule{0mm}{4mm} \\[\sep]
-
         $integer_s$ & \(\conT{\conIntegerType{}}{s}\)\\[\sep]
-
-        $bytestring_s$ & \(\conT{\conBytestringType{}}{s}\)\\[\sep]
-
-        $size_s$ & \(\conT{\conSizeType{}}{s}\)\\[\sep]
-
-        $integer_s$ & \(\conT{\conIntegerType{}}{s}\)\\[\sep]
-
+        
         $bytestring_s$ & \(\conT{\conBytestringType{}}{s}\)\\[\sep]
 
         $size_s$ & \(\conT{\conSizeType{}}{s}\)\\[\sep]

--- a/plutus-core-spec/figures/PlutusCoreBuiltins.tex
+++ b/plutus-core-spec/figures/PlutusCoreBuiltins.tex
@@ -24,11 +24,11 @@
         \hline
         $\forall \alpha :: K.\ B$ & \(\allT{\alpha}{K}{B}\) \rule{0mm}{4mm} \\[\sep]
 
-        $integer_s$ & \(\conT{\conIntegerType{}}{s}\)\\\\
+        $integer_s$ & \(\conT{\conIntegerType{}}{s}\)\\[\sep]
 
-        $bytestring_s$ & \(\conT{\conBytestringType{}}{s}\)\\\\
+        $bytestring_s$ & \(\conT{\conBytestringType{}}{s}\)\\[\sep]
 
-        $size_s$ & \(\conT{\conSizeType{}}{s}\)\\\\
+        $size_s$ & \(\conT{\conSizeType{}}{s}\)\\[\sep]
 
         $integer_s$ & \(\conT{\conIntegerType{}}{s}\)\\[\sep]
 

--- a/plutus-core-spec/figures/PlutusCoreGrammar.tex
+++ b/plutus-core-spec/figures/PlutusCoreGrammar.tex
@@ -9,7 +9,7 @@
                                   &        &     & \con{cn}                   & \textrm{constant}\\
                                   &        &     & \abs{\alpha}{K}{V}         & \textrm{type abstraction}\\
                                   &        &     & \inst{M}{A}                & \textrm{type instantiation}\\
-                                  &        &     & \wrap{\alpha}{A}{M}        & \textrm{fix type's wrap}\\
+                                  &        &     & \wrap{A}{B}{M}             & \textrm{fix type's wrap}\\
                                   &        &     & \unwrap{M}                 & \textrm{fix type's unwrap}\\
                                   &        &     & \lam{x}{A}{M}              & \textrm{$\lambda$ abstraction}\\
                                   &        &     & \app{M}{N}                 & \textrm{function application}\\
@@ -23,7 +23,7 @@
                                   &        &     & s                          & \textrm{size}\\
                                   &        &     & \funT{A}{B}                & \textrm{function type}\\
                                   &        &     & \allT{\alpha}{K}{A}        & \textrm{polymorphic type}\\
-                                  &        &     & \fixT{\alpha}{A}           & \textrm{fixed point type}\\
+                                  &        &     & \fixT{A}{B}                & \textrm{fixed point type}\\
                                   &        &     & \lamT{\alpha}{K}{A}        & \textrm{$\lambda$ abstraction}\\
                                   &        &     & \appT{A}{B}                & \textrm{function application}\\
                                   &        &     & \conT{tcn}{A}          & \textrm{type constant}\\

--- a/plutus-core-spec/figures/PlutusCoreLexicalGrammar.tex
+++ b/plutus-core-spec/figures/PlutusCoreLexicalGrammar.tex
@@ -15,7 +15,7 @@
 
         \textrm{ByteString}   & b  & ::= & \texttt{\#}([\texttt{a}\!\hyphen{}\!\texttt{fA}\!\hyphen{}\!\texttt{F0}\!\hyphen{}\!\texttt{9}][\texttt{a}\!\hyphen{}\!\texttt{fA}\!\hyphen{}\!\texttt{F0}\!\hyphen{}\!\texttt{9}])^+ & \textrm{hex string}\\
 
-        \textrm{Size} & s  & ::= & [\texttt{0}\!\hyphen{}\!\texttt{9}]^+ & \textrm{size}\\
+        \textrm{Size} & s  & ::= & [\texttt{0}\!\hyphen{}\!\texttt{9}]^+ \texttt{bytes}^? & \textrm{size}\\
 
         \textrm{Version} & v & ::= & [\texttt{0}\!\hyphen{}\!\texttt{9}]^+(.[\texttt{0}\!\hyphen{}\!\texttt{9}]^+)^* & \textrm{version}\\
 

--- a/plutus-core-spec/figures/PlutusCoreReduction-Algorithmic-Restricted.tex
+++ b/plutus-core-spec/figures/PlutusCoreReduction-Algorithmic-Restricted.tex
@@ -11,12 +11,7 @@
 	
 	\begin{prooftree}
 		\AxiomC{}
-		\UnaryInfC{\(\typeBoundedMultistep{0}{A}{\error{A}}\)}
-	\end{prooftree}
-	
-	\begin{prooftree}
-		\AxiomC{}
-		\UnaryInfC{\(\typeBoundedMultistep{n+1}{S}{S}\)}
+		\UnaryInfC{\(\typeBoundedMultistep{n}{S}{S}\)}
 	\end{prooftree}
 	
 	\begin{prooftree}

--- a/plutus-core-spec/figures/PlutusCoreReduction.tex
+++ b/plutus-core-spec/figures/PlutusCoreReduction.tex
@@ -1,0 +1,196 @@
+\documentclass[../main.tex]{subfiles}
+
+\begin{document}
+
+
+
+
+
+\begin{figure*}
+    \centering
+    \[\begin{array}{lrclr}
+        \textrm{Type Frame} & f  & ::= & \inConT{tcn}{\_}                          & \textrm{type constant}\\
+                            &    &     & \inFunTLeft{\_}{A}                        & \textrm{left arrow}\\
+                            &    &     & \inFunTRight{S}{\_}                       & \textrm{right arrow}\\
+                            &    &     & \inAllT{\alpha}{K}{\_}                    & \textrm{all}\\
+                            &    &     & \inFixT{\alpha}{\_}                       & \textrm{fix}\\
+                            &    &     & \inLamT{\alpha}{K}{\_}                    & \textrm{$\lambda$}\\
+                            &    &     & \inAppTLeft{\_}{A}                        & \textrm{left app}\\
+                            &    &     & \inAppTRight{S}{\_}                       & \textrm{right app}\\
+    \end{array}\]
+
+    \caption{Grammar of Type Reduction Frames}
+    \label{fig:Plutus_core_type_reduction_frames}
+\end{figure*}
+
+
+
+
+
+\begin{figure*}[t]
+    \judgmentdef{\(\typeStep{A}{A'}\)}{Type $A$ reduces in one step to type $A'$}
+
+    \begin{prooftree}
+        \AxiomC{}
+        \UnaryInfC{\(\typeStep{\appT{\lamT{\alpha}{K}{B}}{S}}{\subst{S}{\alpha}{B}}\)}
+    \end{prooftree}
+
+    \begin{prooftree}
+        \AxiomC{\(\typeStep{A}{A'}\)}
+        \UnaryInfC{\(\typeStep{\ctxsubst{f}{A}}{\ctxsubst{f}{A'}}\)}
+    \end{prooftree}
+
+    \caption{Type Reduction via Contextual Dynamics}
+    \label{fig:Plutus_core_type_reduction}
+\end{figure*}
+
+
+
+\begin{figure*}[t]
+	\judgmentdef{\(\kindEqual{K}{K'}\)}{Kind $K$ is syntactically identical to kind $K'$. (Inductive definition omitted.)}
+	\vspace{2em}
+	
+	\judgmentdef{\(\typeEqual{A}{A'}\)}{Type $A$ is syntactically identical to type $A'$ modulo $\alpha$ conversion. (Inductive definition omitted.)}
+	\vspace{2em}
+	
+	
+	\judgmentdef{\(\typeEquiv{A}{A'}\)}{Type $A$ is equivalent to type $A'$ modulo $\beta$ reduction}
+	
+	\begin{prooftree}
+		\AxiomC{\(\typeMultistep{A}{S}\)}
+		\AxiomC{\(\typeMultistep{A'}{S'}\)}
+		\AxiomC{\(\typeEqual{S}{S'}\)}
+		\TrinaryInfC{\(\typeEquiv{A}{A'}\)}
+	\end{prooftree}
+	
+	
+	
+	\caption{Equalities and Equivalences}
+	\label{fig:Plutus_core_equalities_and_equivalences}
+\end{figure*}
+
+
+
+
+
+\begin{figure*}[t]
+    \centering
+    \[\begin{array}{lrclr}
+        \textrm{Frame} &   &     & \inInstLeftFrame{A}                     & \textrm{left instantiation}\\
+                       %&   &     & \inInstRightFrame{V}                    & \textrm{right instantiation}\\
+                       %&   &     & \inWrapLeftFrame{\alpha}{M}             & \textrm{left wrap}\\
+                       &   &     & \inWrapRightFrame{\alpha}{A}            & \textrm{right wrap}\\
+                       &   &     & \inUnwrapFrame{}                        & \textrm{unwrap}\\
+                       %&   &     & \inLamLeftFrame{x}{M}                   & \textrm{$\lambda$}\\
+                       &   &     & \inAppLeftFrame{M}                      & \textrm{left app}\\
+                       &   &     & \inAppRightFrame{V}                     & \textrm{right app}\\
+                       &   &     & \inBuiltin{bn}{A^*}{V^*}{\_}{M^*}        & \textrm{builtin}\\
+    \end{array}\]
+    \caption{Grammar of Reduction Frames}
+    \label{fig:Plutus_core_reduction_frames}
+\end{figure*}
+
+
+
+
+\begin{figure*}[t]
+    \judgmentdef{\(\step{M}{M'}\)}{Term $M$ reduces in one step to term $M'$}
+
+    \begin{prooftree}
+        \AxiomC{}
+        \UnaryInfC{\(\step{\inst{\abs{\alpha}{K}{V}}{A}}{V}\)}
+    \end{prooftree}
+
+    \begin{prooftree}
+        \AxiomC{}
+        \UnaryInfC{\(\step{\unwrap{\wrap{\alpha}{A}{V}}}{V}\)}
+    \end{prooftree}
+
+    \begin{prooftree}
+        \AxiomC{}
+        \UnaryInfC{\(\step{\app{\lam{x}{A}{M}}{V}}{\subst{V}{x}{M}}\)}
+    \end{prooftree}
+
+    \begin{prooftree}
+        \AxiomC{$bn$ computes on $\repetition{A}$ and $\repetition{V}$ to $U$ according to \ref{fig:Plutus_core_builtins}}
+        \UnaryInfC{\(\step{\builtin{bn}{\repetition{A}}{\repetition{V}}}{U}\)}
+    \end{prooftree}
+
+    %\begin{prooftree}
+    %    \AxiomC{\(\typeStep{A}{A'}\)}
+    %    \UnaryInfC{\(\step{\ctxsubst{f}{A}}{\ctxsubst{f}{A'}}\)}
+    %\end{prooftree}
+
+    \begin{prooftree}
+        \AxiomC{\(\step{M}{M'}\)}
+        \AxiomC{\(M' = \error{B}\)}
+        \RightLabel{\footnotesize\textit{($A$ is the type of the frame, $B$ is the type of its hole)}}
+        \BinaryInfC{\(\step{\ctxsubst{f}{M}}{\error{A}}\)}
+    \end{prooftree}
+
+    \begin{prooftree}
+        \AxiomC{\(\step{M}{M'}\)}
+        \AxiomC{\(M' \not= \error{B}\)}
+        \BinaryInfC{\(\step{\ctxsubst{f}{M}}{\ctxsubst{f}{M'}}\)}
+    \end{prooftree}
+
+
+
+
+
+
+    \caption{Reduction via Contextual Dynamics}
+    \label{fig:Plutus_core_reduction}
+\end{figure*}
+
+
+
+
+
+\begin{figure*}
+    \centering
+    \[\begin{array}{lrclr}
+        \textrm{Stack} & s      & ::= & f^*                               & \textrm{stacks}\\
+        \textrm{State} & \sigma & ::= & \ckforward{s}{M}                  & \textrm{computing a term}\\
+                       %&        &     & \ckforward{s}{A}                  & \textrm{computing a type}\\
+                       &        &     & \ckbackward{s}{V}                 & \textrm{returning a term value}\\
+                       %&        &     & \ckbackward{s}{S}                 & \textrm{returning a type value}\\
+                       &        &     & \ckerror{}                        & \textrm{throwing an error}
+    \end{array}\]
+
+    \caption{Grammar of CK Machine States}
+    \label{fig:Plutus_core_ck_frames}
+\end{figure*}
+
+
+
+\begin{figure*}[t]
+    \judgmentdef{\(\cksteps{\sigma}{\sigma'}\)}{Machine state $\sigma$ transitions in one step to machine state $\sigma'$}
+
+    \begin{align*}
+        &\cksteps{\ckforward{s}{\con{cn}}}{\ckbackward{s}{\con{cn}}}\\
+        &\cksteps{\ckforward{s}{\abs{\alpha}{K}{V}}}{\ckbackward{s}{\abs{\alpha}{K}{V}}}\\
+        &\cksteps{\ckforward{s}{\inst{M}{A}}}{\ckforward{s, \inInstLeftFrame{A}}{M}}\\
+        &\cksteps{\ckforward{s}{\wrap{\alpha}{A}{M}}}{\ckforward{s, \inWrapRightFrame{\alpha}{A}}{M}}\\
+        &\cksteps{\ckforward{s}{\unwrap{M}}}{\ckforward{s, \inUnwrapFrame{}}{M}}\\
+        &\cksteps{\ckforward{s}{\lam{x}{A}{M}}}{\ckbackward{s}{\lam{x}{A}{M}}}\\
+        &\cksteps{\ckforward{s}{\app{M}{N}}}{\ckforward{s, \inAppLeftFrame{N}}{M}}\\
+        &\cksteps{\ckforward{s}{\builtin{bn}{\repetition{A}}{}}}{\ckbackward{s}{U}} \qquad \textit{$bn$ computes on $\repetition{A}$ to $U$ according to \ref{fig:Plutus_core_builtins}}\\
+        &\cksteps{\ckforward{s}{\builtin{bn}{\repetition{A}}{M \repetition{M}}}}{\ckforward{s, \inBuiltin{bn}{\repetition{A}}{}{\_}{\repetition{M}}}{M}}\\
+        &\cksteps{\ckforward{s}{\error{A}}}{\ckerror{}}\\
+        &\cksteps{\ckbackward{s, \inInstLeftFrame{A}}{\abs{\alpha}{K}{M}}}{\ckforward{s}{M}}\\
+        &\cksteps{\ckbackward{s, \inWrapRightFrame{\alpha}{A}}{V}}{\ckbackward{s}{\wrap{\alpha}{A}{V}}}\\
+        &\cksteps{\ckbackward{s, \inUnwrapFrame{}}{\wrap{\alpha}{A}{V}}}{\ckbackward{s}{V}}\\
+        &\cksteps{\ckbackward{s, \inAppLeftFrame{N}}{V}}{\ckforward{s, \inAppRightFrame{V}}{N}}\\
+        &\cksteps{\ckbackward{s, \inAppRightFrame{\lam{x}{A}{M}}}{V}}{\ckforward{s}{\subst{V}{x}{M}}}\\
+        &\cksteps{\ckbackward{s, \inBuiltin{bn}{\repetition{A}}{\repetition{V}}{\_}{}}{V}}{\ckbackward{s}{U}} \qquad \textit{$bn$ computes on $\repetition{A}$ and $\repetition{V}V$ to $U$ according to \ref{fig:Plutus_core_builtins}}\\
+        &\cksteps{\ckbackward{s, \inBuiltin{bn}{\repetition{A}}{\repetition{V}}{\_}{M \repetition{M}}}{V}}{\ckforward{s, \inBuiltin{bn}{\repetition{A}}{\repetition{V} V}{\_}{\repetition{M}}}{M}}\\
+    \end{align*}
+
+    \caption{CK Machine}
+    \label{fig:Plutus_core_ck_machine}
+\end{figure*}
+
+
+
+\end{document}

--- a/plutus-core-spec/figures/PlutusCoreReduction.tex
+++ b/plutus-core-spec/figures/PlutusCoreReduction.tex
@@ -9,15 +9,15 @@
 \begin{figure*}
     \centering
     \[\begin{array}{lrclr}
-        \textrm{Type Frame} & f  & ::= & \inConT{tcn}{\_}                          & \textrm{type constant}\\
-                            &    &     & \inFunTLeft{\_}{A}                        & \textrm{left arrow}\\
-                            &    &     & \inFunTRight{S}{\_}                       & \textrm{right arrow}\\
-                            &    &     & \inAllT{\alpha}{K}{\_}                    & \textrm{all}\\
-                            &	 &     & \inFixTLeft{\_}{B}                        & \textrm{left fix}\\
-                            &    &     & \inFixTRight{S}{\_}                       & \textrm{right fix}\\
-                            &    &     & \inLamT{\alpha}{K}{\_}                    & \textrm{$\lambda$}\\
-                            &    &     & \inAppTLeft{\_}{A}                        & \textrm{left app}\\
-                            &    &     & \inAppTRight{S}{\_}                       & \textrm{right app}\\
+        \textrm{Type Frame} & f  & ::= & \inConTFrame{tcn}                          & \textrm{type constant}\\
+                            &    &     & \inFunTLeftFrame{A}                        & \textrm{left arrow}\\
+                            &    &     & \inFunTRightFrame{S}                       & \textrm{right arrow}\\
+                            &    &     & \inAllTFrame{\alpha}{K}                    & \textrm{all}\\
+                            &	 &     & \inFixTLeftFrame{B}                        & \textrm{left fix}\\
+                            &    &     & \inFixTRightFrame{S}                       & \textrm{right fix}\\
+                            &    &     & \inLamTFrame{\alpha}{K}                    & \textrm{$\lambda$}\\
+                            &    &     & \inAppTLeftFrame{A}                        & \textrm{left app}\\
+                            &    &     & \inAppTRightFrame{S}                       & \textrm{right app}\\
     \end{array}\]
 
     \caption{Grammar of Type Reduction Frames}

--- a/plutus-core-spec/figures/PlutusCoreReduction.tex
+++ b/plutus-core-spec/figures/PlutusCoreReduction.tex
@@ -56,12 +56,52 @@
 	
 	\judgmentdef{\(\typeEquiv{A}{A'}\)}{Type $A$ is equivalent to type $A'$ modulo $\beta$ reduction}
 	
+	% beta conversion
+	
 	\begin{prooftree}
-		\AxiomC{\(\typeMultistep{A}{S}\)}
-		\AxiomC{\(\typeMultistep{A'}{S'}\)}
-		\AxiomC{\(\typeEqual{S}{S'}\)}
-		\TrinaryInfC{\(\typeEquiv{A}{A'}\)}
+		\AxiomC{}
+		\UnaryInfC{\(\typeEquiv{\appT{\lamT{\alpha}{K}{B}}{A}}{\subst{A}{\alpha}{B}}\)}
 	\end{prooftree}
+	
+	% alpha
+	
+	\begin{prooftree}
+		\AxiomC{\(\typeEqual{A}{A'}\)}
+		\RightLabel{$\alpha$}
+		\UnaryInfC{\(\typeEquiv{A}{A'}\)}
+	\end{prooftree}
+	
+	% sym
+	
+	\begin{prooftree}
+		\AxiomC{\(\typeEquiv{A}{A'}\)}
+		\RightLabel{sym}
+		\UnaryInfC{\(\typeEquiv{A'}{A}\)}
+	\end{prooftree}
+	
+	% trans
+	
+	\begin{prooftree}
+		\AxiomC{\(\typeEquiv{A}{A'}\)}
+		\AxiomC{\(\typeEquiv{A'}{A''}\)}
+		\RightLabel{trans}
+		\BinaryInfC{\(\typeEquiv{A}{A''}\)}
+	\end{prooftree}
+	
+	% cong
+	
+	\begin{prooftree}
+		\AxiomC{\(\typeEquiv{A}{A'}\)}
+		\RightLabel{cong}
+		\UnaryInfC{\(\typeEquiv{\ctxsubst{f}{A}}{\ctxsubst{f}{A'}}\)}
+	\end{prooftree}
+	
+	%\begin{prooftree}
+	%	\AxiomC{\(\typeMultistep{A}{S}\)}
+	%	\AxiomC{\(\typeMultistep{A'}{S'}\)}
+	%	\AxiomC{\(\typeEqual{S}{S'}\)}
+	%	\TrinaryInfC{\(\typeEquiv{A}{A'}\)}
+	%\end{prooftree}
 	
 	
 	

--- a/plutus-core-spec/figures/PlutusCoreReduction.tex
+++ b/plutus-core-spec/figures/PlutusCoreReduction.tex
@@ -13,7 +13,8 @@
                             &    &     & \inFunTLeft{\_}{A}                        & \textrm{left arrow}\\
                             &    &     & \inFunTRight{S}{\_}                       & \textrm{right arrow}\\
                             &    &     & \inAllT{\alpha}{K}{\_}                    & \textrm{all}\\
-                            &    &     & \inFixT{\alpha}{\_}                       & \textrm{fix}\\
+                            &	 &     & \inFixTLeft{\_}{B}                        & \textrm{left fix}\\
+                            &    &     & \inFixTRight{S}{\_}                       & \textrm{right fix}\\
                             &    &     & \inLamT{\alpha}{K}{\_}                    & \textrm{$\lambda$}\\
                             &    &     & \inAppTLeft{\_}{A}                        & \textrm{left app}\\
                             &    &     & \inAppTRight{S}{\_}                       & \textrm{right app}\\
@@ -119,12 +120,12 @@
         \textrm{Frame} &   &     & \inInstLeftFrame{A}                     & \textrm{left instantiation}\\
                        %&   &     & \inInstRightFrame{V}                    & \textrm{right instantiation}\\
                        %&   &     & \inWrapLeftFrame{\alpha}{M}             & \textrm{left wrap}\\
-                       &   &     & \inWrapRightFrame{\alpha}{A}            & \textrm{right wrap}\\
+                       &   &     & \inWrapRightFrame{A}{B}                 & \textrm{right wrap}\\
                        &   &     & \inUnwrapFrame{}                        & \textrm{unwrap}\\
                        %&   &     & \inLamLeftFrame{x}{M}                   & \textrm{$\lambda$}\\
                        &   &     & \inAppLeftFrame{M}                      & \textrm{left app}\\
                        &   &     & \inAppRightFrame{V}                     & \textrm{right app}\\
-                       &   &     & \inBuiltin{bn}{A^*}{V^*}{\_}{M^*}        & \textrm{builtin}\\
+                       &   &     & \inBuiltin{bn}{A^*}{V^*}{\_}{M^*}       & \textrm{builtin}\\
     \end{array}\]
     \caption{Grammar of Reduction Frames}
     \label{fig:Plutus_core_reduction_frames}
@@ -143,7 +144,7 @@
 
     \begin{prooftree}
         \AxiomC{}
-        \UnaryInfC{\(\step{\unwrap{\wrap{\alpha}{A}{V}}}{V}\)}
+        \UnaryInfC{\(\step{\unwrap{\wrap{A}{B}{V}}}{V}\)}
     \end{prooftree}
 
     \begin{prooftree}
@@ -211,7 +212,7 @@
         &\cksteps{\ckforward{s}{\con{cn}}}{\ckbackward{s}{\con{cn}}}\\
         &\cksteps{\ckforward{s}{\abs{\alpha}{K}{V}}}{\ckbackward{s}{\abs{\alpha}{K}{V}}}\\
         &\cksteps{\ckforward{s}{\inst{M}{A}}}{\ckforward{s, \inInstLeftFrame{A}}{M}}\\
-        &\cksteps{\ckforward{s}{\wrap{\alpha}{A}{M}}}{\ckforward{s, \inWrapRightFrame{\alpha}{A}}{M}}\\
+        &\cksteps{\ckforward{s}{\wrap{A}{B}{M}}}{\ckforward{s, \inWrapRightFrame{A}{B}}{M}}\\
         &\cksteps{\ckforward{s}{\unwrap{M}}}{\ckforward{s, \inUnwrapFrame{}}{M}}\\
         &\cksteps{\ckforward{s}{\lam{x}{A}{M}}}{\ckbackward{s}{\lam{x}{A}{M}}}\\
         &\cksteps{\ckforward{s}{\app{M}{N}}}{\ckforward{s, \inAppLeftFrame{N}}{M}}\\
@@ -219,8 +220,8 @@
         &\cksteps{\ckforward{s}{\builtin{bn}{\repetition{A}}{M \repetition{M}}}}{\ckforward{s, \inBuiltin{bn}{\repetition{A}}{}{\_}{\repetition{M}}}{M}}\\
         &\cksteps{\ckforward{s}{\error{A}}}{\ckerror{}}\\
         &\cksteps{\ckbackward{s, \inInstLeftFrame{A}}{\abs{\alpha}{K}{M}}}{\ckforward{s}{M}}\\
-        &\cksteps{\ckbackward{s, \inWrapRightFrame{\alpha}{A}}{V}}{\ckbackward{s}{\wrap{\alpha}{A}{V}}}\\
-        &\cksteps{\ckbackward{s, \inUnwrapFrame{}}{\wrap{\alpha}{A}{V}}}{\ckbackward{s}{V}}\\
+        &\cksteps{\ckbackward{s, \inWrapRightFrame{A}{B}}{V}}{\ckbackward{s}{\wrap{A}{B}{V}}}\\
+        &\cksteps{\ckbackward{s, \inUnwrapFrame{}}{\wrap{A}{B}{V}}}{\ckbackward{s}{V}}\\
         &\cksteps{\ckbackward{s, \inAppLeftFrame{N}}{V}}{\ckforward{s, \inAppRightFrame{V}}{N}}\\
         &\cksteps{\ckbackward{s, \inAppRightFrame{\lam{x}{A}{M}}}{V}}{\ckforward{s}{\subst{V}{x}{M}}}\\
         &\cksteps{\ckbackward{s, \inBuiltin{bn}{\repetition{A}}{\repetition{V}}{\_}{}}{V}}{\ckbackward{s}{U}} \qquad \textit{$bn$ computes on $\repetition{A}$ and $\repetition{V}V$ to $U$ according to \ref{fig:Plutus_core_builtins}}\\

--- a/plutus-core-spec/figures/PlutusCoreTypeCorrectness-Algorithmic-Restricted.tex
+++ b/plutus-core-spec/figures/PlutusCoreTypeCorrectness-Algorithmic-Restricted.tex
@@ -58,7 +58,7 @@
     \begin{prooftree}
         \AxiomC{\(\hypJ{\Gamma}{\istermJ{L}{\funT{S}{T}}}\)}
         \AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{S'}}\)}
-        \AxiomC{\(S \equiv S'\)}
+        \AxiomC{\(\typeEqual{S}{S'}\)}
         \RightLabel{app}
         \TrinaryInfC{\(\hypJ{\Gamma}{\istermJ{\app{L}{M}}{T}}\)}
     \end{prooftree}
@@ -68,7 +68,7 @@
         \AxiomC{$bn$ has signature $\sig{\alpha_0 :: K_0, ..., \alpha_m :: K_m}{B_0, ..., B_n}{C}$ in Fig. \ref{fig:Plutus_core_builtins}}
         \UnaryInfC{\(\diffbox{\typeBoundedMultistep{\textit{MAX}}{\subst{S_0, ..., S_m}{\alpha_0, ..., \alpha_m}{B_i}}{T_i}}\)}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{M_i}{T'_i}}\)}
-        \UnaryInfC{\(T_i \equiv T'_i\)}
+        \UnaryInfC{\(\typeEqual{T_i}{T'_i}\)}
         \UnaryInfC{\(\diffbox{\typeBoundedMultistep{\textit{MAX}}{\subst{S_0, ..., S_m}{\alpha_0, ..., \alpha_m}{C}}{R}}\)}
         \alwaysSingleLine
         \RightLabel{builtin}

--- a/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
+++ b/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
@@ -212,6 +212,13 @@
         \RightLabel{error}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\error{A}}{A}}\)}
     \end{prooftree}
+    
+    \begin{prooftree}
+    	\AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{A}}\)}
+		\AxiomC{\(\typeEquiv{A}{A'}\)}
+		\RightLabel{conv}
+		\BinaryInfC{\(\hypJ{\Gamma}{\istermJ{M}{A'}}\)}
+    \end{prooftree}
 
     \captionof{figure}{Type Synthesis}
     \label{fig:Plutus_core_type_synthesis}

--- a/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
+++ b/plutus-core-spec/figures/PlutusCoreTypeCorrectness.tex
@@ -94,9 +94,10 @@
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{\(\hypJ{\Gamma, \typeJ{\alpha}{\typeK{}}}{\istypeJ{A}{\typeK{}}}\)}
+		\AxiomC{\(\hypJ{\Gamma}{\istypeJ{B}{K}}\)}
+		\AxiomC{\(\hypJ{\Gamma}{\istypeJ{A}{\funK{\funK{K}{\typeK{}}}{\funK{K}{\typeK{}}}}}\)}
         \RightLabel{tyfix}
-        \UnaryInfC{\(\hypJ{\Gamma}{\istypeJ{\fixT{\alpha}{A}}{\typeK{}}}\)}
+        \BinaryInfC{\(\hypJ{\Gamma}{\istypeJ{\fixT{A}{B}}{\typeK{}}}\)}
     \end{prooftree}
 
     \begin{prooftree}
@@ -165,20 +166,20 @@
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{\(\Gamma \vdash Q :: \typeK{}\)}
-        \AxiomC{\(Q = \mathcal{E}\{\fixT{\alpha}{A}\}\)}
-		\AxiomC{\(\Gamma \vdash M : \mathcal{E}\{[\fixT{\alpha}{A}/\alpha]A\}\)}
-		\RightLabel{wrap}
-		\TrinaryInfC{\(\hypJ{\Gamma}{\istermJ{\wrap{\alpha}{A}{M}}{Q}}\)}
+    	\AxiomC{\(\hypJ{\Gamma}{\istypeJ{B}{K}}\)}
+		\alwaysNoLine
+		\UnaryInfC{\(\hypJ{\Gamma}{\istypeJ{A}{\funK{\funK{K}{\typeK{}}}{\funK{K}{\typeK{}}}}}\)}
+		\UnaryInfC{\(\hypJ{\Gamma}{\istermJ{M}{\appT{\appT{A}{\lamT{\beta}{K}{\fixT{A}{\beta}}}}{B}}}\)}
+		\alwaysSingleLine
+    	\RightLabel{wrap}
+        \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\wrap{A}{B}{M}}{\fixT{A}{B}}}\)}
     \end{prooftree}
-    
-    Where $\mathcal{E}$ is an elimination context $\mathcal{E} ::= \bullet \mid [\mathcal{E} \,\, A]$, $A$ a type, such that $\mathcal{E}\{Q\}$ denotes the type expression obtained by replacing the $\bullet$ in $\mathcal{E}$ with $Q$. That is, $[\bullet\,\, A]\{B\} = [B\,\,A]$, and so on. 
 
     \begin{prooftree}
-        \AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{C}}\)}
-        \AxiomC{\(\typeEquiv{C}{\fixT{\alpha}{A}}\)}
-        \RightLabel{unwrap}
-        \BinaryInfC{\(\hypJ{\Gamma}{\istermJ{\unwrap{M}}{\subst{\fixT{\alpha}{A}}{\alpha}{A}}}\)}
+    	\AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{\fixT{A}{B}}}\)}
+		\AxiomC{\(\hypJ{\Gamma}{\istypeJ{B}{K}}\)}
+		\RightLabel{unwrap}
+        \BinaryInfC{\(\hypJ{\Gamma}{\istermJ{\unwrap{M}}{\appT{\appT{A}{\lamT{\beta}{K}{\fixT{A}{\beta}}}}{B}}}\)}
     \end{prooftree}
 
     \begin{prooftree}

--- a/plutus-core-spec/main.tex
+++ b/plutus-core-spec/main.tex
@@ -461,15 +461,15 @@
 \newcommand{\typeEquiv}[2]{#1 \equiv_{\mathit{ty}} #2}
 
 
-\newcommand{\inConT}[2]{\conT{#1}{#2}}
-\newcommand{\inAppTLeft}[2]{\appT{#1}{#2}}
-\newcommand{\inAppTRight}[2]{\appT{#1}{#2}}
-\newcommand{\inFunTLeft}[2]{\funT{#1}{#2}}
-\newcommand{\inFunTRight}[2]{\funT{#1}{#2}}
-\newcommand{\inAllT}[3]{\allT{#1}{#2}{#3}}
-\newcommand{\inFixTLeft}[2]{\fixT{#1}{#2}}
-\newcommand{\inFixTRight}[2]{\fixT{#1}{#2}}
-\newcommand{\inLamT}[3]{\lamT{#1}{#2}{#3}}
+\newcommand{\inConTFrame}[1]{\conT{#1}{\_}}
+\newcommand{\inAppTLeftFrame}[1]{\appT{\_}{#1}}
+\newcommand{\inAppTRightFrame}[1]{\appT{#1}{\_}}
+\newcommand{\inFunTLeftFrame}[1]{\funT{\_}{#1}}
+\newcommand{\inFunTRightFrame}[1]{\funT{#1}{\_}}
+\newcommand{\inAllTFrame}[2]{\allT{#1}{#2}{\_}}
+\newcommand{\inFixTLeftFrame}[1]{\fixT{\_}{#1}}
+\newcommand{\inFixTRightFrame}[1]{\fixT{#1}{\_}}
+\newcommand{\inLamTFrame}[2]{\lamT{#1}{#2}{\_}}
 
 \newcommand{\inBuiltin}[5]{\builtin{#1}{#2}{#3 #4 #5}}
 

--- a/plutus-core-spec/main.tex
+++ b/plutus-core-spec/main.tex
@@ -1,0 +1,852 @@
+
+%% bare_conf.tex
+%% V1.3
+%% 2007/01/11
+%% by Michael Shell
+%% See:
+%% http://www.michaelshell.org/
+%% for current contact information.
+%%
+%% This is a skeleton file demonstrating the use of IEEEtran.cls
+%% (requires IEEEtran.cls version 1.7 or later) with an IEEE conference paper.
+%%
+%% Support sites:
+%% http://www.michaelshell.org/tex/ieeetran/
+%% http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+%% and
+%% http://www.ieee.org/
+
+%%*************************************************************************
+%% Legal Notice:
+%% This code is offered as-is without any warranty either expressed or
+%% implied; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE!
+%% User assumes all risk.
+%% In no event shall IEEE or any contributor to this code be liable for
+%% any damages or losses, including, but not limited to, incidental,
+%% consequential, or any other damages, resulting from the use or misuse
+%% of any information contained here.
+%%
+%% All comments are the opinions of their respective authors and are not
+%% necessarily endorsed by the IEEE.
+%%
+%% This work is distributed under the LaTeX Project Public License (LPPL)
+%% ( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+%% distributed and modified. A copy of the LPPL, version 1.3, is included
+%% in the base LaTeX documentation of all distributions of LaTeX released
+%% 2003/12/01 or later.
+%% Retain all contribution notices and credits.
+%% ** Modified files should be clearly indicated as such, including  **
+%% ** renaming them and changing author support contact information. **
+%%
+%% File list of work: IEEEtran.cls, IEEEtran_HOWTO.pdf, bare_adv.tex,
+%%                    bare_conf.tex, bare_jrnl.tex, bare_jrnl_compsoc.tex
+%%*************************************************************************
+
+% *** Authors should verify (and, if needed, correct) their LaTeX system  ***
+% *** with the testflow diagnostic prior to trusting their LaTeX platform ***
+% *** with production work. IEEE's font choices can trigger bugs that do  ***
+% *** not appear when using other class files.                            ***
+% The testflow support page is at:
+% http://www.michaelshell.org/tex/testflow/
+
+
+
+% Note that the a4paper option is mainly intended so that authors in
+% countries using A4 can easily print to A4 and see how their papers will
+% look in print - the typesetting of the document will not typically be
+% affected with changes in paper size (but the bottom and side margins will).
+% Use the testflow package mentioned above to verify correct handling of
+% both paper sizes by the user's LaTeX system.
+%
+% Also note that the "draftcls" or "draftclsnofoot", not "draft", option
+% should be used if it is desired that the figures are to be displayed in
+% draft mode.
+%
+\documentclass[conference]{IEEEtran}
+\usepackage{blindtext, graphicx}
+\usepackage{url}
+% Add the compsoc option for Computer Society conferences.
+%
+% If IEEEtran.cls has not been installed into the LaTeX system files,
+% manually specify the path to it like:
+% \documentclass[conference]{../sty/IEEEtran}
+
+
+
+
+
+% Some very useful LaTeX packages include:
+% (uncomment the ones you want to load)
+
+
+% *** MISC UTILITY PACKAGES ***
+%
+%\usepackage{ifpdf}
+% Heiko Oberdiek's ifpdf.sty is very useful if you need conditional
+% compilation based on whether the output is pdf or dvi.
+% usage:
+% \ifpdf
+%   % pdf code
+% \else
+%   % dvi code
+% \fi
+% The latest version of ifpdf.sty can be obtained from:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/oberdiek/
+% Also, note that IEEEtran.cls V1.7 and later provides a builtin
+% \ifCLASSINFOpdf conditional that works the same way.
+% When switching from latex to pdflatex and vice-versa, the compiler may
+% have to be run twice to clear warning/error messages.
+
+
+
+
+
+
+% *** CITATION PACKAGES ***
+%
+%\usepackage{cite}
+% cite.sty was written by Donald Arseneau
+% V1.6 and later of IEEEtran pre-defines the format of the cite.sty package
+% \cite{} output to follow that of IEEE. Loading the cite package will
+% result in citation numbers being automatically sorted and properly
+% "compressed/ranged". e.g., [1], [9], [2], [7], [5], [6] without using
+% cite.sty will become [1], [2], [5]--[7], [9] using cite.sty. cite.sty's
+% \cite will automatically add leading space, if needed. Use cite.sty's
+% noadjust option (cite.sty V3.8 and later) if you want to turn this off.
+% cite.sty is already installed on most LaTeX systems. Be sure and use
+% version 4.0 (2003-05-27) and later if using hyperref.sty. cite.sty does
+% not currently provide for hyperlinked citations.
+% The latest version can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/cite/
+% The documentation is contained in the cite.sty file itself.
+
+
+
+
+
+
+% *** GRAPHICS RELATED PACKAGES ***
+%
+\ifCLASSINFOpdf
+  % \usepackage[pdftex]{graphicx}
+  % declare the path(s) where your graphic files are
+  % \graphicspath{{../pdf/}{../jpeg/}}
+  % and their extensions so you won't have to specify these with
+  % every instance of \includegraphics
+  % \DeclareGraphicsExtensions{.pdf,.jpeg,.png}
+\else
+  % or other class option (dvipsone, dvipdf, if not using dvips). graphicx
+  % will default to the driver specified in the system graphics.cfg if no
+  % driver is specified.
+  % \usepackage[dvips]{graphicx}
+  % declare the path(s) where your graphic files are
+  % \graphicspath{{../eps/}}
+  % and their extensions so you won't have to specify these with
+  % every instance of \includegraphics
+  % \DeclareGraphicsExtensions{.eps}
+\fi
+% graphicx was written by David Carlisle and Sebastian Rahtz. It is
+% required if you want graphics, photos, etc. graphicx.sty is already
+% installed on most LaTeX systems. The latest version and documentation can
+% be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/graphics/
+% Another good source of documentation is "Using Imported Graphics in
+% LaTeX2e" by Keith Reckdahl which can be found as epslatex.ps or
+% epslatex.pdf at: http://www.ctan.org/tex-archive/info/
+%
+% latex, and pdflatex in dvi mode, support graphics in encapsulated
+% postscript (.eps) format. pdflatex in pdf mode supports graphics
+% in .pdf, .jpeg, .png and .mps (metapost) formats. Users should ensure
+% that all non-photo figures use a vector format (.eps, .pdf, .mps) and
+% not a bitmapped formats (.jpeg, .png). IEEE frowns on bitmapped formats
+% which can result in "jaggedy"/blurry rendering of lines and letters as
+% well as large increases in file sizes.
+%
+% You can find documentation about the pdfTeX application at:
+% http://www.tug.org/applications/pdftex
+
+
+
+
+
+% *** MATH PACKAGES ***
+%
+\usepackage[cmex10]{amsmath}
+\usepackage{stmaryrd}
+% A popular package from the American Mathematical Society that provides
+% many useful and powerful commands for dealing with mathematics. If using
+% it, be sure to load this package with the cmex10 option to ensure that
+% only type 1 fonts will utilized at all point sizes. Without this option,
+% it is possible that some math symbols, particularly those within
+% footnotes, will be rendered in bitmap form which will result in a
+% document that can not be IEEE Xplore compliant!
+%
+% Also, note that the amsmath package sets \interdisplaylinepenalty to 10000
+% thus preventing page breaks from occurring within multiline equations. Use:
+%\interdisplaylinepenalty=2500
+% after loading amsmath to restore such page breaks as IEEEtran.cls normally
+% does. amsmath.sty is already installed on most LaTeX systems. The latest
+% version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/amslatex/math/
+
+
+
+
+
+% *** SPECIALIZED LIST PACKAGES ***
+%
+%\usepackage{algorithmic}
+% algorithmic.sty was written by Peter Williams and Rogerio Brito.
+% This package provides an algorithmic environment fo describing algorithms.
+% You can use the algorithmic environment in-text or within a figure
+% environment to provide for a floating algorithm. Do NOT use the algorithm
+% floating environment provided by algorithm.sty (by the same authors) or
+% algorithm2e.sty (by Christophe Fiorio) as IEEE does not use dedicated
+% algorithm float types and packages that provide these will not provide
+% correct IEEE style captions. The latest version and documentation of
+% algorithmic.sty can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/algorithms/
+% There is also a support site at:
+% http://algorithms.berlios.de/index.html
+% Also of interest may be the (relatively newer and more customizable)
+% algorithmicx.sty package by Szasz Janos:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/algorithmicx/
+
+
+
+
+% *** ALIGNMENT PACKAGES ***
+%
+\usepackage{array}
+% Frank Mittelbach's and David Carlisle's array.sty patches and improves
+% the standard LaTeX2e array and tabular environments to provide better
+% appearance and additional user controls. As the default LaTeX2e table
+% generation code is lacking to the point of almost being broken with
+% respect to the quality of the end results, all users are strongly
+% advised to use an enhanced (at the very least that provided by array.sty)
+% set of table tools. array.sty is already installed on most systems. The
+% latest version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/tools/
+
+
+%\usepackage{mdwmath}
+%\usepackage{mdwtab}
+% Also highly recommended is Mark Wooding's extremely powerful MDW tools,
+% especially mdwmath.sty and mdwtab.sty which are used to format equations
+% and tables, respectively. The MDWtools set is already installed on most
+% LaTeX systems. The lastest version and documentation is available at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/mdwtools/
+
+
+% IEEEtran contains the IEEEeqnarray family of commands that can be used to
+% generate multiline equations as well as matrices, tables, etc., of high
+% quality.
+
+
+%\usepackage{eqparbox}
+% Also of notable interest is Scott Pakin's eqparbox package for creating
+% (automatically sized) equal width boxes - aka "natural width parboxes".
+% Available at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/eqparbox/
+
+
+
+
+
+% *** SUBFIGURE PACKAGES ***
+%\usepackage[tight,footnotesize]{subfigure}
+% subfigure.sty was written by Steven Douglas Cochran. This package makes it
+% easy to put subfigures in your figures. e.g., "Figure 1a and 1b". For IEEE
+% work, it is a good idea to load it with the tight package option to reduce
+% the amount of white space around the subfigures. subfigure.sty is already
+% installed on most LaTeX systems. The latest version and documentation can
+% be obtained at:
+% http://www.ctan.org/tex-archive/obsolete/macros/latex/contrib/subfigure/
+% subfigure.sty has been superceeded by subfig.sty.
+
+
+
+%\usepackage[caption=false]{caption}
+%\usepackage[font=footnotesize]{subfig}
+% subfig.sty, also written by Steven Douglas Cochran, is the modern
+% replacement for subfigure.sty. However, subfig.sty requires and
+% automatically loads Axel Sommerfeldt's caption.sty which will override
+% IEEEtran.cls handling of captions and this will result in nonIEEE style
+% figure/table captions. To prevent this problem, be sure and preload
+% caption.sty with its "caption=false" package option. This is will preserve
+% IEEEtran.cls handing of captions. Version 1.3 (2005/06/28) and later
+% (recommended due to many improvements over 1.2) of subfig.sty supports
+% the caption=false option directly:
+%\usepackage[caption=false,font=footnotesize]{subfig}
+%
+% The latest version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/subfig/
+% The latest version and documentation of caption.sty can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/caption/
+
+
+
+
+% *** FLOAT PACKAGES ***
+%
+%\usepackage{fixltx2e}
+% fixltx2e, the successor to the earlier fix2col.sty, was written by
+% Frank Mittelbach and David Carlisle. This package corrects a few problems
+% in the LaTeX2e kernel, the most notable of which is that in current
+% LaTeX2e releases, the ordering of single and double column floats is not
+% guaranteed to be preserved. Thus, an unpatched LaTeX2e can allow a
+% single column figure to be placed prior to an earlier double column
+% figure. The latest version and documentation can be found at:
+% http://www.ctan.org/tex-archive/macros/latex/base/
+
+
+
+%\usepackage{stfloats}
+% stfloats.sty was written by Sigitas Tolusis. This package gives LaTeX2e
+% the ability to do double column floats at the bottom of the page as well
+% as the top. (e.g., "\begin{figure*}[!b]" is not normally possible in
+% LaTeX2e). It also provides a command:
+%\fnbelowfloat
+% to enable the placement of footnotes below bottom floats (the standard
+% LaTeX2e kernel puts them above bottom floats). This is an invasive package
+% which rewrites many portions of the LaTeX2e float routines. It may not work
+% with other packages that modify the LaTeX2e float routines. The latest
+% version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/sttools/
+% Documentation is contained in the stfloats.sty comments as well as in the
+% presfull.pdf file. Do not use the stfloats baselinefloat ability as IEEE
+% does not allow \baselineskip to stretch. Authors submitting work to the
+% IEEE should note that IEEE rarely uses double column equations and
+% that authors should try to avoid such use. Do not be tempted to use the
+% cuted.sty or midfloat.sty packages (also by Sigitas Tolusis) as IEEE does
+% not format its papers in such ways.
+
+
+
+
+
+% *** PDF, URL AND HYPERLINK PACKAGES ***
+%
+%\usepackage{url}
+% url.sty was written by Donald Arseneau. It provides better support for
+% handling and breaking URLs. url.sty is already installed on most LaTeX
+% systems. The latest version can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/misc/
+% Read the url.sty source comments for usage information. Basically,
+% \url{my_url_here}.
+
+
+
+
+
+% *** Do not adjust lengths that control margins, column widths, etc. ***
+% *** Do not use packages that alter fonts (such as pslatex).         ***
+% There should be no need to do such things with IEEEtran.cls V1.6 and later.
+% (Unless specifically asked to do so by the journal or conference you plan
+% to submit to, of course. )
+
+
+% correct bad hyphenation here
+\hyphenation{op-tical net-works semi-conduc-tor}
+
+
+
+
+\usepackage{subfiles}
+\usepackage{geometry}
+\usepackage{pdflscape}
+
+% *** IMPORTS FOR PLUTUS LANGUAGE ***
+
+\usepackage[T1]{fontenc}
+\usepackage{bussproofs,amsmath,amssymb}
+\usepackage{listings}
+\usepackage{xcolor}
+
+
+%\subfile{PlutusDefinitions}
+
+
+
+
+
+
+% *** DEFINITIONS FOR PLUTUS LANGUAGE ***
+
+
+
+%%% General Misc. Definitions
+
+\newcommand{\diffbox}[1]{\text{\colorbox{lightgray}{\(#1\)}}}
+\newcommand{\judgmentdef}[2]{\fbox{#1}
+
+\vspace{0.5em}
+
+#2}
+\newcommand{\hyphen}{\operatorname{-}}
+\newcommand{\repetition}[1]{\overline{#1}}
+\newcommand{\Fomega}{F$^{\omega}$}
+\newcommand{\keyword}[1]{\texttt{#1}}
+\newcommand{\construct}[1]{\texttt{(} #1 \texttt{)}}
+
+
+
+%%% Term Grammar
+
+\newcommand{\sig}[3]{[#1](#2)#3}
+\newcommand{\constsig}[2]{#1,#2}
+\newcommand{\con}[1]{\construct{\keyword{con} ~ #1}}
+\newcommand{\abs}[3]{\construct{\keyword{abs} ~ #1 ~ #2 ~ #3}}
+\newcommand{\inst}[2]{\texttt{\{}#1 ~ #2\texttt{\}}}
+\newcommand{\lam}[3]{\construct{\keyword{lam} ~ #1 ~ #2 ~ #3}}
+\newcommand{\app}[2]{\texttt{[} #1 ~ #2 \texttt{]}}
+\newcommand{\wrap}[3]{\construct{\keyword{wrap} ~ #1 ~ #2 ~ #3}}
+\newcommand{\unwrap}[1]{\construct{\keyword{unwrap} ~ #1}}
+\newcommand{\builtin}[3]{\construct{\keyword{builtin} ~ #1 ~ #2 ~ #3}}
+\newcommand{\error}[1]{\construct{\keyword{error} ~ #1}}
+\newcommand{\sizedBuiltin}[2]{#1\keyword{!}#2}
+
+
+
+%%%  Type Grammar
+
+\newcommand{\funT}[2]{\construct{\keyword{fun} ~ #1 ~ #2}}
+\newcommand{\fixT}[2]{\construct{\keyword{fix} ~ #1 ~ #2}}
+\newcommand{\allT}[3]{\construct{\keyword{all} ~ #1 ~ #2 ~ #3}}
+\newcommand{\conIntegerType}[1]{\keyword{integer}}
+\newcommand{\conBytestringType}[1]{\keyword{bytestring}}
+\newcommand{\conSizeType}[1]{\keyword{size}}
+\newcommand{\builtinT}[2]{\construct{\keyword{builtin} ~ #1 ~ #2}}
+\newcommand{\conT}[2]{\construct{\keyword{con} ~ #1 ~ #2}}
+\newcommand{\lamT}[3]{\construct{\keyword{lam} ~ #1 ~ #2 ~ #3}}
+\newcommand{\appT}[2]{\texttt{[} #1 ~ #2 \texttt{]}}
+
+\newcommand{\typeK}{\construct{\keyword{type}}}
+\newcommand{\funK}[2]{\construct{\keyword{fun} ~ #1 ~ #2}}
+\newcommand{\sizeK}{\construct{\keyword{size}}}
+
+
+
+%%% Program Grammar
+
+\newcommand{\version}[2]{\construct{\keyword{version} ~ #1 ~ #2}}
+
+
+
+%%% Judgments
+
+\newcommand{\hypJ}[2]{#1 \vdash #2}
+\newcommand{\ctxni}[2]{#1 \ni #2}
+\newcommand{\validJ}[1]{#1 \ \operatorname{valid}}
+\newcommand{\termJ}[2]{#1 : #2}
+\newcommand{\typeJ}[2]{#1 :: #2}
+\newcommand{\istermJ}[2]{#1 : #2}
+\newcommand{\istypeJ}[2]{#1 :: #2}
+
+
+
+%%% Contextual Normalization
+
+\newcommand{\ctxsubst}[2]{#1\{#2\}}
+\newcommand{\typeStep}[2]{#1 ~ \rightarrow_{ty} ~ #2}
+\newcommand{\typeMultistep}[2]{#1 ~ \rightarrow_{ty}^{*} ~ #2}
+\newcommand{\typeBoundedMultistep}[3]{#2 ~ \rightarrow_{ty}^{#1} ~ #3}
+\newcommand{\step}[2]{#1 ~ \rightarrow ~ #2}
+\newcommand{\multistepIndexed}[3]{#1 ~ \rightarrow^{#2} ~ #3}
+\newcommand{\normalform}[1]{\lfloor #1 \rfloor}
+\newcommand{\subst}[3]{[#1/#2]#3}
+\newcommand{\kindEqual}[2]{#1 =_{\mathit{k}} #2}
+\newcommand{\typeEqual}[2]{#1 =_{\mathit{ty}} #2}
+\newcommand{\typeEquiv}[2]{#1 \equiv_{\mathit{ty}} #2}
+
+
+\newcommand{\inConT}[2]{\conT{#1}{#2}}
+\newcommand{\inAppTLeft}[2]{\appT{#1}{#2}}
+\newcommand{\inAppTRight}[2]{\appT{#1}{#2}}
+\newcommand{\inFunTLeft}[2]{\funT{#1}{#2}}
+\newcommand{\inFunTRight}[2]{\funT{#1}{#2}}
+\newcommand{\inAllT}[3]{\allT{#1}{#2}{#3}}
+\newcommand{\inFixTLeft}[2]{\fixT{#1}{#2}}
+\newcommand{\inFixTRight}[2]{\fixT{#1}{#2}}
+\newcommand{\inLamT}[3]{\lamT{#1}{#2}{#3}}
+
+\newcommand{\inBuiltin}[5]{\builtin{#1}{#2}{#3 #4 #5}}
+
+
+
+%%% CK Machine Normalization
+
+\newcommand{\cksteps}[2]{#1 ~\mapsto~ #2}
+\newcommand{\ckforward}[2]{#1 \triangleright #2}
+\newcommand{\ckbackward}[2]{#1 \triangleleft #2}
+\newcommand{\ckerror}{\blacklozenge}
+
+\newcommand{\inInstLeftFrame}[1]{\inst{\_}{#1}}
+\newcommand{\inWrapRightFrame}[2]{\wrap{#1}{#2}{\_}}
+\newcommand{\inUnwrapFrame}{\unwrap{\_}}
+\newcommand{\inAppLeftFrame}[1]{\app{\_}{#1}}
+\newcommand{\inAppRightFrame}[1]{\app{#1}{\_}}
+
+
+
+
+
+
+
+
+\begin{document}
+%
+% paper title
+% can use linebreaks \\ within to get better formatting as desired
+\title{Formal Specification of\\the Plutus Core Language v1.0 (RC5.5)}
+
+
+% author names and affiliations
+% use a multiple column layout for up to three different
+% affiliations
+
+
+
+%\author{\IEEEauthorblockN{Rebecca Valentine}
+%\IEEEauthorblockA{Email: rebecca.valentine@iohk.io\\
+%Slack: @rebecca.valentine}
+
+
+
+%\and
+%\IEEEauthorblockN{Homer Simpson}
+%\IEEEauthorblockA{Twentieth Century Fox\\
+%Springfield, USA\\
+%Email: homer@thesimpsons.com}
+
+
+% conference papers do not typically use \thanks and this command
+% is locked out in conference mode. If really needed, such as for
+% the acknowledgment of grants, issue a \IEEEoverridecommandlockouts
+% after \documentclass
+
+% for over three affiliations, or if they all won't fit within the width
+% of the page, use this alternative format:
+%
+%\author{\IEEEauthorblockN{Michael Shell\IEEEauthorrefmark{1},
+%Homer Simpson\IEEEauthorrefmark{2},
+%James Kirk\IEEEauthorrefmark{3},
+%Montgomery Scott\IEEEauthorrefmark{3} and
+%Eldon Tyrell\IEEEauthorrefmark{4}}
+%\IEEEauthorblockA{\IEEEauthorrefmark{1}School of Electrical and Computer Engineering\\
+%Georgia Institute of Technology,
+%Atlanta, Georgia 30332--0250\\ Email: see http://www.michaelshell.org/contact.html}
+%\IEEEauthorblockA{\IEEEauthorrefmark{2}Twentieth Century Fox, Springfield, USA\\
+%Email: homer@thesimpsons.com}
+%\IEEEauthorblockA{\IEEEauthorrefmark{3}Starfleet Academy, San Francisco, California 96678-2391\\
+%Telephone: (800) 555--1212, Fax: (888) 555--1212}
+%\IEEEauthorblockA{\IEEEauthorrefmark{4}Tyrell Inc., 123 Replicant Street, Los Angeles, California 90210--4321}}
+
+
+
+
+% use for special paper notices
+%\IEEEspecialpapernotice{(Invited Paper)}
+
+
+
+
+% make the title area
+\maketitle
+
+\thispagestyle{plain}
+\pagestyle{plain}
+
+
+%\begin{abstract}
+%\boldmath
+%The Plutus Language is outlined, together with the major
+%design decisions for implementations. A formal specification of the
+%language is given, including an elaborator and bidirectional type
+%system.
+%\end{abstract}
+% IEEEtran.cls defaults to using nonbold math in the Abstract.
+% This preserves the distinction between vectors and scalars. However,
+% if the journal you are submitting to favors bold math in the abstract,
+% then you can use LaTeX's standard command \boldmath at the very start
+% of the abstract to achieve this. Many IEEE journals frown on math
+% in the abstract anyway.
+
+% Note that keywords are not normally used for peerreview papers.
+%\begin{IEEEkeywords}
+%IEEEtran, journal, \LaTeX, paper, template.
+%\end{IEEEkeywords}
+
+
+
+
+
+
+% For peer review papers, you can put extra information on the cover
+% page as needed:
+% \ifCLASSOPTIONpeerreview
+% \begin{center} \bfseries EDICS Category: 3-BBND \end{center}
+% \fi
+%
+% For peerreview papers, this IEEEtran command inserts a page break and
+% creates the second title. It will be ignored for other modes.
+\IEEEpeerreviewmaketitle
+
+
+
+
+\section{Plutus Core}
+
+Plutus Core is the target for compilation of Plutus TX, the smart
+contract language to validate transactions on Cardano. Plutus Core is
+designed to be simple and easy to reason about using proof assistants
+and automated theorem provers.
+
+Plutus Core has a strong formal basis. For those familiar with
+programming language theory, it can be described in one line: higher
+kinded System F with isorecursive types, and suitable
+primitive types and values. There are no constructs for data types,
+which are represented using Scott encodings---we do not use Church
+encodings since they may require linear rather than constant time to
+access the components of a data structure. Primitive types, such as
+Integer and Bytestring, are indexed by their size, which allows the
+cost (in gas) of operations such as addition to be determined at
+compile time. In contrast, IELE uses unbounded integers, which never
+overflow, but require that the gas used is calculated at run time. We
+use \Fomega{} (as opposed to F) because it supports types indexed by
+size and parameterised types (such as ``List of A'').
+
+Plutus Core also notably lacks obvious built-in support for recursion,
+either general or otherwise. The reason for this is simply that in
+the presence of type-level fixed points, it's possible to give a valid
+type to recursion combinators. This is analogous to the fact that in
+Haskell, you can define the Y combinator but you need to use a newtype
+declaration to do. Precisely which combinators one defines is up to
+the user, but as Plutus itself is eagerly reduced, some of them will
+lead to looping behavior, including Y. Libraries can of course
+be defined with various combinators provided as a convenient way to
+gain access to recursion.
+
+%Plutus Core is a typed, strict, eagerly-reduced $\lambda$-calculus design to run as a transaction validation scripting language on blockchain systems. It's designed to be simple and easy to reason about using mechanized proof assistants and automated theorem provers. The grammar of the language is given in Figures \ref{fig:Plutus_core_grammar} and \ref{fig:Plutus_core_lexical_grammar}, using a modified s-expression format. The language can be described as a higher-kinded Church-style/intrinsically-typed System F variant with fixedpoint terms, equirecursive fixedpoint types, constant terms, constant types, and size-indexed types. As such, we have the following syntactic constructs at the term level: variables, type annotation, type abstraction, type instantiation, $\lambda$ abstraction, application, term-level fixed points, and term constants. At the type level, we have the following syntactic constructs: variables, polymorphic types, function types, fixedpoint types, $\lambda$ abstraction, application, and constant types. Additionally we have the following kind-level constructs: type kind, function kind, and size kind. The language also explicitly tracks versions for tracking which version of the normalizer is to be run.
+
+%By using a variant of System F, we're able to capture various desirable abstraction properties via the continuation-based encoding of existential types. The choice to use fixedpoint types is so that we can represent recursive types via Scott encodings (instead of the less efficient and harder-to-program Church encodings typical of pure System F). Higher-kindedness makes it possible to define type operators like $\textit{List}$ rather than defining the non-parametric types $\textit{ListOfA}$ for each choice of $A$. Finally, sized types make it possible to specify for certain constant types precise what kind of memory usage they'll have. In particular, we track the size of integers and bytestrings explicitly in the types for them, which makes many kinds of formal reasoning about computation time possible.
+
+\section{Syntax}
+
+The grammar of Plutus Core is given in \ref{fig:Plutus_core_grammar} and
+\ref{fig:Plutus_core_lexical_grammar}. This grammar describes the abstract
+syntax trees of Plutus Core, in a convenient notation, and also describes
+the string syntax to be used when referring to those ASTs. The string
+syntax is not fundamental to Plutus Core, and only exists because we must
+refer to programs in documents such as this. Plutus Core programs are
+intended exist only as ASTs produced by compilers from higher languages,
+and as serialized representations on blockchains, and therefore we do not
+expect anyone to write programs in Plutus Core, nor need to use a parser
+for the language.
+
+Lexemes are described in standard regular expression notation.  The only other
+lexemes are round \texttt{()}, square \texttt{[]}, and curly \texttt{\{\}}
+brackets.  Spaces and tabs are allowed anywhere, and have no effect
+save to separate lexemes.
+
+Application in both terms and types is indicated by square
+brackets, and instantiation in terms is indicated by curly brackets. We
+permit the use of multi-argument application and instantiation as
+syntactic sugar for iterated application.
+For instance,
+\[
+  [M_0 ~ M_1 ~ M_2 ~ M_3]
+\]
+is sugar for
+\[
+  [[[M_0 ~ M_1] ~ M_2] ~ M_3]
+\]
+All subsequent definitions assume iterated application and instantiation
+has been expanded out, and use only the binary form. To the extent that
+a standard utility parser for Plutus Core might be made, for debugging
+purposes and other such things, iterated application and instantiation
+ought to be included as sugar.
+
+%In this grammar, we have multi-argument application, both in types (\(\appT{A}{B^+}\)) and in terms (\(\app{M}{N^+}\)), as well as multi-argument instantiation in terms (\(\inst{M}{A^*}\)). This is to be understood as a convenient form of syntactic sugar for iterated binary application associated to the left, and the formal rules treat only the binary case.
+
+
+
+\subfile{figures/PlutusCoreLexicalGrammar}
+
+\subfile{figures/PlutusCoreGrammar}
+
+
+
+
+
+% As an example, consider the program in Figure \ref{fig:Plutus_core_example}, which defines the type of natural numbers as well as lists, and the factorial and map functions. This program is not the most readable, which is to be expected from a representation intended for machine interpretation rather than human interpretation, but it does make explicit precisely what the roles are of the various parts.
+
+
+
+
+%\subfile{figures/PlutusCoreExample}
+
+
+
+
+% !!!! Example
+
+
+
+
+\section{Type Correctness}
+
+We define for Plutus Core a number of typing judgments which explain ways that a program can be well-formed. First, in Figure \ref{fig:Plutus_core_contexts}, we define the grammar of variable contexts that these judgments hold under. Variable contexts contain information about the nature of variables --- type variables with their kind, and term variables with their type.
+
+Then, in Figure \ref{fig:Plutus_core_kind_synthesis}, we define what it means for a type synthesize a kind. Plutus Core is a higher-kinded version of System F, so we have a number of standard System F rules together with some obvious extensions. In Figure \ref{fig:Plutus_core_type_synthesis}, we define the type synthesis judgment, which explains how a term synthesizes a type.
+
+Finally, type synthesis for constants ($\con{bn}$ and $\conT{bt}$) is given in tabular form rather than in inference rule form, in Figure \ref{fig:Plutus_core_builtins}, which also gives the reduction semantics. This table also specifies what conditions trigger an error.
+
+
+
+
+
+
+\subfile{figures/PlutusCoreTypeCorrectness}
+
+
+
+
+
+
+
+
+
+\section{Reduction and Execution}
+
+In figure \ref{fig:Plutus_core_reduction}, we define a standard eager, small-step contextual semantics for Plutus Core in terms of the reduction relation for types (\(\typeStep{A}{A'}\)) and terms (\(\step{M}{M'}\)), which incorporates both $\beta$ reduction and contextual congruence. We make use of the transitive closure of these stepping relations via the usual Kleene star notation.
+
+In the context of a blockchain system, it can be useful to also have a step indexed version of stepping, indicated by a superscript count of steps (\(\multistepIndexed{M}{n}{M'}\)). In order to prevent transaction validation from looping indefinitely, or from simply taking an inordinate amount of time, which would be a serious security flaw in the blockchain system, we can use step indexing to put an upper bound on the number of computational steps that a program can have. In this setting, we would pick some upper bound $\mathit{max}$ and then perform steps of terms $M$ by computing which $M'$ is such that \(\multistepIndexed{M}{\mathit{max}}{M'}\).
+
+
+
+\subfile{figures/PlutusCoreReduction}
+
+\subfile{figures/PlutusCoreBuiltins}
+
+
+
+
+
+\section{Basic Validation Program Structure}
+
+The basic way that validation is done in Plutus Core is somewhat similar to what's in Bitcoin Script. Whereas in Bitcoin Script, a validation is successful if the validating script successfully executes and leaves $\textit{true}$ on the top of the stack, in Plutus Core, validation is successful when the script reduces to any value other than \(\error{A}\) in the allotted number of steps.
+
+
+
+
+
+
+
+%\section{Erasure}
+
+%TO WRITE
+
+%\subfile{figures/PlutusCoreErasureGrammar}
+
+%\subfile{figures/PlutusCoreErasureReduction}
+
+%\subfile{figures/PlutusCoreErasureTheorem}
+
+%\section{Example}
+
+%\subfile{figures/PlutusCoreExampleAgain}
+
+
+
+
+
+
+\section{Unrestricted Algorithmic Type System}
+
+For implementation purposes, it's useful to have a variant of the type system that is more algorithmic in its presentation. We give this here, showing the figures that have been changed (relative to the declarative version above), and highlighting the specific parts of each rule that is different, where possible.
+
+\subfile{figures/PlutusCoreTypeCorrectness-Algorithmic-Unrestricted.tex}
+
+
+
+\section{Restricted Algorithmic Type System}
+
+For blockchain purposes, it is useful to not only have an algorithmic system, but to require that no un-normalized types are present in programs, so as to reduce the amount of computation necessary to typecheck a program. It's also useful to have a way of bounding the amount of computation that can be done in type checking, for security purposes. To that end, we present a restricted grammar and type reduction, and a type system that reflects these. The figures below are additions with respect to the unrestricted version, and show only the new or changed figures and their respective highlighted differences.
+
+\subfile{figures/PlutusCoreGrammar-Algorithmic-Restricted.tex}
+
+\subfile{figures/PlutusCoreReduction-Algorithmic-Restricted.tex}
+
+\subfile{figures/PlutusCoreTypeCorrectness-Algorithmic-Restricted.tex}
+
+
+
+
+
+
+
+
+% trigger a \newpage just before the given reference
+% number - used to balance the columns on the last page
+% adjust value as needed - may need to be readjusted if
+% the document is modified later
+%\IEEEtriggeratref{8}
+% The "triggered" command can be changed if desired:
+%\IEEEtriggercmd{\enlargethispage{-5in}}
+
+% references section
+
+% can use a bibliography generated by BibTeX as a .bbl file
+% BibTeX documentation can be easily obtained at:
+% http://www.ctan.org/tex-archive/biblio/bibtex/contrib/doc/
+% The IEEEtran BibTeX style support page is at:
+% http://www.michaelshell.org/tex/ieeetran/bibtex/
+%\bibliographystyle{IEEEtran}
+% argument is your BibTeX string definitions and bibliography database(s)
+%\bibliography{IEEEabrv,../bib/paper}
+%
+% <OR> manually copy in the resultant .bbl file
+% set second argument of \begin to the number of references
+% (used to reserve space for the reference number labels box)
+
+%\begin{thebibliography}{1}
+
+%\bibitem{pfpl}
+%Harper, R. \emph{Practical Foundations for Programming Languages}.
+
+%\end{thebibliography}
+
+% biography section
+%
+% If you have an EPS/PDF photo (graphicx package needed) extra braces are
+% needed around the contents of the optional argument to biography to prevent
+% the LaTeX parser from getting confused when it sees the complicated
+% \includegraphics command within an optional argument. (You could create
+% your own custom macro containing the \includegraphics command to make things
+% simpler here.)
+%\begin{biography}[{\includegraphics[width=1in,height=1.25in,clip,keepaspectratio]{mshell}}]{Michael Shell}
+% or if you just want to reserve a space for a photo:
+
+%\begin{IEEEbiography}[{\includegraphics[width=1in,height=1.25in,clip,keepaspectratio]{picture}}]{John Doe}
+%\blindtext
+%\end{IEEEbiography}
+
+% You can push biographies down or up by placing
+% a \vfill before or after them. The appropriate
+% use of \vfill depends on what kind of text is
+% on the last page and whether or not the columns
+% are being equalized.
+
+%\vfill
+
+% Can be used to pull up biographies so that the bottom of the last one
+% is flush with the other column.
+%\enlargethispage{-5in}
+
+
+
+
+% that's all folks
+\end{document}

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -288,7 +288,7 @@ ought to be included as sugar.
   Note that we require the body of the abstraction to be a
   \textit{value}, not a term: see the note on the value restriction below.
 \item $\inst{M}{A}$ represents a polymorphic term instantiated at a particular type.
-\item $\wrap{\alpha}{A}{V}$ and $\unwrap{M}$: see the note on recursive types below.
+\item $\wrap{A}{B}{M}$ and $\unwrap{M}$: see the note on recursive types below.
 \item $\lam{x}{A}{M}$ is standard lambda-abstraction: $\lambda{}x{:}{A}.{M}$.
 \item $\app{M}{N}$ is standard function application.
 \item $\builtin{bn}{A^*}{M^*}$ is application of a built-in function: see \S\ref{sec:builtins} for more information.
@@ -316,7 +316,7 @@ ought to be included as sugar.
 \item Sizes $s$ are natural numbers used to enforce bounds on certain types of values: see below.
 \item $\funT{A}{B}$ is the type of functions from $A$ to $B$, $A \rightarrow B$.
 \item $\allT{\alpha}{K}{A}$ represents the type of a polymorphic term (eg a type abstraction), $\forall \alpha{::}K.A$.
-\item $\fixT{\alpha}{A}$ represents a recursive type $\fixtype{A}$: see the note on recursive types below.
+\item $\fixT{A}{B}$ represents a recursive type $\fixtype{A}$: see the note on recursive types below.
 \item $\lamT{\alpha}{K}{A}$ is abstraction of types over types, $\lambda \alpha{::}K.A$.
 \item $\appT{A}{B}$ is function application at the type level.
 \item $\conT{tcn}{A}$ represents a built-in type, and $A$ will often be a size.  For example, $\conT{\textrm{integer}}{8}$
@@ -394,6 +394,10 @@ which will increase as the size of the integers involved increases.
 
 
 \subsubsection{Recursive types}
+\red{This section will need to be rewritten to conform to the new
+  mechanism for fixed point types.}
+
+\noindent
 The operator $\texttt{fix}$ allows one to
 define recursive types in Plutus Core: $\fixT{\alpha}{A}$ is a type
 $\fixtype{A}$ such that $\fixtype{A} \cong [\fixtype{A}/\alpha]A$; in
@@ -552,11 +556,8 @@ conjunction with \texttt{size} provides integers of specified sizes,
 and the \texttt{bytestring} type provides sequences of bytes, again of
 specified sizes.  These types are given in
 Figure~\ref{fig:Plutus_core_type_constants}:  for example 
-\texttt{(builtin integer 10)} is the type of signed 10-byte integers.
+\texttt{(con integer 10)} is the type of signed 10-byte integers.
 
-\red{Is it \texttt{con} or \texttt{builtin}?  I think there's a 
-conflict between Figure~\ref{fig:Plutus_core_type_abbreviations}
-and Figure~\ref{fig:Plutus_core_grammar}.}
 
 Terms of these types are written using the \texttt{!} character, as
 shown in Figure~\ref{fig:Plutus_core_constants}.  For example


### PR DESCRIPTION
# PLEASE READ

This PR will create mildly broken results b/c of Kenneth's previous PR which reorgs. I expect the big issue will be files have been moved around, but there will also be some merge conflicts in some files that hopefully can be resolved easily enough b/c they shouldn't be very overlapping.

### Added

- Add CHANGELOG.md to track changes.



### Changed

- Changes the lexical syntax for sizes to include the `bytes` suffixe so that
  one can write, e.g., `10bytes` instead of just `10` for sizes.

- Replaces the old definition of fixed points with the new canonical indexed
  fixed point definition of fixed point types.

- Replaces the reduction based type equality with declarative equality of types
  that includes standard properties for equality (i.e. symmetry, transitivity,
  and congruence).



### Fixed

- Fix typos in the definition of the CK machine that used just a return value
  instead of a machine state.

- Fix a bug in the definition of bounded type reduction that made not sense,
  wherein it was somehow return the *term* `(error A)` instead of simply being
  impossible to reduce. This obviously is nonsensical because types don't reduce
  to terms.

- Fix typo in the list of abbreviations that left `builtinT` in place instead of
  changing it to `conT`.

- Fix inconsistency between type frames and term frames, where type frames were
  not named as such, and required the hole to be explicitly written, while the
  term frames were named as such and did not require the hole to be explicity\
  written. The new form is that all are explicitly named as frames and the holes
  need not be written.