### PR TITLE
Add ghc <= 8.4 for plutus-tx and add ghc-8.4.4 to the cabal.project file

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,6 +9,7 @@ packages: language-plutus-core
           plutus-playground/plutus-playground-server
           plutus-playground/plutus-playground-lib
           plutus-tutorial
+with-compiler: ghc-8.4.4
 optimization: 2
 constraints: language-plutus-core +development
            , wallet-api +development

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -86,7 +86,7 @@ library plutus-tx-compiler
         base >=4.9 && <5,
         bytestring -any,
         containers -any,
-        ghc -any,
+        ghc <8.5,
         language-plutus-core -any,
         lens -any,
         mtl -any,


### PR DESCRIPTION
This is mostly for my purposes, but it additionally makes bounds for `plutus-tx` correct.