### PR TITLE
Add sizeTerm

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -95,6 +95,7 @@ library
         Language.PlutusCore.Pretty.Readable
         Language.PlutusCore.Renamer
         Language.PlutusCore.Error
+        Language.PlutusCore.Size
         Language.PlutusCore.TypeCheck.Internal
         Language.PlutusCore.TypeCheck
         Language.PlutusCore.Analysis.Definitions

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -100,7 +100,7 @@ module Language.PlutusCore
     -- * Combining programs
     , applyProgram
     -- * Benchmarking
-    , sizeTerm
+    , termSize
     ) where
 
 import           Control.Monad.Except

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -99,6 +99,8 @@ module Language.PlutusCore
     , EvaluationResult
     -- * Combining programs
     , applyProgram
+    -- * Benchmarking
+    , sizeTerm
     ) where
 
 import           Control.Monad.Except
@@ -118,6 +120,7 @@ import           Language.PlutusCore.Parser
 import           Language.PlutusCore.Pretty
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Renamer
+import           Language.PlutusCore.Size
 import           Language.PlutusCore.TH
 import           Language.PlutusCore.Type
 import           Language.PlutusCore.TypeCheck              as TypeCheck

--- a/language-plutus-core/src/Language/PlutusCore/Size.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Size.hs
@@ -21,7 +21,8 @@ typeSize = cata a where
     a (TyLamF _ _ k ty)    = 1 + kindSize k + ty
     a (TyAppF _ ty ty')    = 1 + ty + ty'
 
--- | This exists so that we can measure term size
+-- | This exists so that we can measure term size. It counts the number of AST
+-- nodes.
 termSize :: Term tyname name a -> Int
 termSize = cata a where
     a VarF{}              = 1

--- a/language-plutus-core/src/Language/PlutusCore/Size.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Size.hs
@@ -1,0 +1,36 @@
+module Language.PlutusCore.Size ( termSize
+                                ) where
+
+import           Data.Functor.Foldable
+import           Language.PlutusCore.Type
+
+kindSize :: Kind a -> Int
+kindSize = cata a where
+    a TypeF{}             = 1
+    a (KindArrowF _ k k') = 1 + k + k'
+    a SizeF{}             = 1
+
+typeSize :: Type tyname a -> Int
+typeSize = cata a where
+    a TyVarF{}             = 1
+    a (TyFunF _ ty ty')    = 1 + ty + ty'
+    a (TyIFixF _ ty ty')   = 1 + ty + ty'
+    a (TyForallF _ _ k ty) = 1 + kindSize k + ty
+    a TyBuiltinF{}         = 1
+    a TyIntF{}             = 1
+    a (TyLamF _ _ k ty)    = 1 + kindSize k + ty
+    a (TyAppF _ ty ty')    = 1 + ty + ty'
+
+-- | This exists so that we can measure term size
+termSize :: Term tyname name a -> Int
+termSize = cata a where
+    a VarF{}              = 1
+    a (TyAbsF _ _ k t)    = 1 + kindSize k + t
+    a (ApplyF _ t t')     = 1 + t + t'
+    a (LamAbsF _ _ ty t)  = 1 + typeSize ty + t
+    a ConstantF{}         = 1
+    a BuiltinF{}          = 1
+    a (TyInstF _ t ty)    = 1 + t + typeSize ty
+    a (UnwrapF _ t)       = 1 + t
+    a (IWrapF _ ty ty' t) = 1 + typeSize ty + typeSize ty' + t
+    a (ErrorF _ ty)       = 1 + typeSize ty


### PR DESCRIPTION
This adds a function `sizeTerm` which is the canonical size of a Plutus Core term. It is used for benchmarking.