### PR TITLE
Measure script sizes and add tests that they're reasonalbe for use cases

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -99,6 +99,10 @@ module Language.PlutusCore
     , applyProgram
     -- * Benchmarking
     , termSize
+    , typeSize
+    , kindSize
+    , programSize
+    , serialisedSize
     ) where
 
 import           Control.Monad.Except

--- a/language-plutus-core/src/Language/PlutusCore/Size.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Size.hs
@@ -1,16 +1,24 @@
 module Language.PlutusCore.Size ( termSize
+                                , typeSize
+                                , kindSize
+                                , programSize
+                                , serialisedSize
                                 ) where
 
+import           Codec.Serialise
+import qualified Data.ByteString.Lazy                       as BSL
 import           Data.Functor.Foldable
 import           Language.PlutusCore.Type
 
-kindSize :: Kind a -> Int
+-- | Count the number of AST nodes in a kind.
+kindSize :: Kind a -> Integer
 kindSize = cata a where
     a TypeF{}             = 1
     a (KindArrowF _ k k') = 1 + k + k'
     a SizeF{}             = 1
 
-typeSize :: Type tyname a -> Int
+-- | Count the number of AST nodes in a type.
+typeSize :: Type tyname a -> Integer
 typeSize = cata a where
     a TyVarF{}             = 1
     a (TyFunF _ ty ty')    = 1 + ty + ty'
@@ -21,9 +29,8 @@ typeSize = cata a where
     a (TyLamF _ _ k ty)    = 1 + kindSize k + ty
     a (TyAppF _ ty ty')    = 1 + ty + ty'
 
--- | This exists so that we can measure term size. It counts the number of AST
--- nodes.
-termSize :: Term tyname name a -> Int
+-- | Count the number of AST nodes in a term.
+termSize :: Term tyname name a -> Integer
 termSize = cata a where
     a VarF{}              = 1
     a (TyAbsF _ _ k t)    = 1 + kindSize k + t
@@ -35,3 +42,11 @@ termSize = cata a where
     a (UnwrapF _ t)       = 1 + t
     a (IWrapF _ ty ty' t) = 1 + typeSize ty + typeSize ty' + t
     a (ErrorF _ ty)       = 1 + typeSize ty
+
+-- | Count the number of AST nodes in a program.
+programSize :: Program tyname name a -> Integer
+programSize (Program _ _ t) = termSize t
+
+-- | Compute the size of the serializabled form of a value.
+serialisedSize :: Serialise a => a -> Integer
+serialisedSize = fromIntegral . BSL.length . serialise

--- a/language-plutus-core/src/Language/PlutusCore/Size.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Size.hs
@@ -6,7 +6,7 @@ module Language.PlutusCore.Size ( termSize
                                 ) where
 
 import           Codec.Serialise
-import qualified Data.ByteString.Lazy                       as BSL
+import qualified Data.ByteString.Lazy     as BSL
 import           Data.Functor.Foldable
 import           Language.PlutusCore.Type
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -20,6 +20,8 @@ module Language.PlutusTx.Coordination.Contracts.CrowdFunding (
     -- * Functionality for campaign owners
     , collect
     , campaignAddress
+    -- * Validator script
+    , contributionScript
     ) where
 
 import           Control.Applicative          (Applicative (..))
@@ -63,7 +65,7 @@ type CampaignActor = PubKey
 PlutusTx.makeLift ''Campaign
 
 collectionRange :: Campaign -> SlotRange
-collectionRange cmp = 
+collectionRange cmp =
     W.interval (campaignDeadline cmp) (campaignCollectionDeadline cmp)
 
 refundRange :: Campaign -> SlotRange

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -4,7 +4,9 @@
 module Language.PlutusTx.Coordination.Contracts.Game(
     lock,
     guess,
-    startGame
+    startGame,
+    -- * Validator script
+    gameValidator
     ) where
 
 import qualified Language.PlutusTx            as PlutusTx

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
@@ -6,6 +6,7 @@
 {-# OPTIONS_GHC -O0 #-}
 module Language.PlutusTx.Coordination.Contracts.Swap(
     Swap(..),
+    -- * Script
     swapValidator
     ) where
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -11,9 +11,10 @@ module Language.PlutusTx.Coordination.Contracts.Vesting (
     VestingData(..),
     vestFunds,
     retrieveFunds,
-    validatorScript,
     totalAmount,
-    validatorScriptHash
+    validatorScriptHash,
+    -- * Script
+    validatorScript
     ) where
 
 import           Control.Monad.Error.Class    (MonadError (..))
@@ -88,11 +89,11 @@ retrieveFunds :: (
     WalletAPI m)
     => Vesting
     -- ^ Definition of vesting scheme
-    -> VestingData 
+    -> VestingData
     -- ^ Value that has already been taken out
-    -> TxOutRef    
+    -> TxOutRef
     -- ^ Transaction output locked by the vesting validator script
-    -> Ada         
+    -> Ada
     -- ^ Value we want to take out now
     -> m VestingData
 retrieveFunds vs vd r anow = do

--- a/wallet-api/src/Ledger/Types.hs
+++ b/wallet-api/src/Ledger/Types.hs
@@ -31,6 +31,7 @@ module Ledger.Types(
     scriptAddress,
     -- ** Scripts
     Script,
+    scriptSize,
     fromCompiledCode,
     compileScript,
     lifted,
@@ -250,6 +251,9 @@ instance Eq Script where
 
 instance Ord Script where
     a `compare` b = serialise a `compare` serialise b
+
+scriptSize :: Script -> Integer
+scriptSize (Script s) = PLC.programSize s
 
 -- TODO: possibly this belongs with CompiledCode
 fromCompiledCode :: CompiledCode a -> Script


### PR DESCRIPTION
I was investigating whether we're getting a script size blowup, and a first step is measuring what they currently are. I wrote some tests for the existing use cases to check that they stay within a reasonable bound of where they are (or more realistically: we know when they get bigger).

The sizes are in number of AST nodes, which I think is actually more useful than number of serialized bytes, although I added a function for that too and I'd expect them to be more or less proportional.

TBH, ~50k AST nodes for the Futures contract is already ridiculously high. I suspect this is due to duplication because of the way we're using TH, see https://github.com/input-output-hk/plutus/issues/693.