### PR TITLE
tutorial: Remove 'Campaign' parameter in solution

### DIFF
--- a/plutus-tutorial/tutorial/Tutorial/Solutions0Mockchain.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions0Mockchain.hs
@@ -22,14 +22,6 @@ import           Tutorial.Solutions0
 import qualified Tutorial.ExUtil       as ExUtil
 import qualified Wallet.Emulator.Types as EM
 
--- | A campaign for the traces
-campaign :: Campaign
-campaign =
-  Campaign
-      [(20, 100), (30, 200)]
-      35
-      ExUtil.pk1
-
 --
 -- The traces defined below this line can be run in GHCi
 -- using the Tutorial.ExUtil module. They are of no use
@@ -39,16 +31,19 @@ campaignSuccess :: MonadWallet m => EM.Trace m ()
 campaignSuccess = do
 
     -- 1. Wallet 'w1' starts watching the contract address using the
-    --    'registerVestingScheme' endpoint.
-    _ <- EM.walletAction ExUtil.w1 (scheduleCollection campaign)
+    --    'scheduleCollection' endpoint.
+    _ <- EM.walletAction ExUtil.w1 scheduleCollection
 
     -- 2. Wallet 'w2' contributes 80 Ada
-    _ <- EM.walletAction ExUtil.w2 (contribute campaign 80)
+    _ <- EM.walletAction ExUtil.w2 (contribute 80)
 
 
-    -- 2. Wallet 'w3' contributes 50 Ada
-    _ <- EM.walletAction ExUtil.w3 (contribute campaign 50)
+    -- 2. Wallet 'w3' contributes 50 Ada. This brings the total contributed
+    --    to 130 Ada before Slot 10, so the campaign has been a success.
+    _ <- EM.walletAction ExUtil.w3 (contribute 50)
 
+    -- 3. Add a number of empty blocks. This causes wallet 1 to collect the
+    --    two contributions.
     _ <- EM.addBlocksAndNotify [ExUtil.w1, ExUtil.w2, ExUtil.w3] 25
 
     pure ()
@@ -57,17 +52,21 @@ campaignSuccess2 :: MonadWallet m => EM.Trace m ()
 campaignSuccess2 = do
 
     -- 1. Wallet 'w1' starts watching the contract address using the
-    --    'registerVestingScheme' endpoint.
-    _ <- EM.walletAction ExUtil.w1 (scheduleCollection campaign)
+    --    'scheduleCollection' endpoint.
+    _ <- EM.walletAction ExUtil.w1 scheduleCollection
 
     -- 2. Wallet 'w2' contributes 80 Ada
-    _ <- EM.walletAction ExUtil.w2 (contribute campaign 80)
+    _ <- EM.walletAction ExUtil.w2 (contribute 80)
 
-    _ <- EM.addBlocksAndNotify [ExUtil.w1, ExUtil.w2, ExUtil.w3] 25
+    -- 3. Advance the clock to slot 16. The first goal (100 Ada by slot 10)
+    --    has been missed but the second goal (200 Ada by slot 20) is still
+    --    possible.
+    _ <- EM.addBlocksAndNotify [ExUtil.w1, ExUtil.w2, ExUtil.w3] 15
 
-    -- 2. Wallet 'w3' contributes 50 Ada
-    _ <- EM.walletAction ExUtil.w3 (contribute campaign 150)
+    -- 4. Wallet 'w3' contributes 150 Ada, taking the total to 230.
+    _ <- EM.walletAction ExUtil.w3 (contribute 150)
 
+    -- 5. Add some empty blocks, prompting wallet 1 to collect the funds.
     _ <- EM.addBlocksAndNotify [ExUtil.w1, ExUtil.w2, ExUtil.w3] 5
 
     pure ()
@@ -76,17 +75,20 @@ campaignFail :: MonadWallet m => EM.Trace m ()
 campaignFail = do
 
     -- 1. Wallet 'w1' starts watching the contract address using the
-    --    'registerVestingScheme' endpoint.
-    _ <- EM.walletAction ExUtil.w1 (scheduleCollection campaign)
+    --    'scheduleCollection' endpoint.
+    _ <- EM.walletAction ExUtil.w1 scheduleCollection
 
     -- 2. Wallet 'w2' contributes 80 Ada
-    _ <- EM.walletAction ExUtil.w2 (contribute campaign 80)
+    _ <- EM.walletAction ExUtil.w2 (contribute 80)
 
+    -- 3. Advance the clock to slot 21. The campaign has failed.
     _ <- EM.addBlocksAndNotify [ExUtil.w1, ExUtil.w2, ExUtil.w3] 20
 
-    -- 2. Wallet 'w3' contributes 50 Ada
-    _ <- EM.walletAction ExUtil.w3 (contribute campaign 50)
+    -- 4. Wallet 'w3' contributes 50 Ada (too late!)
+    _ <- EM.walletAction ExUtil.w3 (contribute 50)
 
+    -- 5. Advance the clock past slot 25, causing w2 and w3 to collect
+    --    their refunds.
     _ <- EM.addBlocksAndNotify [ExUtil.w1, ExUtil.w2, ExUtil.w3] 20
 
     pure ()


### PR DESCRIPTION
The `Campaign` type used in the solution to one of the exercises has a
field of type `[(Slot, Ada)]`. Lists cannot be entered in the
Playground. I therefore changed the endpoints in Tutorial.Solutions0 to
use a specific campaign -- `aCampaign` -- instead of a configurable `Campaign` parameter.