### PR TITLE
use-cases: Add multi sig contract

### DIFF
--- a/plutus-tx/src/Language/PlutusTx/Prelude/Stage1.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude/Stage1.hs
@@ -5,7 +5,7 @@
 -- reusing functions.
 module Language.PlutusTx.Prelude.Stage1 where
 
-import           Prelude                    (Bool (..), Int, (+), (>))
+import           Prelude                    (Bool (..), Int, (>))
 
 import           Language.PlutusTx.Prelude.Stage0
 
@@ -17,7 +17,7 @@ import           Language.Haskell.TH
 --   4
 --
 length :: Q (TExp ([a] -> Int))
-length = [|| $$(foldr) (\_ acc -> acc+1) 0 ||]
+length = [|| $$(foldr) (\_ acc -> $$plus acc 1) 0 ||]
 
 -- | PlutusTx version of 'Data.List.all'.
 --

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -23,6 +23,7 @@ library
         Language.PlutusTx.Coordination.Contracts.CrowdFunding
         Language.PlutusTx.Coordination.Contracts.Future
         Language.PlutusTx.Coordination.Contracts.Game
+        Language.PlutusTx.Coordination.Contracts.MultiSig
         Language.PlutusTx.Coordination.Contracts.Vesting
         Language.PlutusTx.Coordination.Contracts.Swap
     hs-source-dirs: src
@@ -52,6 +53,7 @@ test-suite plutus-use-cases-test
         Spec.Crowdfunding
         Spec.Future
         Spec.Game
+        Spec.MultiSig
         Spec.Vesting
     default-language: Haskell2010
     ghc-options: -Wall -Wnoncanonical-monad-instances
@@ -68,4 +70,6 @@ test-suite plutus-use-cases-test
         wallet-api -any,
         plutus-use-cases -any,
         plutus-tx -any,
-        template-haskell -any
+        template-haskell -any,
+        lens -any,
+        mtl -any

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+-- | Implements an n-out-of-m multisig contract.
+module Language.PlutusTx.Coordination.Contracts.MultiSig
+    ( MultiSig(..)
+    , msValidator
+    , msDataScript
+    , msRedeemer
+    , msAddress
+    , lock
+    , initialise
+    , unlockTx
+    ) where
+
+import qualified Data.Map                     as Map
+import qualified Data.Set                     as Set
+import           Data.Foldable                (fold)
+import qualified Ledger.Ada                   as Ada
+import qualified Ledger.Value                 as Value
+import qualified Language.PlutusTx            as P
+import           Ledger                       as Ledger hiding (initialise, to)
+import           Ledger.Validation            as V
+import           Wallet.API                   as WAPI
+
+data MultiSig = MultiSig 
+                { signatories :: [Ledger.PubKey]
+                -- ^ List of public keys of people who may sign the transaction
+                , requiredSignatures :: Int
+                -- ^ Minimum number of signatures required to unlock
+                --   the output (should not exceed @length signatories@)
+                }
+P.makeLift ''MultiSig
+
+msValidator :: MultiSig -> ValidatorScript
+msValidator sig = 
+  ValidatorScript (Ledger.applyScript mkValidator (Ledger.lifted sig)) where
+    mkValidator = Ledger.fromCompiledCode ($$(P.compile [||
+      let 
+        validate :: MultiSig -> () -> () -> PendingTx -> ()
+        validate (MultiSig keys num) () () p = 
+            let 
+                present = $$(P.length) ($$(P.filter) ($$(V.txSignedBy) p) keys)
+            in
+                if $$(P.geq) present num
+                then ()
+                else $$(P.error) ($$(P.traceH) "WRONG!" ())
+
+      in
+        validate
+      ||]))
+
+-- | Multisig data script (unit value).
+msDataScript :: DataScript
+msDataScript = DataScript $ Ledger.lifted ()
+
+-- | Multisig redeemer (unit value).
+msRedeemer :: RedeemerScript
+msRedeemer = RedeemerScript $ Ledger.lifted ()
+
+-- | The address of a 'MultiSig' contract.
+msAddress :: MultiSig -> Address
+msAddress = Ledger.scriptAddress . msValidator
+
+-- | Lock some funds in a 'MultiSig' contract.
+lock :: (WalletAPI m, WalletDiagnostics m) => MultiSig -> Value -> m ()
+lock ms vl = payToScript_ defaultSlotRange (msAddress ms) vl msDataScript
+
+-- | Instruct the wallet to start watching the contract address
+initialise :: (WalletAPI m) => MultiSig -> m ()
+initialise = startWatching . msAddress
+
+-- | Create a transaction that unlocks the funds. It has the signature of the
+--   current wallet attached.
+unlockTx :: (Monad m, WalletAPI m) => MultiSig -> m Tx
+unlockTx ms = do
+    let
+        validator = msValidator ms
+        address   = msAddress ms
+
+    utxos <- WAPI.outputsAt address
+
+    let 
+
+        mkIn :: TxOutRef -> TxIn
+        mkIn r = Ledger.scriptTxIn r validator msRedeemer
+
+        ins = Set.map mkIn (Map.keysSet utxos)
+        val = fold (Ledger.txOutValue . snd <$> Map.toList utxos)
+
+    ownOutput <- WAPI.ownPubKeyTxOut val
+
+    let tx = Ledger.Tx
+                { txInputs = ins
+                , txOutputs = [ownOutput]
+                , txForge = Value.zero
+                , txFee   = Ada.zero
+                , txValidRange = defaultSlotRange
+                , txSignatures = Map.empty
+                }
+
+    signTxn tx

