### PR TITLE
refactor playground errors to make them more generic

### DIFF
--- a/interpreter/interpreter.cabal
+++ b/interpreter/interpreter.cabal
@@ -41,6 +41,8 @@ library
         temporary -any,
         text -any,
         time -any,
+        time-out -any,
+        time-units -any,
         transformers -any,
         unordered-containers -any,
         wai -any,

--- a/interpreter/src/Language/Haskell/Interpreter.hs
+++ b/interpreter/src/Language/Haskell/Interpreter.hs
@@ -1,11 +1,12 @@
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-module Language.Haskell.Interpreter (runghc, CompilationError(..)) where
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+module Language.Haskell.Interpreter (runghc, CompilationError(..), InterpreterError(..), SourceCode(..), avoidUnsafe) where
 
 import           Control.Exception         (IOException)
 import           Control.Monad             (unless)
@@ -16,6 +17,7 @@ import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.State (StateT, evalStateT, get, put)
 import           Control.Newtype.Generics  (Newtype)
 import qualified Control.Newtype.Generics  as Newtype
+import           Control.Timeout           (timeout)
 import           Data.Aeson                (FromJSON, ToJSON)
 import           Data.Bifunctor            (second)
 import           Data.Maybe                (fromMaybe)
@@ -24,6 +26,7 @@ import           Data.Text                 (Text)
 import qualified Data.Text                 as Text
 import qualified Data.Text.Internal.Search as Text
 import qualified Data.Text.IO              as Text
+import           Data.Time.Units           (TimeUnit)
 import           GHC.Generics              (Generic)
 import           System.Directory          (removeFile)
 import           System.Environment        (lookupEnv)
