### PR TITLE
plutus-ir: use let-bindings in compilation, exploit with later dead-binding removal

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -20,8 +20,8 @@ module Language.PlutusCore.MkPlc ( TermLike (..)
                                  , functionDefToType
                                  , functionDefVarDecl
                                  , mkFunctionDef
-                                 , mkTermLet
-                                 , mkTypeLet
+                                 , mkImmediateLamAbs
+                                 , mkImmediateTyAbs
                                  , mkIterTyForall
                                  , mkIterTyLam
                                  , mkIterApp
@@ -66,8 +66,8 @@ instance TermLike (Term tyname name) tyname name where
     unwrap   = Unwrap
     iWrap    = IWrap
     error    = Error
-    termLet  = mkTermLet
-    typeLet  = mkTypeLet
+    termLet  = mkImmediateLamAbs
+    typeLet  = mkImmediateTyAbs
 
 embed :: TermLike term tyname name => Term tyname name a -> term a
 embed = \case
@@ -154,23 +154,23 @@ mkFunctionDef annName name (TyFun annTy dom cod) term =
     Just $ FunctionDef annName name (FunctionType annTy dom cod) term
 mkFunctionDef _       _    _                     _    = Nothing
 
--- | Make a "let-binding" for a term.
-mkTermLet
+-- | Make a "let-binding" for a term as an immediately applied lambda abstraction.
+mkImmediateLamAbs
     :: TermLike term tyname name
     => a
     -> TermDef term tyname name a
     -> term a -- ^ The body of the let, possibly referencing the name.
     -> term a
-mkTermLet x1 (Def (VarDecl x2 name ty) bind) body = apply x1 (lamAbs x2 name ty body) bind
+mkImmediateLamAbs x1 (Def (VarDecl x2 name ty) bind) body = apply x1 (lamAbs x2 name ty body) bind
 
--- | Make a "let-binding" for a type. Note: the body must be a value.
-mkTypeLet
+-- | Make a "let-binding" for a type as an immediately instantiated type abstraction. Note: the body must be a value.
+mkImmediateTyAbs
     :: TermLike term tyname name
     => a
     -> TypeDef tyname a
     -> term a -- ^ The body of the let, possibly referencing the name.
     -> term a
-mkTypeLet x1 (Def (TyVarDecl x2 name k) bind) body = tyInst x1 (tyAbs x2 name k body) bind
+mkImmediateTyAbs x1 (Def (TyVarDecl x2 name k) bind) body = tyInst x1 (tyAbs x2 name k body) bind
 
 -- | Make an iterated application.
 mkIterApp

--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -52,6 +52,8 @@ class TermLike term tyname name | term -> tyname, term -> name where
     unwrap   :: a -> term a -> term a
     iWrap    :: a -> Type tyname a -> Type tyname a -> term a -> term a
     error    :: a -> Type tyname a -> term a
+    termLet  :: a -> TermDef term tyname name a -> term a -> term a
+    typeLet  :: a -> TypeDef tyname a -> term a -> term a
 
 instance TermLike (Term tyname name) tyname name where
     var      = Var
@@ -64,6 +66,8 @@ instance TermLike (Term tyname name) tyname name where
     unwrap   = Unwrap
     iWrap    = IWrap
     error    = Error
+    termLet  = mkTermLet
+    typeLet  = mkTypeLet
 
 embed :: TermLike term tyname name => Term tyname name a -> term a
 embed = \case

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Tuple.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Tuple.hs
@@ -106,7 +106,7 @@ bindTuple ann names (Tuple elTys term) body = liftQuote $ do
     let tupVar = Tuple elTys $ var ann tup
     tupTy <- getTupleType ann tupVar
     tupDefs <- itraverse (\i name -> tupleDefAt ann i name tupVar) names
-    pure $ apply ann (lamAbs ann tup tupTy $ foldr (mkTermLet ann) body tupDefs) term
+    pure $ apply ann (lamAbs ann tup tupTy $ foldr (termLet ann) body tupDefs) term
 
 -- | Given an arity @n@, create the n-ary product type.
 --

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -27,7 +27,7 @@ import           PlutusPrelude
 import           Language.PlutusCore        (Kind, Name, TyName, Type (..))
 import qualified Language.PlutusCore        as PLC
 import           Language.PlutusCore.CBOR   ()
-import           Language.PlutusCore.MkPlc  (TermLike (..), TyVarDecl (..), VarDecl (..), Def(..))
+import           Language.PlutusCore.MkPlc  (Def (..), TermLike (..), TyVarDecl (..), VarDecl (..))
 import qualified Language.PlutusCore.Pretty as PLC
 
 import           Codec.Serialise            (Serialise)
@@ -128,8 +128,8 @@ instance TermLike (Term tyname name) tyname name where
     unwrap   = Unwrap
     iWrap    = IWrap
     error    = Error
-    termLet x (Def vd bind) body = Let x NonRec [TermBind x vd bind] body
-    typeLet x (Def vd bind) body = Let x NonRec [TypeBind x vd bind] body
+    termLet x (Def vd bind) = Let x NonRec [TermBind x vd bind]
+    typeLet x (Def vd bind) = Let x NonRec [TypeBind x vd bind]
 
 -- no version as PIR is not versioned
 data Program tyname name a = Program a (Term tyname name a) deriving Generic

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -27,7 +27,7 @@ import           PlutusPrelude
 import           Language.PlutusCore        (Kind, Name, TyName, Type (..))
 import qualified Language.PlutusCore        as PLC
 import           Language.PlutusCore.CBOR   ()
-import           Language.PlutusCore.MkPlc  (TermLike (..), TyVarDecl (..), VarDecl (..))
+import           Language.PlutusCore.MkPlc  (TermLike (..), TyVarDecl (..), VarDecl (..), Def(..))
 import qualified Language.PlutusCore.Pretty as PLC
 
 import           Codec.Serialise            (Serialise)
@@ -128,6 +128,8 @@ instance TermLike (Term tyname name) tyname name where
     unwrap   = Unwrap
     iWrap    = IWrap
     error    = Error
+    termLet x (Def vd bind) body = Let x NonRec [TermBind x vd bind] body
+    typeLet x (Def vd bind) body = Let x NonRec [TypeBind x vd bind] body
 
 -- no version as PIR is not versioned
 data Program tyname name a = Program a (Term tyname name a) deriving Generic

--- a/plutus-ir/src/Language/PlutusIR/Compiler.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler.hs
@@ -22,9 +22,9 @@ import qualified Language.PlutusIR.Compiler.Let              as Let
 import           Language.PlutusIR.Compiler.Lower
 import           Language.PlutusIR.Compiler.Provenance
 import           Language.PlutusIR.Compiler.Types
+import qualified Language.PlutusIR.Optimizer.DeadCode        as DeadCode
 import           Language.PlutusIR.Transform.Rename          ()
 import qualified Language.PlutusIR.Transform.ThunkRecursions as ThunkRec
-import qualified Language.PlutusIR.Optimizer.DeadCode        as DeadCode
 
 import qualified Language.PlutusCore                         as PLC
 

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
@@ -74,8 +74,10 @@ compileRecTypeBindings _ body bs = getEnclosing >>= \p -> pure $ Let p Rec bs bo
 
 compileNonRecBinding :: Compiling m e a => LetKind -> PIRTerm a -> Binding TyName Name (Provenance a) -> m (PIRTerm a)
 compileNonRecBinding NonRecTerms body (TermBind x d rhs) = withEnclosing (const $ TermBinding (varDeclNameString d) x) $
+    -- Note this is *not* from 'TermLike', which would created exactly the let binding we are trying to get rid of
    PIR.mkTermLet <$> getEnclosing <*> pure (PIR.Def d rhs) <*> pure body
 compileNonRecBinding Types body (TypeBind x d rhs) = withEnclosing (const $ TypeBinding (tyVarDeclNameString d) x) $
+    -- Note this is *not* from 'TermLike', which would created exactly the let binding we are trying to get rid of
    PIR.mkTypeLet <$> getEnclosing <*> pure (PIR.Def d rhs) <*> pure body
 compileNonRecBinding Types body (DatatypeBind x d) = withEnclosing (const $ TypeBinding (datatypeNameString d) x) $
    compileDatatype NonRec body d

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
@@ -14,7 +14,6 @@ import qualified Language.PlutusIR.MkPir               as PIR
 
 import           Control.Monad
 import           Control.Monad.Error.Lens
-import           Control.Monad.Reader
 
 import           Data.List
 
@@ -23,7 +22,7 @@ data LetKind = RecTerms | NonRecTerms | Types
 -- | Compile the let terms out of a 'Term'. Note: the result does *not* have globally unique names.
 compileLets :: Compiling m e a => LetKind -> PIRTerm a -> m (PIRTerm a)
 compileLets kind = \case
-    Let p r bs body -> local (const $ LetBinding r p) $ do
+    Let p r bs body -> withEnclosing (const $ LetBinding r p) $ do
         body' <- compileLets kind body
         bs' <- traverse (compileInBinding kind) bs
         case r of
@@ -53,7 +52,7 @@ compileRecBindings :: Compiling m e a => LetKind -> PIRTerm a -> [Binding TyName
 compileRecBindings kind body bs
     | null typeBinds = compileRecTermBindings kind body termBinds
     | null termBinds = compileRecTypeBindings kind body typeBinds
-    | otherwise      = ask >>= \p -> throwing _Error $ CompilationError p "Mixed term and type bindings in recursive let"
+    | otherwise      = getEnclosing >>= \p -> throwing _Error $ CompilationError p "Mixed term and type bindings in recursive let"
     where
         (termBinds, typeBinds) = partition (\case { TermBind {} -> True ; _ -> False; }) bs
 
@@ -61,23 +60,23 @@ compileRecTermBindings :: Compiling m e a => LetKind -> PIRTerm a -> [Binding Ty
 compileRecTermBindings RecTerms body bs = do
     binds <- forM bs $ \case
         TermBind _ vd rhs -> pure $ PIR.Def vd rhs
-        _ -> ask >>= \p -> throwing _Error $ CompilationError p "Internal error: type binding in term binding group"
+        _ -> getEnclosing >>= \p -> throwing _Error $ CompilationError p "Internal error: type binding in term binding group"
     compileRecTerms body binds
-compileRecTermBindings _ body bs = ask >>= \p -> pure $ Let p Rec bs body
+compileRecTermBindings _ body bs = getEnclosing >>= \p -> pure $ Let p Rec bs body
 
 compileRecTypeBindings :: Compiling m e a => LetKind -> PIRTerm a -> [Binding TyName Name (Provenance a)] -> m (PIRTerm a)
 compileRecTypeBindings Types body bs = do
     binds <- forM bs $ \case
         DatatypeBind _ d -> pure d
-        _ -> ask >>= \p -> throwing _Error $ CompilationError p "Internal error: term or type binding in datatype binding group"
+        _ -> getEnclosing >>= \p -> throwing _Error $ CompilationError p "Internal error: term or type binding in datatype binding group"
     compileRecDatatypes body binds
-compileRecTypeBindings _ body bs = ask >>= \p -> pure $ Let p Rec bs body
+compileRecTypeBindings _ body bs = getEnclosing >>= \p -> pure $ Let p Rec bs body
 
 compileNonRecBinding :: Compiling m e a => LetKind -> PIRTerm a -> Binding TyName Name (Provenance a) -> m (PIRTerm a)
-compileNonRecBinding NonRecTerms body (TermBind x d rhs) = local (const $ TermBinding (varDeclNameString d) x) $
-   PIR.mkTermLet <$> ask <*> pure (PIR.Def d rhs) <*> pure body
-compileNonRecBinding Types body (TypeBind x d rhs) = local (const $ TypeBinding (tyVarDeclNameString d) x) $
-   PIR.mkTypeLet <$> ask <*> pure (PIR.Def d rhs) <*> pure body
-compileNonRecBinding Types body (DatatypeBind x d) = local (const $ TypeBinding (datatypeNameString d) x) $
+compileNonRecBinding NonRecTerms body (TermBind x d rhs) = withEnclosing (const $ TermBinding (varDeclNameString d) x) $
+   PIR.mkTermLet <$> getEnclosing <*> pure (PIR.Def d rhs) <*> pure body
+compileNonRecBinding Types body (TypeBind x d rhs) = withEnclosing (const $ TypeBinding (tyVarDeclNameString d) x) $
+   PIR.mkTypeLet <$> getEnclosing <*> pure (PIR.Def d rhs) <*> pure body
+compileNonRecBinding Types body (DatatypeBind x d) = withEnclosing (const $ TypeBinding (datatypeNameString d) x) $
    compileDatatype NonRec body d
-compileNonRecBinding _ body b = ask >>= \p -> pure $ Let p NonRec [b] body
+compileNonRecBinding _ body b = getEnclosing >>= \p -> pure $ Let p NonRec [b] body

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
@@ -74,11 +74,9 @@ compileRecTypeBindings _ body bs = getEnclosing >>= \p -> pure $ Let p Rec bs bo
 
 compileNonRecBinding :: Compiling m e a => LetKind -> PIRTerm a -> Binding TyName Name (Provenance a) -> m (PIRTerm a)
 compileNonRecBinding NonRecTerms body (TermBind x d rhs) = withEnclosing (const $ TermBinding (varDeclNameString d) x) $
-    -- Note this is *not* from 'TermLike', which would created exactly the let binding we are trying to get rid of
-   PIR.mkTermLet <$> getEnclosing <*> pure (PIR.Def d rhs) <*> pure body
+   PIR.mkImmediateLamAbs <$> getEnclosing <*> pure (PIR.Def d rhs) <*> pure body
 compileNonRecBinding Types body (TypeBind x d rhs) = withEnclosing (const $ TypeBinding (tyVarDeclNameString d) x) $
-    -- Note this is *not* from 'TermLike', which would created exactly the let binding we are trying to get rid of
-   PIR.mkTypeLet <$> getEnclosing <*> pure (PIR.Def d rhs) <*> pure body
+   PIR.mkImmediateTyAbs <$> getEnclosing <*> pure (PIR.Def d rhs) <*> pure body
 compileNonRecBinding Types body (DatatypeBind x d) = withEnclosing (const $ TypeBinding (datatypeNameString d) x) $
    compileDatatype NonRec body d
 compileNonRecBinding _ body b = getEnclosing >>= \p -> pure $ Let p NonRec [b] body

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Recursion.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Recursion.hs
@@ -11,7 +11,6 @@ import qualified Language.PlutusIR.MkPir                    as PIR
 
 import           Control.Monad
 import           Control.Monad.Error.Lens
-import           Control.Monad.Reader
 
 import qualified Language.PlutusCore                        as PLC
 import           Language.PlutusCore.Quote
@@ -60,7 +59,7 @@ Here we merely have to provide it with the types of the f_is, which we *do* know
 -- | Compile a mutually recursive list of var decls bound in a body.
 compileRecTerms :: Compiling m e a => PIRTerm a -> [TermDef TyName Name (Provenance a)] -> m (PIRTerm a)
 compileRecTerms body bs = do
-    p <- ask
+    p <- getEnclosing
     fixpoint <- mkFixpoint bs
     Tuple.bindTuple p (PIR.varDeclName . PIR.defVar <$> bs) fixpoint body
 
@@ -70,7 +69,7 @@ mkFixpoint
     => [TermDef TyName Name (Provenance a)]
     -> m (Tuple.Tuple (Term TyName Name) (Provenance a))
 mkFixpoint bs = do
-    p0 <- ask
+    p0 <- getEnclosing
 
     funs <- forM bs $ \(PIR.Def (PIR.VarDecl p name ty) term) ->
         case PIR.mkFunctionDef p name ty term of

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ConstraintKinds  #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TemplateHaskell  #-}
 module Language.PlutusIR.Compiler.Types where
 
 import qualified Language.PlutusIR                     as PIR
@@ -9,10 +10,42 @@ import           Language.PlutusIR.Compiler.Provenance
 import           Control.Monad.Except
 import           Control.Monad.Reader
 
+import           Control.Lens
+
 import qualified Language.PlutusCore                   as PLC
 import qualified Language.PlutusCore.MkPlc             as PLC
 import           Language.PlutusCore.Quote
 import qualified Language.PlutusCore.StdLib.Type       as Types
+
+newtype CompilationOpts = CompilationOpts {
+    _coOptimize :: Bool
+    } deriving (Eq, Show)
+
+makeLenses ''CompilationOpts
+
+defaultCompilationOpts :: CompilationOpts
+defaultCompilationOpts = CompilationOpts True
+
+data CompilationCtx a = CompilationCtx {
+    _ccOpts :: CompilationOpts
+    , _ccEnclosing :: Provenance a
+    } deriving (Eq, Show)
+
+makeLenses ''CompilationCtx
+
+defaultCompilationCtx :: CompilationCtx a
+defaultCompilationCtx = CompilationCtx defaultCompilationOpts NoProvenance
+
+getEnclosing :: MonadReader (CompilationCtx a) m => m (Provenance a)
+getEnclosing = view ccEnclosing
+
+withEnclosing :: MonadReader (CompilationCtx a) m => (Provenance a -> Provenance a) -> m b -> m b
+withEnclosing f = local (over ccEnclosing f)
+
+runIfOpts :: MonadReader (CompilationCtx a) m => (b -> m b) -> (b -> m b)
+runIfOpts pass arg = do
+    doOpt <- view (ccOpts . coOptimize)
+    if doOpt then pass arg else pure arg
 
 type PLCTerm a = PLC.Term PLC.TyName PLC.Name (Provenance a)
 type PLCType a = PLC.Type PLC.TyName (Provenance a)
@@ -41,6 +74,6 @@ unwrap p r t = case r of
 type PIRTerm a = PIR.Term PIR.TyName PIR.Name (Provenance a)
 type PIRType a = PIR.Type PIR.TyName (Provenance a)
 
-type Compiling m e a = (Monad m, MonadReader (Provenance a) m, AsError e (Provenance a), MonadError e m, MonadQuote m)
+type Compiling m e a = (Monad m, MonadReader (CompilationCtx a) m, AsError e (Provenance a), MonadError e m, MonadQuote m)
 
 type TermDef tyname name a = PLC.Def (PLC.VarDecl tyname name a) (PIR.Term tyname name a)

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
@@ -27,7 +27,7 @@ defaultCompilationOpts :: CompilationOpts
 defaultCompilationOpts = CompilationOpts True
 
 data CompilationCtx a = CompilationCtx {
-    _ccOpts :: CompilationOpts
+    _ccOpts        :: CompilationOpts
     , _ccEnclosing :: Provenance a
     } deriving (Eq, Show)
 

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -50,7 +50,7 @@ asIfThrown
 asIfThrown = withExceptT SomeException . hoist (pure . runIdentity)
 
 compileAndMaybeTypecheck :: Bool -> Term TyName Name a -> Except (Error (Provenance a)) (PLC.Term TyName Name (Provenance a))
-compileAndMaybeTypecheck doTypecheck pir = flip runReaderT NoProvenance $ runQuoteT $ do
+compileAndMaybeTypecheck doTypecheck pir = flip runReaderT defaultCompilationCtx $ runQuoteT $ do
     compiled <- compileTerm pir
     when doTypecheck $ void $ PLC.inferType PLC.defOffChainConfig compiled
     pure compiled

--- a/plutus-ir/test/datatypes/listMatchEval.golden
+++ b/plutus-ir/test/datatypes/listMatchEval.golden
@@ -1,1 +1,1 @@
-(abs a_8 (type) (lam x_9 a_8 x_9))
+(abs a_11 (type) (lam x_12 a_11 x_12))

--- a/plutus-ir/test/recursion/even3.golden
+++ b/plutus-ir/test/recursion/even3.golden
@@ -43,27 +43,7 @@
                                             (lam
                                               even_i0
                                               (fun Nat_i11 Bool_i6)
-                                              [
-                                                (lam
-                                                  odd_i0
-                                                  (fun Nat_i12 Bool_i7)
-                                                  [ even_i2 three_i8 ]
-                                                )
-                                                [
-                                                  {
-                                                    tup_i2 (fun Nat_i11 Bool_i6)
-                                                  }
-                                                  (lam
-                                                    arg_0_i0
-                                                    (fun Nat_i12 Bool_i7)
-                                                    (lam
-                                                      arg_1_i0
-                                                      (fun Nat_i13 Bool_i8)
-                                                      arg_1_i1
-                                                    )
-                                                  )
-                                                ]
-                                              ]
+                                              [ even_i1 three_i7 ]
                                             )
                                             [
                                               { tup_i1 (fun Nat_i10 Bool_i5) }

--- a/plutus-ir/test/recursion/even3Eval.golden
+++ b/plutus-ir/test/recursion/even3Eval.golden
@@ -1,5 +1,7 @@
 (abs
-  out_Bool_19
+  out_Bool_103
   (type)
-  (lam case_True_20 out_Bool_19 (lam case_False_21 out_Bool_19 case_False_21))
+  (lam
+    case_True_104 out_Bool_103 (lam case_False_105 out_Bool_103 case_False_105)
+  )
 )

--- a/plutus-ir/test/recursion/mutuallyRecursiveValues.golden
+++ b/plutus-ir/test/recursion/mutuallyRecursiveValues.golden
@@ -8,36 +8,8 @@
           x_thunked_i0
           (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
           [
-            (lam
-              y_thunked_i0
-              (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-              [
-                (lam
-                  y_i0
-                  (all a_i0 (type) (fun a_i1 a_i1))
-                  [
-                    (lam x_i0 (all a_i0 (type) (fun a_i1 a_i1)) x_i1)
-                    [ x_thunked_i3 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
-                  ]
-                )
-                [ y_thunked_i1 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
-              ]
-            )
-            [
-              {
-                tup_i2
-                (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-              }
-              (lam
-                arg_0_i0
-                (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-                (lam
-                  arg_1_i0
-                  (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-                  arg_1_i1
-                )
-              )
-            ]
+            (lam x_i0 (all a_i0 (type) (fun a_i1 a_i1)) x_i1)
+            [ x_thunked_i1 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
           ]
         )
         [

--- a/plutus-tx/compiler/Language/PlutusTx/Lift.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Lift.hs
@@ -31,7 +31,7 @@ import           Data.Functor                           (void)
 lift :: (Lift.Lift a, AsError e (Provenance ()), MonadError e m, MonadQuote m) => a -> m (PLC.Term TyName Name ())
 lift x = do
     lifted <- runDefT () $ Lift.lift x
-    compiled <- flip runReaderT NoProvenance $ compileTerm lifted
+    compiled <- flip runReaderT defaultCompilationCtx $ compileTerm lifted
     pure $ void compiled
 
 -- | Get a Plutus Core program corresponding to the given value.

--- a/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
@@ -33,7 +33,6 @@ import           Language.PlutusCore.Quote
 import qualified Language.PlutusIR                      as PIR
 import qualified Language.PlutusIR.Compiler             as PIR
 import qualified Language.PlutusIR.Compiler.Definitions as PIR
-import qualified Language.PlutusIR.Optimizer.DeadCode   as PIR
 
 import           Language.Haskell.TH.Syntax             as TH
 
@@ -42,6 +41,7 @@ import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Control.Monad.State
+import           Control.Lens
 
 import qualified Data.ByteString                        as BS
 import qualified Data.ByteString.Lazy                   as BSL
@@ -187,11 +187,11 @@ makeByteStringLiteral bs = do
 -- 'GHC.TyThing's for later reference.
 makePrimitiveNameInfo :: [TH.Name] -> GHC.CoreM BuiltinNameInfo
 makePrimitiveNameInfo names = do
-    mapped <- forM names $ \name -> do
+    infos <- forM names $ \name -> do
         ghcName <- thNameToGhcNameOrFail name
         thing <- GHC.lookupThing ghcName
         pure (name, thing)
-    pure $ Map.fromList mapped
+    pure $ Map.fromList infos
 
 -- | Strips all enclosing 'GHC.Tick's off an expression.
 stripTicks :: GHC.CoreExpr -> GHC.CoreExpr
@@ -305,11 +305,14 @@ runCompiler
     -> GHC.CoreExpr
     -> m (PIRProgram, PLCProgram)
 runCompiler opts expr = do
+    let (ctx :: PIR.CompilationCtx ()) = PIR.defaultCompilationCtx & set (PIR.ccOpts . PIR.coOptimize) (poOptimize opts)
+
     (pirT::PIRTerm) <- PIR.runDefT () $ convExprWithDefs expr
-    let (pirP::PIRProgram) = PIR.Program () $ if poOptimize opts then PIR.removeDeadBindings pirT else pirT
+    -- We manually run a simplifier pass here before dumping/storing the PIR
+    (pirP::PIRProgram) <- PIR.Program () <$> (flip runReaderT ctx $ PIR.simplifyTerm pirT)
     when (poDumpPir opts) $ liftIO $ print $ PP.pretty pirP
 
-    (plcP::PLCProgram) <- void <$> (flip runReaderT PIR.NoProvenance $ PIR.compileProgram pirP)
+    (plcP::PLCProgram) <- void <$> (flip runReaderT ctx $ PIR.compileProgram pirP)
     when (poDumpPlc opts) $ liftIO $ print $ PP.pretty plcP
 
     -- We do this after dumping the programs so that if we fail typechecking we still get the dump

--- a/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
@@ -37,11 +37,11 @@ import qualified Language.PlutusIR.Compiler.Definitions as PIR
 import           Language.Haskell.TH.Syntax             as TH
 
 import           Codec.Serialise                        (serialise)
+import           Control.Lens
 import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Control.Monad.State
-import           Control.Lens
 
 import qualified Data.ByteString                        as BS
 import qualified Data.ByteString.Lazy                   as BSL

--- a/plutus-tx/test/Lift/boolInterop.plc.golden
+++ b/plutus-tx/test/Lift/boolInterop.plc.golden
@@ -1,9 +1,9 @@
 (abs
-  out_GHC_Types_Bool_9
+  out_GHC_Types_Bool_6
   (type)
   (lam
-    case_GHC_Types_True_10
-    out_GHC_Types_Bool_9
-    (lam case_GHC_Types_False_11 out_GHC_Types_Bool_9 case_GHC_Types_True_10)
+    case_GHC_Types_True_7
+    out_GHC_Types_Bool_6
+    (lam case_GHC_Types_False_8 out_GHC_Types_Bool_6 case_GHC_Types_True_7)
   )
 )

--- a/plutus-tx/test/Plugin/Data/recursive/sameEmptyRoseEval.plc.golden
+++ b/plutus-tx/test/Plugin/Data/recursive/sameEmptyRoseEval.plc.golden
@@ -1,53 +1,53 @@
 (iwrap
-  (lam rec_112 (fun (fun (type) (type)) (type)) (lam spine_113 (fun (type) (type)) [spine_113 [(lam EmptyRose_86 (type) (all out_EmptyRose_106 (type) (fun (fun [List_81 EmptyRose_86] out_EmptyRose_106) out_EmptyRose_106))) [rec_112 (lam dat_111 (type) dat_111)]]]))
-  (lam dat_114 (type) dat_114)
+  (lam rec_188 (fun (fun (type) (type)) (type)) (lam spine_189 (fun (type) (type)) [spine_189 [(lam EmptyRose_190 (type) (all out_EmptyRose_191 (type) (fun (fun [List_0 EmptyRose_190] out_EmptyRose_191) out_EmptyRose_191))) [rec_188 (lam dat_192 (type) dat_192)]]]))
+  (lam dat_193 (type) dat_193)
   (abs
-    out_EmptyRose_115
+    out_EmptyRose_194
     (type)
     (lam
-      case_EmptyRose_116
-      (fun [List_81 (ifix (lam rec_109 (fun (fun (type) (type)) (type)) (lam spine_110 (fun (type) (type)) [spine_110 [(lam EmptyRose_86 (type) (all out_EmptyRose_106 (type) (fun (fun [List_81 EmptyRose_86] out_EmptyRose_106) out_EmptyRose_106))) [rec_109 (lam dat_108 (type) dat_108)]]])) (lam dat_107 (type) dat_107))] out_EmptyRose_115)
+      case_EmptyRose_195
+      (fun [List_0 (ifix (lam rec_196 (fun (fun (type) (type)) (type)) (lam spine_197 (fun (type) (type)) [spine_197 [(lam EmptyRose_198 (type) (all out_EmptyRose_199 (type) (fun (fun [List_0 EmptyRose_198] out_EmptyRose_199) out_EmptyRose_199))) [rec_196 (lam dat_200 (type) dat_200)]]])) (lam dat_201 (type) dat_201))] out_EmptyRose_194)
       [
-        case_EmptyRose_116
+        case_EmptyRose_195
         (iwrap
-          (lam rec_125 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_126 (fun (fun (type) (type)) (type)) [spine_126 [(lam List_81 (fun (type) (type)) (lam a_82 (type) (all out_List_119 (type) (fun out_List_119 (fun (fun a_82 (fun [List_81 a_82] out_List_119)) out_List_119))))) (lam a_82 (type) [rec_125 (lam dat_124 (fun (type) (type)) [dat_124 a_82])])]]))
-          (lam dat_127 (fun (type) (type)) [dat_127 a_82])
+          (lam rec_251 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_252 (fun (fun (type) (type)) (type)) [spine_252 [(lam List_253 (fun (type) (type)) (lam a_254 (type) (all out_List_255 (type) (fun out_List_255 (fun (fun a_254 (fun [List_253 a_254] out_List_255)) out_List_255))))) (lam a_256 (type) [rec_251 (lam dat_257 (fun (type) (type)) [dat_257 a_256])])]]))
+          (lam dat_258 (fun (type) (type)) [dat_258 a_239])
           (abs
-            out_List_131
+            out_List_259
             (type)
             (lam
-              case_Nil_132
-              out_List_131
+              case_Nil_260
+              out_List_259
               (lam
-                case_Cons_133
-                (fun a_82 (fun [(lam a_82 (type) (ifix (lam rec_122 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_123 (fun (fun (type) (type)) (type)) [spine_123 [(lam List_81 (fun (type) (type)) (lam a_82 (type) (all out_List_119 (type) (fun out_List_119 (fun (fun a_82 (fun [List_81 a_82] out_List_119)) out_List_119))))) (lam a_82 (type) [rec_122 (lam dat_121 (fun (type) (type)) [dat_121 a_82])])]])) (lam dat_120 (fun (type) (type)) [dat_120 a_82]))) a_82] out_List_131))
+                case_Cons_261
+                (fun a_239 (fun [(lam a_262 (type) (ifix (lam rec_263 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_264 (fun (fun (type) (type)) (type)) [spine_264 [(lam List_265 (fun (type) (type)) (lam a_266 (type) (all out_List_267 (type) (fun out_List_267 (fun (fun a_266 (fun [List_265 a_266] out_List_267)) out_List_267))))) (lam a_268 (type) [rec_263 (lam dat_269 (fun (type) (type)) [dat_269 a_268])])]])) (lam dat_270 (fun (type) (type)) [dat_270 a_262]))) a_239] out_List_259))
                 [
                   [
-                    case_Cons_133
+                    case_Cons_261
                     (iwrap
-                      (lam rec_112 (fun (fun (type) (type)) (type)) (lam spine_113 (fun (type) (type)) [spine_113 [(lam EmptyRose_86 (type) (all out_EmptyRose_106 (type) (fun (fun [List_81 EmptyRose_86] out_EmptyRose_106) out_EmptyRose_106))) [rec_112 (lam dat_111 (type) dat_111)]]]))
-                      (lam dat_114 (type) dat_114)
+                      (lam rec_188 (fun (fun (type) (type)) (type)) (lam spine_189 (fun (type) (type)) [spine_189 [(lam EmptyRose_190 (type) (all out_EmptyRose_191 (type) (fun (fun [List_0 EmptyRose_190] out_EmptyRose_191) out_EmptyRose_191))) [rec_188 (lam dat_192 (type) dat_192)]]]))
+                      (lam dat_193 (type) dat_193)
                       (abs
-                        out_EmptyRose_115
+                        out_EmptyRose_194
                         (type)
                         (lam
-                          case_EmptyRose_116
-                          (fun [List_81 (ifix (lam rec_109 (fun (fun (type) (type)) (type)) (lam spine_110 (fun (type) (type)) [spine_110 [(lam EmptyRose_86 (type) (all out_EmptyRose_106 (type) (fun (fun [List_81 EmptyRose_86] out_EmptyRose_106) out_EmptyRose_106))) [rec_109 (lam dat_108 (type) dat_108)]]])) (lam dat_107 (type) dat_107))] out_EmptyRose_115)
+                          case_EmptyRose_195
+                          (fun [List_0 (ifix (lam rec_196 (fun (fun (type) (type)) (type)) (lam spine_197 (fun (type) (type)) [spine_197 [(lam EmptyRose_198 (type) (all out_EmptyRose_199 (type) (fun (fun [List_0 EmptyRose_198] out_EmptyRose_199) out_EmptyRose_199))) [rec_196 (lam dat_200 (type) dat_200)]]])) (lam dat_201 (type) dat_201))] out_EmptyRose_194)
                           [
-                            case_EmptyRose_116
+                            case_EmptyRose_195
                             (iwrap
-                              (lam rec_125 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_126 (fun (fun (type) (type)) (type)) [spine_126 [(lam List_81 (fun (type) (type)) (lam a_82 (type) (all out_List_119 (type) (fun out_List_119 (fun (fun a_82 (fun [List_81 a_82] out_List_119)) out_List_119))))) (lam a_82 (type) [rec_125 (lam dat_124 (fun (type) (type)) [dat_124 a_82])])]]))
-                              (lam dat_127 (fun (type) (type)) [dat_127 a_82])
+                              (lam rec_219 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_220 (fun (fun (type) (type)) (type)) [spine_220 [(lam List_221 (fun (type) (type)) (lam a_222 (type) (all out_List_223 (type) (fun out_List_223 (fun (fun a_222 (fun [List_221 a_222] out_List_223)) out_List_223))))) (lam a_224 (type) [rec_219 (lam dat_225 (fun (type) (type)) [dat_225 a_224])])]]))
+                              (lam dat_226 (fun (type) (type)) [dat_226 a_218])
                               (abs
-                                out_List_128
+                                out_List_227
                                 (type)
                                 (lam
-                                  case_Nil_129
-                                  out_List_128
+                                  case_Nil_228
+                                  out_List_227
                                   (lam
-                                    case_Cons_130
-                                    (fun a_82 (fun [(lam a_82 (type) (ifix (lam rec_122 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_123 (fun (fun (type) (type)) (type)) [spine_123 [(lam List_81 (fun (type) (type)) (lam a_82 (type) (all out_List_119 (type) (fun out_List_119 (fun (fun a_82 (fun [List_81 a_82] out_List_119)) out_List_119))))) (lam a_82 (type) [rec_122 (lam dat_121 (fun (type) (type)) [dat_121 a_82])])]])) (lam dat_120 (fun (type) (type)) [dat_120 a_82]))) a_82] out_List_128))
-                                    case_Nil_129
+                                    case_Cons_229
+                                    (fun a_218 (fun [(lam a_230 (type) (ifix (lam rec_231 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_232 (fun (fun (type) (type)) (type)) [spine_232 [(lam List_233 (fun (type) (type)) (lam a_234 (type) (all out_List_235 (type) (fun out_List_235 (fun (fun a_234 (fun [List_233 a_234] out_List_235)) out_List_235))))) (lam a_236 (type) [rec_231 (lam dat_237 (fun (type) (type)) [dat_237 a_236])])]])) (lam dat_238 (fun (type) (type)) [dat_238 a_230]))) a_218] out_List_227))
+                                    case_Nil_228
                                   )
                                 )
                               )
@@ -58,44 +58,44 @@
                     )
                   ]
                   (iwrap
-                    (lam rec_125 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_126 (fun (fun (type) (type)) (type)) [spine_126 [(lam List_81 (fun (type) (type)) (lam a_82 (type) (all out_List_119 (type) (fun out_List_119 (fun (fun a_82 (fun [List_81 a_82] out_List_119)) out_List_119))))) (lam a_82 (type) [rec_125 (lam dat_124 (fun (type) (type)) [dat_124 a_82])])]]))
-                    (lam dat_127 (fun (type) (type)) [dat_127 a_82])
+                    (lam rec_251 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_252 (fun (fun (type) (type)) (type)) [spine_252 [(lam List_253 (fun (type) (type)) (lam a_254 (type) (all out_List_255 (type) (fun out_List_255 (fun (fun a_254 (fun [List_253 a_254] out_List_255)) out_List_255))))) (lam a_256 (type) [rec_251 (lam dat_257 (fun (type) (type)) [dat_257 a_256])])]]))
+                    (lam dat_258 (fun (type) (type)) [dat_258 a_239])
                     (abs
-                      out_List_131
+                      out_List_259
                       (type)
                       (lam
-                        case_Nil_132
-                        out_List_131
+                        case_Nil_260
+                        out_List_259
                         (lam
-                          case_Cons_133
-                          (fun a_82 (fun [(lam a_82 (type) (ifix (lam rec_122 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_123 (fun (fun (type) (type)) (type)) [spine_123 [(lam List_81 (fun (type) (type)) (lam a_82 (type) (all out_List_119 (type) (fun out_List_119 (fun (fun a_82 (fun [List_81 a_82] out_List_119)) out_List_119))))) (lam a_82 (type) [rec_122 (lam dat_121 (fun (type) (type)) [dat_121 a_82])])]])) (lam dat_120 (fun (type) (type)) [dat_120 a_82]))) a_82] out_List_131))
+                          case_Cons_261
+                          (fun a_239 (fun [(lam a_262 (type) (ifix (lam rec_263 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_264 (fun (fun (type) (type)) (type)) [spine_264 [(lam List_265 (fun (type) (type)) (lam a_266 (type) (all out_List_267 (type) (fun out_List_267 (fun (fun a_266 (fun [List_265 a_266] out_List_267)) out_List_267))))) (lam a_268 (type) [rec_263 (lam dat_269 (fun (type) (type)) [dat_269 a_268])])]])) (lam dat_270 (fun (type) (type)) [dat_270 a_262]))) a_239] out_List_259))
                           [
                             [
-                              case_Cons_133
+                              case_Cons_261
                               (iwrap
-                                (lam rec_112 (fun (fun (type) (type)) (type)) (lam spine_113 (fun (type) (type)) [spine_113 [(lam EmptyRose_86 (type) (all out_EmptyRose_106 (type) (fun (fun [List_81 EmptyRose_86] out_EmptyRose_106) out_EmptyRose_106))) [rec_112 (lam dat_111 (type) dat_111)]]]))
-                                (lam dat_114 (type) dat_114)
+                                (lam rec_188 (fun (fun (type) (type)) (type)) (lam spine_189 (fun (type) (type)) [spine_189 [(lam EmptyRose_190 (type) (all out_EmptyRose_191 (type) (fun (fun [List_0 EmptyRose_190] out_EmptyRose_191) out_EmptyRose_191))) [rec_188 (lam dat_192 (type) dat_192)]]]))
+                                (lam dat_193 (type) dat_193)
                                 (abs
-                                  out_EmptyRose_115
+                                  out_EmptyRose_194
                                   (type)
                                   (lam
-                                    case_EmptyRose_116
-                                    (fun [List_81 (ifix (lam rec_109 (fun (fun (type) (type)) (type)) (lam spine_110 (fun (type) (type)) [spine_110 [(lam EmptyRose_86 (type) (all out_EmptyRose_106 (type) (fun (fun [List_81 EmptyRose_86] out_EmptyRose_106) out_EmptyRose_106))) [rec_109 (lam dat_108 (type) dat_108)]]])) (lam dat_107 (type) dat_107))] out_EmptyRose_115)
+                                    case_EmptyRose_195
+                                    (fun [List_0 (ifix (lam rec_196 (fun (fun (type) (type)) (type)) (lam spine_197 (fun (type) (type)) [spine_197 [(lam EmptyRose_198 (type) (all out_EmptyRose_199 (type) (fun (fun [List_0 EmptyRose_198] out_EmptyRose_199) out_EmptyRose_199))) [rec_196 (lam dat_200 (type) dat_200)]]])) (lam dat_201 (type) dat_201))] out_EmptyRose_194)
                                     [
-                                      case_EmptyRose_116
+                                      case_EmptyRose_195
                                       (iwrap
-                                        (lam rec_125 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_126 (fun (fun (type) (type)) (type)) [spine_126 [(lam List_81 (fun (type) (type)) (lam a_82 (type) (all out_List_119 (type) (fun out_List_119 (fun (fun a_82 (fun [List_81 a_82] out_List_119)) out_List_119))))) (lam a_82 (type) [rec_125 (lam dat_124 (fun (type) (type)) [dat_124 a_82])])]]))
-                                        (lam dat_127 (fun (type) (type)) [dat_127 a_82])
+                                        (lam rec_219 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_220 (fun (fun (type) (type)) (type)) [spine_220 [(lam List_221 (fun (type) (type)) (lam a_222 (type) (all out_List_223 (type) (fun out_List_223 (fun (fun a_222 (fun [List_221 a_222] out_List_223)) out_List_223))))) (lam a_224 (type) [rec_219 (lam dat_225 (fun (type) (type)) [dat_225 a_224])])]]))
+                                        (lam dat_226 (fun (type) (type)) [dat_226 a_218])
                                         (abs
-                                          out_List_128
+                                          out_List_227
                                           (type)
                                           (lam
-                                            case_Nil_129
-                                            out_List_128
+                                            case_Nil_228
+                                            out_List_227
                                             (lam
-                                              case_Cons_130
-                                              (fun a_82 (fun [(lam a_82 (type) (ifix (lam rec_122 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_123 (fun (fun (type) (type)) (type)) [spine_123 [(lam List_81 (fun (type) (type)) (lam a_82 (type) (all out_List_119 (type) (fun out_List_119 (fun (fun a_82 (fun [List_81 a_82] out_List_119)) out_List_119))))) (lam a_82 (type) [rec_122 (lam dat_121 (fun (type) (type)) [dat_121 a_82])])]])) (lam dat_120 (fun (type) (type)) [dat_120 a_82]))) a_82] out_List_128))
-                                              case_Nil_129
+                                              case_Cons_229
+                                              (fun a_218 (fun [(lam a_230 (type) (ifix (lam rec_231 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_232 (fun (fun (type) (type)) (type)) [spine_232 [(lam List_233 (fun (type) (type)) (lam a_234 (type) (all out_List_235 (type) (fun out_List_235 (fun (fun a_234 (fun [List_233 a_234] out_List_235)) out_List_235))))) (lam a_236 (type) [rec_231 (lam dat_237 (fun (type) (type)) [dat_237 a_236])])]])) (lam dat_238 (fun (type) (type)) [dat_238 a_230]))) a_218] out_List_227))
+                                              case_Nil_228
                                             )
                                           )
                                         )
@@ -106,18 +106,18 @@
                               )
                             ]
                             (iwrap
-                              (lam rec_125 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_126 (fun (fun (type) (type)) (type)) [spine_126 [(lam List_81 (fun (type) (type)) (lam a_82 (type) (all out_List_119 (type) (fun out_List_119 (fun (fun a_82 (fun [List_81 a_82] out_List_119)) out_List_119))))) (lam a_82 (type) [rec_125 (lam dat_124 (fun (type) (type)) [dat_124 a_82])])]]))
-                              (lam dat_127 (fun (type) (type)) [dat_127 a_82])
+                              (lam rec_219 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_220 (fun (fun (type) (type)) (type)) [spine_220 [(lam List_221 (fun (type) (type)) (lam a_222 (type) (all out_List_223 (type) (fun out_List_223 (fun (fun a_222 (fun [List_221 a_222] out_List_223)) out_List_223))))) (lam a_224 (type) [rec_219 (lam dat_225 (fun (type) (type)) [dat_225 a_224])])]]))
+                              (lam dat_226 (fun (type) (type)) [dat_226 a_218])
                               (abs
-                                out_List_128
+                                out_List_227
                                 (type)
                                 (lam
-                                  case_Nil_129
-                                  out_List_128
+                                  case_Nil_228
+                                  out_List_227
                                   (lam
-                                    case_Cons_130
-                                    (fun a_82 (fun [(lam a_82 (type) (ifix (lam rec_122 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_123 (fun (fun (type) (type)) (type)) [spine_123 [(lam List_81 (fun (type) (type)) (lam a_82 (type) (all out_List_119 (type) (fun out_List_119 (fun (fun a_82 (fun [List_81 a_82] out_List_119)) out_List_119))))) (lam a_82 (type) [rec_122 (lam dat_121 (fun (type) (type)) [dat_121 a_82])])]])) (lam dat_120 (fun (type) (type)) [dat_120 a_82]))) a_82] out_List_128))
-                                    case_Nil_129
+                                    case_Cons_229
+                                    (fun a_218 (fun [(lam a_230 (type) (ifix (lam rec_231 (fun (fun (fun (type) (type)) (type)) (type)) (lam spine_232 (fun (fun (type) (type)) (type)) [spine_232 [(lam List_233 (fun (type) (type)) (lam a_234 (type) (all out_List_235 (type) (fun out_List_235 (fun (fun a_234 (fun [List_233 a_234] out_List_235)) out_List_235))))) (lam a_236 (type) [rec_231 (lam dat_237 (fun (type) (type)) [dat_237 a_236])])]])) (lam dat_238 (fun (type) (type)) [dat_238 a_230]))) a_218] out_List_227))
+                                    case_Nil_228
                                   )
                                 )
                               )

--- a/plutus-tx/test/Plugin/Functions/recursive/even3.plc.golden
+++ b/plutus-tx/test/Plugin/Functions/recursive/even3.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_105
+  out_Bool_104
   (type)
   (lam
-    case_True_106 out_Bool_105 (lam case_False_107 out_Bool_105 case_False_107)
+    case_True_105 out_Bool_104 (lam case_False_106 out_Bool_104 case_False_106)
   )
 )

--- a/plutus-tx/test/Plugin/Functions/recursive/even4.plc.golden
+++ b/plutus-tx/test/Plugin/Functions/recursive/even4.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_102
+  out_Bool_101
   (type)
   (lam
-    case_True_103 out_Bool_102 (lam case_False_104 out_Bool_102 case_True_103)
+    case_True_102 out_Bool_101 (lam case_False_103 out_Bool_101 case_True_102)
   )
 )

--- a/plutus-tx/test/Plugin/Laziness/joinErrorEval.plc.golden
+++ b/plutus-tx/test/Plugin/Laziness/joinErrorEval.plc.golden
@@ -1,1 +1,1 @@
-(abs out_Unit_104 (type) (lam case_Unit_105 out_Unit_104 case_Unit_105))
+(abs out_Unit_32 (type) (lam case_Unit_33 out_Unit_32 case_Unit_33))

--- a/plutus-tx/test/Plugin/Primitives/andApply.plc.golden
+++ b/plutus-tx/test/Plugin/Primitives/andApply.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  out_Bool_69
+  out_Bool_9
   (type)
-  (lam case_True_70 out_Bool_69 (lam case_False_71 out_Bool_69 case_False_71))
+  (lam case_True_10 out_Bool_9 (lam case_False_11 out_Bool_9 case_False_11))
 )

--- a/plutus-tx/test/Plugin/Primitives/equalsByteString.plc.golden
+++ b/plutus-tx/test/Plugin/Primitives/equalsByteString.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  out_Bool_75
+  out_Bool_13
   (type)
-  (lam case_True_76 out_Bool_75 (lam case_False_77 out_Bool_75 case_True_76))
+  (lam case_True_14 out_Bool_13 (lam case_False_15 out_Bool_13 case_True_14))
 )

--- a/plutus-tx/test/Plugin/Primitives/intEqApply.plc.golden
+++ b/plutus-tx/test/Plugin/Primitives/intEqApply.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  out_Bool_75
+  out_Bool_13
   (type)
-  (lam case_True_76 out_Bool_75 (lam case_False_77 out_Bool_75 case_True_76))
+  (lam case_True_14 out_Bool_13 (lam case_False_15 out_Bool_13 case_True_14))
 )

--- a/plutus-tx/test/TH/all.plc.golden
+++ b/plutus-tx/test/TH/all.plc.golden
@@ -1,7 +1,5 @@
 (abs
-  out_Bool_146
+  out_Bool_63
   (type)
-  (lam
-    case_True_147 out_Bool_146 (lam case_False_148 out_Bool_146 case_True_147)
-  )
+  (lam case_True_64 out_Bool_63 (lam case_False_65 out_Bool_63 case_True_64))
 )


### PR DESCRIPTION
This implements the other main suggestion in #610, by generating PIR let-bindings during compilation of recursive bindings. These can then be eliminated with another dead-binding pass.

The main effect of this is when we have a pair of mutually recursive functions of which only one is used in the body - in this case we can delete the "forwarding" binding that converts from the tuple form we use for the recursion combinator into a form that's easier to consume. We can see this firing in a number of cases in our tests.

A minor win, but every little helps.

I also did some refactoring to have an "optimization on" compilation option. One wrinkle is that in the plugin we want to manually run the simplifier once before we hand over to the PIR compiler, so that we can store/dump slightly better PIR.