### PR TITLE
wallet-api: Build tutorial, nicer type

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -77969,11 +77969,13 @@ license = stdenv.lib.licenses.mit;
 , containers
 , cryptonite
 , deriving-compat
+, doctest
 , hashable
 , hedgehog
 , http-media
 , language-plutus-core
 , lens
+, markdown-unlit
 , memory
 , mtl
 , natural-transformation
@@ -78040,12 +78042,16 @@ warp
 testHaskellDepends = [
 base
 containers
+doctest
 hedgehog
 lens
 plutus-tx
 tasty
 tasty-hedgehog
 transformers
+];
+testToolDepends = [
+markdown-unlit
 ];
 doHaddock = false;
 description = "Wallet API";

--- a/plutus-playground/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground/plutus-playground-server/usecases/CrowdFunding.hs
@@ -143,7 +143,7 @@ campaignAddress = Ledger.scriptAddress . contributionScript
 
 -- | Contribute funds to the campaign (contributor)
 --
-contribute :: Campaign -> Value -> MockWallet ()
+contribute :: MonadWallet m => Campaign -> Value -> m ()
 contribute cmp value = do
     _ <- if value <= 0 then throwOtherError "Must contribute a positive value" else pure ()
     keyPair <- myKeyPair
@@ -174,7 +174,7 @@ contribute cmp value = do
 
 -- | Register a [[EventHandler]] to collect all the funds of a campaign
 --
-scheduleCollection :: Campaign -> MockWallet ()
+scheduleCollection :: MonadWallet m => Campaign -> m ()
 scheduleCollection cmp = do
     keyPair <- myKeyPair
     let sig = signature keyPair
@@ -197,7 +197,7 @@ collectFundsTrigger c = andT
     (slotRangeT (collectionRange c))
 
 -- | Claim a refund of our campaign contribution
-refundHandler :: TxId -> Signature -> Campaign -> EventHandler MockWallet
+refundHandler :: MonadWallet m => TxId -> Signature -> Campaign -> EventHandler m
 refundHandler txid signature cmp = EventHandler (\_ -> do
     logMsg "Claiming refund"
     let validatorScript = contributionScript cmp

--- a/plutus-playground/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Game.hs
@@ -55,7 +55,7 @@ gameAddress :: Address
 gameAddress = Ledger.scriptAddress gameValidator
 
 -- | The "lock" contract endpoint. See note [Contract endpoints]
-lock :: String -> Value -> MockWallet ()
+lock :: MonadWallet m => String -> Value -> m ()
 lock word value =
     -- 'payToScript_' is a function of the wallet API. It takes a script
     -- address, a value and a data script, and submits a transaction that
@@ -67,7 +67,7 @@ lock word value =
     payToScript_ defaultSlotRange gameAddress value (mkDataScript word)
 
 -- | The "guess" contract endpoint. See note [Contract endpoints]
-guess :: String -> MockWallet ()
+guess :: MonadWallet m => String -> m ()
 guess word =
     -- 'collectFromScript' is a function of the wallet API. It consumes the
     -- unspent transaction outputs at a script address and pays them to a
@@ -81,7 +81,7 @@ guess word =
 
 -- | The "startGame" contract endpoint, telling the wallet to start watching
 --   the address of the game script. See note [Contract endpoints]
-startGame :: MockWallet ()
+startGame :: MonadWallet m => m ()
 startGame =
     -- 'startWatching' is a function of the wallet API. It instructs the wallet
     -- to keep track of all outputs at the address. Player 2 needs to call

--- a/plutus-playground/plutus-playground-server/usecases/Messages.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Messages.hs
@@ -10,10 +10,10 @@ import           Ledger.Validation
 import           Wallet
 import           Playground.Contract
 
-logAMessage :: MockWallet ()
+logAMessage :: MonadWallet m => m ()
 logAMessage = logMsg "wallet log"
 
-submitInvalidTxn :: MockWallet ()
+submitInvalidTxn :: MonadWallet m => m ()
 submitInvalidTxn = do
     logMsg "Preparing to submit an invalid transaction"
     let tx = Tx
@@ -25,7 +25,7 @@ submitInvalidTxn = do
             }
     submitTxn tx
 
