### PR TITLE
plutus-wallet-api: make the result type of validator scripts be Bool

### DIFF
--- a/nix/overlays/required.nix
+++ b/nix/overlays/required.nix
@@ -14,6 +14,7 @@ let
   doctest = opts: drv: overrideCabal drv (attrs: {
     postCheck = "./Setup doctest --doctest-options=\"${opts}\"";
   });
+  # cabal doctest doesn't seem to be clever enough to pick these up from the cabal file
   doctestOpts = "-pgmL markdown-unlit -XTemplateHaskell -XDeriveFunctor -XScopedTypeVariables -fno-ignore-interface-pragmas -fobject-code";
 in
 
@@ -22,15 +23,11 @@ self: super: {
     ########################################################################
     # Overides of local packages
     language-plutus-core = addRealTimeTestLogs super.language-plutus-core;
-    # cabal doctest doesn't seem to be clever enough to pick these up from the cabal file
     plutus-tx = doctest doctestOpts super.plutus-tx;
-
     plutus-tutorial = doctest doctestOpts (deferPluginErrors super.plutus-tutorial);
-
     plutus-use-cases = deferPluginErrors super.plutus-use-cases;
-
     plutus-playground-server = deferPluginErrors super.plutus-playground-server;
-
+    plutus-wallet-api = deferPluginErrors super.plutus-wallet-api;
     marlowe = deferPluginErrors super.marlowe;
 
     ########################################################################

--- a/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground-server/usecases/CrowdFunding.hs
@@ -81,7 +81,7 @@ PlutusTx.makeLift ''CampaignAction
 --
 -- 3. A 'PendingTx value. It contains information about the current transaction and is provided by the slot leader.
 --    See note [PendingTx]
-type CrowdfundingValidator = PubKey -> CampaignAction -> PendingTx -> ()
+type CrowdfundingValidator = PubKey -> CampaignAction -> PendingTx -> Bool
 
 validRefund :: Campaign -> PubKey -> PendingTx -> Bool
 validRefund campaign contributor ptx =
@@ -105,14 +105,11 @@ validCollection campaign p =
 -- As a result, the 'Campaign' definition is part of the script address, and different campaigns have different addresses.
 -- The Campaign{..} syntax means that all fields of the 'Campaign' value are in scope (for example 'campaignDeadline' in l. 70).
 mkValidator :: Campaign -> CrowdfundingValidator
-mkValidator c con act p =
-    let
-        isValid = case act of
-            -- the "refund" branch
-            Refund -> validRefund c con p
-            -- the "collection" branch
-            Collect -> validCollection c p
-    in if isValid then () else P.error ()
+mkValidator c con act p = case act of
+    -- the "refund" branch
+    Refund -> validRefund c con p
+    -- the "collection" branch
+    Collect -> validCollection c p
 
 -- | The validator script that determines whether the campaign owner can
 --   retrieve the funds or the contributors can claim a refund.

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -38,11 +38,8 @@ correctGuess :: HashedString -> ClearString -> Bool
 correctGuess (HashedString actual) (ClearString guess') =
     P.equalsByteString actual (P.sha2_256 guess')
 
-validateGuess :: HashedString -> ClearString -> PendingTx -> ()
-validateGuess dataScript redeemerScript _ =
-    if correctGuess dataScript redeemerScript
-    then ()
-    else P.traceErrorH "WRONG!"
+validateGuess :: HashedString -> ClearString -> PendingTx -> Bool
+validateGuess dataScript redeemerScript _ = correctGuess dataScript redeemerScript
 
 -- | The validator script of the game.
 gameValidator :: ValidatorScript

--- a/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground-server/usecases/Vesting.hs
@@ -108,7 +108,7 @@ availableFrom (VestingTranche d v) range =
 -}
 
 -- | The validator script
-mkValidator :: Vesting -> () -> () -> PendingTx -> ()
+mkValidator :: Vesting -> () -> () -> PendingTx -> Bool
 mkValidator d@Vesting{..} () () p@PendingTx{pendingTxValidRange = range} =
     let
         -- We need the hash of this validator script in order to ensure
@@ -144,10 +144,7 @@ mkValidator d@Vesting{..} () () p@PendingTx{pendingTxValidRange = range} =
         -- transaction 'p'.
         con2 :: Bool
         con2 = p `V.txSignedBy` vestingOwner
-    in
-        if con1 `P.and` con2
-        then ()
-        else P.traceErrorH "Cannot withdraw"
+    in con1 `P.and` con2
 
 validatorScript :: Vesting -> ValidatorScript
 validatorScript v = ValidatorScript $

--- a/plutus-tutorial/tutorial/Tutorial/Solutions0.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions0.hs
@@ -196,7 +196,7 @@ mkValidatorScript campaign = ValidatorScript val where
                           p `signedBy` campaignOwner
 
                             -- END OF NEW CODE
-      in if isValid then () else (P.error ()) ||])
+      in isValid ||])
 
 campaignAddress :: Campaign -> Address
 campaignAddress cmp = L.scriptAddress (mkValidatorScript cmp)

