### PR TITLE
Ignore yarn.nix for github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 pkgs/default.nix linguist-generated=true
+meadow-client/yarn.nix linguist-generated=true
+plutus-playground-client/yarn.nix linguist-generated=true


### PR DESCRIPTION
Modifies the `.gitattributes` file so that github will (correctly) detect this repository as mostly Haskell.