### PR TITLE
Disable building documentation by default

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -25,7 +25,6 @@ max-backjumps: 40000
 write-ghc-environment-files: never
 tests: true
 benchmarks: true
-documentation: true
 
 allow-boot-library-installs:
     true


### PR DESCRIPTION
Building the haddock takes a surprisingly long time, and slows down
development for me at least.

`cabal new-haddock` will still build with `--enable-documentation` just
fine.

@vmchale just checking there isn't another reason for having this?