### PR TITLE
playground: Increase timeout

### DIFF
--- a/plutus-playground-server/src/Playground/Server.hs
+++ b/plutus-playground-server/src/Playground/Server.hs
@@ -36,7 +36,7 @@ import qualified Wallet.Graph                 as V
 acceptSourceCode ::
        SourceCode -> Handler (Either InterpreterError (InterpreterResult CompilationResult))
 acceptSourceCode sourceCode = do
-    let maxInterpretationTime :: Microsecond = fromMicroseconds (10 * 1000 * 1000)
+    let maxInterpretationTime :: Microsecond = fromMicroseconds (20 * 1000 * 1000)
     r <-
         liftIO .
         runExceptT $ PI.compile maxInterpretationTime sourceCode
@@ -53,7 +53,7 @@ throwJSONError err json =
 
 runFunction :: Evaluation -> Handler EvaluationResult
 runFunction evaluation = do
-    let maxInterpretationTime :: Microsecond = fromMicroseconds (10 * 1000 * 1000)
+    let maxInterpretationTime :: Microsecond = fromMicroseconds (20 * 1000 * 1000)
     result <-
         liftIO .
         runExceptT $ PI.runFunction maxInterpretationTime evaluation


### PR DESCRIPTION
Double the server timeout to 20s in order to allow the state-machine based guessing game to go through.

https://gist.github.com/j-mueller/47b1dcfbfb1478537acf3aa505ffb0cb
