### PR TITLE
use-cases: Add currency contract

### DIFF
--- a/plutus-playground-lib/test/Playground/APISpec.hs
+++ b/plutus-playground-lib/test/Playground/APISpec.hs
@@ -93,7 +93,7 @@ toSimpleArgumentSchemaSpec =
                                            [ ( "unMap"
                                              , SimpleArraySchema
                                                    (SimpleTupleSchema
-                                                        ( SimpleHexSchema
+                                                        ( SimpleStringSchema
                                                         , SimpleIntSchema)))
                                            ])))
                         ])

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -169,7 +169,7 @@ vestingSpec =
                                                              [ ( "unMap"
                                                                , SimpleArraySchema
                                                                      (SimpleTupleSchema
-                                                                          ( SimpleHexSchema
+                                                                          ( SimpleStringSchema
                                                                           , SimpleIntSchema)))
                                                              ])))
                                           ])

--- a/plutus-tutorial/tutorial/Tutorial/Emulator.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Emulator.hs
@@ -253,7 +253,7 @@ simpleTraceDist = EM.fundsDistribution $ snd $ runTrace simpleTrace
 {- |
 
     >>> simpleTraceDist
-    fromList [(Wallet {getWallet = 1},Value {getValue = Map {unMap = [(,Map {unMap = [(SizedByteString {unSizedByteString = ""},900)]})]}}),(Wallet {getWallet = 2},Value {getValue = Map {unMap = [(,Map {unMap = [(SizedByteString {unSizedByteString = ""},1100)]})]}})]
+    fromList [(Wallet {getWallet = 1},Value {getValue = Map {unMap = [(,Map {unMap = [(,900)]})]}}),(Wallet {getWallet = 2},Value {getValue = Map {unMap = [(,Map {unMap = [(,1100)]})]}})]
 
     'simpleTraceDist' shows that our transaction was successful: Wallet 1 now 
     owns 900 Ada (the currency identified by )
@@ -292,7 +292,7 @@ gameSuccess = do
     The final distribution after 'gameSuccess' looks as we would expect:
 
     >>> EM.fundsDistribution $ snd $ runTrace simpleTrace
-    fromList [(Wallet {getWallet = 1},Value {getValue = Map {unMap = [(,Map {unMap = [(SizedByteString {unSizedByteString = ""},900)]})]}}),(Wallet {getWallet = 2},Value {getValue = Map {unMap = [(,Map {unMap = [(SizedByteString {unSizedByteString = ""},1100)]})]}})]
+    fromList [(Wallet {getWallet = 1},Value {getValue = Map {unMap = [(,Map {unMap = [(,900)]})]}}),(Wallet {getWallet = 2},Value {getValue = Map {unMap = [(,Map {unMap = [(,1100)]})]}})]
 
 -}
 

--- a/plutus-tutorial/tutorial/Tutorial/Vesting.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Vesting.hs
@@ -337,7 +337,7 @@ vestingSuccess = do
         functions `runTraceDist` and `runTraceLog` from `Ledger.ExUtil`
     >>> import Tutorial.ExUtil
     >>> runTraceDist vestingSuccess
