### PR TITLE
plutus-tx: improve interface to CompiledCode

### DIFF
--- a/plutus-tutorial/doctest/Tutorial/01-plutus-tx.md
+++ b/plutus-tutorial/doctest/Tutorial/01-plutus-tx.md
@@ -252,14 +252,11 @@ we need to apply the function to it.
 >>> pretty $ runCk program
 (con 8 ! 5)
 -}
-addOneToN :: Int -> Program TyName Name ()
-addOneToN n = (getPlc addOne) `applyProgram` unsafeLiftProgram n
+addOneToN :: Int -> CompiledCode Int
+addOneToN n = addOne `applyCode` unsafeLiftCode n
 ```
 
-`Program` is a real PLC program, extracted from the `CompiledCode` wrapper. In later
-tutorials we'll see some higher-level functions that hide this from us.
-
-We lifted the argument `n` using the `unsafeLiftProgram` function ("unsafe" because
+We lifted the argument `n` using the `unsafeLiftCode` function ("unsafe" because
 we're ignoring any errors that might occur from lifting something that we don't support).
 In order to use this, a type must have an instance of the `Lift` class. In
 practice, you should generate these with the `makeLift` TH function from
@@ -283,11 +280,11 @@ makeLift ''EndDate
   out_Bool (type) (lam case_True out_Bool (lam case_False out_Bool case_False))
 )
 -}
-pastEndAt :: EndDate -> Int -> Program TyName Name ()
+pastEndAt :: EndDate -> Int -> CompiledCode Bool
 pastEndAt end current =
-    (getPlc pastEnd)
-    `applyProgram`
-    unsafeLiftProgram end
-    `applyProgram`
-    unsafeLiftProgram current
+    pastEnd
+    `applyCode`
+    unsafeLiftCode end
+    `applyCode`
+    unsafeLiftCode current
 ```

--- a/plutus-tx/compiler/Language/PlutusTx/Code.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Code.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE ViewPatterns       #-}
+module Language.PlutusTx.Code where
+
+import qualified Language.PlutusTx.Lift.Class as Lift
+
+import qualified Language.PlutusIR            as PIR
+import qualified Language.PlutusIR.MkPir      as PIR
+
+import qualified Language.PlutusCore          as PLC
+
+import           Codec.Serialise              (DeserialiseFailure, deserialiseOrFail)
+import           Control.Exception
+
+import qualified Data.ByteString              as BS
+import qualified Data.ByteString.Lazy         as BSL
+
+-- NOTE: any changes to this type must be paralleled by changes
+-- in the plugin code that generates values of this type. That is
+-- done by code generation so it's not typechecked normally.
+-- | A compiled Plutus Tx program. The type parameter indicates
+-- the type of the Haskell expression that was compiled, and
+-- hence the type of the compiled code.
+data CompiledCode a =
+    -- | Serialized PLC code and possibly serialized PIR code.
+    SerializedCode BS.ByteString (Maybe BS.ByteString)
+    -- | Deserialized PLC program and possibly deserialized PIR program.
+    | DeserializedCode (PLC.Program PLC.TyName PLC.Name ()) (Maybe (PIR.Program PLC.TyName PLC.Name ()))
+
+-- Note that we do *not* have a TypeablePlc instance, since we don't know what the type is. We could in principle store it after the plugin
+-- typechecks the code, but we don't currently.
+instance Lift.Lift (CompiledCode a) where
+    lift (getPlc -> (PLC.Program () _ body)) = PIR.embed <$> PLC.rename body
+
+-- | Apply a compiled function to a compiled argument.
+applyCode :: CompiledCode (a -> b) -> CompiledCode a -> CompiledCode b
+applyCode fun arg = DeserializedCode (getPlc fun `PLC.applyProgram` getPlc arg) Nothing
+
+-- | The size of a 'CompiledCode', in AST nodes.
+sizePlc :: CompiledCode a -> Integer
+sizePlc = PLC.programSize . getPlc
+
+{- Note [Deserializing the AST]
+The types suggest that we can fail to deserialize the AST that we embedded in the program.
+However, we just did it ourselves, so this should be impossible, and we signal this with an
+exception.
+-}
+newtype ImpossibleDeserialisationFailure = ImpossibleDeserialisationFailure DeserialiseFailure
+instance Show ImpossibleDeserialisationFailure where
+    show (ImpossibleDeserialisationFailure e) = "Failed to deserialise our own program! This is a bug, please report it. Caused by: " ++ show e
+instance Exception ImpossibleDeserialisationFailure
+
+-- | Get the actual Plutus Core program out of a 'CompiledCode'.
+getPlc :: CompiledCode a -> PLC.Program PLC.TyName PLC.Name ()
+getPlc wrapper = case wrapper of
+    SerializedCode plc _ -> case deserialiseOrFail (BSL.fromStrict plc) of
+        Left e  -> throw $ ImpossibleDeserialisationFailure e
+        Right p -> p
+    DeserializedCode plc _ -> plc
+
+-- | Get the Plutus IR program, if there is one, out of a 'CompiledCode'.
+getPir :: CompiledCode a -> Maybe (PIR.Program PIR.TyName PIR.Name ())
+getPir wrapper = case wrapper of
+    SerializedCode _ pir -> case pir of
+        Just bs -> case deserialiseOrFail (BSL.fromStrict bs) of
+            Left e  -> throw $ ImpossibleDeserialisationFailure e
+            Right p -> Just p
+        Nothing -> Nothing
+    DeserializedCode _ pir -> pir