-throwWalletAPIError :: Text -> MockWallet ()
+throwWalletAPIError :: MonadWallet m => Text -> m ()
 throwWalletAPIError = throwOtherError
 
 $(mkFunctions ['logAMessage, 'submitInvalidTxn, 'throwWalletAPIError])

--- a/plutus-playground/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground/plutus-playground-server/usecases/Vesting.hs
@@ -44,7 +44,7 @@ PlutusTx.makeLift ''VestingData
 
 -- | Lock some funds with the vesting validator script and return a
 --   [[VestingData]] representing the current state of the process
-vestFunds :: Vesting -> Value -> MockWallet ()
+vestFunds :: MonadWallet m => Vesting -> Value -> m ()
 vestFunds vst value = do
     _ <- if value < totalAmount vst then throwOtherError "Value must not be smaller than vested amount" else pure ()
     (payment, change) <- createPaymentWithChange value
@@ -58,7 +58,7 @@ vestFunds vst value = do
 --   released so far.
 --   This function has to be called before the funds are vested, so that the
 --   wallet can start watching the contract address for changes.
-registerVestingOwner :: Vesting -> MockWallet ()
+registerVestingOwner :: MonadWallet m => Vesting -> m ()
 registerVestingOwner v = do
     ourPubKey <- ownPubKey
     let
@@ -147,7 +147,7 @@ tranche1Trigger v =
     (slotRangeT (singleton dt1))
 
 -- | Collect the remaining funds at the end of tranche 2
-tranche2Handler :: Vesting -> EventHandler MockWallet
+tranche2Handler :: MonadWallet m => Vesting -> EventHandler m
 tranche2Handler vesting = EventHandler (\_ -> do
     logMsg "Collecting tranche 2"
     let vlscript = validatorScript vesting

--- a/wallet-api/src/Wallet/API.hs
+++ b/wallet-api/src/Wallet/API.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ConstraintKinds    #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
@@ -10,6 +11,7 @@
 module Wallet.API(
     WalletAPI(..),
     WalletDiagnostics(..),
+    MonadWallet,
     EventHandler(..),
     KeyPair(..),
     PubKey(..),
@@ -221,6 +223,8 @@ newtype WalletLog = WalletLog { getWalletLog :: [Text] }
 
 instance FromJSON WalletLog
 instance ToJSON WalletLog
+
+type MonadWallet m = (WalletAPI m, WalletDiagnostics m)
 
 -- | The ability to log messages and throw errors
 class MonadError WalletAPIError m => WalletDiagnostics m where

--- a/wallet-api/tutorial/Tutorial.md
+++ b/wallet-api/tutorial/Tutorial.md
@@ -35,7 +35,7 @@ import           Ledger                       (Address, DataScript(..), PubKey(.
 import qualified Ledger                       as L
 import           Ledger.Validation            (PendingTx(..), PendingTxIn(..), PendingTxOut)
 import qualified Ledger.Validation            as V
-import           Wallet                       (WalletAPI(..), EventHandler(..), EventTrigger)
+import           Wallet                       (WalletAPI(..), WalletDiagnostics(..), EventHandler(..), EventTrigger)
 import qualified Wallet                       as W
 import           Prelude                      hiding ((&&))
 import           GHC.Generics                 (Generic)
@@ -252,7 +252,7 @@ Contract endpoints use the `WalletAPI` class, which means that they can create a
 Since `WalletAPI` is a sub-class of `Monad` we can use Haskell's `do` notation, allowing us to list our instructions to the wallet in a sequence (see [here](https://en.wikibooks.org/wiki/Haskell/do_notation) for more information).
 
 ```haskell
-contribute :: WalletAPI m => Campaign -> Value -> m ()
+contribute :: (WalletAPI m, WalletDiagnostics m) => Campaign -> Value -> m ()
 contribute cmp amount = do
 ```
 
@@ -274,7 +274,7 @@ mkRedeemer action = RedeemerScript (L.lifted (action))
 To collect the funds we use [`collectFromScript`](https://input-output-hk.github.io/plutus/wallet-api-0.1.0.0/html/Wallet-API.html#v:collectFromScript), which expects a validator script and a redeemer script.
 
 ```haskell
-collect :: WalletAPI m => Campaign -> m ()
+collect :: (WalletAPI m, WalletDiagnostics m) => Campaign -> m ()
 collect cmp = do
       sig <- W.ownSignature
       let validator = mkValidatorScript cmp
@@ -286,7 +286,7 @@ collect cmp = do
 If we run `collect` now, nothing will happen. Why? Because in order to spend all outputs at the script address, the wallet needs to be aware of this address _before_ the outputs are produced. That way, it can scan incoming blocks from the blockchain for contributions to that address, and doesn't have to keep a record of all unspent outputs of the entire blockchain. So before the campaign starts, the campaign owner needs to run the following action:
 
 ```haskell
-startCampaign :: WalletAPI m => Campaign -> m ()
+startCampaign :: (WalletAPI m, WalletDiagnostics m) => Campaign -> m ()
 startCampaign campaign = W.startWatching (campaignAddress campaign)
 ```
 
@@ -314,7 +314,7 @@ The campaign owner can collect contributions when two conditions hold: The funds
 Now we can define an event handler that collects the contributions:
 
 ```haskell
-collectionHandler :: WalletAPI m => Campaign -> EventHandler m
+collectionHandler :: (WalletAPI m, WalletDiagnostics m) => Campaign -> EventHandler m
 collectionHandler cmp = EventHandler (\_ -> do
         W.logMsg "Collecting funds"
         sig <- W.ownSignature
@@ -330,7 +330,7 @@ Note that the trigger mechanism is a feature of the wallet, not of the blockchai
 With that, we can re-write the `startCampaign` endpoint to register a `collectFundsTrigger` and collect the funds automatically if the campaign is successful:
 
 ```haskell
-scheduleCollection :: WalletAPI m => Campaign -> m ()
+scheduleCollection :: (WalletAPI m, WalletDiagnostics m) => Campaign -> m ()
 scheduleCollection cmp = W.register (collectFundsTrigger cmp) (collectionHandler cmp)
 ```
 
@@ -343,7 +343,7 @@ Let's start with the event handler. Just like the `collection` handler, our refu
 If we submitted a refund transaction for all outputs, that transaction would fail to validate because our validator script checks that refunds go to their intended recipients (see the equation for `contributorOnly` above). Instead of [`collectFromScript`](https://input-output-hk.github.io/plutus/wallet-api-0.1.0.0/html/Wallet-API.html#v:collectFromScript) we can use [`collectFromScriptTxn`](https://input-output-hk.github.io/plutus/wallet-api-0.1.0.0/html/Wallet-API.html#v:collectFromScriptTxn), which takes an additional `TxId` parameter and only collects outputs produced by that transaction.
 
 ```haskell
-refundHandler :: WalletAPI m => TxId -> Campaign -> EventHandler m
+refundHandler :: (WalletAPI m, WalletDiagnostics m) => TxId -> Campaign -> EventHandler m
 refundHandler txid cmp = EventHandler (\_ -> do
     W.logMsg "Claiming refund"
     sig <- W.ownSignature
@@ -364,7 +364,7 @@ refundTrigger c = W.andT
 We will call the new endpoint `contribute2` because it replaces the `contribute` endpoint defined above.
 
 ```haskell
-contribute2 :: WalletAPI m => Campaign -> Value -> m ()
+contribute2 :: (WalletAPI m, WalletDiagnostics m) => Campaign -> Value -> m ()
 contribute2 cmp amount = do
       pk <- W.ownPubKey
       let dataScript = mkDataScript pk

--- a/wallet-api/tutorial/Tutorial.md
+++ b/wallet-api/tutorial/Tutorial.md
@@ -35,7 +35,7 @@ import           Ledger                       (Address, DataScript(..), PubKey(.
 import qualified Ledger                       as L
 import           Ledger.Validation            (PendingTx(..), PendingTxIn(..), PendingTxOut)
 import qualified Ledger.Validation            as V
-import           Wallet                       (WalletAPI(..), WalletDiagnostics(..), EventHandler(..), EventTrigger)
+import           Wallet                       (WalletAPI(..), WalletDiagnostics(..), MonadWallet, EventHandler(..), EventTrigger)
 import qualified Wallet                       as W
 import           Prelude                      hiding ((&&))
 import           GHC.Generics                 (Generic)
@@ -252,7 +252,7 @@ Contract endpoints use the `WalletAPI` class, which means that they can create a
 Since `WalletAPI` is a sub-class of `Monad` we can use Haskell's `do` notation, allowing us to list our instructions to the wallet in a sequence (see [here](https://en.wikibooks.org/wiki/Haskell/do_notation) for more information).
 
 ```haskell
-contribute :: (WalletAPI m, WalletDiagnostics m) => Campaign -> Value -> m ()
+contribute :: MonadWallet m => Campaign -> Value -> m ()
 contribute cmp amount = do
 ```
 
@@ -274,7 +274,7 @@ mkRedeemer action = RedeemerScript (L.lifted (action))
 To collect the funds we use [`collectFromScript`](https://input-output-hk.github.io/plutus/wallet-api-0.1.0.0/html/Wallet-API.html#v:collectFromScript), which expects a validator script and a redeemer script.
 
 ```haskell
-collect :: (WalletAPI m, WalletDiagnostics m) => Campaign -> m ()
+collect :: MonadWallet m => Campaign -> m ()
 collect cmp = do
       sig <- W.ownSignature
       let validator = mkValidatorScript cmp
@@ -286,7 +286,7 @@ collect cmp = do
 If we run `collect` now, nothing will happen. Why? Because in order to spend all outputs at the script address, the wallet needs to be aware of this address _before_ the outputs are produced. That way, it can scan incoming blocks from the blockchain for contributions to that address, and doesn't have to keep a record of all unspent outputs of the entire blockchain. So before the campaign starts, the campaign owner needs to run the following action:
 
 ```haskell
-startCampaign :: (WalletAPI m, WalletDiagnostics m) => Campaign -> m ()
+startCampaign :: MonadWallet m => Campaign -> m ()
 startCampaign campaign = W.startWatching (campaignAddress campaign)
 ```
 
@@ -314,7 +314,7 @@ The campaign owner can collect contributions when two conditions hold: The funds
 Now we can define an event handler that collects the contributions:
 
 ```haskell
-collectionHandler :: (WalletAPI m, WalletDiagnostics m) => Campaign -> EventHandler m
+collectionHandler :: MonadWallet m => Campaign -> EventHandler m
 collectionHandler cmp = EventHandler (\_ -> do
         W.logMsg "Collecting funds"
         sig <- W.ownSignature
@@ -330,7 +330,7 @@ Note that the trigger mechanism is a feature of the wallet, not of the blockchai
 With that, we can re-write the `startCampaign` endpoint to register a `collectFundsTrigger` and collect the funds automatically if the campaign is successful:
 
 ```haskell
-scheduleCollection :: (WalletAPI m, WalletDiagnostics m) => Campaign -> m ()
+scheduleCollection :: MonadWallet m => Campaign -> m ()
 scheduleCollection cmp = W.register (collectFundsTrigger cmp) (collectionHandler cmp)
 ```
 
@@ -343,7 +343,7 @@ Let's start with the event handler. Just like the `collection` handler, our refu
 If we submitted a refund transaction for all outputs, that transaction would fail to validate because our validator script checks that refunds go to their intended recipients (see the equation for `contributorOnly` above). Instead of [`collectFromScript`](https://input-output-hk.github.io/plutus/wallet-api-0.1.0.0/html/Wallet-API.html#v:collectFromScript) we can use [`collectFromScriptTxn`](https://input-output-hk.github.io/plutus/wallet-api-0.1.0.0/html/Wallet-API.html#v:collectFromScriptTxn), which takes an additional `TxId` parameter and only collects outputs produced by that transaction.
 
 ```haskell
-refundHandler :: (WalletAPI m, WalletDiagnostics m) => TxId -> Campaign -> EventHandler m
+refundHandler :: MonadWallet m => TxId -> Campaign -> EventHandler m
 refundHandler txid cmp = EventHandler (\_ -> do
     W.logMsg "Claiming refund"
     sig <- W.ownSignature
@@ -364,7 +364,7 @@ refundTrigger c = W.andT
 We will call the new endpoint `contribute2` because it replaces the `contribute` endpoint defined above.
 
 ```haskell
-contribute2 :: (WalletAPI m, WalletDiagnostics m) => Campaign -> Value -> m ()
+contribute2 :: MonadWallet m => Campaign -> Value -> m ()
 contribute2 cmp amount = do
       pk <- W.ownPubKey
       let dataScript = mkDataScript pk

--- a/wallet-api/wallet-api.cabal
+++ b/wallet-api/wallet-api.cabal
@@ -116,7 +116,6 @@ test-suite wallet-api-test
         lens -any
 
 test-suite wallet-api-doctests
-    buildable: False
     type: exitcode-stdio-1.0
     main-is: tutorial-doctests.hs
     build-tool-depends: markdown-unlit:markdown-unlit -any


### PR DESCRIPTION
* Enable building of the tutorial in wallet-api.cabal
* Add a constraint `MonadWallet` that combines `WalletAPI` and `WalletDiagnostics` because they are usually used together.