### PR TITLE
Restrict plutus tx package bounds

### DIFF
--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -87,7 +87,7 @@ library plutus-tx-compiler
         base >=4.9 && <5,
         bytestring -any,
         containers -any,
-        ghc <8.7,
+        ghc >=8.6 && <8.7,
         language-plutus-core -any,
         lens -any,
         mtl -any,


### PR DESCRIPTION
As of the last update, `plutus-tx` no longer builds with GHC 8.4.4. We should reflect that in the `.cabal` file so that everything is well when we upload to Hackage. 