### PR TITLE
Remove second cabal-version field

### DIFF
--- a/plutus-playground/plutus-playground-lib/plutus-playground-lib.cabal
+++ b/plutus-playground/plutus-playground-lib/plutus-playground-lib.cabal
@@ -12,7 +12,6 @@ license-files:
   LICENSE
   NOTICE
 build-type:     Simple
-cabal-version:  >= 1.10
 extra-source-files:
 
 source-repository head


### PR DESCRIPTION
This fixes builds for both `stack` and `cabal`. I'm not entirely sure what was up with CI but we may want to fix them to prevent such things from happening.