### PR TITLE
Bump to GHC 8.6.5 in cabal.project file

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,6 @@ packages: language-plutus-core
           interpreter
           meadow
           plutus-contract-exe
-with-compiler: ghc-8.6.5
 optimization: 2
 constraints: language-plutus-core +development
            , wallet-api +development

--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,7 @@ packages: language-plutus-core
           interpreter
           meadow
           plutus-contract-exe
-with-compiler: ghc-8.6.4
+with-compiler: ghc-8.6.5
 optimization: 2
 constraints: language-plutus-core +development
            , wallet-api +development


### PR DESCRIPTION
This bumps to GHC 8.6.5 in the cabal.project file, since that is what I have installed now.