### PR TITLE
plutus-ir: parser for plutus IR

### DIFF
--- a/language-plutus-core/generators/Language/PlutusCore/Generators/AST.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/AST.hs
@@ -1,8 +1,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Generators ( genTerm
-                  , genProgram
-                  ) where
+module Language.PlutusCore.Generators.AST
+    ( genTerm
+    , genProgram
+    , genVersion
+    , genTyName
+    , genName
+    , genKind
+    , genBuiltinName
+    , genBuiltin
+    , genConstant
+    , genType
+    , simpleRecursive
+    ) where
 
 import qualified Data.ByteString.Lazy         as BSL
 import           Hedgehog                     hiding (Size, Var)

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -67,6 +67,7 @@ library
         Language.PlutusCore.StdLib.Type
         Language.PlutusCore.Examples.Everything
         Language.PlutusCore.Generators
+        Language.PlutusCore.Generators.AST
         Language.PlutusCore.Generators.Interesting
         Language.PlutusCore.Generators.Test
         PlutusPrelude
@@ -188,7 +189,6 @@ test-suite language-plutus-core-test
         Evaluation.Constant.SuccessFailure
         Evaluation.Constant.Failure
         Evaluation.Constant.Resize
-        Generators
         Normalization.Type
         Pretty.Readable
         Check.Spec

--- a/language-plutus-core/test/Check/Spec.hs
+++ b/language-plutus-core/test/Check/Spec.hs
@@ -5,12 +5,12 @@ module Check.Spec (tests) where
 import           Language.PlutusCore
 import qualified Language.PlutusCore.Check.Uniques          as Uniques
 import qualified Language.PlutusCore.Check.ValueRestriction as VR
+import           Language.PlutusCore.Generators.AST
 import           Language.PlutusCore.Quote
 import           PlutusPrelude
 
 import           Control.Monad.Except
 import           Data.Foldable                              (traverse_)
-import           Generators
 import           Hedgehog                                   hiding (Var)
 import           Test.Tasty
 import           Test.Tasty.Hedgehog

--- a/language-plutus-core/test/Normalization/Type.hs
+++ b/language-plutus-core/test/Normalization/Type.hs
@@ -5,12 +5,11 @@ module Normalization.Type
     ) where
 
 import           Language.PlutusCore
+import           Language.PlutusCore.Generators.AST
 import           Language.PlutusCore.MkPlc
 import           Language.PlutusCore.Normalize
 
-import           Generators
-
-import           Control.Monad.Morph           (hoist)
+import           Control.Monad.Morph                (hoist)
 
 import           Hedgehog
 import           Test.Tasty

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -12,7 +12,6 @@ import qualified Data.Text                                  as T
 import           Data.Text.Encoding                         (encodeUtf8)
 import           Evaluation.CkMachine
 import           Evaluation.Constant.All
-import           Generators
 import           Hedgehog                                   hiding (Var)
 import qualified Hedgehog.Gen                               as Gen
 import qualified Hedgehog.Range                             as Range
@@ -20,6 +19,7 @@ import           Language.PlutusCore
 import           Language.PlutusCore.Constant
 import           Language.PlutusCore.DeBruijn
 import           Language.PlutusCore.Generators
+import           Language.PlutusCore.Generators.AST
 import           Language.PlutusCore.Generators.Interesting
 import           Language.PlutusCore.Pretty
 import           Normalization.Type

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -56410,15 +56410,19 @@ license = stdenv.lib.licenses.bsd3;
   mkDerivation
 , algebraic-graphs
 , base
+, bytestring
 , containers
+, hedgehog
 , language-plutus-core
 , lens
+, megaparsec
 , mmorph
 , mtl
 , prettyprinter
 , serialise
 , stdenv
 , tasty
+, tasty-hedgehog
 , text
 , transformers
 }:
