### PR TITLE
Remove the `Ord` instnance for `Value`

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -53427,6 +53427,7 @@ license = stdenv.lib.licenses.asl20;
 , template-haskell
 , text
 , transformers
+, unordered-containers
 , warp
 }:
 mkDerivation {
@@ -53468,6 +53469,7 @@ swagger2
 template-haskell
 text
 transformers
+unordered-containers
 ];
 executableHaskellDepends = [
 base

--- a/plutus-contract-exe/src/Language/Plutus/Contract.hs
+++ b/plutus-contract-exe/src/Language/Plutus/Contract.hs
@@ -54,8 +54,7 @@ data UnbalancedTx = UnbalancedTx
         , utxOutputs :: [L.TxOut]
         , utxForge   :: V.Value
         }
-
-        deriving stock (Eq, Ord, Show, Generic)
+        deriving stock (Eq, Show, Generic)
         deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 
 -- | Make an unbalanced transaction that does not forge any value.
@@ -134,7 +133,7 @@ data ContractOut =
       --   with this contract instance can be deleted. See note
       --   [ContractFinished event]
 
-      deriving stock (Eq, Ord, Show, Generic)
+      deriving stock (Eq, Show, Generic)
       deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 
 -- | Events that inform the contract about changes to the ledger state.
@@ -159,5 +158,5 @@ data LedgerUpdate =
     | SlotChange L.Slot
     -- ^ The current slot has changed.
 
-    deriving stock (Eq, Ord, Show, Generic)
+    deriving stock (Eq, Show, Generic)
     deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)

--- a/plutus-emulator/plutus-emulator.cabal
+++ b/plutus-emulator/plutus-emulator.cabal
@@ -59,6 +59,7 @@ library
         bytestring -any,
         cborg -any,
         containers -any,
+        unordered-containers -any,
         cryptonite >=0.25,
         hashable -any,
         hedgehog -any,

--- a/plutus-emulator/test/Spec.hs
+++ b/plutus-emulator/test/Spec.hs
@@ -336,7 +336,7 @@ watchFundsAtAddress = property $ do
             let mkPayment =
                     EventHandler $ \_ -> payToPublicKey_ W.always (Ada.adaValueOf 100) pubKey2
                 t1 = slotRangeT (W.interval 3 4)
