### PR TITLE
wallet-api: Value is Map Currency Int

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ result*
 *.tfvars
 
 gh-pages
+.psc-ide-port

--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -48,7 +48,7 @@ import           Ledger                         ( DataScript(..)
                                                 , scriptTxOut
                                                 )
 import qualified Ledger                         as Ledger
-import           Ledger.Ada.TH                  (Ada(..))
+import           Ledger.Ada.TH                  (Ada)
 import qualified Ledger.Ada                     as Ada
 import           Ledger.Validation
 import           Language.Marlowe
@@ -129,7 +129,7 @@ marloweTx ::
     -> m ()
 marloweTx inputState txOut validator f = let
     (TxOutOf _ vl _, ref) = txOut
-    Ada contractValue = Ada.fromValue vl
+    contractValue = Ada.toInt $ Ada.fromValue vl
     lifted = Ledger.lifted inputState
     scriptIn = scriptTxIn ref validator $ Ledger.RedeemerScript lifted
     dataScript = DataScript lifted
@@ -211,8 +211,8 @@ commit txOut validator oracles choices identCC value inputState inputContract = 
     sig <- signature <$> myKeyPair
     let inputCommand = Commit identCC sig
     let input = Input inputCommand oracles choices
-    let scriptInValue@(Ada contractValue) = Ada.fromValue . txOutValue . fst $ txOut
-    let scriptOutValue = Ada $ contractValue + value
+    let scriptInValue = Ada.fromValue . txOutValue . fst $ txOut
+    let scriptOutValue = scriptInValue + Ada.fromInt value
     let (expectedState, expectedCont, isValid) =
             evalContract (PubKey 1) input bh scriptInValue scriptOutValue inputState inputContract
     when (not isValid) $ throwOtherError "Invalid commit"