@@ -56430,9 +56434,12 @@ src = .././plutus-ir;
 libraryHaskellDepends = [
 algebraic-graphs
 base
+bytestring
 containers
+hedgehog
 language-plutus-core
 lens
+megaparsec
 mmorph
 mtl
 prettyprinter
@@ -56442,12 +56449,16 @@ transformers
 ];
 testHaskellDepends = [
 base
+bytestring
+hedgehog
 language-plutus-core
+megaparsec
 mmorph
 mtl
 prettyprinter
 serialise
 tasty
+tasty-hedgehog
 ];
 doHaddock = false;
 description = "Plutus IR language";

--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -29,6 +29,8 @@ library
         Language.PlutusIR.Compiler
         Language.PlutusIR.Compiler.Names
         Language.PlutusIR.Compiler.Definitions
+        Language.PlutusIR.Generators.AST
+        Language.PlutusIR.Parser
         Language.PlutusIR.MkPir
         Language.PlutusIR.Value
         Language.PlutusIR.Optimizer.DeadCode
@@ -60,6 +62,8 @@ library
                  -Wredundant-constraints -Widentities
     build-depends:
         base >=4.9 && <5,
+        bytestring -any,
+        hedgehog -any,
         containers -any,
         language-plutus-core -any,
         lens -any,
@@ -69,7 +73,8 @@ library
         serialise -any,
         text -any,
         transformers -any,
-        algebraic-graphs <0.3
+        algebraic-graphs <0.3,
+        megaparsec -any
 
     if (flag(development) && impl(ghc <8.4))
         ghc-options: -Werror
@@ -81,14 +86,19 @@ test-suite plutus-ir-test
     other-modules:
         OptimizerSpec
         TransformSpec
+        ParserSpec
         TestLib
     default-language: Haskell2010
     build-depends:
         base >=4.9 && <5,
+        bytestring -any,
+        hedgehog -any,
         plutus-ir -any,
         language-plutus-core -any,
+        megaparsec -any,
         mtl -any,
         mmorph -any,
         prettyprinter -any,
         serialise -any,
-        tasty -any
+        tasty -any,
+        tasty-hedgehog -any

--- a/plutus-ir/src/Language/PlutusIR/Generators/AST.hs
+++ b/plutus-ir/src/Language/PlutusIR/Generators/AST.hs
@@ -1,0 +1,58 @@
+-- | This module defines generators for PIR syntax trees for testing purposes.
+-- It should only contain those generators that can't be reused from PLC
+-- (PIR-exclusive constructs, Term, and Program)
+module Language.PlutusIR.Generators.AST
+    ( module Export
+    , genProgram
+    , genTerm
+    , genBinding
+    , genDatatype
+    , genTyVarDecl
+    , genVarDecl
+    , genRecursivity
+    ) where
+
+import           Language.PlutusIR
+
+import           Language.PlutusCore.Generators.AST as Export (genBuiltin, genBuiltinName, genConstant, genKind,
+                                                               genName, genTyName, genType, genVersion, simpleRecursive)
+
+import           Hedgehog                           hiding (Var)
+import qualified Hedgehog.Gen                       as Gen
+import qualified Hedgehog.Range                     as Range
+
+genRecursivity :: MonadGen m => m Recursivity
+genRecursivity = Gen.element [Rec, NonRec]
+
+genVarDecl :: MonadGen m => m (VarDecl TyName Name ())
+genVarDecl = VarDecl () <$> genName <*> genType
+
+genTyVarDecl :: MonadGen m => m (TyVarDecl TyName ())
+genTyVarDecl = TyVarDecl () <$> genTyName <*> genKind
+
+genDatatype :: MonadGen m => m (Datatype TyName Name ())
+genDatatype = Datatype () <$> genTyVarDecl <*> listOf genTyVarDecl <*> genName <*> listOf genVarDecl
+    where listOf = Gen.list (Range.linear 1 10)
+
+genBinding :: MonadGen m => m (Binding TyName Name ())
+genBinding = Gen.choice [genTermBind, genTypeBind, genDatatypeBind]
+    where genTermBind = TermBind () <$> genVarDecl <*> genTerm
+          genTypeBind = TypeBind () <$> genTyVarDecl <*> genType
+          genDatatypeBind = DatatypeBind () <$> genDatatype
+
+genTerm :: MonadGen m => m (Term TyName Name ())
+genTerm = simpleRecursive nonRecursive recursive
+    where varGen = Var () <$> genName
+          absGen = TyAbs () <$> genTyName <*> genKind <*> genTerm
+          instGen = TyInst () <$> genTerm <*> genType
+          lamGen = LamAbs () <$> genName <*> genType <*> genTerm
+          applyGen = Apply () <$> genTerm <*> genTerm
+          unwrapGen = Unwrap () <$> genTerm
+          wrapGen = IWrap () <$> genType <*> genType <*> genTerm
+          errorGen = Error () <$> genType
+          letGen = Let () <$> genRecursivity <*> Gen.list (Range.linear 1 10) genBinding <*> genTerm
+          recursive = [absGen, instGen, lamGen, applyGen, unwrapGen, wrapGen, letGen]
+          nonRecursive = [varGen, Constant () <$> genConstant, Builtin () <$> genBuiltin, errorGen]
+
+genProgram :: MonadGen m => m (Program TyName Name ())
+genProgram = Program () <$> genTerm

