### PR TITLE
wallet-api: Delete dead code

### DIFF
--- a/plutus-playground/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground/plutus-playground-server/usecases/CrowdFunding.hs
@@ -53,7 +53,7 @@ PlutusTx.makeLift ''CampaignAction
 contributionScript :: Campaign -> ValidatorScript
 contributionScript cmp  = ValidatorScript val where
     val = Ledger.applyScript mkValidator (Ledger.lifted cmp)
-    mkValidator = Ledger.fromCompiledCode $$(PlutusTx.compile [||
+    mkValidator = $$(Ledger.compileScript [||
 
         -- The validator script is a function of four arguments:
         -- 1. The 'Campaign' definition. This argument is provided by the Plutus client, using 'Ledger.applyScript'.

--- a/plutus-playground/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Game.hs
@@ -37,7 +37,7 @@ mkRedeemerScript word =
 
 -- | The validator script of the game.
 gameValidator :: ValidatorScript
-gameValidator = ValidatorScript (Ledger.fromCompiledCode $$(PlutusTx.compile [||
+gameValidator = ValidatorScript ($$(Ledger.compileScript [||
     -- The code between the '[||' and  '||]' quotes is on-chain code.
     \(ClearString guess) (HashedString actual) (p :: PendingTx) ->
 

--- a/plutus-playground/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Vesting.hs
@@ -86,7 +86,7 @@ validatorScriptHash =
 validatorScript :: Vesting -> ValidatorScript
 validatorScript v = ValidatorScript val where
     val = Ledger.applyScript inner (Ledger.lifted v)
-    inner = Ledger.fromCompiledCode $$(PlutusTx.compile [|| \Vesting{..} () VestingData{..} (p :: PendingTx) ->
+    inner = $$(Ledger.compileScript [|| \Vesting{..} () VestingData{..} (p :: PendingTx) ->
         let
 
             eqPk :: PubKey -> PubKey -> Bool

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -137,7 +137,7 @@ contributionScript cmp  = ValidatorScript val where
 
     --   See note [Contracts and Validator Scripts] in
     --       Language.Plutus.Coordination.Contracts
-    inner = Ledger.fromCompiledCode $$(PlutusTx.compile [|| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx) ->
+    inner = $$(Ledger.compileScript [|| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx) ->
         let
 
             infixr 3 &&

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -197,7 +197,7 @@ data FutureRedeemer =
 validatorScript :: Future -> ValidatorScript
 validatorScript ft = ValidatorScript val where
     val = Ledger.applyScript inner (Ledger.lifted ft)
-    inner = Ledger.fromCompiledCode $$(PlutusTx.compile [||
+    inner = $$(Ledger.compileScript [||
         \Future{..} (r :: FutureRedeemer) FutureData{..} (p :: PendingTx) ->
 
             let

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -25,7 +25,7 @@ data ClearString = ClearString ByteString
 PlutusTx.makeLift ''ClearString
 
 gameValidator :: ValidatorScript
-gameValidator = ValidatorScript (Ledger.fromCompiledCode $$(PlutusTx.compile [||
+gameValidator = ValidatorScript ($$(Ledger.compileScript [||
     \(ClearString guess') (HashedString actual) (_ :: PendingTx) ->
 
     if $$(P.equalsByteString) actual ($$(P.sha2_256) guess')

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
@@ -57,7 +57,7 @@ type SwapOracle = OracleValue (Ratio Int)
 --       Language.Plutus.Coordination.Contracts
 swapValidator :: Swap -> ValidatorScript
 swapValidator _ = ValidatorScript result where
-    result = Ledger.fromCompiledCode $$(PlutusTx.compile [|| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx) Swap{..} ->
+    result = $$(Ledger.compileScript [|| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx) Swap{..} ->
         let
             infixr 3 &&
             (&&) :: Bool -> Bool -> Bool

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -110,7 +110,7 @@ validatorScriptHash =
 validatorScript :: Vesting -> ValidatorScript
 validatorScript v = ValidatorScript val where
     val = Ledger.applyScript inner (Ledger.lifted v)
-    inner = Ledger.fromCompiledCode $$(PlutusTx.compile [|| \Vesting{..} () VestingData{..} (p :: PendingTx) ->
+    inner = $$(Ledger.compileScript [|| \Vesting{..} () VestingData{..} (p :: PendingTx) ->
         let
 
             eqBs :: ValidatorHash -> ValidatorHash -> Bool

--- a/wallet-api/src/Ledger/Types.hs
+++ b/wallet-api/src/Ledger/Types.hs
@@ -29,8 +29,9 @@ module Ledger.Types(
     pubKeyAddress,
     scriptAddress,
     -- ** Scripts
-    Script, -- abstract
+    Script,
     fromCompiledCode,
+    compileScript,
     lifted,
     applyScript,
     evaluateScript,
@@ -52,8 +53,6 @@ module Ledger.Types(
     TxOut,
     TxOutRefOf(..),
     TxOutRef,
-    simpleInput,
-    simpleOutput,
     pubKeyTxIn,
     scriptTxIn,
     pubKeyTxOut,
@@ -64,9 +63,7 @@ module Ledger.Types(
     -- * Blockchain & UTxO model
     Block,
     Blockchain,
-    BlockchainState(..),
     ValidationData(..),
-    state,
     transaction,
     out,
     value,
@@ -74,16 +71,12 @@ module Ledger.Types(
     spentOutputs,
     unspentOutputs,
     updateUtxo,
-    validTx,
     txOutPubKey,
     pubKeyTxo,
     validValuesTx,
     -- * Scripts
-    validate,
-    emptyValidator,
     unitRedeemer,
     unitData,
-    unitValidationData,
     runScript,
     -- * Lenses
     inputs,
@@ -113,23 +106,21 @@ import qualified Data.ByteString                          as BSS
 import qualified Data.ByteString.Base64                   as Base64
 import qualified Data.ByteString.Char8                    as BS8
 import qualified Data.ByteString.Lazy                     as BSL
-import           Data.Foldable                            (foldMap)
 import           Data.Map                                 (Map)
 import qualified Data.Map                                 as Map
-import           Data.Maybe                               (fromMaybe, isJust, listToMaybe)
-import           Data.Monoid                              (Sum (..))
+import           Data.Maybe                               (isJust, listToMaybe)
 import           Data.Proxy                               (Proxy(Proxy))
 import qualified Data.Set                                 as Set
 import qualified Data.Text.Encoding                       as TE
 import           GHC.Generics                             (Generic)
 import           Data.Swagger.Internal.Schema             (ToSchema(declareNamedSchema), plain, paramSchemaToSchema)
+import qualified Language.Haskell.TH                      as TH
 import qualified Language.PlutusCore                      as PLC
 import           Language.PlutusTx.Evaluation             (evaluateCekTrace)
 import           Language.PlutusCore.Evaluation.Result
 import           Language.PlutusTx.Lift                   (makeLift, unsafeLiftProgram)
 import           Language.PlutusTx.Lift.Class             (Lift)
-import           Language.PlutusTx.Plugin                 (CompiledCode, getSerializedPlc)
-import           Language.PlutusTx.TH                     (compile)
+import           Language.PlutusTx.TH                     (CompiledCode, compile, getSerializedPlc)
 
 import           Ledger.Interval                          (Slot(..), SlotRange)
 
@@ -241,9 +232,13 @@ deriving anyclass instance FromJSON Address
 newtype Script = Script { getSerialized :: BSL.ByteString }
   deriving newtype (Serialise, Eq, Ord)
 
--- TODO: possibly this belongs with CompiledCode
+  -- TODO: possibly this belongs with CompiledCode
 fromCompiledCode :: CompiledCode a -> Script
 fromCompiledCode = Script . getSerializedPlc
+
+-- | Compile a quoted Haskell expression to a 'Script'
+compileScript :: TH.Q (TH.TExp a) -> TH.Q (TH.TExp Script)
+compileScript a = [|| Script $ getSerializedPlc $ $$(compile a) ||]
 
 getPlc :: Script -> PLC.Program PLC.TyName PLC.Name ()
 getPlc = deserialise . getSerialized
@@ -611,14 +606,6 @@ updateUtxo t unspent = (unspent `Map.difference` lift' (spentOutputs t)) `Map.un
     lift' = Map.fromSet (const ())
     outs = unspentOutputsTx t
 
--- | Ledger and transaction state available to both the validator and redeemer
---   scripts
---
-data BlockchainState = BlockchainState {
-    blockchainSlot        :: Slot,
-    blockchainStateTxHash :: TxId
-    }
-
 -- | Information about the state of the blockchain and about the transaction
 --   that is currently being validated, represented as a value in PLC.
 --
@@ -631,50 +618,6 @@ newtype ValidationData = ValidationData Script
 
 instance Show ValidationData where
     show = const "ValidationData { <script> }"
-
--- | Get blockchain state for a transaction
-state :: Tx -> Blockchain -> BlockchainState
-state tx bc = BlockchainState (lastSlot bc) (hashTx tx)
-
--- | Determine whether a transaction is valid in a given ledger
---
--- * The inputs refer to unspent outputs, which they unlock (input validity).
---
--- * The transaction preserves value (value preservation).
---
--- * All values in the transaction are non-negative.
---
-validTx :: ValidationData -> Tx -> Blockchain -> Bool
-validTx v t bc = inputsAreValid && valueIsPreserved && validValuesTx t where
-    inputsAreValid = all (`validatesIn` unspentOutputs bc) (txInputs t)
-    valueIsPreserved = inVal == outVal
-    inVal =
-        txForge t + getSum (foldMap (Sum . fromMaybe 0 . value bc . txInRef) (txInputs t))
-    outVal =
-        txFee t + sum (map txOutValue (txOutputs t))
-    txIn `validatesIn` allOutputs =
-        maybe False (validate v txIn)
-        $ txInRef txIn `Map.lookup` allOutputs
-
--- | Check whether a transaction output can be spent by the given
---   transaction input. This involves
---
---   * Checking that pay-to-script (P2S) output is spent by a P2S input, and a
---     pay-to-public key (P2PK) output is spend by a P2PK input
---   * If it is a P2S input:
---     * Verifying the hash of the validator script
---     * Evaluating the validator script with the redeemer and data script
---   * If it is a P2PK input:
---     * Verifying that the signature matches the public key
---
-validate :: ValidationData -> TxIn -> TxOut -> Bool
-validate bs TxInOf{ txInType = ti } TxOutOf{..} =
-    case (ti, txOutType) of
-        (ConsumeScriptAddress v r, PayToScript d)
-            | txOutAddress /= scriptAddress v -> False
-            | otherwise                       -> snd $ runScript bs v r d
-        (ConsumePublicKeyAddress sig, PayToPubKey pk) -> sig `signedBy` pk
-        _ -> False
 
 -- | Evaluate a validator script with the given inputs
 runScript :: ValidationData -> ValidatorScript -> RedeemerScript -> DataScript -> ([String], Bool)
@@ -690,32 +633,6 @@ runScript (ValidationData valData) (ValidatorScript validator) (RedeemerScript r
 unitData :: DataScript
 unitData = DataScript $ fromCompiledCode $$(compile [|| () ||])
 
--- | \() () () -> () as a validator
---
---   NB. The signature of a validator script is *d -> r -> v -> ()*
---       where *d*, *r* and *v* are the (PLC) types of data script, redeemer
---       script, and validation data. *d*, *r* and *v* are
---       determined by the validator script itself (because applying it to
---       values of different types will cause the script to be ill-typed).
---       As a result, if you lock a transaction output with `emptyValidator`,
---       you need to provide `unitData`, `unitRedeemer` and
---       `unitValidationData` to consume it.
-emptyValidator :: ValidatorScript
-emptyValidator = ValidatorScript $ fromCompiledCode $$(compile [|| \() () () -> () ||])
-
 -- | () as a redeemer
 unitRedeemer :: RedeemerScript
 unitRedeemer = RedeemerScript $ fromCompiledCode $$(compile [|| () ||])
-
--- | () as validation data
-unitValidationData :: ValidationData
-unitValidationData = ValidationData $ fromCompiledCode $$(compile [|| () ||])
-
--- | Transaction output locked by the empty validator and unit data scripts.
-simpleOutput :: Value -> TxOut
-simpleOutput vl = scriptTxOut vl emptyValidator unitData
-
--- | Transaction input that spends an output using the empty validator and
---   unit redeemer scripts.
-simpleInput :: TxOutRefOf a -> TxInOf a
-simpleInput ref = scriptTxIn ref emptyValidator unitRedeemer

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -18,7 +18,6 @@ import qualified Hedgehog.Gen               as Gen
 import qualified Hedgehog.Range             as Range
 import           Test.Tasty
 import           Test.Tasty.Hedgehog        (testProperty)
-import           Language.PlutusTx.TH       (compile)
 import qualified Language.PlutusTx.Builtins as Builtins
 import qualified Language.PlutusTx.Prelude  as PlutusTx
 
@@ -182,7 +181,7 @@ invalidScript = property $ do
 
     where
         failValidator :: ValidatorScript
-        failValidator = ValidatorScript $ fromCompiledCode $$(compile [|| \() () () -> $$(PlutusTx.traceH) "I always fail everything" (Builtins.error @()) ||])
+        failValidator = ValidatorScript $ $$(compileScript [|| \() () () -> $$(PlutusTx.traceH) "I always fail everything" (Builtins.error @()) ||])
 
 splitVal :: Property
 splitVal = property $ do


### PR DESCRIPTION
* Delete some old validation code from 'Ledger.Types' (the real
  validation code lives in 'Ledger.Index')
* Add 'compileScript' which removes 1 function application from every
  validator script in the contracts