### PR TITLE
[Plutus Core] [Builtins] Deleted the 'BlockNum' and 'TxHash' builtin names

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -76,11 +76,9 @@ instance Serialise BuiltinName where
                 SHA3                 -> 17
                 VerifySignature      -> 18
                 EqByteString         -> 19
-                TxHash               -> 20
-                BlockNum             -> 21
-                SizeOfInteger        -> 22
-                QuotientInteger      -> 23
-                ModInteger           -> 24
+                SizeOfInteger        -> 20
+                QuotientInteger      -> 21
+                ModInteger           -> 22
         in encodeTag i
 
     decode = go =<< decodeTag
@@ -104,11 +102,9 @@ instance Serialise BuiltinName where
               go 17 = pure SHA3
               go 18 = pure VerifySignature
               go 19 = pure EqByteString
-              go 20 = pure TxHash
-              go 21 = pure BlockNum
-              go 22 = pure SizeOfInteger
-              go 23 = pure QuotientInteger
-              go 24 = pure ModInteger
+              go 20 = pure SizeOfInteger
+              go 21 = pure QuotientInteger
+              go 22 = pure ModInteger
               go _  = fail "Failed to decode BuiltinName"
 
 instance Serialise Unique where

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
@@ -245,6 +245,4 @@ applyBuiltinName SHA2                 = applyTypedBuiltinName typedSHA2         
 applyBuiltinName SHA3                 = applyTypedBuiltinName typedSHA3                 Hash.sha3
 applyBuiltinName VerifySignature      = applyTypedBuiltinName typedVerifySignature      undefined
 applyBuiltinName EqByteString         = applyTypedBuiltinName typedEqByteString         (==)
-applyBuiltinName TxHash               = applyTypedBuiltinName typedTxHash               undefined
-applyBuiltinName BlockNum             = applyTypedBuiltinName typedBlockNum             undefined
 applyBuiltinName SizeOfInteger        = applyTypedBuiltinName typedSizeOfInteger        (const ())

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Function.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Function.hs
@@ -135,8 +135,6 @@ withTypedBuiltinName SHA3                 k = k typedSHA3
 withTypedBuiltinName VerifySignature      k = k typedVerifySignature
 withTypedBuiltinName ResizeByteString     k = k typedResizeByteString
 withTypedBuiltinName EqByteString         k = k typedEqByteString
-withTypedBuiltinName TxHash               k = k typedTxHash
-withTypedBuiltinName BlockNum             k = k typedBlockNum
 withTypedBuiltinName SizeOfInteger        k = k typedSizeOfInteger
 
 -- | Return the 'Type' of a 'TypedBuiltinName'.

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Name.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Name.hs
@@ -21,8 +21,6 @@ module Language.PlutusCore.Constant.Name
     , typedVerifySignature
     , typedResizeByteString
     , typedEqByteString
-    , typedTxHash
-    , typedBlockNum
     , typedSizeOfInteger
     ) where
 
@@ -180,20 +178,6 @@ typedEqByteString =
             TypeSchemeBuiltin (TypedBuiltinSized (SizeBound s) TypedBuiltinSizedBS) `TypeSchemeArrow`
             TypeSchemeBuiltin (TypedBuiltinSized (SizeBound s) TypedBuiltinSizedBS) `TypeSchemeArrow`
             TypeSchemeBuiltin TypedBuiltinBool
-
--- | Typed 'TxHash'.
-typedTxHash :: TypedBuiltinName BSL.ByteString BSL.ByteString
-typedTxHash =
-    TypedBuiltinName TxHash $
-        TypeSchemeBuiltin (TypedBuiltinSized (SizeValue 32) TypedBuiltinSizedBS)
-
--- | Typed 'BlockNum'.
-typedBlockNum :: TypedBuiltinName (() -> Integer) Integer
-typedBlockNum =
-    TypedBuiltinName BlockNum $
-        TypeSchemeAllSize $ \s ->
-            TypeSchemeBuiltin (TypedBuiltinSized (SizeBound s) TypedBuiltinSizedSize) `TypeSchemeArrow`
-            TypeSchemeBuiltin (TypedBuiltinSized (SizeBound s) TypedBuiltinSizedInt)
 
 -- | Typed 'SizeOfInteger'.
 typedSizeOfInteger :: TypedBuiltinName (Integer -> ()) ()

