### PR TITLE
wallet-api: order of validator script arguments

### DIFF
--- a/marlowe/src/Language/Marlowe/Common.hs
+++ b/marlowe/src/Language/Marlowe/Common.hs
@@ -752,8 +752,8 @@ mergeChoices = [|| \ input choices -> let
 validatorScript :: Q (TExp (PubKey -> (Input, MarloweData) -> (Input, MarloweData) -> PendingTx -> ()))
 validatorScript = [|| \
         creator
-        (input@(Input inputCommand _ inputChoices :: Input), MarloweData expectedState expectedContract)
         (_ :: Input, MarloweData{..} :: MarloweData)
+        (input@(Input inputCommand _ inputChoices :: Input), MarloweData expectedState expectedContract)
         (PendingTx{ pendingTxOutputs, pendingTxValidRange, pendingTxIn } :: PendingTx) -> let
 
         {-  Embed contract creator public key. This makes validator script unique,

--- a/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground-server/usecases/CrowdFunding.hs
@@ -63,13 +63,13 @@ contributionScript cmp  = ValidatorScript val where
         --    The Campaign{..} syntax means that all fields of the 'Campaign' value are in scope (for example 'campaignDeadline' in l. 70).
         --    See note [RecordWildCards].
         --
-        -- 2. A 'CampaignAction'. This is the redeemer script. It is provided by the redeeming transaction.
+        -- 2. A 'PubKey'. This is the data script. It is provided by the producing transaction (the contribution)
         --
-        -- 3. A 'PubKey'. This is the data script. It is provided by the producing transaction (the contribution)
+        -- 3. A 'CampaignAction'. This is the redeemer script. It is provided by the redeeming transaction.
         --
         -- 4. A 'PendingTx value. It contains information about the current transaction and is provided by the slot leader.
         --    See note [PendingTx]
-        \Campaign{..} (act :: CampaignAction) (con :: PubKey) (p :: PendingTx) ->
+        \Campaign{..} (con :: PubKey) (act :: CampaignAction) (p :: PendingTx) ->
             let
 
                 -- In Haskell we can define new operators. We import

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -41,7 +41,7 @@ mkRedeemerScript word =
 gameValidator :: ValidatorScript
 gameValidator = ValidatorScript ($$(Ledger.compileScript [||
     -- The code between the '[||' and  '||]' quotes is on-chain code.
-    \(ClearString guess) (HashedString actual) (p :: PendingTx) ->
+    \(HashedString actual) (ClearString guess) (p :: PendingTx) ->
 
     -- inside the on-chain code we can write $$(P.xxx) to use functions
     -- from the PlutusTx Prelude (imported qualified at the top of the

--- a/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground-server/usecases/Vesting.hs
@@ -88,7 +88,7 @@ totalVested (Vesting l r _) = Ada.plus (vestingTrancheAmount l) (vestingTrancheA
 vestingValidator :: Vesting -> ValidatorScript
 vestingValidator v = ValidatorScript val where
     val = L.applyScript inner (L.lifted v)
-    inner = $$(L.compileScript [|| \(scheme :: Vesting) (sig :: Signature) () (p :: V.PendingTx) ->
+    inner = $$(L.compileScript [|| \(scheme :: Vesting) () (sig :: Signature) (p :: V.PendingTx) ->
         let
 
             Vesting tranche1 tranche2 owner = scheme

--- a/plutus-tutorial/doctest/Tutorial/02-validator-scripts.md
+++ b/plutus-tutorial/doctest/Tutorial/02-validator-scripts.md
@@ -93,9 +93,9 @@ mkRedeemerScript word =
 
 ## 1.2 The Validator Script
 
-The general form of a validator script is `Redeemer -> DataScript -> PendingTx -> Answer`. That is, the validator script is a function of three arguments that produces a value of type `Answer` (or fails with an error). As contract authors we can freely choose the types of `Redeemer`, `DataScript` and `Answer`. The third argument has to be of type [`PendingTx`](https://input-output-hk.github.io/plutus/wallet-api-0.1.0.0/html/Ledger-Validation.html#t:PendingTx) because that is the information about the current transaction, provided by the slot leader. When the evaluation of the script has finished without an error, the result is discarded and never used again. The value of `Answer` is not relevant, and therefore we usually choose `Answer` to be the unit type `()`.
+The general form of a validator script is `DataScript -> Redeemer -> PendingTx -> Answer`. That is, the validator script is a function of three arguments that produces a value of type `Answer` (or fails with an error). As contract authors we can freely choose the types of `DataScript`, `Redeemer` and `Answer`. The third argument has to be of type [`PendingTx`](https://input-output-hk.github.io/plutus/wallet-api-0.1.0.0/html/Ledger-Validation.html#t:PendingTx) because that is the information about the current transaction, provided by the slot leader. When the evaluation of the script has finished without an error, the result is discarded and never used again. The value of `Answer` is not relevant, and therefore we usually choose `Answer` to be the unit type `()`.
 
-In our case, the redeemer is a `ClearText`, and the data script is a `HashedText`. This gives us a script with the signature `ClearText -> HashedText -> PendingTx -> ()`. The function needs to be wrapped in Template Haskell quotes, beginning with `[||` and ending with `||]`.
+In our case, the data script is a `HashedText`, and the redeemer is a `ClearText`. This gives us a script with the signature `HashedText -> ClearText -> PendingTx -> ()`. The function needs to be wrapped in Template Haskell quotes, beginning with `[||` and ending with `||]`.
 
 We can then use `L.compileScript`, a function exported by the `Ledger` module, to compile the TH quote to its on-chain representation:
 
@@ -104,7 +104,7 @@ We can then use `L.compileScript`, a function exported by the `Ledger` module, t
 gameValidator :: ValidatorScript
 gameValidator = ValidatorScript ($$(L.compileScript [||
     -- The code between the '[||' and  '||]' quotes is on-chain code.
-    \(ClearText guessed) (HashedText actual) (_ :: PendingTx) ->
+    \(HashedText actual) (ClearText guessed) (_ :: PendingTx) ->
 ```
 
 The actual game logic is very simple: We compare the hash of the `guessed` argument with the `actual` secret hash, and throw an error if the two don't match. In on-chain code, we can use the `$$()` splicing operator to access functions from the Plutus prelude, imported as `P`. For example, `$$(P.equalsByteString) :: ByteString -> ByteString -> Bool`  compares two `ByteString` values for equality.

--- a/plutus-tutorial/tutorial/Tutorial/Solutions2.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions2.hs
@@ -51,7 +51,7 @@ trickier10Light = $$(P.compile [|| $$(TH.trickierLight 10) ||])
 -}
 intGameValidator :: ValidatorScript
 intGameValidator = ValidatorScript ($$(L.compileScript [||
-  \(ClearNumber guess') (SecretNumber actual) (_ :: PendingTx) ->
+  \(SecretNumber actual) (ClearNumber guess') (_ :: PendingTx) ->
     if $$(P.eq) actual ($$(TH.trickier 2) guess')
     then ()
     else $$(P.error) ($$(P.traceH) "Wrong number" ())

--- a/plutus-tutorial/tutorial/Tutorial/Vesting.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Vesting.hs
@@ -108,7 +108,7 @@ totalVested (Vesting l r _) = Ada.plus (vestingTrancheAmount l) (vestingTrancheA
 vestingValidator :: Vesting -> ValidatorScript
 vestingValidator v = ValidatorScript val where
     val = L.applyScript inner (L.lifted v)
-    inner = $$(L.compileScript [|| \(scheme :: Vesting) (sig :: Signature) () (p :: V.PendingTx) ->
+    inner = $$(L.compileScript [|| \(scheme :: Vesting) () (sig :: Signature) (p :: V.PendingTx) ->
         let
             
             Vesting tranche1 tranche2 owner = scheme

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -142,7 +142,7 @@ contributionScript cmp  = ValidatorScript val where
 
     --   See note [Contracts and Validator Scripts] in
     --       Language.Plutus.Coordination.Contracts
-    inner = $$(Ledger.compileScript [|| (\Campaign{..} (act :: CampaignAction) (a :: CampaignActor) (p :: PendingTx) ->
+    inner = $$(Ledger.compileScript [|| (\Campaign{..} (a :: CampaignActor) (act :: CampaignAction) (p :: PendingTx) ->
         let
 
             infixr 3 &&

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -200,7 +200,7 @@ validatorScript :: Future -> ValidatorScript
 validatorScript ft = ValidatorScript val where
     val = Ledger.applyScript inner (Ledger.lifted ft)
     inner = $$(Ledger.compileScript [||
-        \Future{..} (r :: FutureRedeemer) FutureData{..} (p :: PendingTx) ->
+        \Future{..} FutureData{..} (r :: FutureRedeemer) (p :: PendingTx) ->
 
             let
                 PendingTx _ outs _ _ (PendingTxIn _ witness _) range = p

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -30,7 +30,7 @@ PlutusTx.makeLift ''ClearString
 
 gameValidator :: ValidatorScript
 gameValidator = ValidatorScript ($$(Ledger.compileScript [||
-    \(ClearString guess') (HashedString actual) (_ :: PendingTx) ->
+    \(HashedString actual) (ClearString guess') (_ :: PendingTx) ->
 
     if $$(P.equalsByteString) actual ($$(P.sha2_256) guess')
     then ()

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
@@ -61,7 +61,7 @@ type SwapOracle = OracleValue (Ratio Int)
 --       Language.Plutus.Coordination.Contracts
 swapValidator :: Swap -> ValidatorScript
 swapValidator _ = ValidatorScript result where
-    result = $$(Ledger.compileScript [|| (\(redeemer :: SwapOracle) SwapOwners{..} (p :: PendingTx) Swap{..} ->
+    result = $$(Ledger.compileScript [|| (\SwapOwners{..} (redeemer :: SwapOracle) (p :: PendingTx) Swap{..} ->
         let
             infixr 3 &&
             (&&) :: Bool -> Bool -> Bool

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -119,7 +119,7 @@ validatorScriptHash =
 validatorScript :: Vesting -> ValidatorScript
 validatorScript v = ValidatorScript val where
     val = Ledger.applyScript inner (Ledger.lifted v)
-    inner = $$(Ledger.compileScript [|| \Vesting{..} () VestingData{..} (p :: PendingTx) ->
+    inner = $$(Ledger.compileScript [|| \Vesting{..} VestingData{..} () (p :: PendingTx) ->
         let
 
             eqBs :: ValidatorHash -> ValidatorHash -> Bool

--- a/wallet-api/src/Ledger/Index.hs
+++ b/wallet-api/src/Ledger/Index.hs
@@ -181,7 +181,7 @@ checkMatch v = \case
             let v' = ValidationData
                     $ lifted
                     $ v { pendingTxIn = pTxIn }
-                (logOut, success) = Ledger.runScript v' vl r d
+                (logOut, success) = Ledger.runScript v' vl d r
             if success
             then pure ()
             else throwError $ ScriptFailure logOut

--- a/wallet-api/src/Ledger/Types.hs
+++ b/wallet-api/src/Ledger/Types.hs
@@ -640,10 +640,10 @@ instance Show ValidationData where
     show = const "ValidationData { <script> }"
 
 -- | Evaluate a validator script with the given inputs
-runScript :: ValidationData -> ValidatorScript -> RedeemerScript -> DataScript -> ([String], Bool)
-runScript (ValidationData valData) (ValidatorScript validator) (RedeemerScript redeemer) (DataScript dataScript) =
+runScript :: ValidationData -> ValidatorScript -> DataScript -> RedeemerScript -> ([String], Bool)
+runScript (ValidationData valData) (ValidatorScript validator) (DataScript dataScript) (RedeemerScript redeemer) =
     let
-        applied = ((validator `applyScript` redeemer) `applyScript` dataScript) `applyScript` valData
+        applied = ((validator `applyScript` dataScript) `applyScript` redeemer) `applyScript` valData
         -- TODO: do something with the error
     in evaluateScript applied
         -- TODO: Enable type checking of the program


### PR DESCRIPTION
Change the order of arguments of validator scripts to the more intuitive

  `DataScript -> RedeemerScript -> PendingTx -> ()`

ie. the chronological order.