### PR TITLE
plutus-tx: moderately improve errors

### DIFF
--- a/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
@@ -31,8 +31,8 @@ instance (PP.Pretty a) => Show (Error a) where
 
 instance PP.Pretty a => PLC.PrettyBy PLC.PrettyConfigPlc (Error a) where
     prettyBy config = \case
-        CompilationError x e -> "Error during compilation" <+> PP.pretty x <> ":" <+> PP.pretty e
-        UnsupportedError x e -> "Unsupported construct at" <+> PP.pretty x <> ":" <+> PP.pretty e
-        PLCError e -> PLC.prettyBy config e
+        CompilationError x e -> "Error during compilation:" <+> PP.pretty e <> "(" <> PP.pretty x <> ")"
+        UnsupportedError x e -> "Unsupported construct:" <+> PP.pretty e <+> "(" <> PP.pretty x <> ")"
+        PLCError e -> PP.vsep [ "Error from the PLC compiler:", PLC.prettyBy config e ]
 
 instance (PP.Pretty a, Typeable a) => Exception (Error a)

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Term.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Term.hs
@@ -64,7 +64,7 @@ compileRecTypeBindings :: Compiling m e a => Recursivity -> PLCTerm a -> [Bindin
 compileRecTypeBindings r body bs = case bs of
     []  -> pure body
     [b] -> compileSingleBinding r body b
-    _   -> ask >>= \p -> throwing _Error $ UnsupportedError p "Mutually recursive types are not supported"
+    _   -> ask >>= \p -> throwing _Error $ UnsupportedError p "Mutually recursive datatypes"
 
 compileSingleBinding :: Compiling m e a => Recursivity -> PLCTerm a -> Binding TyName Name (Provenance a) ->  m (PLCTerm a)
 compileSingleBinding r body b =  case b of

--- a/plutus-ir/test/errors/mutuallyRecursiveTypes.golden
+++ b/plutus-ir/test/errors/mutuallyRecursiveTypes.golden
@@ -1,1 +1,1 @@
-Unsupported construct at (recursive) let binding; from mutuallyRecursiveTypes:1:2: Mutually recursive types are not supported
+Unsupported construct: Mutually recursive datatypes ((recursive) let binding; from mutuallyRecursiveTypes:1:2)

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Builtins.hs
@@ -165,7 +165,7 @@ getThing :: Converting m => TH.Name -> m GHC.TyThing
 getThing name = do
     ConvertingContext{ccBuiltinNameInfo=names} <- ask
     case Map.lookup name names of
-        Nothing    -> throwSd ConversionError $ "Missing builtin name:" GHC.<+> (GHC.text $ show name)
+        Nothing    -> throwSd CompilationError $ "Missing builtin name:" GHC.<+> (GHC.text $ show name)
         Just thing -> pure thing
 
 defineBuiltinTerm :: Converting m => TH.Name -> PIRTerm -> [GHC.Name] -> m ()
@@ -296,7 +296,7 @@ lookupBuiltinTerm name = do
     maybeTerm <- PIR.lookupTerm () ghcName
     case maybeTerm of
         Just t  -> pure t
-        Nothing -> throwSd ConversionError $ "Missing builtin definition:" GHC.<+> (GHC.text $ show name)
+        Nothing -> throwSd CompilationError $ "Missing builtin definition:" GHC.<+> (GHC.text $ show name)
 
 -- | Lookup a builtin type by its TH name. These are assumed to be present, so fails if it is cannot find it.
 lookupBuiltinType :: Converting m => TH.Name -> m PIRType
@@ -305,7 +305,7 @@ lookupBuiltinType name = do
     maybeType <- PIR.lookupType () ghcName
     case maybeType of
         Just t  -> pure t
-        Nothing -> throwSd ConversionError $ "Missing builtin definition:" GHC.<+> (GHC.text $ show name)
+        Nothing -> throwSd CompilationError $ "Missing builtin definition:" GHC.<+> (GHC.text $ show name)
 
 -- | The function 'error :: forall a . () -> a'.
 errorFunc :: Converting m => m PIRTerm

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
@@ -12,7 +12,7 @@ module Language.PlutusTx.Compiler.Error (
     , withContext
     , withContextM
     , throwPlain
-    , stripContext) where
+    , pruneContext) where
 
 import qualified Language.PlutusIR.Compiler as PIR
 