-    fromList [(Wallet {getWallet = 1},Value {getValue = Map {unMap = [(,Map {unMap = [(SizedByteString {unSizedByteString = ""},1010)]})]}}),(Wallet {getWallet = 2},Value {getValue = Map {unMap = [(,Map {unMap = [(SizedByteString {unSizedByteString = ""},940)]})]}}),(Wallet {getWallet = 3},Value {getValue = Map {unMap = [(,Map {unMap = [(SizedByteString {unSizedByteString = ""},1000)]})]}})]
+    fromList [(Wallet {getWallet = 1},Value {getValue = Map {unMap = [(,Map {unMap = [(,1010)]})]}}),(Wallet {getWallet = 2},Value {getValue = Map {unMap = [(,Map {unMap = [(,940)]})]}}),(Wallet {getWallet = 3},Value {getValue = Map {unMap = [(,Map {unMap = [(,1000)]})]}})]
 
 
     E9. Write traces similar to `vestingSuccess` that

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -5,6 +5,8 @@ module Language.PlutusTx.Prelude (
     toPlutusString,
     trace,
     traceH,
+    traceIfTrueH,
+    traceIfFalseH,
     -- * Error
     error,
     -- * Boolean operators

--- a/plutus-tx/src/Language/PlutusTx/Prelude/Stage0.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude/Stage0.hs
@@ -43,6 +43,14 @@ trace = [||
 traceH :: Q (TExp (String -> a -> a))
 traceH = [|| \str a -> $$(trace) ($$(toPlutusString) str) a||]
 
+-- | Emit the given Haskell 'String' only if the argument evaluates to 'False'.
+traceIfFalseH :: Q (TExp (String -> Bool -> Bool))
+traceIfFalseH = [|| \str a -> if a then True else $$traceH str False ||]
+
+-- | Emit the given Haskell 'String' only if the argument evaluates to 'True'.
+traceIfTrueH :: Q (TExp (String -> Bool -> Bool))
+traceIfTrueH = [|| \str a -> if a then $$traceH str True else False ||]
+
 -- | Logical AND
 --
 --   >>> $$([|| $$(and) True False ||])

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -21,9 +21,11 @@ library
     exposed-modules:
         Language.PlutusTx.Coordination.Contracts
         Language.PlutusTx.Coordination.Contracts.CrowdFunding
+        Language.PlutusTx.Coordination.Contracts.Currency
         Language.PlutusTx.Coordination.Contracts.Future
         Language.PlutusTx.Coordination.Contracts.Game
         Language.PlutusTx.Coordination.Contracts.MultiSig
+        Language.PlutusTx.Coordination.Contracts.PubKey
         Language.PlutusTx.Coordination.Contracts.Vesting
         Language.PlutusTx.Coordination.Contracts.Swap
     hs-source-dirs: src
@@ -43,7 +45,8 @@ library
         template-haskell -any,
         plutus-tx -any,
         wallet-api -any,
-        lens -any
+        lens -any,
+        text -any
 
 test-suite plutus-use-cases-test
     type: exitcode-stdio-1.0
@@ -51,6 +54,7 @@ test-suite plutus-use-cases-test
     hs-source-dirs: test
     other-modules:
         Spec.Crowdfunding
+        Spec.Currency
         Spec.Future
         Spec.Game
         Spec.MultiSig

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -22,6 +22,7 @@ library
         Language.PlutusTx.Coordination.Contracts
         Language.PlutusTx.Coordination.Contracts.CrowdFunding
         Language.PlutusTx.Coordination.Contracts.Currency
+        Language.PlutusTx.Coordination.Contracts.Currency.Stage0
         Language.PlutusTx.Coordination.Contracts.Future
         Language.PlutusTx.Coordination.Contracts.Game
         Language.PlutusTx.Coordination.Contracts.MultiSig
@@ -58,6 +59,7 @@ test-suite plutus-use-cases-test
         Spec.Future
         Spec.Game
         Spec.MultiSig
+        Spec.Size
         Spec.Vesting
     default-language: Haskell2010
     ghc-options: -Wall -Wnoncanonical-monad-instances

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -94,13 +94,13 @@ contribute cmp adaAmount = do
     tx <- payToScript range (campaignAddress cmp) value ds
     logMsg "Submitted contribution"
 
-    register (refundTrigger cmp) (refund (Ledger.hashTx tx) cmp)
+    W.register (refundTrigger cmp) (refund (Ledger.hashTx tx) cmp)
     logMsg "Registered refund trigger"
 
 -- | Register a [[EventHandler]] to collect all the funds of a campaign
 --
 collect :: (WalletAPI m, WalletDiagnostics m) => Campaign -> m ()
-collect cmp = register (collectFundsTrigger cmp) $ EventHandler $ \_ -> do
+collect cmp = W.register (collectFundsTrigger cmp) $ EventHandler $ \_ -> do
         logMsg "Collecting funds"
         am <- watchedAddresses
         let scr        = contributionScript cmp

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -1,0 +1,171 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -O0 #-}
+-- | Implements a custom currency with a monetary policy that allows
+--   the forging of a fixed amount of units.
+module Language.PlutusTx.Coordination.Contracts.Currency(
+      Currency(..)
+    , curValidator
+    , curDataScript
+    , curRedeemer
+    , curAddress
+    -- * Actions etc
+    , forge
+    , forgedValue
+    ) where
+
+import           Control.Lens              ((^.), at, to)
+import qualified Data.Set                  as Set
+import qualified Data.Map                  as Map
+import           Data.Maybe                (fromMaybe)
+import qualified Data.Text                 as Text
+
+import qualified Language.PlutusTx         as P
+
+import qualified Ledger.Ada                as Ada
+import           Ledger.Scripts            (ValidatorScript(..))
+import           Ledger.Validation         (TxHash)
+import qualified Ledger.Validation         as V
+import qualified Ledger.Value.TH           as Value
+import           Ledger                    as Ledger hiding (to)
+import           Ledger.Value              (TokenName, Value, mkTokenName)
+import           Wallet.API                as WAPI
+
+import qualified Language.PlutusTx.Coordination.Contracts.PubKey as PK
+
+data Currency = Currency
+                    { curRefTransactionOutput :: (TxHash, Int)
+                    -- ^ Transaction input that must be spent when
+                    --   the currency is forged.
+                    , curRefAmount            :: Int
+                    -- ^ How much of the currency can be forged
+                    , curRefTokenName         :: TokenName
+                    -- ^ Token name
+                    }
+
+P.makeLift ''Currency
+
+mkCurrency :: TxOutRef -> Int -> String -> Currency
+mkCurrency (TxOutRefOf h i) amt n = 
+    Currency
+        { curRefTransactionOutput = (V.plcTxHash h, i)
+        , curRefAmount            = amt
+        , curRefTokenName         = mkTokenName n
+        }
+
+curValidator :: Currency -> ValidatorScript
+curValidator cur =
+    ValidatorScript (Ledger.applyScript mkValidator (Ledger.lifted cur)) where
+        mkValidator = Ledger.fromCompiledCode ($$(P.compile [||
+            let validate :: Currency -> () -> () -> V.PendingTx -> ()
+                validate (Currency (refHash, refIdx) amt token) () () p = 
+                    let 
+                        ownSymbol = $$(V.ownCurrencySymbol) p
+                        forged = $$(V.valueForged) p
+                        expected = $$(Value.singleton) ownSymbol token amt 
+
+                        -- True if the pending transaction forges the amount of
+                        -- currency that we expect
+                        forgeOK =
+                            let v = $$(Value.eq) expected forged
+                            in $$(P.traceIfFalseH) "Value forged different from expected" v
+
+                        -- True if the pending transaction spends the output
+                        -- identified by @(refHash, refIdx)@
+                        txOutputSpent = 
+                            let v = $$(V.spendsOutput) p refHash refIdx
+                            in  $$(P.traceIfFalseH) "Pending transaction does not spend the designated transaction output" v
+
+                    in
+                        if $$(P.and) forgeOK txOutputSpent
+                        then ()
+                        else $$(P.error) ($$(P.traceH) "Invalid forge" ())
+            in
+                validate
+            ||]))
+
+-- | Currency data script (unit value).
+curDataScript :: DataScript
+curDataScript = DataScript $ Ledger.lifted ()
+
+-- | Currency redeemer (unit value).
+curRedeemer :: RedeemerScript
+curRedeemer = RedeemerScript $ Ledger.lifted ()
+
+-- | The address of a 'Currency' contract.
+curAddress :: Currency -> Address
+curAddress = Ledger.scriptAddress . curValidator
+
+-- | The 'Value' forged by the 'curValidator' contract
+forgedValue :: Currency -> Value
+forgedValue cur = 
+    let a = plcCurrencySymbol (curAddress cur)
+        t = curRefTokenName cur
+        i = curRefAmount cur
+    in
+        $$(Value.singleton) a t i
+
+-- | @forge c n@ forges @n@ units of a currency called @c@ and
+--   pays them to a public key address owned by the wallet.
+forge :: (WalletAPI m, WalletDiagnostics m) => String -> Int -> m Currency
+forge nm amount = do
+    pk <- WAPI.ownPubKey
+
+    -- 1. We need to create the reference transaction output using the 
+    --    'PublicKey' contract. That way we get an output that behaves
+    --    like a normal public key output, but is not selected by the
+    --    wallet during coin selection. This ensures that the output still 
+    --    exists when we spend it in our forging transaction.
+    (refAddr, refTxIn) <- PK.lock pk (Ada.adaValueOf 1)
+
+    let
+         -- With that we can define the currency
+        theCurrency = mkCurrency (txInRef refTxIn) amount nm
+        curAddr     = curAddress theCurrency
+        forgedVal   = forgedValue theCurrency
+        oneOrMore   = WAPI.intervalFrom $ Ada.adaValueOf 1
+
+        -- trg1 fires when 'refTxIn' can be spent by our forging transaction
+        trg1 = fundsAtAddressT refAddr oneOrMore
+        
+        -- trg2 fires when the pay-to-script output locked by 'curValidator' 
+        -- is ready to be spent.
+        trg2 = fundsAtAddressT curAddr oneOrMore
+
+        -- The 'forge_' action creates a transaction that spends the contract
+        -- output, forging the currency in the process.
+        forge_ :: (WalletAPI m, WalletDiagnostics m) => m ()
+        forge_ = do
+            ownOutput <- WAPI.ownPubKeyTxOut (forgedVal <> Ada.adaValueOf 2)
+            am <- WAPI.watchedAddresses
+
+            let inputs' = am ^. at curAddr . to (Map.toList . fromMaybe Map.empty)
+                con (r, _) = scriptTxIn r (curValidator theCurrency) curRedeemer
+                ins        = con <$> inputs'
+
+            let tx = Ledger.Tx
+                        { txInputs = Set.fromList (refTxIn:ins)
+                        , txOutputs = [ownOutput]
+                        , txForge = forgedVal
+                        , txFee   = Ada.zero
+                        , txValidRange = defaultSlotRange
+                        , txSignatures = Map.empty
+                        }
+
+            WAPI.logMsg $ Text.pack $ "Forging transaction: " <> show (Ledger.hashTx tx)
+            WAPI.signTxAndSubmit_  tx
+
+    -- 2. We start watching the contract address, ready to forge
+    --    our currency once the monetary policy script has been
+    --    placed on the chain.
+    registerOnce trg2 (EventHandler $ const forge_)
+
+    -- 3. When trg1 fires we submit a transaction that creates a 
+    --    pay-to-script output locked by the monetary policy
+    registerOnce trg1 (EventHandler $ const $ do
+        payToScript_ defaultSlotRange (curAddress theCurrency) (Ada.adaValueOf 1) curDataScript)
+
+    -- Return the currency definition so that we can use the symbol
+    -- in other places
+    pure theCurrency

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -19,6 +19,7 @@ import           Control.Lens              ((^.), at, to)
 import qualified Data.Set                  as Set
 import qualified Data.Map                  as Map
 import           Data.Maybe                (fromMaybe)
+import           Data.String               (IsString(fromString))
 import qualified Data.Text                 as Text
 
 import qualified Language.PlutusTx         as P
@@ -29,7 +30,7 @@ import           Ledger.Validation         (TxHash)
 import qualified Ledger.Validation         as V
 import qualified Ledger.Value.TH           as Value
 import           Ledger                    as Ledger hiding (to)
-import           Ledger.Value              (TokenName, Value, mkTokenName)
+import           Ledger.Value              (TokenName, Value)
 import           Wallet.API                as WAPI
 
 import qualified Language.PlutusTx.Coordination.Contracts.PubKey as PK
@@ -51,7 +52,7 @@ mkCurrency (TxOutRefOf h i) amt n =
     Currency
         { curRefTransactionOutput = (V.plcTxHash h, i)
         , curRefAmount            = amt
-        , curRefTokenName         = mkTokenName n
+        , curRefTokenName         = fromString n
         }
 
 curValidator :: Currency -> ValidatorScript

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency/Stage0.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency/Stage0.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Language.PlutusTx.Coordination.Contracts.Currency.Stage0 where
+
+import qualified Language.PlutusTx         as P
+
+import           Ledger.Validation         (TxHash)
+import qualified Ledger.Map                as LMap
+import qualified Ledger.Map.TH             as LMap.TH
+import           Ledger.Value              (CurrencySymbol, TokenName, Value)
+import qualified Ledger.Value.TH           as Value.TH
+
+import           Language.Haskell.TH       (Q, TExp)
+
+data Currency = Currency
+  { curRefTransactionOutput :: (TxHash, Int)
+  -- ^ Transaction input that must be spent when
+  --   the currency is forged.
+  , curAmounts              :: LMap.Map TokenName Int
+  -- ^ How many units of each 'TokenName' are to
+  --   be forged.
+  }
+
+P.makeLift ''Currency
+
+currencyValue :: Q (TExp (CurrencySymbol -> Currency -> Value))
+currencyValue = [||
+        let currencyValue' :: CurrencySymbol -> Currency -> Value
+            currencyValue' s c = 
+                let 
+                    Currency _ amts = c
+                    values = $$(P.map) (\(tn, i) -> ($$(Value.TH.singleton) s tn i)) ($$(LMap.TH.toList) amts)
+                in $$(P.foldr) $$(Value.TH.plus) $$(Value.TH.zero) values
+
+        in currencyValue'
+    ||]

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+-- | A "pay-to-pubkey" transaction output implemented as a Plutus
+--   contract. This is useful if you need something that behaves like
+--   a pay-to-pubkey output, but is not (easily) identified by wallets
+--   as one.
+module Language.PlutusTx.Coordination.Contracts.PubKey(
+      pkValidator
+    , pkRedeemer
+    , pkDataScript
+    , lock
+    , spend
+    ) where
+
+import           Data.Maybe (listToMaybe)
+import qualified Data.Map   as Map
+import qualified Data.Text  as Text
+
+import qualified Language.PlutusTx            as P
+import           Ledger                       as Ledger hiding (initialise, to)
+import           Ledger.Validation            as V
+import           Wallet.API                   as WAPI
+
+pkValidator :: PubKey -> ValidatorScript
+pkValidator pk = 
+    ValidatorScript (Ledger.applyScript mkValidator (Ledger.lifted pk)) where
+        mkValidator = 
+            Ledger.fromCompiledCode ($$(P.compile [||
+                let 
+                    validate :: PubKey -> () -> () -> PendingTx -> ()
+                    validate pk' () () p =
+                        if $$(V.txSignedBy) p pk'
+                        then ()
+                        else $$(P.error) ($$(P.traceH) "Required signature not present!" ())
+                in validate
+            ||]))
+
+-- | PayToPubKey data script (unit value).
+pkDataScript :: DataScript
+pkDataScript = DataScript $ Ledger.lifted ()
+
+-- | PayToPubKey redeemer (unit value).
+pkRedeemer :: RedeemerScript
+pkRedeemer = RedeemerScript $ Ledger.lifted ()
+
+-- | The address of a 'PayToPubKey' contract.
+pkAddress :: PubKey -> Address
+pkAddress = Ledger.scriptAddress . pkValidator
+
+-- | Lock some funds in a 'PayToPubKey' contract, returning the output's address
+--   and a 'TxIn' transaction input that can spend it.
+lock :: (WalletAPI m, WalletDiagnostics m) => PubKey -> Value -> m (Address, TxIn)
+lock pk vl = getRef =<< payToScript defaultSlotRange addr vl pkDataScript where
+    addr = pkAddress pk
+    getRef tx = do
+        let scriptOuts = listToMaybe
+                            $ fmap fst
+                            $ filter ((==) addr . txOutAddress . snd)
+                            $ Map.toList (unspentOutputsTx tx)
+
+        txin <- case scriptOuts of
+                    Nothing -> throwOtherError
+                                $ "transaction did not contain script output"
+                                <> "for public key '"
+                                <> Text.pack (show pk)
+                                <> "'"
+                    Just o  -> pure (scriptTxIn o (pkValidator pk) pkRedeemer)
+            
+        pure (addr, txin)
+
+-- | Make a 'TxIn' that spends a pay-to-script transaction output locked
+--   by the 
+spend :: TxOutRef -> PubKey -> TxIn
+spend ref pk = Ledger.scriptTxIn ref (pkValidator pk) pkRedeemer

--- a/plutus-use-cases/test/Spec.hs
+++ b/plutus-use-cases/test/Spec.hs
@@ -2,6 +2,7 @@
 module Main(main) where
 
 import qualified Spec.Crowdfunding
+import qualified Spec.Currency
 import qualified Spec.Future
 import qualified Spec.Game
 import qualified Spec.MultiSig
@@ -25,5 +26,6 @@ tests = localOption limit $ testGroup "use cases" [
     Spec.Vesting.tests,
     Spec.Future.tests,
     Spec.Game.tests,
-    Spec.MultiSig.tests
+    Spec.MultiSig.tests,
+    Spec.Currency.tests
     ]

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -7,12 +7,12 @@
 module Spec.Crowdfunding(tests) where
 
 import           Control.Monad                                         (void)
-import           Control.Monad.IO.Class
 import           Data.Either                                           (isRight)
 import           Data.Foldable                                         (traverse_)
 import qualified Data.Map                                              as Map
 import           Hedgehog                                              (Property, forAll, property)
 import qualified Hedgehog
+import qualified Spec.Size                                             as Size
 import           Test.Tasty
 import           Test.Tasty.Hedgehog                                   (testProperty)
 import qualified Test.Tasty.HUnit                                      as HUnit
@@ -41,16 +41,8 @@ tests = testGroup "crowdfunding" [
         testProperty "cannot collect money too late" cantCollectLate,
         testProperty "cannot collect unless notified" cantCollectUnlessNotified,
         testProperty "can claim a refund" canRefund,
-        HUnit.testCase "script size is reasonable" size
+        HUnit.testCase "script size is reasonable" (Size.reasonable (CF.contributionScript (cfCampaign scenario1)) 50000)
         ]
-
-size :: HUnit.Assertion
-size = do
-    let Ledger.ValidatorScript s = CF.contributionScript (cfCampaign scenario1)
-    let sz = Ledger.scriptSize s
-    -- so the actual size is visible in the log
-    liftIO $ putStrLn ("Script size: " ++ show sz)
-    HUnit.assertBool "script too big" (sz <= 45000)
 
 -- | Make a contribution to the campaign from a wallet. Returns the reference
 --   to the transaction output that is locked by the campaign's validator

--- a/plutus-use-cases/test/Spec/Currency.hs
+++ b/plutus-use-cases/test/Spec/Currency.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE FlexibleContexts #-}
+module Spec.Currency(tests) where
+
+import           Control.Monad                                     (void, when)
+import           Control.Monad.Except
+import           Data.Either                                       (isLeft, isRight)
+import qualified Data.Map                                          as Map
+import qualified Data.Text                                         as T
+import           Test.Tasty
+import qualified Test.Tasty.HUnit                                  as HUnit
+
+import qualified Language.PlutusTx.Coordination.Contracts.Currency as Cur
+import qualified Ledger.Ada                                        as Ada
+import           Ledger.Value                                      (Value)
+import qualified Wallet.Emulator                                   as EM
+
+tests :: TestTree
+tests = HUnit.testCaseSteps "forge a simple currency" $ \step -> do
+    let initialState = EM.emulatorStateInitialDist (Map.singleton (EM.walletPubKey w1) initialVal)
+        (result, st) = EM.runEmulator initialState runForge
+
+    when (isLeft result) $ step (show st)
+
+    HUnit.assertBool "own funds not equal" (isRight result)
+
+initialVal :: Value
+initialVal = Ada.adaValueOf 10
+
+w1 :: EM.Wallet
+w1 = EM.Wallet 1
+
+runForge :: (EM.MonadEmulator m) => m ()
+runForge = do
+    let
+        processAndNotify = void (EM.addBlocksAndNotify [w1] 1)
+        amount = 1000 -- how much of the currency to forge
+        currencyName = "my token"
+
+    (r, _) <- EM.processEmulated $ do
+        processAndNotify
+        cur <- EM.runWalletAction w1 (Cur.forge currencyName amount)
+        processAndNotify
+        processAndNotify
+        processAndNotify
+        processAndNotify
+        pure cur
+
+    c <- either (throwError . EM.AssertionError . T.pack . show) pure r
+    EM.processEmulated $
+        EM.assertOwnFundsEq w1 (initialVal <> Cur.forgedValue c)

--- a/plutus-use-cases/test/Spec/Currency.hs
+++ b/plutus-use-cases/test/Spec/Currency.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Spec.Currency(tests) where
 
-import           Control.Monad                                     (void, when)
+import           Control.Monad                                     (void)
 import           Control.Monad.Except
-import           Data.Either                                       (isLeft, isRight)
 import qualified Data.Map                                          as Map
 import qualified Data.Text                                         as T
+import qualified Spec.Size                                         as Size
 import           Test.Tasty
 import qualified Test.Tasty.HUnit                                  as HUnit
 
+import           Language.PlutusTx.Coordination.Contracts.Currency (Currency)
 import qualified Language.PlutusTx.Coordination.Contracts.Currency as Cur
 import qualified Ledger.Ada                                        as Ada
 import           Ledger.Value                                      (Value)
@@ -19,9 +20,13 @@ tests = HUnit.testCaseSteps "forge a simple currency" $ \step -> do
     let initialState = EM.emulatorStateInitialDist (Map.singleton (EM.walletPubKey w1) initialVal)
         (result, st) = EM.runEmulator initialState runForge
 
-    when (isLeft result) $ step (show st)
-
-    HUnit.assertBool "own funds not equal" (isRight result)
+    case result of
+        Left  err   -> do
+            step (show st)
+            step (show err)
+            HUnit.assertFailure "own funds not equal"
+        Right cur ->
+            Size.reasonable (Cur.curValidator cur) 50000
 
 initialVal :: Value
 initialVal = Ada.adaValueOf 10
@@ -29,16 +34,15 @@ initialVal = Ada.adaValueOf 10
 w1 :: EM.Wallet
 w1 = EM.Wallet 1
 
-runForge :: (EM.MonadEmulator m) => m ()
+runForge :: (EM.MonadEmulator m) => m Currency
 runForge = do
     let
         processAndNotify = void (EM.addBlocksAndNotify [w1] 1)
-        amount = 1000 -- how much of the currency to forge
-        currencyName = "my token"
+        amounts = [("my currency", 1000), ("my token", 1)]
 
     (r, _) <- EM.processEmulated $ do
         processAndNotify
-        cur <- EM.runWalletAction w1 (Cur.forge currencyName amount)
+        cur <- EM.runWalletAction w1 (Cur.forge amounts)
         processAndNotify
         processAndNotify
         processAndNotify
@@ -48,3 +52,5 @@ runForge = do
     c <- either (throwError . EM.AssertionError . T.pack . show) pure r
     EM.processEmulated $
         EM.assertOwnFundsEq w1 (initialVal <> Cur.forgedValue c)
+
+    pure c

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -3,12 +3,12 @@
 module Spec.Future(tests) where
 
 import           Control.Monad                                   (void)
-import           Control.Monad.IO.Class
 import           Data.Either                                     (isRight)
 import           Data.Foldable                                   (traverse_)
 import qualified Data.Map                                        as Map
 import           Hedgehog                                        (Property, forAll, property)
 import qualified Hedgehog
+import qualified Spec.Size                                       as Size
 import           Test.Tasty
 import           Test.Tasty.Hedgehog                             (testProperty)
 import qualified Test.Tasty.HUnit                                as HUnit
@@ -40,16 +40,8 @@ tests = testGroup "futures" [
     testProperty "close the position" settle,
     testProperty "close early if margin payment was missed" settleEarly,
     testProperty "increase the margin" increaseMargin,
-    HUnit.testCase "script size is reasonable" size
+    HUnit.testCase "script size is reasonable" (Size.reasonable (F.validatorScript contract) 50000)
     ]
-
-size :: HUnit.Assertion
-size = do
-    let Ledger.ValidatorScript s = F.validatorScript contract
-    let sz = Ledger.scriptSize s
-    -- so the actual size is visible in the log
-    liftIO $ putStrLn ("Script size: " ++ show sz)
-    HUnit.assertBool "script too big" (sz <= 50000)
 
 init :: Wallet -> Trace MockWallet Ledger.TxOutRef
 init w = outp <$> walletAction w (F.initialise (walletPubKey wallet1) (walletPubKey wallet2) contract) where

--- a/plutus-use-cases/test/Spec/Game.hs
+++ b/plutus-use-cases/test/Spec/Game.hs
@@ -1,13 +1,13 @@
 module Spec.Game(tests) where
 
 import           Control.Monad                                 (void)
-import           Control.Monad.IO.Class
 import           Data.Either                                   (isRight)
 import           Data.Foldable                                 (traverse_)
 import qualified Data.Map                                      as Map
 
 import           Hedgehog                                      (Property, forAll, property)
 import qualified Hedgehog
+import qualified Spec.Size                                     as Size
 import           Test.Tasty
 import           Test.Tasty.Hedgehog                           (testProperty)
 import qualified Test.Tasty.HUnit                              as HUnit
@@ -29,16 +29,8 @@ tests = testGroup "game" [
     testProperty "lock" lockProp,
     testProperty "guess right" guessRightProp,
     testProperty "guess wrong" guessWrongProp,
-    HUnit.testCase "script size is reasonable" size
+    HUnit.testCase "script size is reasonable" (Size.reasonable gameValidator 25000)
     ]
-
-size :: HUnit.Assertion
-size = do
-    let Ledger.ValidatorScript s = gameValidator
-    let sz = Ledger.scriptSize s
-    -- so the actual size is visible in the log
-    liftIO $ putStrLn ("Script size: " ++ show sz)
-    HUnit.assertBool "script too big" (sz <= 25000)
 
 lockProp :: Property
 lockProp = checkTrace $ do

--- a/plutus-use-cases/test/Spec/Size.hs
+++ b/plutus-use-cases/test/Spec/Size.hs
@@ -1,0 +1,17 @@
+module Spec.Size(reasonable) where
+
+import           Control.Monad.IO.Class (MonadIO (liftIO))
+import qualified Test.Tasty.HUnit       as HUnit
+
+import           Ledger                 (ValidatorScript)
+import qualified Ledger
+
+-- | Assert that the size of a 'ValidatorScript' is below
+--   the maximum.
+reasonable :: ValidatorScript -> Integer -> HUnit.Assertion
+reasonable (Ledger.ValidatorScript s) maxSize = do
+    let sz = Ledger.scriptSize s
+        msg = "Script too big! Max. size: " <> show maxSize <> ". Actual size: " <> show sz
+    -- so the actual size is visible in the log
+    liftIO $ putStrLn ("Script size: " ++ show sz)
+    HUnit.assertBool msg (sz <= maxSize)

--- a/wallet-api/src/Ledger/Map.hs
+++ b/wallet-api/src/Ledger/Map.hs
@@ -7,6 +7,7 @@ module Ledger.Map(
     , singleton
     , empty
     , fromList
+    , toList
     , keys
     , map
     , lookup
@@ -49,9 +50,14 @@ empty = $$(TH.empty)
 these :: (a -> c) -> (b -> c) -> (a -> b -> c) -> These a b -> c
 these = $$(TH.these)
 
+-- | See 'Ledger.Map.TH.fromList'
 fromList :: [(k, v)] -> Map k v
 fromList = $$(TH.fromList)
 
--- | See 'Ledger.Mpa.TH.keys'.
+-- | See 'Ledger.Map.TH.toList'
+toList :: Map k v -> [(k, v)]
+toList = $$(TH.toList)
+
+-- | See 'Ledger.Map.TH.keys'.
 keys :: Map k v -> [k]
 keys = $$(TH.keys)

--- a/wallet-api/src/Ledger/Map/TH.hs
+++ b/wallet-api/src/Ledger/Map/TH.hs
@@ -15,6 +15,7 @@ module Ledger.Map.TH(
     , singleton
     , empty
     , fromList
+    , toList
     , keys
     , map
     , lookup
@@ -52,6 +53,9 @@ instance (FromJSON v, FromJSON k) => FromJSON (Map k v) where
 
 fromList :: Q (TExp ([(k, v)] -> Map k v))
 fromList = [|| Map ||]
+
+toList :: Q (TExp (Map k v -> [(k, v)]))
+toList = [|| \(Map l) -> l ||]
 
 -- | Apply a function to the values of a 'Map'.
 map :: Q (TExp ((v -> w) -> Map k v -> Map k w))

--- a/wallet-api/src/Ledger/Validation.hs
+++ b/wallet-api/src/Ledger/Validation.hs
@@ -27,6 +27,7 @@ module Ledger.Validation
     , plcValidatorDigest
     , plcRedeemerHash
     , plcTxHash
+    , plcCurrencySymbol
     -- * Oracles
     , OracleValue(..)
     -- * Validator functions
@@ -43,7 +44,10 @@ module Ledger.Validation
     , adaLockedBy
     , ownHash
     , signsTransaction
+    , spendsOutput
     , txHash
+    , valueForged
+    , ownCurrencySymbol
     -- * Hashes
     , plcSHA2_256
     , plcSHA3_256
@@ -72,8 +76,10 @@ import           Ledger.Crypto                (PubKey (..), Signature (..))
 import           Ledger.Scripts
 import           Ledger.Slot                  (Slot, SlotRange)
 import qualified Ledger.TxId                  as Tx
-import           Ledger.Value.TH              (Value, CurrencySymbol(..))
-import           LedgerBytes                     (LedgerBytes(..))
+import           Ledger.Tx                    (Address, getAddress)
+import           Ledger.Value                 (CurrencySymbol(..), Value)
+import qualified Ledger.Value.TH              as VTH
+import           LedgerBytes                  (LedgerBytes(..))
 
 -- Ignore newtype warnings related to `Oracle` and `Signed` because it causes
 -- problems with the plugin
@@ -245,12 +251,16 @@ plcSHA3_256 = Builtins.SizedByteString . Hash.sha3 . Builtins.unSizedByteString
 plcDigest :: Digest SHA256 -> P.SizedByteString 32
 plcDigest = P.SizedByteString . BSL.pack . BA.unpack
 
+-- | The 'CurrencySymbol' of an 'Address'
+plcCurrencySymbol :: Address -> CurrencySymbol
+plcCurrencySymbol = $$(VTH.currencySymbol) . plcDigest . getAddress
+
 -- | Check if two public keys are equal.
 eqPubKey :: Q (TExp (PubKey -> PubKey -> Bool))
 eqPubKey = [|| 
     \(PubKey (LedgerBytes l)) (PubKey (LedgerBytes r)) -> $$(P.equalsByteString) l r
     ||]
-    
+
 -- | Check if a transaction was signed by the given public key.
 txSignedBy :: Q (TExp (PendingTx -> PubKey -> Bool))
 txSignedBy = [||
@@ -343,6 +353,41 @@ signsTransaction :: Q (TExp (Signature -> PubKey -> PendingTx -> Bool))
 signsTransaction = [|| 
     \(Signature sig) (PubKey (LedgerBytes pk)) (p :: PendingTx) -> 
         $$(P.verifySignature) pk (let TxHash h = $$(txHash) p in h) sig
+    ||]
+
+-- | Value forged by a 'PendingTx'.
+valueForged :: Q (TExp (PendingTx -> Value))
+valueForged = [||
+        let valueForged' :: PendingTx -> Value
+            valueForged' (PendingTx _ _ _ forge _ _ _ _) = forge
+        in valueForged'
+    ||]
+
+-- | The 'CurrencySymbol' of the current validator script.
+ownCurrencySymbol :: Q (TExp (PendingTx -> CurrencySymbol))
+ownCurrencySymbol = [||
+        let ownCurrencySymbol' :: PendingTx -> CurrencySymbol
+            ownCurrencySymbol' p = 
+                let ValidatorHash h = $$ownHash p
+                in  $$(VTH.currencySymbol) h
+        in ownCurrencySymbol'
+    ||]
+
+-- | Check if the pending transaction spends a specific transaction output
+--   (identified by the hash of a transaction and an index into that 
+--   transactions' outputs)
+spendsOutput :: Q (TExp (PendingTx -> TxHash -> Int -> Bool))
+spendsOutput = [||
+        let spendsOutput' :: PendingTx -> TxHash -> Int -> Bool
+            spendsOutput' p (TxHash h) i = 
+                let PendingTx ins _ _ _ _ _ _ _ = p
+                    spendsOutRef (PendingTxIn (PendingTxOutRef (TxHash h') i') _ _) = 
+                        $$(P.and) ($$(P.equalsByteString) h h') ($$(P.eq) i i')
+
+                in $$(P.any) spendsOutRef ins
+
+        in
+            spendsOutput'
     ||]
 
 makeLift ''PendingTxOutType

--- a/wallet-api/src/Ledger/Validation.hs
+++ b/wallet-api/src/Ledger/Validation.hs
@@ -323,7 +323,10 @@ eqTx = [|| \(TxHash l) (TxHash r) -> Builtins.equalsByteString l r ||]
 
 -- | Get the hash of the validator script that is currently being validated.
 ownHash :: Q (TExp (PendingTx -> ValidatorHash))
-ownHash = [|| \(PendingTx _ _ _ _ i _ _ _) -> let PendingTxIn _ (Just (h, _)) _ = i in h ||]
+ownHash = [|| \(PendingTx _ _ _ _ i _ _ _) -> 
+    case i of
+        PendingTxIn _ (Just (h, _)) _ -> h
+        _ -> $$(P.error) () ||]
 
 -- | Convert a 'CurrencySymbol' to a 'ValidatorHash'
 fromSymbol :: CurrencySymbol -> ValidatorHash
@@ -360,6 +363,7 @@ valueForged :: Q (TExp (PendingTx -> Value))
 valueForged = [||
         let valueForged' :: PendingTx -> Value
             valueForged' (PendingTx _ _ _ forge _ _ _ _) = forge
+            valueForged' _                               = $$(P.error) ()
         in valueForged'
     ||]
 

--- a/wallet-api/src/Ledger/Value.hs
+++ b/wallet-api/src/Ledger/Value.hs
@@ -9,6 +9,7 @@ module Ledger.Value(
     , currencySymbol
     , TokenName
     , tokenName
+    , mkTokenName
     , singleton
     , valueOf
     , scale
@@ -29,10 +30,11 @@ module Ledger.Value(
     , isZero
     ) where
 
-import qualified Ledger.Value.TH as TH
-import           Ledger.Value.TH (CurrencySymbol, TokenName, Value)
-import           Prelude         hiding (negate)
-import qualified Language.PlutusTx.Prelude    as P
+import qualified Data.ByteString.Lazy.Char8 as C8
+import qualified Ledger.Value.TH            as TH
+import           Ledger.Value.TH            (CurrencySymbol, TokenName, Value)
+import           Prelude                    hiding (negate)
+import qualified Language.PlutusTx.Prelude  as P
 
 instance Eq Value where
   (==) = $$(TH.eq)
@@ -51,6 +53,11 @@ currencySymbol = $$(TH.currencySymbol)
 
 tokenName :: P.ByteString -> TokenName
 tokenName = $$(TH.tokenName)
+
+-- | Convert a Haskell 'String' to a PLC 'TokenName' using
+--   the Char8 encoding (see 'Data.ByteString.Char8').
+mkTokenName :: String -> TokenName
+mkTokenName = tokenName . P.SizedByteString . C8.pack
 
 -- | See 'TH.singleton'.
 singleton :: CurrencySymbol -> TokenName -> Int -> Value

--- a/wallet-api/src/Ledger/Value.hs
+++ b/wallet-api/src/Ledger/Value.hs
@@ -9,7 +9,6 @@ module Ledger.Value(
     , currencySymbol
     , TokenName
     , tokenName
-    , mkTokenName
     , singleton
     , valueOf
     , scale
@@ -30,7 +29,6 @@ module Ledger.Value(
     , isZero
     ) where
 
-import qualified Data.ByteString.Lazy.Char8 as C8
 import qualified Ledger.Value.TH            as TH
 import           Ledger.Value.TH            (CurrencySymbol, TokenName, Value)
 import           Prelude                    hiding (negate)
@@ -53,11 +51,6 @@ currencySymbol = $$(TH.currencySymbol)
 
 tokenName :: P.ByteString -> TokenName
 tokenName = $$(TH.tokenName)
-
--- | Convert a Haskell 'String' to a PLC 'TokenName' using
---   the Char8 encoding (see 'Data.ByteString.Char8').
-mkTokenName :: String -> TokenName
-mkTokenName = tokenName . P.SizedByteString . C8.pack
 
 -- | See 'TH.singleton'.
 singleton :: CurrencySymbol -> TokenName -> Int -> Value

--- a/wallet-api/src/Ledger/Value/TH.hs
+++ b/wallet-api/src/Ledger/Value/TH.hs
@@ -288,7 +288,12 @@ isZero = [||
 checkPred :: Q (TExp ((Map.These Int Int -> Bool) -> Value -> Value -> Bool))
 checkPred = [||
     let checkPred' :: (Map.These Int Int -> Bool) -> Value -> Value -> Bool
-        checkPred' f l r = $$(Map.all) ($$(Map.all) f) ($$unionVal l r)
+        checkPred' f l r = 
+          let
+            inner :: Map.Map TokenName (Map.These Int Int) -> Bool
+            inner = ($$(Map.all) f)
+          in
+            $$(Map.all) inner ($$unionVal l r)
     in checkPred'
      ||]
 

--- a/wallet-api/src/Ledger/Value/TH.hs
+++ b/wallet-api/src/Ledger/Value/TH.hs
@@ -19,6 +19,7 @@ module Ledger.Value.TH(
     , TokenName(..)
     , tokenName
     , eqTokenName
+    , toString
     -- ** Value
     , Value(..)
     , singleton
@@ -53,7 +54,7 @@ import           Data.Swagger.Schema          (ToSchema(declareNamedSchema))
 import qualified Data.Swagger.Lens            as S
 import           Data.Swagger                 (SwaggerType(SwaggerObject), NamedSchema(NamedSchema), declareSchemaRef)
 import           Data.Proxy                   (Proxy(Proxy))
-import           Data.String                  (IsString)
+import           Data.String                  (IsString(fromString))
 import qualified Data.Text                    as Text
 import           GHC.Generics                 (Generic)
 import qualified Language.PlutusTx.Builtins as Builtins
@@ -67,6 +68,9 @@ import           Data.Function                ((&))
 
 hexSchema :: S.Schema
 hexSchema = mempty & set S.type_ S.SwaggerString & set S.format (Just "hex")
+
+stringSchema :: S.Schema
+stringSchema = mempty & set S.type_ S.SwaggerString
 
 newtype CurrencySymbol = CurrencySymbol { unCurrencySymbol :: Builtins.SizedByteString 32 }
     deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise) via LedgerBytes
@@ -101,29 +105,31 @@ currencySymbol :: Q (TExp (P.ByteString -> CurrencySymbol))
 currencySymbol = [|| CurrencySymbol ||]
 
 newtype TokenName = TokenName { unTokenName :: Builtins.SizedByteString 32 }
-    deriving (ToJSONKey, FromJSONKey, Serialise) via LedgerBytes
-    deriving (Show, IsString) via (Builtins.SizedByteString 32)
+    deriving (Serialise) via LedgerBytes
     deriving stock (Eq, Ord, Generic)
 
+instance IsString TokenName where
+  fromString = TokenName . P.SizedByteString . C8.pack
+
+toString :: TokenName -> String
+toString = C8.unpack . Builtins.unSizedByteString . unTokenName
+
+instance Show TokenName where
+  show = toString
+
 instance ToSchema TokenName where
-    declareNamedSchema _ = pure $ S.NamedSchema (Just "TokenName") hexSchema
+    declareNamedSchema _ = pure $ S.NamedSchema (Just "TokenName") stringSchema
 
 instance ToJSON TokenName where
     toJSON tokenName =
         JSON.object
-        [ ( "unTokenName"
-            , JSON.String .
-              Text.pack .
-              C8.unpack . Builtins.unSizedByteString . unTokenName $
-              tokenName)
-        ]
+        [ ( "unTokenName", JSON.toJSON $ toString tokenName)]
 
 instance FromJSON TokenName where
     parseJSON =
         JSON.withObject "TokenName" $ \object -> do
         raw <- object .: "unTokenName"
-        let bytes = Text.unpack raw
-        pure . TokenName . Builtins.SizedByteString . C8.pack $ bytes
+        pure . fromString . Text.unpack $ raw
 
 makeLift ''TokenName
 

--- a/wallet-api/src/Wallet/Emulator/Client.hs
+++ b/wallet-api/src/Wallet/Emulator/Client.hs
@@ -98,7 +98,7 @@ instance WalletAPI WalletClient where
   sign bs = Crypto.sign (BSL.toStrict bs) . walletPrivKey <$> asks getWallet
   ownPubKey = liftWallet ownPubKey'
   createPaymentWithChange value = liftWallet (`createPaymentWithChange'` value)
-  register _ _ = pure () -- TODO: Keep track of triggers in emulated wallet
+  registerOnce _ _ = pure () -- TODO: Keep track of triggers in emulated wallet
   watchedAddresses = liftWallet getAddresses
   slot = liftWallet getSlot
   startWatching a = void $ liftWallet (`startWatching'` a)

--- a/wallet-api/src/Wallet/Emulator/Types.hs
+++ b/wallet-api/src/Wallet/Emulator/Types.hs
@@ -215,6 +215,11 @@ data EmulatorEvent =
 instance FromJSON EmulatorEvent
 instance ToJSON EmulatorEvent
 
+-- | Delete all 'EventHandler' values that are registered for an
+--   'EventTrigger'.
+deleteHandlers :: MonadState WalletState m => EventTrigger -> m ()
+deleteHandlers t = modify (over triggers (set (at t) Nothing))
+
 -- | Process a list of 'Notification's in the mock wallet environment.
 handleNotifications :: [Notification] -> MockWallet ()
 handleNotifications = mapM_ (updateState >=> runTriggers)  where
@@ -229,15 +234,17 @@ handleNotifications = mapM_ (updateState >=> runTriggers)  where
 
         let values = AM.values adrs
             annotate = annTruthValue h values
+            trueConditions = filter (getAnnot . fst) $ fmap (first annotate) $ Map.toList trg
 
-        let runIfTrue annotTr action =
-                if getAnnot annotTr -- get the top-level annotation (just like `checkTrigger`, but here we need to hold on to the `annotTr` value to pass it to the handler)
-                then runEventHandler action annotTr
-                else pure ()
-
-        traverse_ (uncurry runIfTrue)
-            $ first annotate
-            <$> Map.toList trg
+        -- We need to do 2 passes over the list of triggers that fired.
+        --
+        -- First pass to delete the old triggers
+        -- Second pass to run the actions
+        --
+        -- Deletion must happen first so that we don't accidentally delete
+        -- triggers that are registered by event handlers.
+        traverse_ (deleteHandlers . WAPI.unAnnot . fst) trueConditions
+        traverse_ (uncurry (flip runEventHandler)) trueConditions
 
     -- Remove spent outputs and add unspent ones, for the addresses that we care about
     update t = over addressMap (AM.updateAddresses t)
@@ -266,7 +273,7 @@ instance WalletAPI MockWallet where
             ins = Set.fromList (flip pubKeyTxIn pubK . fst <$> spend)
         pure (ins, txOutput)
 
-    register tr action =
+    registerOnce tr action =
         modify (over triggers (Map.insertWith (<>) tr action))
         >> modify (over addressMap (AM.addAddresses (addresses tr)))
 

--- a/wallet-api/test/Spec.hs
+++ b/wallet-api/test/Spec.hs
@@ -95,6 +95,7 @@ tests = testGroup "all tests" [
     testGroup "Value" ([
         testProperty "Value ToJSON/FromJSON" (jsonRoundTrip Gen.genValue),
         testProperty "CurrencySymbol ToJSON/FromJSON" (jsonRoundTrip $ Value.currencySymbol <$> Gen.genSizedByteStringExact),
+        testProperty "TokenName ToJSON/FromJSON" (jsonRoundTrip $ fromString @Value.TokenName <$> Gen.string (Range.linear 0 32) Gen.latin1),
         testProperty "CurrencySymbol IsString/Show" currencySymbolIsStringShow
         ] ++ (let   vlJson :: BSL.ByteString
                     vlJson = "{\"getValue\":[[{\"unCurrencySymbol\":\"ab01ff\"},[[{\"unTokenName\":\"myToken\"},50]]]]}"


### PR DESCRIPTION
Add a contract that creates a simple currency.

Also improve the way blockchain triggers work: WalletAPI now has a
function `registerOnce` that deletes the handler after the trigger has
fired once. `register`, the old function, is now implemented in terms of
`registerOnce`.

Depends on #866 