### PR TITLE
Restrict th-abstraction bounds

### DIFF
--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -97,7 +97,7 @@ library plutus-tx-compiler
         prettyprinter -any,
         serialise -any,
         template-haskell -any,
-        th-abstraction -any,
+        th-abstraction <0.3.0.0,
         text -any,
         transformers -any
 


### PR DESCRIPTION
This restricts `th-abstraction` bounds, as the latest release contains some breaking changes.