### PR TITLE
[PlutusCore] Split the normalizer

### DIFF
--- a/language-plutus-core/examples/Language/PlutusCore/Examples/Data/TreeForest.hs
+++ b/language-plutus-core/examples/Language/PlutusCore/Examples/Data/TreeForest.hs
@@ -176,7 +176,7 @@ getBuiltinForest = do
 -- > /\(a :: *) -> \(x : a) (fr : forest a) ->
 -- >     wrapTree [a] /\(r :: *) -> \(f : a -> forest a -> r) -> f x fr
 getBuiltinTreeNode :: Quote (Term TyName Name ())
-getBuiltinTreeNode = runNormalizeTypeDownM . normalizeTypesIn =<< rename =<< do
+getBuiltinTreeNode = normalizeTypesFullIn =<< do
     RecursiveType _      wrapTree <- getBuiltinTree
     RecursiveType forest _        <- getBuiltinForest
     a  <- freshTyName () "a"
@@ -186,7 +186,7 @@ getBuiltinTreeNode = runNormalizeTypeDownM . normalizeTypesIn =<< rename =<< do
     f  <- freshName () "f"
     let vA = TyVar () a
         vR = TyVar () r
-    Normalized forestA <- normalizeTypeDown $ TyApp () forest vA
+    Normalized forestA <- normalizeTypeFull $ TyApp () forest vA
     return
         . TyAbs () a (Type ())
         . LamAbs () x vA
@@ -203,7 +203,7 @@ getBuiltinTreeNode = runNormalizeTypeDownM . normalizeTypesIn =<< rename =<< do
 -- > /\(a :: *) ->
 -- >     wrapForest [a] /\(r :: *) -> \(z : r) (f : tree a -> forest a -> r) -> z
 getBuiltinForestNil :: Quote (Term TyName Name ())
-getBuiltinForestNil = runNormalizeTypeDownM . normalizeTypesIn =<< rename =<< do
+getBuiltinForestNil = normalizeTypesFullIn =<< do
     RecursiveType tree   _          <- getBuiltinTree
     RecursiveType forest wrapForest <- getBuiltinForest
     a <- freshTyName () "a"
@@ -212,8 +212,8 @@ getBuiltinForestNil = runNormalizeTypeDownM . normalizeTypesIn =<< rename =<< do
     f <- freshName () "f"
     let vA = TyVar () a
         vR = TyVar () r
-    Normalized treeA   <- normalizeTypeDown $ TyApp () tree   vA
-    Normalized forestA <- normalizeTypeDown $ TyApp () forest vA
+    Normalized treeA   <- normalizeTypeFull $ TyApp () tree   vA
+    Normalized forestA <- normalizeTypeFull $ TyApp () forest vA
     return
         . TyAbs () a (Type ())
         . wrapForest [vA]
@@ -227,7 +227,7 @@ getBuiltinForestNil = runNormalizeTypeDownM . normalizeTypesIn =<< rename =<< do
 -- > /\(a :: *) -> \(tr : tree a) (fr : forest a)
 -- >     wrapForest [a] /\(r :: *) -> \(z : r) (f : tree a -> forest a -> r) -> f tr fr
 getBuiltinForestCons :: Quote (Term TyName Name ())
-getBuiltinForestCons = runNormalizeTypeDownM . normalizeTypesIn =<< rename =<< do
+getBuiltinForestCons = normalizeTypesFullIn =<< do
     RecursiveType tree   _          <- getBuiltinTree
     RecursiveType forest wrapForest <- getBuiltinForest
     a  <- freshTyName () "a"
@@ -238,8 +238,8 @@ getBuiltinForestCons = runNormalizeTypeDownM . normalizeTypesIn =<< rename =<< d
     f  <- freshName () "f"
     let vA = TyVar () a
         vR = TyVar () r
-    Normalized treeA   <- normalizeTypeDown $ TyApp () tree   vA
-    Normalized forestA <- normalizeTypeDown $ TyApp () forest vA
+    Normalized treeA   <- normalizeTypeFull $ TyApp () tree   vA
+    Normalized forestA <- normalizeTypeFull $ TyApp () forest vA
     return
         . TyAbs () a (Type ())
         . LamAbs () tr treeA

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
@@ -54,7 +54,7 @@ instance ann ~ () => AsTypeError TypeEvalCheckError ann where
 
 -- | Type-eval checking of a term results in a value of this type.
 data TypeEvalCheckResult = TypeEvalCheckResult