--- a/plutus-tutorial/tutorial/Tutorial/Solutions2.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions2.hs
@@ -51,10 +51,7 @@ trickier10Light = $$(P.compile [|| $$(TH.trickierLight 10) ||])
 -}
 intGameValidator :: ValidatorScript
 intGameValidator = ValidatorScript ($$(L.compileScript [||
-  \(SecretNumber actual) (ClearNumber guess') (_ :: PendingTx) ->
-    if P.eq actual ($$(TH.trickier 2) guess')
-    then ()
-    else P.error (P.traceH "Wrong number" ())
+  \(SecretNumber actual) (ClearNumber guess') (_ :: PendingTx) -> P.eq actual ($$(TH.trickier 2) guess')
   ||]))
 
 gameAddress :: Address

--- a/plutus-tutorial/tutorial/Tutorial/Vesting.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Vesting.hs
@@ -199,12 +199,7 @@ vestingValidator v = ValidatorScript val where
             con2 :: Bool
             con2 = V.txSignedBy p owner
 
-        in
-
-            if P.and con1 con2
-            then ()
-            else P.error (P.traceH "Cannot withdraw" ())
-
+        in con1 `P.and` con2
         ||])
 
 contractAddress :: Vesting -> Address

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -11,6 +11,7 @@ module Language.PlutusTx.Prelude (
     traceErrorH,
     -- * Error
     error,
+    check,
     -- * Boolean operators
     and,
     or,
@@ -77,9 +78,14 @@ import           Prelude                    (Bool (..), Integer, Maybe (..), Str
 -- >>> import Prelude (Bool (..), Integer, Maybe (..), String, (+), (==), (>))
 
 {-# INLINABLE error #-}
--- | Terminate the evaluation of the script with an error message
+-- | Terminate the evaluation of the script with an error message.
 error :: () -> a
 error = Builtins.error
+
+{-# INLINABLE check #-}
+-- | Checks a 'Bool' and aborts if it is false.
+check :: Bool -> ()
+check b = if b then () else error ()
 
 {-# INLINABLE toPlutusString #-}
 -- | Convert a Haskell 'String' into a PlutusTx 'Builtins.String'.

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -81,7 +81,7 @@ data CampaignAction = Collect | Refund
 
 PlutusTx.makeLift ''CampaignAction
 
-type CrowdfundingValidator = PubKey -> CampaignAction -> PendingTx -> ()
+type CrowdfundingValidator = PubKey -> CampaignAction -> PendingTx -> Bool
 
 validRefund :: Campaign -> PubKey -> PendingTx -> Bool
 validRefund campaign contributor ptx =
@@ -95,12 +95,9 @@ validCollection campaign p =
     `P.and` (p `V.txSignedBy` campaignOwner campaign)
 
 mkValidator :: Campaign -> CrowdfundingValidator
-mkValidator c con act p =
-    let
-        isValid = case act of
-            Refund -> validRefund c con p
-            Collect -> validCollection c p
-    in if isValid then () else P.error ()
+mkValidator c con act p = case act of
+    Refund -> validRefund c con p
+    Collect -> validCollection c p
 
 -- | The validator script that determines whether the campaign owner can
 --   retrieve the funds or the contributors can claim a refund.

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -58,7 +58,7 @@ mkCurrency (TxOutRefOf h i) amts =
         , curAmounts              = LMap.fromList (fmap (first fromString) amts)
         }
 
-validate :: Currency -> () -> () -> V.PendingTx -> ()
+validate :: Currency -> () -> () -> V.PendingTx -> Bool
 validate c@(Currency (refHash, refIdx) _) () () p =
     let
         -- see note [Obtaining the currency symbol]
@@ -79,10 +79,7 @@ validate c@(Currency (refHash, refIdx) _) () () p =
             let v = V.spendsOutput p refHash refIdx
             in  P.traceIfFalseH "Pending transaction does not spend the designated transaction output" v
 
-    in
-        if forgeOK `P.and` txOutputSpent
-        then ()
-        else P.traceErrorH "Invalid forge"
+    in forgeOK `P.and` txOutputSpent
 
 curValidator :: Currency -> ValidatorScript
 curValidator cur = ValidatorScript $

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -33,11 +33,8 @@ correctGuess :: HashedString -> ClearString -> Bool
 correctGuess (HashedString actual) (ClearString guess') =
     P.equalsByteString actual (P.sha2_256 guess')
 
-validateGuess :: HashedString -> ClearString -> PendingTx -> ()
-validateGuess dataScript redeemerScript _ =
-    if correctGuess dataScript redeemerScript
-    then ()
-    else P.traceErrorH "WRONG!"
+validateGuess :: HashedString -> ClearString -> PendingTx -> Bool
+validateGuess dataScript redeemerScript _ = correctGuess dataScript redeemerScript
 
 gameValidator :: ValidatorScript
 gameValidator =

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
@@ -76,7 +76,7 @@ data GameInput =
 
 PlutusTx.makeLift ''GameInput
 
-mkValidator :: (GameState, Maybe GameInput) -> (GameState, Maybe GameInput) -> PendingTx -> ()
+mkValidator :: (GameState, Maybe GameInput) -> (GameState, Maybe GameInput) -> PendingTx -> Bool
 mkValidator ds vs p =
     let
 
@@ -116,8 +116,7 @@ mkValidator ds vs p =
 
         sm = SM.StateMachine trans stateEq
 
-    in
-        SM.mkValidator sm ds vs p
+    in SM.mkValidator sm ds vs p
 
 gameValidator :: ValidatorScript
 gameValidator = ValidatorScript $$(Ledger.compileScript [|| mkValidator ||])

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
@@ -36,12 +36,10 @@ data MultiSig = MultiSig
                 }
 P.makeLift ''MultiSig
 
-validate :: MultiSig -> () -> () -> PendingTx -> ()
+validate :: MultiSig -> () -> () -> PendingTx -> Bool
 validate (MultiSig keys num) () () p =
-    let present = P.length (P.filter (V.txSignedBy p) keys) in
-    if present `P.geq` num
-    then ()
-    else P.traceErrorH "WRONG!"
+    let present = P.length (P.filter (V.txSignedBy p) keys)
+    in present `P.geq` num
 
 msValidator :: MultiSig -> ValidatorScript
 msValidator sig = ValidatorScript $

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
@@ -216,13 +216,13 @@ stepWithChecks p ptx s i =
             else P.traceErrorH "Pay invalid"
         _ -> P.traceErrorH "invalid transition"
 
-mkValidator :: Params -> (State, Maybe Input) -> (State, Maybe Input) -> PendingTx -> ()
-mkValidator p ds vs ptx = 
+mkValidator :: Params -> (State, Maybe Input) -> (State, Maybe Input) -> PendingTx -> Bool
+mkValidator p ds vs ptx =
     let sm = StateMachine (stepWithChecks p ptx) stateEq in
     SM.mkValidator sm ds vs ptx
 
 validator :: Params -> ValidatorScript
-validator params = ValidatorScript $ 
+validator params = ValidatorScript $
     $$(Ledger.compileScript [|| mkValidator ||])
         `Ledger.applyScript`
             Ledger.lifted params

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
@@ -20,11 +20,8 @@ import           Ledger                       as Ledger hiding (initialise, to)
 import           Ledger.Validation            as V
 import           Wallet.API                   as WAPI
 
-mkValidator :: PubKey -> () -> () -> PendingTx -> ()
-mkValidator pk' () () p =
-    if V.txSignedBy p pk'
-    then ()
-    else P.traceErrorH "Required signature not present!"
+mkValidator :: PubKey -> () -> () -> PendingTx -> Bool
+mkValidator pk' () () p = V.txSignedBy p pk'
 
 pkValidator :: PubKey -> ValidatorScript
 pkValidator pk = ValidatorScript $

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
@@ -67,7 +67,7 @@ PlutusTx.makeLift ''SwapOwners
 
 type SwapOracle = OracleValue (Ratio Integer)
 
-mkValidator :: Swap -> SwapOwners -> SwapOracle -> PendingTx -> ()
+mkValidator :: Swap -> SwapOwners -> SwapOracle -> PendingTx -> Bool
 mkValidator Swap{..} SwapOwners{..} redeemer p =
     let
         extractVerifyAt :: OracleValue (Ratio Integer) -> PubKey -> Ratio Integer -> Slot -> Ratio Integer
@@ -159,8 +159,7 @@ mkValidator Swap{..} SwapOwners{..} redeemer p =
 
         outConditions = (ol1 o1 `P.and` ol2 o2) `P.or` (ol1 o2 `P.and` ol2 o1)
 
-    in
-    if inConditions `P.and` outConditions then () else PlutusTx.error ()
+    in inConditions `P.and` outConditions
 
 -- | Validator script for the two transactions that initialise the swap.
 --   See note [Swap Transactions]

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -125,7 +125,7 @@ validatorScriptHash =
     . Ledger.scriptAddress
     . validatorScript
 
-mkValidator :: Vesting -> VestingData -> () -> PendingTx -> ()
+mkValidator :: Vesting -> VestingData -> () -> PendingTx -> Bool
 mkValidator d@Vesting{..} VestingData{..} () p@PendingTx{pendingTxValidRange = range} =
     let
         -- We assume here that the txn outputs are always given in the same
@@ -151,9 +151,7 @@ mkValidator d@Vesting{..} VestingData{..} () p@PendingTx{pendingTxValidRange = r
             let remaining = Validation.valueLockedBy p (Validation.ownHash p) in
             remaining `Value.eq` (totalAmount d `Value.minus` newAmount)
 
-        isValid = amountsValid `PlutusTx.and` txnOutputsValid
-    in
-    if isValid then () else PlutusTx.error ()
+    in amountsValid `PlutusTx.and` txnOutputsValid
 
 validatorScript :: Vesting -> ValidatorScript
 validatorScript v = ValidatorScript $

--- a/plutus-wallet-api/plutus-wallet-api.cabal
+++ b/plutus-wallet-api/plutus-wallet-api.cabal
@@ -39,6 +39,12 @@ flag development
     default: False
     manual: True
 
+flag defer-plugin-errors
+    description:
+        Defer errors from the plugin, useful for things like Haddock that can't handle it.
+    default: False
+    manual: True
+
 library
     import: lang
     hs-source-dirs: src
@@ -87,6 +93,9 @@ library
 
     if (flag(development) && impl(ghc <8.4))
         ghc-options: -Werror
+
+    if flag(defer-plugin-errors)
+        ghc-options: -fplugin-opt Language.PlutusTx.Plugin:defer-errors
 
 library plutus-ledger
     import: lang
@@ -138,6 +147,9 @@ library plutus-ledger
         newtype-generics,
         http-api-data,
         cardano-crypto
+
+    if flag(defer-plugin-errors)
+        ghc-options: -fplugin-opt Language.PlutusTx.Plugin:defer-errors
 
 test-suite plutus-wallet-api-test
     type: exitcode-stdio-1.0

--- a/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
+++ b/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
@@ -37,7 +37,7 @@ transition newState input = (newState, Just input)
 
 {-# INLINABLE mkValidator #-}
 -- | Turn a transition function 's -> i -> s' into a validator script.
-mkValidator :: StateMachine s i -> (s, Maybe i) -> (s, Maybe i) -> PendingTx -> ()
+mkValidator :: StateMachine s i -> (s, Maybe i) -> (s, Maybe i) -> PendingTx -> Bool
 mkValidator sm (currentState, _) (newState, Just input) p =
     let
         StateMachine trans sEq = sm
@@ -56,8 +56,5 @@ mkValidator sm (currentState, _) (newState, Just input) p =
             in
                 P.traceIfFalseH "State transition invalid - data script hash not equal to redeemer hash"
                 (P.all dsHashOk relevantOutputs)
-    in
-        if P.and stateOk dataScriptHashOk
-        then ()
-        else P.error (P.traceH "State transition failed" ())
-mkValidator _ _ _ _ = P.error ()
+    in stateOk `P.and` dataScriptHashOk
+mkValidator _ _ _ _ = False


### PR DESCRIPTION
See the note in `Index.hs`.

This makes things easier for script authors. We do need to apply an
adaptor during validation so we can still have a simple check (is it
error or not).