### PR TITLE
playground-lib: Ada is a known currency

### DIFF
--- a/plutus-playground-lib/src/Playground/API.hs
+++ b/plutus-playground-lib/src/Playground/API.hs
@@ -19,7 +19,7 @@ import           Control.Monad.Trans.State    (StateT, evalStateT, get, put)
 import           Data.Aeson                   (FromJSON, ToJSON, Value)
 import           Data.Bifunctor               (second)
 import qualified Data.HashMap.Strict.InsOrd   as HM
-import           Data.List.NonEmpty           (NonEmpty)
+import           Data.List.NonEmpty           (NonEmpty ((:|)))
 import           Data.Maybe                   (fromMaybe)
 import           Data.Proxy                   (Proxy (Proxy))
 import           Data.Swagger                 (ParamSchema (ParamSchema), Referenced (Inline, Ref), Schema (Schema),
@@ -36,7 +36,8 @@ import           Language.Haskell.Interpreter (CompilationError (CompilationErro
 import qualified Language.Haskell.Interpreter as HI
 import qualified Language.Haskell.TH.Syntax   as TH
 import           Ledger                       (Blockchain, PubKey, Tx, TxId)
-import           Ledger.Validation            (ValidatorHash)
+import qualified Ledger.Ada                   as Ada
+import           Ledger.Validation            (ValidatorHash, fromSymbol)
 import qualified Ledger.Value                 as V
 import           Servant.API                  ((:<|>), (:>), Get, JSON, Post, ReqBody)
 import           Text.Read                    (readMaybe)
@@ -59,6 +60,14 @@ data KnownCurrency = KnownCurrency
     , knownTokens  :: NonEmpty TokenId
     }
     deriving (Eq, Show, Generic, ToJSON, FromJSON)
+
+adaCurrency :: KnownCurrency
+adaCurrency = KnownCurrency
+    { hash = fromSymbol Ada.adaSymbol
+    , friendlyName = "Ada"
+    , knownTokens = TokenId "ada" :| []
+    }
+
 --------------------------------------------------------------------------------
 
 newtype Fn = Fn Text

--- a/plutus-playground-lib/src/Playground/Contract.hs
+++ b/plutus-playground-lib/src/Playground/Contract.hs
@@ -28,6 +28,7 @@ module Playground.Contract
     , ValidatorHash(ValidatorHash)
     , TokenId(TokenId)
     , NonEmpty((:|))
+    , adaCurrency
     ) where
 
 import           Data.Aeson                  (FromJSON, ToJSON, encode)
@@ -41,7 +42,8 @@ import           Data.Swagger                (Schema, ToSchema)
 import           GHC.Generics                (Generic)
 import           Ledger.Validation           (ValidatorHash (ValidatorHash))
 import           Ledger.Value                (Value)
-import           Playground.API              (FunctionSchema, KnownCurrency (KnownCurrency), TokenId (TokenId))
+import           Playground.API              (FunctionSchema, KnownCurrency (KnownCurrency), TokenId (TokenId),
+                                              adaCurrency)
 import           Playground.Interpreter.Util
 import           Playground.TH               (mkFunction, mkFunctions, mkKnownCurrencies, mkSingleFunction)
 import           Wallet.API                  (SlotRange, WalletAPI, payToPublicKey_)

--- a/plutus-playground-lib/src/Playground/TH.hs
+++ b/plutus-playground-lib/src/Playground/TH.hs
@@ -15,7 +15,7 @@ import           Data.Text           (pack)
 import           Language.Haskell.TH (Body (NormalB), Clause (Clause), Dec (FunD, SigD, ValD), Exp (ListE, VarE),
                                       Info (VarI), Name, Pat (VarP), Q,
                                       Type (AppT, ArrowT, ConT, ForallT, ListT, TupleT, VarT), mkName, nameBase, reify)
-import           Playground.API      (Fn (Fn), FunctionSchema (FunctionSchema))
+import           Playground.API      (Fn (Fn), FunctionSchema (FunctionSchema), adaCurrency)
 
 mkFunctions :: [Name] -> Q [Dec]
 mkFunctions names = do
@@ -91,7 +91,7 @@ args a                          = error $ "incorrect type in template haskell fu
 mkKnownCurrencies :: [Name] -> Q [Dec]
 mkKnownCurrencies ks = do
     let name = mkName "registeredKnownCurrencies"
-        names = fmap VarE ks
+        names = fmap VarE ('Playground.API.adaCurrency : ks)
         body = NormalB (ListE names)
         val = ValD (VarP name) body []
         typeName = mkName "KnownCurrency"

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -24,9 +24,9 @@ import           Playground.API               (CompilationResult (CompilationRes
                                                Expression (Action, Wait), Fn (Fn), FunctionSchema (FunctionSchema),
                                                KnownCurrency (KnownCurrency), PlaygroundError,
                                                SimpleArgumentSchema (SimpleArraySchema, SimpleIntSchema, SimpleObjectSchema, SimpleStringSchema, SimpleTupleSchema, ValueSchema),
-                                               SimulatorWallet (SimulatorWallet), TokenId (TokenId), argumentSchema,
-                                               functionName, isSupportedByFrontend, simulatorWalletBalance,
-                                               simulatorWalletWallet)
+                                               SimulatorWallet (SimulatorWallet), TokenId (TokenId), adaCurrency,
+                                               argumentSchema, functionName, isSupportedByFrontend,
+                                               simulatorWalletBalance, simulatorWalletWallet)
 import qualified Playground.Interpreter       as PI
 import           Playground.Usecases          (crowdfunding, game, messages, vesting)
 import           Test.Hspec                   (Spec, describe, it, shouldBe, shouldSatisfy)
@@ -446,8 +446,8 @@ knownCurrencySpec =
             , "myCurrency = KnownCurrency (ValidatorHash \"\") \"MyCurrency\" (TokenId \"MyToken\" :| [])"
             , "$(mkKnownCurrencies ['myCurrency])"
             ]
-    hasKnownCurrency (Right (InterpreterResult _ (CompilationResult _ [KnownCurrency (ValidatorHash "") "MyCurrency" (TokenId "MyToken" :| [])]))) =
-        True
+    hasKnownCurrency (Right (InterpreterResult _ (CompilationResult _ [cur1, cur2]))) =
+        cur1 == adaCurrency && cur2 == KnownCurrency (ValidatorHash "") "MyCurrency" (TokenId "MyToken" :| [])
     hasKnownCurrency _ = False
 
 sourceCode :: BSC.ByteString -> SourceCode

--- a/wallet-api/src/Ledger/Validation.hs
+++ b/wallet-api/src/Ledger/Validation.hs
@@ -47,6 +47,7 @@ module Ledger.Validation
     -- * Hashes
     , plcSHA2_256
     , plcSHA3_256
+    , fromSymbol
     ) where
 
 import           Codec.Serialise              (Serialise)
