### PR TITLE
multi-currency: Mirror -> reserve

### DIFF
--- a/docs/multi-currency/multi-currency.md
+++ b/docs/multi-currency/multi-currency.md
@@ -134,7 +134,7 @@ Note that creating an NFT with this contract requires three transactions: One fo
 
 The following contract implements a monetary policy of a currency `c` that can be forged repeatedly, up to a predefined maximum amount.
 
-We use the data script to keep track of how much `c` has been issued so far. However, when authorising the forging of new `c` (that is, when running the validator script whose hash is `c`) we cannot verify that the data script we received contains the correct amount of `c` in circulation, because anyone can produce a pay-to-script transaction output locked by `c` and with an arbitrary data script. To prevent this kind of unauthorised forging of `c` we use a *mirror currency*, `c*`. This mirror currency represents the potential amount of `c` that can still be forged. Whenever we increase the supply of `c`, we destroy the same amount of `c*` and vice versa. The total circulation of `c` plus the total supply of `c*` equals the maximum supply of `c` at all times. To legitimise the forging of `c` we require the forger to present the entire amount of `c*` that exists.
+We use the data script to keep track of how much `c` has been issued so far. However, when authorising the forging of new `c` (that is, when running the validator script whose hash is `c`) we cannot verify that the data script we received contains the correct amount of `c` in circulation, because anyone can produce a pay-to-script transaction output locked by `c` and with an arbitrary data script. To prevent this kind of unauthorised forging of `c` we use a *reserve currency*, `c*`. This reserve currency represents the potential amount of `c` that can still be forged. Whenever we increase the supply of `c`, we destroy the same amount of `c*` and vice versa. The total circulation of `c` plus the total supply of `c*` equals the maximum supply of `c` at all times. To legitimise the forging of `c` we require the forger to present the entire amount of `c*` that exists.
 
 We can think of `c` as paper notes and `c*` as a gold bar that we keep in our vault. Every unit of `c` is a claim to some of our gold bar. We can trade this claim away but we always keep the gold (although now the amount of gold that is available is smaller).
 