--- a/plutus-tx/compiler/Language/PlutusTx/Lift.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Lift.hs
@@ -4,9 +4,12 @@ module Language.PlutusTx.Lift (
     makeLift,
     lift,
     liftProgram,
+    liftCode,
     unsafeLift,
-    unsafeLiftProgram) where
+    unsafeLiftProgram,
+    unsafeLiftCode) where
 
+import           Language.PlutusTx.Code
 import           Language.PlutusTx.Lift.Class           (makeLift)
 import qualified Language.PlutusTx.Lift.Class           as Lift
 import           Language.PlutusTx.Lift.Instances       ()
@@ -22,6 +25,8 @@ import           Control.Exception
 import           Control.Monad.Except                   hiding (lift)
 import           Control.Monad.Reader                   hiding (lift)
 
+import           Data.Functor                           (void)
+
 -- | Get a Plutus Core term corresponding to the given value.
 lift :: (Lift.Lift a, AsError e (Provenance ()), MonadError e m, MonadQuote m) => a -> m (PLC.Term TyName Name ())
 lift x = do
@@ -33,14 +38,24 @@ lift x = do
 liftProgram :: (Lift.Lift a, AsError e (Provenance ()), MonadError e m, MonadQuote m) => a -> m (PLC.Program TyName Name ())
 liftProgram x = PLC.Program () (PLC.defaultVersion ()) <$> lift x
 
+liftCode :: (Lift.Lift a, AsError e (Provenance ()), MonadError e m, MonadQuote m) => a -> m (CompiledCode a)
+liftCode x = DeserializedCode <$> liftProgram x <*> pure Nothing
+
+unsafely :: ExceptT (Error (Provenance ())) Quote a -> a
+unsafely ma = runQuote $ do
+    run <- runExceptT ma
+    case run of
+        Left e  -> throw e
+        Right t -> pure t
+
 -- | Get a Plutus Core term corresponding to the given value, throwing any errors that occur as exceptions and ignoring fresh names.
 unsafeLift :: Lift.Lift a => a -> PLC.Term TyName Name ()
-unsafeLift a = runQuote $ do
-    run <- runExceptT $ lift a
-    case run of
-        Left (e::Error (Provenance ())) -> throw e
-        Right t                         -> pure t
+unsafeLift a = unsafely $ lift a
 
 -- | Get a Plutus Core program corresponding to the given value, throwing any errors that occur as exceptions and ignoring fresh names.
 unsafeLiftProgram :: Lift.Lift a => a -> PLC.Program TyName Name ()
 unsafeLiftProgram x = PLC.Program () (PLC.defaultVersion ()) $ unsafeLift x
