### PR TITLE
wallet-api: Fix bug in emulator

### DIFF
--- a/wallet-api/src/Ledger/Index.hs
+++ b/wallet-api/src/Ledger/Index.hs
@@ -117,9 +117,13 @@ lkpTxOut t = liftEither  . lookup t =<< ask
 validateTransaction :: ValidationMonad m
     => Ledger.Slot
     -> Tx
-    -> m ()
-validateTransaction h t =
-    checkSlotRange h t >> checkValuePreserved t >> checkPositiveValues t >> checkValidInputs t
+    -> m UtxoIndex
+validateTransaction h t = do
+    _ <- checkSlotRange h t
+    _ <- checkValuePreserved t
+    _ <- checkPositiveValues t
+    _ <- checkValidInputs t
+    insert t <$> ask
 
 -- | Check that a transaction can be validated in the given slot.
 checkSlotRange :: ValidationMonad m => Ledger.Slot -> Tx -> m ()


### PR DESCRIPTION
* Fix a bug in the emulator where the UTXO set would only be updated
  after each block (instead of each transaction)

There is a unit test for this at the moment, but I'll improve the test suite for the emulator next week so we should get better tests soon.