### PR TITLE
plutus-playground: refactor usecases

### DIFF
--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -7,8 +7,8 @@
 import qualified Language.PlutusTx            as PlutusTx
 import qualified Language.PlutusTx.Prelude    as P
 import           Ledger
-import qualified Ledger.Value                   as Value
-import           Ledger.Value                   (Value)
+import qualified Ledger.Value                 as Value
+import           Ledger.Value                 (Value)
 import           Ledger.Validation
 import           Wallet
 import           Playground.Contract
@@ -19,38 +19,36 @@ data HashedString = HashedString P.ByteString
 
 PlutusTx.makeLift ''HashedString
 
--- create a data script for the guessing game by hashing the string
--- and lifting the hash to its on-chain representation
-mkDataScript :: String -> DataScript
-mkDataScript word =
-    let hashedWord = plcSHA2_256 (C.pack word)
-    in  DataScript (Ledger.lifted (HashedString hashedWord))
-
 data ClearString = ClearString P.ByteString
 
 PlutusTx.makeLift ''ClearString
 
--- create a redeemer script for the guessing game by lifting the
--- string to its on-chain representation
-mkRedeemerScript :: String -> RedeemerScript
-mkRedeemerScript word =
-    let clearWord = C.pack word
-    in RedeemerScript (Ledger.lifted (ClearString clearWord))
+correctGuess :: HashedString -> ClearString -> Bool
+correctGuess (HashedString actual) (ClearString guess') =
+    P.equalsByteString actual (P.sha2_256 guess')
+
+validateGuess :: HashedString -> ClearString -> PendingTx -> ()
+validateGuess dataScript redeemerScript _ =
+    if correctGuess dataScript redeemerScript
+    then ()
+    else P.traceErrorH "WRONG!"
 
 -- | The validator script of the game.
 gameValidator :: ValidatorScript
-gameValidator = ValidatorScript ($$(Ledger.compileScript [||
-    -- The code between the '[||' and  '||]' quotes is on-chain code.
-    \(HashedString actual) (ClearString guess) (p :: PendingTx) ->
+gameValidator =
+    ValidatorScript ($$(Ledger.compileScript [|| validateGuess ||]))
 
-    -- inside the on-chain code we can write $$(P.xxx) to use functions
-    -- from the PlutusTx Prelude (imported qualified at the top of the
-    -- module)
-    if P.equalsByteString actual (P.sha2_256 guess)
-    then ()
-    else (P.error (P.traceH "WRONG!" ()))
+-- create a data script for the guessing game by hashing the string
+-- and lifting the hash to its on-chain representation
+gameDataScript :: String -> DataScript
+gameDataScript =
+    DataScript . Ledger.lifted . HashedString . plcSHA2_256 . C.pack
 
-    ||]))
+-- create a redeemer script for the guessing game by lifting the
+-- string to its on-chain representation
+gameRedeemerScript :: String -> RedeemerScript
+gameRedeemerScript =
+    RedeemerScript . Ledger.lifted . ClearString . C.pack
 
 -- | The address of the game (the hash of its validator script)
 gameAddress :: Address
@@ -58,7 +56,7 @@ gameAddress = Ledger.scriptAddress gameValidator
 
 -- | The "lock" contract endpoint. See note [Contract endpoints]
 lock :: MonadWallet m => String -> Value -> m ()
-lock word value =
+lock word vl =
     -- 'payToScript_' is a function of the wallet API. It takes a script
     -- address, a currency value and a data script, and submits a transaction
     -- that pays the value to the address, using the data script.
@@ -66,11 +64,12 @@ lock word value =
     -- The underscore at the end of the name indicates that 'payToScript_'
     -- discards its result. If you want to hold on to the transaction you can
     -- use 'payToScript'.
-    payToScript_ defaultSlotRange gameAddress value (mkDataScript word)
+    payToScript_ defaultSlotRange gameAddress vl (gameDataScript word)
 
 -- | The "guess" contract endpoint. See note [Contract endpoints]
-guess :: MonadWallet m => String -> m ()
-guess word =
+guess :: (WalletAPI m, WalletDiagnostics m) => String -> m ()
+guess word = do
+    let redeemer = gameRedeemerScript word
     -- 'collectFromScript' is a function of the wallet API. It consumes the
     -- unspent transaction outputs at a script address and pays them to a
     -- public key address owned by this wallet. It takes the validator script
@@ -79,7 +78,7 @@ guess word =
     -- Note that before we can use 'collectFromScript', we need to tell the
     -- wallet to start watching the address for transaction outputs (because
     -- the wallet does not keep track of the UTXO set of the entire chain).
-    collectFromScript defaultSlotRange gameValidator (mkRedeemerScript word)
+    collectFromScript defaultSlotRange gameValidator redeemer
 
 -- | The "startGame" contract endpoint, telling the wallet to start watching
 --   the address of the game script. See note [Contract endpoints]

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -86,16 +86,16 @@ type CrowdfundingValidator = PubKey -> CampaignAction -> PendingTx -> ()
 validRefund :: Campaign -> PubKey -> PendingTx -> Bool
 validRefund campaign contributor ptx =
     Slot.contains (refundRange campaign) (pendingTxValidRange ptx)
-        `P.and` (ptx `V.txSignedBy` contributor)
+    `P.and` (ptx `V.txSignedBy` contributor)
 
 validCollection :: Campaign -> PendingTx -> Bool
-validCollection campaign p = 
-     (collectionRange campaign `Slot.contains` pendingTxValidRange p)
-        `P.and` (valueSpent p `VTH.geq` campaignTarget campaign)
-        `P.and` (p `V.txSignedBy` campaignOwner campaign)
+validCollection campaign p =
+    (collectionRange campaign `Slot.contains` pendingTxValidRange p)
+    `P.and` (valueSpent p `VTH.geq` campaignTarget campaign)
+    `P.and` (p `V.txSignedBy` campaignOwner campaign)
 
 mkValidator :: Campaign -> CrowdfundingValidator
-mkValidator c con act p = 
+mkValidator c con act p =
     let
         isValid = case act of
             Refund -> validRefund c con p
@@ -107,8 +107,8 @@ mkValidator c con act p =
 --
 contributionScript :: Campaign -> ValidatorScript
 contributionScript cmp  = ValidatorScript $
-    $$(Ledger.compileScript [|| mkValidator ||]) 
-        `Ledger.applyScript` 
+    $$(Ledger.compileScript [|| mkValidator ||])
+        `Ledger.applyScript`
             Ledger.lifted cmp
 
 -- | The address of a [[Campaign]]


### PR DESCRIPTION
Analogously but not identically to the ones in `plutus-use-cases`

I also added a simplification to the vesting examples, which I think make them a lot easier to read.