### PR TITLE
plutus-tx: add red-black tree implementation for Maps

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -54015,6 +54015,7 @@ license = stdenv.lib.licenses.asl20;
 , doctest
 , extra
 , ghc
+, hedgehog
 , language-plutus-core
 , lens
 , mtl
@@ -54025,6 +54026,7 @@ license = stdenv.lib.licenses.asl20;
 , stdenv
 , tasty
 , tasty-hunit
+, tasty-hedgehog
 , template-haskell
 , text
 , th-abstraction
@@ -54059,6 +54061,7 @@ doctest
 testHaskellDepends = [
 base
 bytestring
+hedgehog
 language-plutus-core
 mtl
 plutus-core-interpreter
@@ -54066,6 +54069,7 @@ plutus-ir
 prettyprinter
 tasty
 tasty-hunit
+tasty-hedgehog
 template-haskell
 ];
 doHaddock = false;

--- a/plutus-emulator/src/Wallet/Emulator/Types.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Types.hs
@@ -302,7 +302,7 @@ selectCoin fnds vl =
                     $ T.unwords
                         [ "Total:", T.pack $ show total
                         , "expected:", T.pack $ show vl]
-        in  if total `Value.lt` vl
+        in  if not (total `Value.geq` vl)
             then err
             else
                 let

--- a/plutus-emulator/test/Spec.hs
+++ b/plutus-emulator/test/Spec.hs
@@ -238,7 +238,6 @@ invalidScript = property $ do
         validator :: () -> () -> PendingTx -> Bool
         validator _ _ _ = PlutusTx.traceErrorH "I always fail everything"
 
-
 txnFlowsTest :: Property
 txnFlowsTest = property $ do
     (_, e) <- forAll $ Gen.runTraceOn Gen.generatorModel pubKeyTransactions

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -43,6 +43,9 @@ library
         Language.PlutusTx.TH
         Language.PlutusTx.Prelude
         Language.PlutusTx.Evaluation
+        Language.PlutusTx.Map
+        Language.PlutusTx.RBTree
+        Language.PlutusTx.These
     reexported-modules:
         Language.PlutusTx.Code,
         Language.PlutusTx.Lift,
@@ -54,6 +57,7 @@ library
         base >=4.9 && <5,
         bytestring -any,
         template-haskell >=2.13.0.0,
+        serialise -any,
         language-plutus-core -any,
         plutus-core-interpreter -any,
         plutus-tx-compiler -any
@@ -118,10 +122,12 @@ test-suite plutus-tx-tests
         Plugin.Lib
         TH.Spec
         TH.TestTH
+        Map.Spec
     default-language: Haskell2010
     build-depends:
         base >=4.9 && <5,
         language-plutus-core -any,
+        hedgehog -any,
         plutus-core-interpreter -any,
         plutus-tx -any,
         plutus-ir -any,
@@ -130,6 +136,7 @@ test-suite plutus-tx-tests
         bytestring -any,
         template-haskell -any,
         tasty -any,
+        tasty-hedgehog -any,
         tasty-hunit -any
     -- this makes the plugin give better errors
     ghc-options: -g

