### PR TITLE
add some notes on git version overlay

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -87,6 +87,11 @@ let
         inherit pkgs;
         filter = localLib.isPlutus;
       };
+      # When building we want the git sha available in the Haskell code, previously we did this with
+      # a template haskell function that ran a git command however the git directory is not available
+      # to the derivation so this fails. What we do now is create a derivation that overrides a magic
+      # Haskell module with the git sha, this comes from `declInput.rev` if available (Hydra), otherwise
+      # it is read from the .git directory which is avilable on local builds.
       gitModuleOverlay = import ./nix/overlays/git-module.nix {
         inherit pkgs declInput;
       };

--- a/nix/overlays/git-module.nix
+++ b/nix/overlays/git-module.nix
@@ -2,6 +2,8 @@
 
 with pkgs.lib;
 
+# This overlay will alter the Git.hs haskell module with the current git revision. If declInput.rev
+# is avilable the it will use that (Hydra) otherwise it will look in the .git directory (local builds)
 let
   headPath = ../../.git/HEAD;
   readRev = let head = if builtins.pathExists headPath then builtins.readFile headPath else "master";

--- a/release.nix
+++ b/release.nix
@@ -35,9 +35,9 @@ let
       lib.mapAttrs (n: p: if p ? testdata then { testrun = supportedSystems; } else supportedSystems)
          packageSet.localPackages;
     # At least the client is broken on darwin for some yarn reason
-    plutus-playground = lib.mapAttrs (_: _: linux) 
+    plutus-playground = lib.mapAttrs (_: _: linux) packageSet.plutus-playground;
     # At least the client is broken on darwin for some yarn reason
-    meadow = lib.mapAttrs (_: _: linux) 
+    meadow = lib.mapAttrs (_: _: linux) packageSet.meadow;
     # texlive is broken on darwin at our nixpkgs pin
     docs = lib.mapAttrs (_: _: linux) packageSet.docs;  
     tests = lib.mapAttrs (_: _: supportedSystems) packageSet.tests;  

--- a/release.nix
+++ b/release.nix
@@ -36,12 +36,8 @@ let
          packageSet.localPackages;
     # At least the client is broken on darwin for some yarn reason
     plutus-playground = lib.mapAttrs (_: _: linux) 
-        # don't build the docker image on hydra
-        (lib.filterAttrs (n: v: n != "docker") packageSet.plutus-playground);  
     # At least the client is broken on darwin for some yarn reason
     meadow = lib.mapAttrs (_: _: linux) 
-        # don't build the docker image on hydra
-        (lib.filterAttrs (n: v: n != "docker") packageSet.meadow);
     # texlive is broken on darwin at our nixpkgs pin
     docs = lib.mapAttrs (_: _: linux) packageSet.docs;  
     tests = lib.mapAttrs (_: _: supportedSystems) packageSet.tests;  


### PR DESCRIPTION
Also docker images are in their own attribute now so we don't need to explicitly ignore them, just don't add them to the release.