### PR TITLE
wallet-api: Extract map

### DIFF
--- a/plutus-playground-client/src/Chain/BlockchainExploration.purs
+++ b/plutus-playground-client/src/Chain/BlockchainExploration.purs
@@ -20,6 +20,7 @@ import Halogen.HTML.Properties (class_, classes, colSpan)
 import Ledger.Ada.TH (Ada(..))
 import Ledger.Types (DataScript(..), PubKey(PubKey), RedeemerScript(..), Signature(Signature), Tx(Tx), TxIdOf(TxIdOf), TxInOf(TxInOf), TxInType(..), TxOutOf(TxOutOf), TxOutRefOf(TxOutRefOf), TxOutType(..))
 import Ledger.Value.TH (CurrencySymbol(..), Value(..))
+import Ledger.Map.TH as LedgerMap
 import Partial.Unsafe (unsafePartial)
 import Prelude (class Eq, class Ord, class Show, map, show, (#), ($), (+), (<#>), (<$>), (<*>), (<<<), (<>), (==))
 import Types (Blockchain)
@@ -147,7 +148,7 @@ toBalanceMap =
                                ))
   where
     forgeTransactions :: Row -> Tuple (TxIdOf String) Tx -> Tuple (Tuple Column Row) Balance
-    forgeTransactions row (Tuple _ (Tx {txForge: (Value { getValue: value})})) =
+    forgeTransactions row (Tuple _ (Tx {txForge: (Value { getValue: LedgerMap.Map { unMap : value}})})) =
       Tuple (Tuple ForgeIx row) (CurrencyBalance value)
 
     feeTransactions :: Row -> Tuple (TxIdOf String) Tx -> Tuple (Tuple Column Row) Balance
@@ -174,11 +175,11 @@ toBalanceMap =
       where
         fromTxOut :: TxOutOf String -> Tuple (Tuple Column Row) Balance
         fromTxOut (TxOutOf { txOutType: (PayToPubKey (PubKey { getPubKey: owner }))
-                           , txOutValue: (Value { getValue: currencyBalances })
+                           , txOutValue: (Value ({ getValue: LedgerMap.Map { unMap: currencyBalances }}))
                            })
           = Tuple (Tuple (OwnerIx owner hash) row) (CurrencyBalance currencyBalances)
         fromTxOut (TxOutOf { txOutType: (PayToScript (DataScript { getDataScript: owner }))
-                           , txOutValue: (Value { getValue: currencyBalances })
+                           , txOutValue: (Value ({ getValue: LedgerMap.Map { unMap: currencyBalances }}))
                            })
           = Tuple (Tuple (ScriptIx owner hash) row) (CurrencyBalance currencyBalances)
 

