### PR TITLE
erasure of declarative and algorithmic terms

### DIFF
--- a/metatheory/Algorithmic/Erasure.lagda
+++ b/metatheory/Algorithmic/Erasure.lagda
@@ -59,3 +59,40 @@ eraseTel {As = x ∷ As} (t ,, tel) = erase t ∷ eraseTel tel
 Porting this from declarative required basically deleting one line but
 I don't think I can fully exploit this by parameterizing the module as
 I need to pattern match on the term constructors
+
+# Erasing decl/alg terms agree
+
+\begin{code}
+open import Relation.Binary.PropositionalEquality
+import Declarative as D
+import Declarative.Erasure as D
+open import Algorithmic.Completeness
+
+lenLemma : ∀ Γ → len (nfCtx Γ) ≡ D.len Γ
+lenLemma D.∅        = refl
+lenLemma (Γ D.,⋆ J) = lenLemma Γ
+lenLemma (Γ D., A)  = cong suc (lenLemma Γ)
+
+{-
+sameVar : ∀{Γ J}{A : D.∥ Γ ∥ ⊢⋆ J}(x : Γ D.∋ A)
+  → D.eraseVar x ≡ subst Fin (lenLemma Γ) (eraseVar (nfTyVar x))
+sameVar D.Z = {!!}
+sameVar {Γ} (D.S x) with lenLemma Γ
+... | p = {!p!}
+sameVar (D.T x) = {!sameVar x!}
+
+same : ∀{Γ J}{A : D.∥ Γ ∥ ⊢⋆ J}(t : Γ D.⊢ A)
+  → D.erase t ≡ subst _⊢ (lenLemma Γ) (erase (nfType t)) 
+same (D.` x) = {!!}
+same (D.ƛ t) = {!!}
+same (t D.· t₁) = {!!}
+same (D.Λ t) = {!!}
+same (t D.·⋆ A) = {!!}
+same (D.wrap1 pat arg t) = {!!}
+same (D.unwrap1 t) = {!!}
+same (D.conv x t) = {!!}
+same (D.con x) = {!!}
+same (D.builtin bn σ x) = {!!}
+same (D.error A) = {!!}
+-}
+\end{code}

--- a/metatheory/Algorithmic/Erasure.lagda
+++ b/metatheory/Algorithmic/Erasure.lagda
@@ -1,0 +1,61 @@
+\begin{code}
+module Algorithmic.Erasure where
+\end{code}
+
+\begin{code}
+open import Algorithmic
+open import Untyped
+open import Type.BetaNormal
+open import Type
+open import Builtin.Constant.Term Ctx⋆ Kind * _⊢Nf⋆_ con renaming (TermCon to TyTermCon)
+
+
+open import Data.Nat
+open import Data.Fin
+open import Data.List
+\end{code}
+
+\begin{code}
+len : Ctx → ℕ
+len ∅ = 0
+len (Γ ,⋆ K) = len Γ
+len (Γ , A)  = suc (len Γ)
+\end{code}
+
+\begin{code}
+eraseVar : ∀{Γ K}{A : ∥ Γ ∥ ⊢Nf⋆ K} → Γ ∋ A → Fin (len Γ)
+eraseVar Z     = zero
+eraseVar (S α) = suc (eraseVar α) 
+eraseVar (T α) = eraseVar α
+
+eraseTC : ∀{Γ}{A : ∥ Γ ∥ ⊢Nf⋆ *} → TyTermCon A → TermCon
+eraseTC (integer i)    = integer i
+eraseTC (bytestring b) = bytestring b
+
+open import Type.BetaNBE.RenamingSubstitution
+
+eraseTel : ∀{Γ Δ}{σ : SubNf Δ ∥ Γ ∥}{As : List (Δ ⊢Nf⋆ *)}
+  → Tel Γ Δ σ As
+  → List (len Γ ⊢)
+erase : ∀{Γ K}{A : ∥ Γ ∥ ⊢Nf⋆ K} → Γ ⊢ A → len Γ ⊢
+
+erase (` α)             = ` (eraseVar α)
+erase (ƛ t)             = ƛ (erase t) 
+erase (t · u)           = erase t · erase u
+erase (Λ t)             = erase t
+erase (t ·⋆ A)          = erase t
+erase (wrap1 pat arg t) = erase t
+erase (unwrap1 t)       = erase t
+erase {Γ} (con t)       = con (eraseTC {Γ} t)
+erase (builtin bn σ ts) = builtin bn (eraseTel ts)
+erase (error A)         = error
+
+open import Data.Product renaming (_,_ to _,,_)
+
+eraseTel {As = []}     _          = []
+eraseTel {As = x ∷ As} (t ,, tel) = erase t ∷ eraseTel tel
+\end{code}
+
+Porting this from declarative required basically deleting one line but
+I don't think I can fully exploit this by parameterizing the module as
+I need to pattern match on the term constructors

--- a/metatheory/Declarative/Erasure.lagda
+++ b/metatheory/Declarative/Erasure.lagda
@@ -1,0 +1,55 @@
+\begin{code}
+module Declarative.Erasure where
+\end{code}
+
+\begin{code}
+open import Declarative
+open import Untyped
+\end{code}
+
+\begin{code}
+open import Type
+open import Declarative
+open import Builtin.Constant.Term Ctx⋆ Kind * _⊢⋆_ con renaming (TermCon to TyTermCon)
+open import Data.Nat
+open import Data.Fin
+open import Data.List
+
+len : Ctx → ℕ
+len ∅ = 0
+len (Γ ,⋆ K) = len Γ
+len (Γ , A)  = suc (len Γ)
+
+eraseVar : ∀{Γ K}{A : ∥ Γ ∥ ⊢⋆ K} → Γ ∋ A → Fin (len Γ)
+eraseVar Z     = zero
+eraseVar (S α) = suc (eraseVar α) 
+eraseVar (T α) = eraseVar α
+
+eraseTC : ∀{Γ}{A : ∥ Γ ∥ ⊢⋆ *} → TyTermCon A → TermCon
+eraseTC (integer i)    = integer i
+eraseTC (bytestring b) = bytestring b
+
+open import Type.RenamingSubstitution
+
+eraseTel : ∀{Γ Δ}{σ : Sub Δ ∥ Γ ∥}{As : List (Δ ⊢⋆ *)}
+  → Tel Γ Δ σ As
+  → List (len Γ ⊢)
+erase : ∀{Γ K}{A : ∥ Γ ∥ ⊢⋆ K} → Γ ⊢ A → len Γ ⊢
+
+erase (` α)             = ` (eraseVar α)
+erase (ƛ t)             = ƛ (erase t) 
+erase (t · u)           = erase t · erase u
+erase (Λ t)             = erase t
+erase (t ·⋆ A)          = erase t
+erase (wrap1 pat arg t) = erase t
+erase (unwrap1 t)       = erase t
+erase (conv p t)        = erase t
+erase {Γ} (con t)       = con (eraseTC {Γ} t)
+erase (builtin bn σ ts) = builtin bn (eraseTel ts)
+erase (error A)         = error
+
+open import Data.Product renaming (_,_ to _,,_)
+
+eraseTel {As = []}     _          = []
+eraseTel {As = x ∷ As} (t ,, tel) = erase t ∷ eraseTel tel
+\end{code}

--- a/metatheory/Everything.lagda
+++ b/metatheory/Everything.lagda
@@ -33,6 +33,7 @@ import Declarative
 import Declarative.RenamingSubstitution
 import Declarative.Reduction
 import Declarative.Evaluation
+import Declarative.Erasure
 
 --import Declarative.Examples
 import Declarative.StdLib.Unit

--- a/metatheory/Main.lagda
+++ b/metatheory/Main.lagda
@@ -88,6 +88,8 @@ mapper : {A B : Set} → (A → B) → Maybe A → Maybe B
 mapper f nothing = nothing
 mapper f (just a) = just (f a)
 
+open import Untyped
+
 -- untyped evaluation
 utestPLC : ByteString → Maybe String
 utestPLC plc = mmap (U.ugly ∘ (λ (t : 0 ⊢) → proj₁ (U.run t 100)) ∘ erase⊢) (mbind (deBruijnifyTm nil) (mmap convP (parse plc)))
@@ -104,7 +106,7 @@ open import Data.Vec hiding (_>>=_)
 stestPLC : ByteString → String
 stestPLC plc with parse plc
 stestPLC plc | just t with deBruijnifyTm nil (convP t)
-stestPLC plc | just t | just t' with S.run (saturate t') 1000
+stestPLC plc | just t | just t' with S.run (saturate t') 1000000
 stestPLC plc | just t | just t' | t'' ,, p ,, inj₁ (just v) =
 --  prettyPrint (unDeBruijnify zero Z (unsaturate t''))
  prettyPrint (deDeBruijnify [] nil (unsaturate t''))

--- a/metatheory/Scoped.lagda
+++ b/metatheory/Scoped.lagda
@@ -413,6 +413,7 @@ uglyTermCon (integer x) = "(integer " ++ Data.Integer.show x ++ ")"
 uglyTermCon (bytestring x) = "bytestring"
 uglyTermCon size = "size"
 -}
+
 postulate showNat : ℕ → String
 
 {-# FOREIGN GHC import qualified Data.Text as T #-}

--- a/metatheory/Type/BetaNBE/RenamingSubstitution.lagda
+++ b/metatheory/Type/BetaNBE/RenamingSubstitution.lagda
@@ -46,6 +46,11 @@ rename-nf σ A = trans
         (symCR (rename-eval A idCR σ))  )))
 \end{code}
 
+\begin{code}
+SubNf : Ctx⋆ → Ctx⋆ → Set
+SubNf φ Ψ = ∀ {J} → φ ∋⋆ J → Ψ ⊢Nf⋆ J
+\end{code}
+
 Substitution for normal forms:
 1. embed back into syntax;
 2. perform substitution;
@@ -53,7 +58,7 @@ Substitution for normal forms:
 
 \begin{code}
 substNf : ∀ {Φ Ψ}
-  → (∀ {J} → Φ ∋⋆ J → Ψ ⊢Nf⋆ J)
+  → SubNf Φ Ψ
     -------------------------
   → (∀ {J} → Φ ⊢Nf⋆ J → Ψ ⊢Nf⋆ J)
 substNf ρ n = nf (subst (embNf ∘ ρ) (embNf n))
@@ -90,7 +95,7 @@ This is often holds definitionally for substitution (e.g. subst) but not here.
 
 \begin{code}
 substNf-∋ : ∀ {Φ Ψ J}
-  → (ρ : ∀{K} → Φ ∋⋆ K → Ψ ⊢Nf⋆ K)
+  → (ρ : SubNf Φ Ψ)
   → (α : Φ ∋⋆ J)
   → substNf ρ (ne (` α)) ≡ ρ α
 substNf-∋ ρ α = stability (ρ α) 
