### PR TITLE
plutus-tx: deal with unpackCStringFoldr#

### DIFF
--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
@@ -182,7 +182,7 @@ hoistExpr :: Converting m => GHC.Var -> GHC.CoreExpr -> m PIRTerm
 hoistExpr var t =
     let
         name = GHC.getName var
-    in withContextM 2 (sdToTxt $ "Converting definition of:" GHC.<+> GHC.ppr var) $ do
+    in withContextM 1 (sdToTxt $ "Converting definition of:" GHC.<+> GHC.ppr var) $ do
         maybeDef <- PIR.lookupTerm () name
         case maybeDef of
             Just term -> pure term

--- a/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
@@ -95,7 +95,7 @@ install args todo = do
         -- See Note [Making sure unfoldings are present]
         mode = GHC.SimplMode {
                     GHC.sm_names = ["Ensure unfoldings are present"]
-                  , GHC.sm_phase = GHC.Phase 0
+                  , GHC.sm_phase = GHC.InitialPhase
                   , GHC.sm_dflags = flags
                   , GHC.sm_rules = False
                   -- You might think you would need this, but apparently not

--- a/plutus-tx/test/Plugin/errors/machInt.plc.golden
+++ b/plutus-tx/test/Plugin/errors/machInt.plc.golden
@@ -1,3 +1,1 @@
-(program 1.0.0
-  (con 1)
-)
+Error: Unsupported feature: Int#: unboxed integers are not supported

--- a/plutus-wallet-api/ledger/Ledger/Validation.hs
+++ b/plutus-wallet-api/ledger/Ledger/Validation.hs
@@ -9,8 +9,6 @@
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
--- FIXME: 'unpackFoldrCString#'
-{-# OPTIONS_GHC -fno-enable-rewrite-rules #-}
 module Ledger.Validation
     (
     -- * Pending transactions and related types


### PR DESCRIPTION
There are so many ways to make string literals!

This one I think is something of an artifact of the way we use `INLINABLE`, but this at least deals with it a bit better than having to turn off rewrite rules...

Few minor refactorings and a fix too.