--- a/plutus-playground/plutus-playground-client/src/Chain.purs
+++ b/plutus-playground/plutus-playground-client/src/Chain.purs
@@ -26,7 +26,7 @@ import Halogen.ECharts (EChartsEffects, echarts)
 import Halogen.HTML (ClassName(ClassName), br_, div, div_, h2_, slot', text)
 import Halogen.HTML.Events (input)
 import Halogen.HTML.Properties (class_)
-import Ledger.Value.TH (Value)
+import Ledger.Ada.TH (Ada)
 import Ledger.Types (TxIdOf(..))
 import Ledger.Interval (Slot(..))
 import Playground.API (EvaluationResult(EvaluationResult))
@@ -171,7 +171,7 @@ toEchartLink (FlowLink link) =
 balancesChartOptions ::
   forall m.
   Monad m
-  => Array (Tuple Wallet Value)
+  => Array (Tuple Wallet Ada)
   -> E.CommandsT ( series :: I
                  , grid :: I
                  , xAxis :: I
@@ -199,7 +199,7 @@ balancesChartOptions wallets = do
     axisLineStyle
   E.series do
     E.bar do
-      E.items $ map (snd >>> unwrap >>> _.getValue >>> Int.toNumber >>> E.numItem) wallets
+      E.items $ map (snd >>> unwrap >>> _.getAda >>> Int.toNumber >>> E.numItem) wallets
       E.itemStyle $ E.normal $ E.color lightPurple
   where
     axisLineStyle :: forall i. E.DSL (axisLine :: I, splitLine :: I | i) m

--- a/plutus-playground/plutus-playground-client/test/evaluation_response1.json
+++ b/plutus-playground/plutus-playground-client/test/evaluation_response1.json
@@ -21,12 +21,12 @@
         "getAda": 0
       },
       "txForge": {
-        "getValue": 0
+        "getValue": []
       },
       "txOutputs": [
         {
           "txOutValue": {
-            "getValue": 26
+            "getValue": [[0,26]]
           },
           "txOutAddress": {
             "getAddress": "nxgcGMMYrRjqGEAY6xj9GJQYQxg6GMAEGHcYfRhoFQwYzhidGLQYxxhxGLwYfRjhGLIYlxinGLcYlRi7GLr/"
@@ -40,7 +40,7 @@
         },
         {
           "txOutValue": {
-            "getValue": 4
+            "getValue": [[0,4]]
           },
           "txOutAddress": {
             "getAddress": "nxicEhjPGNwEGMcYRRiEGNcYhxisGD0YIxh3GCEYMhjBGIUYJBi8GHoYshiNGOwYQhgZGLgY/BhbGEIYXxhw/w=="
@@ -81,12 +81,12 @@
         "getAda": 0
       },
       "txForge": {
-        "getValue": 50
+        "getValue": [[0,50]]
       },
       "txOutputs": [
         {
           "txOutValue": {
-            "getValue": 10
+            "getValue": [[0,10]]
           },
           "txOutAddress": {
             "getAddress": "nxicEhjPGNwEGMcYRRiEGNcYhxisGD0YIxh3GCEYMhjBGIUYJBi8GHoYshiNGOwYQhgZGLgY/BhbGEIYXxhw/w=="
@@ -100,7 +100,7 @@
         },
         {
           "txOutValue": {
-            "getValue": 30
+            "getValue": [[0,30]]
           },
           "txOutAddress": {
             "getAddress": "nxgcGMMYrRjqGEAY6xj9GJQYQxg6GMAEGHcYfRhoFQwYzhidGLQYxxhxGLwYfRjhGLIYlxinGLcYlRi7GLr/"
@@ -114,7 +114,7 @@
         },
         {
           "txOutValue": {
-            "getValue": 10
+            "getValue": [[0,10]]
           },
           "txOutAddress": {
             "getAddress": "nxjJGEIYoBhsEhh8GCwYGAIYJhh3GOgYiAIKGPsXGEIIGNIYmRg1GE8YPhjPGO0YsRgkGKEY8xj6GEX/"

--- a/plutus-playground/plutus-playground-client/test/evaluation_response2.json
+++ b/plutus-playground/plutus-playground-client/test/evaluation_response2.json
@@ -54,12 +54,12 @@
           "getAda": 0
         },
         "txForge": {
-          "getValue": 0
+          "getValue": []
         },
         "txOutputs": [
           {
             "txOutValue": {
-              "getValue": 5
+              "getValue": [[0,5]]
             },
             "txOutAddress": {
               "getAddress": "nxgcGMMYrRjqGEAY6xj9GJQYQxg6GMAEGHcYfRhoFQwYzhidGLQYxxhxGLwYfRjhGLIYlxinGLcYlRi7GLr/"
@@ -73,7 +73,7 @@
           },
           {
             "txOutValue": {
-              "getValue": 5
+              "getValue": [[0,5]]
             },
             "txOutAddress": {
               "getAddress": "nxicEhjPGNwEGMcYRRiEGNcYhxisGD0YIxh3GCEYMhjBGIUYJBi8GHoYshiNGOwYQhgZGLgY/BhbGEIYXxhw/w=="
@@ -104,12 +104,12 @@
           "getAda": 0
         },
         "txForge": {
-          "getValue": 20
+          "getValue": [[0,20]]
         },
         "txOutputs": [
           {
             "txOutValue": {
-              "getValue": 10
+              "getValue": [[0,10]]
             },
             "txOutAddress": {
               "getAddress": "nxicEhjPGNwEGMcYRRiEGNcYhxisGD0YIxh3GCEYMhjBGIUYJBi8GHoYshiNGOwYQhgZGLgY/BhbGEIYXxhw/w=="
@@ -123,7 +123,7 @@
           },
           {
             "txOutValue": {
-              "getValue": 10
+              "getValue": [[0,10]]
             },
             "txOutAddress": {
               "getAddress": "nxgcGMMYrRjqGEAY6xj9GJQYQxg6GMAEGHcYfRhoFQwYzhidGLQYxxhxGLwYfRjhGLIYlxinGLcYlRi7GLr/"
@@ -228,7 +228,7 @@
         "getWallet": 1
       },
       {
-        "getValue": 5
+        "getAda": 5
       }
     ],
     [
@@ -236,7 +236,7 @@
         "getWallet": 2
       },
       {
-        "getValue": 15
+        "getAda": 15
       }
     ]
   ]

--- a/plutus-playground/plutus-playground-lib/src/Playground/API.hs
+++ b/plutus-playground/plutus-playground-lib/src/Playground/API.hs
@@ -29,8 +29,8 @@ import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import           GHC.Generics               (Generic)
 import qualified Language.Haskell.TH.Syntax as TH
+import           Ledger.Ada                 (Ada)
 import           Ledger.Types               (Blockchain, PubKey)
-import qualified Ledger.Types               as Ledger
 import           Servant.API                ((:<|>), (:>), JSON, Post, ReqBody)
 import           Text.Read                  (readMaybe)
 import           Wallet.Emulator.Types      (EmulatorEvent, Wallet)
@@ -75,7 +75,7 @@ data EvaluationResult = EvaluationResult
   { resultBlockchain  :: Blockchain
   , resultGraph       :: FlowGraph
   , emulatorLog       :: [EmulatorEvent]
-  , fundsDistribution :: [(Wallet, Ledger.Value)]
+  , fundsDistribution :: [(Wallet, Ada)]
   }
   deriving (Generic, ToJSON)
 

--- a/plutus-playground/plutus-playground-server/app/PSGenerator.hs
+++ b/plutus-playground/plutus-playground-server/app/PSGenerator.hs
@@ -38,7 +38,7 @@ import           Ledger.Interval                           (Interval, Slot)
 import           Ledger.Types                              (AddressOf, DataScript, PubKey, RedeemerScript, Signature,
                                                             Tx, TxIdOf, TxInOf, TxInType, TxOutOf, TxOutRefOf,
                                                             TxOutType, ValidatorScript)
-import           Ledger.Value.TH                           (Value)
+import           Ledger.Value.TH                           (CurrencySymbol, Value)
 import           Playground.API                            (CompilationError, CompilationResult, Evaluation,
                                                             EvaluationResult, Expression, Fn, FunctionSchema,
                                                             SimpleArgumentSchema, SourceCode, Warning)
@@ -192,6 +192,7 @@ myTypes =
     , mkSumType (Proxy @NewGist)
     , mkSumType (Proxy @NewGistFile)
     , mkSumType (Proxy @Owner)
+    , mkSumType (Proxy @CurrencySymbol)
     ]
 
 mySettings :: Settings

--- a/plutus-playground/plutus-playground-server/src/Playground/Interpreter.hs
+++ b/plutus-playground/plutus-playground-server/src/Playground/Interpreter.hs
@@ -19,6 +19,7 @@ import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import qualified Data.Text.Internal.Search  as Text
 import qualified Data.Text.IO               as Text
+import           Ledger.Ada                 (Ada)
 import           Ledger.Types               (Blockchain, Value)
 import           Playground.API             (CompilationResult (CompilationResult), Evaluation (sourceCode),
                                              Expression (Action, Wait), Fn (Fn), FunctionSchema (FunctionSchema),
@@ -104,7 +105,7 @@ compile source = do
 runFunction ::
        (MonadMask m, MonadIO m, MonadError PlaygroundError m)
     => Evaluation
-    -> m (Blockchain, [EmulatorEvent], [(Wallet, Value)])
+    -> m (Blockchain, [EmulatorEvent], [(Wallet, Ada)])
 runFunction evaluation = do
     let source = sourceCode evaluation
     avoidUnsafe source
@@ -121,7 +122,7 @@ runFunction evaluation = do
                 JSON.eitherDecodeStrict . BS8.pack $ result :: Either String (Either PlaygroundError ( Blockchain
                                                                                                      , [EmulatorEvent]
                                                                                                      , [( Wallet
-                                                                                                        , Value)]))
+                                                                                                        , Ada)]))
         case decodeResult of
             Left err ->
                 throwError . OtherError $

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -36,6 +36,9 @@ module Language.PlutusTx.Prelude (
     foldl,
     length,
     all,
+    any,
+    append,
+    filter,
     -- * Hashes
     ByteString,
     sha2_256,

--- a/plutus-tx/src/Language/PlutusTx/Prelude/Stage1.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude/Stage1.hs
@@ -34,3 +34,19 @@ all = [|| \pred -> $$(foldr) (\a acc -> $$(and) acc (pred a)) True ||]
 --
 any :: Q (TExp ((a -> Bool) -> [a] -> Bool))
 any = [|| \pred -> $$(foldr) (\a acc -> $$(or) acc (pred a)) False ||]
+
+-- | PlutusTx version of 'Data.List.(++)'.
+--
+--   >>> $$([|| $$(append) [0, 1, 2] [1, 2, 3, 4] ||])
+--   [0,1,2,1,2,3,4]
+--
+append :: Q (TExp ([a] -> [a] -> [a]))
+append = [|| \l r -> $$(foldr) (\x xs -> x:xs) r l ||]
+
+-- | PlutusTx version of 'Data.List.filter'.
+--
+--   >>> $$([|| $$(filter) (> 1) [1, 2, 3, 4] ||])
+--   [2,3,4]
+--
+filter :: Q (TExp ((a -> Bool) -> [a] -> [a] ))
+filter = [|| \pred -> $$(foldr) (\e xs -> if pred e then e:xs else xs) [] ||]

--- a/wallet-api/src/Ledger/Value.hs
+++ b/wallet-api/src/Ledger/Value.hs
@@ -1,13 +1,20 @@
 {-# LANGUAGE TemplateHaskell #-}
+
+-- need orphan instances due to staging restriction
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Ledger.Value(
       Value
+    , CurrencySymbol
+    , currencySymbol
+    , singleton
+    , valueOf
+    , scale
       -- * Constants
     , zero
       -- * Num operations
     , plus
     , minus
     , multiply
-    , divide
     , negate
     , geq
     , gt
@@ -16,12 +23,29 @@ module Ledger.Value(
     , eq
       -- * Etc.
     , isZero
-    , size
     ) where
 
 import qualified Ledger.Value.TH as TH
-import           Ledger.Value.TH (Value)
+import           Ledger.Value.TH (CurrencySymbol, Value)
 import           Prelude         hiding (negate)
+
+currencySymbol :: Int -> CurrencySymbol
+currencySymbol = $$(TH.currencySymbol)
+
+instance Eq Value where
+  (==) = $$(TH.eq)
+
+instance Ord Value where
+  (<=) = $$(TH.leq)
+
+singleton :: CurrencySymbol -> Int -> Value
+singleton = $$(TH.singleton)
+
+valueOf :: Value -> CurrencySymbol -> Int
+valueOf = $$(TH.valueOf)
+
+scale :: Int -> Value -> Value
+scale = $$(TH.scale)
 
 zero :: Value
 zero = $$(TH.zero)
@@ -34,9 +58,6 @@ minus = $$(TH.minus)
 
 multiply :: Value -> Value -> Value
 multiply = $$(TH.multiply)
-
-divide :: Value -> Value -> Value
-divide = $$(TH.divide)
 
 negate :: Value -> Value
 negate = $$(TH.negate)
@@ -58,6 +79,3 @@ eq = $$(TH.eq)
 
 isZero :: Value -> Bool
 isZero = $$(TH.isZero)
-
-size :: Value -> Int
-size = $$(TH.size)

--- a/wallet-api/src/Ledger/Value/TH.hs
+++ b/wallet-api/src/Ledger/Value/TH.hs
@@ -2,15 +2,20 @@
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE LambdaCase         #-}
 module Ledger.Value.TH(
       Value(..)
+    , CurrencySymbol
+    , currencySymbol
+    , singleton
+    , valueOf
+    , scale
       -- * Constants
     , zero
       -- * Num operations
     , plus
     , minus
     , multiply
-    , divide
     , negate
     , geq
     , gt
@@ -19,7 +24,6 @@ module Ledger.Value.TH(
     , eq
       -- * Etc.
     , isZero
-    , size
     ) where
 
 import           Codec.Serialise.Class        (Serialise)
@@ -29,12 +33,22 @@ import           GHC.Generics                 (Generic)
 import           Language.PlutusTx.Lift       (makeLift)
 import qualified Language.PlutusTx.Prelude    as P
 import           Language.Haskell.TH          (Q, TExp)
-import           Prelude                      hiding (negate)
+import           Prelude                      hiding (all, lookup, negate)
+
+data CurrencySymbol = CurrencySymbol Int
+  deriving (Eq, Ord, Show)
+  deriving stock (Generic)
+  deriving anyclass (ToSchema, ToJSON, FromJSON, Serialise)
+
+makeLift ''CurrencySymbol
+
+currencySymbol :: Q (TExp (Int -> CurrencySymbol))
+currencySymbol = [|| CurrencySymbol ||]
 
 -- | Cryptocurrency value
 --   See note [Currencies]
-newtype Value = Value { getValue :: Int }
-    deriving (Eq, Ord, Show, Enum)
+newtype Value = Value { getValue :: [(CurrencySymbol, Int)] }
+    deriving (Show)
     deriving stock (Generic)
     deriving anyclass (ToSchema, ToJSON, FromJSON)
     deriving newtype (Serialise)
@@ -58,44 +72,136 @@ using 'Ledger.Ada.adaValueOf'. To get the ada dimension of 'Value' we use
 similar to 'Ledger.Ada' for their own currencies.
 
 -}
+   
+type CurrencyMap v = [(CurrencySymbol, v)]
+
+cmap :: Q (TExp ((v -> w) -> CurrencyMap v -> CurrencyMap w))
+cmap = [|| 
+    \f ->
+        let go [] = []
+            go ((c, i):xs') = (c, f i) : go xs'
+        in go
+    ||]
+
+lookup :: Q (TExp (CurrencySymbol -> CurrencyMap v -> Maybe v))
+lookup = [|| 
+    \(CurrencySymbol cur) xs -> 
+        let 
+            go :: [(CurrencySymbol, v)] -> Maybe v
+            go []                          = Nothing
+            go ((CurrencySymbol c, i):xs') = if $$(P.eq) c cur then Just i else go xs'
+        in go xs
+ ||]
+
+-- | How much of a given currency is in a 'Value'
+valueOf :: Q (TExp (Value -> CurrencySymbol -> Int))
+valueOf = [|| 
+  \(Value xs) cur -> 
+      case $$(lookup) cur xs of
+        Nothing -> 0 :: Int
+        Just i  -> i
+   ||]
+
+data These a b = This a | That b | These a b
+
+these :: Q (TExp (a -> b -> (a -> b -> c) -> These a b -> c))
+these = [|| 
+    \a' b' f -> \case 
+        This a -> f a b'
+        That b -> f a' b
+        These a b -> f a b
+    ||]
+
+union :: Q (TExp (CurrencyMap a -> CurrencyMap b -> CurrencyMap (These a b)))
+union = [|| 
+    \ls rs -> 
+        let 
+            f a b' = case b' of
+                Nothing -> This a
+                Just b  -> These a b
+            ls' = $$(P.map) (\(c, i) -> (c, (f i ($$(lookup) c rs)))) ls
+            rs' = $$(P.filter) (\(CurrencySymbol c, _) -> $$(P.not) ($$(P.any) (\(CurrencySymbol c', _) -> $$(P.eq) c' c) ls)) rs
+            rs'' = $$(P.map) (\(c, b) -> (c, (That b))) rs'
+        in $$(P.append) ls' rs''
+  ||]
+
+singleton :: Q (TExp (CurrencySymbol -> Int -> Value))
+singleton = [|| \c i -> Value [(c, i)] ||]
+
+unionWith :: Q (TExp ((Int -> Int -> Int) -> Value -> Value -> Value))
+unionWith = [||
+  \f (Value ls) (Value rs) -> 
+    let 
+        combined = $$(union) ls rs
+        unThese k = case k of
+            This a    -> f a 0
+            That b    -> f 0 b
+            These a b -> f a b
+    in Value ($$(cmap) unThese combined)
+  ||]
+
+all :: Q (TExp ((v -> Bool) -> CurrencyMap v -> Bool))
+all = [|| \p -> let go xs = case xs of { [] -> True; (_, x):xs' -> $$(P.and) (p x) (go xs') } in go ||]
+
+scale :: Q (TExp (Int -> Value -> Value))
+scale = [|| \i (Value xs) -> Value ($$(P.map) (\(c, i') -> (c, $$(P.multiply) i i')) xs) ||]
 
 -- Num operations
 
 plus :: Q (TExp (Value -> Value -> Value))
-plus = [|| \(Value a) (Value b) -> Value ($$(P.plus) a b)||]
-
-minus :: Q (TExp (Value -> Value -> Value))
-minus = [|| \(Value a) (Value b) -> Value ($$(P.minus) a b)||]
-
-multiply :: Q (TExp (Value -> Value -> Value))
-multiply = [|| \(Value a) (Value b) -> Value ($$(P.multiply) a b)||]
-
-divide :: Q (TExp (Value -> Value -> Value))
-divide = [|| \(Value a) (Value b) -> Value ($$(P.divide) a b)||]
-
-zero :: Q (TExp Value)
-zero = [|| Value 0 ||]
+plus = [|| $$(unionWith) $$(P.plus) ||]
 
 negate :: Q (TExp (Value -> Value))
-negate = [|| \(Value i) -> Value ($$(P.multiply) (-1) i) ||]
+negate = [|| $$(scale) (-1) ||]
+
+minus :: Q (TExp (Value -> Value -> Value))
+minus = [|| $$(unionWith) $$(P.minus) ||]
+
+multiply :: Q (TExp (Value -> Value -> Value))
+multiply = [|| $$(unionWith) $$(P.multiply) ||]
+
+zero :: Q (TExp Value)
+zero = [|| Value [] ||]
 
 isZero :: Q (TExp (Value -> Bool))
-isZero = [|| \(Value i) -> $$(P.eq) i 0 ||]
+isZero = [|| \(Value xs) -> $$(P.all) (\(_, i) -> $$(P.eq) 0 i) xs ||]
 
 geq :: Q (TExp (Value -> Value -> Bool))
-geq = [|| \(Value i) (Value j) -> $$(P.geq) i j ||]
+geq = [|| 
+  \(Value ls) (Value rs) -> 
+    let 
+        p = $$(these) 0 0 $$(P.geq)
+    in
+      $$(all) p ($$(union) ls rs) ||]
 
 gt :: Q (TExp (Value -> Value -> Bool))
-gt = [|| \(Value i) (Value j) -> $$(P.gt) i j ||]
+gt = [|| 
+    \(Value ls) (Value rs) -> 
+    let 
+        p = $$(these) 0 0 $$(P.gt)
+    in
+        $$(all) p ($$(union) ls rs) ||]
 
 leq :: Q (TExp (Value -> Value -> Bool))
-leq = [|| \(Value i) (Value j) -> $$(P.leq) i j ||]
+leq = [|| 
+    \(Value ls) (Value rs) -> 
+    let 
+        p = $$(these) 0 0 $$(P.leq)
+    in
+        $$(all) p ($$(union) ls rs) ||]
 
 lt :: Q (TExp (Value -> Value -> Bool))
-lt = [|| \(Value i) (Value j) -> $$(P.lt) i j ||]
+lt = [|| 
+    \(Value ls) (Value rs) -> 
+        let 
+            p = $$(these) 0 0 $$(P.lt)
+        in
+        $$(all) p ($$(union) ls rs) ||]
 
 eq :: Q (TExp (Value -> Value -> Bool))
-eq = [|| \(Value i) (Value j) -> $$(P.eq) i j ||]
-
-size :: Q (TExp (Value -> Int))
-size = [|| \(Value i) -> i ||]
+eq = [|| 
+    \(Value ls) (Value rs) -> 
+    let 
+        p = $$(these) 0 0 $$(P.eq)
+    in
+        $$(all) p ($$(union) ls rs) ||]

--- a/wallet-api/src/Wallet/Emulator/Types.hs
+++ b/wallet-api/src/Wallet/Emulator/Types.hs
@@ -244,15 +244,15 @@ selectCoin fnds vl =
                     $ T.unwords
                         [ "Total:", T.pack $ show total
                         , "expected:", T.pack $ show vl]
-        in  if total < vl
+        in  if total `Value.lt` vl
             then err
             else
                 let
-                    fundsToSpend   = takeUntil (\(_, runningTotal) -> vl <= runningTotal) fundsWithTotal
+                    fundsToSpend   = takeUntil (\(_, runningTotal) -> vl `Value.leq` runningTotal) fundsWithTotal
                     totalSpent     = case reverse fundsToSpend of
                                         []            -> Value.zero
                                         (_, total'):_ -> total'
-                    change         = Value.minus totalSpent vl
+                    change         = totalSpent `Value.minus` vl
                 in pure (fst <$> fundsToSpend, change)
 
 -- | Take elements from a list until the predicate is satisfied.

--- a/wallet-api/src/Wallet/Graph.hs
+++ b/wallet-api/src/Wallet/Graph.hs
@@ -22,10 +22,10 @@ import           Data.Maybe       (catMaybes)
 import qualified Data.Set         as Set
 import qualified Data.Text        as Text
 import           GHC.Generics     (Generic)
+import qualified Ledger.Ada       as Ada
 import           Ledger.Types     (Blockchain, PubKey, Tx, TxId, TxOutOf (TxOutOf), TxOutRef, TxOutRefOf (TxOutRefOf),
                                    TxOutType (PayToPubKey, PayToScript), getTxId, hashTx, out, txInRef, txInputs,
                                    txOutRefId, txOutRefs, txOutType, txOutValue, unspentOutputs)
-import qualified Ledger.Value     as Value
 
 -- | Owner of unspent funds
 data UtxOwner
@@ -111,7 +111,7 @@ txnFlows keys bc = catMaybes (utxoLinks ++ foldMap extract bc')
       pure FlowLink
             { flowLinkSource = sourceRef
             , flowLinkTarget = tgtRef
-            , flowLinkValue = fromIntegral $ Value.size $ txOutValue src
+            , flowLinkValue = fromIntegral $ Ada.fromValue $ txOutValue src
             , flowLinkOwner = owner knownKeys src
             , flowLinkSourceLoc = sourceLoc
             , flowLinkTargetLoc = tgtLoc


### PR DESCRIPTION
Change the definition of `Value` to `[(Int, Int)]`. We use a list of
key-value pairs for now and will change it to an `IntMap` later. None
of the examples use more than one currency anyway.