### PR TITLE
plutus-tx: remove special case handling of typeclass methods

### DIFF
--- a/marlowe/src/Language/Marlowe/Common.hs
+++ b/marlowe/src/Language/Marlowe/Common.hs
@@ -90,8 +90,6 @@ import           Prelude                        ( Show(..)
                                                 , Int
                                                 , Maybe(..)
                                                 , Either(..)
-                                                , Num(..)
-                                                , div
                                                 )
 
 import qualified Language.PlutusTx              as PlutusTx
@@ -265,7 +263,7 @@ makeLift ''State
 
 -- | 'IdentCC' equality
 eqIdentCC :: Q (TExp (IdentCC -> IdentCC -> Bool))
-eqIdentCC = [|| \(IdentCC a) (IdentCC b) -> a == b ||]
+eqIdentCC = [|| \(IdentCC a) (IdentCC b) -> a `Builtins.equalsInteger` b ||]
 
 -- | 'Value' equality
 equalValue :: Q (TExp (Value -> Value -> Bool))
@@ -280,7 +278,7 @@ equalValue = [|| \l r -> let
 
     eq l r = case (l, r) of
         (Committed idl, Committed idr) -> $$(eqIdentCC) idl idr
-        (Value vl, Value vr) -> vl == vr
+        (Value vl, Value vr) -> vl `Builtins.equalsInteger` vr
         (AddValue v1l v2l, AddValue v1r v2r) -> eq v1l v1r && eq v2l v2r
         (MulValue v1l v2l, MulValue v1r v2r) -> eq v1l v1r && eq v2l v2r
         (DivValue v1l v2l v3l, DivValue v1r v2r v3r) ->
@@ -288,7 +286,7 @@ equalValue = [|| \l r -> let
             && eq v2l v2r
             && eq v3l v3r
         (ValueFromChoice (IdentChoice idl) pkl vl, ValueFromChoice (IdentChoice idr) pkr vr) ->
-            idl == idr
+            idl `Builtins.equalsInteger` idr
             && pkl `eqPk` pkr
             && eq vl vr
         (ValueFromOracle pkl vl, ValueFromOracle pkr vr) -> pkl `eqPk` pkr && eq vl vr
@@ -308,14 +306,14 @@ equalObservation = [|| \eqValue l r -> let
 
     eq :: Observation -> Observation -> Bool
     eq l r = case (l, r) of
-        (BelowTimeout tl, BelowTimeout tr) -> tl == tr
+        (BelowTimeout tl, BelowTimeout tr) -> tl `Builtins.equalsInteger` tr
         (AndObs o1l o2l, AndObs o1r o2r) -> o1l `eq` o1r && o2l `eq` o2r
         (OrObs o1l o2l, OrObs o1r o2r) -> o1l `eq` o1r && o2l `eq` o2r
         (NotObs ol, NotObs or) -> ol `eq` or
         (PersonChoseThis (IdentChoice idl) pkl cl, PersonChoseThis (IdentChoice idr) pkr cr) ->
-            idl == idr && pkl `eqPk` pkr && cl == cr
+            idl `Builtins.equalsInteger` idr && pkl `eqPk` pkr && cl `Builtins.equalsInteger` cr
         (PersonChoseSomething (IdentChoice idl) pkl, PersonChoseSomething (IdentChoice idr) pkr) ->
-            idl == idr && pkl `eqPk` pkr
+            idl `Builtins.equalsInteger` idr && pkl `eqPk` pkr
         (ValueGE v1l v2l, ValueGE v1r v2r) -> v1l `eqValue` v1r && v2l `eqValue` v2r
         (TrueObs, TrueObs) -> True
         (FalseObs, FalseObs) -> True
@@ -337,18 +335,18 @@ equalContract = [|| \eqValue eqObservation l r -> let
     eq l r = case (l, r) of
         (Null, Null) -> True
         (CommitCash (IdentCC idl) pkl vl t1l t2l c1l c2l, CommitCash (IdentCC idr) pkr vr t1r t2r c1r c2r) ->
-            idl == idr
+            idl `Builtins.equalsInteger` idr
             && pkl `eqPk` pkr
             && vl `eqValue` vr
-            && t1l == t1r && t2l == t2r
+            && t1l `Builtins.equalsInteger` t1r && t2l `Builtins.equalsInteger` t2r
             && eq c1l c1r && eq c2l c2r
-        (RedeemCC (IdentCC idl) c1l, RedeemCC (IdentCC idr) c1r) -> idl == idr && eq c1l c1r
+        (RedeemCC (IdentCC idl) c1l, RedeemCC (IdentCC idr) c1r) -> idl `Builtins.equalsInteger` idr && eq c1l c1r
         (Pay (IdentPay idl) pk1l pk2l vl tl cl, Pay (IdentPay idr) pk1r pk2r vr tr cr) ->
-            idl == idr
+            idl `Builtins.equalsInteger` idr
             && pk1l `eqPk` pk1r
             && pk2l `eqPk` pk2r
             && vl `eqValue` vr
-            && tl == tr
+            && tl `Builtins.equalsInteger` tr
             && eq cl cr
         (Both c1l c2l, Both c1r c2r) -> eq c1l c1r && eq c2l c2r
         (Choice ol c1l c2l, Choice or c1r c2r) ->
@@ -357,7 +355,7 @@ equalContract = [|| \eqValue eqObservation l r -> let
             && eq c2l c2r
         (When ol tl c1l c2l, When or tr c1r c2r) ->
             ol `eqObservation` or
-            && tl == tr
+            && tl `Builtins.equalsInteger` tr
             && eq c1l c1r
             && eq c2l c2r
         _ -> False
@@ -382,9 +380,9 @@ validateContract = [|| \State{stateCommitted} contract (Slot bn) actualMoney' ->
 
     calcCommittedMoney :: [Commit] -> Cash -> Cash
     calcCommittedMoney [] r = r
-    calcCommittedMoney ((_, (_, NotRedeemed money timeout)) : cs) acc = if bn > timeout
+    calcCommittedMoney ((_, (_, NotRedeemed money timeout)) : cs) acc = if bn `Builtins.greaterThanInteger` timeout
         then calcCommittedMoney cs acc
-        else calcCommittedMoney cs (acc + money)
+        else calcCommittedMoney cs (acc `Builtins.addInteger` money)
 
     checkBoth :: ValidatorState -> Contract -> Contract -> (ValidatorState, Bool)
     checkBoth state c1 c2 = let
@@ -396,19 +394,19 @@ validateContract = [|| \State{stateCommitted} contract (Slot bn) actualMoney' ->
     validateIds state@(ValidatorState maxCCId maxPayId) contract = case contract of
         Null -> (state, True)
         CommitCash (IdentCC id) _ _ _ _ c1 c2 ->
-            if id > maxCCId
+            if id `Builtins.greaterThanInteger` maxCCId
             then checkBoth (ValidatorState id maxPayId) c1 c2
             else (state, False)
         RedeemCC _ c -> validateIds state c
         Pay (IdentPay id) _ _ _ _ c ->
-            if id > maxPayId
+            if id `Builtins.greaterThanInteger` maxPayId
             then validateIds (ValidatorState maxCCId id) c
             else (state, False)
         Both c1 c2 -> checkBoth state c1 c2
         Choice _ c1 c2 -> checkBoth state c1 c2
         When _ _ c1 c2 -> checkBoth state c1 c2
 
-    enoughMoney = calcCommittedMoney stateCommitted 0 <= actualMoney
+    enoughMoney = calcCommittedMoney stateCommitted 0 `Builtins.lessThanEqInteger` actualMoney
 
     in if enoughMoney then
             let (_, validIds) = validateIds (ValidatorState 0 0) contract
@@ -430,20 +428,20 @@ evaluateValue = [|| \pendingTxSlot inputOracles state value -> let
 
     findCommit :: IdentCC -> [Commit] -> Maybe CCStatus
     findCommit i@(IdentCC searchId) commits = case commits of
-        (IdentCC id, status) : _ | id == searchId -> Just status
+        (IdentCC id, status) : _ | id `Builtins.equalsInteger` searchId -> Just status
         _ : xs -> findCommit i xs
         _ -> Nothing
 
     fromOracle :: PubKey -> Slot -> [OracleValue Int] -> Maybe Int
     fromOracle pubKey h@(Slot blockNumber) oracles = case oracles of
         OracleValue pk (Slot bn) value : _
-            | pk `eqPk` pubKey && bn == blockNumber -> Just value
+            | pk `eqPk` pubKey && bn `Builtins.equalsInteger` blockNumber -> Just value
         _ : rest -> fromOracle pubKey h rest
         _ -> Nothing
 
     fromChoices :: IdentChoice -> PubKey -> [Choice] -> Maybe ConcreteChoice
     fromChoices identChoice@(IdentChoice id) pubKey choices = case choices of
-        ((IdentChoice i, party), value) : _ | id == i && party `eqPk` pubKey -> Just value
+        ((IdentChoice i, party), value) : _ | id `Builtins.equalsInteger` i && party `eqPk` pubKey -> Just value
         _ : rest -> fromChoices identChoice pubKey rest
         _ -> Nothing
 
@@ -453,13 +451,13 @@ evaluateValue = [|| \pendingTxSlot inputOracles state value -> let
             Just (_, NotRedeemed c _) -> c
             _ -> 0
         Value v -> v
-        AddValue lhs rhs -> evalValue state lhs + evalValue state rhs
-        MulValue lhs rhs -> evalValue state lhs * evalValue state rhs
+        AddValue lhs rhs -> evalValue state lhs `Builtins.addInteger` evalValue state rhs
+        MulValue lhs rhs -> evalValue state lhs `Builtins.multiplyInteger` evalValue state rhs
         DivValue lhs rhs def -> do
             let divident = evalValue state lhs
             let divisor  = evalValue state rhs
             let defVal   = evalValue state def
-            if divisor == 0 then defVal else divident `div` divisor
+            if divisor `Builtins.equalsInteger` 0 then defVal else divident `Builtins.divideInteger` divisor
         ValueFromChoice ident pubKey def -> case fromChoices ident pubKey choices of
             Just v -> v
             _ -> evalValue state def
@@ -498,20 +496,20 @@ interpretObservation = [|| \evalValue blockNumber state@(State _ choices) obs ->
     find :: IdentChoice -> Person -> [Choice] -> Maybe ConcreteChoice
     find choiceId@(IdentChoice cid) person choices = case choices of
         (((IdentChoice id, party), choice) : _)
-            | cid == id && party `eqPk` person -> Just choice
+            | cid `Builtins.equalsInteger` id && party `eqPk` person -> Just choice
         (_ : cs) -> find choiceId person cs
         _ -> Nothing
 
     go :: Observation -> Bool
     go obs = case obs of
-        BelowTimeout n -> blockNumber <= n
+        BelowTimeout n -> blockNumber `Builtins.lessThanEqInteger` n
         AndObs obs1 obs2 -> go obs1 && go obs2
         OrObs obs1 obs2 -> go obs1 || go obs2
         NotObs obs -> not (go obs)
         PersonChoseThis choiceId person referenceChoice ->
-            maybe False (== referenceChoice) (find choiceId person choices)
+            maybe False (Builtins.equalsInteger referenceChoice) (find choiceId person choices)
         PersonChoseSomething choiceId person -> isJust (find choiceId person choices)
-        ValueGE a b -> evalValue state a >= evalValue state b
+        ValueGE a b -> evalValue state a `Builtins.greaterThanEqInteger` evalValue state b
         TrueObs -> True
         FalseObs -> False
     in go obs
@@ -534,7 +532,7 @@ insertCommit = [|| \ commit commits -> let
         in case commits of
             [] -> commit : []
             (_, (pk, NotRedeemed _ t)) : _
-                | pk `eqPk` pubKey && endTimeout < t -> commit : commits
+                | pk `eqPk` pubKey && endTimeout `Builtins.lessThanInteger` t -> commit : commits
             c : cs -> c : insert commit cs
     in insert commit commits
     ||]
@@ -555,16 +553,16 @@ discountFromPairList = [|| \ from (Slot currentBlockNumber) value' commits -> le
     discount :: Int -> [Commit] -> Maybe [Commit]
     discount value commits = case commits of
         (ident, (party, NotRedeemed available expire)) : rest
-            | currentBlockNumber <= expire && $$(Validation.eqPubKey) from party ->
-            if available > value then let
-                change = available - value
+            | currentBlockNumber `Builtins.lessThanEqInteger` expire && $$(Validation.eqPubKey) from party ->
+            if available `Builtins.greaterThanInteger` value then let
+                change = available `Builtins.subtractInteger` value
                 updatedCommit = (ident, (party, NotRedeemed change expire))
                 in Just (updatedCommit : rest)
-            else discount (value - available) rest
+            else discount (value `Builtins.subtractInteger` available) rest
         commit : rest -> case discount value rest of
                             Just acc -> Just (commit : acc)
                             Nothing -> Nothing
-        [] -> if value == 0 then Just [] else Nothing
+        [] -> if value `Builtins.equalsInteger` 0 then Just [] else Nothing
     in discount value commits
     ||]
 
@@ -622,10 +620,10 @@ evaluateContract = [|| \
     (||) = $$(PlutusTx.or)
 
     signedBy :: Signature -> PubKey -> Bool
-    signedBy (Signature sig) (PubKey pk) = sig == pk
+    signedBy (Signature sig) (PubKey pk) = sig `Builtins.equalsInteger` pk
 
     eqIdentCC :: IdentCC -> IdentCC -> Bool
-    eqIdentCC (IdentCC a) (IdentCC b) = a == b
+    eqIdentCC (IdentCC a) (IdentCC b) = a `Builtins.equalsInteger` b
 
     nullContract :: Contract -> Bool
     nullContract Null = True
@@ -640,7 +638,7 @@ evaluateContract = [|| \
     eval :: InputCommand -> State -> Contract -> (State, Contract, Bool)
     eval input state@(State commits choices) contract = case (contract, input) of
         (When obs timeout con con2, _)
-            | currentBlockNumber > timeout -> eval input state con2
+            | currentBlockNumber `Builtins.greaterThanInteger` timeout -> eval input state con2
             | interpretObs currentBlockNumber state obs -> eval input state con
 
         (Choice obs conT conF, _) -> if interpretObs currentBlockNumber state obs
@@ -657,7 +655,7 @@ evaluateContract = [|| \
 
         -- expired CommitCash
         (CommitCash _ _ _ startTimeout endTimeout _ con2, _)
-            | currentBlockNumber > startTimeout || currentBlockNumber > endTimeout -> eval input state con2
+            | currentBlockNumber `Builtins.greaterThanInteger` startTimeout || currentBlockNumber `Builtins.greaterThanInteger` endTimeout -> eval input state con2
 
         (CommitCash id1 pubKey value _ endTimeout con1 _, Commit id2 signature) | id1 `eqIdentCC` id2 -> let
             vv = evalValue state value
@@ -665,8 +663,8 @@ evaluateContract = [|| \
             insert :: Commit -> [Commit] -> [Commit]
             insert a b = $$(insertCommit) a b
 
-            isValid = vv > 0
-                && scriptOutValue == scriptInValue + vv
+            isValid = vv `Builtins.greaterThanInteger` 0
+                && scriptOutValue `Builtins.equalsInteger` (scriptInValue `Builtins.addInteger` vv)
                 && signature `signedBy` pubKey
             in  if isValid then let
                     cns = (pubKey, NotRedeemed vv endTimeout)
@@ -676,14 +674,14 @@ evaluateContract = [|| \
                 else (state, contract, False)
 
         (Pay _ _ _ _ timeout con, _)
-            | currentBlockNumber > timeout -> eval input state con
+            | currentBlockNumber `Builtins.greaterThanInteger` timeout -> eval input state con
 
         (Pay (IdentPay contractIdentPay) from to payValue _ con, Payment (IdentPay pid) signature) -> let
             pv = evalValue state payValue
 
-            isValid = pid == contractIdentPay
-                && pv > 0
-                && scriptOutValue == scriptInValue - pv
+            isValid = pid `Builtins.equalsInteger` contractIdentPay
+                && pv `Builtins.greaterThanInteger` 0
+                && scriptOutValue `Builtins.equalsInteger` (scriptInValue `Builtins.subtractInteger` pv)
                 && signature `signedBy` to
             in  if isValid then let
                 in case $$(discountFromPairList) from blockHeight ($$(Ada.fromInt) pv) commits of
@@ -697,7 +695,7 @@ evaluateContract = [|| \
             predicate :: Commit -> Bool
             predicate (i, (pk, NotRedeemed val _)) =
                 i `eqIdentCC` id1
-                && scriptOutValue == scriptInValue - val
+                && scriptOutValue `Builtins.equalsInteger` (scriptInValue `Builtins.subtractInteger` val)
                 && signature `signedBy` pk
             -- validate and remove a Commit
             in case $$(findAndRemove) predicate commits of
@@ -708,8 +706,8 @@ evaluateContract = [|| \
             predicate :: Commit -> Bool
             predicate (i, (pk, NotRedeemed val expire)) =
                     i `eqIdentCC` identCC
-                    && scriptOutValue == scriptInValue - val
-                    && currentBlockNumber > expire
+                    && scriptOutValue `Builtins.equalsInteger` (scriptInValue `Builtins.subtractInteger` val)
+                    && currentBlockNumber `Builtins.greaterThanInteger` expire
                     && signature `signedBy` pk
             -- validate and remove a Commit
             in case $$(findAndRemove) predicate commits of
@@ -734,8 +732,8 @@ mergeChoices = [|| \ input choices -> let
             [] -> choice : []
             current@((IdentChoice id, pk), _) : rest -> let
                 ((IdentChoice insId, insPK), _) = choice
-                in   if insId < id then choice : choices
-                else if insId == id then
+                in   if insId `Builtins.lessThanInteger` id then choice : choices
+                else if insId `Builtins.equalsInteger` id then
                         if $$(Validation.eqPubKey) insPK pk
                         then choices
                         else current : insert choice rest
@@ -765,7 +763,7 @@ validatorScript = [|| \
         eqPk = $$(Validation.eqPubKey)
 
         eqIdentCC :: IdentCC -> IdentCC -> Bool
-        eqIdentCC (IdentCC a) (IdentCC b) = a == b
+        eqIdentCC (IdentCC a) (IdentCC b) = a `Builtins.equalsInteger` b
 
         infixr 3 &&
         (&&) :: Bool -> Bool -> Bool
@@ -788,11 +786,11 @@ validatorScript = [|| \
 
         eqCommit :: Commit -> Commit -> Bool
         eqCommit (id1, (pk1, (NotRedeemed val1 t1))) (id2, (pk2, (NotRedeemed val2 t2))) =
-            id1 `eqIdentCC` id2 && pk1 `eqPk` pk2 && val1 == val2 && t1 == t2
+            id1 `eqIdentCC` id2 && pk1 `eqPk` pk2 && val1 `Builtins.equalsInteger` val2 && t1 `Builtins.equalsInteger` t2
 
         eqChoice :: Choice -> Choice -> Bool
         eqChoice ((IdentChoice id1, pk1), c1) ((IdentChoice id2, pk2), c2) =
-            id1 == id2 && c1 == c2 && pk1 `eqPk` pk2
+            id1 `Builtins.equalsInteger` id2 && c1 `Builtins.equalsInteger` c2 && pk1 `eqPk` pk2
 
         eqState :: State -> State -> Bool
         eqState (State commits1 choices1) (State commits2 choices2) =

--- a/plutus-tutorial/doctest/Tutorial/03-wallet-api.md
+++ b/plutus-tutorial/doctest/Tutorial/03-wallet-api.md
@@ -227,7 +227,7 @@ In the `Collect` case, the current slot must be between `deadline` and `collecti
               in
 ```
 
-**Note (Operators in On-Chain Code)** We can use the operators `>`, `<`, `>=`, `<=` and `==` to compare `Int` values in PLC without having to define them in the script itself, as we did with `&&`. The compiler plugin that translates Haskell Core to Plutus Core knows about those operators because `Int` is a primitive type in Plutus Core and operations on it are built in. `Bool` on the other hand is treated like any other user-defined data type, and all functions that operate on it must be defined locally. More details can be found in the [PlutusTx tutorial](../plutus-tx/tutorial/Tutorial.md).
+**Note (Builtins in On-Chain Code)** We can use the functions `greaterThanInteger`, `lessThanInteger`, `greaterThanEqInteger`, `lessThanEqInteger` and `equalsInteger` from the `Language.PlutusTx.Builtins` module to compare `Int` values in PLC without having to define them in the script itself, as we did with `&&`. The compiler plugin that translates Haskell Core to Plutus Core knows about those functions because `Int` is a primitive type in Plutus Core and operations on it are built in. `Bool` on the other hand is treated like any other user-defined data type, and all functions that operate on it must be defined locally. More details can be found in the [PlutusTx tutorial](../plutus-tx/tutorial/Tutorial.md).
 
 Finally, we can return `()` if `isValid` is true, or fail with an error if it isn't.
 

--- a/plutus-tutorial/tutorial/Tutorial/Solutions1.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions1.hs
@@ -6,7 +6,8 @@ module Tutorial.Solutions1 where
 -- (Rest of the solutions can be found in Tutorial.Solutions2 because of
 --  TH staging restrictions)
 
-import Tutorial.TH          (tricky)
+import Tutorial.TH               (tricky)
+import Language.PlutusTx.Prelude (lt, minus)
 import Language.Haskell.TH
 
 {-
@@ -21,7 +22,7 @@ import Language.Haskell.TH
 
 -}
 trickier :: Int -> Q (TExp (Int -> Int))
-trickier i = if i <= 1 then tricky else [|| \k -> $$(tricky) ($$(trickier (i - 1)) k)  ||]
+trickier i = if $$lt i 1 then tricky else [|| \k -> $$(tricky) ($$(trickier ($$minus i 1)) k)  ||]
 
 
 -- E3*. `trickier n` inlines the `tricky` function n times. In `trickierLight`
@@ -32,6 +33,6 @@ trickierLight i = [||
   \(j :: Int) ->
     let
       trk = $$(tricky)
-      go k = if k <= (1 :: Int) then trk j else trk (go (k - 1))
+      go k = if $$lt k (1 :: Int) then trk j else trk (go ($$minus k 1))
       
   in go i ||]

--- a/plutus-tutorial/tutorial/Tutorial/TH.hs
+++ b/plutus-tutorial/tutorial/Tutorial/TH.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
 {- 
   A small tutorial on Template Haskell as relevant to Plutus. It is split 
   split across two modules, `Tutorial.TH` (this module) and 
@@ -31,6 +32,7 @@
 module Tutorial.TH where
 
 import           Language.Haskell.TH
+import           Language.PlutusTx.Prelude hiding (error)
 
 {- |
   Part 1. Template Haskell
@@ -44,7 +46,19 @@ import           Language.Haskell.TH
 -}
 
 tricky :: Q (TExp (Int -> Int))
-tricky = [|| \i -> 2 * i - i * i + 5 * i * i * i - 6 * i * i * i - 8 ||]
+tricky = [|| 
+  let 
+    infixl 6 +
+    (+) :: Int -> Int -> Int
+    (+) = $$plus
+    infixl 6 -
+    (-) :: Int -> Int -> Int
+    (-) = $$minus
+    infixl 7 *
+    (*) :: Int -> Int -> Int
+    (*) = $$multiply
+  in \i -> (2 * i) - i * i + 5 * i * i * i - 6 * i * i * i - 8 
+  ||]
 
 {- |
     E1: Test `tricky` in the repl (ghci) on various values
@@ -70,7 +84,7 @@ tricky = [|| \i -> 2 * i - i * i + 5 * i * i * i - 6 * i * i * i - 8 ||]
     Then test it in GHCi.
 -}
 trickier :: Int -> Q (TExp (Int -> Int))
-trickier i = if i <= 1 then tricky else [|| error "exercise" ||]
+trickier i = if $$lt i 1 then tricky else [|| error "exercise" ||]
 
 {- 
 

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
@@ -149,18 +149,6 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
     case e of
         -- See Note [Literals]
         GHC.App (GHC.Var (isPrimitiveWrapper -> True)) arg -> convExpr arg
-        -- special typeclass method calls
-        GHC.App (GHC.App
-                (GHC.Var n@(GHC.idDetails -> GHC.ClassOpId (GHC.getName -> className)))
-                -- we only support applying to int
-                (GHC.Type (GHC.eqType GHC.intTy -> True)))
-            -- last arg is typeclass dictionary
-            _ -> case className of
-                     ((==) GHC.eqClassName -> True) -> convEqMethod (GHC.getName n)
-                     ((==) GHC.ordClassName -> True) -> convOrdMethod (GHC.getName n)
-                     ((==) GHC.numClassName -> True) -> convNumMethod (GHC.getName n)
-                     ((==) GHC.integralClassName -> True) -> convIntegralMethod (GHC.getName n)
-                     _ -> throwSd UnsupportedError $ "Typeclass method:" GHC.<+> GHC.ppr n
         -- void# - values of type void get represented as error, since they should be unreachable
         GHC.Var n | n == GHC.voidPrimId || n == GHC.voidArgId -> errorFunc
         -- See note [GHC runtime errors]

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Primitives.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Primitives.hs
@@ -15,7 +15,6 @@ import           Language.PlutusTx.Compiler.Utils
 import           Language.PlutusTx.PIRTypes
 
 import qualified GhcPlugins                          as GHC
-import qualified PrelNames                           as GHC
 import qualified PrimOp                              as GHC
 
 -- These never seem to come up, rather we get the typeclass operations. Not sure if we need them.
@@ -33,33 +32,3 @@ convPrimitiveOp = \case
     GHC.IntLeOp   -> lookupBuiltinTerm 'Builtins.lessThanEqInteger
     GHC.IntEqOp   -> lookupBuiltinTerm 'Builtins.equalsInteger
     po            -> throwSd UnsupportedError $ "Primitive operation:" GHC.<+> GHC.ppr po
-
--- Typeclasses
-
-convEqMethod :: (Converting m) => GHC.Name -> m PIRTerm
-convEqMethod name
-    | name == GHC.eqName = lookupBuiltinTerm 'Builtins.equalsInteger
-    | otherwise = throwSd UnsupportedError $ "Eq method:" GHC.<+> GHC.ppr name
-
-convOrdMethod :: (Converting m) => GHC.Name -> m PIRTerm
-convOrdMethod name
-    -- only this one has a name defined in the lib??
-    | name == GHC.geName = lookupBuiltinTerm 'Builtins.greaterThanEqInteger
-    | GHC.getOccString name == ">" = lookupBuiltinTerm 'Builtins.greaterThanInteger
-    | GHC.getOccString name == "<=" = lookupBuiltinTerm 'Builtins.lessThanEqInteger
-    | GHC.getOccString name == "<" = lookupBuiltinTerm 'Builtins.lessThanInteger
-    | otherwise = throwSd UnsupportedError $ "Ord method:" GHC.<+> GHC.ppr name
-
-convNumMethod :: (Converting m) => GHC.Name -> m PIRTerm
-convNumMethod name
-    -- only this one has a name defined in the lib??
-    | name == GHC.minusName = lookupBuiltinTerm 'Builtins.subtractInteger
-    | GHC.getOccString name == "+" = lookupBuiltinTerm 'Builtins.addInteger
-    | GHC.getOccString name == "*" = lookupBuiltinTerm 'Builtins.multiplyInteger
-    | otherwise = throwSd UnsupportedError $ "Num method:" GHC.<+> GHC.ppr name
-
-convIntegralMethod :: (Converting m) => GHC.Name -> m PIRTerm
-convIntegralMethod name
-    | GHC.getOccString name == "div" = lookupBuiltinTerm 'Builtins.divideInteger
-    | GHC.getOccString name == "rem" = lookupBuiltinTerm 'Builtins.remainderInteger
-    | otherwise = throwSd UnsupportedError $ "Integral method:" GHC.<+> GHC.ppr name

--- a/plutus-tx/src/Language/PlutusTx/Prelude/Stage0.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude/Stage0.hs
@@ -151,7 +151,7 @@ remainder = [|| Builtins.remainderInteger ||]
 --   5
 --
 min :: Q (TExp (Int -> Int -> Int))
-min = [|| \(a :: Int) (b :: Int) -> if a < b then a else b ||]
+min = [|| \(a :: Int) (b :: Int) -> if Builtins.lessThanInteger a b then a else b ||]
 
 -- | The larger of two 'Int's
 --
@@ -159,7 +159,7 @@ min = [|| \(a :: Int) (b :: Int) -> if a < b then a else b ||]
 --   10
 --
 max :: Q (TExp (Int -> Int -> Int))
-max = [|| \(a :: Int) (b :: Int) -> if a > b then a else b ||]
+max = [|| \(a :: Int) (b :: Int) -> if Builtins.greaterThanInteger a b then a else b ||]
 
 -- | Check if a 'Maybe' @a@ is @Just a@
 --

--- a/plutus-tx/test/Plugin/Spec.hs
+++ b/plutus-tx/test/Plugin/Spec.hs
@@ -110,26 +110,26 @@ tupleMatch :: CompiledCode ((Int, Int) -> Int)
 tupleMatch = plc @"tupleMatch" (\(x:: (Int, Int)) -> let (a, b) = x in a)
 
 intCompare :: CompiledCode (Int -> Int -> Bool)
-intCompare = plc @"intCompare" (\(x::Int) (y::Int) -> x < y)
+intCompare = plc @"intCompare" (\(x::Int) (y::Int) -> Builtins.lessThanInteger x y)
 
 intEq :: CompiledCode (Int -> Int -> Bool)
-intEq = plc @"intEq" (\(x::Int) (y::Int) -> x == y)
+intEq = plc @"intEq" (\(x::Int) (y::Int) -> Builtins.equalsInteger x y)
 
 -- Has a Void in it
 void :: CompiledCode (Int -> Int -> Bool)
-void = plc @"void" (\(x::Int) (y::Int) -> let a x' y' = case (x', y') of { (True, True) -> True; _ -> False; } in (x == y) `a` (y == x))
+void = plc @"void" (\(x::Int) (y::Int) -> let a x' y' = case (x', y') of { (True, True) -> True; _ -> False; } in (Builtins.equalsInteger x y) `a` (Builtins.equalsInteger y x))
 
 intPlus :: CompiledCode (Int -> Int -> Int)
-intPlus = plc @"intPlus" (\(x::Int) (y::Int) -> x + y)
+intPlus = plc @"intPlus" (\(x::Int) (y::Int) -> Builtins.addInteger x y)
 
 intDiv :: CompiledCode (Int -> Int -> Int)
-intDiv = plc @"intDiv" (\(x::Int) (y::Int) -> x `div` y)
+intDiv = plc @"intDiv" (\(x::Int) (y::Int) -> Builtins.divideInteger x y)
 
 errorPlc :: CompiledCode (() -> Int)
 errorPlc = plc @"errorPlc" (Builtins.error @Int)
 
 ifThenElse :: CompiledCode (Int -> Int -> Int)
-ifThenElse = plc @"ifThenElse" (\(x::Int) (y::Int) -> if x == y then x else y)
+ifThenElse = plc @"ifThenElse" (\(x::Int) (y::Int) -> if Builtins.equalsInteger x y then x else y)
 
 --blocknumPlc :: CompiledCode
 --blocknumPlc = plc @"blocknumPlc" Builtins.blocknum
@@ -156,7 +156,7 @@ structure = testNested "structure" [
 
 -- GHC acutually turns this into a lambda for us, try and make one that stays a let
 letFun :: CompiledCode (Int -> Int -> Bool)
-letFun = plc @"lefFun" (\(x::Int) (y::Int) -> let f z = x == z in f y)
+letFun = plc @"lefFun" (\(x::Int) (y::Int) -> let f z = Builtins.equalsInteger x z in f y)
 
 datat :: TestNested
 datat = testNested "data" [
@@ -209,7 +209,7 @@ irrefutableMatch :: CompiledCode (MyMonoData -> Int)
 irrefutableMatch = plc @"irrefutableMatch" (\(x :: MyMonoData) -> case x of { Mono2 a -> a })
 
 atPattern :: CompiledCode ((Int, Int) -> Int)
-atPattern = plc @"atPattern" (\t@(x::Int, y::Int) -> let fst (a, b) = a in y + fst t)
+atPattern = plc @"atPattern" (\t@(x::Int, y::Int) -> let fst (a, b) = a in Builtins.addInteger y (fst t))
 
 data MyMonoRecord = MyMonoRecord { mrA :: Int , mrB :: Int}
 
@@ -327,7 +327,7 @@ polyRec = plc @"polyRec" (
         depth :: B a -> Int
         depth tree = case tree of
             One _     -> 1
-            Two inner -> 1 + depth inner
+            Two inner -> Builtins.addInteger 1 (depth inner)
     in \(t::B Int) -> depth t)
 
 ptreeFirst :: CompiledCode (B Int -> Int)
@@ -374,22 +374,26 @@ fib :: CompiledCode (Int -> Int)
 -- not using case to avoid literal cases
 fib = plc @"fib" (
     let fib :: Int -> Int
-        fib n = if n == 0 then 0 else if n == 1 then 1 else fib(n-1) + fib(n-2)
+        fib n = if Builtins.equalsInteger n 0
+            then 0
+            else if Builtins.equalsInteger n 1
+            then 1
+            else Builtins.addInteger (fib(Builtins.subtractInteger n 1)) (fib(Builtins.subtractInteger n 2))
     in fib)
 
 sumDirect :: CompiledCode ([Int] -> Int)
 sumDirect = plc @"sumDirect" (
     let sum :: [Int] -> Int
         sum []     = 0
-        sum (x:xs) = x + sum xs
+        sum (x:xs) = Builtins.addInteger x (sum xs)
     in sum)
 
 evenMutual :: CompiledCode (Int -> Bool)
 evenMutual = plc @"evenMutual" (
     let even :: Int -> Bool
-        even n = if n == 0 then True else odd (n-1)
+        even n = if Builtins.equalsInteger n 0 then True else odd (Builtins.subtractInteger n 1)
         odd :: Int -> Bool
-        odd n = if n == 0 then False else even (n-1)
+        odd n = if Builtins.equalsInteger n 0 then False else even (Builtins.subtractInteger n 1)
     in even)
 
 errors :: TestNested

--- a/plutus-tx/test/TH/Spec.hs
+++ b/plutus-tx/test/TH/Spec.hs
@@ -77,7 +77,7 @@ andPlc :: CompiledCode Bool
 andPlc = $$(compile [|| $$(andTH) True False ||])
 
 allPlc :: CompiledCode Bool
-allPlc = $$(compile [|| $$(all) (\(x::Int) -> x > 5) [7, 6] ||])
+allPlc = $$(compile [|| $$(all) (\(x::Int) -> $$gt x 5) [7, 6] ||])
 
 convertString :: CompiledCode Builtins.String
 convertString = $$(compile [|| $$(toPlutusString) "test" ||])
@@ -95,6 +95,6 @@ traceRepeatedly = $$(compile
                -- is the same behaviour as Debug.trace
                let i1 = $$(traceH) "Making my first int" (1::Int)
                    i2 = $$(traceH) "Making my second int" (2::Int)
-                   i3 = $$(traceH) "Adding them up" (i1 + i2)
+                   i3 = $$(traceH) "Adding them up" ($$plus i1 i2)
               in i3
     ||])

--- a/plutus-tx/test/TH/TestTH.hs
+++ b/plutus-tx/test/TH/TestTH.hs
@@ -3,6 +3,7 @@
 module TH.TestTH where
 
 import           Language.Haskell.TH
+import           Language.PlutusTx.Prelude
 
 {-# ANN module "HLint: ignore" #-}
 
@@ -11,9 +12,9 @@ power n =
     if n <= 0 then
         [|| \ _ -> (1::Int) ||]
     else if even n then
-        [|| \(x::Int) -> let y = $$(power (n `div` (2::Int))) x in y * y ||]
+        [|| \(x::Int) -> let y = $$(power ($$divide n (2::Int))) x in $$multiply y y ||]
     else
-        [|| \(x::Int) -> x * ($$(power (n - (1::Int))) x) ||]
+        [|| \(x::Int) -> $$multiply x ($$(power ($$minus n (1::Int))) x) ||]
 
 andTH :: Q (TExp (Bool -> Bool -> Bool))
 andTH = [||\(a :: Bool) -> \(b::Bool) -> if a then if b then True else False else False||]

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
@@ -11,6 +11,7 @@ module Language.PlutusTx.Coordination.Contracts.Swap(
     ) where
 
 import qualified Language.PlutusTx            as PlutusTx
+import qualified Language.PlutusTx.Prelude    as P
 import           Ledger                       (Slot, PubKey, ValidatorScript (..))
 import qualified Ledger                       as Ledger
 import           Ledger.Validation            (OracleValue (..), PendingTx (..), PendingTxIn (..), PendingTxOut (..))
@@ -19,7 +20,7 @@ import qualified Ledger.Ada.TH                as Ada
 import           Ledger.Ada.TH                (Ada)
 import           Ledger.Value                 (Value)
 
-import           Prelude                      (Bool (..), Eq (..), Int, Num (..))
+import           Prelude                      (Bool (..), Eq (..), Int)
 
 data Ratio a = a :% a  deriving Eq
 
@@ -74,13 +75,13 @@ swapValidator _ = ValidatorScript result where
             mx = $$(PlutusTx.max)
 
             timesR :: Ratio Int -> Ratio Int -> Ratio Int
-            timesR (x :% y) (x' :% y') = (x*x') :% (y*y')
+            timesR (x :% y) (x' :% y') = ($$(P.multiply) x x') :% ($$(P.multiply) y y')
 
             plusR :: Ratio Int -> Ratio Int -> Ratio Int
-            plusR (x :% y) (x' :% y') = (x*y' + x'*y) :% (y*y')
+            plusR (x :% y) (x' :% y') = ($$(P.plus) ($$(P.multiply) x y') ($$(P.multiply) x' y)) :% ($$(P.multiply) y y')
 
             minusR :: Ratio Int -> Ratio Int -> Ratio Int
-            minusR (x :% y) (x' :% y') = (x*y' - x'*y) :% (y*y')
+            minusR (x :% y) (x' :% y') = ($$(P.minus) ($$(P.multiply) x y') ($$(P.multiply) x' y)) :% ($$(P.multiply) y y')
 
             extractVerifyAt :: OracleValue (Ratio Int) -> PubKey -> Ratio Int -> Slot -> Ratio Int
             extractVerifyAt = $$(PlutusTx.error) ()
@@ -131,9 +132,9 @@ swapValidator _ = ValidatorScript result where
             -- payments), ensuring that it is at least 0 and does not exceed
             -- the total amount of money at stake (2 * margin)
             clamp :: Int -> Int
-            clamp x = mn 0 (mx (2 * margin) x)
-            fixedRemainder = clamp (margin - fixedPayment + floatPayment)
-            floatRemainder = clamp (margin - floatPayment + fixedPayment)
+            clamp x = mn 0 (mx ($$(P.multiply) 2 margin) x)
+            fixedRemainder = clamp ($$(P.plus) ($$(P.minus) margin fixedPayment) floatPayment)
+            floatRemainder = clamp ($$(P.plus) ($$(P.minus) margin floatPayment) fixedPayment)
 
             -- The transaction must have one input from each of the
             -- participants.

--- a/wallet-api/src/Ledger/Validation.hs
+++ b/wallet-api/src/Ledger/Validation.hs
@@ -239,7 +239,7 @@ txSignedBy = [||
             PendingTx txins _ _ _ _ _ = p
 
             signedBy' :: Signature -> Bool
-            signedBy' (Signature s) = s == k
+            signedBy' (Signature s) = Builtins.equalsInteger s k
 
             go :: [PendingTxIn] -> Bool
             go l = case l of
@@ -254,7 +254,7 @@ txSignedBy = [||
 txInSignedBy :: Q (TExp (PendingTxIn -> PubKey -> Bool))
 txInSignedBy = [||
     \(i :: PendingTxIn) (PubKey k) -> case i of
-        PendingTxIn _ (Right (Signature sig)) _ -> sig == k
+        PendingTxIn _ (Right (Signature sig)) _ -> Builtins.equalsInteger sig k
         _ -> False
     ||]
 
@@ -273,7 +273,7 @@ scriptOutput = [|| \(o:: PendingTxOut) -> case o of
 
 -- | Equality of public keys
 eqPubKey :: Q (TExp (PubKey -> PubKey -> Bool))
-eqPubKey = [|| \(PubKey l) (PubKey r) -> l == r ||]
+eqPubKey = [|| \(PubKey l) (PubKey r) -> Builtins.equalsInteger l r ||]
 
 -- | Equality of data scripts
 eqDataScript :: Q (TExp (DataScriptHash -> DataScriptHash -> Bool))
@@ -313,10 +313,10 @@ adaLockedBy = [|| \(PendingTx _ outs _ _ _ _) h ->
     in go outs
       ||]
 
--- | Check if the provided signature is the result of signing the pending 
+-- | Check if the provided signature is the result of signing the pending
 --   transaction (without witnesses) with the public key.
 signsTransaction :: Q (TExp (Signature -> PubKey -> PendingTx -> Bool))
-signsTransaction = [|| \(Signature i) (PubKey j) (_ :: PendingTx) -> i == j ||]
+signsTransaction = [|| \(Signature i) (PubKey j) (_ :: PendingTx) -> Builtins.equalsInteger i j ||]
 
 makeLift ''PendingTxOutType
 


### PR DESCRIPTION
This is misleading and suggests that we have more support for
typeclasses than we do. In addition, it complicates doing things
generically with GHC names since some of them are special.

Clients who want to avoid TH splices can still use the names in
`Language.PlutusTx.Builtins`, those who wish to have a consistent
interface can use the quotes in `Language.PlutusTx.Prelude`.