### PR TITLE
Pass an argument that hydra passes to prevent CI doing something different

### DIFF
--- a/ci/check-hydra.sh
+++ b/ci/check-hydra.sh
@@ -5,7 +5,8 @@ echo '~~~ Evaluating release.nix'
 command time --format '%e' -o eval-time.txt \
     hydra-eval-jobs \
     --option allowed-uris "https://github.com/NixOS https://github.com/input-output-hk" \
-    -I . release.nix > eval.json
+    -I . release.nix \
+    --arg plutus '{ rev = "fake"; }' > eval.json
 EVAL_EXIT_CODE="$?"
 if [ "$EVAL_EXIT_CODE" != 0 ]
 then


### PR DESCRIPTION
Otherwise it will try and build the git revs, which we don't want.

Draft until I see if it works.