-                t2 = fundsAtAddressT (pubKeyAddress pkTarget) (W.intervalFrom (Ada.adaValueOf 1))
+                t2 = fundsAtAddressGtT (pubKeyAddress pkTarget) Value.zero
             walletNotifyBlock w =<<
                 (walletAction wallet1 $ do
                     register t1 mkPayment

--- a/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground-server/usecases/CrowdFunding.hs
@@ -169,13 +169,13 @@ scheduleCollection deadline target collectionDeadline ownerWallet = do
 -- | An event trigger that fires when a refund of campaign contributions can be claimed
 refundTrigger :: Value -> Campaign -> EventTrigger
 refundTrigger vl c = andT
-    (fundsAtAddressT (campaignAddress c) (W.intervalFrom vl))
+    (fundsAtAddressGeqT (campaignAddress c) vl)
     (slotRangeT (refundRange c))
 
 -- | An event trigger that fires when the funds for a campaign can be collected
 collectFundsTrigger :: Campaign -> EventTrigger
 collectFundsTrigger c = andT
-    (fundsAtAddressT (campaignAddress c) (W.intervalFrom (campaignTarget c)))
+    (fundsAtAddressGeqT (campaignAddress c) (campaignTarget c))
     (slotRangeT (collectionRange c))
 
 -- | Claim a refund of our campaign contribution

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -143,13 +143,13 @@ scheduleCollection deadline target collectionDeadline ownerWallet = do
 -- | An event trigger that fires when a refund of campaign contributions can be claimed
 refundTrigger :: Value -> Campaign -> EventTrigger
 refundTrigger vl c = andT
-    (fundsAtAddressT (campaignAddress c) (W.intervalFrom vl))
+    (fundsAtAddressGeqT (campaignAddress c) vl)
     (slotRangeT (refundRange c))
 
 -- | An event trigger that fires when the funds for a campaign can be collected
 collectFundsTrigger :: Campaign -> EventTrigger
 collectFundsTrigger c = andT
-    (fundsAtAddressT (campaignAddress c) (W.intervalFrom (campaignTarget c)))
+    (fundsAtAddressGeqT (campaignAddress c) (campaignTarget c))
     (slotRangeT (collectionRange c))
 
 -- | Claim a refund of our campaign contribution

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -86,7 +86,7 @@ validate c@(Currency (refHash, refIdx) _) () () p =
 
 curValidator :: Currency -> ValidatorScript
 curValidator cur = ValidatorScript $
-    Ledger.fromCompiledCode $$(P.compile [|| validate ||]) 
+    Ledger.fromCompiledCode $$(P.compile [|| validate ||])
         `Ledger.applyScript`
             Ledger.lifted cur
 
@@ -132,14 +132,13 @@ forge amounts = do
         theCurrency = mkCurrency (txInRef refTxIn) amounts
         curAddr     = Ledger.scriptAddress (curValidator theCurrency)
         forgedVal   = forgedValue theCurrency
-        oneOrMore   = WAPI.intervalFrom $ Ada.adaValueOf 1
 
         -- trg1 fires when 'refTxIn' can be spent by our forging transaction
-        trg1 = fundsAtAddressT refAddr oneOrMore
+        trg1 = fundsAtAddressGtT refAddr Value.zero
 
         -- trg2 fires when the pay-to-script output locked by 'curValidator'
         -- is ready to be spent.
-        trg2 = fundsAtAddressT curAddr oneOrMore
+        trg2 = fundsAtAddressGtT curAddr Value.zero
 
         -- The 'forge_' action creates a transaction that spends the contract
         -- output, forging the currency in the process.

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
@@ -185,8 +185,7 @@ lock initialWord vl = do
 
     -- 2. Define a trigger that fires when the first transaction (1.) is
     --    placed on the chain.
-    let oneOrMore   = WAPI.intervalFrom $ Ada.adaValueOf 1
-        trg1        = fundsAtAddressT addr oneOrMore
+    let trg1        = fundsAtAddressGtT addr V.zero
 
     -- 3. Define a forge_ action that creates the token by and puts the contract
     --    into its new state.

--- a/plutus-wallet-api/ledger/Ledger/Index.hs
+++ b/plutus-wallet-api/ledger/Ledger/Index.hs
@@ -51,7 +51,7 @@ type ValidationMonad m = (MonadReader UtxoIndex m, MonadError ValidationError m)
 
 -- | The UTxOs of a blockchain indexed by their references.
 newtype UtxoIndex = UtxoIndex { getIndex :: Map.Map TxOutRef TxOut }
-    deriving (Eq, Ord, Show, Semigroup, Monoid)
+    deriving (Eq, Show, Semigroup, Monoid)
 
 -- | Create an index of all UTxOs on the chain.
 initialise :: Blockchain -> UtxoIndex

--- a/plutus-wallet-api/ledger/Ledger/Interval.hs
+++ b/plutus-wallet-api/ledger/Ledger/Interval.hs
@@ -19,6 +19,7 @@ module Ledger.Interval(
 
 import           Codec.Serialise.Class        (Serialise)
 import           Data.Aeson                   (FromJSON, ToJSON)
+import           Data.Hashable                (Hashable)
 import           Data.Maybe                   (isNothing)
 import           Data.Semigroup               (Max (..), Min (..), Option (..), Semigroup ((<>)))
 import           Data.Swagger.Internal.Schema (ToSchema)
@@ -33,7 +34,7 @@ import           Language.PlutusTx.Lift       (makeLift)
 data Interval a = Interval { ivFrom :: Maybe a, ivTo :: Maybe a }
     deriving (Eq, Ord, Show)
     deriving stock (Generic)
-    deriving anyclass (ToSchema, FromJSON, ToJSON, Serialise)
+    deriving anyclass (ToSchema, FromJSON, ToJSON, Serialise, Hashable)
 
 makeLift ''Interval
 

--- a/plutus-wallet-api/ledger/Ledger/Map.hs
+++ b/plutus-wallet-api/ledger/Ledger/Map.hs
@@ -29,6 +29,7 @@ module Ledger.Map(
 
 import           Codec.Serialise.Class        (Serialise)
 import           Data.Aeson                   (FromJSON (parseJSON), ToJSON (toJSON))
+import           Data.Hashable                (Hashable)
 import           Data.Swagger.Internal.Schema (ToSchema)
 import           GHC.Generics                 (Generic)
 import           Language.PlutusTx.Lift       (makeLift)
@@ -43,7 +44,7 @@ import           Ledger.These
 data Map k v = Map { unMap :: [(k, v)] }
     deriving (Show)
     deriving stock (Generic)
-    deriving anyclass (ToSchema, Serialise)
+    deriving anyclass (ToSchema, Serialise, Hashable)
 
 makeLift ''Map
 

--- a/plutus-wallet-api/ledger/Ledger/Slot.hs
+++ b/plutus-wallet-api/ledger/Ledger/Slot.hs
@@ -23,6 +23,7 @@ module Ledger.Slot(
 
 import           Codec.Serialise.Class        (Serialise)
 import           Data.Aeson                   (FromJSON, ToJSON)
+import           Data.Hashable                (Hashable)
 import           Data.Swagger.Internal.Schema (ToSchema)
 import           GHC.Generics                 (Generic)
 
@@ -39,7 +40,7 @@ newtype Slot = Slot { getSlot :: Integer }
     deriving (Eq, Ord, Show, Enum)
     deriving stock (Generic)
     deriving anyclass (ToSchema, FromJSON, ToJSON)
-    deriving newtype (Num, Real, Integral, Serialise)
+    deriving newtype (Num, Real, Integral, Serialise, Hashable)
 
 makeLift ''Slot
 

--- a/plutus-wallet-api/ledger/Ledger/Tx.hs
+++ b/plutus-wallet-api/ledger/Ledger/Tx.hs
@@ -65,6 +65,7 @@ import           Data.Aeson                   (FromJSON, ToJSON)
 import qualified Data.ByteArray               as BA
 import qualified Data.ByteString.Char8        as BS8
 import qualified Data.ByteString.Lazy         as BSL
+import           Data.Hashable                (Hashable, hashWithSalt)
 import           Data.Map                     (Map)
 import qualified Data.Map                     as Map
 import           Data.Maybe                   (isJust)
@@ -106,10 +107,13 @@ especially because we only need one direction (to binary).
 
 -- | A payment address using some id type. This corresponds to a Bitcoin pay-to-witness-script-hash.
 newtype AddressOf h = AddressOf { getAddress :: h }
-    deriving (Eq, Ord, Show, Generic)
+    deriving stock (Eq, Ord, Show, Generic)
 
 -- | A payment address using a SHA256 hash as the address id type.
 type Address = AddressOf (Digest SHA256)
+
+instance Hashable Address where
+    hashWithSalt s (AddressOf digest) = hashWithSalt s $ BA.unpack digest
 
 deriving newtype instance Serialise Address
 deriving anyclass instance ToJSON Address
@@ -129,7 +133,7 @@ data Tx = Tx {
     -- ^ The 'SlotRange' during which this transaction may be validated.
     txSignatures :: Map PubKey Signature
     -- ^ Signatures of this transaction
-    } deriving stock (Show, Eq, Ord, Generic)
+    } deriving stock (Show, Eq, Generic)
       deriving anyclass (ToJSON, FromJSON, Serialise)
 
 -- | The inputs of a transaction.
@@ -175,7 +179,7 @@ data TxStripped = TxStripped {
     -- ^ The 'Value' forged by this transaction.
     txStrippedFee     :: !Ada
     -- ^ The fee for this transaction.
-    } deriving (Show, Eq, Ord)
+    } deriving (Show, Eq)
 
 instance BA.ByteArrayAccess TxStripped where
     length = BA.length . BS8.pack . show
@@ -290,7 +294,7 @@ data TxOutOf h = TxOutOf {
     txOutValue   :: !Value,
     txOutType    :: !TxOutType
     }
-    deriving (Show, Eq, Ord, Generic)
+    deriving (Show, Eq, Generic)
 
 -- | A transaction output, using a SHA256 hash as the transaction id type.
 type TxOut = TxOutOf (Digest SHA256)

--- a/plutus-wallet-api/plutus-wallet-api.cabal
+++ b/plutus-wallet-api/plutus-wallet-api.cabal
@@ -73,6 +73,7 @@ library
         bytestring -any,
         containers -any,
         hedgehog -any,
+        hashable -any,
         lens -any,
         memory -any,
         mtl -any,


### PR DESCRIPTION
It's only a partial order, so it's misleading. Two large-ish changes were needed:
- We put a derived type in a `Map`, which won't fly. Fortunately, `HashMap` works fine, but I had to add a bunch of instances.
- We use it in an `Interval` for `fundsAtAddress`. This is questionable given it being a partial order, and we only actually check whether funds are greater than something, so we use that. That also has the advantage of being more honest, since we can't tell if funds are less than something, given that we're only watching a subset of the funds. Possibly it should be `geq`, though.

I then found an awful bug in `Value.lt` and `Value.gt`, which were saying that `zero lt zero` and `zero gt zero`, since there's a degenerate case where both maps are empty.