### PR TITLE
plutus-ir: use lens-based traversals

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -53547,6 +53547,7 @@ license = stdenv.lib.licenses.asl20;
 , mmorph
 , mtl
 , prettyprinter
+, recursion-schemes
 , serialise
 , stdenv
 , tasty
@@ -53571,6 +53572,7 @@ megaparsec
 mmorph
 mtl
 prettyprinter
+recursion-schemes
 serialise
 text
 transformers

--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -72,6 +72,7 @@ library
         mtl -any,
         mmorph -any,
         prettyprinter -any,
+        recursion-schemes -any,
         serialise -any,
         text -any,
         transformers -any,

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -14,11 +14,16 @@ module Language.PlutusIR (
     tyVarDeclNameString,
     Kind (..),
     Type (..),
+    typeSubtypes,
     Datatype (..),
     datatypeNameString,
     Recursivity (..),
     Binding (..),
+    bindingSubterms,
+    bindingSubtypes,
     Term (..),
+    termSubterms,
+    termSubtypes,
     Program (..)
     ) where
 
@@ -30,8 +35,13 @@ import           Language.PlutusCore.CBOR   ()
 import           Language.PlutusCore.MkPlc  (Def (..), TermLike (..), TyVarDecl (..), VarDecl (..))
 import qualified Language.PlutusCore.Pretty as PLC
 
+import           Control.Lens
+
 import           Codec.Serialise            (Serialise)
+
+import           Data.Functor.Foldable      (embed, project)
 import qualified Data.Text                  as T
+
 import           GHC.Generics               (Generic)
 
 -- Datatypes
@@ -58,6 +68,11 @@ tyVarDeclNameString = T.unpack . PLC.nameString . PLC.unTyName . tyVarDeclName
 datatypeNameString :: Datatype TyName name a -> String
 datatypeNameString (Datatype _ tn _ _ _) = tyVarDeclNameString tn
 
+-- TODO: move to language-plutus-core
+-- | Get all the direct child 'Type's of the given 'Type'.
+typeSubtypes :: Traversal' (Type tyname a) (Type tyname a)
+typeSubtypes f = fmap embed . traverse f . project
+
 -- Bindings
 
 data Recursivity = NonRec | Rec