@@ -71,7 +72,7 @@ import           Ledger.Crypto                (PubKey (..), Signature (..))
 import           Ledger.Scripts
 import           Ledger.Slot                  (Slot, SlotRange)
 import qualified Ledger.TxId                  as Tx
-import           Ledger.Value                 (Value)
+import           Ledger.Value.TH              (Value, CurrencySymbol(..))
 import           LedgerBytes                     (LedgerBytes(..))
 
 -- Ignore newtype warnings related to `Oracle` and `Signed` because it causes
@@ -313,6 +314,10 @@ eqTx = [|| \(TxHash l) (TxHash r) -> Builtins.equalsByteString l r ||]
 -- | Get the hash of the validator script that is currently being validated.
 ownHash :: Q (TExp (PendingTx -> ValidatorHash))
 ownHash = [|| \(PendingTx _ _ _ _ i _ _ _) -> let PendingTxIn _ (Just (h, _)) _ = i in h ||]
+
+-- | Convert a 'CurrencySymbol' to a 'ValidatorHash'
+fromSymbol :: CurrencySymbol -> ValidatorHash
+fromSymbol (CurrencySymbol s) = ValidatorHash s
 
 -- | Get the total amount of 'Ada' locked by the given validator in this transaction.
 adaLockedBy :: Q (TExp (PendingTx -> ValidatorHash -> Ada))

--- a/wallet-api/src/Ledger/Value/TH.hs
+++ b/wallet-api/src/Ledger/Value/TH.hs
@@ -9,7 +9,7 @@
 -- | Functions for working with 'Value' in Template Haskell.
 module Ledger.Value.TH(
       Value(..)
-    , CurrencySymbol
+    , CurrencySymbol(..)
     , currencySymbol
     , singleton
     , valueOf


### PR DESCRIPTION
Define a `KnownCurrency` for Ada and add it to
mkKnownCurrencies, so that the frontend does not
have to deal with a special case.