@@ -43,6 +46,17 @@ data CompilationError
     deriving stock (Show, Eq, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
+data InterpreterError
+    = CompilationErrors [CompilationError]
+    | TimeoutError Text
+    deriving stock (Show, Eq, Generic)
+    deriving anyclass (ToJSON, FromJSON)
+
+newtype SourceCode = SourceCode Text
+   deriving stock (Generic)
+   deriving newtype (ToJSON, FromJSON)
+   deriving anyclass (Newtype)
+
 -- | spawn an external process to runghc a file
 --
 --   If you set the environmental varaiable GHC_BIN_DIR
@@ -50,34 +64,52 @@ data CompilationError
 --   This is useful if you want to your file to be run with some packages
 --   available, you can create a wrapper runghc that includes these
 --
---   Any errors are converted to [CompilationError]
+--   Any errors are converted to InterpreterError
 runghc
-    :: (MonadIO m, MonadError [CompilationError] m, MonadMask m)
-    => [String]
+    :: (Show t, TimeUnit t, MonadIO m, MonadError InterpreterError m, MonadMask m)
+    => t
+    -> [String]
     -> FilePath
     -> m String
-runghc runghcOpts file = do
+runghc t runghcOpts file = do
     bin <- liftIO lookupRunghc
-    (exitCode, stdout, stderr) <- runProcess bin runghcOpts file
+    (exitCode, stdout, stderr) <- runProcess bin t runghcOpts file
     case exitCode of
         ExitSuccess -> pure stdout
         _ ->
             throwError
+                . CompilationErrors
                 . parseErrorsText
                 . Text.pack
                 $ stderr
 
 runProcess
-    :: (MonadIO m, MonadError [CompilationError] m, MonadMask m)
+    :: (Show t, TimeUnit t, MonadIO m, MonadError InterpreterError m, MonadMask m)
     => FilePath
+    -> t
     -> [String]
     -> String
     -> m (ExitCode, String, String)
-runProcess runghc runghcOpts file = do
-    result <- liftIO $ tryIOError $ readProcessWithExitCode runghc (runghcOpts <> [file]) ""
+runProcess bin timeoutValue runghcOpts file = do
+    result <- timeout' timeoutValue $ liftIO $ tryIOError $ readProcessWithExitCode bin (runghcOpts <> [file]) ""
     case result of
-        Left e  -> throwError . pure . RawError . Text.pack . show $ e
+        Left e  -> throwError . CompilationErrors . pure . RawError . Text.pack . show $ e
         Right v -> pure v
+    where
+        timeout' :: (Show t, TimeUnit t, MonadIO m, MonadError InterpreterError m, MonadCatch m) => t -> m a -> m a
+        timeout' timeoutValue a = do
+            mr <- timeout timeoutValue a
+            case mr of
+                Nothing -> throwError (TimeoutError . Text.pack . show $ timeoutValue)
+                Just r  -> pure r
+
+avoidUnsafe :: (MonadError InterpreterError m) => SourceCode -> m ()
+avoidUnsafe s =
+    unless (null . Text.indices "unsafe" . Newtype.unpack $ s)
+        . throwError
+        . CompilationErrors
+        . pure
+        $ RawError "Cannot interpret unsafe functions"
 
 lookupRunghc :: IO String
 lookupRunghc = do

--- a/meadow-client/src/Types.purs
+++ b/meadow-client/src/Types.purs
@@ -16,7 +16,7 @@ import Data.Maybe (Maybe)
 import Data.Symbol (SProxy(..))
 import Gist (Gist)
 import Halogen.Component.ChildPath (ChildPath, cpL, cpR)
-import Language.Haskell.Interpreter (CompilationError)
+import Language.Haskell.Interpreter (CompilationError, InterpreterError)
 import Marlowe.Types (BlockNumber, Choice, Contract, IdChoice, IdOracle, Person)
 import Network.RemoteData (RemoteData)
 import Prelude (class Eq, class Ord, class Show, Unit)
@@ -90,7 +90,7 @@ instance showView :: Show View where
   show = gShow
 
 type FrontendState
-  = {view :: View, runResult :: RemoteData AjaxError (Either (Array CompilationError) RunResult), marloweCompileResult :: Either (Array MarloweError) Unit, authStatus :: RemoteData AjaxError AuthStatus, createGistResult :: RemoteData AjaxError Gist, marloweState :: MarloweState, oldContract :: Maybe String}
+  = {view :: View, runResult :: RemoteData AjaxError (Either InterpreterError RunResult), marloweCompileResult :: Either (Array MarloweError) Unit, authStatus :: RemoteData AjaxError AuthStatus, createGistResult :: RemoteData AjaxError Gist, marloweState :: MarloweState, oldContract :: Maybe String}
 
 data MarloweError
   = MarloweError String

--- a/meadow/app/PSGenerator.hs
+++ b/meadow/app/PSGenerator.hs
@@ -15,7 +15,7 @@ module PSGenerator
     ( generate
     ) where
 
-import           API                                (MeadowError, RunResult, SourceCode)
+import           API                                (RunResult)
 import qualified API
 import           Auth                               (AuthRole, AuthStatus)
 import qualified Auth
@@ -29,7 +29,7 @@ import qualified Data.Text                          as T ()
 import qualified Data.Text.Encoding                 as T ()
 import qualified Data.Text.IO                       as T ()
 import           Gist                               (Gist, GistFile, GistId, NewGist, NewGistFile, Owner)
-import           Language.Haskell.Interpreter       (CompilationError)
+import           Language.Haskell.Interpreter       (CompilationError, InterpreterError, SourceCode)
 import           Language.PureScript.Bridge         (BridgePart, Language (Haskell), PSType, SumType,
                                                      TypeInfo (TypeInfo), buildBridge, mkSumType, psTypeParameters,
                                                      typeModule, typeName, writePSTypes, (^==))
@@ -102,7 +102,7 @@ myTypes =
     [ mkSumType (Proxy @RunResult)
     , mkSumType (Proxy @SourceCode)
     , mkSumType (Proxy @CompilationError)
-    , mkSumType (Proxy @MeadowError)
+    , mkSumType (Proxy @InterpreterError)
     , mkSumType (Proxy @AuthStatus)
     , mkSumType (Proxy @AuthRole)
     , mkSumType (Proxy @GistId)

--- a/meadow/meadow.cabal
+++ b/meadow/meadow.cabal
@@ -69,6 +69,7 @@ library
         temporary -any,
         text -any,
         time -any,
+        time-units -any,
         transformers -any,
         wai -any
 
@@ -124,7 +125,9 @@ test-suite meadow-test
         hspec -any,
         hspec-wai -any,
         hspec-wai-json -any,
+        interpreter -any,
         meadow -any,
         mtl -any,
         raw-strings-qq -any,
-        text -any
+        text -any,
+        time-units -any

--- a/meadow/src/API.hs
+++ b/meadow/src/API.hs
@@ -10,26 +10,15 @@ import           Control.Newtype.Generics     (Newtype)
 import           Data.Aeson                   (FromJSON, ToJSON)
 import           Data.Text                    (Text)
 import           GHC.Generics                 (Generic)
-import           Language.Haskell.Interpreter (CompilationError)
+import           Language.Haskell.Interpreter (InterpreterError, SourceCode)
 import           Servant.API                  ((:<|>) ((:<|>)), (:>), Get, JSON, Post, ReqBody)
 
 type API
-   = "contract" :> "haskell" :> ReqBody '[ JSON] SourceCode :> Post '[ JSON] (Either [CompilationError] RunResult)
+   = "contract" :> "haskell" :> ReqBody '[ JSON] SourceCode :> Post '[ JSON] (Either InterpreterError RunResult)
      :<|> "health" :> Get '[ JSON] ()
 
-newtype SourceCode = SourceCode Text
-   deriving stock (Generic)
-   deriving newtype (ToJSON, FromJSON)
-   deriving anyclass (Newtype)
 
 newtype RunResult = RunResult Text
    deriving stock (Show, Eq, Generic)
    deriving newtype (ToJSON, FromJSON)
    deriving anyclass (Newtype)
-
-data MeadowError
-   = CompilationErrors [CompilationError]
-   | OtherError Text
-   | MeadowTimeout
-   deriving stock (Eq, Show, Generic)
-   deriving anyclass (ToJSON, FromJSON)

--- a/meadow/src/Server.hs
+++ b/meadow/src/Server.hs
@@ -11,8 +11,7 @@ module Server
     )
 where
 
-import           API                          (API, MeadowError (CompilationErrors, MeadowTimeout), RunResult,
-                                               SourceCode (SourceCode))
+import           API                          (API, RunResult)
 import           Control.Monad.Catch          (MonadCatch, MonadMask, bracket, catch)
 import           Control.Monad.Except         (MonadError, runExceptT, throwError)
 import           Control.Monad.IO.Class       (MonadIO, liftIO)
@@ -21,8 +20,9 @@ import           Data.Aeson                   (ToJSON, encode)
 import qualified Data.ByteString.Char8        as BS
 import qualified Data.ByteString.Lazy.Char8   as BSL
 import qualified Data.Text                    as Text
+import           Data.Time.Units              (Microsecond, fromMicroseconds)
 import qualified Interpreter
-import           Language.Haskell.Interpreter (CompilationError)
+import           Language.Haskell.Interpreter (InterpreterError (CompilationErrors), SourceCode (SourceCode))
 import           Meadow.Contracts             (basicContract)
 import           Network.HTTP.Types           (hContentType)
 import           Servant                      (ServantErr, err400, errBody, errHeaders)
@@ -30,17 +30,16 @@ import           Servant.API                  ((:<|>) ((:<|>)), (:>), JSON, Post
 import           Servant.Server               (Handler, Server)
 import           System.Timeout               (timeout)
 
-acceptSourceCode :: SourceCode -> Handler (Either [CompilationError] RunResult)
+acceptSourceCode :: SourceCode -> Handler (Either InterpreterError RunResult)
 acceptSourceCode sourceCode = do
-    let maxInterpretationTime = 5000000
+    let maxInterpretationTime :: Microsecond = fromMicroseconds 5000000
     r <-
         liftIO
-        . timeoutInterpreter maxInterpretationTime
         $ runExceptT
-        $ Interpreter.runHaskell sourceCode
+        $ Interpreter.runHaskell maxInterpretationTime sourceCode
     case r of
         Right vs                        -> pure $ Right vs
-        Left (CompilationErrors errors) -> pure . Left $ errors
+        Left (CompilationErrors errors) -> pure . Left $ CompilationErrors errors
         Left  e                         -> throwError $ err400 { errBody = BSL.pack . show $ e }
 
 throwJSONError :: (MonadError ServantErr m, ToJSON a) => ServantErr -> a -> m b
@@ -54,13 +53,6 @@ checkHealth = do
     case res of
         Left e  -> throwError $ err400 {errBody = BSL.pack . show $ e}
         Right _ -> pure ()
-
-timeoutInterpreter :: Int -> IO (Either MeadowError a) -> IO (Either MeadowError a)
-timeoutInterpreter n action = do
-    res <- timeout n action
-    case res of
-        Nothing -> pure . Left $ MeadowTimeout
-        Just a  -> pure a
 
 {-# ANN mkHandlers
           ("HLint: ignore Avoid restricted function" :: String)

--- a/meadow/test/Spec.hs
+++ b/meadow/test/Spec.hs
@@ -1,16 +1,19 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE QuasiQuotes         #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Main (main) where
 
-import           API                   (MeadowError, RunResult (RunResult), SourceCode (SourceCode))
-import           Control.Monad.Except  (runExceptT)
-import           Data.ByteString       (ByteString)
-import qualified Data.ByteString.Char8 as BSC
-import qualified Data.Text             as Text
+import           API                          (RunResult (RunResult))
+import           Control.Monad.Except         (runExceptT)
+import           Data.ByteString              (ByteString)
+import qualified Data.ByteString.Char8        as BSC
+import qualified Data.Text                    as Text
+import           Data.Time.Units              (Microsecond, fromMicroseconds)
 import qualified Interpreter
-import           Meadow.Contracts      (basicContract)
-import           Test.Hspec            (Spec, describe, hspec, it, shouldBe)
-import           Text.RawString.QQ     (r)
+import           Language.Haskell.Interpreter (InterpreterError, SourceCode (SourceCode))
+import           Meadow.Contracts             (basicContract)
+import           Test.Hspec                   (Spec, describe, hspec, it, shouldBe)
+import           Text.RawString.QQ            (r)
 
 main :: IO ()
 main = hspec runBasicSpec
@@ -22,5 +25,6 @@ runBasicSpec = describe "Basic Contract" $
         basicResult = Right . RunResult $ [r|Commit 1 1 1 (Constant 450) 10 100 (When (OrObs (OrObs (AndObs (ChoseThis (1,1) 0) (OrObs (ChoseThis (1,2) 0) (ChoseThis (1,3) 0))) (AndObs (ChoseThis (1,2) 0) (ChoseThis (1,3) 0))) (OrObs (AndObs (ChoseThis (1,1) 1) (OrObs (ChoseThis (1,2) 1) (ChoseThis (1,3) 1))) (AndObs (ChoseThis (1,2) 1) (ChoseThis (1,3) 1)))) 90 (Choice (OrObs (AndObs (ChoseThis (1,1) 1) (OrObs (ChoseThis (1,2) 1) (ChoseThis (1,3) 1))) (AndObs (ChoseThis (1,2) 1) (ChoseThis (1,3) 1))) (Pay 2 1 2 (Committed 1) 100 Null Null) (Pay 3 1 1 (Committed 1) 100 Null Null)) (Pay 4 1 1 (Committed 1) 100 Null Null)) Null
 |]
 
-runHaskell :: ByteString -> IO (Either MeadowError RunResult)
-runHaskell = runExceptT . Interpreter.runHaskell . SourceCode . Text.pack . BSC.unpack
+runHaskell :: ByteString -> IO (Either InterpreterError RunResult)
+runHaskell = let maxInterpretationTime :: Microsecond = fromMicroseconds 5000000 in
+                runExceptT . Interpreter.runHaskell maxInterpretationTime . SourceCode . Text.pack . BSC.unpack

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -40904,7 +40904,6 @@ license = stdenv.lib.licenses.bsd3;
 , filepath
 , hashable
 , http-types
-, marlowe
 , monad-logger
 , mtl
 , newtype-generics
@@ -40917,6 +40916,8 @@ license = stdenv.lib.licenses.bsd3;
 , temporary
 , text
 , time
+, time-out
+, time-units
 , transformers
 , unordered-containers
 , wai
@@ -40938,7 +40939,6 @@ file-embed
 filepath
 hashable
 http-types
-marlowe
 monad-logger
 mtl
 newtype-generics
@@ -40950,13 +40950,15 @@ servant-server
 temporary
 text
 time
+time-out
+time-units
 transformers
 unordered-containers
 wai
 warp
 ];
 doHaddock = false;
-license = stdenv.lib.licenses.bsd3;
+license = stdenv.lib.licenses.asl20;
 
 }) {};
 "intervals" = callPackage
