### PR TITLE
Re-export modules from plutus-tx to avoid needing deps on plutus-tx-plugin

### DIFF
--- a/plutus-playground/plutus-playground-lib/plutus-playground-lib.cabal
+++ b/plutus-playground/plutus-playground-lib/plutus-playground-lib.cabal
@@ -40,7 +40,6 @@ library
     , bytestring
     , containers
     , plutus-tx -any
-    , plutus-tx-plugin -any
     , hint >= 0.9.0
     , http-media
     , insert-ordered-containers

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.18
+cabal-version: 2.0
 name: plutus-tx
 version: 0.1.0.0
 license: BSD3
@@ -23,6 +23,11 @@ library
         Language.PlutusTx.TH
         Language.PlutusTx.Prelude
         Language.PlutusTx.Evaluation
+    reexported-modules:
+        Language.PlutusTx.Lift,
+        Language.PlutusTx.Lift.Class,
+        Language.PlutusTx.Builtins,
+        Language.PlutusTx.Plugin
     other-modules:
         Language.PlutusTx.Prelude.Stage0
         Language.PlutusTx.Prelude.Stage1
@@ -58,7 +63,6 @@ test-suite plutus-tx-tests
     build-depends:
         base >=4.9 && <5,
         language-plutus-core -any,
-        plutus-tx-plugin -any,
         plutus-tx -any,
         plutus-ir -any,
         prettyprinter -any,
@@ -78,7 +82,6 @@ test-suite plutus-tx-tutorial-doctests
     build-depends:
         base >=4.9 && <5,
         plutus-tx -any,
-        plutus-tx-plugin -any,
         language-plutus-core -any,
         prettyprinter -any,
         doctest -any

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -28,7 +28,6 @@ library
     mtl -any,
     template-haskell -any,
     plutus-tx -any,
-    plutus-tx-plugin -any,
     wallet-api -any,
     lens -any
   default-language: Haskell2010
@@ -68,7 +67,6 @@ test-suite plutus-use-cases-test
         wallet-api -any,
         plutus-use-cases,
         plutus-tx -any,
-        plutus-tx-plugin -any,
         template-haskell -any
   ghc-options:
     -Wall -Wnoncanonical-monad-instances

--- a/wallet-api/wallet-api.cabal
+++ b/wallet-api/wallet-api.cabal
@@ -60,7 +60,6 @@ library
         cborg -any,
         containers -any,
         plutus-tx -any,
-        plutus-tx-plugin -any,
         cryptonite >=0.25,
         hashable -any,
         hedgehog -any,
@@ -113,7 +112,6 @@ test-suite wallet-api-test
         transformers -any,
         wallet-api -any,
         plutus-tx -any,
-        plutus-tx-plugin -any,
         lens -any
 
 test-suite wallet-api-doctests
@@ -129,7 +127,6 @@ test-suite wallet-api-doctests
     build-depends:
         base >=4.9 && <5,
         plutus-tx -any,
-        plutus-tx-plugin -any,
         wallet-api -any,
         doctest -any
 


### PR DESCRIPTION
I thought this wouldn't work because the plugin needs to be in a
different package. But to my surprise it does, which removes the last
ergonomic issue with plugins that I was aware of.