### PR TITLE
Restrict megaparsec bounds

### DIFF
--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -74,7 +74,7 @@ library
         text -any,
         transformers -any,
         algebraic-graphs <0.3,
-        megaparsec -any
+        megaparsec <7.0
 
     if (flag(development) && impl(ghc <8.4))
         ghc-options: -Werror


### PR DESCRIPTION
Tightens bounds on `megaparsec` appropriately.