@@ -47449,6 +47451,7 @@ license = stdenv.lib.licenses.mit;
 , temporary
 , text
 , time
+, time-units
 , transformers
 , wai
 , wai-cors
@@ -47495,6 +47498,7 @@ servant-server
 temporary
 text
 time
+time-units
 transformers
 wai
 ];
@@ -47532,9 +47536,11 @@ bytestring
 hspec
 hspec-wai
 hspec-wai-json
+interpreter
 mtl
 raw-strings-qq
 text
+time-units
 ];
 doHaddock = false;
 license = stdenv.lib.licenses.asl20;
@@ -56808,6 +56814,7 @@ license = stdenv.lib.licenses.asl20;
 "plutus-playground-server" = callPackage
 ({
   mkDerivation
+, adjunctions
 , aeson
 , aeson-casing
 , base
@@ -56850,6 +56857,7 @@ license = stdenv.lib.licenses.asl20;
 , temporary
 , text
 , time
+, time-units
 , transformers
 , wai
 , wai-cors
@@ -56898,10 +56906,12 @@ swagger2
 temporary
 text
 time
+time-units
 transformers
 wallet-api
 ];
 executableHaskellDepends = [
+adjunctions
 aeson
 base
 bytestring
@@ -56942,6 +56952,7 @@ mtl
 plutus-playground-lib
 swagger2
 text
+time-units
 transformers
 wallet-api
 ];
@@ -74182,6 +74193,29 @@ description = "Compatibility with old-time for the time package";
 license = stdenv.lib.licenses.bsd3;
 
 }) {};
