### PR TITLE
Fix #462 - conditionally clearing out actions when the underlying program is incompatible.

### DIFF
--- a/plutus-playground/plutus-playground-client/src/Action.purs
+++ b/plutus-playground/plutus-playground-client/src/Action.purs
@@ -22,23 +22,23 @@ import Halogen.HTML.Properties (InputType(InputText, InputNumber), class_, class
 import Halogen.Query as HQ
 import Icons (Icon(..), icon)
 import Network.RemoteData (RemoteData(Loading, NotAsked, Failure, Success))
-import Playground.API (EvaluationResult, FunctionSchema, SimpleArgumentSchema, _EvaluationResult, _Fn, _FunctionSchema)
+import Playground.API (EvaluationResult, _EvaluationResult, _Fn, _FunctionSchema)
 import Prelude (map, show, unit, ($), (+), (/=), (<$>), (<<<), (<>))
 import Servant.PureScript.Affjax (AjaxError)
-import Types (Action(Wait, Action), Blockchain, ChildQuery, ChildSlot, FormEvent(SetSubField, SetStringField, SetIntField), MockWallet, Query(EvaluateActions, AddWaitAction, PopulateAction, SetWaitTime, RemoveAction), SimpleArgument(Unknowable, SimpleObject, SimpleString, SimpleInt), ValidationError, _MockWallet, _argumentSchema, _functionName, _wallet, validate)
+import Types (Action(Wait, Action), Blockchain, ChildQuery, ChildSlot, FormEvent(SetSubField, SetStringField, SetIntField), MockWallet, Query(EvaluateActions, AddWaitAction, PopulateAction, SetWaitTime, RemoveAction), SimpleArgument(Unknowable, SimpleObject, SimpleString, SimpleInt), ValidationError, Signatures, _MockWallet, _argumentSchema, _functionName, _wallet, validate)
 import Wallet (walletIdPane, walletsPane)
 
 simulationPane ::
   forall m aff.
   MonadAff (EChartsEffects aff) m
-  => Array (FunctionSchema SimpleArgumentSchema)
-  -> Array MockWallet
+  => Array MockWallet
+  -> Signatures
   -> Array Action
   -> RemoteData AjaxError EvaluationResult
   -> ParentHTML Query ChildQuery ChildSlot m
-simulationPane schemas wallets actions evaluationResult =
+simulationPane wallets signature actions evaluationResult =
   div_
-    [ walletsPane schemas wallets
+    [ walletsPane signature wallets
     , br_
     , actionsPane actions (view (_EvaluationResult <<< to _.resultBlockchain) <$> evaluationResult)
     ]

--- a/plutus-playground/plutus-playground-client/src/Editor.purs
+++ b/plutus-playground/plutus-playground-client/src/Editor.purs
@@ -7,7 +7,7 @@ import Ace.Editor as Editor
 import Ace.Halogen.Component (AceEffects, Autocomplete(Live), aceComponent)
 import Ace.Types (ACE, Editor)
 import AjaxUtils (ajaxErrorPane)
-import Bootstrap (btn, btnDanger, btnInfo, btnPrimary, btnSecondary, btnSmall, btnSuccess, empty, listGroupItem_, listGroup_, pullRight, row_)
+import Bootstrap (btn, btnDanger, btnInfo, btnPrimary, btnSecondary, btnSmall, btnSuccess, empty, listGroupItem_, listGroup_, pullRight)
 import Control.Alternative ((<|>))
 import Control.Monad.Aff.Class (class MonadAff)
 import Control.Monad.Eff (Eff)

--- a/plutus-playground/plutus-playground-client/src/Types.purs
+++ b/plutus-playground/plutus-playground-client/src/Types.purs
@@ -1,5 +1,7 @@
 module Types where
 
+import Prelude
+
 import Ace.Halogen.Component (AceMessage, AceQuery)
 import Auth (AuthStatus)
 import Control.Comonad (class Comonad, extract)
@@ -17,13 +19,13 @@ import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
 import Data.Symbol (SProxy(..))
 import Data.Tuple (Tuple(..))
+import Data.Tuple.Nested (type (/\))
 import Gist (Gist)
 import Halogen.Component.ChildPath (ChildPath, cp1, cp2, cp3)
 import Halogen.ECharts (EChartsMessage, EChartsQuery)
 import Ledger.Types (Tx)
 import Network.RemoteData (RemoteData)
 import Playground.API (CompilationError, CompilationResult, EvaluationResult, FunctionSchema, SimpleArgumentSchema(SimpleObjectArgument, UnknownArgument, SimpleStringArgument, SimpleIntArgument), _FunctionSchema)
-import Prelude (class Eq, class Functor, class Ord, class Show, Unit, show, ($), (<$>), (<<<), (<>))
 import Servant.PureScript.Affjax (AjaxError)
 import Wallet.Emulator.Types (Wallet)
 
@@ -210,12 +212,13 @@ cpBalancesChart = cp3
 -----------------------------------------------------------
 
 type Blockchain = Array (Array Tx)
+type Signatures = Array (FunctionSchema SimpleArgumentSchema)
 
 type State =
   { view :: View
   , compilationResult :: RemoteData AjaxError (Either (Array CompilationError) CompilationResult)
   , wallets :: Array MockWallet
-  , actions :: Array Action
+  , simulation :: Maybe (Signatures /\ Array Action)
   , evaluationResult :: RemoteData AjaxError EvaluationResult
   , authStatus :: RemoteData AjaxError AuthStatus
   , createGistResult :: RemoteData AjaxError Gist
@@ -224,8 +227,8 @@ type State =
 _view :: forall s a. Lens' {view :: a | s} a
 _view = prop (SProxy :: SProxy "view")
 
-_actions :: forall s a. Lens' {actions :: a | s} a
-_actions = prop (SProxy :: SProxy "actions")
+_simulation :: forall s a. Lens' {simulation :: a | s} a
+_simulation = prop (SProxy :: SProxy "simulation")
 
 _wallets :: forall s a. Lens' {wallets :: a | s} a
 _wallets = prop (SProxy :: SProxy "wallets")

--- a/plutus-playground/plutus-playground-client/src/Wallet.purs
+++ b/plutus-playground/plutus-playground-client/src/Wallet.purs
@@ -16,30 +16,30 @@ import Halogen.Query as HQ
 import Icons (Icon(..), icon)
 import Playground.API (FunctionSchema, SimpleArgumentSchema, _Fn, _FunctionSchema)
 import Prelude (map, show, ($), (<$>), (<<<))
-import Types (Action(..), MockWallet, Query(..), _MockWallet, _balance, _functionName, _wallet, toValueLevel)
+import Types (Action(..), MockWallet, Query(..), Signatures, _MockWallet, _balance, _functionName, _wallet, toValueLevel)
 import Wallet.Emulator.Types (Wallet)
 
 walletsPane ::
   forall p.
-  Array (FunctionSchema SimpleArgumentSchema)
+  Signatures
   -> Array MockWallet
   -> HTML p Query
-walletsPane schemas mockWallets =
+walletsPane signatures mockWallets =
   div_
     [ h2_ [ text "Wallets" ]
     , p_ [ text "Add some initial wallets, then click one of your function calls inside the wallet to begin a chain of actions." ]
     , Keyed.div
         [ class_ row ]
-        (Array.snoc (mapWithIndex (walletPane schemas) mockWallets) addWalletPane)
+        (Array.snoc (mapWithIndex (walletPane signatures) mockWallets) addWalletPane)
     ]
 
 walletPane ::
   forall p.
-  Array (FunctionSchema SimpleArgumentSchema)
+  Signatures
   -> Int
   -> MockWallet
   -> Tuple String (HTML p Query)
-walletPane schemas index mockWallet =
+walletPane signatures index mockWallet =
   Tuple (show index) $
     col4_
       [ div
@@ -65,7 +65,7 @@ walletPane schemas index mockWallet =
                       ]
                   , h4_ [ text "Available functions" ]
                   , div_
-                      (actionButton mockWallet <$> schemas)
+                      (actionButton mockWallet <$> signatures)
                   ]
               ]
           ]


### PR DESCRIPTION
This required a bit of a reshuffle of the core `State` type.