--- a/language-plutus-core/src/Language/PlutusCore/Lexer.x
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer.x
@@ -94,8 +94,6 @@ tokens :-
     <0> "sha2_256"               { mkBuiltin SHA2 }
     <0> "sha3_256"               { mkBuiltin SHA3 }
     <0> verifySignature          { mkBuiltin VerifySignature }
-    <0> txhash                   { mkBuiltin TxHash }
-    <0> blocknum                 { mkBuiltin BlockNum }
     <0> sizeOfInteger            { mkBuiltin SizeOfInteger }
 
     -- Various special characters

--- a/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
@@ -53,8 +53,6 @@ data BuiltinName = AddInteger
                  | SHA3
                  | VerifySignature
                  | EqByteString
-                 | TxHash
-                 | BlockNum
                  -- See Note [sizeOfInteger].
                  | SizeOfInteger
                  deriving (Show, Eq, Ord, Enum, Bounded, Generic, NFData, Lift)
@@ -215,8 +213,6 @@ instance Pretty BuiltinName where
     pretty SHA2                 = "sha2_256"
     pretty SHA3                 = "sha3_256"
     pretty VerifySignature      = "verifySignature"
-    pretty TxHash               = "txhash"
-    pretty BlockNum             = "blocknum"
     pretty SizeOfInteger        = "sizeOfInteger"
 
 instance Pretty DynamicBuiltinName where

--- a/language-plutus-core/test/TypeSynthesis/Golden/BlockNum.plc.golden
+++ b/language-plutus-core/test/TypeSynthesis/Golden/BlockNum.plc.golden
@@ -1,1 +1,0 @@
-(all s0 (size) (fun [(con size) s0] [(con integer) s0]))

--- a/language-plutus-core/test/TypeSynthesis/Golden/TxHash.plc.golden
+++ b/language-plutus-core/test/TypeSynthesis/Golden/TxHash.plc.golden
@@ -1,1 +1,0 @@
-[(con bytestring) (con 32)]