+"time-interval" = callPackage
+({
+  mkDerivation
+, base
+, stdenv
+, time-units
+}:
+mkDerivation {
+
+pname = "time-interval";
+version = "0.1.1";
+sha256 = "3473e1c2a35fecee898ed4d7afcc5353e5a663a4a627550ca6f7b624c152fe24";
+libraryHaskellDepends = [
+base
+time-units
+];
+doHaddock = false;
+doCheck = false;
+homepage = "http://hub.darcs.net/fr33domlover/time-interval";
+description = "Use a time unit class, but hold a concrete time type";
+license = stdenv.lib.licenses.publicDomain;
+
+}) {};
 "time-lens" = callPackage
 ({
   mkDerivation
@@ -74255,6 +74289,37 @@ description = "Vietnamese locale for date and time format";
 license = stdenv.lib.licenses.asl20;
 
 }) {};
+"time-out" = callPackage
+({
+  mkDerivation
+, base
+, data-default-class
+, exceptions
+, stdenv
+, time-interval
+, time-units
+, transformers
+}:
+mkDerivation {
+
+pname = "time-out";
+version = "0.2";
+sha256 = "2e3a1dcfe8eb6d283de6441894bd4ca2e3b56982f1fe0407b1216f5b2c109fda";
+libraryHaskellDepends = [
+base
+data-default-class
+exceptions
+time-interval
+time-units
+transformers
+];
+doHaddock = false;
+doCheck = false;
+homepage = "http://hub.darcs.net/fr33domlover/time-out";
+description = "Timers, timeouts, alarms, monadic wrappers";
+license = stdenv.lib.licenses.publicDomain;
+
+}) {};
 "time-parsers" = callPackage
 ({
   mkDerivation
@@ -74281,6 +74346,27 @@ doHaddock = false;
 doCheck = false;
 homepage = "https://github.com/phadej/time-parsers#readme";
 description = "Parsers for types in `time`";
+license = stdenv.lib.licenses.bsd3;
+
+}) {};
+"time-units" = callPackage
+({
+  mkDerivation
+, base
+, stdenv
+}:
+mkDerivation {
+
+pname = "time-units";
+version = "1.0.0";
+sha256 = "e181997dd05321f09b21c5e0bf38524ccab51ecc588a6017253cc96db289e099";
+libraryHaskellDepends = [
+base
+];
+doHaddock = false;
+doCheck = false;
+homepage = "http://github.com/acw/time-units";
+description = "A basic library for defining units of time as types";
 license = stdenv.lib.licenses.bsd3;
 
 }) {};