--- a/plutus-tx/src/Language/PlutusTx/Map.hs
+++ b/plutus-tx/src/Language/PlutusTx/Map.hs
@@ -1,0 +1,9 @@
+module Language.PlutusTx.Map (Map, module Tree) where
+
+import           Prelude hiding (lookup, map, foldr, all, any)
+import           Language.PlutusTx.RBTree as Tree
+
+-- | A map, implemented as a binary search tree. Unlike @Data.Map@ from @containers@,
+-- this does not require an 'Ord' instance for keys, but rather the comparison function
+-- must be passed on each usage, with the user required to ensure consistency.
+type Map = RBTree

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -23,6 +23,7 @@ module Language.PlutusTx.Prelude (
     lt,
     leq,
     eq,
+    compareInteger,
     plus,
     minus,
     multiply,
@@ -54,6 +55,7 @@ module Language.PlutusTx.Prelude (
     equalsByteString,
     lessThanByteString,
     greaterThanByteString,
+    compareByteString,
     takeByteString,
     dropByteString,
     concatenate,
@@ -207,6 +209,10 @@ leq = Builtins.lessThanEqInteger
 eq :: Integer -> Integer -> Bool
 eq = Builtins.equalsInteger
 
+{-# INLINABLE compareInteger #-}
+compareInteger :: Integer -> Integer -> Ordering
+compareInteger x y = if gt x y then GT else if lt x y then LT else EQ
+
 {-# INLINABLE plus #-}
 -- | Addition
 --
@@ -251,6 +257,10 @@ divide = Builtins.divideInteger
 --
 remainder :: Integer -> Integer -> Integer
 remainder = Builtins.remainderInteger
+
+{-# INLINABLE compareByteString #-}
+compareByteString :: ByteString -> ByteString -> Ordering
+compareByteString x y = if Builtins.greaterThanByteString x y then GT else if Builtins.lessThanByteString x y then LT else EQ
 
 {-# INLINABLE min #-}
 -- | The smaller of two 'Integer's

--- a/plutus-tx/src/Language/PlutusTx/RBTree.hs
+++ b/plutus-tx/src/Language/PlutusTx/RBTree.hs
@@ -1,0 +1,425 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+-- Otherwise we get specializations inside our unfoldings, and the specialisations
+-- lack unfoldings themselves!
+{-# OPTIONS_GHC -fno-spec-constr #-}
+-- Otherwise we get tuple type reps, which we can't deal with
+{-# OPTIONS_GHC -fno-strictness #-}
+-- | This module defines a red-black tree suitable for use as a map or set.
+--
+-- The code is heavily inspired by the @llrbtree@ Haskell library, as well
+-- as @https://github.com/sweirich/dth/blob/master/examples/red-black/RedBlack.lhs@.
+-- However, this version has been modified significantly for TH usage and clarity.
+--
+-- This implementation also aims to be relatively elementary, since we don't have
+-- features like GADTs which some implementations use to improve safety.
+--
+-- As a reminder, red-black trees have a number of invariants (some of the things that
+-- are normally enforced as invariants are here ensured by the types):
+-- (1) The root is black.
+-- (2) If a node is red, then both its children are black.
+-- (3) Every path from a given node to any of its leaves has the same number of
+--     black nodes.
+-- Invariant (2) and (3) between them ensure that the tree is balanced.
+module Language.PlutusTx.RBTree (
+    RBTree(..),
+    Color(..),
+    Comparison,
+    empty,
+    singleton,
+    lookup,
+    keys,
+    values,
+    toList,
+    fromList,
+    size,
+    map,
+    foldr,
+    valid,
+    insert,
+    --delete,
+    union,
+    unionWith,
+    unionThese,
+    all,
+    any)
+where
+
+import           Language.PlutusTx.Prelude    hiding (map, foldr, lookup, all, any)
+import qualified Language.PlutusTx.Prelude    as P
+import           Language.PlutusTx.These
+import           Language.PlutusTx.Lift
+import           Codec.Serialise
+import           GHC.Generics
+
+type Comparison k = k -> k -> Ordering
+
+data Color = B | R
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (Serialise)
+
+-- | The number of black nodes between this node and the leaves. Invariant (3) states
+-- that this is the same for all paths, so can be represented with a single value.
+type BlackHeight = Integer
+
+data RBTree k v = Leaf | Branch Color BlackHeight (RBTree k v) k v (RBTree k v)
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (Serialise)
+
+makeLift ''Color
+makeLift ''RBTree
+
+------------------------------------------------------------
+-- Straightforward functions
+------------------------------------------------------------
+
+{-# INLINABLE empty #-}
+empty :: RBTree k v
+empty = Leaf
+
+{-# INLINABLE singleton #-}
+singleton :: k -> v -> RBTree k v
+singleton k v = Branch B 1 Leaf k v Leaf
+
+{-# INLINABLE blackHeight #-}
+blackHeight :: RBTree k v -> BlackHeight
+blackHeight = \case { Leaf -> 0 ; Branch _ h _ _ _ _ -> h }
+
+{-# INLINABLE color #-}
+color :: RBTree k v -> Color
+color = \case { Leaf -> B ; Branch c _ _ _ _ _ -> c }
+
+{-# INLINABLE lookup #-}
+lookup :: Comparison k -> k -> RBTree k v -> Maybe v
+lookup comp k =
+    let go = \case
+            Leaf -> Nothing
+            Branch _ _ l k' v r -> case comp k k' of
+                LT -> go l
+                GT -> go r
+                EQ -> Just v
+    in go
+
+{-# INLINABLE size #-}
+size :: RBTree k v -> Integer
+size t = length $ keys t
+
+-- eta-expanded to avoid value restriction
+{-# INLINABLE keys #-}
+keys :: RBTree k v -> [k]
+keys t = foldr (\(k,_) ks -> k:ks) [] t
+
+-- eta-expanded to avoid value restriction
+{-# INLINABLE values #-}
+values :: RBTree k v -> [v]
+values t = foldr (\(_,v) vs -> v:vs) [] t
+
+-- eta-expanded to avoid value restriction
+{-# INLINABLE toList #-}
+toList :: RBTree k v -> [(k, v)]
+toList t = foldr (\m ms -> m:ms) [] t
+
+{-# INLINABLE fromList #-}
+fromList :: Comparison k -> [(k, v)] -> RBTree k v
+fromList comp entries = P.foldr (\(k, v) m -> insert comp k v m) empty entries
+
+{-# INLINABLE map #-}
+map :: (a -> b) -> RBTree k a -> RBTree k b
+map f = \case
+    Leaf -> Leaf
+    Branch c h l k v r -> Branch c h (map f l) k (f v) (map f r)
+
+{-# INLINABLE foldr #-}
+foldr :: ((k, v) -> b -> b) -> b -> RBTree k v -> b
+foldr f acc = \case
+    Leaf -> acc
+    Branch _ _ l k v r ->
+        let
+            right = foldr f acc r
+            center = f (k, v) right
+            left = foldr f center l
+        in left
+
+------------------------------------------------------------
+-- Invariants and validity
+------------------------------------------------------------
+
+{-# INLINABLE isBalanced #-}
+isBalanced :: RBTree k v -> Bool
+isBalanced t = sameBlacksToLeaves t && checkChildren t
+
+{-# INLINABLE sameBlacksToLeaves #-}
+sameBlacksToLeaves :: RBTree k v -> Bool
+sameBlacksToLeaves t = case blacksToLeaves t of
+    [] -> True
+    n:ns -> P.all (eq n) ns
+
+{-# INLINABLE blacksToLeaves #-}
+blacksToLeaves :: RBTree k v -> [Integer]
+blacksToLeaves =
+    let blacksToLeavesFrom :: Integer -> RBTree k v -> [Integer]
+        blacksToLeavesFrom n = \case
+          Leaf -> [n `plus` 1]
+          Branch R _ l _ _ r -> blacksToLeavesFrom n l ++ blacksToLeavesFrom n r
+          Branch B _ l _ _ r -> blacksToLeavesFrom (n `plus` 1) l ++ blacksToLeavesFrom (n `plus` 1) r
+    in blacksToLeavesFrom 0
+
+{-# INLINABLE checkChildren #-}
+checkChildren :: RBTree k v -> Bool
+checkChildren t =
+    let
+        checkVsParentColor _ Leaf = True
+        -- Red child of red parent - invariant violation!
+        checkVsParentColor R (Branch R _ _ _ _ _) = False
+        checkVsParentColor _ (Branch c _ l _ _ r) = checkVsParentColor c l && checkVsParentColor c r
+    in checkVsParentColor (color t) t
+
+{-# INLINABLE keysSorted #-}
+keysSorted :: Comparison k -> RBTree k v -> Bool
+keysSorted comp t =
+    let sorted [] = True
+        sorted [_] = True
+        sorted (x:y:xys) = case comp x y of
+            LT -> sorted (y:xys)
+            _ -> False
+    in sorted $ keys t
+
+{-# INLINABLE correctBlackHeight #-}
+correctBlackHeight :: RBTree k v -> Bool
+correctBlackHeight t =
+    let correct n Leaf = n `eq` 0
+        correct n (Branch R h l _ _ r) = n `eq` h' && correct n l && correct n r
+          where h' = h `minus` 1
+        correct n (Branch B h l _ _ r) = n `eq` h && correct n' l && correct n' r
+          where n' = n `minus` 1
+    in correct (blackHeight t) t
+
+{-# INLINABLE valid #-}
+valid :: Comparison k -> RBTree k v -> Bool
+valid comp t = isBalanced t && correctBlackHeight t && keysSorted comp t
+
+------------------------------------------------------------
+-- Colour switching
+------------------------------------------------------------
+
+{-# INLINABLE redden #-}
+redden :: RBTree k v -> RBTree k v
+redden = \case { Leaf -> Leaf; Branch _ h l k v r -> Branch R h l k v r }
+
+{-# INLINABLE blacken #-}
+blacken :: RBTree k v -> RBTree k v
+blacken = \case { Leaf -> Leaf; Branch _ h l k v r -> Branch B h l k v r }
+
+------------------------------------------------------------
+-- Insertion and balancing
+------------------------------------------------------------
+
+{-# INLINABLE insert #-}
+insert :: Comparison k -> k -> v -> RBTree k v -> RBTree k v
+insert comp k v t =
+    let go = \case
+            Leaf -> Branch R 1 Leaf k v Leaf
+            (Branch B h l k' v' r) -> case comp k k' of
+                LT -> balanceL (Branch B h (go l) k' v' r)
+                GT -> balanceR (Branch B h l k' v' (go r))
+                EQ -> Branch B h l k' v r
+            (Branch R h l k' v' r) -> case comp k k' of
+                LT -> Branch R h (go l) k' v' r
+                GT -> Branch R h l k' v' (go r)
+                EQ -> Branch R h l k' v r
+    in blacken (go t)
+
+{- Note [Balancing]
+There are four cases for (locally) balancing a subtree, each of which
+produces the same top-level pattern, visible on the right-hand sides
+of each of the cases below.
+
+The cases split into those that balance the left side, and those that
+balance the right side. Often we know that only one side can be unbalanced,
+so it is advantageous to run only one side.
+
+L1:
+          B3           R2
+         /  \         /  \
+        R2   T  ->   B1  B3
+       /  \         / \  / \
+      R1   T        T T  T T
+     /  \
+    T    T
+
+L2:
+        B3             R2
+       /  \           /  \
+      R1   T    ->   B1  B3
+     /  \           / \  / \
+    T    R2         T T  T T
+        /  \
+       T    T
+
+R1:
+      B1               R2
+     /  \             /  \
+    T   R2      ->   B1  B3
+       /  \         / \  / \
+      T   R1        T T  T T
+         /  \
+        T    T
+
+R2:
+      B1               R2
+     /  \             /  \
+    T   R2      ->   B1  B3
+       /  \         / \  / \
+      R1   T        T T  T T
+     /  \
+    T    T
+-}
+
+{-# INLINABLE balanceL #-}
+-- | Correct a local imbalance on the left side of the tree.
+balanceL :: RBTree k v -> RBTree k v
+balanceL t = case t of
+    Branch B h toSplit k3 v3 t4 -> case toSplit of
+        -- See note [Balancing], this is case L1
+        Branch R _ (Branch R _ t1 k1 v1 t2) k2 v2 t3 ->
+            Branch R (h `plus` 1) (Branch B h t1 k1 v1 t2) k2 v2 (Branch B h t3 k3 v3 t4)
+        -- See note [Balancing], this is case L2
+        Branch R _ t1 k1 v1 (Branch R _ t2 k2 v2 t3) ->
+            Branch R (h `plus` 1) (Branch B h t1 k1 v1 t2) k2 v2 (Branch B h t3 k3 v3 t4)
+        _ -> t
+    _ -> t
+
+{-# INLINABLE balanceR #-}
+-- | Correct a local imbalance on the right side of the tree.
+balanceR :: RBTree k v -> RBTree k v
+balanceR t = case t of
+    Branch B h t1 k1 v1 toSplit -> case toSplit of
+        -- See note [Balancing], this is case R1
+        Branch R _ t2 k2 v2 (Branch R _ t3 k3 v3 t4) ->
+            Branch R (h `plus` 1) (Branch B h t1 k1 v1 t2) k2 v2 (Branch B h t3 k3 v3 t4)
+        -- See note [Balancing], this is case R2
+        Branch R _ (Branch R _ t2 k2 v2 t3) k3 v3 t4 ->
+            Branch R (h `plus` 1) (Branch B h t1 k1 v1 t2) k2 v2 (Branch B h t3 k3 v3 t4)
+        _ -> t
+    _ -> t
+
+------------------------------------------------------------
+-- Joining and splitting
+------------------------------------------------------------
+
+{-# INLINABLE join #-}
+-- | Join two trees, with a key-value mapping in the middle. The keys in the
+-- left tree are assumed to be less than the key in the middle, which is less than the
+-- keys in the right tree.
+join :: Comparison k -> k -> v -> RBTree k v -> RBTree k v -> RBTree k v
+join comp k v =
+    let join Leaf t2 = insert comp k v t2
+        join t1 Leaf = insert comp k v t1
+        join t1 t2 = case compareInteger h1 h2 of
+            LT -> blacken $ joinLT t1 t2 h1
+            GT -> blacken $ joinGT t1 t2 h2
+            EQ -> blacken $ joinEQ t1 t2 h1
+          where
+            h1 = blackHeight t1
+            h2 = blackHeight t2
+
+        joinLT t1 t2@(Branch c h l k' v' r) h1
+          | h `eq` h1   = joinEQ t1 t2 h
+          | otherwise = balanceL (Branch c h (joinLT t1 l h1) k' v' r)
+        joinLT t1 Leaf _ = t1
+
+        joinGT t1@(Branch c h l k' v' r) t2 h2
+          | h `eq` h2   = joinEQ t1 t2 h
+          | otherwise = balanceR (Branch c h l k' v' (joinGT r t2 h2))
+        joinGT Leaf t2 _ = t2
+
+        joinEQ t1 t2 h = Branch R (h `plus` 1) t1 k v t2
+    in join
+
+{-# INLINABLE split #-}
+-- | Given a key @k@, spits a tree into a left tree with keys less than @k@, optionally a value
+-- corresponding to the mapping for @k@ if there is one, and a right tree with keys greater
+-- than @k@.
+split :: Comparison k -> k -> RBTree k v -> (RBTree k v, Maybe v, RBTree k v)
+split comp needle =
+    let jn = join comp
+        go = \case
+            Leaf -> (Leaf, Nothing, Leaf)
+            Branch _ _ l k v r -> case comp needle k of
+                LT -> let (l', mid, r') = go l in (l', mid, jn k v r' (blacken r))
+                GT -> let (l', mid, r') = go r in (jn k v (blacken l) l', mid, r')
+                EQ -> (blacken l, Just v, blacken r)
+    in go
+
+------------------------------------------------------------
+-- Union
+------------------------------------------------------------
+
+{-# INLINABLE unionThese #-}
+-- | Union two trees, keeping both values for a key in case it appears on both sides.
+-- This is the most general union function, but it is less efficient than 'unionWith'
+-- and 'union'.
+unionThese :: Comparison k -> RBTree k a -> RBTree k b -> RBTree k (These a b)
+unionThese comp =
+    -- The cases for leaves meant that this is less efficient than a simple union:
+    -- it must look at every element (this is obvious from the type!).
+    let union l Leaf = blacken $ map This l
+        union Leaf r = blacken $ map That r
+        union (Branch _ _ l k v r) t =
+            -- There are several ways to do a union of RBTree. This way has the
+            -- key advantage of pulling out the mapping for k if there is one,
+            -- so we can package it up in a 'These' properly.
+            let (l', maybeV, r') = split comp k t
+                theseVs = andMaybe v maybeV
+            in join comp k theseVs (union l l') (union r r')
+    in union
+
+{-# INLINABLE unionWith #-}
+-- | Union two trees, using the given function to compute a value when a key has a
+-- mapping on both sides.
+unionWith :: Comparison k -> (a -> a -> a) -> RBTree k a -> RBTree k a -> RBTree k a
+unionWith comp with =
+    let union l Leaf = blacken l
+        union Leaf r = blacken r
+        union (Branch _ _ l k v r) t =
+            let (l', maybeV, r') = split comp k t
+                newV = case maybeV of
+                    Just v' -> with v v'
+                    Nothing -> v
+            in join comp k newV (union l l') (union r r')
+    in union
+
+{-# INLINABLE union #-}
+-- | Left-biased union of two trees.
+union :: Comparison k -> RBTree k a -> RBTree k a -> RBTree k a
+union comp = unionWith comp (\a _ -> a)
+
+------------------------------------------------------------
+-- Deletion
+------------------------------------------------------------
+
+{-
+delete :: Q (TExp (Comparison k -> k -> RBTree k v -> RBTree k v))
+delete = [|| \comp k t -> let (l, _, r) =  $$split comp k t in $$join comp l r ||]
+-}
+
+------------------------------------------------------------
+-- Derived operations
+------------------------------------------------------------
+
+-- eta-expanded to avoid value restriction
+{-# INLINABLE all #-}
+all :: (v -> Bool) -> RBTree k v -> Bool
+all p t = foldr (\(_, v) acc -> p v && acc) True t
+
+-- eta-expanded to avoid value restriction
+{-# INLINABLE any #-}
+any :: (v -> Bool) -> RBTree k v -> Bool
+any p t = foldr (\(_, v) acc -> p v || acc) False t

--- a/plutus-tx/src/Language/PlutusTx/These.hs
+++ b/plutus-tx/src/Language/PlutusTx/These.hs
@@ -1,11 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module Ledger.These(
-    These(..)
-  , these
-  , theseWithDefault
-  ) where
+module Language.PlutusTx.These where
 
 -- | A 'These' @a@ @b@ is either an @a@, or a @b@ or an @a@ and a @b@.
 -- Plutus version of 'Data.These'.
@@ -25,3 +20,19 @@ these f g h = \case
     This a -> f a
     That b -> g b
     These a b -> h a b
+
+{-# INLINABLE mergeThese #-}
+mergeThese :: (a -> a -> a) -> These a a -> a
+mergeThese = these (\a -> a) (\a -> a)
+
+{-# INLINABLE andDefinitely #-}
+andDefinitely :: Maybe a -> b -> These a b
+andDefinitely ma b = case ma of
+    Just a -> These a b
+    Nothing -> That b
+
+{-# INLINABLE andMaybe #-}
+andMaybe :: a -> Maybe b -> These a b
+andMaybe a mb = case mb of
+    Just b -> These a b
+    Nothing -> This a

--- a/plutus-tx/test/Map/Spec.hs
+++ b/plutus-tx/test/Map/Spec.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Map.Spec (tests) where
+
+import Prelude hiding (lookup, map)
+import Hedgehog
+import Language.PlutusTx.Map hiding (foldr, empty)
+import qualified Language.PlutusTx.Map as Map
+import Test.Tasty.Hedgehog
+import Test.Tasty
+import Control.Applicative
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import qualified Hedgehog.Internal.Property as Prop
+import qualified Data.List as L
+
+genMap :: (Ord k) => Gen k -> Gen v -> Gen (Map k v)
+genMap genKey genValue = Gen.recursive
+    Gen.choice
+    [pure Map.empty]
+    [insert compare <$> genKey <*> genValue <*> genMap genKey genValue]
+
+genIntKey :: Gen Integer
+genIntKey = Gen.integral (Range.linear 0 100)
+
+genIntValue :: Gen Integer
+genIntValue = Gen.integral (Range.linear 0 100)
+
+genIntMap :: Gen (Map Integer Integer)
+genIntMap = genMap genIntKey genIntValue
+
+prop_GenValid :: Property
+prop_GenValid = property $ do
+    t <- forAll genIntMap
+    assert (valid compare t)
+
+prop_NilValid :: Property
+prop_NilValid = property $ assert (valid compare (Map.empty @Integer @Integer))
+
+prop_InsertValid :: Property
+prop_InsertValid = property $ do
+    k <- forAll genIntKey
+    v <- forAll genIntValue
+    t <- forAll genIntMap
+    assert $ valid compare (insert compare k v t)
+
+{-
+prop_DeleteValid :: Property
+prop_DeleteValid = property $ do
+    k <- forAll genIntKey
+    t <- forAll genIntMap
+    assert $ valid compare (delete compare k t)
+-}
+
+prop_UnionValid :: Property
+prop_UnionValid = property $ do
+    t1 <- forAll genIntMap
+    t2 <- forAll genIntMap
+    let u = union compare t1 t2
+    annotateShow $ u
+    assert $ valid compare u
+
+prop_NilPost :: Property
+prop_NilPost = property $ do
+    k <- forAll genIntKey
+    lookup compare k (Map.empty @Integer @Integer) === Nothing
+
+prop_InsertPost :: Property
+prop_InsertPost = property $ do
+  k <- forAll genIntKey
+  k' <- forAll genIntKey
+  v <- forAll genIntValue
+  t <- forAll genIntMap
+  lookup compare k' (insert compare k v t) === if k==k' then Just v else lookup compare k' t
+
+{-
+prop_DeletePost :: Property
+prop_DeletePost = property $ do
+  k <- forAll genIntKey
+  k' <- forAll genIntKey
+  t <- forAll genIntMap
+  lookup compare k' (delete compare k t) === if k==k' then Nothing else lookup compare k' t
+-}
+
+prop_LookupPostPresent :: Property
+prop_LookupPostPresent = property $ do
+  k <- forAll genIntKey
+  v <- forAll genIntValue
+  t <- forAll genIntMap
+  lookup compare k (insert compare k v t) === Just v
+
+{-
+prop_LookupPostAbsent :: Property
+prop_LookupPostAbsent = property $ do
+  k <- forAll genIntKey
+  t <- forAll genIntMap
+  lookup compare k (delete compare k t) === Nothing
+-}
+
+prop_UnionPost :: Property
+prop_UnionPost = property $ do
+  k <- forAll genIntKey
+  t1 <- forAll genIntMap
+  t2 <- forAll genIntMap
+  lookup compare k (union compare t1 t2) === (lookup compare k t1 <|> lookup compare k t2)
+
+prop_UnionListPost :: Property
+prop_UnionListPost = property $ do
+  k <- forAll genIntKey
+  ts <- forAll (Gen.list (Range.linear 0 1000) genIntMap)
+  lookup compare k (foldr (\m1 m2 -> union compare m1 m2) Map.empty ts) === foldr (\m res -> lookup compare k m <|> res) empty ts
+
+prop_SizeNil :: Property
+prop_SizeNil = property $ size (Map.empty @Integer @Integer) === 0
+
+prop_SizeInsert :: Property
+prop_SizeInsert = property $ do
+  k <- forAll genIntKey
+  v <- forAll genIntValue
+  t <- forAll genIntMap
+  assert $ size (insert compare k v t) >= size t
+
+{-
+prop_SizeDelete :: Property
+prop_SizeDelete = property $ do
+  k <- forAll genIntKey
+  t <- forAll genIntMap
+  assert $ size (delete compare k t) <= size t
+-}
+
+prop_SizeUnion :: Property
+prop_SizeUnion = property $ do
+  t1 <- forAll genIntMap
+  t2 <- forAll genIntMap
+  assert $ size (union compare t1 t2) <= size t1 + size t2
+
+deleteKey :: Eq k => k -> [(k, v)] -> [(k, v)]
+deleteKey k = filter ((/=k).fst)
+
+prop_NilModel :: Property
+prop_NilModel = property $ toList (Map.empty @Integer @Integer) === []
+
+prop_InsertModel :: Property
+prop_InsertModel = property $ do
+  k <- forAll genIntKey
+  v <- forAll genIntValue
+  t <- forAll genIntMap
+  toList (insert compare k v t) === L.insert (k,v) (deleteKey k $ toList t)
+
+{-
+prop_DeleteModel :: Property
+prop_DeleteModel = property $ do
+  k <- forAll genIntKey
+  t <- forAll genIntMap
+  toList (delete compare k t) === deleteKey k (toList t)
+-}
+
+prop_LookupModel :: Property
+prop_LookupModel = property $ do
+  k <- forAll genIntKey
+  t <- forAll genIntMap
+  lookup compare k t === L.lookup k (toList t)
+
+prop_UnionModel :: Property
+prop_UnionModel = property $ do
+  t1 <- forAll genIntMap
+  t2 <- forAll genIntMap
+  toList (union compare t1 t2) === L.sort (toList t1 ++ foldr deleteKey (toList t2) (keys t1))
+
+tests :: TestTree
+tests =
+    let g = $$(discover)
+    -- TODO: upstream this
+    in testGroup
+       (Prop.unGroupName $ groupName g)
+       (fmap (\(n, p) -> testProperty (Prop.unPropertyName n) p) (groupProperties g))

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import qualified Lift.Spec   as Lift
+import qualified Map.Spec    as Map
 import qualified Plugin.Spec as Plugin
 import qualified TH.Spec     as TH
 
@@ -9,11 +10,14 @@ import           Common
 import           Test.Tasty
 
 main :: IO ()
-main = defaultMain $ runTestNestedIn ["test"] tests
+main = defaultMain tests
 
-tests :: TestNested
-tests = testGroup "tests" <$> sequence [
-    Plugin.tests
-  , Lift.tests
-  , TH.tests
-  ]
+tests :: TestTree
+tests = testGroup "tests" [
+      runTestNestedIn ["test"] $ testGroup "tests" <$> sequence [
+          Plugin.tests
+        , Lift.tests
+        , TH.tests
+      ]
+      , Map.tests
+    ]

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -58,7 +58,7 @@ mkCurrency :: TxOutRef -> [(String, Integer)] -> Currency
 mkCurrency (TxOutRefOf h i) amts =
     Currency
         { curRefTransactionOutput = (V.plcTxHash h, i)
-        , curAmounts              = LMap.fromList (fmap (first fromString) amts)
+        , curAmounts              = LMap.fromList Value.compareTokenName (fmap (first fromString) amts)
         }
 
 validate :: Currency -> () -> () -> V.PendingTx -> Bool

--- a/plutus-wallet-api/plutus-wallet-api.cabal
+++ b/plutus-wallet-api/plutus-wallet-api.cabal
@@ -62,7 +62,6 @@ library
         Ledger.Ada,
         Ledger.AddressMap,
         Ledger.Map,
-        Ledger.These,
         Ledger.Blockchain,
         Ledger.Crypto,
         Ledger.Slot,
@@ -109,7 +108,6 @@ library plutus-ledger
         Ledger.Ada
         Ledger.AddressMap
         Ledger.Map
-        Ledger.These
         Ledger.Blockchain
         Ledger.Crypto
         Ledger.Slot


### PR DESCRIPTION
This can also be used for Set, I'll add an implementation in due course.

Deletion is still unimplemented, since it's quite non-trivial.

I *haven't* incremented the amount of currencies in the generator. The reason is that although this implementation is faster, it still takes about 30s if you bump the generator to 100 max currencies. I believe the reason for this is that `unionWith` is simply not *that* great complexity, it's `O(m + n)`, so unioning a big list of big things is not going to be that fast.

My implementation is fairly textbook, so I'm relatively confident that it's not just my mistake. Also a good opportunity to roll out the property tests.

I also fixed a bug in coin selection due to it assuming a total order rather than a partial order on values.