-    { _termCheckResultType  :: NormalizedType TyName ()
+    { _termCheckResultType  :: Normalized (Type TyName ())
       -- ^ The type of the term.
     , _termCheckResultValue :: EvaluationResult
       -- ^ The result of evaluation of the term.

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -46,6 +46,7 @@ library
         Language.PlutusCore.Rename.Internal
         Language.PlutusCore.Rename
         Language.PlutusCore.Normalize
+        Language.PlutusCore.Normalize.Internal
         Language.PlutusCore.Pretty
         Language.PlutusCore.View
         Language.PlutusCore.Subst

--- a/language-plutus-core/prelude/PlutusPrelude.hs
+++ b/language-plutus-core/prelude/PlutusPrelude.hs
@@ -19,6 +19,7 @@ module PlutusPrelude ( -- * Reëxports from base
                      , throw
                      , join
                      , (<=<)
+                     , (>=>)
                      , ($>)
                      , fromRight
                      , isRight
@@ -98,7 +99,7 @@ import           Control.Composition                     ((.*))
 import           Control.DeepSeq                         (NFData)
 import           Control.Exception                       (Exception, throw)
 import           Control.Lens
-import           Control.Monad                           (guard, join, (<=<))
+import           Control.Monad                           (guard, join, (<=<), (>=>))
 import           Data.Bifunctor                          (first, second)
 import           Data.Bool                               (bool)
 import qualified Data.ByteString.Lazy                    as BSL

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -30,8 +30,6 @@ module Language.PlutusCore
     , StagedBuiltinName (..)
     , TypeBuiltin (..)
     , Normalized (..)
-    , NormalizedType
-    , getNormalizedType
     , defaultVersion
     , allBuiltinNames
     , termLoc
@@ -201,7 +199,7 @@ parseTypecheck
         AsTypeError e AlexPosn,
         MonadError e m,
         MonadQuote m)
-    => TypeCheckConfig -> BSL.ByteString -> m (NormalizedType TyName ())
+    => TypeCheckConfig -> BSL.ByteString -> m (Normalized (Type TyName ()))
 parseTypecheck cfg = typecheckPipeline cfg <=< parseScoped
 
 -- | Typecheck a program.
@@ -212,7 +210,7 @@ typecheckPipeline
         MonadQuote m)
     => TypeCheckConfig
     -> Program TyName Name a
-    -> m (NormalizedType TyName ())
+    -> m (Normalized (Type TyName ()))
 typecheckPipeline cfg =
     inferTypeOfProgram cfg
     <=< through (unless (_tccDoNormTypes cfg) . checkProgram)

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Function.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Function.hs
@@ -138,5 +138,5 @@ withTypedBuiltinName EqByteString         k = k typedEqByteString
 withTypedBuiltinName SizeOfInteger        k = k typedSizeOfInteger
 
 -- | Return the 'Type' of a 'TypedBuiltinName'.
-typeOfTypedBuiltinName :: TypedBuiltinName a r -> Quote (Type TyName ())
-typeOfTypedBuiltinName (TypedBuiltinName _ scheme) = typeSchemeToType scheme
+typeOfTypedBuiltinName :: MonadQuote m => TypedBuiltinName a r -> m (Type TyName ())
+typeOfTypedBuiltinName (TypedBuiltinName _ scheme) = liftQuote $ typeSchemeToType scheme

--- a/language-plutus-core/src/Language/PlutusCore/Error.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Error.hs
@@ -92,7 +92,7 @@ data TypeError a
     = KindMismatch a (Type TyName ()) (Kind ()) (Kind ())
     | TypeMismatch a (Term TyName Name ())
                      (Type TyName ())
-                     (NormalizedType TyName ())
+                     (Normalized (Type TyName ()))
     | UnknownDynamicBuiltinName a UnknownDynamicBuiltinNameError
     | InternalTypeErrorE a (InternalTypeError a)
     | FreeTypeVariableE (TyName a)

--- a/language-plutus-core/src/Language/PlutusCore/Normalize.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Normalize.hs
@@ -1,237 +1,60 @@
--- | Normalization of PLC entities.
-
--- Due to the generated 'normalizeEnvCountStep' below which is not used.
-{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
-
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell    #-}
+-- | The user-facing API of the normalizer.
 
 module Language.PlutusCore.Normalize
-    ( NormalizeTypeT
-    , runNormalizeTypeM
-    , runNormalizeTypeDownM
-    , runNormalizeTypeGasM
-    , withExtendedTypeVarEnv
-    , normalizeTypeM
-    , substNormalizeTypeM
-    , normalizeType
-    , normalizeTypeDown
+    ( normalizeType
+    , normalizeTypeFull
+    , normalizeTypeGas
     , normalizeTypesIn
+    , normalizeTypesFullIn
+    , normalizeTypesGasIn
     ) where
 
 import           Language.PlutusCore.Name
+import           Language.PlutusCore.Normalize.Internal
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Rename
 import           Language.PlutusCore.Type
-import           PlutusPrelude
 
-import           Control.Lens
-import           Control.Monad.Reader
-import           Control.Monad.State
-import           Control.Monad.Trans.Maybe
-
-{- Note [Global uniqueness]
-WARNING: everything in this module works under the assumption that the global uniqueness condition
-is satisfied. The invariant is not checked, enforced or automatically fulfilled. So you must ensure
-that the global uniqueness condition is satisfied before calling ANY function from this module.
-
-The invariant is preserved. In future we will enforce the invariant.
--}
-
--- | Mapping from variables to what they stand for (each row represents a substitution).
--- Needed for efficiency reasons, otherwise we could just use substitutions.
-type TypeVarEnv tyname ann = UniqueMap TypeUnique (NormalizedType tyname ann)
-
--- | The environments that type normalization runs in.
-data NormalizeTypeEnv m tyname ann = NormalizeTypeEnv
-    { _normalizeTypeEnvTypeVarEnv :: TypeVarEnv tyname ann
-    , _normalizeTypeEnvCountStep  :: m ()
-      -- ^ How to count a type normalization step.
-    }
-
-makeLenses ''NormalizeTypeEnv
-
-{- Note [NormalizeTypeT]
-Type normalization requires 'Quote' (because we need to be able to generate fresh names), but we
-do not put 'Quote' into 'NormalizeTypeT'. The reason for this is that it makes type signatures of
-various runners much nicer and also more generic. For example, we have
-
-    runNormalizeTypeDownM :: MonadQuote m => NormalizeTypeT m tyname ann a -> m a
-
-If 'NormalizeTypeT' contained 'Quote', it would be
-
-    runNormalizeTypeDownM :: NormalizeTypeT m tyname ann a -> QuoteT m a
-
-which hardcodes 'QuoteT' to be the outermost transformer.
-
-Type normalization can run in any @m@ (as long as it's a 'MonadQuote') as witnessed by
-the following type signature:
-
-    normalizeTypeM
-        :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
-        => Type tyname ann -> NormalizeTypeT m tyname ann (NormalizedType tyname ann)
-
-so it's natural to have runners that do not break this genericity.
--}
-
-{- Note [Normalization API]
-Normalization is split in two parts:
-
-1. functions returning computations that perform reductions and run in defined in this module
-   monad transformers (e.g. 'NormalizeTypeT')
-2. runners of those computations
-
-The reason for splitting the API is that this way the type-theoretic notion of normalization is
-separated from implementation-specific details like how to count gas (we hardcode *where* to count
-gas, but this can be generalized in case we need it). And this is important, because gas counting
-requires access to different monads in different scenarios, so in the end we have a fine-grained API
-instead of a single function that reflects all possible effects from distinct scenarios in its type
-signature.
--}
-
--- See Note [NormalizedTypeT].
--- | The monad transformer that type normalization runs in.
-newtype NormalizeTypeT m tyname ann a = NormalizeTypeT
-    { unNormalizeTypeT :: ReaderT (NormalizeTypeEnv m tyname ann) m a
-    } deriving newtype
-        ( Functor, Applicative, Alternative, Monad, MonadPlus
-        , MonadReader (NormalizeTypeEnv m tyname ann), MonadState s
-        , MonadQuote
-        )
-
--- | Run a 'NormalizeTypeM' computation.
-runNormalizeTypeM :: m () -> NormalizeTypeT m tyname ann a -> m a
-runNormalizeTypeM countStep (NormalizeTypeT a) =
-    runReaderT a $ NormalizeTypeEnv mempty countStep
-
--- | Run a 'NormalizeTypeM' computation without dealing with gas.
-runNormalizeTypeDownM
-    :: MonadQuote m => NormalizeTypeT m tyname ann a -> m a
-runNormalizeTypeDownM = runNormalizeTypeM $ pure ()
-
--- | Run a gas-consuming 'NormalizeTypeM' computation.
--- Count a single substitution step by subtracting @1@ from available gas or
--- fail when there is no available gas.
-runNormalizeTypeGasM
-    :: MonadQuote m => Gas -> NormalizeTypeT (StateT Gas (MaybeT m)) tyname ann a -> m (Maybe a)
-runNormalizeTypeGasM gas a = runMaybeT $ evalStateT (runNormalizeTypeM countSubst a) gas where
-    countSubst = do
-        Gas gas' <- get
-        if gas' == 0
-            then mzero
-            else put . Gas $ gas' - 1
-
-countTypeNormalizationStep :: NormalizeTypeT m tyname ann ()
-countTypeNormalizationStep = NormalizeTypeT . ReaderT $ _normalizeTypeEnvCountStep
-
--- | Locally extend a 'TypeVarEnv' in a 'NormalizeTypeM' computation.
-withExtendedTypeVarEnv
-    :: (HasUnique (tyname ann) TypeUnique, Monad m)
-    => tyname ann
-    -> NormalizedType tyname ann
-    -> NormalizeTypeT m tyname ann a
-    -> NormalizeTypeT m tyname ann a
-withExtendedTypeVarEnv name = local . over normalizeTypeEnvTypeVarEnv . insertByName name
-
--- | Look up a @tyname@ in a 'TypeVarEnv'.
-lookupTyNameM
-    :: (HasUnique (tyname ann) TypeUnique, Monad m)
-    => tyname ann -> NormalizeTypeT m tyname ann (Maybe (NormalizedType tyname ann))
-lookupTyNameM name = asks $ lookupName name . _normalizeTypeEnvTypeVarEnv
-
-{- Note [Normalization]
-Normalization works under the assumption that variables are globally unique.
-We use environments instead of substitutions as they're more efficient.
-
-Since all names are unique and there is no need to track scopes, type normalization has only two
-interesting cases: function application and a variable usage. In the function application case we
-normalize a function and its argument, add the normalized argument to the environment and continue
-normalization. In the variable case we look up the variable in the current environment: if it's not
-found, we leave the variable untouched. If the variable is found, then what this variable stands for
-was previously added to an environment (while handling the function application case), so we pick
-this value and rename all bound variables in it to preserve the global uniqueness condition. It is
-safe to do so, because picked values cannot contain uninstantiated variables as only normalized types
-are added to environments and normalization instantiates all variables presented in an environment.
--}
-
--- See Note [Normalization].
--- | Normalize a 'Type' in the 'NormalizeTypeM' monad.
-normalizeTypeM
-    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
-    => Type tyname ann -> NormalizeTypeT m tyname ann (NormalizedType tyname ann)
-normalizeTypeM (TyForall ann name kind body) =
-    TyForall ann name kind <<$>> normalizeTypeM body
-normalizeTypeM (TyIFix ann pat arg)          =
-    TyIFix ann <<$>> normalizeTypeM pat <<*>> normalizeTypeM arg
-normalizeTypeM (TyFun ann dom cod)           =
-    TyFun ann <<$>> normalizeTypeM dom <<*>> normalizeTypeM cod
-normalizeTypeM (TyLam ann name kind body)    =
-    TyLam ann name kind <<$>> normalizeTypeM body
-normalizeTypeM (TyApp ann fun arg)           = do
-    vFun <- normalizeTypeM fun
-    vArg <- normalizeTypeM arg
-    case getNormalizedType vFun of
-        TyLam _ nArg _ body -> do
-            countTypeNormalizationStep
-            substNormalizeTypeM vArg nArg body
-        _                   -> pure $ TyApp ann <$> vFun <*> vArg
-normalizeTypeM var@(TyVar _ name)            = do
-    mayTy <- lookupTyNameM name
-    case mayTy of
-        Nothing -> pure $ NormalizedType var
-        Just ty -> traverse rename ty
-normalizeTypeM size@TyInt{}                  =
-    pure $ NormalizedType size
-normalizeTypeM builtin@TyBuiltin{}           =
-    pure $ NormalizedType builtin
-
-{- Note [Normalizing substitution]
-@substituteNormalize[M]@ is only ever used as normalizing substitution that receives two already
-normalized types. However we do not enforce this in the type signature, because
-1) it's perfectly correct for the last argument to be non-normalized
-2) it would be annoying to wrap 'Type's into 'NormalizedType's
--}
-
--- See Note [Normalizing substitution].
--- | Substitute a type for a variable in a type and normalize in the 'NormalizeTypeM' monad.
-substNormalizeTypeM
-    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
-    => NormalizedType tyname ann                                -- ^ @ty@
-    -> tyname ann                                               -- ^ @name@
-    -> Type tyname ann                                          -- ^ @body@
-    -> NormalizeTypeT m tyname ann (NormalizedType tyname ann)  -- ^ @NORM ([ty / name] body)@
-substNormalizeTypeM ty name = withExtendedTypeVarEnv name ty . normalizeTypeM
+import           Control.Monad                          ((>=>))
 
 -- See Note [Normalization].
 -- | Normalize a 'Type'.
 normalizeType
     :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
-    => m () -> Type tyname ann -> m (NormalizedType tyname ann)
-normalizeType countStep = runNormalizeTypeM countStep . normalizeTypeM
+    => m () -> Type tyname ann -> m (Normalized (Type tyname ann))
+normalizeType countStep = rename >=> runNormalizeTypeM countStep . normalizeTypeM
 
 -- See Note [Normalization].
 -- | Normalize a 'Type' without dealing with gas.
-normalizeTypeDown
+normalizeTypeFull
     :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
-    => Type tyname ann -> m (NormalizedType tyname ann)
-normalizeTypeDown = normalizeType $ pure ()
+    => Type tyname ann -> m (Normalized (Type tyname ann))
+normalizeTypeFull = normalizeType $ pure ()
+
+-- | Normalize a 'Type' in the gas-consuming way.
+-- Count a single substitution step by subtracting @1@ from available gas or
+-- fail when there is no available gas.
+normalizeTypeGas
+    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
+    => Gas -> Type tyname ann -> m (Maybe (Normalized (Type tyname ann)))
+normalizeTypeGas gas = rename >=> runNormalizeTypeGasM gas . normalizeTypeM
 
 -- | Normalize every 'Type' in a 'Term'.
 normalizeTypesIn
-    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
-    => Term tyname name ann -> NormalizeTypeT m tyname ann (Term tyname name ann)
-normalizeTypesIn = go where
-    -- | Normalize a 'Type' and return the result as a 'Type' (as opposed to 'NormalizedType').
-    normalizeReturnType = fmap getNormalizedType . normalizeTypeM
+    :: (HasUnique (tyname ann) TypeUnique, HasUnique (name ann) TermUnique, MonadQuote m)
+    => m () -> Term tyname name ann -> m (Term tyname name ann)
+normalizeTypesIn countStep = rename >=> runNormalizeTypeM countStep . normalizeTypesInM
 
-    go (LamAbs ann name ty body)  = LamAbs ann name <$> normalizeReturnType ty <*> go body
-    go (TyAbs ann name kind body) = TyAbs ann name kind <$> go body
-    go (IWrap ann pat arg term)   =
-        IWrap ann <$> normalizeReturnType pat <*> normalizeReturnType arg <*> go term
-    go (Apply ann fun arg)        = Apply ann <$> go fun <*> go arg
-    go (Unwrap ann term)          = Unwrap ann <$> go term
-    go (Error ann ty)             = Error ann <$> normalizeReturnType ty
-    go (TyInst ann body ty)       = TyInst ann <$> go body <*> normalizeReturnType ty
-    go (Var ann name)             = return $ Var ann name
-    go con@Constant{}             = pure con
-    go bi@Builtin{}               = pure bi
+-- | Normalize every 'Type' in a 'Term' without dealing with gas.
+normalizeTypesFullIn
+    :: (HasUnique (tyname ann) TypeUnique, HasUnique (name ann) TermUnique, MonadQuote m)
+    => Term tyname name ann -> m (Term tyname name ann)
+normalizeTypesFullIn = normalizeTypesIn $ pure ()
+
+-- | Normalize every 'Type' in a 'Term' in the gas-consuming way.
+-- Count a single substitution step by subtracting @1@ from available gas or
+-- fail when there is no available gas.
+normalizeTypesGasIn
+    :: (HasUnique (tyname ann) TypeUnique, HasUnique (name ann) TermUnique, MonadQuote m)
+    => Gas -> Term tyname name ann -> m (Maybe (Term tyname name ann))
+normalizeTypesGasIn gas = rename >=> runNormalizeTypeGasM gas . normalizeTypesInM

--- a/language-plutus-core/src/Language/PlutusCore/Normalize/Internal.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Normalize/Internal.hs
@@ -1,0 +1,221 @@
+-- | The internals of the normalizer.
+
+-- Due to the generated 'normalizeEnvCountStep' below which is not used.
+{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TemplateHaskell    #-}
+
+module Language.PlutusCore.Normalize.Internal
+    ( NormalizeTypeT
+    , runNormalizeTypeM
+    , runNormalizeTypeFullM
+    , runNormalizeTypeGasM
+    , withExtendedTypeVarEnv
+    , normalizeTypeM
+    , substNormalizeTypeM
+    , normalizeTypesInM
+    ) where
+
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Quote
+import           Language.PlutusCore.Rename
+import           Language.PlutusCore.Type
+import           PlutusPrelude
+
+import           Control.Lens
+import           Control.Monad.Reader
+import           Control.Monad.State
+import           Control.Monad.Trans.Maybe
+
+{- Note [Global uniqueness]
+WARNING: everything in this module works under the assumption that the global uniqueness condition
+is satisfied. The invariant is not checked, enforced or automatically fulfilled. So you must ensure
+that the global uniqueness condition is satisfied before calling ANY function from this module.
+
+The invariant is preserved. In future we will enforce the invariant.
+-}
+
+-- | Mapping from variables to what they stand for (each row represents a substitution).
+-- Needed for efficiency reasons, otherwise we could just use substitutions.
+type TypeVarEnv tyname ann = UniqueMap TypeUnique (Normalized (Type tyname ann))
+
+-- | The environments that type normalization runs in.
+data NormalizeTypeEnv m tyname ann = NormalizeTypeEnv
+    { _normalizeTypeEnvTypeVarEnv :: TypeVarEnv tyname ann
+    , _normalizeTypeEnvCountStep  :: m ()
+      -- ^ How to count a type normalization step.
+    }
+
+makeLenses ''NormalizeTypeEnv
+
+{- Note [NormalizeTypeT]
+Type normalization requires 'Quote' (because we need to be able to generate fresh names), but we
+do not put 'Quote' into 'NormalizeTypeT'. The reason for this is that it makes type signatures of
+various runners much nicer and also more generic. For example, we have
+
+    runNormalizeTypeFullM :: MonadQuote m => NormalizeTypeT m tyname ann a -> m a
+
+If 'NormalizeTypeT' contained 'Quote', it would be
+
+    runNormalizeTypeFullM :: NormalizeTypeT m tyname ann a -> QuoteT m a
+
+which hardcodes 'QuoteT' to be the outermost transformer.
+
+Type normalization can run in any @m@ (as long as it's a 'MonadQuote') as witnessed by
+the following type signature:
+
+    normalizeTypeM
+        :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
+        => Type tyname ann -> NormalizeTypeT m tyname ann (Normalized (Type tyname ann))
+
+so it's natural to have runners that do not break this genericity.
+-}
+
+{- Note [Normalization API]
+Normalization is split in two parts:
+
+1. functions returning computations that perform reductions and run in defined in this module
+   monad transformers (e.g. 'NormalizeTypeT')
+2. runners of those computations
+
+The reason for splitting the API is that this way the type-theoretic notion of normalization is
+separated from implementation-specific details like how to count gas (we hardcode *where* to count
+gas, but this can be generalized in case we need it). And this is important, because gas counting
+requires access to different monads in different scenarios, so in the end we have a fine-grained API
+instead of a single function that reflects all possible effects from distinct scenarios in its type
+signature.
+-}
+
+-- See Note [NormalizedTypeT].
+-- | The monad transformer that type normalization runs in.
+newtype NormalizeTypeT m tyname ann a = NormalizeTypeT
+    { unNormalizeTypeT :: ReaderT (NormalizeTypeEnv m tyname ann) m a
+    } deriving newtype
+        ( Functor, Applicative, Alternative, Monad, MonadPlus
+        , MonadReader (NormalizeTypeEnv m tyname ann), MonadState s
+        , MonadQuote
+        )
+
+-- | Run a 'NormalizeTypeM' computation.
+runNormalizeTypeM :: m () -> NormalizeTypeT m tyname ann a -> m a
+runNormalizeTypeM countStep (NormalizeTypeT a) =
+    runReaderT a $ NormalizeTypeEnv mempty countStep
+
+-- | Run a 'NormalizeTypeM' computation without dealing with gas.
+runNormalizeTypeFullM
+    :: MonadQuote m => NormalizeTypeT m tyname ann a -> m a
+runNormalizeTypeFullM = runNormalizeTypeM $ pure ()
+
+-- | Run a gas-consuming 'NormalizeTypeM' computation.
+-- Count a single substitution step by subtracting @1@ from available gas or
+-- fail when there is no available gas.
+runNormalizeTypeGasM
+    :: MonadQuote m => Gas -> NormalizeTypeT (StateT Gas (MaybeT m)) tyname ann a -> m (Maybe a)
+runNormalizeTypeGasM gas a = runMaybeT $ evalStateT (runNormalizeTypeM countSubst a) gas where
+    countSubst = do
+        Gas gas' <- get
+        if gas' == 0
+            then mzero
+            else put . Gas $ gas' - 1
+
+countTypeNormalizationStep :: NormalizeTypeT m tyname ann ()
+countTypeNormalizationStep = NormalizeTypeT $ ReaderT _normalizeTypeEnvCountStep
+
+-- | Locally extend a 'TypeVarEnv' in a 'NormalizeTypeM' computation.
+withExtendedTypeVarEnv
+    :: (HasUnique (tyname ann) TypeUnique, Monad m)
+    => tyname ann
+    -> Normalized (Type tyname ann)
+    -> NormalizeTypeT m tyname ann a
+    -> NormalizeTypeT m tyname ann a
+withExtendedTypeVarEnv name = local . over normalizeTypeEnvTypeVarEnv . insertByName name
+
+-- | Look up a @tyname@ in a 'TypeVarEnv'.
+lookupTyNameM
+    :: (HasUnique (tyname ann) TypeUnique, Monad m)
+    => tyname ann -> NormalizeTypeT m tyname ann (Maybe (Normalized (Type tyname ann)))
+lookupTyNameM name = asks $ lookupName name . _normalizeTypeEnvTypeVarEnv
+
+{- Note [Normalization]
+Normalization works under the assumption that variables are globally unique.
+We use environments instead of substitutions as they're more efficient.
+
+Since all names are unique and there is no need to track scopes, type normalization has only two
+interesting cases: function application and a variable usage. In the function application case we
+normalize a function and its argument, add the normalized argument to the environment and continue
+normalization. In the variable case we look up the variable in the current environment: if it's not
+found, we leave the variable untouched. If the variable is found, then what this variable stands for
+was previously added to an environment (while handling the function application case), so we pick
+this value and rename all bound variables in it to preserve the global uniqueness condition. It is
+safe to do so, because picked values cannot contain uninstantiated variables as only normalized types
+are added to environments and normalization instantiates all variables presented in an environment.
+-}
+
+-- See Note [Normalization].
+-- | Normalize a 'Type' in the 'NormalizeTypeM' monad.
+normalizeTypeM
+    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
+    => Type tyname ann -> NormalizeTypeT m tyname ann (Normalized (Type tyname ann))
+normalizeTypeM (TyForall ann name kind body) =
+    TyForall ann name kind <<$>> normalizeTypeM body
+normalizeTypeM (TyIFix ann pat arg)          =
+    TyIFix ann <<$>> normalizeTypeM pat <<*>> normalizeTypeM arg
+normalizeTypeM (TyFun ann dom cod)           =
+    TyFun ann <<$>> normalizeTypeM dom <<*>> normalizeTypeM cod
+normalizeTypeM (TyLam ann name kind body)    =
+    TyLam ann name kind <<$>> normalizeTypeM body
+normalizeTypeM (TyApp ann fun arg)           = do
+    vFun <- normalizeTypeM fun
+    vArg <- normalizeTypeM arg
+    case unNormalized vFun of
+        TyLam _ nArg _ body -> do
+            countTypeNormalizationStep
+            substNormalizeTypeM vArg nArg body
+        _                   -> pure $ TyApp ann <$> vFun <*> vArg
+normalizeTypeM var@(TyVar _ name)            = do
+    mayTy <- lookupTyNameM name
+    case mayTy of
+        Nothing -> pure $ Normalized var
+        Just ty -> traverse rename ty
+normalizeTypeM size@TyInt{}                  =
+    pure $ Normalized size
+normalizeTypeM builtin@TyBuiltin{}           =
+    pure $ Normalized builtin
+
+{- Note [Normalizing substitution]
+@substituteNormalize[M]@ is only ever used as normalizing substitution that receives two already
+normalized types. However we do not enforce this in the type signature, because
+1) it's perfectly correct for the last argument to be non-normalized
+2) it would be annoying to wrap 'Type's into 'NormalizedType's
+-}
+
+-- See Note [Normalizing substitution].
+-- | Substitute a type for a variable in a type and normalize in the 'NormalizeTypeM' monad.
+substNormalizeTypeM
+    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
+    => Normalized (Type tyname ann)                                -- ^ @ty@
+    -> tyname ann                                                  -- ^ @name@
+    -> Type tyname ann                                             -- ^ @body@
+    -> NormalizeTypeT m tyname ann (Normalized (Type tyname ann))  -- ^ @NORM ([ty / name] body)@
+substNormalizeTypeM ty name = withExtendedTypeVarEnv name ty . normalizeTypeM
+
+-- | Normalize every 'Type' in a 'Term'.
+normalizeTypesInM
+    :: (HasUnique (tyname ann) TypeUnique, MonadQuote m)
+    => Term tyname name ann -> NormalizeTypeT m tyname ann (Term tyname name ann)
+normalizeTypesInM = go where
+    -- | Normalize a 'Type' and return the result as a 'Type' (as opposed to 'NormalizedType').
+    normalizeReturnType = fmap unNormalized . normalizeTypeM
+
+    go (LamAbs ann name ty body)  = LamAbs ann name <$> normalizeReturnType ty <*> go body
+    go (TyAbs ann name kind body) = TyAbs ann name kind <$> go body
+    go (IWrap ann pat arg term)   =
+        IWrap ann <$> normalizeReturnType pat <*> normalizeReturnType arg <*> go term
+    go (Apply ann fun arg)        = Apply ann <$> go fun <*> go arg
+    go (Unwrap ann term)          = Unwrap ann <$> go term
+    go (Error ann ty)             = Error ann <$> normalizeReturnType ty
+    go (TyInst ann body ty)       = TyInst ann <$> go body <*> normalizeReturnType ty
+    go (Var ann name)             = return $ Var ann name
+    go con@Constant{}             = pure con
+    go bi@Builtin{}               = pure bi

--- a/language-plutus-core/src/Language/PlutusCore/Rename.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Rename.hs
@@ -11,26 +11,38 @@ import           Language.PlutusCore.Name
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Rename.Internal
 import           Language.PlutusCore.Type
+import           PlutusPrelude
+
+{- Note [Marking]
+We use functions from the @markNonFresh*@ family in order to ensure that bound variables never get
+renamed to free ones. This means types/terms/etc are processed twice: once by a @markNonFresh*@
+function and once for the actual renaming. We may consider later to do some kind of meta-circular
+programming trick in order to perform renaming in a single pass.
+-}
 
 -- | The class of things that can be renamed.
 -- I.e. things that are capable of satisfying the global uniqueness condition.
 class Rename a where
     -- | Rename 'Unique's so that they're globally unique.
-    -- In case there are any free variables, they must be left untouched.
+    -- In case there are any free variables, they must be left untouched and bound variables
+    -- must not get renamed to free ones.
     -- Must always assign new names to bound variables,
-    -- so that @rename@ can be used for alpha renaming as well.
+    -- so that @rename@ can be used for alpha-renaming as well.
     rename :: MonadQuote m => a -> m a
 
 instance HasUnique (tyname ann) TypeUnique => Rename (Type tyname ann) where
-    rename = runDirectRenameM . renameTypeM
+    -- See Note [Marking].
+    rename = through markNonFreshType >=> runDirectRenameM . renameTypeM
 
 instance (HasUnique (tyname ann) TypeUnique, HasUnique (name ann) TermUnique) =>
         Rename (Term tyname name ann) where
-    rename = runScopedRenameM . renameTermM
+    -- See Note [Marking].
+    rename = through markNonFreshTerm >=> runScopedRenameM . renameTermM
 
 instance (HasUnique (tyname ann) TypeUnique, HasUnique (name ann) TermUnique) =>
         Rename (Program tyname name ann) where
-    rename = runScopedRenameM . renameProgramM
+    -- See Note [Marking].
+    rename = through markNonFreshProgram >=> runScopedRenameM . renameProgramM
 
-instance HasUnique (tyname ann) TypeUnique => Rename (NormalizedType tyname ann) where
+instance Rename a => Rename (Normalized a) where
     rename = traverse rename

--- a/language-plutus-core/src/Language/PlutusCore/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Type.hs
@@ -28,10 +28,6 @@ module Language.PlutusCore.Type ( Term (..)
                                 , termLoc
                                 -- * Normalized
                                 , Normalized (..)
-                                -- * Backwards compatibility
-                                , NormalizedType
-                                , pattern NormalizedType
-                                , getNormalizedType
                                 ) where
 
 import           Control.Lens
@@ -320,21 +316,13 @@ instance Recursive (Kind a) where
 data Program tyname name a = Program a (Version a) (Term tyname name a)
                  deriving (Show, Eq, Functor, Generic, NFData, Lift)
 
-newtype Normalized a = Normalized { getNormalized :: a }
+newtype Normalized a = Normalized { unNormalized :: a }
     deriving (Show, Eq, Functor, Foldable, Traversable, Generic)
     deriving newtype NFData
 
 instance Applicative Normalized where
     pure = Normalized
     Normalized f <*> Normalized x = Normalized $ f x
-
-type NormalizedType tyname a = Normalized (Type tyname a)
-
-pattern NormalizedType :: Type tyname a -> NormalizedType tyname a
-pattern NormalizedType ty = Normalized ty
-
-getNormalizedType :: NormalizedType tyname a -> Type tyname a
-getNormalizedType (Normalized ty) = ty
 
 instance PrettyBy config a => PrettyBy config (Normalized a) where
     prettyBy config (Normalized x) = prettyBy config x

--- a/language-plutus-core/src/Language/PlutusCore/TypeCheck.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeCheck.hs
@@ -66,7 +66,7 @@ dynamicBuiltinNameMeaningsToTypes ann (DynamicBuiltinNameMeanings means) = do
             ty <- liftQuote $ dynamicBuiltinNameMeaningToType mean
             _ <- inferKind (offChainConfig mempty) $ ann <$ ty
             tyRen <- rename ty
-            normalizeTypeDown tyRen
+            normalizeTypeFull tyRen
     DynamicBuiltinNameTypes <$> traverse getType means
 
 -- | Infer the kind of a type.
@@ -86,7 +86,7 @@ checkKind config ann ty = runTypeCheckM config . checkKindM ann ty
 -- | Infer the type of a term.
 inferType
     :: (AsTypeError e ann, MonadError e m, MonadQuote m)
-    => TypeCheckConfig -> Term TyName Name ann -> m (NormalizedType TyName ())
+    => TypeCheckConfig -> Term TyName Name ann -> m (Normalized (Type TyName ()))
 inferType config = rename >=> runTypeCheckM config . inferTypeM
 
 -- | Check a term against a type.
@@ -94,7 +94,7 @@ inferType config = rename >=> runTypeCheckM config . inferTypeM
 -- throwing a 'TypeError' (annotated with the value of the @ann@ argument) otherwise.
 checkType
     :: (AsTypeError e ann, MonadError e m, MonadQuote m)
-    => TypeCheckConfig -> ann -> Term TyName Name ann -> NormalizedType TyName () -> m ()
+    => TypeCheckConfig -> ann -> Term TyName Name ann -> Normalized (Type TyName ()) -> m ()
 checkType config ann term ty = do
     termRen <- rename term
     runTypeCheckM config $ checkTypeM ann termRen ty
@@ -102,7 +102,7 @@ checkType config ann term ty = do
 -- | Infer the type of a program.
 inferTypeOfProgram
     :: (AsTypeError e ann, MonadError e m, MonadQuote m)
-    => TypeCheckConfig -> Program TyName Name ann -> m (NormalizedType TyName ())
+    => TypeCheckConfig -> Program TyName Name ann -> m (Normalized (Type TyName ()))
 inferTypeOfProgram config (Program _ _ term) = inferType config term
 
 -- | Check a program against a type.
@@ -110,5 +110,5 @@ inferTypeOfProgram config (Program _ _ term) = inferType config term
 -- throwing a 'TypeError' (annotated with the value of the @ann@ argument) otherwise.
 checkTypeOfProgram
     :: (AsTypeError e ann, MonadError e m, MonadQuote m)
-    => TypeCheckConfig -> ann -> Program TyName Name ann -> NormalizedType TyName () -> m ()
+    => TypeCheckConfig -> ann -> Program TyName Name ann -> Normalized (Type TyName ()) -> m ()
 checkTypeOfProgram config ann (Program _ _ term) = checkType config ann term

--- a/language-plutus-core/src/Language/PlutusCore/TypeCheck/Internal.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeCheck/Internal.hs
@@ -29,21 +29,22 @@ module Language.PlutusCore.TypeCheck.Internal
 
 import           Language.PlutusCore.Constant
 import           Language.PlutusCore.Error
-import           Language.PlutusCore.Lexer.Type hiding (name)
+import           Language.PlutusCore.Lexer.Type         hiding (name)
 import           Language.PlutusCore.MkPlc
 import           Language.PlutusCore.Name
-import qualified Language.PlutusCore.Normalize  as Norm
+import           Language.PlutusCore.Normalize
+import qualified Language.PlutusCore.Normalize.Internal as Norm
 import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Rename
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
-import           Control.Lens.TH                (makeLenses)
+import           Control.Lens.TH                        (makeLenses)
 import           Control.Monad.Error.Lens
 import           Control.Monad.Except
 import           Control.Monad.Reader
-import           Data.Map                       (Map)
-import qualified Data.Map                       as Map
+import           Data.Map                               (Map)
+import qualified Data.Map                               as Map
 
 {- Note [Global uniqueness]
 WARNING: type inference/checking works under the assumption that the global uniqueness condition
@@ -97,11 +98,11 @@ functions that cannot fail looks like this:
 
 -- | Mapping from 'DynamicBuiltinName's to their 'Type's.
 newtype DynamicBuiltinNameTypes = DynamicBuiltinNameTypes
-    { unDynamicBuiltinNameTypes :: Map DynamicBuiltinName (NormalizedType TyName ())
+    { unDynamicBuiltinNameTypes :: Map DynamicBuiltinName (Normalized (Type TyName ()))
     } deriving (Semigroup, Monoid)
 
 type TyVarKinds = UniqueMap TypeUnique (Kind ())
-type VarTypes   = UniqueMap TermUnique (NormalizedType TyName ())
+type VarTypes   = UniqueMap TermUnique (Normalized (Type TyName ()))
 
 -- | Configuration of the type checker.
 data TypeCheckConfig = TypeCheckConfig
@@ -144,11 +145,11 @@ withTyVar :: TyName ann -> Kind () -> TypeCheckM ann a -> TypeCheckM ann a
 withTyVar name = local . over tceTyVarKinds . insertByName name
 
 -- | Extend the context of a 'TypeCheckM' computation with a typed variable.
-withVar :: Name ann -> NormalizedType TyName () -> TypeCheckM ann a -> TypeCheckM ann a
+withVar :: Name ann -> Normalized (Type TyName ()) -> TypeCheckM ann a -> TypeCheckM ann a
 withVar name = local . over tceVarTypes . insertByName name
 
 -- | Look up a 'DynamicBuiltinName' in the 'DynBuiltinNameTypes' environment.
-lookupDynamicBuiltinNameM :: ann -> DynamicBuiltinName -> TypeCheckM ann (NormalizedType TyName ())
+lookupDynamicBuiltinNameM :: ann -> DynamicBuiltinName -> TypeCheckM ann (Normalized (Type TyName ()))
 lookupDynamicBuiltinNameM ann name = do
     DynamicBuiltinNameTypes dbnts <- asks $ _tccDynamicBuiltinNameTypes . _tceTypeCheckConfig
     case Map.lookup name dbnts of
@@ -165,7 +166,7 @@ lookupTyVarM name = do
         Just kind -> pure kind
 
 -- | Look up a term variable in the current context.
-lookupVarM :: Name ann -> TypeCheckM ann (NormalizedType TyName ())
+lookupVarM :: Name ann -> TypeCheckM ann (Normalized (Type TyName ()))
 lookupVarM name = do
     mayTy <- asks $ lookupName name . _tceVarTypes
     case mayTy of
@@ -194,14 +195,14 @@ dummyType = TyVar () dummyTyName
 
 -- | Run a 'NormalizeTypeT' computation in the 'TypeCheckM' context.
 -- Depending on whether gas is finite or infinite, calls either
--- 'Norm.runNormalizeTypeDownM' or 'Norm.runNormalizeTypeGasM'.
+-- 'Norm.runNormalizeTypeFullM' or 'Norm.runNormalizeTypeGasM'.
 -- Throws 'OutOfGas' if type normalization runs out of gas.
 runNormalizeTypeTM
     :: (forall m. MonadQuote m => Norm.NormalizeTypeT m tyname ann1 a) -> TypeCheckM ann2 a
 runNormalizeTypeTM a = do
     mayGas <- asks $ _tccMayGas . _tceTypeCheckConfig
     case mayGas of
-        Nothing  -> Norm.runNormalizeTypeDownM a
+        Nothing  -> Norm.runNormalizeTypeFullM a
         Just gas -> do
             mayX <- Norm.runNormalizeTypeGasM gas a
             case mayX of
@@ -209,25 +210,25 @@ runNormalizeTypeTM a = do
                 Just x  -> pure x
 
 -- | Normalize a 'Type'.
-normalizeTypeM :: Type TyName () -> TypeCheckM ann (NormalizedType TyName ())
+normalizeTypeM :: Type TyName () -> TypeCheckM ann (Normalized (Type TyName ()))
 normalizeTypeM ty = runNormalizeTypeTM $ Norm.normalizeTypeM ty
 
 -- | Substitute a type for a variable in a type and normalize the result.
 substNormalizeTypeM
-    :: NormalizedType TyName ()  -- ^ @ty@
-    -> TyName ()                 -- ^ @name@
-    -> Type TyName ()            -- ^ @body@
-    -> TypeCheckM ann (NormalizedType TyName ())
+    :: Normalized (Type TyName ())  -- ^ @ty@
+    -> TyName ()                    -- ^ @name@
+    -> Type TyName ()               -- ^ @body@
+    -> TypeCheckM ann (Normalized (Type TyName ()))
 substNormalizeTypeM ty name body = runNormalizeTypeTM $ Norm.substNormalizeTypeM ty name body
 
 -- | Normalize a 'Type' or simply wrap it in the 'NormalizedType' constructor
 -- if we are working with normalized type annotations.
-normalizeTypeOptM :: Type TyName () -> TypeCheckM ann (NormalizedType TyName ())
+normalizeTypeOptM :: Type TyName () -> TypeCheckM ann (Normalized (Type TyName ()))
 normalizeTypeOptM ty = do
     normTypes <- asks $ _tccDoNormTypes . _tceTypeCheckConfig
     if normTypes
         then normalizeTypeM ty
-        else pure $ NormalizedType ty
+        else pure $ Normalized ty
 
 -- ###################
 -- ## Kind checking ##
@@ -328,30 +329,30 @@ checkKindOfPatternFunctorM ann pat k =
 -- ###################
 
 -- | Get the 'Type' of a 'Constant' wrapped in 'NormalizedType'.
-typeOfConstant :: Constant ann -> NormalizedType TyName ()
+typeOfConstant :: Constant ann -> Normalized (Type TyName ())
 typeOfConstant = \case
     BuiltinInt  _ size _ -> applySizedNormalized TyInteger    size
     BuiltinBS   _ size _ -> applySizedNormalized TyByteString size
     BuiltinSize _ size   -> applySizedNormalized TySize       size
-    BuiltinStr _ _       -> NormalizedType $ TyBuiltin () TyString
+    BuiltinStr _ _       -> Normalized $ TyBuiltin () TyString
   where
     -- | Apply a 'TypeBuiltin' to a 'Size' and wrap in 'NormalizedType'.
-    applySizedNormalized :: TypeBuiltin -> Size -> NormalizedType tyname ()
-    applySizedNormalized tb = NormalizedType . TyApp () (TyBuiltin () tb) . TyInt ()
+    applySizedNormalized :: TypeBuiltin -> Size -> Normalized (Type tyname ())
+    applySizedNormalized tb = Normalized . TyApp () (TyBuiltin () tb) . TyInt ()
 
 -- | Return the 'Type' of a 'BuiltinName'.
-typeOfBuiltinName :: BuiltinName -> Quote (Type TyName ())
+typeOfBuiltinName :: MonadQuote m => BuiltinName -> m (Type TyName ())
 typeOfBuiltinName bn = withTypedBuiltinName bn typeOfTypedBuiltinName
 
 -- | @unfoldFixOf pat arg k = NORM (vPat (\(a :: k) -> ifix vPat a) arg)@
 unfoldFixOf
-    :: NormalizedType TyName ()  -- ^ @vPat@
-    -> NormalizedType TyName ()  -- ^ @vArg@
-    -> Kind ()                   -- ^ @k@
-    -> TypeCheckM ann (NormalizedType TyName ())
+    :: Normalized (Type TyName ())  -- ^ @vPat@
+    -> Normalized (Type TyName ())  -- ^ @vArg@
+    -> Kind ()                      -- ^ @k@
+    -> TypeCheckM ann (Normalized (Type TyName ()))
 unfoldFixOf pat arg k = do
-    let vPat = getNormalizedType pat
-        vArg = getNormalizedType arg
+    let vPat = unNormalized pat
+        vArg = unNormalized arg
     a <- liftQuote $ freshTyName () "a"
     normalizeTypeM $
         mkIterTyApp () vPat
@@ -360,20 +361,19 @@ unfoldFixOf pat arg k = do
             ]
 
 -- | Infer the type of a 'Builtin'.
-inferTypeOfBuiltinM :: Builtin ann -> TypeCheckM ann (NormalizedType TyName ())
+inferTypeOfBuiltinM :: Builtin ann -> TypeCheckM ann (Normalized (Type TyName ()))
 -- We have a weird corner case here: the type of a 'BuiltinName' can contain 'TypedBuiltinDyn', i.e.
 -- a static built-in name is allowed to depend on a dynamic built-in type which are not required
 -- to be normalized. For dynamic built-in names we store a map from them to their *normalized types*,
 -- with the normalization happening in this module, but what should we do for static built-in names?
 -- Right now we just renormalize the type of a static built-in name each time we encounter that name.
-inferTypeOfBuiltinM (BuiltinName    _   name) =
-    liftQuote (typeOfBuiltinName name) >>= rename >>= Norm.normalizeTypeDown
+inferTypeOfBuiltinM (BuiltinName    _   name) = typeOfBuiltinName name >>= normalizeTypeFull
 -- TODO: inline this definition once we have only dynamic built-in names.
 inferTypeOfBuiltinM (DynBuiltinName ann name) = lookupDynamicBuiltinNameM ann name >>= rename
 
 -- See the [Global uniqueness] and [Type rules] notes.
 -- | Synthesize the type of a term, returning a normalized type.
-inferTypeM :: Term TyName Name ann -> TypeCheckM ann (NormalizedType TyName ())
+inferTypeM :: Term TyName Name ann -> TypeCheckM ann (Normalized (Type TyName ()))
 
 -- c : vTy
 -- -------------------------
@@ -413,11 +413,11 @@ inferTypeM (TyAbs _ n nK body)      = do
 -- [infer| G !- fun arg : vCod]
 inferTypeM (Apply ann fun arg)      = do
     vFunTy <- inferTypeM fun
-    case getNormalizedType vFunTy of
+    case unNormalized vFunTy of
         TyFun _ vDom vCod -> do
             -- Subparts of a normalized type, so normalized.
-            checkTypeM ann arg $ NormalizedType vDom
-            pure $ NormalizedType vCod
+            checkTypeM ann arg $ Normalized vDom
+            pure $ Normalized vCod
         _ -> throwError (TypeMismatch ann (void fun) (TyFun () dummyType dummyType) vFunTy)
 
 -- [infer| G !- body : all (n :: nK) vCod]    [check| G !- ty :: tyK]    ty ~>? vTy
@@ -425,7 +425,7 @@ inferTypeM (Apply ann fun arg)      = do
 -- [infer| G !- body {ty} : NORM ([vTy / n] vCod)]
 inferTypeM (TyInst ann body ty)     = do
     vBodyTy <- inferTypeM body
-    case getNormalizedType vBodyTy of
+    case unNormalized vBodyTy of
         TyForall _ n nK vCod -> do
             checkKindM ann ty nK
             vTy <- normalizeTypeOptM $ void ty
@@ -449,11 +449,11 @@ inferTypeM (IWrap ann pat arg term) = do
 -- [infer| G !- unwrap term : NORM (vPat (\(a :: k) -> ifix vPat a) vArg)]
 inferTypeM (Unwrap ann term)        = do
     vTermTy <- inferTypeM term
-    case getNormalizedType vTermTy of
+    case unNormalized vTermTy of
         TyIFix _ vPat vArg -> do
             k <- inferKindM $ ann <$ vArg
             -- Subparts of a normalized type, so normalized.
-            unfoldFixOf (NormalizedType vPat) (NormalizedType vArg) k
+            unfoldFixOf (Normalized vPat) (Normalized vArg) k
         _                  -> throwError (TypeMismatch ann (void term) (TyIFix () dummyType dummyType) vTermTy)
 
 -- [check| G !- ty :: *]    ty ~>? vTy
@@ -465,11 +465,11 @@ inferTypeM (Error ann ty)           = do
 
 -- See the [Global uniqueness] and [Type rules] notes.
 -- | Check a 'Term' against a 'NormalizedType'.
-checkTypeM :: ann -> Term TyName Name ann -> NormalizedType TyName () -> TypeCheckM ann ()
+checkTypeM :: ann -> Term TyName Name ann -> Normalized (Type TyName ()) -> TypeCheckM ann ()
 
 -- [infer| G !- term : vTermTy]    vTermTy ~ vTy
 -- ---------------------------------------------
 -- [check| G !- term : vTy]
 checkTypeM ann term vTy = do
     vTermTy <- inferTypeM term
-    when (vTermTy /= vTy) $ throwError (TypeMismatch ann (void term) (getNormalizedType vTermTy) vTy)
+    when (vTermTy /= vTy) $ throwError (TypeMismatch ann (void term) (unNormalized vTermTy) vTy)

--- a/language-plutus-core/test/Check/Spec.hs
+++ b/language-plutus-core/test/Check/Spec.hs
@@ -6,8 +6,6 @@ import           Language.PlutusCore
 import qualified Language.PlutusCore.Check.Uniques          as Uniques
 import qualified Language.PlutusCore.Check.ValueRestriction as VR
 import           Language.PlutusCore.Generators.AST
-import           Language.PlutusCore.Quote
-import           PlutusPrelude
 
 import           Control.Monad.Except
 import           Data.Foldable                              (traverse_)
@@ -78,7 +76,7 @@ propRenameCheck :: Property
 propRenameCheck = property $ do
     prog <- forAll genProgram
     -- we didn't generate prog in Quote, so mark all the uniques as non-fresh
-    renamed <- runQuoteT $ (rename <=< through markNonFreshProgram) prog
+    renamed <- runQuoteT $ rename prog
     annotateShow renamed
     Hedgehog.evalExceptT $ checkUniques renamed
         where

--- a/language-plutus-core/test/Normalization/Type.hs
+++ b/language-plutus-core/test/Normalization/Type.hs
@@ -22,7 +22,7 @@ test_appAppLamLam = do
         Normalized integer2' = runQuote $ do
             x <- freshTyName () "x"
             y <- freshTyName () "y"
-            normalizeTypeDown $ mkIterTyApp ()
+            normalizeTypeFull $ mkIterTyApp ()
                 (TyLam () x (Type ()) (TyLam () y (Type ()) $ TyVar () y))
                 [integer2, integer2]
     integer2 @?= integer2'
@@ -30,11 +30,11 @@ test_appAppLamLam = do
 test_normalizeTypesInIdempotent :: Property
 test_normalizeTypesInIdempotent = property . hoist (pure . runQuote) $ do
     term <- forAll genTerm
-    mayTermNormTypes <- liftQuote . runNormalizeTypeGasM (Gas 100) $ normalizeTypesIn term
+    mayTermNormTypes <- normalizeTypesGasIn (Gas 100) term
     case mayTermNormTypes of
         Nothing            -> return ()
         Just termNormTypes -> do
-            termNormTypes' <- liftQuote . runNormalizeTypeDownM $ normalizeTypesIn termNormTypes
+            termNormTypes' <- normalizeTypesFullIn termNormTypes
             termNormTypes === termNormTypes'
 
 test_typeNormalization :: TestTree

--- a/plutus-exe/src/Main.hs
+++ b/plutus-exe/src/Main.hs
@@ -165,7 +165,7 @@ toTermExample getTerm = TermExample ty term where
     program = PLC.Program () (PLC.defaultVersion ()) term
     ty = case PLC.runQuote . runExceptT $ PLC.typecheckPipeline PLC.defOffChainConfig program of
         Left (err :: PLC.Error ()) -> error $ PLC.prettyPlcDefString err
-        Right vTy                  -> PLC.getNormalizedType vTy
+        Right vTy                  -> PLC.unNormalized vTy
 
 availableExamples :: [(ExampleName, SomeExample)]
 availableExamples =


### PR DESCRIPTION
This splits the normalizer into

1. internals which rely on global uniqueness and are used by the type checker
2. the safe user-facing API that performs renaming on types before normalizing them

I also deleted the `NormalizedType tyname ann` alias and its pattern synonym. `Normalized (Type tyname ann)` is not much more verbose, but saves the reader from thinking what `NormalizedType` is, and indicates that you can use the `Functor`/`Foldable`/`Traversable` instances of `Normalized`.

See some comments below.