+
+-- | Get a Plutus Core program corresponding to the given value as a 'CompiledCode', throwing any errors that occur as exceptions and ignoring fresh names.
+unsafeLiftCode :: Lift.Lift a => a -> CompiledCode a
+unsafeLiftCode x = unsafely $ liftCode x

--- a/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
@@ -9,22 +9,14 @@
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE ViewPatterns               #-}
 {-# OPTIONS_GHC -Wno-unused-foralls #-}
-module Language.PlutusTx.Plugin (
-    CompiledCode,
-    getSerializedPlc,
-    getSerializedPir,
-    getPlc,
-    sizePlc,
-    getPir,
-    plugin,
-    plc) where
+module Language.PlutusTx.Plugin (plugin, plc) where
 
+import           Language.PlutusTx.Code
 import           Language.PlutusTx.Compiler.Builtins
 import           Language.PlutusTx.Compiler.Error
 import           Language.PlutusTx.Compiler.Expr
 import           Language.PlutusTx.Compiler.Types
 import           Language.PlutusTx.Compiler.Utils
-import qualified Language.PlutusTx.Lift.Class           as Lift
 import           Language.PlutusTx.PIRTypes
 import           Language.PlutusTx.PLCTypes
 import           Language.PlutusTx.Utils
@@ -40,13 +32,11 @@ import           Language.PlutusCore.Quote
 import qualified Language.PlutusIR                      as PIR
 import qualified Language.PlutusIR.Compiler             as PIR
 import qualified Language.PlutusIR.Compiler.Definitions as PIR
-import qualified Language.PlutusIR.MkPir                as PIR
 import qualified Language.PlutusIR.Optimizer.DeadCode   as PIR
 
 import           Language.Haskell.TH.Syntax             as TH
 
-import           Codec.Serialise                        (DeserialiseFailure, deserialiseOrFail, serialise)
-import           Control.Exception
+import           Codec.Serialise                        (serialise)
 import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.Reader
@@ -54,60 +44,16 @@ import           Control.Monad.Reader
 import qualified Data.ByteString                        as BS
 import qualified Data.ByteString.Lazy                   as BSL
 import qualified Data.ByteString.Unsafe                 as BSUnsafe
-import           Data.Int                               (Int64)
 import qualified Data.Map                               as Map
 import qualified Data.Text.Prettyprint.Doc              as PP
 
 import           GHC.TypeLits
 import           System.IO.Unsafe                       (unsafePerformIO)
 
--- | A compiled Plutus Tx program. The type parameter indicates
--- the type of the Haskell expression that was compiled, and
--- hence the type of the compiled code.
-data CompiledCode a = CompiledCode {
-    serializedPlc   :: BS.ByteString
-    , serializedPir :: BS.ByteString
-    }
-
--- Note that we do *not* have a TypeablePlc instance, since we don't know what the type is. We could in principle store it after the plugin
--- typechecks the code, but we don't currently.
-instance Lift.Lift (CompiledCode a) where
-    lift (getPlc -> (PLC.Program () _ body)) = PIR.embed <$> PLC.rename body
-
-getSerializedPlc :: CompiledCode a -> BSL.ByteString
-getSerializedPlc = BSL.fromStrict . serializedPlc
-
-getSerializedPir :: CompiledCode a -> BSL.ByteString
-getSerializedPir = BSL.fromStrict . serializedPir
-
--- | The size of a `CompiledCode a` when embedded into a transaction, in bytes.
-sizePlc :: CompiledCode a -> Int64
-sizePlc = BSL.length . getSerializedPlc
-
-{- Note [Deserializing the AST]
-The types suggest that we can fail to deserialize the AST that we embedded in the program.
-However, we just did it ourselves, so this should be impossible, and we signal this with an
-exception.
--}
-newtype ImpossibleDeserialisationFailure = ImpossibleDeserialisationFailure DeserialiseFailure
-instance Show ImpossibleDeserialisationFailure where
-    show (ImpossibleDeserialisationFailure e) = "Failed to deserialise our own program! This is a bug, please report it. Caused by: " ++ show e
-instance Exception ImpossibleDeserialisationFailure
-
-getPlc :: CompiledCode a -> PLC.Program PLC.TyName PLC.Name ()
-getPlc wrapper = case deserialiseOrFail $ getSerializedPlc wrapper of
-    Left e  -> throw $ ImpossibleDeserialisationFailure e
-    Right p -> p
-
-getPir :: CompiledCode a -> PIR.Program PIR.TyName PIR.Name ()
-getPir wrapper = case deserialiseOrFail $ getSerializedPir wrapper of
-    Left e  -> throw $ ImpossibleDeserialisationFailure e
-    Right p -> p
-
 -- | Marks the given expression for conversion to PLC.
 plc :: forall (loc::Symbol) a . a -> CompiledCode a
 -- this constructor is only really there to get rid of the unused warning
-plc _ = CompiledCode mustBeReplaced mustBeReplaced
+plc _ = SerializedCode mustBeReplaced mustBeReplaced
 
 data PluginOptions = PluginOptions {
     poDoTypecheck    :: Bool
@@ -270,6 +216,10 @@ getStringBuiltinTypes ann =
        PLC.insertDynamicBuiltinNameDefinition PLC.dynamicCharToStringDefinition $
        PLC.insertDynamicBuiltinNameDefinition PLC.dynamicAppendDefinition mempty
 
+-- Helper to avoid doing too much construction of Core ourselves
+mkCompiledCode :: forall a . BS.ByteString -> BS.ByteString -> CompiledCode a
+mkCompiledCode plcBS pirBS = SerializedCode plcBS (Just pirBS)
+
 -- | Actually invokes the Core to PLC compiler to convert an expression into a PLC literal.
 convertExpr :: PluginOptions -> String -> GHC.Type -> GHC.CoreExpr -> GHC.CoreM GHC.CoreExpr
 convertExpr opts locStr codeTy origE = do
@@ -305,11 +255,10 @@ convertExpr opts locStr codeTy origE = do
             bsLitPir <- makeByteStringLiteral $ BSL.toStrict $ serialise pirP
             bsLitPlc <- makeByteStringLiteral $ BSL.toStrict $ serialise plcP
 
-            dcName <- thNameToGhcNameOrFail 'CompiledCode
-            dc <- GHC.lookupDataCon dcName
+            builder <- GHC.lookupId =<< thNameToGhcNameOrFail 'mkCompiledCode
 
             pure $
-                GHC.Var (GHC.dataConWrapId dc)
+                GHC.Var builder
                 `GHC.App` GHC.Type codeTy
                 `GHC.App` bsLitPlc
                 `GHC.App` bsLitPir

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -42,6 +42,7 @@ library
         Language.PlutusTx.Prelude
         Language.PlutusTx.Evaluation
     reexported-modules:
+        Language.PlutusTx.Code,
         Language.PlutusTx.Lift,
         Language.PlutusTx.Lift.Class,
         Language.PlutusTx.Builtins,
@@ -71,6 +72,7 @@ library plutus-tx-compiler
         Language.PlutusTx.Lift.Class
         Language.PlutusTx.Lift.THUtils
         Language.PlutusTx.Lift.Instances
+        Language.PlutusTx.Code
         Language.PlutusTx.Compiler.Error
         Language.PlutusTx.Compiler.Binders
         Language.PlutusTx.Compiler.Builtins

--- a/plutus-tx/src/Language/PlutusTx.hs
+++ b/plutus-tx/src/Language/PlutusTx.hs
@@ -1,5 +1,14 @@
-module Language.PlutusTx (module Export, makeLift) where
+module Language.PlutusTx (
+    module Export,
+    CompiledCode,
+    getPlc,
+    getPir,
+    applyCode,
+    makeLift,
+    liftCode,
+    unsafeLiftCode) where
 
-import           Language.PlutusTx.Lift    (makeLift)
+import           Language.PlutusTx.Code    (CompiledCode, applyCode, getPir, getPlc)
+import           Language.PlutusTx.Lift    (liftCode, makeLift, unsafeLiftCode)
 import           Language.PlutusTx.Prelude as Export
 import           Language.PlutusTx.TH      as Export

--- a/plutus-tx/src/Language/PlutusTx/TH.hs
+++ b/plutus-tx/src/Language/PlutusTx/TH.hs
@@ -3,13 +3,9 @@
 {-# LANGUAGE TypeApplications #-}
 module Language.PlutusTx.TH (
     compile,
-    compileUntyped,
-    CompiledCode,
-    getSerializedPlc,
-    getSerializedPir,
-    getPlc,
-    getPir) where
+    compileUntyped) where
 
+import           Language.PlutusTx.Code
 import           Language.PlutusTx.Plugin
 
 import qualified Language.Haskell.TH        as TH

--- a/plutus-tx/test/Lift/Spec.hs
+++ b/plutus-tx/test/Lift/Spec.hs
@@ -12,8 +12,8 @@ import           Common
 import           PlcTestUtils
 
 import qualified Language.PlutusTx.Builtins as Builtins
+import           Language.PlutusTx.Code
 import qualified Language.PlutusTx.Lift     as Lift
-import           Language.PlutusTx.Plugin
 
 Lift.makeLift ''MyMonoData
 Lift.makeLift ''MyMonoRecord

--- a/plutus-tx/test/Plugin/ReadValue.hs
+++ b/plutus-tx/test/Plugin/ReadValue.hs
@@ -12,22 +12,15 @@ module Plugin.ReadValue
     ( readDyns
     ) where
 
-import           Common
-import           PlcTestUtils
 
-import qualified Language.PlutusTx.Builtins                 as Builtins
-import           Language.PlutusTx.Lift
+import           Language.PlutusTx.Code
 import           Language.PlutusTx.Plugin
 
 import qualified Language.PlutusCore                        as PLC
 import qualified Language.PlutusCore.Constant               as PLC
 import qualified Language.PlutusCore.Constant.Dynamic       as PLC
-import qualified Language.PlutusCore.Evaluation.Result      as PLC
 import qualified Language.PlutusCore.Interpreter.CekMachine as PLC
 
-import           Data.ByteString.Lazy
-import           Data.Text.Prettyprint.Doc
-import           GHC.Generics
 import           Test.Tasty
 import           Test.Tasty.HUnit
 

--- a/plutus-tx/test/Plugin/Spec.hs
+++ b/plutus-tx/test/Plugin/Spec.hs
@@ -18,12 +18,12 @@ import           PlcTestUtils
 import           Plugin.ReadValue
 
 import qualified Language.PlutusTx.Builtins as Builtins
+import           Language.PlutusTx.Code
 import           Language.PlutusTx.Lift
 import           Language.PlutusTx.Plugin
 
 import           Data.ByteString.Lazy       ()
 import           Data.Text.Prettyprint.Doc
-import           GHC.Generics
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}

--- a/plutus-tx/test/TH/Spec.hs
+++ b/plutus-tx/test/TH/Spec.hs
@@ -15,6 +15,7 @@ import           PlcTestUtils
 import           TH.TestTH
 
 import           Language.PlutusTx.TH
+import           Language.PlutusTx.Code
 import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Prelude
 import           Language.PlutusTx.Evaluation


### PR DESCRIPTION
- Put it in its own module.
- Allow it to contain a deserialized program too, and for the PIR
  to be optional.
- Expose a typed `applyCode`.
- Expose a `liftCode` that produces `CompiledCode`.
- Use in tutorial.