### PR TITLE
expose Lexer and Parser in language-plutus-core

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -72,6 +72,10 @@ library
         Language.PlutusCore.Generators.AST
         Language.PlutusCore.Generators.Interesting
         Language.PlutusCore.Generators.Test
+        Language.PlutusCore.Type
+        Language.PlutusCore.Lexer
+        Language.PlutusCore.Lexer.Type
+        Language.PlutusCore.Parser
         PlutusPrelude
         Common
         Data.ByteString.Lazy.Hash
@@ -80,10 +84,6 @@ library
     hs-source-dirs: src prelude stdlib examples generators common
     other-modules:
         Crypto
-        Language.PlutusCore.Type
-        Language.PlutusCore.Lexer
-        Language.PlutusCore.Lexer.Type
-        Language.PlutusCore.Parser
         Language.PlutusCore.Constant.Apply
         Language.PlutusCore.Constant.Dynamic.BuiltinName
         Language.PlutusCore.Constant.Dynamic.Call

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -72,9 +72,7 @@ library
         Language.PlutusCore.Generators.AST
         Language.PlutusCore.Generators.Interesting
         Language.PlutusCore.Generators.Test
-        Language.PlutusCore.Type
         Language.PlutusCore.Lexer
-        Language.PlutusCore.Lexer.Type
         Language.PlutusCore.Parser
         PlutusPrelude
         Common
@@ -84,6 +82,8 @@ library
     hs-source-dirs: src prelude stdlib examples generators common
     other-modules:
         Crypto
+        Language.PlutusCore.Type
+        Language.PlutusCore.Lexer.Type
         Language.PlutusCore.Constant.Apply
         Language.PlutusCore.Constant.Dynamic.BuiltinName
         Language.PlutusCore.Constant.Dynamic.Call


### PR DESCRIPTION
To allow plutus-metatheory to use the language-plutus-core lexer and
parser the following additional modules need to be exposed:

Language.PlutusCore.Type
Language.PlutusCore.Lexer
Language.PlutusCore.Lexer.Type
Language.PlutusCore.Parser