### PR TITLE
Pass compiler to iohk-nix again

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -78,11 +78,17 @@ let
         filter = localLib.isPlutus;
       };
       customOverlays = optional forceError errorOverlay;
+      # We can pass an evaluated version of our packages into
+      # iohk-nix, and then we can also get out the compiler
+      # so we make sure it uses the same one.
+      pkgsGenerated = import ./pkgs { inherit pkgs; };
     in self.callPackage localLib.iohkNix.haskellPackages {
       inherit forceDontCheck enableProfiling enablePhaseMetrics
       enableHaddockHydra enableBenchmarks fasterBuild enableDebugging
-      enableSplitCheck customOverlays;
-      pkgsGenerated = ./pkgs;
+      enableSplitCheck customOverlays pkgsGenerated;
+
+      inherit (pkgsGenerated) ghc;
+
       filter = localLib.isPlutus;
       filterOverrides = {
         splitCheck = let


### PR DESCRIPTION
Inexplicably removed in 6ea46bb6599f744eab2bb602aa57ccd8611d07b4 (@shmish111 wot?)

I honestly don't know how anything works with this, given that iohk-nix
will then try and override the compiler for the package set to 8.2.2!

In fact, this seems to have no effect. I think perhaps overriding several times just doesn't work, so the one in `iohk-nix` is ineffective.