### PR TITLE
Forbid hedgehog 1.0

### DIFF
--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -152,7 +152,7 @@ library
         safe-exceptions -any,
         dependent-sum -any,
         dependent-map -any,
-        hedgehog -any,
+        hedgehog <1.0,
         filepath -any,
         tasty -any,
         tasty-golden -any,


### PR DESCRIPTION
Forbid latest hedgehog release, so that our packages can be built with `cabal`.