--- a/plutus-ir/src/Language/PlutusIR/Parser.hs
+++ b/plutus-ir/src/Language/PlutusIR/Parser.hs
@@ -1,0 +1,326 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Language.PlutusIR.Parser where
+
+import           Prelude                      hiding (fail)
+
+import           Control.Applicative          hiding (many, some)
+import           Control.Monad.State          hiding (fail)
+
+import qualified Language.PlutusCore          as PLC
+import qualified Language.PlutusCore.Constant as PLC
+import           Language.PlutusIR            as PIR
+import           PlutusPrelude                (prettyString)
+import           Text.Megaparsec              hiding (ParseError, State, parse)
+import qualified Text.Megaparsec              as Parsec
+
+import           Data.ByteString.Internal     (c2w)
+import qualified Data.ByteString.Lazy         as BS
+import           Data.Char
+import           Data.Foldable
+import qualified Data.Map                     as M
+import qualified Data.Text                    as T
+import           Data.Word
+import           GHC.Natural
+
+import           Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer   as Lex
+
+newtype ParserState = ParserState { identifiers :: M.Map T.Text PLC.Unique }
+    deriving (Show)
+
+data ParseError = Overflow Natural Integer
+                | UnexpectedKeyword String
+                | InternalError String
+                deriving (Eq, Ord, Show)
+
+instance ShowErrorComponent ParseError where
+    showErrorComponent (Overflow sz i) = "Integer overflow: " ++ show i ++ " does not fit in " ++ show sz ++ " bytes"
+    showErrorComponent (UnexpectedKeyword kw) = "Keyword " ++ kw ++ " used as identifier"
+    showErrorComponent (InternalError cause) = "Internal error: " ++ cause
+
+initial :: ParserState
+initial = ParserState M.empty
+
+intern :: (MonadState ParserState m, PLC.MonadQuote m) => T.Text -> m PLC.Unique
+intern n = do
+    st <- get
+    case M.lookup n (identifiers st) of
+        Just u -> return u
+        Nothing -> do
+            fresh <- PLC.freshUnique
+            let identifiers' = M.insert n fresh $ identifiers st
+            put $ ParserState identifiers'
+            return fresh
+
+type Parser = ParsecT ParseError String (StateT ParserState PLC.Quote)
+instance (Stream s, PLC.MonadQuote m) => PLC.MonadQuote (ParsecT e s m)
+
+parse :: Parser a -> String -> String -> Either (Parsec.ParseError Char ParseError) a
+parse p file str = PLC.runQuote $ flip evalStateT initial $ runParserT p file str
+
+whitespace :: Parser ()
+whitespace = Lex.space space1 (Lex.skipLineComment "--") (Lex.skipBlockCommentNested "{-" "-}")
+
+-- Tokens
+-- TODO: move this to separate module?
+
+lexeme :: Parser a -> Parser a
+lexeme = Lex.lexeme whitespace
+
+symbol :: String -> Parser (Tokens String)
+symbol = Lex.symbol whitespace
+
+lparen :: Parser String
+lparen = symbol "("
+rparen :: Parser String
+rparen = symbol ")"
+
+lbracket :: Parser String
+lbracket = symbol "["
+rbracket :: Parser String
+rbracket = symbol "]"
+
+lbrace :: Parser String
+lbrace = symbol "{"
+rbrace :: Parser String
+rbrace = symbol "}"
+
+inParens :: Parser a -> Parser a
+inParens = between lparen rparen
+
+inBrackets :: Parser a -> Parser a
+inBrackets = between lbracket rbracket
+
+inBraces :: Parser a -> Parser a
+inBraces = between lbrace rbrace
+
+reservedWords :: [String]
+reservedWords =
+    map prettyString PLC.allBuiltinNames ++
+    [ "abs"
+    , "lam"
+    , "ifix"
+    , "fun"
+    , "all"
+    , "bytestring"
+    , "integer"
+    , "size"
+    , "type"
+    , "program"
+    , "con"
+    , "iwrap"
+    , "builtin"
+    , "unwrap"
+    , "error"
+    -- pir-exclusive reserved words
+    , "vardecl"
+    , "typedecl"
+    , "let"
+    , "nonrec"
+    , "rec"
+    , "termbind"
+    , "typebind"
+    , "datatypebind"
+    , "datatype"
+    ]
+
+isIdentifierChar :: Char -> Bool
+isIdentifierChar c = isAlphaNum c || c == '_' || c == '\''
+
+reservedWord :: String -> Parser SourcePos
+reservedWord w = lexeme $ try $ do
+    p <- getPosition
+    void $ string w
+    notFollowedBy (satisfy isIdentifierChar)
+    return p
+
+builtinName :: Parser PLC.BuiltinName
+builtinName = lexeme $ choice $ map parseBuiltinName PLC.allBuiltinNames
+    where parseBuiltinName :: PLC.BuiltinName -> Parser PLC.BuiltinName
+          parseBuiltinName builtin = try $ string (prettyString builtin) >> pure builtin
+
+name :: Parser (Name SourcePos)
+name = lexeme $ try $ do
+    pos <- getPosition
+    void $ lookAhead letterChar
+    str <- takeWhileP (Just "identifier") isIdentifierChar
+    let word = T.pack str
+    if str `elem` reservedWords
+        then customFailure $ UnexpectedKeyword $ show word
+        else Name pos word <$> intern word
+
+var :: Parser (Name SourcePos)
+var = name
+tyVar :: Parser (TyName SourcePos)
+tyVar = TyName <$> name
+builtinVar :: Parser (PLC.Builtin SourcePos)
+builtinVar = PLC.BuiltinName <$> getPosition <*> builtinName
+
+-- This should not accept spaces after the sign, hence the `return ()`
+integer :: Parser Integer
+integer = lexeme $ Lex.signed (return ()) Lex.decimal
+
+natural :: Parser Natural
+natural = lexeme Lex.decimal
+
+hexChar :: Parser Char
+hexChar = toLower <$> oneOf (['0' .. '9'] ++ ['a' .. 'f'] ++ ['A' .. 'F'])
+
+hexPair :: Parser Word8
+hexPair = do
+    c1 <- hexChar
+    c2 <- hexChar
+    (+) <$> hexValue c2 <*> ((16 *) <$> hexValue c1)
+    where hexValue c
+              | isDigit c = pure $ c2w c - c2w '0'
+              | c >= 'a' && c <= 'f' = pure $ 10 + (c2w c - c2w 'a')
+              | otherwise = customFailure $ InternalError "non-hexadecimal character in bytestring literal"
+
+bytestring :: Parser BS.ByteString
+bytestring = lexeme $ BS.pack <$> (char '#' >> many hexPair)
+
+size :: Parser Natural
+size = lexeme $ do
+    i <- Lex.decimal
+    option () $ void $ reservedWord "bytes"
+    return i
+
+version :: Parser (PLC.Version SourcePos)
+version = lexeme $ do
+    p <- getPosition
+    x <- Lex.decimal
+    void $ char '.'
+    y <- Lex.decimal
+    void $ char '.'
+    PLC.Version p x y <$> Lex.decimal
+
+handleInteger :: SourcePos -> Natural -> Integer -> Parser (PLC.Constant SourcePos)
+handleInteger pos s i = case PLC.makeBuiltinInt s i of
+    Nothing -> customFailure $ Overflow s i
+    Just bi -> pure $ pos <$ bi
+
+constant :: Parser (PLC.Constant SourcePos)
+constant = do
+    p <- getPosition
+    s <- size
+    (char '!' >> whitespace >> (handleInteger p s =<< integer) <|> (PLC.BuiltinBS p s <$> bytestring))
+        <|> (notFollowedBy (char '!') >> (pure $ PLC.BuiltinSize p s))
+
+recursivity :: Parser Recursivity
+recursivity = inParens $ (reservedWord "rec" >> return Rec) <|> (reservedWord "nonrec" >> return NonRec)
+
+funType :: Parser (Type TyName SourcePos)
+funType = TyFun <$> reservedWord "fun" <*> typ <*> typ
+
+allType :: Parser (Type TyName SourcePos)
+allType = TyForall <$> reservedWord "all" <*> tyVar <*> kind <*> typ
+
+lamType :: Parser (Type TyName SourcePos)
+lamType = TyLam <$> reservedWord "lam" <*> tyVar <*> kind <*> typ
+
+ifixType :: Parser (Type TyName SourcePos)
+ifixType = TyIFix <$> reservedWord "ifix" <*> typ <*> typ
+
+conType :: Parser (Type TyName SourcePos)
+conType = reservedWord "con" >> builtinType
+
+builtinType :: Parser (Type TyName SourcePos)
+builtinType = TyBuiltin <$> reservedWord "size" <*> return PLC.TySize
+    <|> TyBuiltin <$> reservedWord "integer" <*> return PLC.TyInteger
+    <|> TyBuiltin <$> reservedWord "bytestring" <*> return PLC.TyByteString
+    <|> TyInt <$> getPosition <*> natural
+
+appType :: Parser (Type TyName SourcePos)
+appType = do
+    pos  <- getPosition
+    fn   <- typ
+    args <- some typ
+    pure $ foldl' (TyApp pos) fn args
+
+kind :: Parser (Kind SourcePos)
+kind = inParens (typeKind <|> sizeKind <|> funKind)
+    where
+        typeKind = Type <$> reservedWord "type"
+        sizeKind = Size <$> reservedWord "size"
+        funKind  = KindArrow <$> reservedWord "fun" <*> kind <*> kind
+
+typ :: Parser (Type TyName SourcePos)
+typ = (tyVar >>= (\n -> return $ TyVar (nameAttribute $ unTyName n) n))
+    <|> (inParens $ funType <|> allType <|> lamType <|> ifixType <|> conType)
+    <|> inBrackets appType
+
+varDecl :: Parser (VarDecl TyName Name SourcePos)
+varDecl = inParens $ VarDecl <$> reservedWord "vardecl" <*> var <*> typ
+
+tyVarDecl :: Parser (TyVarDecl TyName SourcePos)
+tyVarDecl = inParens $ TyVarDecl <$> reservedWord "tyvardecl" <*> tyVar <*> kind
+
+datatype :: Parser (Datatype TyName Name SourcePos)
+datatype = inParens $ Datatype <$> reservedWord "datatype"
+    <*> tyVarDecl
+    <*> some tyVarDecl
+    <*> var
+    <*> some varDecl
+
+binding :: Parser (Binding TyName Name SourcePos)
+binding =  inParens $
+    (try $ reservedWord "termbind" >> TermBind <$> getPosition <*> varDecl <*> term)
+    <|> (reservedWord "typebind" >> TypeBind <$> getPosition <*> tyVarDecl <*> typ)
+    <|> (reservedWord "datatypebind" >> DatatypeBind <$> getPosition <*> datatype)
+
+absTerm :: Parser (Term TyName Name SourcePos)
+absTerm = TyAbs <$> reservedWord "abs" <*> tyVar <*> kind <*> term
+
+lamTerm :: Parser (Term TyName Name SourcePos)
+lamTerm = LamAbs <$> reservedWord "lam" <*> name <*> typ <*> term
+
+conTerm :: Parser (Term TyName Name SourcePos)
+conTerm = Constant <$> reservedWord "con" <*> constant
+
+iwrapTerm :: Parser (Term TyName Name SourcePos)
+iwrapTerm = IWrap <$> reservedWord "iwrap" <*> typ <*> typ <*> term
+
+builtinTerm :: Parser (Term TyName Name SourcePos)
+builtinTerm = Builtin <$> reservedWord "builtin" <*> builtinVar
+
+unwrapTerm :: Parser (Term TyName Name SourcePos)
+unwrapTerm = Unwrap <$> reservedWord "unwrap" <*> term
+
+errorTerm :: Parser (Term TyName Name SourcePos)
+errorTerm = Error <$> reservedWord "error" <*> typ
+
+letTerm :: Parser (Term TyName Name SourcePos)
+letTerm = Let <$> reservedWord "let" <*> recursivity <*> some (try binding) <*> term
+
+appTerm :: Parser (Term TyName Name SourcePos)
+appTerm = do
+    pos  <- getPosition
+    fn   <- term
+    args <- some term
+    pure $ foldl' (Apply pos) fn args
+
+tyInstTerm :: Parser (Term TyName Name SourcePos)
+tyInstTerm = do
+    pos  <- getPosition
+    fn   <- term
+    args <- some typ
+    pure $ foldl' (TyInst pos) fn args
+
+term :: Parser (Term TyName Name SourcePos)
+term = (var >>= (\n -> return $ Var (nameAttribute n) n))
+    <|> (inParens $ absTerm <|> lamTerm <|> conTerm <|> iwrapTerm <|> builtinTerm <|> unwrapTerm <|> errorTerm <|> letTerm)
+    <|> inBraces tyInstTerm
+    <|> inBrackets appTerm
+
+-- Note that PIR programs do not actually carry a version number
+-- we (optionally) parse it all the same so we can parse all PLC code
+program :: Parser (Program TyName Name SourcePos)
+program = whitespace >> do
+    prog <- inParens $ do
+        p <- reservedWord "program"
+        option () $ void version
+        Program p <$> term
+    notFollowedBy anyChar
+    return prog