@@ -142,7 +142,7 @@ See below the script for an example.
 
 ```haskell
 
-data CurRole = ActualCurrency | MirrorCurrency
+data CurRole = ActualCurrency | ReserveCurrency
 
 newtype Currency = Currency {
     curMaxCirculation :: Int,
@@ -156,26 +156,26 @@ newtype Currency = Currency {
 -- | Current state of the state machine
 newtype CurState =
   InitialState
-  -- ^ Initial state, the mirror currency has not been forged
+  -- ^ Initial state, the reserve currency has not been forged
   | Circulating {
       csCurrentSupply :: Int,
       -- ^ How much of c has been issued
-      csMirrorAddr :: ByteString,
-      -- ^ Identifier of the mirror currency
+      csReserveAddr :: ByteString,
+      -- ^ Identifier of the reserve currency
       csCurAddr    :: ByteString
       -- ^ Identifier of the currency itself
       }
 
 -- | State machine input
 data CurAction =
-  Initialise { caMirror :: ByteString, caActual :: ByteString }
+  Initialise { caReserve :: ByteString, caActual :: ByteString }
   | CurForge { cfForge :: Int }
 
 -- | Data needed to verify a change in the circulation of the currency
 --   (forging or destroying value)
 data CirculationChange = CirculationChange {
-    ccMirrorAddr         :: ByteString,
-    -- ^ Address of the mirror currency
+    ccReserveAddr        :: ByteString,
+    -- ^ Address of the reserve currency
     ccCurAddr            :: ByteString,
     -- ^ Address of the currency itself
     ccCurrentSupply      :: Int,
@@ -195,36 +195,36 @@ currencyScript cur = ValidatorScript val where
       -- and c* preserves the invariant of "supply(c) + supply(c*) = maxSupply",
       -- and produces the entire amount of c* that is left.
       balancesOk :: CirculationChange -> PendingTx -> Bool
-      balancesOk (CirculationChange mirrorAdr curAdr currentCirc forged) ptx =
+      balancesOk (CirculationChange reserveAddr curAdr currentCirc forged) ptx =
         let newCirc = currentCirc + forged
         in
              -- the required amount of c is forged by ptx
              ptx `forges` forged curAdr
 
              -- the same amount of c* is destroyed
-          && ptx `forges` (negate forged) mirrorAdr
+          && ptx `forges` (negate forged) reserveAddr
 
              -- ptx produces the entire remaining amount of c*
-          && ptx `outputs` (maxCirc - newCirc) mirrorAdr
+          && ptx `outputs` (maxCirc - newCirc) reserveAddr
 
-      -- A state machine for the mirror currency, c*.
+      -- A state machine for the reserve currency, c*.
       -- In the initial state we verify the transaction forges an amount of
       -- c* equal to `maxCirc`, and 0 of c. We also check that the script addresses
       -- from the `Initialise` argument match those of the pending transaction.
       -- In all other states we check that the action preserves the currency invariant.
-      mirrorStateMachine :: CurState -> CurAction -> PendingTx -> CurState
-      mirrorStateMachine InitialState (Initialise mirror actual) ptx =
+      reserveStateMachine :: CurState -> CurAction -> PendingTx -> CurState
+      reserveStateMachine InitialState (Initialise reserve actual) ptx =
         if
              ptx `forges` 0 actual
           && ptx `forges`  maxCirc (ownAddress ptx)
           && ptx `spends` txout
-          && addressEq mirror (ownAddress ptx)
+          && addressEq reserve (ownAddress ptx)
           && ptx `spendsFrom` actual
-        then Circulating 0 mirror actual
+        then Circulating 0 reserve actual
         else $$(P.error)
-      mirrorStateMachine (Circulating currentCirc mirrorAdr curAdr) (CurForge forged) ptx =
-        if balancesOk (CirculationChange mirrorAdr curAdr currentCirc forged)
-           && addressEq mirrorAdr (ownAddress ptx)
+      reserveStateMachine (Circulating currentCirc reserveAdr curAdr) (CurForge forged) ptx =
+        if balancesOk (CirculationChange reserveAdr curAdr currentCirc forged)
+           && addressEq reserveAdr (ownAddress ptx)
         then Circulating newCirc actualCur
         else $$(P.error)
 
@@ -235,16 +235,16 @@ currencyScript cur = ValidatorScript val where
       -- In all other states we check that the action preserves the currency
       -- invariant.
       currencyStateMachine :: CurState -> CurAction -> PendingTx -> CurState
-      currencyStateMachine InitialState (Initialise mirror actual) ptx =
+      currencyStateMachine InitialState (Initialise reserve actual) ptx =
         if
              ptx `forges` 0 (ownAddress ptx)
-          && ptx `forges`  maxCirc mirror
+          && ptx `forges`  maxCirc reserve
           && ptx `spends` txout
           && addressEq actual (ownAddress ptx)
-        then Circulating 0 mirror actual
+        then Circulating 0 reserve actual
         else $$(P.error)
-      currencyStateMachine (Circulating currentCirc mirrorAdr curAdr) (CurForge forged) ptx =
-        if balancesOk (CirculationChange mirrorAdr curAdr currentCirc forged)
+      currencyStateMachine (Circulating currentCirc reserveAdr curAdr) (CurForge forged) ptx =
+        if balancesOk (CirculationChange reserveAdr curAdr currentCirc forged)
            && addressEq curAdr (ownAddress ptx)
         then Circulating newCirc actualCur
         else $$(P.error)
@@ -252,7 +252,7 @@ currencyScript cur = ValidatorScript val where
     in
       case role of
         ActualCurrency -> $$(P.mkStateMachine) currencyStateMachine
-        MirrorCurrency -> $$(P.mkStateMachine) mirrorStateMachine
+        MirrorCurrency -> $$(P.mkStateMachine) reserveStateMachine
 
     ||]
 ```
@@ -262,16 +262,16 @@ currencyScript cur = ValidatorScript val where
 To create a new currency with a maximum supply of 10000 and an initial supply of 100 we need to do the following. Steps 1-4 cover the initial setup and are only needed once. Step 5 demonstrates a regular interaction with the currency (changing its supply).
 
 1. Select an unspent transaction output `txout` owned by us