@@ -26,33 +26,35 @@ import qualified Data.Text                  as T
 import qualified Data.Text.Prettyprint.Doc  as PP
 import           Data.Typeable
 
--- | An error with some (nested) context.
-data WithContext c e = NoContext e | WithContextC c (WithContext c e)
+-- | An error with some (nested) context. The integer argument to 'WithContextC' represents
+-- the priority of the context when displaying it. Lower numbers are more prioritised.
+data WithContext c e = NoContext e | WithContextC Int c (WithContext c e)
     deriving Functor
 makeClassyPrisms ''WithContext
 
 type ConvError = WithContext T.Text (Error ())
 
-withContext :: (MonadError (WithContext c e) m) => c -> m a -> m a
-withContext c act = catchError act $ \err -> throwError (WithContextC c err)
+withContext :: (MonadError (WithContext c e) m) => Int -> c -> m a -> m a
+withContext p c act = catchError act $ \err -> throwError (WithContextC p c err)
 
-withContextM :: (MonadError (WithContext c e) m) => m c -> m a -> m a
-withContextM mc act = do
+withContextM :: (MonadError (WithContext c e) m) => Int -> m c -> m a -> m a
+withContextM p mc act = do
     c <- mc
-    catchError act $ \err -> throwError (WithContextC c err)
+    catchError act $ \err -> throwError (WithContextC p c err)
 
 throwPlain :: MonadError (WithContext c e) m => e -> m a
 throwPlain = throwError . NoContext
 
-stripContext :: WithContext c e -> e
-stripContext = \case
-    NoContext e -> e
-    WithContextC _ e -> stripContext e
+pruneContext :: Int -> WithContext c e -> WithContext c e
+pruneContext prio = \case
+    NoContext e -> NoContext e
+    WithContextC p c e ->
+        let inner = pruneContext prio e in if p > prio then inner else WithContextC p c inner
 
 instance (PP.Pretty c, PP.Pretty e) => PP.Pretty (WithContext c e) where
     pretty = \case
         NoContext e     -> "Error:" PP.<+> (PP.align $ PP.pretty e)
