### PR TITLE
expose Crypto module for use in plc-agda

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -78,10 +78,10 @@ library
         Common
         Data.ByteString.Lazy.Hash
         PlcTestUtils
+        Crypto
     build-tool-depends: alex:alex -any, happy:happy >=1.17.1
     hs-source-dirs: src prelude stdlib examples generators common
     other-modules:
-        Crypto
         Language.PlutusCore.Type
         Language.PlutusCore.Lexer.Type
         Language.PlutusCore.Constant.Apply


### PR DESCRIPTION
To validate signatures in `plc-agda` I would like to use this module.