### PR TITLE
[plutus-ir] Switched the pir parser to using TermLike

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE LambdaCase             #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
 
 module Language.PlutusCore.MkPlc ( TermLike (..)
                                  , VarDecl (..)
@@ -32,7 +33,7 @@ module Language.PlutusCore.MkPlc ( TermLike (..)
                                  , mkIterKindArrow
                                  ) where
 
-import           Prelude hiding (error)
+import           Prelude                  hiding (error)
 
 import           Language.PlutusCore.Type
 
@@ -73,7 +74,7 @@ embed = \case
     Constant a c      -> constant a c
     Builtin a bi      -> builtin a bi
     TyInst a t ty     -> tyInst a (embed t) ty
-    Error a ty        -> error a ty
+    Error a ty        -> Language.PlutusCore.MkPlc.error a ty
     Unwrap a t        -> unwrap a (embed t)
     IWrap a ty1 ty2 t -> iWrap a ty1 ty2 (embed t)
 

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -27,7 +27,7 @@ import           PlutusPrelude
 import           Language.PlutusCore        (Kind, Name, TyName, Type (..))
 import qualified Language.PlutusCore        as PLC
 import           Language.PlutusCore.CBOR   ()
-import           Language.PlutusCore.MkPlc  (TyVarDecl (..), VarDecl (..), TermLike (..))
+import           Language.PlutusCore.MkPlc  (TermLike (..), TyVarDecl (..), VarDecl (..))
 import qualified Language.PlutusCore.Pretty as PLC
 
 import           Codec.Serialise            (Serialise)

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -19,8 +19,7 @@ module Language.PlutusIR (
     Recursivity (..),
     Binding (..),
     Term (..),
-    Program (..),
-    embedIntoIR
+    Program (..)
     ) where
 
 import           PlutusPrelude
@@ -28,7 +27,7 @@ import           PlutusPrelude
 import           Language.PlutusCore        (Kind, Name, TyName, Type (..))
 import qualified Language.PlutusCore        as PLC
 import           Language.PlutusCore.CBOR   ()
-import           Language.PlutusCore.MkPlc  (TyVarDecl (..), VarDecl (..))
+import           Language.PlutusCore.MkPlc  (TyVarDecl (..), VarDecl (..), TermLike (..))
 import qualified Language.PlutusCore.Pretty as PLC
 
 import           Codec.Serialise            (Serialise)
@@ -118,18 +117,17 @@ data Term tyname name a =
 
 instance (Serialise a, Serialise (tyname a), Serialise (name a)) => Serialise (Term tyname name a)
 
-embedIntoIR :: PLC.Term tyname name a -> Term tyname name a
-embedIntoIR = \case
-    PLC.Var a n -> Var a n
-    PLC.TyAbs a tn k t -> TyAbs a tn k (embedIntoIR t)
-    PLC.LamAbs a n ty t -> LamAbs a n ty (embedIntoIR t)
-    PLC.Apply a t1 t2 -> Apply a (embedIntoIR t1) (embedIntoIR t2)
-    PLC.Constant a c ->  Constant a c
-    PLC.Builtin a bi -> Builtin a bi
-    PLC.TyInst a t ty -> TyInst a (embedIntoIR t) ty
-    PLC.Error a ty -> Error a ty
-    PLC.Unwrap a t -> Unwrap a (embedIntoIR t)
-    PLC.IWrap a ty1 ty2 t -> IWrap a ty1 ty2 (embedIntoIR t)
+instance TermLike (Term tyname name) tyname name where
+    var      = Var
+    tyAbs    = TyAbs
+    lamAbs   = LamAbs
+    apply    = Apply
+    constant = Constant
+    builtin  = Builtin
+    tyInst   = TyInst
+    unwrap   = Unwrap
+    iWrap    = IWrap
+    error    = Error
 
 -- no version as PIR is not versioned
 data Program tyname name a = Program a (Term tyname name a) deriving Generic

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Definitions.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Definitions.hs
@@ -47,7 +47,7 @@ mapDefs :: (a -> b) -> DefMap key a -> DefMap key b
 mapDefs f = Map.map (\(def, deps) -> (f def, deps))
 
 data DefState key ann = DefState {
-    _termDefs     :: DefMap key (TermDef TyName Name ann),
+    _termDefs     :: DefMap key (TermDef (Term TyName Name) TyName Name ann),
     _typeDefs     :: DefMap key (TypeDef TyName ann),
     _datatypeDefs :: DefMap key (DatatypeDef TyName Name ann),
     _aliases      :: Set.Set key
@@ -107,7 +107,7 @@ instance MonadDefs key ann m => MonadDefs key ann (StateT s m)
 instance MonadDefs key ann m => MonadDefs key ann (ExceptT e m)
 instance MonadDefs key ann m => MonadDefs key ann (ReaderT r m)
 
-defineTerm :: MonadDefs key ann m => key -> TermDef TyName Name ann -> Set.Set key -> m ()
+defineTerm :: MonadDefs key ann m => key -> TermDef (Term TyName Name) TyName Name ann -> Set.Set key -> m ()
 defineTerm name def deps = liftDef $ modify $ over termDefs $ Map.insert name (def, deps)
 
 defineType :: MonadDefs key ann m => key -> TypeDef TyName ann -> Set.Set key -> m ()

--- a/plutus-ir/src/Language/PlutusIR/MkPir.hs
+++ b/plutus-ir/src/Language/PlutusIR/MkPir.hs
@@ -11,18 +11,6 @@ import           Language.PlutusIR
 
 import           Language.PlutusCore.MkPlc as MkPlc
 
-instance TermLike (Term tyname name) tyname name where
-    var      = Var
-    tyAbs    = TyAbs
-    lamAbs   = LamAbs
-    apply    = Apply
-    constant = Constant
-    builtin  = Builtin
-    tyInst   = TyInst
-    unwrap   = Unwrap
-    iWrap    = IWrap
-    error    = Error
-
 -- | A datatype definition as a type variable.
 type DatatypeDef tyname name a = Def (TyVarDecl tyname a) (Datatype tyname name a)
 

--- a/plutus-ir/src/Language/PlutusIR/MkPir.hs
+++ b/plutus-ir/src/Language/PlutusIR/MkPir.hs
@@ -1,31 +1,28 @@
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Language.PlutusIR.MkPir ( Def (..)
-                               , TermDef
-                               , TypeDef
+module Language.PlutusIR.MkPir ( module MkPlc
                                , DatatypeDef
-                               , mkVar
-                               , mkTyVar
                                , mkLet
-                               , mkIterTyForall
-                               , mkIterTyLam
-                               , mkIterApp
-                               , mkIterTyFun
-                               , mkIterLamAbs
-                               , mkIterInst
-                               , mkIterTyAbs
-                               , mkIterTyApp
                                ) where
 
 import           Language.PlutusIR
 
-import           Language.PlutusCore.MkPlc (Def (..), mkTyVar)
+import           Language.PlutusCore.MkPlc as MkPlc
 
-import           Data.List                 (foldl')
+instance TermLike (Term tyname name) tyname name where
+    var      = Var
+    tyAbs    = TyAbs
+    lamAbs   = LamAbs
+    apply    = Apply
+    constant = Constant
+    builtin  = Builtin
+    tyInst   = TyInst
+    unwrap   = Unwrap
+    iWrap    = IWrap
+    error    = Error
 
--- | A term definition as a variable.
-type TermDef tyname name a = Def (VarDecl tyname name a) (Term tyname name a)
--- | A type definition as a type variable.
-type TypeDef tyname a = Def (TyVarDecl tyname a) (Type tyname a)
 -- | A datatype definition as a type variable.
 type DatatypeDef tyname name a = Def (TyVarDecl tyname a) (Datatype tyname name a)
 
@@ -38,71 +35,3 @@ mkLet
     -> Term tyname name a
     -> Term tyname name a
 mkLet x r bs t = if null bs then t else Let x r bs t
-
--- | Make a 'Var' referencing the given 'VarDecl'.
-mkVar :: a -> VarDecl tyname name a -> Term tyname name a
-mkVar x = Var x . varDeclName
-
--- | Make an iterated application.
-mkIterApp
-    :: a
-    -> Term tyname name a -- ^ @f@
-    -> [Term tyname name a] -- ^@[ x0 ... xn ]@
-    -> Term tyname name a -- ^ @[f x0 ... xn ]@
-mkIterApp x = foldl' (Apply x)
-
--- | Make an iterated instantiation.
-mkIterInst
-    :: a
-    -> Term tyname name a -- ^ @a@
-    -> [Type tyname a] -- ^ @ [ x0 ... xn ] @
-    -> Term tyname name a -- ^ @{ a x0 ... xn }@
-mkIterInst x = foldl' (TyInst x)
-
--- | Lambda abstract a list of names.
-mkIterLamAbs
-    :: a
-    -> [VarDecl tyname name a]
-    -> Term tyname name a
-    -> Term tyname name a
-mkIterLamAbs x args body = foldr (\(VarDecl _ n ty) acc -> LamAbs x n ty acc) body args
-
--- | Type abstract a list of names.
-mkIterTyAbs
-    :: a
-    -> [TyVarDecl tyname a]
-    -> Term tyname name a
-    -> Term tyname name a
-mkIterTyAbs x args body = foldr (\(TyVarDecl _ n k) acc -> TyAbs x n k acc) body args
-
--- | Make an iterated type application.
-mkIterTyApp
-    :: a
-    -> Type tyname a -- ^ @f@
-    -> [Type tyname a] -- ^ @[ x0 ... xn ]@
-    -> Type tyname a -- ^ @[ f x0 ... xn ]@
-mkIterTyApp x = foldl' (TyApp x)
-
--- | Make an iterated function type.
-mkIterTyFun
-    :: a
-    -> [Type tyname a]
-    -> Type tyname a
-    -> Type tyname a
-mkIterTyFun x tys target = foldr (\ty acc -> TyFun x ty acc) target tys
-
--- | Universally quantify a list of names.
-mkIterTyForall
-    :: a
-    -> [TyVarDecl tyname a]
-    -> Type tyname a
-    -> Type tyname a
-mkIterTyForall x args body = foldr (\(TyVarDecl _ n k) acc -> TyForall x n k acc) body args
-
--- | Lambda abstract a list of names.
-mkIterTyLam
-    :: a
-    -> [TyVarDecl tyname a]
-    -> Type tyname a
-    -> Type tyname a
-mkIterTyLam x args body = foldr (\(TyVarDecl _ n k) acc -> TyLam x n k acc) body args

--- a/plutus-ir/src/Language/PlutusIR/Parser.hs
+++ b/plutus-ir/src/Language/PlutusIR/Parser.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Rank2Types        #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Language.PlutusIR.Parser
@@ -8,6 +9,8 @@ module Language.PlutusIR.Parser
     , term
     , typ
     , program
+    , plcTerm
+    , plcProgram
     , Parser
     , ParseError (..)
     , Error
@@ -22,6 +25,7 @@ import           Control.Monad.State          hiding (fail)
 import qualified Language.PlutusCore          as PLC
 import qualified Language.PlutusCore.Constant as PLC
 import           Language.PlutusIR            as PIR
+import qualified Language.PlutusIR.MkPir      as PIR
 import           PlutusPrelude                (prettyText)
 import           Text.Megaparsec              hiding (ParseError, State, parse)
 import qualified Text.Megaparsec              as Parsec
@@ -285,49 +289,51 @@ binding =  inParens $
     <|> (reservedWord "typebind" >> TypeBind <$> getPosition <*> tyVarDecl <*> typ)
     <|> (reservedWord "datatypebind" >> DatatypeBind <$> getPosition <*> datatype)
 
-absTerm :: Parser (Term TyName Name SourcePos)
-absTerm = TyAbs <$> reservedWord "abs" <*> tyVar <*> kind <*> term
+-- A small type wrapper for parsers that are parametric in the type of term they parse
+type Parametric = forall term. PIR.TermLike term TyName Name => Parser (term SourcePos) -> Parser (term SourcePos)
 
-lamTerm :: Parser (Term TyName Name SourcePos)
-lamTerm = LamAbs <$> reservedWord "lam" <*> name <*> typ <*> term
+absTerm :: Parametric
+absTerm tm = PIR.tyAbs <$> reservedWord "abs" <*> tyVar <*> kind <*> tm
 
-conTerm :: Parser (Term TyName Name SourcePos)
-conTerm = Constant <$> reservedWord "con" <*> constant
+lamTerm :: Parametric
+lamTerm tm = PIR.lamAbs <$> reservedWord "lam" <*> name <*> typ <*> tm
 
-iwrapTerm :: Parser (Term TyName Name SourcePos)
-iwrapTerm = IWrap <$> reservedWord "iwrap" <*> typ <*> typ <*> term
+conTerm :: Parametric
+conTerm _tm = PIR.constant <$> reservedWord "con" <*> constant
 
-builtinTerm :: Parser (Term TyName Name SourcePos)
-builtinTerm = Builtin <$> reservedWord "builtin" <*> builtinVar
+iwrapTerm :: Parametric
+iwrapTerm tm = PIR.iWrap <$> reservedWord "iwrap" <*> typ <*> typ <*> tm
 
-unwrapTerm :: Parser (Term TyName Name SourcePos)
-unwrapTerm = Unwrap <$> reservedWord "unwrap" <*> term
+builtinTerm :: Parametric
+builtinTerm _term = PIR.builtin <$> reservedWord "builtin" <*> builtinVar
 
-errorTerm :: Parser (Term TyName Name SourcePos)
-errorTerm = Error <$> reservedWord "error" <*> typ
+unwrapTerm :: Parametric
+unwrapTerm tm = PIR.unwrap <$> reservedWord "unwrap" <*> tm
+
+errorTerm :: Parametric
+errorTerm _tm = PIR.error <$> reservedWord "error" <*> typ
 
 letTerm :: Parser (Term TyName Name SourcePos)
 letTerm = Let <$> reservedWord "let" <*> recursivity <*> some (try binding) <*> term
 
-appTerm :: Parser (Term TyName Name SourcePos)
-appTerm = do
-    pos  <- getPosition
-    fn   <- term
-    args <- some term
-    pure $ foldl' (Apply pos) fn args
+appTerm :: Parametric
+appTerm tm = PIR.mkIterApp <$> getPosition <*> tm <*> some tm
 
-tyInstTerm :: Parser (Term TyName Name SourcePos)
-tyInstTerm = do
-    pos  <- getPosition
-    fn   <- term
-    args <- some typ
-    pure $ foldl' (TyInst pos) fn args
+tyInstTerm :: Parametric
+tyInstTerm tm = PIR.mkIterInst <$> getPosition <*> tm <*> some typ
+
+term' :: Parametric
+term' other = (var >>= (\n -> return $ PIR.var (nameAttribute n) n))
+    <|> (inParens $ absTerm self <|> lamTerm self <|> conTerm self <|> iwrapTerm self <|> builtinTerm self <|> unwrapTerm self <|> errorTerm self <|> other)
+    <|> inBraces (tyInstTerm self)
+    <|> inBrackets (appTerm self)
+    where self = term' other
 
 term :: Parser (Term TyName Name SourcePos)
-term = (var >>= (\n -> return $ Var (nameAttribute n) n))
-    <|> (inParens $ absTerm <|> lamTerm <|> conTerm <|> iwrapTerm <|> builtinTerm <|> unwrapTerm <|> errorTerm <|> letTerm)
-    <|> inBraces tyInstTerm
-    <|> inBrackets appTerm
+term = term' letTerm
+
+plcTerm :: Parser (PLC.Term TyName Name SourcePos)
+plcTerm = term' empty
 
 -- Note that PIR programs do not actually carry a version number
 -- we (optionally) parse it all the same so we can parse all PLC code
@@ -337,5 +343,11 @@ program = whitespace >> do
         p <- reservedWord "program"
         option () $ void version
         Program p <$> term
+    notFollowedBy anyChar
+    return prog
+
+plcProgram :: Parser (PLC.Program TyName Name SourcePos)
+plcProgram = whitespace >> do
+    prog <- inParens $ PLC.Program <$> reservedWord "program" <*> version <*> plcTerm
     notFollowedBy anyChar
     return prog

--- a/plutus-ir/src/Language/PlutusIR/Parser.hs
+++ b/plutus-ir/src/Language/PlutusIR/Parser.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE Rank2Types        #-}
+{-# LANGUAGE RankNTypes        #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Language.PlutusIR.Parser

--- a/plutus-ir/src/Language/PlutusIR/Transform/ThunkRecursions.hs
+++ b/plutus-ir/src/Language/PlutusIR/Transform/ThunkRecursions.hs
@@ -173,7 +173,7 @@ constructThunkedLet ann okay needThunking body = do
     -- as we rename before typechecking.
     argName <- liftQuote $ freshName ann "arg"
     let unit = ann <$ Unit.unit
-        unitval = ann <$ embedIntoIR Unit.unitval
+        unitval = ann <$ Unit.unitval
 
     {-
     We need several pieces, and it is convenient to construct them simultaneously:

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Builtins.hs
@@ -351,7 +351,7 @@ wrapIntRel arity term = do
     converter <- scottBoolToHaskellBool
 
     pure $
-        PIR.mkIterLamAbs () args $
+        PIR.mkIterLamAbs args $
         PIR.Apply () converter (PIR.mkIterApp () term (fmap (PIR.mkVar ()) args))
 
 mkIntRel :: Converting m => PLC.BuiltinName -> m PIRTerm
@@ -368,7 +368,7 @@ wrapBsRel arity term = do
     converter <- scottBoolToHaskellBool
 
     pure $
-        PIR.mkIterLamAbs () args $
+        PIR.mkIterLamAbs args $
         PIR.Apply () converter (PIR.mkIterApp () term (fmap (PIR.mkVar ()) args))
 
 mkBsRel :: Converting m => PLC.BuiltinName -> m PIRTerm
@@ -394,5 +394,5 @@ wrapUnitFun argTy term = do
     converter <- scottUnitToHaskellUnit
 
     pure $
-        PIR.mkIterLamAbs () [arg] $
+        PIR.mkIterLamAbs [arg] $
         PIR.Apply () converter (PIR.Apply () term (PIR.mkVar () arg))

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
@@ -83,7 +83,7 @@ convLiteral = \case
         in convExpr listExpr
     GHC.MachChar c     ->
         case PLC.makeDynamicBuiltin c of
-            Just t  -> pure $ PIR.embedIntoIR t
+            Just t  -> pure $ PIR.embed t
             Nothing -> throwPlain $ UnsupportedError "Conversion of character failed"
     GHC.LitInteger _ _ -> throwPlain $ UnsupportedError "Literal (unbounded) integer"
     GHC.MachWord _     -> throwPlain $ UnsupportedError "Literal word"

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
@@ -267,7 +267,7 @@ convAlt mustDelay instArgTys (alt, vars, body) = withContextM (sdToTxt $ "Creati
         -- need to consume the args
         argTypes <- mapM convType instArgTys
         argNames <- forM [0..(length argTypes -1)] (\i -> safeFreshName () $ "default_arg" <> (T.pack $ show i))
-        pure $ PIR.mkIterLamAbs () (zipWith (PIR.VarDecl ()) argNames argTypes) body'
+        pure $ PIR.mkIterLamAbs (zipWith (PIR.VarDecl ()) argNames argTypes) body'
     -- We just package it up as a lambda bringing all the
     -- vars into scope whose body is the body of the case alternative.
     -- See Note [Iterated abstraction and application]

--- a/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
@@ -40,6 +40,7 @@ import           Language.PlutusCore.Quote
 import qualified Language.PlutusIR                      as PIR
 import qualified Language.PlutusIR.Compiler             as PIR
 import qualified Language.PlutusIR.Compiler.Definitions as PIR
+import qualified Language.PlutusIR.MkPir                as PIR
 import qualified Language.PlutusIR.Optimizer.DeadCode   as PIR
 
 import           Language.Haskell.TH.Syntax             as TH
@@ -71,7 +72,7 @@ data CompiledCode a = CompiledCode {
 -- Note that we do *not* have a TypeablePlc instance, since we don't know what the type is. We could in principle store it after the plugin
 -- typechecks the code, but we don't currently.
 instance Lift.Lift (CompiledCode a) where
-    lift (getPlc -> (PLC.Program () _ body)) = PIR.embedIntoIR <$> PLC.rename body
+    lift (getPlc -> (PLC.Program () _ body)) = PIR.embed <$> PLC.rename body
 
 getSerializedPlc :: CompiledCode a -> BSL.ByteString
 getSerializedPlc = BSL.fromStrict . serializedPlc


### PR DESCRIPTION
We have a `TermLike` class now so we can delete a bunch of code in `MkPir.hs` and reuse the entirety of the PIR parser to parse PLC code.