### PR TITLE
Playground: Bugfix for drag and drop actions on Firefox.

### DIFF
--- a/plutus-playground-client/src/MainFrame.purs
+++ b/plutus-playground-client/src/MainFrame.purs
@@ -41,6 +41,7 @@ import Data.Lens.Index (ix)
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe)
+import Data.MediaType.Common (textPlain)
 import Data.Newtype (unwrap)
 import Data.String as String
 import Data.Traversable (foldl)
@@ -66,7 +67,7 @@ import Ledger.Extra (LedgerMap(LedgerMap))
 import Ledger.Extra as LedgerMap
 import Ledger.Value.TH (CurrencySymbol(CurrencySymbol), TokenName(TokenName), Value(Value))
 import LocalStorage (LOCALSTORAGE)
-import MonadApp (class MonadApp, editorGetContents, editorGotoLine, editorSetAnnotations, editorSetContents, getGistByGistId, getOauthStatus, patchGistByGistId, postContract, postEvaluation, postGist, preventDefault, readFileFromDragEvent, runHalogenApp, saveBuffer, setDropEffect, updateChartsIfPossible)
+import MonadApp (class MonadApp, editorGetContents, editorGotoLine, editorSetAnnotations, editorSetContents, getGistByGistId, getOauthStatus, patchGistByGistId, postContract, postEvaluation, postGist, preventDefault, readFileFromDragEvent, runHalogenApp, saveBuffer, setDataTransferData, setDropEffect, updateChartsIfPossible)
 import Network.HTTP.Affjax (AJAX)
 import Network.RemoteData (RemoteData(NotAsked, Loading, Failure, Success), _Success, isSuccess)
 import Playground.API (KnownCurrency(..), SimulatorWallet(SimulatorWallet), _CompilationResult, _FunctionSchema)
@@ -193,6 +194,7 @@ eval (HandleEditorMessage (TextChanged text) next) = do
   pure next
 
 eval (ActionDragAndDrop index DragStart event next) = do
+  setDataTransferData event textPlain (show index)
   assign _actionDrag (Just index)
   pure next
 
@@ -218,6 +220,7 @@ eval (ActionDragAndDrop destination Drop event next) = do
     Just source ->
       modifying (_simulations <<< _current <<< _actions) (Array.move source destination)
     _ -> pure unit
+  preventDefault event
   assign _actionDrag Nothing
   pure next
 

--- a/plutus-playground-client/src/MonadApp.purs
+++ b/plutus-playground-client/src/MonadApp.purs
@@ -24,6 +24,7 @@ import DOM.HTML.Event.Types (DragEvent)
 import Data.Either (Either)
 import Data.Lens (use)
 import Data.Maybe (Maybe(..))
+import Data.MediaType (MediaType)
 import Data.Newtype (class Newtype, unwrap, wrap)
 import ECharts.Monad (interpret)
 import FileEvents (FILE)
@@ -54,6 +55,7 @@ class Monad m <= MonadApp m where
   saveBuffer :: String -> m Unit
   preventDefault :: DragEvent -> m Unit
   setDropEffect :: DropEffect -> DragEvent -> m Unit
+  setDataTransferData :: DragEvent -> MediaType -> String -> m Unit
   readFileFromDragEvent :: DragEvent -> m String
   updateChartsIfPossible :: m Unit
   --
@@ -119,6 +121,8 @@ instance monadAppHalogenApp ::
   preventDefault event = wrap $ liftEff $ FileEvents.preventDefault event
 
   setDropEffect dropEffect event = wrap $ liftEff $ DataTransfer.setDropEffect dropEffect $ dataTransfer event
+  setDataTransferData event mimeType value =
+    wrap $ liftEff $ DataTransfer.setData mimeType value $ dataTransfer event
 
   readFileFromDragEvent event = wrap $ liftAff $ FileEvents.readFileFromDragEvent event
 

--- a/plutus-playground-client/test/MainFrameTests.purs
+++ b/plutus-playground-client/test/MainFrameTests.purs
@@ -125,6 +125,7 @@ instance monadAppMockApp :: Monad m => MonadApp (MockApp m) where
 
   preventDefault event = pure unit
   setDropEffect effectType event = pure unit
+  setDataTransferData event mimeType value = pure unit
   readFileFromDragEvent event = pure "TEST"
   updateChartsIfPossible = pure unit
   --


### PR DESCRIPTION
It seems Firefox needs a couple of extra changes for drag and drop to work.