@@ -71,6 +86,28 @@ data Binding tyname name a = TermBind a (VarDecl tyname name a) (Term tyname nam
     deriving (Functor, Show, Eq, Generic)
 
 instance (Serialise a, Serialise (tyname a), Serialise (name a)) => Serialise (Binding tyname name a)
+
+-- | Get all the direct child 'Term's of the given 'Binding'.
+bindingSubterms :: Traversal' (Binding tyname name a) (Term tyname name a)
+bindingSubterms f = \case
+    TermBind x d t -> TermBind x d <$> f t
+    b@TypeBind {} -> pure b
+    d@DatatypeBind {} -> pure d
+
+-- | Get all the direct child 'Type's of the given 'VarDecl'.
+varDeclSubtypes :: Traversal' (VarDecl tyname name a) (Type tyname a)
+varDeclSubtypes f (VarDecl a n ty) = VarDecl a n <$> f ty
+
+-- | Get all the direct child 'Type's of the given 'Datatype'.
+datatypeSubtypes :: Traversal' (Datatype tyname name a) (Type tyname a)
+datatypeSubtypes f (Datatype a n vs m cs) = Datatype a n vs m <$> (traverse . varDeclSubtypes) f cs
+
+-- | Get all the direct child 'Type's of the given 'Binding'.
+bindingSubtypes :: Traversal' (Binding tyname name a) (Type tyname a)
+bindingSubtypes f = \case
+    TermBind x d t -> TermBind x <$> varDeclSubtypes f d <*> pure t
+    DatatypeBind x d -> DatatypeBind x <$> datatypeSubtypes f d
+    TypeBind a d ty -> TypeBind a d <$> f ty
 
 -- Terms
 
@@ -130,6 +167,36 @@ instance TermLike (Term tyname name) tyname name where
     error    = Error
     termLet x (Def vd bind) = Let x NonRec [TermBind x vd bind]
     typeLet x (Def vd bind) = Let x NonRec [TypeBind x vd bind]
+
+-- | Get all the direct child 'Term's of the given 'Term', including those within 'Binding's.
+termSubterms :: Traversal' (Term tyname name a) (Term tyname name a)
+termSubterms f = \case
+    Let x r bs t -> Let x r <$> (traverse . bindingSubterms) f bs <*> f t
+    TyAbs x tn k t -> TyAbs x tn k <$> f t
+    LamAbs x n ty t -> LamAbs x n ty <$> f t
+    Apply x t1 t2 -> Apply x <$> f t1 <*> f t2
+    TyInst x t ty -> TyInst x <$> f t <*> pure ty
+    IWrap x ty1 ty2 t -> IWrap x ty1 ty2 <$> f t
+    Unwrap x t -> Unwrap x <$> f t
+    e@Error {} -> pure e
+    v@Var {} -> pure v
+    c@Constant {} -> pure c
+    b@Builtin {} -> pure b
+
+-- | Get all the direct child 'Type's of the given 'Term', including those within 'Binding's.
+termSubtypes :: Traversal' (Term tyname name a) (Type tyname a)
+termSubtypes f = \case
+    Let x r bs t -> Let x r <$> (traverse . bindingSubtypes) f bs <*> pure t
+    LamAbs x n ty t -> LamAbs x n <$> f ty <*> pure t
+    TyInst x t ty -> TyInst x t <$> f ty
+    IWrap x ty1 ty2 t -> IWrap x <$> f ty1 <*> f ty2 <*> pure t
+    Error x ty -> Error x <$> f ty
+    t@TyAbs {} -> pure t
+    a@Apply {} -> pure a
+    u@Unwrap {} -> pure u
+    v@Var {} -> pure v
+    c@Constant {} -> pure c
+    b@Builtin {} -> pure b
 
 -- no version as PIR is not versioned
 data Program tyname name a = Program a (Term tyname name a) deriving Generic

--- a/plutus-ir/src/Language/PlutusIR/Analysis/Usages.hs
+++ b/plutus-ir/src/Language/PlutusIR/Analysis/Usages.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase       #-}
 -- | Functions for computing variable usage inside terms and types.
 module Language.PlutusIR.Analysis.Usages (runTermUsages, runTypeUsages, Usages, isUsed, allUsed) where
 
@@ -51,54 +50,13 @@ termUsages
     :: (MonadState Usages m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
     => Term tyname name a
     -> m ()
-termUsages term = case term of
-    Let _ _ bs t      -> traverse_ bindingUsages bs >> termUsages t
-    Var _ n           -> modify (addUsage n)
-    TyAbs _ _ _ t     -> termUsages t
-    LamAbs _ _ ty t   -> typeUsages ty >> termUsages t
-    Apply _ t1 t2     -> termUsages t1 >> termUsages t2
-    TyInst _ t ty     -> termUsages t >> typeUsages ty
-    Error _ ty        -> typeUsages ty
-    IWrap _ pat arg t -> typeUsages pat >> typeUsages arg >> termUsages t
-    Unwrap _ t        -> termUsages t
-    Constant _ _      -> pure ()
-    Builtin _ _       -> pure ()
-
-varDeclUsages
-    :: (MonadState Usages m, PLC.HasUnique (tyname a) PLC.TypeUnique)
-    => VarDecl tyname name a
-    -> m ()
-varDeclUsages (VarDecl _ _ ty) = typeUsages ty
-
--- Here for completeness but doesn't do much. Would matter if we had kind variables we had to check for.
-tyVarDeclUsages
-    :: (MonadState Usages m)
-    => TyVarDecl tyname a
-    -> m ()
-tyVarDeclUsages _ = pure ()
-
-bindingUsages
-    :: (MonadState Usages m, PLC.HasUnique (name a) PLC.TermUnique, PLC.HasUnique (tyname a) PLC.TypeUnique)
-    => Binding tyname name a
-    -> m ()
-bindingUsages = \case
-    TermBind _ _ rhs -> termUsages rhs
-    TypeBind _ _ rhs -> typeUsages rhs
-    DatatypeBind _ (Datatype _ d tvs _ constrs) -> do
-        tyVarDeclUsages d
-        traverse_ tyVarDeclUsages tvs
-        traverse_ varDeclUsages constrs
+termUsages (Var _ n) = modify (addUsage n)
+termUsages term      = traverse_ termUsages (term ^.. termSubterms) >> traverse_ typeUsages (term ^.. termSubtypes)
 
 -- TODO: move to language-plutus-core
 typeUsages
     :: (MonadState Usages m, PLC.HasUnique (tyname a) PLC.TypeUnique)
     => Type tyname a
     -> m ()
-typeUsages ty = case ty of
-    TyVar _ n        -> modify (addUsage n)
-    TyFun _ t1 t2    -> typeUsages t1 >> typeUsages t2
-    TyIFix _ pat arg -> typeUsages pat >> typeUsages arg
-    TyForall _ _ _ t -> typeUsages t
-    TyLam _ _ _ t    -> typeUsages t
-    TyApp _ t1 t2    -> typeUsages t1 >> typeUsages t2
-    TyBuiltin _ _    -> pure ()
+typeUsages (TyVar _ n) = modify (addUsage n)
+typeUsages ty          = traverse_ typeUsages (ty ^.. typeSubtypes)

--- a/plutus-ir/src/Language/PlutusIR/Transform/Substitute.hs
+++ b/plutus-ir/src/Language/PlutusIR/Transform/Substitute.hs
@@ -1,61 +1,44 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE ViewPatterns     #-}
 -- | Implements naive substitution functions for replacing type and term variables.
-module Language.PlutusIR.Transform.Substitute (substTerm, PLC.substTy, substBinding) where
+module Language.PlutusIR.Transform.Substitute (
+      typeSubstTyNames
+    , termSubstNames
+    , termSubstTyNames
+    , bindingSubstNames
+    , bindingSubstTyNames
+    ) where
 
 import           Language.PlutusIR
 
-import qualified Language.PlutusCore.Subst as PLC
+import           Control.Lens
 
--- | Naively substitute names using the given functions (i.e. do not account for scoping).
-substTerm ::
-  (tyname a -> Maybe (Type tyname a)) ->
-  (name a -> Maybe (Term tyname name a)) ->
-  Term tyname name a ->
-  Term tyname name a
-substTerm tynameF nameF = \case
-    Var a bnd          -> case nameF bnd of
-      Just t  -> t
-      Nothing -> Var a bnd
-    LamAbs a bnd ty t  -> LamAbs a bnd (sTy ty) (sTerm t)
-    TyInst a t ty      -> TyInst a (sTerm t) (sTy ty)
-    IWrap a pat arg t  -> IWrap a (sTy pat) (sTy arg) (sTerm t)
-    Error a ty         -> Error a (sTy ty)
-    Let a r bs t       -> Let a r (fmap (substBinding tynameF nameF) bs) (sTerm t)
-    TyAbs a tn k t     -> TyAbs a tn k (sTerm t)
-    Apply a t1 t2      -> Apply a (sTerm t1) (sTerm t2)
-    Unwrap a t         -> Unwrap a (sTerm t)
-    x                  -> x
-    where
-        sTerm = substTerm tynameF nameF
-        sTy = PLC.substTy tynameF
+-- | Replace a type variable using the given function.
+substTyVar :: (tyname a -> Maybe (Type tyname a)) -> Type tyname a -> Type tyname a
+substTyVar tynameF (TyVar _ (tynameF -> Just t)) = t
+substTyVar _ t                                   = t
 
-substVarDecl ::
-  (tyname a -> Maybe (Type tyname a)) ->
-  (name a -> Maybe (Term tyname name a)) ->
-  VarDecl tyname name a ->
-  VarDecl tyname name a
-substVarDecl tynameF _ (VarDecl x n ty) = VarDecl x n (PLC.substTy tynameF ty)
+-- | Replace a variable using the given function.
+substVar :: (name a -> Maybe (Term tyname name a)) -> Term tyname name a -> Term tyname name a
+substVar nameF (Var _ (nameF -> Just t)) = t
+substVar _ t                             = t
 
-substTyVarDecl ::
-  (tyname a -> Maybe (Type tyname a)) ->
-  TyVarDecl tyname a ->
-  TyVarDecl tyname a
-substTyVarDecl _ (TyVarDecl x tn k) = TyVarDecl x tn k
+-- | Naively substitute type names (i.e. do not substitute binders).
+typeSubstTyNames :: (tyname a -> Maybe (Type tyname a)) -> Type tyname a -> Type tyname a
+typeSubstTyNames tynameF = transformOf typeSubtypes (substTyVar tynameF)
 
--- | Naively substitute names using the given functions (i.e. do not account for scoping).
-substBinding ::
-  (tyname a -> Maybe (Type tyname a)) ->
-  (name a -> Maybe (Term tyname name a)) ->
-  Binding tyname name a ->
-  Binding tyname name a
-substBinding tynameF nameF = \case
-    TermBind x vd t -> TermBind x (sVd vd) (sTerm t)
-    TypeBind x tvd ty -> TypeBind x (sTyVd tvd) (sTy ty)
-    DatatypeBind x (Datatype x' tvd tvs destr constrs) ->
-        DatatypeBind x (Datatype x' (sTyVd tvd) (fmap sTyVd tvs) destr (fmap sVd constrs))
-    where
-        sTerm = substTerm tynameF nameF
-        sTy = PLC.substTy tynameF
-        sVd = substVarDecl tynameF nameF
-        sTyVd = substTyVarDecl tynameF
+-- | Naively substitute names using the given functions (i.e. do not substitute binders).
+termSubstNames :: (name a -> Maybe (Term tyname name a)) -> Term tyname name a -> Term tyname name a
+termSubstNames nameF = transformOf termSubterms (substVar nameF)
+
+-- | Naively substitute type names using the given functions (i.e. do not substitute binders).
+termSubstTyNames :: (tyname a -> Maybe (Type tyname a)) -> Term tyname name a -> Term tyname name a
+termSubstTyNames tynameF = over termSubterms (termSubstTyNames tynameF) . over termSubtypes (typeSubstTyNames tynameF)
+
+-- | Naively substitute names using the given functions (i.e. do not substitute binders).
+bindingSubstNames :: (name a -> Maybe (Term tyname name a)) -> Binding tyname name a -> Binding tyname name a
+bindingSubstNames nameF = over bindingSubterms (termSubstNames nameF)
+
+-- | Naively substitute type names using the given functions (i.e. do not substitute binders).
+bindingSubstTyNames :: (tyname a -> Maybe (Type tyname a)) -> Binding tyname name a -> Binding tyname name a
+bindingSubstTyNames tynameF = over bindingSubterms (termSubstTyNames tynameF) . over bindingSubtypes (typeSubstTyNames tynameF)

--- a/plutus-ir/src/Language/PlutusIR/Transform/ThunkRecursions.hs
+++ b/plutus-ir/src/Language/PlutusIR/Transform/ThunkRecursions.hs
@@ -203,9 +203,7 @@ constructThunkedLet ann okay needThunking body = do
           let substitutionMap = Map.fromList $ processed ^.. traverse . _1
               -- substitution function for names
               nameF n = Map.lookup n substitutionMap
-              -- do nothing for type names
-              tynameF = const Nothing
-          in fmap (substBinding tynameF nameF) newBindings
+          in fmap (bindingSubstNames nameF) newBindings
 
     let adaptorBindings = processed ^.. traverse . _3
 


### PR DESCRIPTION
A slightly more experimental refactoring here.

We can't (easily) use `recursion-schemes` for the PIR AST, because it has two mutually recursive datatypes, `Term` and `Binding`. However, we can get a lot of the benefit by defining suitable `Traversal`s for getting sub-terms/types of our AST. In particular, we can get the sub-terms of a `Term`, looking through `Binding`s. Then we can use combinators from `Lens.Plated` to do nice bottom-up recursive traversals and generic operations.

This lets us ditch a lot of boilerplate. I think it's no weirder to think about than the `recursion-schemes` approach, so overall I think I like it.

As a bonus, you can naturally do fusion of optimization/compilation passes with this approach. I'm not going to do that here, because I don't think it gains us much, but it's cool that it's possible.