### PR TITLE
Build doctest with --enable-executable dynamic

### DIFF
--- a/nix/overlays/required.nix
+++ b/nix/overlays/required.nix
@@ -39,6 +39,10 @@ self: super: {
         src = iohkNix.cleanSourceHaskell args.src;
     });
 
+    # Cuts down time for doctests by an order of magnitude, see https://gitlab.haskell.org/ghc/ghc/issues/15524
+    # Should also not be necessary once we bump nixpkgs to 19.03 and --enable-library-for-ghci isn't the default
+    doctest = enableSharedExecutables super.doctest;
+
     # stack2nix doesn't have the right set of GHC base packages nulled out for 8.4, as
     # per https://github.com/input-output-hk/stack2nix/issues/84, which means
     # we can hit https://github.com/input-output-hk/stack2nix/issues/134 unless


### PR DESCRIPTION
Significantly improves the slow doctest problem!

Time for `plutus-tx` went from 350s to 35s, `plutus-tutorial` from 150s to 25s.