### PR TITLE
Seriously rework release.nix, include dev scripts for all platforms

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -221,7 +221,7 @@ let
 
     dev = rec {
       packages = localLib.getPackages {
-        inherit (self) haskellPackages; filter = name: builtins.elem name [ "cabal-install" "ghcid" ];
+        inherit (self) haskellPackages; filter = name: builtins.elem name [ "cabal-install" ];
       };
       scripts = {
         inherit (localLib) regeneratePackages fixStylishHaskell;

--- a/default.nix
+++ b/default.nix
@@ -219,12 +219,17 @@ let
       };
     };
 
-    devPackages = localLib.getPackages {
-      inherit (self) haskellPackages; filter = name: builtins.elem name [ "cabal-install" "ghcid" ];
+    dev = rec {
+      packages = localLib.getPackages {
+        inherit (self) haskellPackages; filter = name: builtins.elem name [ "cabal-install" "ghcid" ];
+      };
+      scripts = {
+        inherit (localLib) regeneratePackages fixStylishHaskell;
+      };
+      withDevTools = env: env.overrideAttrs (attrs: { nativeBuildInputs = attrs.nativeBuildInputs ++ [ packages.cabal-install packages.ghcid ]; });
+      shellTemplate = name: withDevTools haskellPackages."${name}".env;
     };
 
-    withDevTools = env: env.overrideAttrs (attrs: { nativeBuildInputs = attrs.nativeBuildInputs ++ [ devPackages.cabal-install devPackages.ghcid ]; });
-    shellTemplate = name: withDevTools haskellPackages."${name}".env;
   });
 
 

--- a/default.nix
+++ b/default.nix
@@ -221,10 +221,29 @@ let
 
     dev = rec {
       packages = localLib.getPackages {
-        inherit (self) haskellPackages; filter = name: builtins.elem name [ "cabal-install" ];
+        inherit (self) haskellPackages; filter = name: builtins.elem name [ "cabal-install" "stylish-haskell" ];
       };
       scripts = {
-        inherit (localLib) regeneratePackages fixStylishHaskell;
+        inherit (localLib) regeneratePackages;
+
+        fixStylishHaskell = pkgs.writeScript "fix-stylish-haskell" ''
+          ${pkgs.git}/bin/git diff > pre-stylish.diff
+          ${pkgs.fd}/bin/fd \
+            --extension hs \
+            --exclude '*/dist/*' \
+            --exclude '*/docs/*' \
+            --exec ${packages.stylish-haskell}/bin/stylish-haskell -i {}
+          ${pkgs.git}/bin/git diff > post-stylish.diff
+          diff pre-stylish.diff post-stylish.diff > /dev/null
+          if [ $? != 0 ]
+          then
+            echo "Changes by stylish have been made. Please commit them."
+          else
+            echo "No stylish changes were made."
+          fi
+          rm pre-stylish.diff post-stylish.diff
+          exit
+        '';
       };
       withDevTools = env: env.overrideAttrs (attrs: { nativeBuildInputs = attrs.nativeBuildInputs ++ [ packages.cabal-install packages.ghcid ]; });
       shellTemplate = name: withDevTools haskellPackages."${name}".env;

--- a/lib.nix
+++ b/lib.nix
@@ -46,25 +46,6 @@ let
 
   regeneratePackages = iohkNix.stack2nix.regeneratePackages { hackageSnapshot = "2019-02-28T09:58:14Z"; };
 
-  fixStylishHaskell = pkgs.writeScript "fix-stylish-haskell" ''
-    ${pkgs.git}/bin/git diff > pre-stylish.diff
-    ${pkgs.fd}/bin/fd \
-      --extension hs \
-      --exclude '*/dist/*' \
-      --exclude '*/docs/*' \
-      --exec ${pkgs.haskellPackages.stylish-haskell}/bin/stylish-haskell -i {}
-    ${pkgs.git}/bin/git diff > post-stylish.diff
-    diff pre-stylish.diff post-stylish.diff > /dev/null
-    if [ $? != 0 ]
-    then
-      echo "Changes by stylish have been made. Please commit them."
-    else
-      echo "No stylish changes were made."
-    fi
-    rm pre-stylish.diff post-stylish.diff
-    exit
-  '';
-
   comp = f: g: (v: f(g v));
 in lib // {
   inherit 
@@ -74,7 +55,6 @@ in lib // {
   plutusHaskellPkgList 
   plutusPkgList 
   regeneratePackages 
-  fixStylishHaskell
   nixpkgs 
   pkgs
   comp;

--- a/pkgs/generate.sh
+++ b/pkgs/generate.sh
@@ -6,4 +6,4 @@ readlink=$(nix-build -A coreutils '<nixpkgs>')/bin/readlink
 
 set -euo pipefail
 cd "$(dirname -- "$(${readlink} -f -- "${BASH_SOURCE[0]}")")"
-exec "$(nix-build ../default.nix -A localLib.regeneratePackages)" "default.nix" "$@"
+exec "$(nix-build ../default.nix -A dev.scripts.regeneratePackages)" "default.nix" "$@"

--- a/release.nix
+++ b/release.nix
@@ -46,8 +46,9 @@ in pkgs.lib.fix (jobsets:  mapped // {
         allLinux = x: map (system: x.${system}) [ "x86_64-linux" ];
         all = x: map (system: x.${system}) supportedSystems;
       in
-    [
-      (builtins.concatLists (map lib.attrValues (all jobsets.all-plutus-tests)))
-    ] ++ (builtins.attrValues jobsets.tests) ++ (builtins.attrValues jobsets.docs) ++ [jobsets.plutus-playground.client];
+      [ (builtins.concatLists (map lib.attrValues (all jobsets.all-plutus-tests))) ] 
+      ++ (builtins.attrValues jobsets.tests) 
+      ++ (builtins.attrValues jobsets.docs) 
+      ++ [ jobsets.plutus-playground.client ];
   });
 })