@@ -79398,7 +79484,9 @@ base
 warp
 ];
 testHaskellDepends = [
+aeson
 base
+bytestring
 containers
 hedgehog
 lens

--- a/plutus-playground-client/src/Gists.purs
+++ b/plutus-playground-client/src/Gists.purs
@@ -29,9 +29,9 @@ import Halogen.HTML (ClassName(ClassName), HTML, IProp, a, br_, button, div, div
 import Halogen.HTML.Events (input_, onClick, onValueInput)
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties (class_, classes, disabled, href, id_, placeholder, target, type_, value)
+import Language.Haskell.Interpreter (SourceCode)
 import Icons (Icon(..), icon)
 import Network.RemoteData (RemoteData(NotAsked, Loading, Failure, Success))
-import Playground.API (SourceCode)
 import Prelude (Unit, bind, pure, ($), (<$>), (<<<), (<>), (=<<), (==))
 import Servant.PureScript.Settings (SPSettings_)
 import Types (Query(SetGistUrl, LoadGist, PublishGist), Simulation, State(State))

--- a/plutus-playground-client/src/MainFrame.purs
+++ b/plutus-playground-client/src/MainFrame.purs
@@ -54,7 +54,7 @@ import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes, href, id_)
 import Halogen.Query (HalogenM)
 import Icons (Icon(..), icon)
-import Language.Haskell.Interpreter (CompilationError(CompilationError, RawError))
+import Language.Haskell.Interpreter (CompilationError(CompilationError, RawError), InterpreterError(CompilationErrors, TimeoutError))
 import Ledger.Ada.TH (Ada(..))
 import LocalStorage (LOCALSTORAGE)
 import MonadApp (class MonadApp, editorGetContents, editorGotoLine, editorSetAnnotations, editorSetContents, getGistByGistId, getOauthStatus, patchGistByGistId, postContract, postEvaluation, postGist, preventDefault, readFileFromDragEvent, runHalogenApp, saveBuffer, updateChartsIfPossible)
@@ -289,7 +289,7 @@ eval (CompileProgram next) = do
       -- Update the error display.
       editorSetAnnotations $
         case result of
-          Success (Left errors) -> catMaybes $ toAnnotation <$> errors
+          Success (Left errors) -> toAnnotations errors
           _ -> []
 
       -- If we have a result with new signatures, we can only hold
@@ -428,6 +428,10 @@ replaceViewOnSuccess result source target = do
     (assign _currentView target)
 
 ------------------------------------------------------------
+
+toAnnotations :: InterpreterError -> Array Annotation
+toAnnotations (TimeoutError _) = []
+toAnnotations (CompilationErrors errors) = catMaybes (toAnnotation <$> errors)
 
 toAnnotation :: CompilationError -> Maybe Annotation
 toAnnotation (RawError _) = Nothing

--- a/plutus-playground-client/src/MonadApp.purs
+++ b/plutus-playground-client/src/MonadApp.purs
@@ -27,13 +27,13 @@ import FileEvents as FileEvents
 import Gist (Gist, GistId, NewGist)
 import Halogen (HalogenM, action, query', request)
 import Halogen.ECharts as EC
-import Language.Haskell.Interpreter (CompilationError)
+import Language.Haskell.Interpreter (InterpreterError, SourceCode(SourceCode))
 import LocalStorage (LOCALSTORAGE)
 import LocalStorage as LocalStorage
 import Network.HTTP.Affjax (AJAX)
 import Network.RemoteData (RemoteData(..))
 import Network.RemoteData as RemoteData
-import Playground.API (CompilationResult, Evaluation, EvaluationResult(EvaluationResult), SourceCode(SourceCode))
+import Playground.API (CompilationResult, Evaluation, EvaluationResult(EvaluationResult))
 import Playground.Server (SPParams_)
 import Playground.Server as Server
 import Servant.PureScript.Affjax (AjaxError)
@@ -57,7 +57,7 @@ class Monad m <= MonadApp m where
   postEvaluation :: Evaluation -> m (WebData EvaluationResult)
   postGist :: NewGist -> m (WebData Gist)
   patchGistByGistId :: NewGist -> GistId -> m (WebData Gist)
-  postContract :: SourceCode -> m (WebData (Either (Array CompilationError) CompilationResult))
+  postContract :: SourceCode -> m (WebData (Either InterpreterError CompilationResult))
 
 newtype HalogenApp m a = HalogenApp (HalogenM State Query ChildQuery ChildSlot Void m a)
 

--- a/plutus-playground-client/src/Types.purs
+++ b/plutus-playground-client/src/Types.purs
@@ -32,12 +32,12 @@ import Data.Tuple.Nested ((/\))
 import Gist (Gist)
 import Halogen.Component.ChildPath (ChildPath, cp1, cp2, cp3)
 import Halogen.ECharts (EChartsMessage, EChartsQuery)
-import Language.Haskell.Interpreter (CompilationError)
+import Language.Haskell.Interpreter (SourceCode, InterpreterError)
 import Ledger.Ada.TH (Ada, _Ada)
 import Ledger.Types (Tx, TxIdOf)
 import Matryoshka (class Corecursive, class Recursive, Algebra, cata)
 import Network.RemoteData (RemoteData)
-import Playground.API (CompilationResult, Evaluation(Evaluation), EvaluationResult, FunctionSchema, SimpleArgumentSchema(UnknownSchema, SimpleObjectSchema, SimpleTupleSchema, SimpleArraySchema, SimpleStringSchema, SimpleIntSchema), SimulatorWallet, SourceCode, _FunctionSchema, _SimulatorWallet)
+import Playground.API (CompilationResult, Evaluation(Evaluation), EvaluationResult, FunctionSchema, SimpleArgumentSchema(UnknownSchema, SimpleObjectSchema, SimpleTupleSchema, SimpleArraySchema, SimpleStringSchema, SimpleIntSchema), SimulatorWallet, _FunctionSchema, _SimulatorWallet)
 import Playground.API as API
 import Servant.PureScript.Affjax (AjaxError)
 import Test.QuickCheck.Arbitrary (class Arbitrary)
@@ -249,7 +249,7 @@ type WebData = RemoteData AjaxError
 
 newtype State = State
   { currentView :: View
-  , compilationResult :: WebData (Either (Array CompilationError) CompilationResult)
+  , compilationResult :: WebData (Either InterpreterError CompilationResult)
   , simulations :: Cursor Simulation
   , evaluationResult :: WebData EvaluationResult
   , authStatus :: WebData AuthStatus
@@ -277,7 +277,7 @@ _wallets = _Newtype <<< prop (SProxy :: SProxy "wallets")
 _evaluationResult :: Lens' State (WebData EvaluationResult)
 _evaluationResult = _Newtype <<< prop (SProxy :: SProxy "evaluationResult")
 
-_compilationResult :: Lens' State (WebData (Either (Array CompilationError) CompilationResult))
+_compilationResult :: Lens' State (WebData (Either InterpreterError CompilationResult))
 _compilationResult = _Newtype <<< prop (SProxy :: SProxy "compilationResult")
 
 _authStatus :: Lens' State (WebData AuthStatus)

--- a/plutus-playground-client/test/BridgeTests.purs
+++ b/plutus-playground-client/test/BridgeTests.purs
@@ -11,7 +11,9 @@ import Data.Argonaut.Core as Argonaut
 import Data.Either (Either(..))
 import Data.List (List)
 import Data.List.Types (NonEmptyList)
-import Language.Haskell.Interpreter (CompilationError)
+import Data.Generic (class Generic)
+import Language.Haskell.Interpreter (CompilationError, InterpreterError)
+import Node.Encoding (Encoding(UTF8))
 import Node.FS (FS)
 import Playground.API (CompilationResult, EvaluationResult, KnownCurrency, TokenId)
 import Test.Unit (TestSuite, suite, test)
@@ -44,7 +46,7 @@ jsonHandling = do
           "test/known_currency.json"
       test "Decode a CompilationResult." do
         assertDecodesTo
-          (Proxy :: Proxy (Either (Array CompilationError) CompilationResult))
+          (Proxy :: Proxy (Either InterpreterError CompilationResult))
           "test/compilation_response1.json"
       test "Decode an EvaluationResult." do
         assertDecodesTo

--- a/plutus-playground-client/test/MainFrameTests.purs
+++ b/plutus-playground-client/test/MainFrameTests.purs
@@ -31,7 +31,7 @@ import Data.Symbol (SProxy(..))
 import Data.Tuple (Tuple(Tuple))
 import FileEvents (FILE)
 import Gist (Gist, GistId, gistId)
-import Language.Haskell.Interpreter (CompilationError)
+import Language.Haskell.Interpreter (CompilationError, SourceCode(SourceCode), InterpreterError)
 import MainFrame (eval, initialState)
 import MonadApp (class MonadApp)
 import Network.RemoteData (RemoteData(..), isNotAsked, isSuccess)
@@ -40,7 +40,7 @@ import Node.Encoding (Encoding(..))
 import Node.FS (FS)
 import Node.FS.Sync as FS
 import Partial.Unsafe (unsafePartial)
-import Playground.API (CompilationResult, EvaluationResult, SourceCode(SourceCode))
+import Playground.API (CompilationResult, EvaluationResult)
 import Playground.Server (SPParams_(..))
 import Servant.PureScript.Settings (SPSettings_, defaultSettings)
 import StaticData (bufferLocalStorageKey)
@@ -62,7 +62,7 @@ type World =
   , editorContents :: Maybe String
   , localStorage :: Map String String
   , evaluationResult :: WebData EvaluationResult
-  , compilationResult :: (WebData (Either (Array CompilationError) CompilationResult))
+  , compilationResult :: (WebData (Either InterpreterError CompilationResult))
   }
 
 _gists :: forall r a. Lens' {gists :: a | r} a
@@ -220,7 +220,7 @@ evalTests =
 
     test "Loading a script clears out some state." do
         contents <- liftEff $ FS.readTextFile UTF8 "test/compilation_response1.json"
-        let compilationResult :: Either (Array CompilationError) CompilationResult
+        let compilationResult :: Either InterpreterError CompilationResult
             compilationResult = unsafePartial $ fromRight (jsonParser contents >>= decodeJson)
         Tuple _ finalState <- execMockApp (mockWorld { compilationResult = Success compilationResult }) do
           send $ LoadScript "Game"

--- a/plutus-playground-client/test/compilation_response1.json
+++ b/plutus-playground-client/test/compilation_response1.json
@@ -381,6 +381,7 @@
         "functionName": "payToPublicKey_"
       }
     ],
