### PR TITLE
plutus-ir: switched pir-parser to Text

### DIFF
--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -101,4 +101,5 @@ test-suite plutus-ir-test
         prettyprinter -any,
         serialise -any,
         tasty -any,
-        tasty-hedgehog -any
+        tasty-hedgehog -any,
+        text -any


### PR DESCRIPTION
Switched the underlying stream type of the pir-parser to use Text instead of String for performance.