@@ -120,8 +125,8 @@ Third Monad Law for substNf
 
 \begin{code}
 substNf-comp : ∀{Φ Ψ Θ}
-  (g : ∀ {J} → Φ ∋⋆ J → Ψ ⊢Nf⋆ J)
-  (f : ∀ {J} → Ψ ∋⋆ J → Θ ⊢Nf⋆ J)
+  (g : SubNf Φ Ψ)
+  (f : SubNf Ψ Θ)
   → ∀{J}(A : Φ ⊢Nf⋆ J)
     -----------------------------------------------
   → substNf (substNf f ∘ g) A ≡ substNf f (substNf g A)
@@ -152,9 +157,9 @@ extending a normal substitution
 
 \begin{code}
 extsNf : ∀ {Φ Ψ}
-  → (∀ {J} → Φ ∋⋆ J → Ψ ⊢Nf⋆ J)
-    -------------------------------------
-  → (∀ {J K} → Φ ,⋆ K ∋⋆ J → Ψ ,⋆ K ⊢Nf⋆ J)
+  → SubNf Φ Ψ
+    -------------------------------
+  → ∀ {K} → SubNf (Φ ,⋆ K) (Ψ ,⋆ K)
 extsNf σ Z      =  ne (` Z)
 extsNf σ (S α)  =  weakenNf (σ α)
 \end{code}

--- a/metatheory/plc-agda.cabal
+++ b/metatheory/plc-agda.cabal
@@ -112,8 +112,6 @@ executable plc-agda
         MAlonzo.Code.Scoped.Reduction
         MAlonzo.Code.Scoped.RenamingSubstitution
         MAlonzo.Code.Type
-        MAlonzo.Code.Type.Equality
-        MAlonzo.Code.Type.RenamingSubstitution
         MAlonzo.Code.Utils
         MAlonzo.RTE
         Raw


### PR DESCRIPTION
i.e. where meaning is given by erasure to untyped terms. So, we need to prove that it given a decl. term converting to an alg. term and then erasing gives the same result as erasing immediately.

This was suggested by an anonymous reviewer.

- [X] erasure from declarative syntax
- [x] erasure from algorithmic syntax
~~proof~~