-    "warnings": []
+    "warnings": [],
+    "knownCurrencies": []
   }
 }

--- a/plutus-playground-server/app/PSGenerator.hs
+++ b/plutus-playground-server/app/PSGenerator.hs
@@ -28,7 +28,7 @@ import qualified Data.Text                                 as T ()
 import qualified Data.Text.Encoding                        as T ()
 import qualified Data.Text.IO                              as T ()
 import           Gist                                      (Gist, GistFile, GistId, NewGist, NewGistFile, Owner)
-import           Language.Haskell.Interpreter              (CompilationError)
+import           Language.Haskell.Interpreter              (CompilationError, InterpreterError, SourceCode)
 import           Language.PureScript.Bridge                (BridgePart, Language (Haskell), PSType, SumType,
                                                             TypeInfo (TypeInfo), buildBridge, equal, mkSumType, order,
                                                             psTypeParameters, typeModule, typeName, writePSTypes, (^==))
@@ -44,7 +44,7 @@ import           Ledger.Types                              (AddressOf, DataScrip
 import           Ledger.Value.TH                           (CurrencySymbol, Value)
 import           Playground.API                            (CompilationResult, Evaluation, EvaluationResult, Expression,
                                                             Fn, FunctionSchema, KnownCurrency, SimpleArgumentSchema,
-                                                            SimulatorWallet, SourceCode, TokenId, Warning)
+                                                            SimulatorWallet, TokenId, Warning)
 import qualified Playground.API                            as API
 import           Playground.Usecases                       (crowdfunding, game, messages, vesting)
 import           Servant                                   ((:<|>))
