### PR TITLE
plutus-use-cases: compile the usecases normally

### DIFF
--- a/nix/overlays/required.nix
+++ b/nix/overlays/required.nix
@@ -29,6 +29,8 @@ self: super: {
 
     plutus-use-cases = deferPluginErrors super.plutus-use-cases;
 
+    plutus-playground-server = deferPluginErrors super.plutus-playground-server;
+
     marlowe = deferPluginErrors super.marlowe;
 
     ########################################################################

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -53696,6 +53696,7 @@ license = stdenv.lib.licenses.asl20;
 , optparse-applicative
 , plutus-emulator
 , plutus-playground-lib
+, plutus-tx
 , plutus-wallet-api
 , process
 , prometheus
@@ -53737,10 +53738,12 @@ containers
 cookie
 exceptions
 file-embed
+hspec
 http-client
 http-client-tls
 http-conduit
 http-types
+insert-ordered-containers
 interpreter
 jwt
 lens
@@ -53749,6 +53752,7 @@ mtl
 newtype-generics
 plutus-emulator
 plutus-playground-lib
+plutus-tx
 plutus-wallet-api
 process
 regex-compat
@@ -53757,6 +53761,7 @@ servant-client
 servant-client-core
 servant-purescript
 servant-server
+swagger2
 template-haskell
 text
 time

--- a/plutus-playground-server/app/PSGenerator.hs
+++ b/plutus-playground-server/app/PSGenerator.hs
@@ -21,12 +21,11 @@ import           Control.Applicative                       (empty, (<|>))
 import           Control.Lens                              (set, (&))
 import           Control.Monad.Representable.Reader        (MonadReader)
 import qualified Data.ByteString                           as BS
-import qualified Data.ByteString.Char8                     as CBS
 import           Data.Monoid                               ()
 import           Data.Proxy                                (Proxy (Proxy))
 import qualified Data.Set                                  as Set ()
 import qualified Data.Text                                 as T
-import qualified Data.Text.Encoding                        as T ()
+import qualified Data.Text.Encoding                        as T
 import qualified Data.Text.IO                              as T ()
 import           Gist                                      (Gist, GistFile, GistId, NewGist, NewGistFile, Owner)
 import           Git                                       (gitRev)
@@ -263,23 +262,23 @@ mySettings =
     (defaultSettings & set apiModuleName "Playground.Server")
         {_generateSubscriberAPI = False}
 
-multilineString :: BS.ByteString -> BS.ByteString -> BS.ByteString
+multilineString :: T.Text -> T.Text -> T.Text
 multilineString name value =
     "\n\n" <> name <> " :: String\n" <> name <> " = \"\"\"" <> value <> "\"\"\""
 
-psModule :: BS.ByteString -> BS.ByteString -> BS.ByteString
+psModule :: T.Text -> T.Text -> T.Text
 psModule name body = "module " <> name <> " where" <> body
 
 writeUsecases :: FilePath -> IO ()
 writeUsecases outputDir = do
     let usecases =
-            multilineString "gitRev" (CBS.pack . T.unpack $ gitRev) <>
+            multilineString "gitRev" gitRev <>
             multilineString "vesting" vesting <>
             multilineString "game" game <>
             multilineString "crowdfunding" crowdfunding <>
             multilineString "messages" messages
         usecasesModule = psModule "Playground.Usecases" usecases
-    BS.writeFile (outputDir </> "Playground" </> "Usecases.purs") usecasesModule
+    BS.writeFile (outputDir </> "Playground" </> "Usecases.purs") (T.encodeUtf8 usecasesModule)
     putStrLn outputDir
 
 generate :: FilePath -> IO ()

--- a/plutus-playground-server/plutus-playground-server.cabal
+++ b/plutus-playground-server/plutus-playground-server.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.0
 name: plutus-playground-server
 version: 0.1.0.0
 license: Apache-2.0
-license-files: 
+license-files:
   LICENSE
   NOTICE
 maintainer: kris.jenkins@tweag.io
@@ -27,6 +27,12 @@ source-repository head
 flag development
     description:
         Enable `-Werror`
+    default: False
+    manual: True
+
+flag defer-plugin-errors
+    description:
+        Defer errors from the plugin, useful for things like Haddock that can't handle it.
     default: False
     manual: True
 
@@ -121,6 +127,36 @@ executable plutus-playground-server
         plutus-emulator -any,
         warp -any,
         yaml -any
+
+library plutus-playground-usecases
+    hs-source-dirs: usecases
+    other-modules:
+        CrowdFunding
+        Game
+        Messages
+        Vesting
+    default-language: Haskell2010
+    ghc-options: -Wincomplete-uni-patterns -Wincomplete-record-updates
+    build-depends:
+        aeson -any,
+        base >=4.7 && <5,
+        bytestring -any,
+        containers -any,
+        hspec -any,
+        insert-ordered-containers -any,
+        interpreter -any,
+        mtl -any,
+        plutus-playground-lib -any,
+        plutus-emulator -any,
+        plutus-tx -any,
+        plutus-wallet-api -any,
+        swagger2 -any,
+        text -any,
+        time-units -any,
+        transformers -any
+
+    if flag(defer-plugin-errors)
+        ghc-options: -fplugin-opt Language.PlutusTx.Plugin:defer-errors
 
 test-suite plutus-playground-server-test
     type: exitcode-stdio-1.0

--- a/plutus-playground-server/src/Playground/Server.hs
+++ b/plutus-playground-server/src/Playground/Server.hs
@@ -74,7 +74,7 @@ runFunction evaluation = do
 
 checkHealth :: Handler ()
 checkHealth = do
-    res <- acceptSourceCode . SourceCode . Text.pack . BS.unpack $ vesting
+    res <- acceptSourceCode . SourceCode $ vesting
     case res of
         Left e  -> throwError $ err400 {errBody = BSL.pack . show $ e}
         Right _ -> pure ()

--- a/plutus-playground-server/src/Playground/Usecases.hs
+++ b/plutus-playground-server/src/Playground/Usecases.hs
@@ -1,18 +1,28 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
 module Playground.Usecases where
 
-import           Data.ByteString (ByteString)
-import           Data.FileEmbed  (embedFile, makeRelativeToProject)
+import           Data.ByteString    (ByteString)
+import qualified Data.ByteString    as BS
+import           Data.FileEmbed     (embedFile, makeRelativeToProject)
+import qualified Data.Text          as T
+import qualified Data.Text.Encoding as T
 
-vesting :: ByteString
-vesting = $(makeRelativeToProject "usecases/Vesting.hs" >>= embedFile)
+marker :: T.Text
+marker = "TRIM TO HERE"
 
-game :: ByteString
-game = $(makeRelativeToProject "usecases/Game.hs" >>= embedFile)
+strip :: T.Text -> T.Text
+strip text = snd $ T.breakOnEnd marker text
 
-messages :: ByteString
-messages = $(makeRelativeToProject "usecases/Messages.hs" >>= embedFile)
+vesting :: T.Text
+vesting = strip $ T.decodeUtf8 $(makeRelativeToProject "usecases/Vesting.hs" >>= embedFile)
 
-crowdfunding :: ByteString
-crowdfunding = $(makeRelativeToProject "usecases/CrowdFunding.hs" >>= embedFile)
+game :: T.Text
+game = strip $ T.decodeUtf8 $(makeRelativeToProject "usecases/Game.hs" >>= embedFile)
+
+messages :: T.Text
+messages = strip $ T.decodeUtf8 $(makeRelativeToProject "usecases/Messages.hs" >>= embedFile)
+
+crowdfunding :: T.Text
+crowdfunding = strip $ T.decodeUtf8 $(makeRelativeToProject "usecases/CrowdFunding.hs" >>= embedFile)

--- a/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground-server/usecases/CrowdFunding.hs
@@ -1,4 +1,15 @@
--- | Crowdfunding contract implemented using the [[Plutus]] interface.
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+module CrowdFunding where
+-- TRIM TO HERE
+-- Crowdfunding contract implemented using the [[Plutus]] interface.
 -- This is the fully parallel version that collects all contributions
 -- in a single transaction.
 --

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -1,9 +1,20 @@
--- | A game with two players. Player 1 thinks of a secret word
---   and uses its hash, and the game validator script, to lock
---   some funds (the prize) in a pay-to-script transaction output.
---   Player 2 guesses the word by attempting to spend the transaction
---   output. If the guess is correct, the validator script releases the funds.
---   If it isn't, the funds stay locked.
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+module Game where
+-- TRIM TO HERE
+-- A game with two players. Player 1 thinks of a secret word
+-- and uses its hash, and the game validator script, to lock
+-- some funds (the prize) in a pay-to-script transaction output.
+-- Player 2 guesses the word by attempting to spend the transaction
+-- output. If the guess is correct, the validator script releases the funds.
+-- If it isn't, the funds stay locked.
 import qualified Language.PlutusTx            as PlutusTx
 import qualified Language.PlutusTx.Prelude    as P
 import           Ledger

--- a/plutus-playground-server/usecases/Messages.hs
+++ b/plutus-playground-server/usecases/Messages.hs
@@ -1,15 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+module Messages where
+-- TRIM TO HERE
 -- Contract endpoints that generate different kinds of errors for the log:
 -- logAMessage produces a log message from a wallet
 -- submitInvalidTxn submits an invalid txn which should result in a "Validation failed" message
 -- throwWalletAPIError throws an error from a wallet (client)
-import qualified Data.Set                     as Set
-import           Data.Text                    (Text)
+import qualified Data.Map            as Map
+import qualified Data.Set            as Set
+import           Data.Text           (Text)
 
 import           Ledger
-import qualified Ledger.Ada                   as Ada
+import qualified Ledger.Ada          as Ada
 import           Ledger.Validation
-import           Wallet
 import           Playground.Contract
+import           Wallet
 
 logAMessage :: MonadWallet m => m ()
 logAMessage = logMsg "wallet log"
@@ -23,6 +28,7 @@ submitInvalidTxn = do
             , txForge = Ada.adaValueOf 2
             , txFee = 0
             , txValidRange = defaultSlotRange
+            , txSignatures = Map.empty
             }
     submitTxn tx
 

--- a/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground-server/usecases/Vesting.hs
@@ -1,5 +1,15 @@
--- | Vesting scheme as a PLC contract
-
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+module Vesting where
+-- TRIM TO HERE
+-- Vesting scheme as a PLC contract
 import           Control.Monad                (void)
 import qualified Data.Map                  as Map
 import qualified Data.Set                  as Set


### PR DESCRIPTION
This makes them *much* easier to work on. The tests are hard to run and
slow, this way you can check that they at least compile with a normal
build.

However, we now need a module header and pragmas. Those need to be stripped off for use, but that's easy enough.

I also needed to include the workaround for Haddock with the plugin.