-2. Define `dsCur :: ValidatorScript, dsMirror :: ValidatorScript` with `dsCur = currencyScript (Currency 10000 ActualCurrency txout)` and `dsMirror = currencyScript (Currency 10000 MirrorCurrency txout)`. Their hashes are `hCur :: ByteString = hash dsCur` and `hMir :: ByteString = hash dsMirror`. `hCur` identifies the new currency, and `hMir` identifies its mirror currency.
-3. Create a transaction `tx1`. `tx1` produces two pay-to-script outputs: `cur1` and `mir1`. The address of `cur1` is `hCur`. The address of `mir1` is `hMir`. `cur1` and `mir1` have the same data script, `(InitialState, Initialise hMir hCur)` (see below for an explanation of the (state, action) tuples in data and redeemer scripts). The `valueForged` field of `tx1` is empty.
-4. Create a transaction `tx2`. `tx2` spends `cur1` and `mir1`, using the redeemer `r = (Circulating hMir hCur 0, Initialise hMir hCur)` for both outputs. `tx2` also spends `txout` and potentially other outputs that are needed to cover the fee. `tx2` produces pay-to-script outputs `cur2` and `mir2`. The address of `cur2` is `hCur` and the address of `mir2` is `hMir`. The outputs `cur2` and `mir2` have the same data script: `r`, and their value is zero. In addition `tx2` produces an output `o` of `10000 hMir` to a pubkey address owned by us. The `valueForged` field of `tx2` is `{ hMirror -> 10000 }`.
-5. To issue `100 hCur` currency, create a transaction `tx3`. `tx3` spends `o` as well as `cur2` and `mir2`, using the redeemer `r = (Circulating hMir hCur 100, Forge 100)`. `tx3` produces outputs `cur3` and `mir3` to the addresses `hCur` and `hMir` respectively, using the data script `r`. In addition, `tx3` produces an output `p` with a value of `100 hCur`, and an output `q` with a value of `9900 hMir`. The address of `q` is a public key address owned by us. The address of `p` can be any public key or script address (wherever we want to send the new currency). The `valueForged` field of `tx3` is `{ hMirror -> -100, hCur -> 100 }`.
+2. Define `dsCur :: ValidatorScript, dsReserve :: ValidatorScript` with `dsCur = currencyScript (Currency 10000 ActualCurrency txout)` and `dsReserve = currencyScript (Currency 10000 MirrorCurrency txout)`. Their hashes are `hCur :: ByteString = hash dsCur` and `hRes :: ByteString = hash dsReserve`. `hCur` identifies the new currency, and `hRes` identifies its reserve currency.
+3. Create a transaction `tx1`. `tx1` produces two pay-to-script outputs: `cur1` and `res1`. The address of `cur1` is `hCur`. The address of `res1` is `hRes`. `cur1` and `res1` have the same data script, `(InitialState, Initialise hRes hCur)` (see below for an explanation of the (state, action) tuples in data and redeemer scripts). The `valueForged` field of `tx1` is empty.
+4. Create a transaction `tx2`. `tx2` spends `cur1` and `res1`, using the redeemer `r = (Circulating hRes hCur 0, Initialise hRes hCur)` for both outputs. `tx2` also spends `txout` and potentially other outputs that are needed to cover the fee. `tx2` produces pay-to-script outputs `cur2` and `res2`. The address of `cur2` is `hCur` and the address of `res2` is `hRes`. The outputs `cur2` and `res2` have the same data script: `r`, and their value is zero. In addition `tx2` produces an output `o` of `10000 hRes` to a pubkey address owned by us. The `valueForged` field of `tx2` is `{ hResror -> 10000 }`.
+5. To issue `100 hCur` currency, create a transaction `tx3`. `tx3` spends `o` as well as `cur2` and `res2`, using the redeemer `r = (Circulating hRes hCur 100, Forge 100)`. `tx3` produces outputs `cur3` and `res3` to the addresses `hCur` and `hRes` respectively, using the data script `r`. In addition, `tx3` produces an output `p` with a value of `100 hCur`, and an output `q` with a value of `9900 hRes`. The address of `q` is a public key address owned by us. The address of `p` can be any public key or script address (wherever we want to send the new currency). The `valueForged` field of `tx3` is `{ hRes -> -100, hCur -> 100 }`.
 
 The reason why the data and redeemer scripts used in steps 2-5 are of the form `(state, input)` is that this is currently the only way we have of [validating the next data script](https://github.com/input-output-hk/plutus/issues/426). The linked github issue explains the encoding under the heading "Possible Solutions", third item.
 
 #### A different monetary policy
 
-Suppose we wanted define a currency with a variable maximum supply, for example bound to interest rate. We can use the same pattern (mirror currency), we just need to change the `mirrorStateMachine` function to allow transactions that forge the mirror currency without destroying the same amount of the actual currency at the same time.
+Suppose we wanted define a currency with a variable maximum supply, for example bound to interest rate. We can use the same pattern (reserve currency), we just need to change the `reserveStateMachine` function to allow transactions that forge the reserve currency without destroying the same amount of the actual currency at the same time.
 
 # Native NFT support
 


### PR DESCRIPTION
Change terminology in the multi-currency example from mirror currency to reserve currency.