@@ -215,6 +215,7 @@ myTypes =
     , mkSumType (Proxy @CurrencySymbol)
     , (equal <*> (order <*> mkSumType)) (Proxy @TokenId)
     , mkSumType (Proxy @KnownCurrency)
+    , mkSumType (Proxy @InterpreterError)
     ]
 
 mySettings :: Settings

--- a/plutus-playground-server/plutus-playground-server.cabal
+++ b/plutus-playground-server/plutus-playground-server.cabal
@@ -76,6 +76,7 @@ library
         temporary -any,
         text -any,
         time -any,
+        time-units -any,
         transformers -any,
         wallet-api -any
 
@@ -149,5 +150,6 @@ test-suite plutus-playground-server-test
         plutus-playground-server -any,
         swagger2 -any,
         text -any,
+        time-units -any,
         transformers -any,
         wallet-api -any

--- a/plutus-playground-server/src/Playground/Server.hs
+++ b/plutus-playground-server/src/Playground/Server.hs
@@ -17,12 +17,12 @@ import           Data.Aeson                   (ToJSON, encode)
 import qualified Data.ByteString.Char8        as BS
 import qualified Data.ByteString.Lazy.Char8   as BSL
 import qualified Data.Text                    as Text
-import           Language.Haskell.Interpreter (CompilationError)
+import           Data.Time.Units              (Microsecond, fromMicroseconds)
+import           Language.Haskell.Interpreter (InterpreterError (CompilationErrors), SourceCode (SourceCode))
 import           Ledger.Types                 (hashTx)
 import           Network.HTTP.Types           (hContentType)
 import           Playground.API               (API, CompilationResult, Evaluation, EvaluationResult (EvaluationResult),
-                                               PlaygroundError (PlaygroundTimeout), SourceCode (SourceCode),
-                                               parseErrorText)
+                                               PlaygroundError (PlaygroundTimeout), parseErrorText)
 import qualified Playground.API               as PA
 import qualified Playground.Interpreter       as PI
 import           Playground.Usecases          (vesting)