--- a/plutus-playground-client/test/evaluation_response1.json
+++ b/plutus-playground-client/test/evaluation_response1.json
@@ -66,17 +66,21 @@
             }
           },
           "txForge": {
-            "getValue": []
+            "getValue": {
+              "unMap": []
+            }
           },
           "txOutputs": [
             {
               "txOutValue": {
-                "getValue": [
-                  [
-                    0,
-                    6
+                "getValue": {
+                  "unMap": [
+                    [
+                      0,
+                      6
+                    ]
                   ]
-                ]
+                }
               },
               "txOutAddress": {
                 "getAddress": "nxgcGMMYrRjqGEAY6xj9GJQYQxg6GMAEGHcYfRhoFQwYzhidGLQYxxhxGLwYfRjhGLIYlxinGLcYlRi7GLr/"
@@ -90,12 +94,14 @@
             },
             {
               "txOutValue": {
-                "getValue": [
-                  [
-                    0,
-                    4
+                "getValue": {
+                  "unMap": [
+                    [
+                      0,
+                      4
+                    ]
                   ]
-                ]
+                }
               },
               "txOutAddress": {
                 "getAddress": "nxicEhjPGNwEGMcYRRiEGNcYhxisGD0YIxh3GCEYMhjBGIUYJBi8GHoYshiNGOwYQhgZGLgY/BhbGEIYXxhw/w=="
@@ -128,22 +134,26 @@
             }
           },
           "txForge": {
-            "getValue": [
-              [
-                0,
-                20
+            "getValue": {
+              "unMap": [
+                [
+                  0,
+                  20
+                ]
               ]
-            ]
+            }
           },
           "txOutputs": [
             {
               "txOutValue": {
-                "getValue": [
-                  [
-                    0,
-                    10
+                "getValue": {
+                  "unMap": [
+                    [
+                      0,
+                      10
+                    ]
                   ]
-                ]
+                }
               },
               "txOutAddress": {
                 "getAddress": "nxicEhjPGNwEGMcYRRiEGNcYhxisGD0YIxh3GCEYMhjBGIUYJBi8GHoYshiNGOwYQhgZGLgY/BhbGEIYXxhw/w=="
@@ -157,12 +167,14 @@
             },
             {
               "txOutValue": {
-                "getValue": [
-                  [
-                    0,
-                    10
+                "getValue": {
+                  "unMap": [
+                    [
+                      0,
+                      10
+                    ]
                   ]
-                ]
+                }
               },
               "txOutAddress": {
                 "getAddress": "nxgcGMMYrRjqGEAY6xj9GJQYQxg6GMAEGHcYfRhoFQwYzhidGLQYxxhxGLwYfRjhGLIYlxinGLcYlRi7GLr/"

--- a/plutus-playground-server/app/PSGenerator.hs
+++ b/plutus-playground-server/app/PSGenerator.hs
@@ -35,10 +35,11 @@ import           Language.PureScript.Bridge                (BridgePart, Language
                                                             psTypeParameters, typeModule, typeName, writePSTypes, (^==))
 import           Language.PureScript.Bridge.Builder        (BridgeData)
 import           Language.PureScript.Bridge.PSTypes        (psArray, psInt, psString)
-import           Language.PureScript.Bridge.TypeParameters (A)
+import           Language.PureScript.Bridge.TypeParameters (A, B)
 import           Ledger.Ada                                (Ada)
 import           Ledger.Index                              (ValidationError)
 import           Ledger.Interval                           (Interval, Slot)
+import           Ledger.Map.TH                             (Map)
 import           Ledger.Types                              (AddressOf, DataScript, PubKey, RedeemerScript, Signature,
                                                             Tx, TxIdOf, TxInOf, TxInType, TxOutOf, TxOutRefOf,
                                                             TxOutType, ValidatorScript)
@@ -218,6 +219,7 @@ myTypes =
     , mkSumType (Proxy @KnownCurrency)
     , mkSumType (Proxy @InterpreterError)
     , mkSumType (Proxy @(InterpreterResult A))
+    , mkSumType (Proxy @(Map A B))
     ]
 
 mySettings :: Settings

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -148,10 +148,12 @@ vestingSpec =
                                   ]
                             , SimpleObjectSchema
                                   [ ( "getValue"
-                                    , SimpleArraySchema
+                                    , SimpleObjectSchema
+                                    [ ( "unMap"
+                                      , SimpleArraySchema
                                           (SimpleTupleSchema
-                                               ( SimpleIntSchema
-                                               , SimpleIntSchema)))
+                                                ( SimpleIntSchema
+                                                , SimpleIntSchema)))])
                                   ]
                             , SimpleObjectSchema
                                   [("getPubKey", SimpleIntSchema)]
@@ -308,27 +310,31 @@ gameSpec =
                   (Fn "payToPublicKey_")
                   (Wallet 1)
                   [ slotRange
-                  , JSON.String "{\"getValue\":[[0,9]]}"
+                  , JSON.String nineAda
                   , JSON.String "{\"getPubKey\":2}"
                   ]
             , Action
                   (Fn "payToPublicKey_")
                   (Wallet 2)
                   [ slotRange
-                  , JSON.String "{\"getValue\":[[0,9]]}"
+                  , JSON.String nineAda
                   , JSON.String "{\"getPubKey\":3}"
                   ]
             , Action
                   (Fn "payToPublicKey_")
                   (Wallet 3)
                   [ slotRange
-                  , JSON.String "{\"getValue\":[[0,9]]}"
+                  , JSON.String nineAda
                   , JSON.String "{\"getPubKey\":1}"
                   ]
             ]
             (sourceCode game)
             []
     slotRange = JSON.String "{\"ivTo\":null,\"ivFrom\":null}"
+    nineAda =
+      TL.toStrict $
+      JSON.encodeToLazyText $
+      Ada.adaValueOf 9
 
 hasFundsDistribution ::
        [SimulatorWallet]

--- a/plutus-tutorial/tutorial/Tutorial/Emulator.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Emulator.hs
@@ -256,7 +256,8 @@ simpleTraceDist = EM.fundsDistribution $ snd $ runTrace simpleTrace
 {- |
 
     >>> simpleTraceDist
-    fromList [(Wallet {getWallet = 1},Value {getValue = [(CurrencySymbol 0,900)]}),(Wallet {getWallet = 2},Value {getValue = [(CurrencySymbol 0,1100)]})]
+    fromList [(Wallet {getWallet = 1},Value {getValue = Map {unMap = [(CurrencySymbol 0,900)]}}),(Wallet {getWallet = 2},Value {getValue = Map {unMap = [(CurrencySymbol 0,1100)]}})]
+
 
     'simpleTraceDist' shows that our transaction was successful: Wallet 1 now 
     owns 900 Ada (the currency identified by )
@@ -295,7 +296,8 @@ gameSuccess = do
     The final distribution after 'gameSuccess' looks as we would expect:
 
     >>> EM.fundsDistribution $ snd $ runTrace simpleTrace
-    fromList [(Wallet {getWallet = 1},Value {getValue = [(CurrencySymbol 0,900)]}),(Wallet {getWallet = 2},Value {getValue = [(CurrencySymbol 0,1100)]})]
+    fromList [(Wallet {getWallet = 1},Value {getValue = Map {unMap = [(CurrencySymbol 0,900)]}}),(Wallet {getWallet = 2},Value {getValue = Map {unMap = [(CurrencySymbol 0,1100)]}})]
+
 -}
 
 gameFailure :: (WalletAPI m, WalletDiagnostics m) => EM.Trace m ()

--- a/plutus-tutorial/tutorial/Tutorial/Vesting.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Vesting.hs
@@ -351,7 +351,7 @@ vestingSuccess = do
         functions `runTraceDist` and `runTraceLog` from `Ledger.ExUtil`
     >>> import Tutorial.ExUtil
     >>> runTraceDist vestingSuccess
-    fromList [(Wallet {getWallet = 1},Value {getValue = [(CurrencySymbol 0,1010)]}),(Wallet {getWallet = 2},Value {getValue = [(CurrencySymbol 0,940)]}),(Wallet {getWallet = 3},Value {getValue = [(CurrencySymbol 0,1000)]})]
+    fromList [(Wallet {getWallet = 1},Value {getValue = Map {unMap = [(CurrencySymbol 0,1010)]}}),(Wallet {getWallet = 2},Value {getValue = Map {unMap = [(CurrencySymbol 0,940)]}}),(Wallet {getWallet = 3},Value {getValue = Map {unMap = [(CurrencySymbol 0,1000)]}})]
 
     E9. Write traces similar to `vestingSuccess` that
 

--- a/wallet-api/src/Ledger/Map.hs
+++ b/wallet-api/src/Ledger/Map.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- A map implementation that can be used in on-chain and off-chain code.
+module Ledger.Map(
+    Map
+    , IsEqual
+    , singleton
+    , empty
+    , map
+    , lookup
+    , union
+    , all
+    -- * These
+    , These(..)
+    , these
+    ) where
+    
+import           Ledger.Map.TH (IsEqual, Map, These(..))
+import qualified Ledger.Map.TH as TH
+import           Prelude hiding (all, lookup, map)
+
+-- | See 'Ledger.Map.TH.map'
+map :: (v -> w) -> Map k v -> Map k w
+map = $$(TH.map)
+
+-- | See 'Ledger.Map.TH.lookup'
+lookup :: IsEqual k -> k -> Map k v -> Maybe v
+lookup = $$(TH.lookup)
+
+-- | See 'Ledger.Map.TH.union'
+union :: IsEqual k -> Map k v -> Map k r -> Map k (These v r)
+union = $$(TH.union)
+
+-- | See 'Ledger.Map.TH.all'
+all :: (v -> Bool) -> Map k v -> Bool
+all = $$(TH.all)
+
+-- | See 'Ledger.Map.TH.singleton'
+singleton :: k -> v -> Map k v
+singleton = $$(TH.singleton)
+
+-- | See 'Ledger.Map.TH.empty'
+empty :: Map k v
+empty = $$(TH.empty)
+
+-- | See 'Ledger.These.TH.these'
+these :: (a -> c) -> (b -> c) -> (a -> b -> c) -> These a b -> c
+these = $$(TH.these)

--- a/wallet-api/src/Ledger/Map/TH.hs
+++ b/wallet-api/src/Ledger/Map/TH.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE DeriveAnyClass         #-}
+{-# LANGUAGE DeriveGeneric          #-}
+{-# LANGUAGE DerivingStrategies     #-}
+{-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE LambdaCase             #-}
+{-# LANGUAGE MonoLocalBinds         #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+-- A map implementation that can be used in on-chain and off-chain code.
+module Ledger.Map.TH(
+    Map
+    , IsEqual
+    , singleton
+    , empty
+    , map
+    , lookup
+    , union
+    , all
+    -- * These
+    , These(..)
+    , these
+    ) where
+
+import           Codec.Serialise.Class        (Serialise)
+import           Data.Aeson                   (FromJSON, ToJSON)
+import           Data.Swagger.Internal.Schema (ToSchema)
+import           GHC.Generics                 (Generic)
+import           Language.PlutusTx.Lift       (makeLift)
+import qualified Language.PlutusTx.Prelude    as P
+import           Language.Haskell.TH          (Q, TExp)
+import           Ledger.These.TH              (These(..), these)
+import           Prelude                      hiding (all, lookup, map, negate)
+
+
+-- | A 'Map' of key-value pairs. 
+data Map k v = Map { unMap :: [(k, v)] }
+    deriving (Show)
+    deriving stock (Generic)
+    deriving anyclass (ToSchema, ToJSON, FromJSON, Serialise)
+
+makeLift ''Map
+
+-- | Apply a function to the values of a 'Map'.
+map :: Q (TExp ((v -> w) -> Map k v -> Map k w))
+map = [|| 
+    let
+        map :: forall k v w. (v -> w) -> Map k v -> Map k w
+        map f (Map mp) =
+            let 
+                go :: [(k, v)] -> [(k, w)]
+                go [] = []
+                go ((c, i):xs') = (c, f i) : go xs'
+            in Map (go mp)
+    in
+        map
+    ||]
+
+-- | Compare two 'k's for equality.
+type IsEqual k = k -> k -> Bool
+
+-- | Find an entry in a 'Map'.
+lookup :: Q (TExp (IsEqual k -> k -> Map k v -> Maybe v))
+lookup = [|| 
+
+    let lookup :: forall k v. IsEqual k -> k -> Map k v -> Maybe v
+        lookup eq c (Map xs) =
+            let 
+                go :: [(k, v)] -> Maybe v
+                go []            = Nothing
+                go ((c', i):xs') = if eq c' c then Just i else go xs'
+            in go xs
+    in
+        lookup
+ ||]
+
+-- | Combine two 'Map's.
+union :: Q (TExp (IsEqual k -> Map k v -> Map k r -> Map k (These v r)))
+union = [|| 
+
+    let union :: forall k v r. IsEqual k -> Map k v -> Map k r -> Map k (These v r)
+        union eq (Map ls) (Map rs) =
+            let 
+                f :: v -> Maybe r -> These v r
+                f a b' = case b' of
+                    Nothing -> This a
+                    Just b  -> These a b
+
+                ls' :: [(k, These v r)]
+                ls' = $$(P.map) (\(c, i) -> (c, (f i ($$(lookup) eq c (Map rs))))) ls
+
+                rs' :: [(k, r)]
+                rs' = $$(P.filter) (\(c, _) -> $$(P.not) ($$(P.any) (\(c', _) -> eq c' c) ls)) rs
+
+                rs'' :: [(k, These v r)]
+                rs'' = $$(P.map) (\(c, b) -> (c, (That b))) rs'
+
+            in Map ($$(P.append) ls' rs'')
+    in union
+    ||]
+
+-- | See 'Data.Map.all'
+all :: Q (TExp ((v -> Bool) -> Map k v -> Bool))
+all = [|| 
+
+    let all :: forall k v. (v -> Bool) -> Map k v -> Bool
+        all p (Map mps) =
+            let go xs = case xs of 
+                    []         -> True
+                    (_, x):xs' -> $$(P.and) (p x) (go xs')
+            in go mps 
+    in all ||]
+
+
+-- | A singleton map.
+singleton :: Q (TExp (k -> v -> Map k v))
+singleton = [|| \c i -> Map [(c, i)] ||]
+
+-- | An empty 'Map'.
+empty :: Q (TExp (Map k v))
+empty = [|| Map ([] :: [(k, v)]) ||]
+
+    

--- a/wallet-api/src/Ledger/These.hs
+++ b/wallet-api/src/Ledger/These.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
+-- A version of 'Data.These' that can be used in on-chain and off-chain code.
+module Ledger.These(
+    These(..)
+  , these
+  , theseWithDefault
+  ) where
+
+import           Ledger.These.TH (These (..))
+import qualified Ledger.These.TH as TH
+
+-- | See 'Ledger.These.TH.these'
+these :: (a -> c) -> (b -> c) -> (a -> b -> c) -> These a b -> c
+these = $$(TH.these)
+
+-- | See 'Ledger.These.TH.theseWithDefault
+theseWithDefault :: a -> b -> (a -> b -> c) -> These a b -> c
+theseWithDefault = $$(TH.theseWithDefault)

--- a/wallet-api/src/Ledger/These/TH.hs
+++ b/wallet-api/src/Ledger/These/TH.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE LambdaCase             #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+module Ledger.These.TH(
+    These(..)
+  , these
+  , theseWithDefault
+  ) where
+
+import           Language.Haskell.TH          (Q, TExp)
+
+-- | A 'These' @a@ @b@ is either an @a@, or a @b@ or an @a@ and a @b@.
+-- Plutus version of 'Data.These'.
+data These a b = This a | That b | These a b
+
+-- | Consume a 'These a b' value.
+theseWithDefault :: Q (TExp (a -> b -> (a -> b -> c) -> These a b -> c))
+theseWithDefault = [|| 
+
+    let theseWithDefault :: forall a b c. a -> b -> (a -> b -> c) -> These a b -> c
+        theseWithDefault a' b' f = \case 
+            This a -> f a b'
+            That b -> f a' b
+            These a b -> f a b
+    in theseWithDefault
+
+    ||]
+
+these :: Q (TExp ((a -> c) -> (b -> c) -> (a -> b -> c) -> These a b -> c))
+these = [||
+    \f g h -> \case
+        This a -> f a
+        That b -> g b
+        These a b -> h a b
+    ||]

--- a/wallet-api/src/Ledger/Value/TH.hs
+++ b/wallet-api/src/Ledger/Value/TH.hs
@@ -34,6 +34,8 @@ import           GHC.Generics                 (Generic)
 import           Language.PlutusTx.Lift       (makeLift)
 import qualified Language.PlutusTx.Prelude    as P
 import           Language.Haskell.TH          (Q, TExp)
+import qualified Ledger.Map.TH                as Map
+import qualified Ledger.These.TH              as These
 import           Prelude                      hiding (all, lookup, negate)
 
 data CurrencySymbol = CurrencySymbol Int
@@ -61,13 +63,16 @@ currencySymbol = [|| CurrencySymbol ||]
 -- taken to be zero.
 --
 -- See note [Currencies] for more details.
-newtype Value = Value { getValue :: [(CurrencySymbol, Int)] }
+newtype Value = Value { getValue :: Map.Map CurrencySymbol Int }
     deriving (Show)
     deriving stock (Generic)
     deriving anyclass (ToSchema, ToJSON, FromJSON)
     deriving newtype (Serialise)
 
 makeLift ''Value
+
+eqCurSymbol :: Q (TExp (CurrencySymbol -> CurrencySymbol -> Bool))
+eqCurSymbol = [|| \(CurrencySymbol l) (CurrencySymbol r) -> $$(P.eq) l r ||]
 
 {- note [Currencies]
 
@@ -87,80 +92,34 @@ similar to 'Ledger.Ada' for their own currencies.
 
 -}
 
-type CurrencyMap v = [(CurrencySymbol, v)]
-
-cmap :: Q (TExp ((v -> w) -> CurrencyMap v -> CurrencyMap w))
-cmap = [||
-    \f ->
-        let go [] = []
-            go ((c, i):xs') = (c, f i) : go xs'
-        in go
-    ||]
-
-lookup :: Q (TExp (CurrencySymbol -> CurrencyMap v -> Maybe v))
-lookup = [||
-    \(CurrencySymbol cur) xs ->
-        let
-            go :: [(CurrencySymbol, v)] -> Maybe v
-            go []                          = Nothing
-            go ((CurrencySymbol c, i):xs') = if $$(P.eq) c cur then Just i else go xs'
-        in go xs
- ||]
-
 -- | Get the quantity of the given currency in the 'Value'.
 valueOf :: Q (TExp (Value -> CurrencySymbol -> Int))
-valueOf = [||
-  \(Value xs) cur ->
-      case $$(lookup) cur xs of
+valueOf = [|| 
+  \(Value mp) cur -> 
+      case $$(Map.lookup) $$(eqCurSymbol) cur mp of
         Nothing -> 0 :: Int
         Just i  -> i
    ||]
 
-data These a b = This a | That b | These a b
-
-these :: Q (TExp (a -> b -> (a -> b -> c) -> These a b -> c))
-these = [||
-    \a' b' f -> \case
-        This a -> f a b'
-        That b -> f a' b
-        These a b -> f a b
-    ||]
-
-union :: Q (TExp (CurrencyMap a -> CurrencyMap b -> CurrencyMap (These a b)))
-union = [||
-    \ls rs ->
-        let
-            f a b' = case b' of
-                Nothing -> This a
-                Just b  -> These a b
-            ls' = $$(P.map) (\(c, i) -> (c, (f i ($$(lookup) c rs)))) ls
-            rs' = $$(P.filter) (\(CurrencySymbol c, _) -> $$(P.not) ($$(P.any) (\(CurrencySymbol c', _) -> $$(P.eq) c' c) ls)) rs
-            rs'' = $$(P.map) (\(c, b) -> (c, (That b))) rs'
-        in $$(P.append) ls' rs''
-  ||]
-
 -- | Make a 'Value' containing only the given quantity of the given currency.
 singleton :: Q (TExp (CurrencySymbol -> Int -> Value))
-singleton = [|| \c i -> Value [(c, i)] ||]
+singleton = [|| \c i -> Value ($$(Map.singleton) c i) ||]
 
 unionWith :: Q (TExp ((Int -> Int -> Int) -> Value -> Value -> Value))
 unionWith = [||
-  \f (Value ls) (Value rs) ->
-    let
-        combined = $$(union) ls rs
+  \f (Value ls) (Value rs) -> 
+    let 
+        combined = $$(Map.union) $$(eqCurSymbol) ls rs
         unThese k = case k of
-            This a    -> f a 0
-            That b    -> f 0 b
-            These a b -> f a b
-    in Value ($$(cmap) unThese combined)
+            Map.This a    -> f a 0
+            Map.That b    -> f 0 b
+            Map.These a b -> f a b
+    in Value ($$(Map.map) unThese combined)
   ||]
-
-all :: Q (TExp ((v -> Bool) -> CurrencyMap v -> Bool))
-all = [|| \p -> let go xs = case xs of { [] -> True; (_, x):xs' -> $$(P.and) (p x) (go xs') } in go ||]
 
 -- | Multiply all the quantities in the 'Value' by the given scale factor.
 scale :: Q (TExp (Int -> Value -> Value))
-scale = [|| \i (Value xs) -> Value ($$(P.map) (\(c, i') -> (c, $$(P.multiply) i i')) xs) ||]
+scale = [|| \i (Value xs) -> Value ($$(Map.map) (\i' -> $$(P.multiply) i i') xs) ||]
 
 -- Num operations
 
@@ -182,53 +141,53 @@ multiply = [|| $$(unionWith) $$(P.multiply) ||]
 
 -- | The empty 'Value'.
 zero :: Q (TExp Value)
-zero = [|| Value [] ||]
+zero = [|| Value $$(Map.empty) ||]
 
 -- | Check whether a 'Value' is zero.
 isZero :: Q (TExp (Value -> Bool))
-isZero = [|| \(Value xs) -> $$(P.all) (\(_, i) -> $$(P.eq) 0 i) xs ||]
+isZero = [|| \(Value xs) -> $$(Map.all) (\i -> $$(P.eq) 0 i) xs ||]
 
 -- | Check whether one 'Value' is greater than or equal to another. See 'Value' for an explanation of how operations on 'Value's work.
 geq :: Q (TExp (Value -> Value -> Bool))
-geq = [||
-  \(Value ls) (Value rs) ->
-    let
-        p = $$(these) 0 0 $$(P.geq)
+geq = [|| 
+  \(Value ls) (Value rs) -> 
+    let 
+        p = $$(These.theseWithDefault) 0 0 $$(P.geq)
     in
-      $$(all) p ($$(union) ls rs) ||]
+      $$(Map.all) p ($$(Map.union) $$(eqCurSymbol) ls rs) ||]
 
 -- | Check whether one 'Value' is strictly greater than another. See 'Value' for an explanation of how operations on 'Value's work.
 gt :: Q (TExp (Value -> Value -> Bool))
-gt = [||
-    \(Value ls) (Value rs) ->
-    let
-        p = $$(these) 0 0 $$(P.gt)
+gt = [|| 
+    \(Value ls) (Value rs) -> 
+    let 
+        p = $$(These.theseWithDefault) 0 0 $$(P.gt)
     in
-        $$(all) p ($$(union) ls rs) ||]
+      $$(Map.all) p ($$(Map.union) $$(eqCurSymbol) ls rs) ||]
 
 -- | Check whether one 'Value' is less than or equal to another. See 'Value' for an explanation of how operations on 'Value's work.
 leq :: Q (TExp (Value -> Value -> Bool))
-leq = [||
-    \(Value ls) (Value rs) ->
-    let
-        p = $$(these) 0 0 $$(P.leq)
+leq = [|| 
+    \(Value ls) (Value rs) -> 
+    let 
+        p = $$(These.theseWithDefault) 0 0 $$(P.leq)
     in
-        $$(all) p ($$(union) ls rs) ||]
+      $$(Map.all) p ($$(Map.union) $$(eqCurSymbol) ls rs) ||]
 
 -- | Check whether one 'Value' is strictly less than another. See 'Value' for an explanation of how operations on 'Value's work.
 lt :: Q (TExp (Value -> Value -> Bool))
-lt = [||
-    \(Value ls) (Value rs) ->
-        let
-            p = $$(these) 0 0 $$(P.lt)
+lt = [|| 
+    \(Value ls) (Value rs) -> 
+        let 
+            p = $$(These.theseWithDefault) 0 0 $$(P.lt)
         in
-        $$(all) p ($$(union) ls rs) ||]
+      $$(Map.all) p ($$(Map.union) $$(eqCurSymbol) ls rs) ||]
 
 -- | Check whether one 'Value' is equal to another. See 'Value' for an explanation of how operations on 'Value's work.
 eq :: Q (TExp (Value -> Value -> Bool))
-eq = [||
-    \(Value ls) (Value rs) ->
-    let
-        p = $$(these) 0 0 $$(P.eq)
+eq = [|| 
+    \(Value ls) (Value rs) -> 
+    let 
+        p = $$(These.theseWithDefault) 0 0 $$(P.eq)
     in
-        $$(all) p ($$(union) ls rs) ||]
+      $$(Map.all) p ($$(Map.union) $$(eqCurSymbol) ls rs) ||]

--- a/wallet-api/wallet-api.cabal
+++ b/wallet-api/wallet-api.cabal
@@ -55,6 +55,10 @@ library
         Ledger
         Ledger.Ada
         Ledger.Ada.TH
+        Ledger.Map
+        Ledger.Map.TH
+        Ledger.These
+        Ledger.These.TH
         Ledger.Types
         Ledger.Validation
         Ledger.Index


### PR DESCRIPTION
Move the map implementation from `Ledger.Value.TH` to its own module. That
way we can easily replace it with the real map once it's available.

This changes the JSON representation of the `Value` type slightly, so a
couple of tests in the tutorials and playground projects had to be
changed.