--- a/language-plutus-core/test/types/verifyIdentity.plc
+++ b/language-plutus-core/test/types/verifyIdentity.plc
@@ -1,30 +1,32 @@
 (program 0.1.0
-  (lam pubkey [(con bytestring) (con 256)]
-    (lam signed [(con bytestring) (con 32)]
-      [ 
-        {
-          (abs a (type)
-            (lam b (all a (type) (fun a (fun a a)))
-              (lam t (fun (all a (type) (fun a a)) a)
-                (lam f (fun (all a (type) (fun a a)) a)
-                  [
-                    [ { b (fun (all a (type) (fun a a)) a) } t f ]
-                    (abs a (type) (lam x a x))
-                  ]
+  (lam txhash [(con bytestring) (con 32)]
+    (lam pubkey [(con bytestring) (con 256)]
+      (lam signed [(con bytestring) (con 32)]
+        [
+          {
+            (abs a (type)
+              (lam b (all a (type) (fun a (fun a a)))
+                (lam t (fun (all a (type) (fun a a)) a)
+                  (lam f (fun (all a (type) (fun a a)) a)
+                    [
+                      [ { b (fun (all a (type) (fun a a)) a) } t f ]
+                      (abs a (type) (lam x a x))
+                    ]
+                  )
                 )
               )
             )
+            (all a (type) (fun a a))
+          }
+          [ {(builtin verifySignature) (con 32) (con 32) (con 256)} signed txhash pubkey ]
+          (lam u (all a (type) (fun a a))
+            (abs a (type) (lam x a x))
           )
-          (all a (type) (fun a a))
-        }
-        [ {(builtin verifySignature) (con 32) (con 32) (con 256)} signed (builtin txhash) pubkey ]
-        (lam u (all a (type) (fun a a))
-          (abs a (type) (lam x a x))
-        )
-        (lam u (all a (type) (fun a a))
-          (error (all a (type) (fun a a)))
-        )
-      ]
+          (lam u (all a (type) (fun a a))
+            (error (all a (type) (fun a a)))
+          )
+        ]
+      )
     )
   )
 )

--- a/language-plutus-core/test/types/verifyIdentity.plc.golden
+++ b/language-plutus-core/test/types/verifyIdentity.plc.golden
@@ -1,1 +1,1 @@
-(fun [(con bytestring) (con 256)] (fun [(con bytestring) (con 32)] (all a (type) (fun a a))))
+(fun [(con bytestring) (con 32)] (fun [(con bytestring) (con 256)] (fun [(con bytestring) (con 32)] (all a (type) (fun a a)))))

--- a/plutus-tx/compiler/Language/PlutusTx/Builtins.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Builtins.hs
@@ -9,9 +9,6 @@ module Language.PlutusTx.Builtins (
                                 , sha3_256
                                 , verifySignature
                                 , equalsByteString
-                                -- * Blockchain builtins
-                                , txhash
-                                , blocknum
                                 -- * Integer builtins
                                 , addInteger
                                 , subtractInteger
@@ -62,12 +59,6 @@ verifySignature = mustBeReplaced
 
 equalsByteString :: ByteString -> ByteString -> Bool
 equalsByteString = (==)
-
-txhash :: ByteString
-txhash = mustBeReplaced
-
-blocknum :: Int
-blocknum = mustBeReplaced
 
 addInteger :: Int -> Int -> Int
 addInteger = (+)

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Builtins.hs
@@ -136,8 +136,6 @@ builtinNames = [
     , 'Builtins.equalsByteString
 
     , 'Builtins.verifySignature
-    , 'Builtins.txhash
-    , 'Builtins.blocknum
 
     , 'Builtins.addInteger
     , 'Builtins.subtractInteger
@@ -248,9 +246,6 @@ defineBuiltinTerms = do
         defineBuiltinTerm 'Builtins.equalsInteger term [int, bool]
 
     -- Blockchain builtins
-    do
-        let term = mkBuiltin PLC.TxHash
-        defineBuiltinTerm 'Builtins.txhash term [bs]
     do
         term <- wrapBsRel 3 $ instSize haskellBSSize $ instSize haskellBSSize $ instSize haskellBSSize $ mkBuiltin PLC.VerifySignature
         defineBuiltinTerm 'Builtins.verifySignature term [bs, bool]

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -38,7 +38,6 @@ module Language.PlutusTx.Prelude (
     all,
     -- * Hashes
     ByteString,
-    txhash,
     sha2_256,
     sha3_256,
     equalsByteString,

--- a/plutus-tx/src/Language/PlutusTx/Prelude/Stage0.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude/Stage0.hs
@@ -65,7 +65,7 @@ or = [|| \(l :: Bool) (r :: Bool) -> if l then True else r ||]
 not :: Q (TExp (Bool -> Bool))
 not = [|| \(a :: Bool) -> if a then False else True  ||]
 
--- | Greater than 
+-- | Greater than
 --
 --   >>> $$([|| $$(gt) 2 1 ||])
 --   True
@@ -81,7 +81,7 @@ gt = [|| Builtins.greaterThanInteger ||]
 geq :: Q (TExp (Int -> Int -> Bool))
 geq = [|| Builtins.greaterThanEqInteger ||]
 
--- | Less than 
+-- | Less than
 --
 --   >>> $$([|| $$(lt) 2 1 ||])
 --   False
@@ -251,9 +251,6 @@ foldl = [||
                 x:xs -> foldl f (f acc x) xs
         in foldl
     ||]
-
-txhash :: Q (TExp ByteString)
-txhash = [|| Builtins.txhash ||]
 
 -- | The double SHA256 hash of a 'ByteString'
 sha2_256 :: Q (TExp (ByteString -> ByteString))

--- a/plutus-tx/test/Lift/boolInterop.plc.golden
+++ b/plutus-tx/test/Lift/boolInterop.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_110
+  out_Bool_109
   (type)
   (lam
-    case_True_111 out_Bool_110 (lam case_False_112 out_Bool_110 case_True_111)
+    case_True_110 out_Bool_109 (lam case_False_111 out_Bool_109 case_True_110)
   )
 )

--- a/plutus-tx/test/Plugin/primitives/andApply.plc.golden
+++ b/plutus-tx/test/Plugin/primitives/andApply.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_113
+  out_Bool_112
   (type)
   (lam
-    case_True_114 out_Bool_113 (lam case_False_115 out_Bool_113 case_False_115)
+    case_True_113 out_Bool_112 (lam case_False_114 out_Bool_112 case_False_114)
   )
 )

--- a/plutus-tx/test/Plugin/primitives/equalsByteString.plc.golden
+++ b/plutus-tx/test/Plugin/primitives/equalsByteString.plc.golden
@@ -1,7 +1,5 @@
 (abs
-  out_Bool_100
+  out_Bool_99
   (type)
-  (lam
-    case_True_101 out_Bool_100 (lam case_False_102 out_Bool_100 case_True_101)
-  )
+  (lam case_True_100 out_Bool_99 (lam case_False_101 out_Bool_99 case_True_100))
 )

--- a/plutus-tx/test/Plugin/primitives/intEqApply.plc.golden
+++ b/plutus-tx/test/Plugin/primitives/intEqApply.plc.golden
@@ -1,7 +1,5 @@
 (abs
-  out_Bool_100
+  out_Bool_99
   (type)
-  (lam
-    case_True_101 out_Bool_100 (lam case_False_102 out_Bool_100 case_True_101)
-  )
+  (lam case_True_100 out_Bool_99 (lam case_False_101 out_Bool_99 case_True_100))
 )

--- a/plutus-tx/test/Plugin/recursiveFunctions/even3.plc.golden
+++ b/plutus-tx/test/Plugin/recursiveFunctions/even3.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_315
+  out_Bool_314
   (type)
   (lam
-    case_True_316 out_Bool_315 (lam case_False_317 out_Bool_315 case_False_317)
+    case_True_315 out_Bool_314 (lam case_False_316 out_Bool_314 case_False_316)
   )
 )

--- a/plutus-tx/test/Plugin/recursiveFunctions/even4.plc.golden
+++ b/plutus-tx/test/Plugin/recursiveFunctions/even4.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_312
+  out_Bool_311
   (type)
   (lam
-    case_True_313 out_Bool_312 (lam case_False_314 out_Bool_312 case_True_313)
+    case_True_312 out_Bool_311 (lam case_False_313 out_Bool_311 case_True_312)
   )
 )

--- a/plutus-tx/test/Plugin/recursiveTypes/sameEmptyRoseEval.plc.golden
+++ b/plutus-tx/test/Plugin/recursiveTypes/sameEmptyRoseEval.plc.golden
@@ -1,53 +1,53 @@
 (iwrap
-  (lam rec_512 (fun (fun (type) (type)) (type)) (lam spine_513 (fun (type) (type)) [spine_513 [(lam EmptyRose_514 (type) (all out_EmptyRose_515 (type) (fun (fun [List_332 EmptyRose_514] out_EmptyRose_515) out_EmptyRose_515))) [rec_512 (lam dat_516 (type) dat_516)]]]))
-  (lam dat_517 (type) dat_517)
+  (lam rec_511 (fun (fun (type) (type)) (type)) (lam spine_512 (fun (type) (type)) [spine_512 [(lam EmptyRose_513 (type) (all out_EmptyRose_514 (type) (fun (fun [List_331 EmptyRose_513] out_EmptyRose_514) out_EmptyRose_514))) [rec_511 (lam dat_515 (type) dat_515)]]]))
+  (lam dat_516 (type) dat_516)
   (abs
-    out_EmptyRose_518
+    out_EmptyRose_517
     (type)
     (lam
-      case_EmptyRose_519
-      (fun [List_332 (ifix (lam rec_520 (fun (fun (type) (type)) (type)) (lam spine_521 (fun (type) (type)) [spine_521 [(lam EmptyRose_522 (type) (all out_EmptyRose_523 (type) (fun (fun [List_332 EmptyRose_522] out_EmptyRose_523) out_EmptyRose_523))) [rec_520 (lam dat_524 (type) dat_524)]]])) (lam dat_525 (type) dat_525))] out_EmptyRose_518)
+      case_EmptyRose_518
+      (fun [List_331 (ifix (lam rec_519 (fun (fun (type) (type)) (type)) (lam spine_520 (fun (type) (type)) [spine_520 [(lam EmptyRose_521 (type) (all out_EmptyRose_522 (type) (fun (fun [List_331 EmptyRose_521] out_EmptyRose_522) out_EmptyRose_522))) [rec_519 (lam dat_523 (type) dat_523)]]])) (lam dat_524 (type) dat_524))] out_EmptyRose_517)
       [
-        case_EmptyRose_519
+        case_EmptyRose_518
         (iwrap
-          (lam rec_575 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_576 (fun (fun (type) (type)) (type)) [spine_576 [(lam List_577 (fun (type) (type)) (lam a_578 (type) (all out_List_579 (type) (fun out_List_579 (fun (fun a_578 (fun [List_577 a_578] out_List_579)) out_List_579))))) (lam a_580 (type) [rec_575 (lam dat_581 (fun (type) (type)) [dat_581 a_580])])]]))
-          (lam dat_582 (fun (type) (type)) [dat_582 a_563])
+          (lam rec_574 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_575 (fun (fun (type) (type)) (type)) [spine_575 [(lam List_576 (fun (type) (type)) (lam a_577 (type) (all out_List_578 (type) (fun out_List_578 (fun (fun a_577 (fun [List_576 a_577] out_List_578)) out_List_578))))) (lam a_579 (type) [rec_574 (lam dat_580 (fun (type) (type)) [dat_580 a_579])])]]))
+          (lam dat_581 (fun (type) (type)) [dat_581 a_562])
           (abs
-            out_List_583
+            out_List_582
             (type)
             (lam
-              case_Nil_584
-              out_List_583
+              case_Nil_583
+              out_List_582
               (lam
-                case_Cons_585
-                (fun a_563 (fun [(lam a_586 (type) (ifix (lam rec_587 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_588 (fun (fun (type) (type)) (type)) [spine_588 [(lam List_589 (fun (type) (type)) (lam a_590 (type) (all out_List_591 (type) (fun out_List_591 (fun (fun a_590 (fun [List_589 a_590] out_List_591)) out_List_591))))) (lam a_592 (type) [rec_587 (lam dat_593 (fun (type) (type)) [dat_593 a_592])])]])) (lam dat_594 (fun (type) (type)) [dat_594 a_586]))) a_563] out_List_583))
+                case_Cons_584
+                (fun a_562 (fun [(lam a_585 (type) (ifix (lam rec_586 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_587 (fun (fun (type) (type)) (type)) [spine_587 [(lam List_588 (fun (type) (type)) (lam a_589 (type) (all out_List_590 (type) (fun out_List_590 (fun (fun a_589 (fun [List_588 a_589] out_List_590)) out_List_590))))) (lam a_591 (type) [rec_586 (lam dat_592 (fun (type) (type)) [dat_592 a_591])])]])) (lam dat_593 (fun (type) (type)) [dat_593 a_585]))) a_562] out_List_582))
                 [
                   [
-                    case_Cons_585
+                    case_Cons_584
                     (iwrap
-                      (lam rec_512 (fun (fun (type) (type)) (type)) (lam spine_513 (fun (type) (type)) [spine_513 [(lam EmptyRose_514 (type) (all out_EmptyRose_515 (type) (fun (fun [List_332 EmptyRose_514] out_EmptyRose_515) out_EmptyRose_515))) [rec_512 (lam dat_516 (type) dat_516)]]]))
-                      (lam dat_517 (type) dat_517)
+                      (lam rec_511 (fun (fun (type) (type)) (type)) (lam spine_512 (fun (type) (type)) [spine_512 [(lam EmptyRose_513 (type) (all out_EmptyRose_514 (type) (fun (fun [List_331 EmptyRose_513] out_EmptyRose_514) out_EmptyRose_514))) [rec_511 (lam dat_515 (type) dat_515)]]]))
+                      (lam dat_516 (type) dat_516)
                       (abs
-                        out_EmptyRose_518
+                        out_EmptyRose_517
                         (type)
                         (lam
-                          case_EmptyRose_519
-                          (fun [List_332 (ifix (lam rec_520 (fun (fun (type) (type)) (type)) (lam spine_521 (fun (type) (type)) [spine_521 [(lam EmptyRose_522 (type) (all out_EmptyRose_523 (type) (fun (fun [List_332 EmptyRose_522] out_EmptyRose_523) out_EmptyRose_523))) [rec_520 (lam dat_524 (type) dat_524)]]])) (lam dat_525 (type) dat_525))] out_EmptyRose_518)
+                          case_EmptyRose_518
+                          (fun [List_331 (ifix (lam rec_519 (fun (fun (type) (type)) (type)) (lam spine_520 (fun (type) (type)) [spine_520 [(lam EmptyRose_521 (type) (all out_EmptyRose_522 (type) (fun (fun [List_331 EmptyRose_521] out_EmptyRose_522) out_EmptyRose_522))) [rec_519 (lam dat_523 (type) dat_523)]]])) (lam dat_524 (type) dat_524))] out_EmptyRose_517)
                           [
-                            case_EmptyRose_519
+                            case_EmptyRose_518
                             (iwrap
-                              (lam rec_543 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_544 (fun (fun (type) (type)) (type)) [spine_544 [(lam List_545 (fun (type) (type)) (lam a_546 (type) (all out_List_547 (type) (fun out_List_547 (fun (fun a_546 (fun [List_545 a_546] out_List_547)) out_List_547))))) (lam a_548 (type) [rec_543 (lam dat_549 (fun (type) (type)) [dat_549 a_548])])]]))
-                              (lam dat_550 (fun (type) (type)) [dat_550 a_542])
+                              (lam rec_542 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_543 (fun (fun (type) (type)) (type)) [spine_543 [(lam List_544 (fun (type) (type)) (lam a_545 (type) (all out_List_546 (type) (fun out_List_546 (fun (fun a_545 (fun [List_544 a_545] out_List_546)) out_List_546))))) (lam a_547 (type) [rec_542 (lam dat_548 (fun (type) (type)) [dat_548 a_547])])]]))
+                              (lam dat_549 (fun (type) (type)) [dat_549 a_541])
                               (abs
-                                out_List_551
+                                out_List_550
                                 (type)
                                 (lam
-                                  case_Nil_552
-                                  out_List_551
+                                  case_Nil_551
+                                  out_List_550
                                   (lam
-                                    case_Cons_553
-                                    (fun a_542 (fun [(lam a_554 (type) (ifix (lam rec_555 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_556 (fun (fun (type) (type)) (type)) [spine_556 [(lam List_557 (fun (type) (type)) (lam a_558 (type) (all out_List_559 (type) (fun out_List_559 (fun (fun a_558 (fun [List_557 a_558] out_List_559)) out_List_559))))) (lam a_560 (type) [rec_555 (lam dat_561 (fun (type) (type)) [dat_561 a_560])])]])) (lam dat_562 (fun (type) (type)) [dat_562 a_554]))) a_542] out_List_551))
-                                    case_Nil_552
+                                    case_Cons_552
+                                    (fun a_541 (fun [(lam a_553 (type) (ifix (lam rec_554 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_555 (fun (fun (type) (type)) (type)) [spine_555 [(lam List_556 (fun (type) (type)) (lam a_557 (type) (all out_List_558 (type) (fun out_List_558 (fun (fun a_557 (fun [List_556 a_557] out_List_558)) out_List_558))))) (lam a_559 (type) [rec_554 (lam dat_560 (fun (type) (type)) [dat_560 a_559])])]])) (lam dat_561 (fun (type) (type)) [dat_561 a_553]))) a_541] out_List_550))
+                                    case_Nil_551
                                   )
                                 )
                               )
@@ -58,44 +58,44 @@
                     )
                   ]
                   (iwrap
-                    (lam rec_575 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_576 (fun (fun (type) (type)) (type)) [spine_576 [(lam List_577 (fun (type) (type)) (lam a_578 (type) (all out_List_579 (type) (fun out_List_579 (fun (fun a_578 (fun [List_577 a_578] out_List_579)) out_List_579))))) (lam a_580 (type) [rec_575 (lam dat_581 (fun (type) (type)) [dat_581 a_580])])]]))
-                    (lam dat_582 (fun (type) (type)) [dat_582 a_563])
+                    (lam rec_574 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_575 (fun (fun (type) (type)) (type)) [spine_575 [(lam List_576 (fun (type) (type)) (lam a_577 (type) (all out_List_578 (type) (fun out_List_578 (fun (fun a_577 (fun [List_576 a_577] out_List_578)) out_List_578))))) (lam a_579 (type) [rec_574 (lam dat_580 (fun (type) (type)) [dat_580 a_579])])]]))
+                    (lam dat_581 (fun (type) (type)) [dat_581 a_562])
                     (abs
-                      out_List_583
+                      out_List_582
                       (type)
                       (lam
-                        case_Nil_584
-                        out_List_583
+                        case_Nil_583
+                        out_List_582
                         (lam
-                          case_Cons_585
-                          (fun a_563 (fun [(lam a_586 (type) (ifix (lam rec_587 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_588 (fun (fun (type) (type)) (type)) [spine_588 [(lam List_589 (fun (type) (type)) (lam a_590 (type) (all out_List_591 (type) (fun out_List_591 (fun (fun a_590 (fun [List_589 a_590] out_List_591)) out_List_591))))) (lam a_592 (type) [rec_587 (lam dat_593 (fun (type) (type)) [dat_593 a_592])])]])) (lam dat_594 (fun (type) (type)) [dat_594 a_586]))) a_563] out_List_583))
+                          case_Cons_584
+                          (fun a_562 (fun [(lam a_585 (type) (ifix (lam rec_586 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_587 (fun (fun (type) (type)) (type)) [spine_587 [(lam List_588 (fun (type) (type)) (lam a_589 (type) (all out_List_590 (type) (fun out_List_590 (fun (fun a_589 (fun [List_588 a_589] out_List_590)) out_List_590))))) (lam a_591 (type) [rec_586 (lam dat_592 (fun (type) (type)) [dat_592 a_591])])]])) (lam dat_593 (fun (type) (type)) [dat_593 a_585]))) a_562] out_List_582))
                           [
                             [
-                              case_Cons_585
+                              case_Cons_584
                               (iwrap
-                                (lam rec_512 (fun (fun (type) (type)) (type)) (lam spine_513 (fun (type) (type)) [spine_513 [(lam EmptyRose_514 (type) (all out_EmptyRose_515 (type) (fun (fun [List_332 EmptyRose_514] out_EmptyRose_515) out_EmptyRose_515))) [rec_512 (lam dat_516 (type) dat_516)]]]))
-                                (lam dat_517 (type) dat_517)
+                                (lam rec_511 (fun (fun (type) (type)) (type)) (lam spine_512 (fun (type) (type)) [spine_512 [(lam EmptyRose_513 (type) (all out_EmptyRose_514 (type) (fun (fun [List_331 EmptyRose_513] out_EmptyRose_514) out_EmptyRose_514))) [rec_511 (lam dat_515 (type) dat_515)]]]))
+                                (lam dat_516 (type) dat_516)
                                 (abs
-                                  out_EmptyRose_518
+                                  out_EmptyRose_517
                                   (type)
                                   (lam
-                                    case_EmptyRose_519
-                                    (fun [List_332 (ifix (lam rec_520 (fun (fun (type) (type)) (type)) (lam spine_521 (fun (type) (type)) [spine_521 [(lam EmptyRose_522 (type) (all out_EmptyRose_523 (type) (fun (fun [List_332 EmptyRose_522] out_EmptyRose_523) out_EmptyRose_523))) [rec_520 (lam dat_524 (type) dat_524)]]])) (lam dat_525 (type) dat_525))] out_EmptyRose_518)
+                                    case_EmptyRose_518
+                                    (fun [List_331 (ifix (lam rec_519 (fun (fun (type) (type)) (type)) (lam spine_520 (fun (type) (type)) [spine_520 [(lam EmptyRose_521 (type) (all out_EmptyRose_522 (type) (fun (fun [List_331 EmptyRose_521] out_EmptyRose_522) out_EmptyRose_522))) [rec_519 (lam dat_523 (type) dat_523)]]])) (lam dat_524 (type) dat_524))] out_EmptyRose_517)
                                     [
-                                      case_EmptyRose_519
+                                      case_EmptyRose_518
                                       (iwrap
-                                        (lam rec_543 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_544 (fun (fun (type) (type)) (type)) [spine_544 [(lam List_545 (fun (type) (type)) (lam a_546 (type) (all out_List_547 (type) (fun out_List_547 (fun (fun a_546 (fun [List_545 a_546] out_List_547)) out_List_547))))) (lam a_548 (type) [rec_543 (lam dat_549 (fun (type) (type)) [dat_549 a_548])])]]))
-                                        (lam dat_550 (fun (type) (type)) [dat_550 a_542])
+                                        (lam rec_542 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_543 (fun (fun (type) (type)) (type)) [spine_543 [(lam List_544 (fun (type) (type)) (lam a_545 (type) (all out_List_546 (type) (fun out_List_546 (fun (fun a_545 (fun [List_544 a_545] out_List_546)) out_List_546))))) (lam a_547 (type) [rec_542 (lam dat_548 (fun (type) (type)) [dat_548 a_547])])]]))
+                                        (lam dat_549 (fun (type) (type)) [dat_549 a_541])
                                         (abs
-                                          out_List_551
+                                          out_List_550
                                           (type)
                                           (lam
-                                            case_Nil_552
-                                            out_List_551
+                                            case_Nil_551
+                                            out_List_550
                                             (lam
-                                              case_Cons_553
-                                              (fun a_542 (fun [(lam a_554 (type) (ifix (lam rec_555 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_556 (fun (fun (type) (type)) (type)) [spine_556 [(lam List_557 (fun (type) (type)) (lam a_558 (type) (all out_List_559 (type) (fun out_List_559 (fun (fun a_558 (fun [List_557 a_558] out_List_559)) out_List_559))))) (lam a_560 (type) [rec_555 (lam dat_561 (fun (type) (type)) [dat_561 a_560])])]])) (lam dat_562 (fun (type) (type)) [dat_562 a_554]))) a_542] out_List_551))
-                                              case_Nil_552
+                                              case_Cons_552
+                                              (fun a_541 (fun [(lam a_553 (type) (ifix (lam rec_554 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_555 (fun (fun (type) (type)) (type)) [spine_555 [(lam List_556 (fun (type) (type)) (lam a_557 (type) (all out_List_558 (type) (fun out_List_558 (fun (fun a_557 (fun [List_556 a_557] out_List_558)) out_List_558))))) (lam a_559 (type) [rec_554 (lam dat_560 (fun (type) (type)) [dat_560 a_559])])]])) (lam dat_561 (fun (type) (type)) [dat_561 a_553]))) a_541] out_List_550))
+                                              case_Nil_551
                                             )
                                           )
                                         )
@@ -106,18 +106,18 @@
                               )
                             ]
                             (iwrap
-                              (lam rec_543 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_544 (fun (fun (type) (type)) (type)) [spine_544 [(lam List_545 (fun (type) (type)) (lam a_546 (type) (all out_List_547 (type) (fun out_List_547 (fun (fun a_546 (fun [List_545 a_546] out_List_547)) out_List_547))))) (lam a_548 (type) [rec_543 (lam dat_549 (fun (type) (type)) [dat_549 a_548])])]]))
-                              (lam dat_550 (fun (type) (type)) [dat_550 a_542])
+                              (lam rec_542 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_543 (fun (fun (type) (type)) (type)) [spine_543 [(lam List_544 (fun (type) (type)) (lam a_545 (type) (all out_List_546 (type) (fun out_List_546 (fun (fun a_545 (fun [List_544 a_545] out_List_546)) out_List_546))))) (lam a_547 (type) [rec_542 (lam dat_548 (fun (type) (type)) [dat_548 a_547])])]]))
+                              (lam dat_549 (fun (type) (type)) [dat_549 a_541])
                               (abs
-                                out_List_551
+                                out_List_550
                                 (type)
                                 (lam
-                                  case_Nil_552
-                                  out_List_551
+                                  case_Nil_551
+                                  out_List_550
                                   (lam
-                                    case_Cons_553
-                                    (fun a_542 (fun [(lam a_554 (type) (ifix (lam rec_555 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_556 (fun (fun (type) (type)) (type)) [spine_556 [(lam List_557 (fun (type) (type)) (lam a_558 (type) (all out_List_559 (type) (fun out_List_559 (fun (fun a_558 (fun [List_557 a_558] out_List_559)) out_List_559))))) (lam a_560 (type) [rec_555 (lam dat_561 (fun (type) (type)) [dat_561 a_560])])]])) (lam dat_562 (fun (type) (type)) [dat_562 a_554]))) a_542] out_List_551))
-                                    case_Nil_552
+                                    case_Cons_552
+                                    (fun a_541 (fun [(lam a_553 (type) (ifix (lam rec_554 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_555 (fun (fun (type) (type)) (type)) [spine_555 [(lam List_556 (fun (type) (type)) (lam a_557 (type) (all out_List_558 (type) (fun out_List_558 (fun (fun a_557 (fun [List_556 a_557] out_List_558)) out_List_558))))) (lam a_559 (type) [rec_554 (lam dat_560 (fun (type) (type)) [dat_560 a_559])])]])) (lam dat_561 (fun (type) (type)) [dat_561 a_553]))) a_541] out_List_550))
+                                    case_Nil_551
                                   )
                                 )
                               )

--- a/plutus-tx/test/TH/all.plc.golden
+++ b/plutus-tx/test/TH/all.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_375
+  out_Bool_374
   (type)
   (lam
-    case_True_376 out_Bool_375 (lam case_False_377 out_Bool_375 case_True_376)
+    case_True_375 out_Bool_374 (lam case_False_376 out_Bool_374 case_True_375)
   )
 )


### PR DESCRIPTION
This deletes the `BlockNum` and `TxHash` builtins. Fixes #568.