--- a/plutus-ir/test/ParserSpec.hs
+++ b/plutus-ir/test/ParserSpec.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE FlexibleContexts #-}
+module ParserSpec (parsing) where
+
+import           PlutusPrelude
+
+import           Common
+
+import           Data.Char
+
+import           Language.PlutusIR
+import           Language.PlutusIR.Generators.AST
+import           Language.PlutusIR.Parser         hiding (whitespace)
+
+import           Hedgehog                         hiding (Var)
+import qualified Hedgehog.Gen                     as Gen
+import qualified Hedgehog.Range                   as Range
+
+import           Text.Megaparsec                  hiding (failure, parse)
+
+import           Test.Tasty
+import           Test.Tasty.Hedgehog
+
+newtype PrettyProg = PrettyProg { prog :: Program TyName Name SourcePos }
+instance Show PrettyProg where
+    show = prettyString . prog
+
+whitespace :: MonadGen m => m String
+whitespace = flip replicate ' ' <$> Gen.integral (Range.linear 1 4)
+
+lineComment :: MonadGen m => m String
+lineComment = Gen.filter (not . ('\n' `elem`)) (Gen.string (Range.linear 0 100) Gen.latin1)
+              >>= (\s -> return $ " --" ++ s ++ "\n")
+
+blockComment :: MonadGen m => m String
+blockComment = Gen.filter (not . hasBlockComments) (Gen.string (Range.linear 0 100) Gen.latin1)
+               >>= (\s -> return $ "{- " ++ s ++ " -}")
+    where hasBlockComments []          = False
+          hasBlockComments [_]         = False
+          hasBlockComments ('{':'-':_) = True
+          hasBlockComments ('-':'}':_) = True
+          hasBlockComments (_:c:r)     = hasBlockComments (c:r)
+
+comment :: MonadGen m => m String
+comment = Gen.choice [Gen.constant "", lineComment, blockComment]
+
+separators :: String
+separators = ['!', '(', ')', '[', ']', '{', '}']
+
+separator :: Char -> Bool
+separator c = c `elem` separators || isSpace c
+
+aroundSeparators :: MonadGen m => m String -> String -> m String
+aroundSeparators _ [] = return []
+aroundSeparators splice [s] = (s:) <$> splice
+aroundSeparators splice (a:b:l)
+    | separator b = do
+          s1 <- splice
+          s2 <- splice
+          rest <- aroundSeparators splice l
+          return $ a : s1 ++ b : s2 ++ rest
+    | otherwise = (a :) <$> aroundSeparators splice (b:l)
+
+genScrambledWith :: MonadGen m => m String -> m (String, String)
+genScrambledWith splice = do
+    original <- prettyString <$> genProgram
+    scrambled <- aroundSeparators splice original
+    return (original, scrambled)
+
+propRoundTrip :: Property
+propRoundTrip = property $ do
+    code <- prettyString <$> forAllWith prettyString genProgram
+    let backward = fmap show
+        forward = fmap PrettyProg . parse program "test"
+    tripping code forward backward
+
+propIgnores :: Gen String -> Property
+propIgnores splice = property $ do
+    (original, scrambled) <- forAll (genScrambledWith splice)
+    (prettyString <$> parse program "test" original) === (prettyString <$> parse program "test" scrambled)
+
+parsing :: TestNested
+parsing = return $ testGroup "parsing"
+    [ testProperty "parser round-trip" propRoundTrip
+    , testProperty "parser ignores whitespace" (propIgnores whitespace)
+    , testProperty "parser ignores comments" (propIgnores comment)
+    ]

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -9,6 +9,7 @@ import           PlcTestUtils
 import           TestLib
 
 import           OptimizerSpec
+import           ParserSpec
 import           TransformSpec
 
 import           Language.PlutusCore.Quote
@@ -62,6 +63,7 @@ compileAndMaybeTypecheck doTypecheck pir = flip runReaderT NoProvenance $ runQuo
 tests :: TestNested
 tests = testGroup "plutus-ir" <$> sequence [
     prettyprinting,
+    parsing,
     datatypes,
     recursion,
     serialization,

--- a/plutus-playground/plutus-playground-server/src/Playground/Interpreter.hs
+++ b/plutus-playground/plutus-playground-server/src/Playground/Interpreter.hs
@@ -154,7 +154,7 @@ runghcOpts =
     , "-XScopedTypeVariables"
     , "-O0"
     -- FIXME: workaround for https://ghc.haskell.org/trac/ghc/ticket/16228
-    -- This appears to sometimes be necessary and sometimes not be, depending 
+    -- This appears to sometimes be necessary and sometimes not be, depending
     -- on apparently unrelated changes in the packages this depends on. I'm
     -- blaming the GHC bug.
     --, "-package plutus-tx"


### PR DESCRIPTION
A parser for plutus IR, written in Megaparsec. Should be able to parse any and all plutus-core programs (except ones that use PIR keywords as identifiers). 