-        WithContextC c e -> PP.vsep [
+        WithContextC _ c e -> PP.vsep [
             PP.pretty e,
             "Context:" PP.<+> (PP.align $ PP.pretty c)
             ]
@@ -78,7 +80,7 @@ instance PIR.AsError ConvError (PIR.Provenance ()) where
 instance (PP.Pretty a) => PLC.PrettyBy PLC.PrettyConfigPlc (Error a) where
     prettyBy config = \case
         PLCError e -> PP.vsep [ "Error from the PLC compiler:", PLC.prettyBy config e ]
-        PIRError e -> PP.vsep [ "Error from the PIR compiler:", PLC.prettyBy config e ] 
+        PIRError e -> PP.vsep [ "Error from the PIR compiler:", PLC.prettyBy config e ]
         CompilationError e -> "Unexpected error during compilation, please report this to the Plutus team:" PP.<+> PP.pretty e
         UnsupportedError e -> "Unsupported feature:" PP.<+> PP.pretty e
         FreeVariableError e -> "Reference to a value which is not a local, nor a builtin:" PP.<+> PP.pretty e

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
@@ -59,10 +59,10 @@ instance (PP.Pretty c, PP.Pretty e) => PP.Pretty (WithContext c e) where
 
 data Error a = PLCError (PLC.Error a)
              | PIRError (PIR.Error (PIR.Provenance a))
-             | ConversionError T.Text
+             | CompilationError T.Text
              | UnsupportedError T.Text
              | FreeVariableError T.Text
-             | ValueRestrictionError T.Text
+             | ValueRestrictionError
              deriving Typeable
 makeClassyPrisms ''Error
 
@@ -77,9 +77,9 @@ instance PIR.AsError ConvError (PIR.Provenance ()) where
 
 instance (PP.Pretty a) => PLC.PrettyBy PLC.PrettyConfigPlc (Error a) where
     prettyBy config = \case
-        PLCError e -> PLC.prettyBy config e
-        PIRError e -> PLC.prettyBy config e
-        ConversionError e -> "Error during conversion:" PP.<+> PP.pretty e
-        UnsupportedError e -> "Unsupported:" PP.<+> PP.pretty e
-        FreeVariableError e -> "Used but not defined in the current conversion:" PP.<+> PP.pretty e
-        ValueRestrictionError e -> "Violation of the value restriction:" PP.<+> PP.pretty e
+        PLCError e -> PP.vsep [ "Error from the PLC compiler:", PLC.prettyBy config e ]
+        PIRError e -> PP.vsep [ "Error from the PIR compiler:", PLC.prettyBy config e ] 
+        CompilationError e -> "Unexpected error during compilation, please report this to the Plutus team:" PP.<+> PP.pretty e
+        UnsupportedError e -> "Unsupported feature:" PP.<+> PP.pretty e
+        FreeVariableError e -> "Reference to a value which is not a local, nor a builtin:" PP.<+> PP.pretty e
+        ValueRestrictionError -> "Attempt to polymorphically generalize something which is not a value (often a let-binding)"

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
@@ -142,7 +142,7 @@ where it's not used, the PIR dead-binding pass will remove it.
 -- Expressions
 
 convExpr :: Converting m => GHC.CoreExpr -> m PIRTerm
-convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
+convExpr e = withContextM 2 (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
     -- See Note [Scopes]
     ConvertingContext {ccScopes=stack} <- ask
     let top = NE.head stack
@@ -243,7 +243,7 @@ convExpr e = withContextM (sdToTxt $ "Converting expr:" GHC.<+> GHC.ppr e) $ do
         -- we can use source notes to get a better context for the inner expression
         -- these are put in when you compile with -g
         GHC.Tick GHC.SourceNote{GHC.sourceSpan=src} body ->
-            withContextM (sdToTxt $ "Converting expr at:" GHC.<+> GHC.ppr src) $ convExpr body
+            withContextM 1 (sdToTxt $ "Converting expr at:" GHC.<+> GHC.ppr src) $ convExpr body
         -- ignore other annotations
         GHC.Tick _ body -> convExpr body
         GHC.Cast body coerce -> do

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Kind.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Kind.hs
@@ -15,7 +15,7 @@ import qualified Kind                             as GHC
 import qualified Language.PlutusCore              as PLC
 
 convKind :: Converting m => GHC.Kind -> m (PLC.Kind ())
-convKind k = withContextM (sdToTxt $ "Converting kind:" GHC.<+> GHC.ppr k) $ case k of
+convKind k = withContextM 2 (sdToTxt $ "Converting kind:" GHC.<+> GHC.ppr k) $ case k of
     -- this is a bit weird because GHC uses 'Type' to represent kinds, so '* -> *' is a 'TyFun'
     (GHC.isStarKind -> True)              -> pure $ PLC.Type ()
     (GHC.splitFunTy_maybe -> Just (i, o)) -> PLC.KindArrow () <$> convKind i <*> convKind o

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
@@ -216,7 +216,7 @@ getConstructors tc = do
     maybeConstrs <- PIR.lookupConstructors () (GHC.getName tc)
     case maybeConstrs of
         Just constrs -> pure constrs
-        Nothing      -> throwPlain $ ConversionError "Constructors have not been converted"
+        Nothing      -> throwPlain $ CompilationError "Constructors have not been compiled"
 
 -- | Get the constructors of the given 'Type' (which must be equal to a type constructor application) as PLC terms instantiated for
     -- the type constructor argument types.
@@ -229,17 +229,17 @@ getConstructorsInstantiated t = withContextM (sdToTxt $ "Creating instantiated c
             args' <- mapM convType args
             pure $ PIR.mkIterInst () c args'
     -- must be a TC app
-    _ -> throwPlain $ ConversionError "Type was not a type constructor application"
+    _ -> throwPlain $ CompilationError "Type was not a type constructor application"
 
 -- | Get the matcher of the given 'TyCon' as a PLC term
 getMatch :: Converting m => GHC.TyCon -> m PIRTerm
 getMatch tc = do
-    -- ensure the tycon has been converted, which will create the matcher
+    -- ensure the tycon has been compiled, which will create the matcher
     _ <- convTyCon tc
     maybeMatch <- PIR.lookupDestructor () (GHC.getName tc)
     case maybeMatch of
         Just match -> pure match
-        Nothing    -> throwPlain $ ConversionError "Match has not been converted"
+        Nothing    -> throwPlain $ CompilationError "Match has not been compiled"
 
 -- | Get the matcher of the given 'Type' (which must be equal to a type constructor application) as a PLC term instantiated for
 -- the type constructor argument types.
@@ -251,7 +251,7 @@ getMatchInstantiated t = withContextM (sdToTxt $ "Creating instantiated matcher 
         args' <- mapM convType args
         pure $ PIR.mkIterInst () match args'
     -- must be a TC app
-    _ -> throwPlain $ ConversionError "Type was not a type constructor application"
+    _ -> throwPlain $ CompilationError "Type was not a type constructor application"
 
 -- | Make the alternative for a given 'CoreAlt'.
 convAlt

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
@@ -49,7 +49,7 @@ import           Data.Traversable
 -- Types
 
 convType :: Converting m => GHC.Type -> m PIRType
-convType t = withContextM (sdToTxt $ "Converting type:" GHC.<+> GHC.ppr t) $ do
+convType t = withContextM 2 (sdToTxt $ "Converting type:" GHC.<+> GHC.ppr t) $ do
     -- See Note [Scopes]
     ConvertingContext {ccScopes=stack} <- ask
     let top = NE.head stack
@@ -202,7 +202,7 @@ mkConstructorType dc =
     let argTys = GHC.dataConOrigArgTys dc
     in
         -- See Note [Scott encoding of datatypes]
-        withContextM (sdToTxt $ "Converting data constructor type:" GHC.<+> GHC.ppr dc) $ do
+        withContextM 3 (sdToTxt $ "Converting data constructor type:" GHC.<+> GHC.ppr dc) $ do
             args <- mapM convType argTys
             resultType <- convType (GHC.dataConOrigResTy dc)
             -- t_c_i_1 -> ... -> t_c_i_j -> resultType
@@ -221,7 +221,7 @@ getConstructors tc = do
 -- | Get the constructors of the given 'Type' (which must be equal to a type constructor application) as PLC terms instantiated for
     -- the type constructor argument types.
 getConstructorsInstantiated :: Converting m => GHC.Type -> m [PIRTerm]
-getConstructorsInstantiated t = withContextM (sdToTxt $ "Creating instantiated constructors for type:" GHC.<+> GHC.ppr t) $ case t of
+getConstructorsInstantiated t = withContextM 3 (sdToTxt $ "Creating instantiated constructors for type:" GHC.<+> GHC.ppr t) $ case t of
     (GHC.splitTyConApp_maybe -> Just (tc, args)) -> do
         constrs <- getConstructors tc
 
@@ -244,7 +244,7 @@ getMatch tc = do
 -- | Get the matcher of the given 'Type' (which must be equal to a type constructor application) as a PLC term instantiated for
 -- the type constructor argument types.
 getMatchInstantiated :: Converting m => GHC.Type -> m PIRTerm
-getMatchInstantiated t = withContextM (sdToTxt $ "Creating instantiated matcher for type:" GHC.<+> GHC.ppr t) $ case t of
+getMatchInstantiated t = withContextM 3 (sdToTxt $ "Creating instantiated matcher for type:" GHC.<+> GHC.ppr t) $ case t of
     (GHC.splitTyConApp_maybe -> Just (tc, args)) -> do
         match <- getMatch tc
 
@@ -260,7 +260,7 @@ convAlt
     -> [GHC.Type] -- ^ The instantiated type arguments for the data constructor.
     -> GHC.CoreAlt -- ^ The 'CoreAlt' representing the branch itself.
     -> m PIRTerm
-convAlt mustDelay instArgTys (alt, vars, body) = withContextM (sdToTxt $ "Creating alternative:" GHC.<+> GHC.ppr alt) $ case alt of
+convAlt mustDelay instArgTys (alt, vars, body) = withContextM 3 (sdToTxt $ "Creating alternative:" GHC.<+> GHC.ppr alt) $ case alt of
     GHC.LitAlt _  -> throwPlain $ UnsupportedError "Literal case"
     GHC.DEFAULT   -> do
         body' <- convExpr body >>= maybeDelay mustDelay

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/ValueRestriction.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/ValueRestriction.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE ConstraintKinds   #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 -- | Functions for dealing with the Plutus Core value restriction.
 module Language.PlutusTx.Compiler.ValueRestriction where
@@ -96,4 +95,4 @@ checkTyAbsBody :: Converting m => PIRTerm -> m ()
 checkTyAbsBody t = do
     ConvertingContext {ccOpts=opts} <- ask
     -- we sometimes need to turn this off, as checking for term values also checks for normalized types at the moment
-    unless (not (coCheckValueRestriction opts) || PIR.isTermValue t) $ throwPlain $ ValueRestrictionError "Type abstraction body is not a value"
+    unless (not (coCheckValueRestriction opts) || PIR.isTermValue t) $ throwPlain ValueRestrictionError

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/ValueRestriction.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/ValueRestriction.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE ConstraintKinds   #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase       #-}
 
 -- | Functions for dealing with the Plutus Core value restriction.
 module Language.PlutusTx.Compiler.ValueRestriction where

--- a/plutus-tx/test/Plugin/Spec.hs
+++ b/plutus-tx/test/Plugin/Spec.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:strip-context #-}
+{-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:no-context #-}
 -- the simplifier messes with things otherwise
 {-# OPTIONS_GHC   -O0 #-}
 {-# OPTIONS_GHC   -Wno-orphans #-}

--- a/plutus-tx/test/Plugin/errors/emptyRoseId1.plc.golden
+++ b/plutus-tx/test/Plugin/errors/emptyRoseId1.plc.golden
@@ -1,1 +1,1 @@
-Attempt to polymorphically generalize something which is not a value (often a let-binding)
+Error: Attempt to polymorphically generalize something which is not a value (often a let-binding)

--- a/plutus-tx/test/Plugin/errors/emptyRoseId1.plc.golden
+++ b/plutus-tx/test/Plugin/errors/emptyRoseId1.plc.golden
@@ -1,1 +1,1 @@
-Violation of the value restriction: Type abstraction body is not a value
+Attempt to polymorphically generalize something which is not a value (often a let-binding)

--- a/plutus-tx/test/Plugin/errors/free.plc.golden
+++ b/plutus-tx/test/Plugin/errors/free.plc.golden
@@ -1,1 +1,1 @@
-Used but not defined in the current conversion: Variable &&
+Reference to a value which is not a local, nor a builtin: Variable &&

--- a/plutus-tx/test/Plugin/errors/free.plc.golden
+++ b/plutus-tx/test/Plugin/errors/free.plc.golden
@@ -1,1 +1,1 @@
-Reference to a value which is not a local, nor a builtin: Variable &&
+Error: Reference to a value which is not a local, nor a builtin: Variable &&

--- a/plutus-tx/test/Plugin/errors/integer.plc.golden
+++ b/plutus-tx/test/Plugin/errors/integer.plc.golden
@@ -1,1 +1,1 @@
-Unsupported: Literal (unbounded) integer
+Unsupported feature: Literal (unbounded) integer

--- a/plutus-tx/test/Plugin/errors/integer.plc.golden
+++ b/plutus-tx/test/Plugin/errors/integer.plc.golden
@@ -1,1 +1,1 @@
-Unsupported feature: Literal (unbounded) integer
+Error: Unsupported feature: Literal (unbounded) integer

--- a/plutus-tx/test/Plugin/errors/recordSelector.plc.golden
+++ b/plutus-tx/test/Plugin/errors/recordSelector.plc.golden
@@ -1,1 +1,1 @@
-Unsupported: Record selectors, use pattern matching
+Unsupported feature: Record selectors, use pattern matching

--- a/plutus-tx/test/Plugin/errors/recordSelector.plc.golden
+++ b/plutus-tx/test/Plugin/errors/recordSelector.plc.golden
@@ -1,1 +1,1 @@
-Unsupported feature: Record selectors, use pattern matching
+Error: Unsupported feature: Record selectors, use pattern matching

--- a/plutus-tx/test/Plugin/errors/valueRestriction.plc.golden
+++ b/plutus-tx/test/Plugin/errors/valueRestriction.plc.golden
@@ -1,1 +1,1 @@
-Attempt to polymorphically generalize something which is not a value (often a let-binding)
+Error: Attempt to polymorphically generalize something which is not a value (often a let-binding)

--- a/plutus-tx/test/Plugin/errors/valueRestriction.plc.golden
+++ b/plutus-tx/test/Plugin/errors/valueRestriction.plc.golden
@@ -1,1 +1,1 @@
-Violation of the value restriction: Type abstraction body is not a value
+Attempt to polymorphically generalize something which is not a value (often a let-binding)


### PR DESCRIPTION
- Moderately improve some error messages
- Give priorities to contexts, so we only print those that are useful for locating the error by default.