### PR TITLE
plutus-contract-exe: Init

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -24,6 +24,7 @@ let
   # List of all plutus pkgs. This is used for `isPlutus` filter and `mapTestOn`
   plutusPkgList = [
     "language-plutus-core"
+    "plutus-contract-exe"
     "plutus-core-interpreter"
     "plutus-playground-server"
     "plutus-playground-lib"

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -56610,6 +56610,51 @@ description = "Haskell bindings to Plotly.js";
 license = stdenv.lib.licenses.mit;
 
 }) {};
+"plutus-contract-exe" = callPackage
+({
+  mkDerivation
+, aeson
+, base
+, containers
+, lens
+, plutus-use-cases
+, servant
+, servant-server
+, stdenv
+, text
+, wallet-api
+, warp
+}:
+mkDerivation {
+
+pname = "plutus-contract-exe";
+version = "0.1.0.0";
+src = .././plutus-contract-exe;
+isLibrary = true;
+isExecutable = true;
+libraryHaskellDepends = [
+aeson
+base
+text
+wallet-api
+];
+executableHaskellDepends = [
+aeson
+base
+containers
+lens
+plutus-use-cases
+servant
+servant-server
+text
+wallet-api
+warp
+];
+doHaddock = false;
+homepage = "https://github.com/iohk/plutus#readme";
+license = stdenv.lib.licenses.asl20;
+
+}) {};
 "plutus-core-interpreter" = callPackage
 ({
   mkDerivation

--- a/plutus-contract-exe/LICENSE
+++ b/plutus-contract-exe/LICENSE
@@ -1,0 +1,53 @@
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/plutus-contract-exe/NOTICE
+++ b/plutus-contract-exe/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2019 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/plutus-contract-exe/README.md
+++ b/plutus-contract-exe/README.md
@@ -1,0 +1,22 @@
+# plutus-contract-exe
+
+A library for turning Plutus contracts into executables that implement the contract endpoints as an HTTP interface.
+
+The `/examples` folder contains some hand-written examples for the use cases we currently have.
+
+## Building the examples
+
+1. `nix build -f default.nix localPackages.plutus-contract-exe` 
+
+Alternatively:
+
+1. `cd plutus-contract-exe`
+2. `nix-shell`
+3. `cabal build <name-of-example>` for example `cabal build contract-exe-guessing-game`
+
+## Docker
+
+To build the docker image for the guessing game contract:
+
+1. `nix build -f default.nix plutus-contract-exe.docker`
+2. `docker load -i result`

--- a/plutus-contract-exe/examples/guessing-game/Main.hs
+++ b/plutus-contract-exe/examples/guessing-game/Main.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeOperators              #-}
+-- | Contract interface for the guessing game
+module Main where
+
+import           Control.Lens                                  (at, (^.))
+import qualified Data.Aeson                                    as Aeson
+import qualified Data.Map                                      as Map
+import           Data.Maybe                                    (fromMaybe)
+import           Data.Proxy                                    (Proxy (Proxy))
+import           Data.Text                                     (Text)
+import           GHC.Generics                                  (Generic)
+import           Network.Wai.Handler.Warp                      (run)
+import           Servant                                       ((:<|>) ((:<|>)), (:>), Get, JSON, Post, ReqBody)
+import           Servant.Server                                (Application, Server, layout, serve)
+
+import           Language.Plutus.Contract                      (ContractOut (ContractFinished, StartWatching, SubmitTransaction),
+                                                                LedgerUpdate (OutputAdded, OutputSpent), mkUnbalancedTx)
+import           Language.PlutusTx.Coordination.Contracts.Game (gameAddress, gameDataScript, gameRedeemerScript,
+                                                                gameValidator)
+import qualified Ledger                                        as L
+import           Ledger.Ada                                    (Ada)
+import qualified Ledger.Ada                                    as Ada
+import qualified Wallet.Emulator.AddressMap                    as AM
+
+-- | Parameters for the "lock" endpoint
+data LockParams = LockParams
+    { secretWord :: String
+    , amount     :: Ada
+    }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
+
+--  | Parameters for the "guess" endpoint
+newtype GuessParams = GuessParams
+    { guess :: String
+    }
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (Aeson.FromJSON, Aeson.ToJSON)
+
+newtype GameState = GameState
+    { interestingAddresses :: AM.AddressMap
+    }
+    deriving stock (Show, Generic)
+    deriving newtype (Aeson.FromJSON, Aeson.ToJSON)
+
+initialState :: GameState
+initialState = GameState mempty
+
+type GuessingGameAPI =
+
+  --  All endpoints (except layout) use the POST method to supply parameters in
+  --  the request body. They expect the current 'GameState' and an
+  --  endpoint-specific argument, and return the new 'GameState' and a list of
+  --  'ContractOut' events.
+
+  --  The first two endpoints are the same for all contracts:
+
+  -- ledger-update, informing the contract about changes to the ledger state
+    "ledger-update" :> ReqBody '[JSON] (GameState, LedgerUpdate) :> Post '[JSON] (GameState, [ContractOut]) -- POST /ledger-update
+
+  -- initialise, a sequence of 'ContractOut' events that need to be processed
+  -- when the contract is first started.
+    :<|> "initialise" :> Get '[JSON] (GameState, [ContractOut])
+
+  -- The following two endpoints are specific to this example (guessing game)
+
+  -- lock some funds
+    :<|> "lock" :> ReqBody '[JSON] (GameState, LockParams) :> Post '[JSON] (GameState, [ContractOut]) -- POST /lock
+
+  -- make a guess
+    :<|> "guess" :> ReqBody '[JSON] (GameState, GuessParams) :> Post '[JSON] (GameState, [ContractOut]) -- POST /guess
+
+  -- returns a textual description of the API (this is only a stand-in until
+  -- we have an actual schema endpoint)
+    :<|> "layout" :> Get '[JSON] Text
+
+server :: Server GuessingGameAPI
+server = ledgerUpdate :<|> initialise :<|> lock :<|> guess_ :<|> l
+    where
+
+        -- To initialise the game contract we start watching the game address
+        -- TODO: We don't need to watch the game address if we are the
+        --       organisers of the game. (See note [ContractFinished event] in
+        --       Language.Plutus.Contract). Maybe we need one initialise
+        --       endpoint per role?
+        initialise          = pure (initialState, [StartWatching gameAddress])
+
+        -- When the outputs at the address change we call 'AM.updateAddresses'
+        -- to update the 'GameState'
+        ledgerUpdate (GameState mp, u) =
+            let mp' = case u of
+                        OutputAdded _ tx -> AM.updateAddresses tx mp
+                        OutputSpent _ tx -> AM.updateAddresses tx mp
+                        _                -> mp
+            in
+                pure (GameState mp', [])
+
+        -- The lock endpoint. Produces a transaction with a single
+        -- pay-to-script output, locked by the game validator using
+        -- the hash of the secret word.
+        lock (s, LockParams secret amt) =
+          let
+              vl         = Ada.toValue amt
+              dataScript = gameDataScript secret
+              output = L.TxOutOf gameAddress vl (L.PayToScript dataScript)
+              tx     = mkUnbalancedTx [] [output]
+          in
+            -- submit transaction, then this contract instance is finished
+            -- see note [ContractFinished event] in Language.Plutus.Contract
+            pure (s, [SubmitTransaction tx, ContractFinished])
+
+        -- The guess endpoint. Produces a transaction that spends all known
+        -- outputs at the game address using the guess
+        guess_ (GameState mp, GuessParams gss)       =
+            let
+                outputs  = fmap fst . Map.toList . fromMaybe Map.empty $ mp ^. at gameAddress
+                redeemer = gameRedeemerScript gss
+                inp      = (\o -> L.scriptTxIn o gameValidator redeemer) <$> outputs
+                tx       = mkUnbalancedTx inp []
+            in
+                pure (GameState mp, [SubmitTransaction tx, ContractFinished])
+
+        l = pure (layout (Proxy @GuessingGameAPI))
+
+app :: Application
+app = serve (Proxy @GuessingGameAPI) server
+
+-- Run the server on port 8080
+main :: IO ()
+main = run 8080 app

--- a/plutus-contract-exe/plutus-contract-exe.cabal
+++ b/plutus-contract-exe/plutus-contract-exe.cabal
@@ -1,0 +1,72 @@
+cabal-version: 2.2
+name: plutus-contract-exe
+version: 0.1.0.0
+license: Apache-2.0
+license-files: 
+  LICENSE
+  NOTICE
+maintainer: jann.mueller@iohk.io
+author: Jann Müller
+homepage: https://github.com/iohk/plutus#readme
+bug-reports: https://github.com/iohk/plutus/issues
+description:
+    Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>
+build-type: Simple
+
+source-repository head
+    type: git
+    location: https://github.com/iohk/plutus
+
+common lang
+    default-language: Haskell2010
+    default-extensions: ExplicitForAll ScopedTypeVariables
+                        DeriveGeneric StandaloneDeriving DeriveLift
+                        GeneralizedNewtypeDeriving DeriveFunctor DeriveFoldable
+                        DeriveTraversable
+    other-extensions: DeriveAnyClass FlexibleContexts FlexibleInstances
+                      MultiParamTypeClasses TypeFamilies OverloadedStrings
+                      MonadComprehensions ConstrainedClassMethods TupleSections GADTs
+                      RankNTypes TemplateHaskell QuasiQuotes TypeApplications
+                      ExistentialQuantification
+    ghc-options: -Wall -Wnoncanonical-monad-instances
+                 -Wincomplete-uni-patterns -Wincomplete-record-updates
+                 -Wredundant-constraints -Widentities
+
+flag development
+    description:
+        Enable `-Werror`
+    default: False
+    manual: True
+
+library
+    import: lang
+    exposed-modules:
+        Language.Plutus.Contract
+    hs-source-dirs: src
+    build-depends:
+        wallet-api -any
+    build-depends:
+        aeson -any,
+        base >=4.7 && <5,
+        text -any,
+
+executable contract-exe-guessing-game
+    import: lang
+    main-is: Main.hs
+    hs-source-dirs: examples/guessing-game
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
+                 -Wincomplete-uni-patterns -Wincomplete-record-updates
+                 -Wmissing-import-lists
+    build-depends:
+        plutus-contract-exe -any,
+        plutus-use-cases -any,
+        wallet-api -any,
+    build-depends:
+        aeson -any,
+        base >=4.7 && <5,
+        servant -any,
+        servant-server -any,
+        text -any,
+        warp -any,
+        lens -any,
+        containers -any,

--- a/plutus-contract-exe/shell.nix
+++ b/plutus-contract-exe/shell.nix
@@ -1,0 +1,1 @@
+(import ../. {}).shellTemplate "plutus-contract-exe"

--- a/plutus-contract-exe/src/Language/Plutus/Contract.hs
+++ b/plutus-contract-exe/src/Language/Plutus/Contract.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-
+    Event-based interface between contract executables and the app platform and
+    (by extension) the wallet.
+
+    Two types of events are defined:
+
+    1. 'ContractOut'. Events produced by the contract for consumption by app
+       platform and wallet. Includes transactions and instructions to start
+       watching interesting addresses on the ledger.
+
+    2. 'LedgerUpdate'. Events that inform the contract about changes to the
+       ledger state.
+
+    Contracts will offer an HTTP interface with the following routes.
+
+    * 1 route per contract endpoint (as defined by contract author)
+    * 1 route for submitting 'LedgerUpdate' events
+
+    NOTE: With this design, there are two classes of input events, only one of
+          which has a proper data type: Input events from the ledger (in the
+          form of 'LedgerUpdate') and input events from the user (in the form
+          of HTTP endpoints).
+
+          In my opinion it would be cleaner to add a
+
+          'ContractEndpoint EndpointArgs'
+
+          constructor to 'LedgerUpdate' (and rename the type) that captures all
+          contract endpoints activated by the user. I think this will make
+          testing a lot easier. But we need to think about the 'EndpointArgs'
+          type and how it maps to the actual contract endpoints.
+-}
+module Language.Plutus.Contract(
+    ContractOut(..),
+    LedgerUpdate(..),
+    UnbalancedTx(..),
+    mkUnbalancedTx
+    ) where
+
+import qualified Data.Aeson   as Aeson
+import           Data.Text    (Text)
+import           GHC.Generics (Generic)
+
+import qualified Ledger       as L
+import           Ledger.Value as V
+
+-- | An unsigned and potentially unbalanced transaction, as returned by
+--   a contract endpoint.
+data UnbalancedTx = UnbalancedTx
+        { utxInputs  :: [L.TxIn]
+        , utxOutputs :: [L.TxOut]
+        , utxForge   :: V.Value
+        }
+
+        deriving stock (Eq, Ord, Show, Generic)
+        deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
+
+-- | Make an unbalanced transaction that does not forge any value.
+mkUnbalancedTx :: [L.TxIn] -> [L.TxOut] -> UnbalancedTx
+mkUnbalancedTx ins outs = UnbalancedTx ins outs V.zero
+
+{- note [Unbalanced transactions]
+
+To turn an 'UnbalancedTx' into a valid transaction that can be submitted to the
+network, the contract backend needs to
+
+* Balance it.
+  If the total value of `utxInputs` + the `txForge` field is
+  greater than the total value of `utxOutput`, then one or more public key
+  outputs need to be added. How many and what addresses they are is up
+  to the wallet (probably configurable).
+  If the total balance `utxInputs` + the `txForge` field is less than
+  the total value of `utxOutput`, then one or more public key inputs need
+  to be added (and potentially some outputs for the change)
+
+* Compute fees.
+  Once the final size of the transaction is known, the fees for the transaction
+  can be computed. The transaction fee needs to be paid for with additional
+  inputs so I assume that this step and the previous step will be combined.
+
+  Also note that even if the 'UnbalancedTx' that we get from the contract
+  endpoint happens to be balanced already, we still need to add fees to it. So
+  we can't skip the balancing & fee computation step.
+
+* Sign it.
+  The signing process needs to provide signatures for all public key
+  inputs in the balanced transaction.
+
+
+-}
+
+{- note [ContractFinished event]
+
+The 'ContractFinished' event signals that this *instance* of the contract is
+finished. This means that no more interactions with the instance are possible.
+It is an opportunity for the contract backend to delete all triggers associated
+with the instance, and to update the UI (disable/archive/etc)
+
+Note that the 'ContractFinished' does not say anything about unspent outputs at
+the contract address. There may still be unspent outputs at the address, but the
+user cannot do anything with them.
+
+For example, the game contract emits a 'ContractFinished' event immediately
+after running 'lock' endpoint. So the contract is finished for the initiator of
+the game. Participants in the game may still submit guesses etc.
+
+('ContractFinished' seems to be tied closely to contract roles, and we
+should think about this some more. This is the difference between the global
+(ie. blockchain/utxo set) view and the local (what can that particular role do)
+view of a contract.)
+
+-}
+
+
+-- | Events that are produced by contract endpoints.
+data ContractOut =
+      SubmitTransaction UnbalancedTx
+      -- ^ Produce an 'UnbalancedTx'. See note [Unbalanced transactions]
+
+      | StartWatching L.Address
+      -- ^ Start watching an address. This adds the address to the set of
+      -- "interesting addresses" of this contract instance.
+
+      | ContractError Text
+      -- ^ An error occurred during contract execution.
+      --   NOTE: Should we also set the appropriate HTTP status code?
+
+      | ContractFinished
+      -- ^ Execution of the contract has ended. No further ledger updates are
+      --   required and no user actions are possible. All triggers associated
+      --   with this contract instance can be deleted. See note
+      --   [ContractFinished event]
+
+      deriving stock (Eq, Ord, Show, Generic)
+      deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
+
+-- | Events that inform the contract about changes to the ledger state.
+data LedgerUpdate =
+    OutputSpent L.TxOutRef L.Tx
+    -- ^ An output from one of the interesting addresses was spent. Includes
+    --   the transaction that spent the output.
+    --   The transaction *spends* the UTXO referenced by 'L.TxOutRef'.
+
+    | OutputAdded L.TxOutRef L.Tx
+    -- ^ An output was produced to one of the interesting addresses.
+    --   The transaction *produces* the UTXO referenced by 'L.TxOutRef'
+
+    -- NOTE: A transaction that spends an output from an interesting address and
+    --       produces a new output to that address will trigger two events:
+    --       'OutputSpent' and 'OutputAdded' (with the same 'L.Tx'
+    --       argument but with different 'L.TxOutRef' arguments).
+    --
+    --       TODO: Does it make sense to have a 3rd event type for this
+    --       situation?
+
+    | SlotChange L.Slot
+    -- ^ The current slot has changed.
+
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)

--- a/release.nix
+++ b/release.nix
@@ -41,12 +41,13 @@ let
     # At least the client is broken on darwin for some yarn reason
     meadow = lib.mapAttrs (_: _: linux) 
         # don't build the docker image on hydra
-        (lib.filterAttrs (n: v: n != "docker") packageSet.meadow);  
+        (lib.filterAttrs (n: v: n != "docker") packageSet.meadow);
     # texlive is broken on darwin at our nixpkgs pin
     docs = lib.mapAttrs (_: _: linux) packageSet.docs;  
     tests = lib.mapAttrs (_: _: supportedSystems) packageSet.tests;  
     dev.packages = lib.mapAttrs (_: _: supportedSystems) packageSet.dev.packages;  
-    dev.scripts = lib.mapAttrs (_: _: supportedSystems) packageSet.dev.scripts;  
+    dev.scripts = lib.mapAttrs (_: _: supportedSystems) packageSet.dev.scripts; 
+
   }; 
   
   testJobsets = mapTestOn systemMapping;

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,7 @@ packages:
 - plutus-playground-server
 - plutus-playground-lib
 - plutus-tutorial
