### PR TITLE
Finally remove workaround for GHC bug

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -97,8 +97,6 @@ let
       enableHaddockHydra enableBenchmarks fasterBuild enableDebugging
       enableSplitCheck customOverlays pkgsGenerated;
 
-      inherit (pkgsGenerated) ghc;
-
       filter = localLib.isPlutus;
       filterOverrides = {
         splitCheck = localButNot [

--- a/iohk-nix.json
+++ b/iohk-nix.json
@@ -1,6 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "9071724eb3e2546ba188e9a7bc3c6b32bfeea22a",
-  "sha256": "1cm11xvpjfzljgjdkln79s58g91fgy9p6s4yih8ikcqdp906bsvb",
+  "rev": "7ee8b2e14f5e8e0d3cfd98f6ec0a3e43aac94fc9",
+  "date": "2019-03-19T20:09:18+08:00",
+  "sha256": "1qf7fc0v3fwns5knndr5ad0fdqgrv4a2r5szdfadk6sz21zx4j2k",
   "fetchSubmodules": false
 }

--- a/plutus-playground-server/src/Playground/Interpreter.hs
+++ b/plutus-playground-server/src/Playground/Interpreter.hs
@@ -144,11 +144,6 @@ runghcOpts =
     , "-XTemplateHaskell"
     , "-XScopedTypeVariables"
     , "-O0"
-    -- FIXME: workaround for https://ghc.haskell.org/trac/ghc/ticket/16228
-    -- This appears to sometimes be necessary and sometimes not be, depending
-    -- on apparently unrelated changes in the packages this depends on. I'm
-    -- blaming the GHC bug.
-    , "-package plutus-tx"
     ]
 
 jsonToString :: ToJSON a => a -> String


### PR DESCRIPTION
My GHC PR is approved (not merged yet, but I expect it will be), and the patch is applied in iohk-nix.
The nixpkgs PR is merged upstream, and the patch is applied in our nixpkgs fork.

So after updating `iohk-nix` we can now delete the workaround for good!