### PR TITLE
use-cases: Add state-machine based multisig contract

### DIFF
--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -27,6 +27,8 @@ library
         Language.PlutusTx.Coordination.Contracts.Game
         Language.PlutusTx.Coordination.Contracts.GameStateMachine
         Language.PlutusTx.Coordination.Contracts.MultiSig
+        Language.PlutusTx.Coordination.Contracts.MultiSig.Stage0
+        Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine
         Language.PlutusTx.Coordination.Contracts.PubKey
         Language.PlutusTx.Coordination.Contracts.Vesting
         Language.PlutusTx.Coordination.Contracts.Swap
@@ -63,6 +65,7 @@ test-suite plutus-use-cases-test
         Spec.Game
         Spec.GameStateMachine
         Spec.MultiSig
+        Spec.MultiSigStateMachine
         Spec.Size
         Spec.Vesting
     default-language: Haskell2010

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
@@ -162,7 +162,7 @@ guess gss newSecret keepAda restAda = do
     (i, own) <- createPaymentWithChange gameTokenVal
 
     let tx = Ledger.Tx
-                { txInputs = Set.union i (Set.fromList ins)
+                { txInputs = Set.union i (Set.fromList $ fmap fst ins)
                 , txOutputs = [ownOutput, scriptOut] ++ maybeToList own
                 , txForge = $$(V.zero)
                 , txFee   = Ada.zero
@@ -200,7 +200,7 @@ lock initialWord adaVl = do
             ins <- WAPI.spendScriptOutputs addr gameValidator redeemer
 
             let tx = Ledger.Tx
-                        { txInputs = Set.fromList ins
+                        { txInputs = Set.fromList (fmap fst ins)
                         , txOutputs = [ownOutput, scriptOut]
                         , txForge = gameTokenVal
                         , txFee   = Ada.zero

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig/Stage0.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig/Stage0.hs
@@ -1,0 +1,222 @@
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE DataKinds         #-}
+{-# OPTIONS_GHC -O0 #-}
+-- | Types and TH quotes for the multisig state machine contract.
+module Language.PlutusTx.Coordination.Contracts.MultiSig.Stage0(
+      Payment(..)
+    , Params(..)
+    , State(..)
+    , Input(..)
+    , step
+    , stateEq
+    ) where
+
+import           Language.Haskell.TH
+import qualified Language.PlutusTx            as PlutusTx
+import qualified Language.PlutusTx.Prelude    as P
+import           Ledger.Slot                  (Slot)
+import qualified Ledger.Slot                  as Slot
+import           Ledger.Value                 (Value)
+import qualified Ledger.Value.TH              as Value
+import           Ledger.Validation            (PendingTx(..))
+import qualified Ledger.Validation            as Validation
+import           Wallet
+
+-- | A proposal for making a payment under the multisig scheme. 
+data Payment = Payment 
+    { paymentAmount    :: Value
+    -- ^ How much to pay out
+    , paymentRecipient :: PubKey
+    -- ^ Address to pay the value to
+    , paymentDeadline  :: Slot
+    -- ^ Time until the required amount of signatures has to be collected.
+    }
+
+PlutusTx.makeLift ''Payment
+
+data Params = Params
+    { mspSignatories :: [PubKey]
+    -- ^ Public keys that are allowed to authorise payments
+    , mspRequiredSigs :: Int
+    -- ^ How many signatures are required for a payment
+    }
+
+PlutusTx.makeLift ''Params
+
+-- | State of the multisig contract.
+data State =
+    InitialState Value
+    -- ^ Money is locked, anyone can make a proposal for a payment-
+
+    | CollectingSignatures Value Payment [PubKey]
+    -- ^ A payment has been proposed and is awaiting signatures.
+
+PlutusTx.makeLift ''State
+
+data Input =
+    ProposePayment Payment
+    -- ^ Propose a payment. The payment can be made as soon as enough 
+    --   signatures have been collected.
+
+    | AddSignature PubKey
+    -- ^ Add a signature to the sigs. that have been collected for the
+    --   current proposal.
+
+    | Cancel
+    -- ^ Cancel the current proposal if the deadline has passed
+ 
+    | Pay
+    -- ^ Make the payment.
+
+PlutusTx.makeLift ''Input
+
+-- | Check if a public key is one of the signatories of the multisig contract.
+isSignatory :: Q (TExp (PubKey -> Params -> Bool))
+isSignatory = [|| 
+
+        let isSignatory' :: PubKey -> Params -> Bool
+            isSignatory' pk (Params sigs _) = $$(P.any) (\pk' -> $$(Validation.eqPubKey) pk pk') sigs
+        in isSignatory'
+
+  ||]
+
+-- | Check whether a list of public keys contains a given key.
+containsPk :: Q (TExp (PubKey -> [PubKey] -> Bool))
+containsPk = [|| \pk -> $$(P.any) (\pk' -> $$(Validation.eqPubKey) pk' pk)
+    ||]
+
+pkListEq :: Q (TExp ([PubKey] -> [PubKey] -> Bool))
+pkListEq = [||
+
+    let pkListEq' :: [PubKey] -> [PubKey] -> Bool
+        pkListEq' [] [] = True
+        pkListEq' (k:ks) (k':ks') = $$(P.and) ($$(Validation.eqPubKey) k k') (pkListEq' ks ks')
+        pkListEq' _ _ = False
+    
+    in pkListEq'
+
+    ||]
+
+-- | Check whether a proposed 'Payment' is valid given the total
+--   amount of funds currently locked in the contract.
+isValidProposal :: Q (TExp (Value -> Payment -> Bool))
+isValidProposal = [||
+
+        let isValidProposal' :: Value -> Payment -> Bool
+            isValidProposal' vl (Payment amt _ _) = $$(Value.leq) amt vl
+        in isValidProposal'
+
+    ||]
+
+-- | Check whether a proposed 'Payment' has expired.
+proposalExpired :: Q (TExp (PendingTx -> Payment -> Bool))
+proposalExpired = [|| 
+    \(PendingTx _ _ _ _ _ rng _ _) (Payment _ _ ddl) -> 
+        $$(Slot.before) ddl rng
+    ||]
+
+-- | Check whether enough signatories (represented as a list of public keys)
+--   have signed a proposed payment.
+proposalAccepted :: Q (TExp (Params -> [PubKey] -> Bool))
+proposalAccepted = [||
+        let proposalAccepted' :: Params -> [PubKey] -> Bool
+            proposalAccepted' (Params signatories numReq) pks = 
+                let numSigned = $$(P.length) ($$(P.filter) (\pk -> $$containsPk pk pks) signatories)
+                in $$(P.geq) numSigned numReq
+        in proposalAccepted'
+    ||]
+
+-- | @valuePreserved v p@ is true if the pending transaction @p@ pays the amount
+--   @v@ to a single pay-to-script output at this script's address.
+valuePreserved :: Q (TExp (Value -> PendingTx -> Bool))
+valuePreserved = [||
+
+        let valuePreserved' :: Value -> PendingTx -> Bool
+            valuePreserved' vl ptx = 
+                let ownHash = $$(Validation.ownHash) ptx
+                    numOutputs = $$(P.length) ($$(Validation.scriptOutputsAt) ownHash ptx)
+                    valueLocked = $$(Validation.valueLockedBy) ptx ownHash
+                in $$(P.and) ($$(P.eq) 1 numOutputs) ($$(Value.eq) valueLocked vl)
+        in valuePreserved'
+
+    ||]
+
+-- | @valuePaid pm ptx@ is true of the pending transaction @ptx@ pays
+--   the amount specified in @pm@ to the public key address specified in @pm@
+valuePaid :: Q (TExp (Payment -> PendingTx -> Bool))
+valuePaid = [||
+
+        let valuePaid' :: Payment -> PendingTx -> Bool
+            valuePaid' (Payment vl pk _) ptx = $$(Value.eq) vl ($$(Validation.valuePaidTo) ptx pk)
+        in valuePaid'
+    ||]
+
+paymentEq :: Q (TExp (Payment -> Payment -> Bool))
+paymentEq = [||
+
+        let paymentEq' :: Payment -> Payment -> Bool
+            paymentEq' (Payment vl pk sl) (Payment vl' pk' sl') = 
+                $$(P.and) ($$(P.and) ($$(Value.eq) vl vl') ($$(Validation.eqPubKey) pk pk')) ($$(Slot.eq) sl sl')
+        in paymentEq'
+
+    ||]
+
+stateEq :: Q (TExp (State -> State -> Bool))
+stateEq = [||
+        let stateEq' :: State -> State -> Bool
+            stateEq' (InitialState v) (InitialState v') =
+                $$(Value.eq) v v'
+            stateEq' (CollectingSignatures vl pmt pks) (CollectingSignatures vl' pmt' pks') =
+                $$(P.and) ($$(P.and) ($$(Value.eq) vl vl') ($$paymentEq pmt pmt')) ($$pkListEq pks pks')
+            stateEq' _ _ = False
+
+        in stateEq'
+    ||]
+
+-- | @step params ptx state input@ computes the next state given current state
+--   @state@ and the input. It checks whether the pending transaction @ptx@
+--   pays the expected amounts to script and public key addresses. Fails with 
+--   'P.error' if an invalid transition is attempted.
+step :: Q (TExp (Params -> PendingTx -> State -> Input -> State))
+step = [||
+
+    let and_ :: Bool -> Bool -> Bool
+        and_ = $$(P.and)
+
+        not_ :: Bool -> Bool
+        not_ = $$(P.not)
+        
+        step' :: Params -> PendingTx -> State -> Input -> State
+        step' p ptx s i = 
+            case (s, i) of
+                (InitialState vl, ProposePayment pmt) -> 
+                    if $$isValidProposal vl pmt `and_`
+                       $$valuePreserved vl ptx
+                    then CollectingSignatures vl pmt []
+                    else $$(P.error) ()
+                (CollectingSignatures vl pmt pks, AddSignature pk) ->
+                    if $$(Validation.txSignedBy) ptx pk `and_` 
+                       $$isSignatory pk p `and_`
+                       not_ ($$containsPk pk pks) `and_`
+                       $$valuePreserved vl ptx
+                    then CollectingSignatures vl pmt (pk:pks)
+                    else $$(P.error) ()
+                (CollectingSignatures vl pmt _, Cancel) ->
+                    if $$proposalExpired ptx pmt `and_`
+                        $$valuePreserved vl ptx
+                    then InitialState vl
+                    else $$(P.error) ()
+                (CollectingSignatures vl pmt@(Payment vp _ _) pks, Pay) ->
+                    let vl' = $$(Value.minus) vl vp in
+                    if not_ ($$proposalExpired ptx pmt) `and_`
+                       $$proposalAccepted p pks `and_`
+                       $$valuePreserved vl' ptx `and_`
+                       $$valuePaid pmt ptx
+                    then InitialState vl'
+                    else $$(P.error) ()
+                _ -> $$(P.error) ($$(P.traceH) "invalid transition" ())
+    in step'
+    ||]

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE DataKinds         #-}
+{-# OPTIONS_GHC -O0 #-}
+-- | A multisig contract written as a state machine. 
+module Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine(
+      Params(..)
+    , validator
+    ) where
+
+import           Ledger                       (ValidatorScript(..))
+import qualified Ledger
+import           Ledger.Validation            (PendingTx)
+
+import Language.PlutusTx.StateMachine
+import Language.PlutusTx.Coordination.Contracts.MultiSig.Stage0
+
+validator :: Params -> ValidatorScript
+validator params = ValidatorScript val where
+    val = Ledger.applyScript script (Ledger.lifted params)
+    
+    script = ($$(Ledger.compileScript [||
+
+        \(p :: Params) (ds :: (State, Maybe Input)) (vs :: (State, Maybe Input)) (ptx :: PendingTx) ->
+            let 
+                trans = $$step p ptx
+                sm = StateMachine trans $$stateEq
+            in $$(mkValidator) sm ds vs ptx
+
+        ||]))

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
@@ -7,15 +7,30 @@
 -- | A multisig contract written as a state machine. 
 module Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine(
       Params(..)
+    , Payment(..)
+    , State
     , validator
+    , initialise
+    , lock
+    , proposePayment
+    , cancelPayment
+    , addSignature
+    , makePayment
     ) where
 
-import           Ledger                       (ValidatorScript(..))
+import           Data.Foldable                (foldMap)
+import qualified Data.Set                     as Set
+import           Ledger                       (DataScript(..), RedeemerScript(..), ValidatorScript(..))
 import qualified Ledger
 import           Ledger.Validation            (PendingTx)
+import           Ledger.Value                 (Value)
+import qualified Ledger.Value                 as Value
+import           Wallet
+import qualified Wallet                       as WAPI
 
-import Language.PlutusTx.StateMachine
-import Language.PlutusTx.Coordination.Contracts.MultiSig.Stage0
+import           Language.PlutusTx.StateMachine
+import           Language.PlutusTx.Coordination.Contracts.MultiSig.Stage0 as MultiSig
+import qualified Language.PlutusTx.StateMachine as SM
 
 validator :: Params -> ValidatorScript
 validator params = ValidatorScript val where
@@ -25,8 +40,120 @@ validator params = ValidatorScript val where
 
         \(p :: Params) (ds :: (State, Maybe Input)) (vs :: (State, Maybe Input)) (ptx :: PendingTx) ->
             let 
-                trans = $$step p ptx
+                trans = $$stepWithChecks p ptx
                 sm = StateMachine trans $$stateEq
             in $$(mkValidator) sm ds vs ptx
 
         ||]))
+
+-- | Start watching the contract address
+initialise :: WalletAPI m => Params -> m ()
+initialise = WAPI.startWatching . Ledger.scriptAddress . validator
+
+-- | Lock some funds in a multisig contract.
+lock
+    :: (WalletAPI m, WalletDiagnostics m)
+    => MultiSig.Params
+    -- ^ Signatories and required signatures
+    -> Value
+    -- ^ The funds we want to lock
+    -> m MultiSig.State
+    -- ^ The initial state of the contract
+lock prms vl = do
+    let 
+        addr = Ledger.scriptAddress (validator prms)
+        state = InitialState vl
+        dataScript = DataScript (Ledger.lifted (SM.initialState @State @Input state))
+
+    WAPI.payToScript_ WAPI.defaultSlotRange addr vl dataScript
+
+    pure state
+
+-- | Propose a payment from funds that are locked up in a state-machine based 
+--   multisig contract.
+proposePayment
+    :: (WalletAPI m, WalletDiagnostics m)
+    => MultiSig.Params
+    -> MultiSig.State
+    -> MultiSig.Payment
+    -> m MultiSig.State
+proposePayment prms st = mkStep prms st . ProposePayment
+
+-- | Cancel a proposed payment
+cancelPayment
+    :: (WalletAPI m, WalletDiagnostics m)
+    => MultiSig.Params
+    -> MultiSig.State
+    -> m MultiSig.State
+cancelPayment prms st = mkStep prms st Cancel
+
+-- | Add a signature to a proposed payment
+addSignature
+    :: (WalletAPI m, WalletDiagnostics m)
+    => MultiSig.Params
+    -> MultiSig.State
+    -> m MultiSig.State
+addSignature prms st = WAPI.ownPubKey >>= mkStep prms st . AddSignature
+
+-- | Make a payment after enough signatures have been collected.
+makePayment
+    :: (WalletAPI m, WalletDiagnostics m)
+    => MultiSig.Params
+    -> MultiSig.State
+    -> m MultiSig.State
+makePayment prms st = do
+    -- we can't use 'mkStep' because the outputs of the transaction are 
+    -- different from the other transitions: We need two outputs, a public
+    -- key output with the payment, and the script output with the remaining
+    -- funds.
+    (currentValue, valuePaid, recipient) <- case st of
+        CollectingSignatures vl (Payment pd pk _) _ -> pure (vl, pd, pk)
+        _ -> WAPI.throwOtherError "Cannot make payment because no payment has been proposed. Run the 'proposePayment' action first."
+    
+    let newState = $$step prms st Pay
+        vl       = validator prms
+        redeemer = RedeemerScript (Ledger.lifted (SM.transition newState Pay))
+        dataScript = DataScript (Ledger.lifted (SM.transition newState Pay))
+
+    inputs <- WAPI.spendScriptOutputs (Ledger.scriptAddress vl) vl redeemer
+    let valueLeft = currentValue `Value.minus` valuePaid
+        scriptOut = Ledger.scriptTxOut valueLeft vl dataScript
+        pkOut     = Ledger.pubKeyTxOut valuePaid recipient
+    _ <- WAPI.createTxAndSubmit WAPI.defaultSlotRange (Set.fromList $ fmap fst inputs) [scriptOut, pkOut]
+    pure newState
+
+-- | Advance a running multisig contract. This applies the transition function 
+--   'SM.transition' to the current contract state and uses the result to unlock
+--   the funds currently in the contract, and lock them again with a data script
+--   containing the new state.
+--
+mkStep
+    :: (WalletAPI m, WalletDiagnostics m)
+    => MultiSig.Params
+    -- ^ The parameters of the contract instance
+    -> MultiSig.State
+    -- ^ Current state of the instance
+    -> MultiSig.Input
+    -- ^ Input to be applied to the contract
+    -> m MultiSig.State
+    -- ^ New state after applying the input
+mkStep prms st input = do
+    let newState = $$step prms st input
+        vl       = validator prms
+        redeemer = RedeemerScript (Ledger.lifted (SM.transition newState input))
+        dataScript = DataScript (Ledger.lifted (SM.transition newState input))
+
+    inputs <- WAPI.spendScriptOutputs (Ledger.scriptAddress vl) vl redeemer
+    let totalVal = foldMap snd inputs
+        output = Ledger.scriptTxOut totalVal vl dataScript
+    _ <- WAPI.createTxAndSubmit WAPI.defaultSlotRange (Set.fromList $ fmap fst inputs) [output]
+    pure newState
+
+{- note [Current state of the contract]
+
+The 'mkStep' function takes the current state of the contract and returns the 
+new state. Both values are placed on the chain, so technically we don't have to
+pass them around like this, but we currently can't decode 'State' values from 
+PLC back to Haskell.
+
+-}

--- a/plutus-use-cases/test/Spec.hs
+++ b/plutus-use-cases/test/Spec.hs
@@ -7,6 +7,7 @@ import qualified Spec.Future
 import qualified Spec.Game
 import qualified Spec.GameStateMachine
 import qualified Spec.MultiSig
+import qualified Spec.MultiSigStateMachine
 import qualified Spec.Vesting
 import           Test.Tasty
 import           Test.Tasty.Hedgehog   (HedgehogTestLimit (..))
@@ -28,6 +29,7 @@ tests = localOption limit $ testGroup "use cases" [
     Spec.Future.tests,
     Spec.Game.tests,
     Spec.MultiSig.tests,
+    Spec.MultiSigStateMachine.tests,
     Spec.Currency.tests,
     Spec.GameStateMachine.tests
     ]

--- a/plutus-use-cases/test/Spec.hs
+++ b/plutus-use-cases/test/Spec.hs
@@ -10,7 +10,7 @@ import qualified Spec.MultiSig
 import qualified Spec.MultiSigStateMachine
 import qualified Spec.Vesting
 import           Test.Tasty
-import           Test.Tasty.Hedgehog   (HedgehogTestLimit (..))
+import           Test.Tasty.Hedgehog       (HedgehogTestLimit (..))
 
 main :: IO ()
 main = defaultMain tests

--- a/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
+++ b/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
@@ -1,13 +1,110 @@
+{-# LANGUAGE FlexibleContexts #-}
 module Spec.MultiSigStateMachine(tests) where
 
-import qualified Spec.Size        as Size
-import           Test.Tasty       (TestTree, testGroup)
-import qualified Test.Tasty.HUnit as HUnit
+import           Control.Monad                                                 (foldM, void, (>=>))
+import           Control.Monad.Except                                          (throwError)
+import           Data.Either                                                   (isLeft, isRight)
+import           Data.Foldable                                                 (traverse_)
+import qualified Data.Map                                                      as Map
+import qualified Data.Text                                                     as Text
+import qualified Spec.Size                                                     as Size
+import           Test.Tasty                                                    (TestTree, testGroup)
+import qualified Test.Tasty.HUnit                                              as HUnit
 
+import qualified Ledger.Ada                                                    as Ada
+import           Ledger.Value                                                  (Value)
+import           Wallet.API                                                    (WalletAPI,
+                                                                                WalletDiagnostics)
+import qualified Wallet.Emulator                                               as EM
+
+import           Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine (Payment, State)
 import qualified Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine as MS
 
 tests :: TestTree
 tests = testGroup "multi sig state machine tests" [
-    let val = MS.validator (MS.Params [] 100) in
-    HUnit.testCase "script size is reasonable" (Size.reasonable val 300000)
+    HUnit.testCaseSteps "lock, propose, sign 3x, pay - SUCCESS" (runTrace (lockProposeSignPay 3) isRight),
+    HUnit.testCaseSteps "lock, propose, sign 2x, pay - FAILURE" (runTrace (lockProposeSignPay 2) isLeft),
+    HUnit.testCase "script size is reasonable" (Size.reasonable (MS.validator params) 330000)
     ]
+
+runTrace :: EM.EmulatorAction a -> (Either EM.AssertionError a -> Bool) -> (String -> IO ()) -> IO ()
+runTrace t f step = do
+    let initialState = EM.emulatorStateInitialDist (Map.singleton (EM.walletPubKey (EM.Wallet 1)) (Ada.adaValueOf 10))
+        (result, st) = EM.runEmulator initialState t
+    if f result
+    then pure ()
+    else do
+        step (show $ EM.emLog st)
+        HUnit.assertFailure "transaction failed to validate"
+
+processAndNotify :: EM.Trace m ()
+processAndNotify = void (EM.addBlocksAndNotify [w1, w2, w3] 1)
+
+w1, w2, w3 :: EM.Wallet
+w1 = EM.Wallet 1
+w2 = EM.Wallet 2
+w3 = EM.Wallet 3
+
+-- | A multisig contract that requires 3 out of 5 signatures
+params :: MS.Params
+params = MS.Params keys 3 where
+    keys = EM.walletPubKey . EM.Wallet <$> [1..5]
+
+-- | A payment of 5 Ada to the public key address of wallet 2
+payment :: MS.Payment
+payment =
+    MS.Payment
+        { MS.paymentAmount    = Ada.adaValueOf 5
+        , MS.paymentRecipient = EM.walletPubKey w2
+        , MS.paymentDeadline  = 20
+        }
+
+initialise' :: WalletAPI m => m ()
+initialise' = MS.initialise params
+
+-- State machine transitions partially applied to the 'payment' multisig contract
+
+lock' :: (WalletAPI m, WalletDiagnostics m) => Value -> m State
+lock' = MS.lock params
+
+proposePayment' :: (WalletAPI m, WalletDiagnostics m) => State -> Payment -> m State
+proposePayment' = MS.proposePayment params
+
+addSignature' :: (WalletAPI m, WalletDiagnostics m) => State -> m State
+addSignature' = MS.addSignature params
+
+makePayment' :: (WalletAPI m, WalletDiagnostics m) => State -> m State
+makePayment' = MS.makePayment params
+
+lockProposeSignPay :: (EM.MonadEmulator m) => Int -> m ()
+lockProposeSignPay i = do
+
+    let getResult = EM.processEmulated >=> extract where
+        extract = either (throwError . EM.AssertionError . Text.pack . show) pure . fst
+
+    -- stX contain the state of the contract. See note [Current state of the 
+    -- contract] in 
+    -- Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine
+    st1 <- getResult $ do
+        processAndNotify
+
+        -- instruct all three wallets to start watching the contract address
+        traverse_ (\w -> EM.walletAction w initialise') [w1, w2, w3]
+        processAndNotify
+
+        -- wallet 1 locks the funds
+        EM.runWalletAction w1 (lock' (Ada.adaValueOf 10))
+
+    -- wallet 2 proposes the payment
+    st2 <- getResult $ do
+        processAndNotify
+        EM.runWalletAction w2 (proposePayment' st1 payment)
+
+    -- i wallets add their signatures
+    st3 <- foldM (\st w -> getResult (processAndNotify >> EM.runWalletAction w (addSignature' st))) st2 (take i [w1, w2, w3])
+
+    EM.processEmulated $ do
+        processAndNotify
+        void $ EM.walletAction w3 (makePayment' st3)
+        processAndNotify
+        EM.assertOwnFundsEq w2 (Ada.adaValueOf 5)

--- a/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
+++ b/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
@@ -1,0 +1,13 @@
+module Spec.MultiSigStateMachine(tests) where
+
+import qualified Spec.Size        as Size
+import           Test.Tasty       (TestTree, testGroup)
+import qualified Test.Tasty.HUnit as HUnit
+
+import qualified Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine as MS
+
+tests :: TestTree
+tests = testGroup "multi sig state machine tests" [
+    let val = MS.validator (MS.Params [] 100) in
+    HUnit.testCase "script size is reasonable" (Size.reasonable val 300000)
+    ]

--- a/plutus-wallet-api/ledger/Ledger/Slot.hs
+++ b/plutus-wallet-api/ledger/Ledger/Slot.hs
@@ -10,6 +10,7 @@ module Ledger.Slot(
       Slot(..)
     , SlotRange
     , singleton
+    , Ledger.Slot.eq
     , empty
     , member
     , width
@@ -25,7 +26,7 @@ import           GHC.Generics                             (Generic)
 import           Language.Haskell.TH
 
 import           Language.PlutusTx.Lift                   (makeLift)
-import           Language.PlutusTx.Prelude
+import           Language.PlutusTx.Prelude                as P
 
 import           Ledger.Interval
 
@@ -45,6 +46,10 @@ type SlotRange = Interval Slot
 -- | A 'SlotRange' that covers only a single slot.
 singleton :: Q (TExp (Slot -> SlotRange))
 singleton = [|| \(Slot s) -> Interval (Just (Slot s)) (Just (Slot ($$plus s 1))) ||]
+
+-- | Equality of 'Slot' values
+eq :: Q (TExp (Slot -> Slot -> Bool))
+eq = [|| \(Slot s) (Slot s') -> $$(P.eq) s s' ||]
 
 -- | Check if a 'SlotRange' is empty.
 empty :: Q (TExp (SlotRange -> Bool))

--- a/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
+++ b/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
@@ -23,7 +23,7 @@ import           Language.Haskell.TH       (Q, TExp)
 
 -- | Specification of a state machine 
 data StateMachine s i = StateMachine {
-        smTransition :: s -> i -> s
+      smTransition :: s -> i -> s
     , smStateEq    :: s -> s -> Bool
     }
 


### PR DESCRIPTION
Another implementation of the n-out-of-m multisig contract. It uses a state machine to implement a proposal system where people can attach their signatures to a proposed payment. This removes the need for the _n_ signatories to all sign the same transaction (which requires off-chain coordination via email etc.)

I only added two unit tests because they take relatively long.

```
  multi sig state machine tests
    lock, propose, sign 3x, pay - SUCCESS:     OK (125.93s)
    lock, propose, sign 2x, pay - FAILURE:     OK (109.45s)
    script size is reasonable:                 Script size: 328114
```

Also the script size seems to be quite large (10x the size of the crowdfunding script for example).