--- a/release.nix
+++ b/release.nix
@@ -3,8 +3,10 @@ let
   fixedNixpkgs = localLib.nixpkgs;
   nixpkgs = import fixedNixpkgs { };
   lib = nixpkgs.lib;
+  linux = ["x86_64-linux"];
+  darwin = ["x86_64-darwin"];
 in
-  { supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
+  { supportedSystems ? linux ++ darwin
   , scrubJobs ? true
   , fasterBuild ? false
   , skipPackages ? []
@@ -24,7 +26,7 @@ let
 
   # This is a mapping from attribute paths to systems. So it needs to mirror the structure of the
   # attributes in default.nix exactly
-  systemMapping = supportedSystems: {
+  systemMapping = {
     localPackages = 
       # Due to the magical split test machinery, packages that have a 'testdata' attribute should
       # have their tests run via the 'testrun' derivation. I don't know how to *also* have a mapping
@@ -32,17 +34,22 @@ let
       # the tests will depend on the main package so that's okay.
       lib.mapAttrs (n: p: if p ? testdata then { testrun = supportedSystems; } else supportedSystems)
          packageSet.localPackages;
-    plutus-playground = lib.mapAttrs (_: _: supportedSystems) 
+    # At least the client is broken on darwin for some yarn reason
+    plutus-playground = lib.mapAttrs (_: _: linux) 
+        # don't build the docker image on hydra
         (lib.filterAttrs (n: v: n != "docker") packageSet.plutus-playground);  
-    meadow = lib.mapAttrs (_: _: supportedSystems) 
+    # At least the client is broken on darwin for some yarn reason
+    meadow = lib.mapAttrs (_: _: linux) 
+        # don't build the docker image on hydra
         (lib.filterAttrs (n: v: n != "docker") packageSet.meadow);  
-    docs = lib.mapAttrs (_: _: supportedSystems) packageSet.docs;  
+    # texlive is broken on darwin at our nixpkgs pin
+    docs = lib.mapAttrs (_: _: linux) packageSet.docs;  
     tests = lib.mapAttrs (_: _: supportedSystems) packageSet.tests;  
     dev.packages = lib.mapAttrs (_: _: supportedSystems) packageSet.dev.packages;  
     dev.scripts = lib.mapAttrs (_: _: supportedSystems) packageSet.dev.scripts;  
   }; 
   
-  testJobsets = mapTestOn (systemMapping supportedSystems);
+  testJobsets = mapTestOn systemMapping;
 
   # Recursively collect all jobs (derivations) in a jobset 
   allJobs = jobset: lib.collect lib.isDerivation jobset;

--- a/shell.nix
+++ b/shell.nix
@@ -1,33 +1,7 @@
 { system ? builtins.currentSystem
 , config ? {}
 , localPackages ? import ./. { inherit config system; }
-, pkgs ? localPackages.pkgs
 }:
-
-let
-  localLib = import ./lib.nix { inherit config system; };
-  fixStylishHaskell = pkgs.stdenv.mkDerivation {
-    name = "fix-stylish-haskell";
-    buildInputs = with pkgs; [ haskellPackages.stylish-haskell git fd ];
-    shellHook = ''
-      git diff > pre-stylish.diff
-      fd --extension hs --exclude '*/dist/*' --exclude '*/docs/*' --exec stylish-haskell -i {}
-      git diff > post-stylish.diff
-      diff pre-stylish.diff post-stylish.diff > /dev/null
-      if [ $? != 0 ]
-      then
-        echo "Changes by stylish have been made. Please commit them."
-      else
-        echo "No stylish changes were made."
-      fi
-      rm pre-stylish.diff post-stylish.diff
-      exit
-    '';
-  };
-  shell = localPackages.withDevTools (localPackages.haskellPackages.shellFor {
-    packages = p: (map (x: p.${x}) localLib.plutusHaskellPkgList);
-  });
-
-in shell // {
-  inherit fixStylishHaskell;
-}
+localPackages.dev.withDevTools (localPackages.haskellPackages.shellFor {
+    packages = p: (map (x: p.${x}) localPackages.localLib.plutusHaskellPkgList);
+})


### PR DESCRIPTION
It's jolly annoying when Hydra builds all our packages but doesn't build the dependencies of some of the dev scripts you use. Similarly, although the `hlint` test will pass on darwin iff it passes on linux, running it on both means that the dependencies are definitely in the cache for local use.

The solution to this is conceptually obvious: add them to `release.nix`. However, in practice in the process of understanding what on Earth was going on in there I more or less rewrote it to something that makes more sense.

However, we'll have to see what Hydra makes of it...