+- plutus-contract-exe
 
 # Needs some patches, but upstream seems to be fairly dead (no activity in > 1 year)
 - location:
@@ -49,6 +50,8 @@ flags:
   plutus-core-interpreter:
     development: true
   plutus-playground-server:
+    development: true
+  plutus-contract-exe:
     development: true
 extra-package-dbs: []
 nix:

--- a/wallet-api/src/Wallet/API.hs
+++ b/wallet-api/src/Wallet/API.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE ConstraintKinds    #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -136,7 +137,8 @@ data EventTriggerF f =
     | TNever
     | TSlotRange !SlotRange
     | TFundsAtAddress !Address !(Interval Value)
-    deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving stock (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
+    deriving anyclass (FromJSON, ToJSON)
 
 $(deriveEq1 ''EventTriggerF)
 $(deriveOrd1 ''EventTriggerF)
@@ -251,7 +253,8 @@ instance FromJSON WalletAPIError
 instance ToJSON WalletAPIError
 
 newtype WalletLog = WalletLog { getWalletLog :: [Text] }
-    deriving (Eq, Ord, Show, Generic, Semigroup, Monoid)
+    deriving stock (Eq, Ord, Show, Generic)
+    deriving newtype (Semigroup, Monoid)
 
 instance FromJSON WalletLog
 instance ToJSON WalletLog


### PR DESCRIPTION
Add 'plutus-contract-exe' with a sample executable contract

@rhyslbw @Sam-Jeston  The most important part is the event types in plutus-contract-exe/src/Language/Plutus/Contract.hs (see comments in that file). 

Things to consider:

* If we have the event based interface, do we need contract-specific HTTP endpoints at all? There could also be another event for "activating contract endpoint"
* Where should the trigger mechanism be implemented? If the contract is notified of changes to the addresses it is interested in, and of slots passing, then it could check the more complex conditions itself (by that I mean the `EventTrigger` type in [`Wallet.API`](https://github.com/input-output-hk/plutus/blob/master/wallet-api/src/Wallet/API.hs#L120))
* Checkpoints & merging of event lists - not implemented in this PR
