### PR TITLE
Get current git revision using IFD if we are not on Hydra

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -59,8 +59,8 @@
 # Forces all warnings as errors
 , forceError ? true
 
-# If we are in Hydra
-, declInput ? null
+# An explicit git rev to use, passed when we are in Hydra
+, rev ? null
 
 }:
 
@@ -80,6 +80,14 @@ let
   packages = self: (rec {
     inherit pkgs localLib;
 
+    # The git revision comes from `rev` if available (Hydra), otherwise
+    # it is read using IFD and git, which is avilable on local builds.
+    # NOTE: depending on this will make your package rebuild on every commit, regardless of whether
+    # anything else has changed!
+    git-rev = 
+      builtins.trace rev (let ifdRev = (import (pkgs.callPackage ./nix/git-rev.nix { gitDir = "/../.git"; })).rev;
+      in removeSuffix "\n" (if isNull rev then ifdRev else rev));
+
     # This is the stackage LTS plus overrides, plus the plutus
     # packages.
     haskellPackages = let
@@ -90,10 +98,9 @@ let
       # When building we want the git sha available in the Haskell code, previously we did this with
       # a template haskell function that ran a git command however the git directory is not available
       # to the derivation so this fails. What we do now is create a derivation that overrides a magic
-      # Haskell module with the git sha, this comes from `declInput.rev` if available (Hydra), otherwise
-      # it is read from the .git directory which is avilable on local builds.
+      # Haskell module with the git sha.
       gitModuleOverlay = import ./nix/overlays/git-module.nix {
-        inherit pkgs declInput;
+        inherit pkgs git-rev;
       };
       customOverlays = optional forceError errorOverlay ++ [gitModuleOverlay];
       # Filter down to local packages, except those named in the given list

--- a/default.nix
+++ b/default.nix
@@ -85,8 +85,8 @@ let
     # NOTE: depending on this will make your package rebuild on every commit, regardless of whether
     # anything else has changed!
     git-rev = 
-      builtins.trace rev (let ifdRev = (import (pkgs.callPackage ./nix/git-rev.nix { gitDir = "/../.git"; })).rev;
-      in removeSuffix "\n" (if isNull rev then ifdRev else rev));
+      let ifdRev = (import (pkgs.callPackage ./nix/git-rev.nix { gitDir = builtins.path { name = "gitDir"; path = ./.git; }; })).rev;
+      in removeSuffix "\n" (if isNull rev then ifdRev else rev);
 
     # This is the stackage LTS plus overrides, plus the plutus
     # packages.

--- a/nix/git-rev.nix
+++ b/nix/git-rev.nix
@@ -1,0 +1,19 @@
+# This produces a nix attribute set containing the git revision from the given
+# git directory. Meant to be used with IFD.
+# Note that 'gitDir' is a string, not a path. This is so we can be maximally lazy,
+# and we don't try to import the path (which may not exist if we're on hydra) until
+# we absolutely have to.
+{ gitDir, git, runCommand }:
+# Convert the relative path into a path. We need the explicit name othewise it tries to use '.git' which is illegal.
+let gitDirPath = builtins.path { name = "gitDir"; path = ./. + gitDir; };
+in runCommand "git-rev" {} ''
+  set -e
+  if [ -d "${gitDirPath}" ]
+  then 
+      rev=$(${git}/bin/git --git-dir ${gitDirPath} rev-parse HEAD)
+      echo "{ rev=\"$rev\"; }" > $out
+  else
+      echo "Git directory ${gitDirPath} is not a file - might be a worktree reference, which we can't handle without pulling in arbitrary bits of the filesystem."
+      exit 1
+  fi
+''

--- a/nix/git-rev.nix
+++ b/nix/git-rev.nix
@@ -1,19 +1,14 @@
 # This produces a nix attribute set containing the git revision from the given
 # git directory. Meant to be used with IFD.
-# Note that 'gitDir' is a string, not a path. This is so we can be maximally lazy,
-# and we don't try to import the path (which may not exist if we're on hydra) until
-# we absolutely have to.
 { gitDir, git, runCommand }:
-# Convert the relative path into a path. We need the explicit name othewise it tries to use '.git' which is illegal.
-let gitDirPath = builtins.path { name = "gitDir"; path = ./. + gitDir; };
-in runCommand "git-rev" {} ''
+runCommand "git-rev" {} ''
   set -e
-  if [ -d "${gitDirPath}" ]
+  if [ -d "${gitDir}" ]
   then 
-      rev=$(${git}/bin/git --git-dir ${gitDirPath} rev-parse HEAD)
+      rev=$(${git}/bin/git --git-dir ${gitDir} rev-parse HEAD)
       echo "{ rev=\"$rev\"; }" > $out
   else
-      echo "Git directory ${gitDirPath} is not a file - might be a worktree reference, which we can't handle without pulling in arbitrary bits of the filesystem."
+      echo "Git directory ${gitDir} is not a file - might be a worktree reference, which we can't handle without pulling in arbitrary bits of the filesystem."
       exit 1
   fi
 ''

--- a/nix/overlays/git-module.nix
+++ b/nix/overlays/git-module.nix
@@ -1,17 +1,10 @@
-{ pkgs, declInput }:
+{ pkgs, git-rev }:
 
 with pkgs.lib;
 
 # This overlay will alter the Git.hs haskell module with the current git revision. If declInput.rev
 # is avilable the it will use that (Hydra) otherwise it will look in the .git directory (local builds)
 let
-  headPath = ../../.git/HEAD;
-  readRev = let head = if builtins.pathExists headPath then builtins.readFile headPath else "master";
-            in
-              if hasPrefix "ref: " head
-                then builtins.readFile (../../.git + ''/${removeSuffix "\n" (removePrefix "ref: " head)}'')
-                else head;
-  git-rev = removeSuffix "\n" (if isNull declInput then readRev else declInput.rev);
   gitModulePatch = pkgs.writeText "gitModulePatch" ''
     diff --git a/src/Git.hs b/src/Git.hs
     index b0398a7..45a9066 100644

--- a/release.nix
+++ b/release.nix
@@ -14,15 +14,21 @@ in
       config = { allowUnfree = false; inHydra = true; };
       inherit fasterBuild;
     }
+  # Passed in by Hydra depending on the configuration, contains the revision and the out path
+  , plutus ? null
   }:
 
-with (import (fixedNixpkgs + "/pkgs/top-level/release-lib.nix") {
-  inherit supportedSystems scrubJobs nixpkgsArgs;
+# The revision passed in by Hydra, if there is one
+let rev = if builtins.isNull plutus then null else plutus.rev;
+
+in with (import (fixedNixpkgs + "/pkgs/top-level/release-lib.nix") {
+  inherit supportedSystems scrubJobs;
+  nixpkgsArgs = nixpkgsArgs // { inherit rev; };
   packageSet = import ./.;
 });
 
 let
-  packageSet = import ./. { };
+  packageSet = import ./. { inherit rev; };
 
   # This is a mapping from attribute paths to systems. So it needs to mirror the structure of the
   # attributes in default.nix exactly


### PR DESCRIPTION
This is much more reliable than looking inside `.git`, which can be in
weird states and is best not to make assumptions about.

Wonderfully, since Nix is lazy, we can do this despite IFD being
disallowed on Hydra: in that case we'll have `declInput` so we'll never
evaluate the bit that needs IFD.

XXX: does not work for worktrees yet