### PR TITLE
playground: Remove validity range parameter from payToWallet_

### DIFF
--- a/plutus-playground-lib/src/Playground/Contract.hs
+++ b/plutus-playground-lib/src/Playground/Contract.hs
@@ -40,17 +40,18 @@ import qualified Data.ByteString.Lazy.Char8  as LBC8
 import           Data.List.NonEmpty          (NonEmpty ((:|)))
 import           Data.Swagger                (Schema, ToSchema)
 import           GHC.Generics                (Generic)
+import           Ledger.Interval             (always)
 import           Ledger.Validation           (ValidatorHash (ValidatorHash))
 import           Ledger.Value                (TokenName (TokenName), Value)
 import           Playground.API              (FunctionSchema, KnownCurrency (KnownCurrency), adaCurrency)
 import           Playground.Interpreter.Util
 import           Playground.TH               (mkFunction, mkFunctions, mkKnownCurrencies, mkSingleFunction)
-import           Wallet.API                  (SlotRange, WalletAPI, payToPublicKey_)
+import           Wallet.API                  (WalletAPI, payToPublicKey_)
 import           Wallet.Emulator             (addBlocksAndNotify, runWalletActionAndProcessPending, walletPubKey)
 import           Wallet.Emulator.Types       (MockWallet, Wallet (..))
 
-payToWallet_ :: (Monad m, WalletAPI m) => SlotRange -> Value -> Wallet -> m ()
-payToWallet_ r v = payToPublicKey_ r v . walletPubKey
+payToWallet_ :: (Monad m, WalletAPI m) => Value -> Wallet -> m ()
+payToWallet_ v = payToPublicKey_ always v . walletPubKey
 
 -- We need to work with lazy 'ByteString's in contracts,
 -- but 'ByteArrayAccess' (which we need for hashing) is only defined for strict

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -160,15 +160,7 @@ vestingSpec =
                 , FunctionSchema
                       { functionName = Fn "payToWallet_"
                       , argumentSchema =
-                            [ SimpleObjectSchema
-                                  [ ( "ivTo"
-                                    , SimpleObjectSchema
-                                          [("getSlot", SimpleIntSchema)])
-                                  , ( "ivFrom"
-                                    , SimpleObjectSchema
-                                          [("getSlot", SimpleIntSchema)])
-                                  ]
-                            , vlSchema
+                            [ vlSchema
                             , SimpleObjectSchema
                                   [("getWallet", SimpleIntSchema)]
                             ]
@@ -264,13 +256,12 @@ gameSpec =
             , mkSimulatorWallet b ten
             , mkSimulatorWallet c ten
             ]
-            [ Action (Fn "payToWallet_") a [slotRange, nineAda, toJSONString b]
-            , Action (Fn "payToWallet_") b [slotRange, nineAda, toJSONString c]
-            , Action (Fn "payToWallet_") c [slotRange, nineAda, toJSONString a]
+            [ Action (Fn "payToWallet_") a [nineAda, toJSONString b]
+            , Action (Fn "payToWallet_") b [nineAda, toJSONString c]
+            , Action (Fn "payToWallet_") c [nineAda, toJSONString a]
             ]
             (SourceCode game)
             []
-    slotRange = JSON.String "{\"ivTo\":null,\"ivFrom\":null}"
     nineAda = toJSONString $ Ada.adaValueOf 9
     twoAda = toJSONString $ Ada.adaValueOf 2
 


### PR DESCRIPTION
The `SlotRange` type isn't displayed very nicely in the Playground, and the validity range doesn't matter for normal payments between wallets anyway. We can just use the default validity range everywhere.