@@ -33,18 +33,16 @@ import           System.Timeout               (timeout)
 import qualified Wallet.Graph                 as V
 
 acceptSourceCode ::
-       SourceCode -> Handler (Either [CompilationError] CompilationResult)
+       SourceCode -> Handler (Either InterpreterError CompilationResult)
 acceptSourceCode sourceCode = do
-    let maxInterpretationTime = 5000000
+    let maxInterpretationTime :: Microsecond = fromMicroseconds 5000000
     r <-
-        liftIO . timeoutInterpreter maxInterpretationTime $
-        runExceptT $ PI.compile sourceCode
+        liftIO .
+        runExceptT $ PI.compile maxInterpretationTime sourceCode
     case r of
-        Right vs -> pure . Right $ vs
-        Left (PA.InterpreterError errors) ->
-            pure $ Left $ map (parseErrorText . Text.pack) errors
-        Left (PA.CompilationErrors errors) -> pure . Left $ errors
-        Left e -> throwError $ err400 {errBody = BSL.pack . show $ e}
+        Right vs                        -> pure . Right $ vs
+        Left (CompilationErrors errors) -> pure . Left $ CompilationErrors errors
+        Left e                          -> throwError $ err400 {errBody = BSL.pack . show $ e}
 
 throwJSONError :: (MonadError ServantErr m, ToJSON a) => ServantErr -> a -> m b
 throwJSONError err json =
@@ -54,10 +52,10 @@ throwJSONError err json =
 
 runFunction :: Evaluation -> Handler EvaluationResult
 runFunction evaluation = do
-    let maxInterpretationTime = 10000000
+    let maxInterpretationTime :: Microsecond = fromMicroseconds 10000000
     result <-
-        liftIO . timeoutInterpreter maxInterpretationTime $
-        runExceptT $ PI.runFunction evaluation
+        liftIO .
+        runExceptT $ PI.runFunction maxInterpretationTime evaluation
     let pubKeys = PA.pubKeys evaluation
     case result of
         Right (blockchain, emulatorLog, fundsDistribution) -> do
@@ -68,8 +66,7 @@ runFunction evaluation = do
                     flowgraph
                     emulatorLog
                     fundsDistribution
-        Left (PA.InterpreterError errors) ->
-            throwJSONError err400 $ map (parseErrorText . Text.pack) errors
+        Left (PA.InterpreterError errors) -> throwJSONError err400 errors
         Left err -> throwError $ err400 {errBody = BSL.pack . show $ err}
 
 checkHealth :: Handler ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -35,6 +35,9 @@ extra-deps:
 - servant-subscriber-0.6.0.2
 - jwt-0.9.0
 - prometheus-2.1.1@sha256:f855cfb55e04d0c82a2a9f6542c08b278e6ef27d86b7491f065f9628c7057ac9
+- time-out-0.2@sha256:b9a6b4dee64f030ecb2a25dca0faff39b3cb3b5fefbb8af3cdec4142bfd291f2
+- time-interval-0.1.1@sha256:7bfd3601853d1af7caa18248ec10b01701d035ac274a93bb4670fea52a14d4e8
+- time-units-1.0.0@sha256:27cf54091c4a0ca73d504fc11d5c31ab4041d17404fe3499945e2055697746c1
 flags:
   language-plutus-core:
     development: true


### PR DESCRIPTION
Apart from a bit of reduction in duplication, the main point here is that we will be able to use the same Editor.purs for both meadow and the playground. The editor is a tool for use with the interpreter, with this change I think we can separate the Editor as a something that is aligned with the interpreter.