--- a/plutus-use-cases/test/Spec.hs
+++ b/plutus-use-cases/test/Spec.hs
@@ -4,6 +4,7 @@ module Main(main) where
 import qualified Spec.Crowdfunding
 import qualified Spec.Future
 import qualified Spec.Game
+import qualified Spec.MultiSig
 import qualified Spec.Vesting
 import           Test.Tasty
 import           Test.Tasty.Hedgehog (HedgehogTestLimit (..))
@@ -23,5 +24,6 @@ tests = localOption limit $ testGroup "use cases" [
     Spec.Crowdfunding.tests,
     Spec.Vesting.tests,
     Spec.Future.tests,
-    Spec.Game.tests
+    Spec.Game.tests,
+    Spec.MultiSig.tests
     ]

--- a/plutus-use-cases/test/Spec/MultiSig.hs
+++ b/plutus-use-cases/test/Spec/MultiSig.hs
@@ -1,0 +1,78 @@
+module Spec.MultiSig(tests) where
+
+import           Control.Lens
+import           Control.Monad                                     (void)
+import           Control.Monad.Except
+import           Data.Either                                       (isLeft, isRight)
+import qualified Data.Map                                          as Map
+import qualified Data.Text                                         as T
+
+import           Test.Tasty
+import qualified Test.Tasty.HUnit                                  as HUnit
+
+import           Language.PlutusTx.Coordination.Contracts.MultiSig as MS
+import           Ledger                                            (PrivateKey, PubKey, Tx)
+import qualified Ledger.Ada                                        as Ada
+import qualified Ledger.Crypto                                     as Crypto
+import qualified Wallet.Emulator                                   as EM
+
+tests :: TestTree
+tests = testGroup "multisig" [
+    HUnit.testCase "three out of five" (nOutOfFiveTest 3),
+    HUnit.testCase "two out of five" (nOutOfFiveTest 2)
+    ]
+
+nOutOfFiveTest :: Int -> HUnit.Assertion
+nOutOfFiveTest i = do
+    let initialState = EM.emulatorStateInitialDist (Map.singleton (EM.walletPubKey (EM.Wallet 1)) (Ada.adaValueOf 10))
+        (result, _) = EM.runEmulator initialState (threeOutOfFive i)
+        isOk = if i < 3 then isLeft result else isRight result
+    HUnit.assertBool "transaction failed to validate" isOk
+
+-- | A mockchain trace that locks funds in a three-out-of-five multisig
+--   contract, and attempts to spend them using the given number of signatures.
+--   @threeOutOfFive 3@ passes, @threeOutOfFive 2@ results in an
+--   'EM.AssertionError'.
+threeOutOfFive :: (EM.MonadEmulator m) => Int -> m ()
+threeOutOfFive n = do
+    
+    let
+        w1 = EM.Wallet 1
+        w2 = EM.Wallet 2
+
+        -- a 'MultiSig' contract that requires three out of five signatures
+        ms = MultiSig
+                { signatories = EM.walletPubKey . EM.Wallet <$> [1..5]
+                , requiredSignatures = 3
+                }
+        addr = msAddress ms
+        processAndNotify = void (EM.addBlocksAndNotify [w1, w2] 1)
+
+    -- the first trace produces the transaction that needs to be signed
+    tx <- EM.processEmulated $ do
+            processAndNotify
+            void $ EM.walletAction w2 (initialise ms)
+            processAndNotify
+            void $ EM.walletAction w1 (lock ms $ Ada.adaValueOf 10)
+            processAndNotify
+            (r, _) <- EM.runWalletAction w2 (unlockTx ms)
+            either (throwError . EM.AssertionError . T.pack . show) pure r
+
+    let
+        -- Attach signatures of the first @n@ wallets' private keys to 'tx'.
+        signedTx = 
+            let signingKeys = take n (EM.walletPrivKey . EM.Wallet <$> [1..]) in
+            foldr attachSignature tx signingKeys
+
+    -- the second trace submits the signed transaction and asserts
+    -- that it has been validated.
+    EM.processEmulated $ do
+        void $ EM.walletAction w2 (submitTxn signedTx)
+        processAndNotify
+        EM.assertIsValidated signedTx
+
+-- | Attach a signature to a transaction.
+attachSignature :: PrivateKey -> Tx -> Tx
+attachSignature pk tx' =
+    let sig = Crypto.signTx (hashTx tx') pk
+    in  tx' & signatures . at (toPublicKey pk) ?~ sig

--- a/wallet-api/src/Wallet/Emulator/Types.hs
+++ b/wallet-api/src/Wallet/Emulator/Types.hs
@@ -39,6 +39,8 @@ module Wallet.Emulator.Types(
     evalTraceTxPool,
     execTraceTxPool,
     walletAction,
+    runWalletAction,
+    execWalletAction,
     walletRecvNotifications,
     walletNotifyBlock,
     walletsNotifyBlock,
@@ -47,12 +49,15 @@ module Wallet.Emulator.Types(
     addBlocksAndNotify,
     assertion,
     assertOwnFundsEq,
+    runEmulator,
     -- * Emulator internals
     MockWallet(..),
     handleNotifications,
     EmulatorState(..),
     emptyEmulatorState,
     emulatorState,
+    emulatorStatePool,
+    emulatorStateInitialDist,
     chainNewestFirst,
     chainOldestFirst,
     txPool,
@@ -94,6 +99,7 @@ import           GHC.Generics               (Generic)
 import           Prelude                    as P
 import           Servant.API                (FromHttpApiData(..), ToHttpApiData(..))
 
+import qualified Ledger.Ada                 as Ada
 import           Ledger                     (Address, Block, Blockchain, PrivateKey(..), PubKey(..), Slot, Tx (..), TxId, TxOut, TxOutOf (..),
                                              TxOutRef, Value, addSignature, hashTx, lastSlot, pubKeyAddress, pubKeyTxIn, pubKeyTxOut,
                                              toPublicKey, txOutAddress)
@@ -103,6 +109,7 @@ import qualified Ledger.Value               as Value
 import           Wallet.API                 (EventHandler (..), EventTrigger, WalletAPI (..),
                                              WalletAPIError (..), WalletDiagnostics (..), WalletLog (..), addresses,
                                              annTruthValue, getAnnot)
+import qualified Wallet.API                 as WAPI
 import qualified Wallet.Emulator.AddressMap as AM
 
 -- | A wallet in the emulator model.
@@ -318,7 +325,7 @@ newtype AssertionError = AssertionError T.Text
 data Event n a where
     -- | An direct action performed by a wallet. Usually represents a "user action", as it is
     -- triggered externally.
-    WalletAction :: Wallet -> n () -> Event n [Tx]
+    WalletAction :: Wallet -> n a -> Event n (Either WalletAPIError a, [Tx])
     -- | A wallet receiving some notifications, and reacting to them.
     WalletRecvNotification :: Wallet -> [Notification] -> Event n [Tx]
     -- | The blockchain processing pending transactions, producing a new block
@@ -326,7 +333,6 @@ data Event n a where
     BlockchainProcessPending :: Event n Block
     -- | An assertion in the event stream, which can inspect the current state.
     Assertion :: Assertion -> Event n ()
-
 
 -- Program is like Free, except it makes the Functor for us so we can have a nice GADT
 -- | A series of 'Event's.
@@ -402,9 +408,22 @@ emulatorState bc = emptyEmulatorState
     & index .~ Index.initialise bc
 
 -- | Initialise the emulator state with a pool of pending transactions.
-emulatorState' :: TxPool -> EmulatorState
-emulatorState' tp = emptyEmulatorState
+emulatorStatePool :: TxPool -> EmulatorState
+emulatorStatePool tp = emptyEmulatorState
     & txPool .~ tp
+
+-- | Initialise the emulator state with a single pending transaction that
+--   creates the initial distribution of funds to public key addresses.
+emulatorStateInitialDist :: Map PubKey Value -> EmulatorState
+emulatorStateInitialDist mp = emulatorStatePool [tx] where
+    tx = Tx
+            { txInputs = Set.empty
+            , txOutputs = uncurry (flip pubKeyTxOut) <$> Map.toList mp
+            , txForge = fold $ snd <$> Map.toList mp
+            , txFee = Ada.zero
+            , txValidRange = WAPI.defaultSlotRange
+            , txSignatures = Map.empty
+            }
 
 -- | Validate a transaction in the current emulator state.
 validateEm :: MonadState Index.UtxoIndex m => Slot -> Tx -> m (Maybe Index.ValidationError)
@@ -439,10 +458,10 @@ evalEmulated = \case
     WalletAction wallet action -> do
         (txns, result) <- liftMockWallet wallet action
         case result of
-            Right _ -> pure txns
+            Right a -> pure (Right a, txns)
             Left err -> do
                 _ <- modifying emulatorLog (WalletError wallet err :)
-                pure txns
+                pure (Left err, txns)
     WalletRecvNotification wallet trigger -> fst <$> liftMockWallet wallet (handleNotifications trigger)
     BlockchainProcessPending -> do
         emState <- get
@@ -514,9 +533,18 @@ mkEvent t result =
 processEmulated :: (MonadEmulator m) => Trace MockWallet a -> m a
 processEmulated = interpretWithMonad evalEmulated
 
--- | Perform a wallet action as the given 'Wallet'.
-walletAction :: Wallet -> m () -> Trace m [Tx]
-walletAction w = Op.singleton . WalletAction w
+-- | A synonym for 'execWalletAction'.
+walletAction :: Wallet -> m a -> Trace m [Tx]
+walletAction = execWalletAction 
+
+-- | Perform a wallet action as the given 'Wallet', returning
+--   the transactions that were submitted.
+execWalletAction :: Wallet -> m a -> Trace m [Tx]
+execWalletAction w = fmap snd . runWalletAction w
+
+-- | Peform a wallet action as the given 'Wallet'.
+runWalletAction :: Wallet -> m a -> Trace m (Either WalletAPIError a, [Tx])
+runWalletAction w = Op.singleton . WalletAction w
 
 -- | Notify the given 'Wallet' of some blockchain events.
 walletRecvNotifications :: Wallet -> [Notification] -> Trace m [Tx]
@@ -556,6 +584,11 @@ assertOwnFundsEq wallet = assertion . OwnFundsEqual wallet
 assertIsValidated :: Tx -> Trace m ()
 assertIsValidated = assertion . IsValidated
 
+-- | Run a 'MonadEmulator' action on an 'EmulatorState', returning the final 
+--   state and either the result of an 'AssertionError'.
+runEmulator :: EmulatorState -> ExceptT AssertionError (State EmulatorState) a -> (Either AssertionError a, EmulatorState)
+runEmulator e t = runState (runExceptT t) e
+
 -- | Run an 'Trace' on a blockchain.
 runTraceChain :: Blockchain -> Trace MockWallet a -> (Either AssertionError a, EmulatorState)
 runTraceChain ch t = runState (runExceptT $ processEmulated t) emState where
@@ -564,7 +597,7 @@ runTraceChain ch t = runState (runExceptT $ processEmulated t) emState where
 -- | Run a 'Trace' on an empty blockchain with a pool of pending transactions.
 runTraceTxPool :: TxPool -> Trace MockWallet a -> (Either AssertionError a, EmulatorState)
 runTraceTxPool tp t = runState (runExceptT $ processEmulated t) emState where
-    emState = emulatorState' tp
+    emState = emulatorStatePool tp
 
 -- | Evaluate a 'Trace' on an empty blockchain with a pool of pending
 --   transactions and return the final value, discarding the final


### PR DESCRIPTION
This implements the simple multisig contract, where the spending transaction needs to be passed around via a separate channel.