### PR TITLE
prometheus alert manager

### DIFF
--- a/deployment/nixops/default-machine.nix
+++ b/deployment/nixops/default-machine.nix
@@ -3,7 +3,9 @@
       nixpkgs.overlays = stdOverlays;
       nix = {
         # FIXME: https://github.com/NixOS/nixpkgs/pull/57910
-        nixPath = [ "nixpkgs=https://github.com/shmish111/nixpkgs/archive/f67d3215edfe40b8d3e494833f10ee78a2adfced.tar.gz"
+        # Changes from jbgi have been squashed into my repo as jbgi/prometheus2 wasn't working for unrelated reasons
+        # Once 19.03 is released we should upgrade to that and we should be able to remove this
+        nixPath = [ "nixpkgs=https://github.com/shmish111/nixpkgs/archive/c73222f0ef9ba859f72e5ea2fb16e3f0e0242492.tar.gz"
                   ];
         binaryCaches = [ https://hydra.iohk.io https://cache.nixos.org https://mantis-hydra.aws.iohkdev.io ];
         requireSignedBinaryCaches = false;

--- a/deployment/nixops/default.nix
+++ b/deployment/nixops/default.nix
@@ -23,7 +23,7 @@ let
   playgroundConfig = mkConfig "https://david.plutus.iohkdev.io" "playground.yaml";
   meadowConfig = mkConfig "https://david.marlowe.iohkdev.io" "marlowe.yaml";
   stdOverlays = [ overlays.journalbeat ];
-  options = { inherit stdOverlays machines defaultMachine plutus; datadogKey = secrets.datadogKey; };
+  options = { inherit stdOverlays machines defaultMachine plutus secrets; };
   defaultMachine = (import ./default-machine.nix) options;
   meadowOptions = options // { serviceConfig = meadowConfig;
                                serviceName = "meadow";

--- a/deployment/nixops/secrets.json.example
+++ b/deployment/nixops/secrets.json.example
@@ -2,5 +2,5 @@
 	"githubClientId": "someclientid",
 	"githubClientSecret": "someclientsecret",
 	"jwtSignature": "somesignature",
-	"datadogKey": "somekey"
+	"pagerdutyKey": "somekey"
 }

--- a/deployment/nixops/server.nix
+++ b/deployment/nixops/server.nix
@@ -1,4 +1,4 @@
-{ mkInstance = { plutus, defaultMachine, machines, serviceConfig, datadogKey, serviceName, server-invoker, client, ... }: node: { config, pkgs, lib, ... }:
+{ mkInstance = { plutus, defaultMachine, machines, serviceConfig, serviceName, server-invoker, client, ... }: node: { config, pkgs, lib, ... }:
   let
     serviceSystemctl = pkgs.writeScriptBin "${serviceName}-systemctl" ''
     COMMAND="$1"

--- a/deployment/terraform/templates/nixops_configuration.nix
+++ b/deployment/terraform/templates/nixops_configuration.nix
@@ -4,7 +4,9 @@
     ec2.hvm = true;
     nix = {
         # FIXME: https://github.com/NixOS/nixpkgs/pull/57910
-        nixPath = [ "nixpkgs=https://github.com/shmish111/nixpkgs/archive/f67d3215edfe40b8d3e494833f10ee78a2adfced.tar.gz"
+        # Changes from jbgi have been squashed into my repo as jbgi/prometheus2 wasn't working for unrelated reasons
+        # Once 19.03 is released we should upgrade to that and we should be able to remove this
+        nixPath = [ "nixpkgs=https://github.com/shmish111/nixpkgs/archive/c73222f0ef9ba859f72e5ea2fb16e3f0e0242492.tar.gz"
                     "nixos-config=/etc/nixos/configuration.nix"
                   ];
         binaryCaches = [ https://hydra.iohk.io https://cache.nixos.org ];


### PR DESCRIPTION
This PR sends alerts to pager duty. I have tested this on a staging environment and saw the expected debug logs despite using a fake pager duty key.

Also we change from my fork of nixpkgs changes to the prometheus module to jbgi's changes merged in to my branch. This is because the branch https://github.com/NixOS/nixpkgs/pull/58255 is based on seemed to have some unrelated errors. We will look to upgrade our servers with the next NixOS release which should include this stuff.