### PR TITLE
language-plutus-core: use traversals to cut down on some boilerplate

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -12,7 +12,10 @@ module Language.PlutusCore
     , parseType
     -- * AST
     , Term (..)
+    , termSubterms
+    , termSubtypes
     , Type (..)
+    , typeSubtypes
     , Constant (..)
     , Builtin (..)
     , Kind (..)

--- a/language-plutus-core/src/Language/PlutusCore/TH.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TH.hs
@@ -76,19 +76,16 @@ metavarSubstType ::
   Type TyName () ->
   Map.Map T.Text (Type TyName ()) ->
   Type TyName ()
-metavarSubstType ty tyMetavars = substTy
-                        (\n -> Map.lookup (nameString $ unTyName n) tyMetavars)
-                        ty
+metavarSubstType ty tyMetavars = typeSubstTyNames (\n -> Map.lookup (nameString $ unTyName n) tyMetavars) ty
 
 metavarSubstTerm ::
   Term TyName Name () ->
   Map.Map T.Text (Type TyName ()) ->
   Map.Map T.Text (Term TyName Name ()) ->
   Term TyName Name ()
-metavarSubstTerm t tyMetavars termMetavars = substTerm
-                        (\n -> Map.lookup (nameString $ unTyName n) tyMetavars)
-                        (\n -> Map.lookup (nameString n) termMetavars)
-                        t
+metavarSubstTerm t tyMetavars termMetavars =
+    termSubstTyNames (\n -> Map.lookup (nameString $ unTyName n) tyMetavars) $
+    termSubstNames (\n -> Map.lookup (nameString n) termMetavars) t
 
 -- | Runs a 'QuoteT' in the 'Q' context. Note that this uses 'runQuoteT', so does note preserve freshness.
 eval :: (Pretty b) => QuoteT (Except (Error b)) a -> Q a

--- a/language-plutus-core/src/Language/PlutusCore/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Type.hs
@@ -88,6 +88,7 @@ instance Corecursive (Type tyname a) where
     embed (TyLamF l tn k ty)    = TyLam l tn k ty
     embed (TyAppF l ty ty')     = TyApp l ty ty'
 
+{-# INLINE typeSubtypes #-}
 -- | Get all the direct child 'Type's of the given 'Type'.
 typeSubtypes :: Traversal' (Type tyname a) (Type tyname a)
 typeSubtypes f = \case
@@ -306,6 +307,7 @@ instance Corecursive (Term tyname name a) where
     embed (IWrapF x pat arg t) = IWrap x pat arg t
     embed (ErrorF x ty)        = Error x ty
 
+{-# INLINE termSubterms #-}
 -- | Get all the direct child 'Term's of the given 'Term'.
 termSubterms :: Traversal' (Term tyname name a) (Term tyname name a)
 termSubterms f = \case
@@ -320,6 +322,7 @@ termSubterms f = \case
     c@Constant {} -> pure c
     b@Builtin {} -> pure b
 
+{-# INLINE termSubtypes #-}
 -- | Get all the direct child 'Type's of the given 'Term'.
 termSubtypes :: Traversal' (Term tyname name a) (Type tyname a)
 termSubtypes f = \case

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -29,7 +29,7 @@ module Language.PlutusIR (
 
 import           PlutusPrelude
 
-import           Language.PlutusCore        (Kind, Name, TyName, Type (..))
+import           Language.PlutusCore        (Kind, Name, TyName, Type (..), typeSubtypes)
 import qualified Language.PlutusCore        as PLC
 import           Language.PlutusCore.CBOR   ()
 import           Language.PlutusCore.MkPlc  (Def (..), TermLike (..), TyVarDecl (..), VarDecl (..))
@@ -39,7 +39,6 @@ import           Control.Lens
 
 import           Codec.Serialise            (Serialise)
 
-import           Data.Functor.Foldable      (embed, project)
 import qualified Data.Text                  as T
 
 import           GHC.Generics               (Generic)
@@ -67,11 +66,6 @@ tyVarDeclNameString = T.unpack . PLC.nameString . PLC.unTyName . tyVarDeclName
 
 datatypeNameString :: Datatype TyName name a -> String
 datatypeNameString (Datatype _ tn _ _ _) = tyVarDeclNameString tn
-
--- TODO: move to language-plutus-core
--- | Get all the direct child 'Type's of the given 'Type'.
-typeSubtypes :: Traversal' (Type tyname a) (Type tyname a)
-typeSubtypes f = fmap embed . traverse f . project
 
 -- Bindings
 

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -81,6 +81,7 @@ data Binding tyname name a = TermBind a (VarDecl tyname name a) (Term tyname nam
 
 instance (Serialise a, Serialise (tyname a), Serialise (name a)) => Serialise (Binding tyname name a)
 
+{-# INLINE bindingSubterms #-}
 -- | Get all the direct child 'Term's of the given 'Binding'.
 bindingSubterms :: Traversal' (Binding tyname name a) (Term tyname name a)
 bindingSubterms f = \case
@@ -88,14 +89,17 @@ bindingSubterms f = \case
     b@TypeBind {} -> pure b
     d@DatatypeBind {} -> pure d
 
+{-# INLINE varDeclSubtypes #-}
 -- | Get all the direct child 'Type's of the given 'VarDecl'.
 varDeclSubtypes :: Traversal' (VarDecl tyname name a) (Type tyname a)
 varDeclSubtypes f (VarDecl a n ty) = VarDecl a n <$> f ty
 
+{-# INLINE datatypeSubtypes #-}
 -- | Get all the direct child 'Type's of the given 'Datatype'.
 datatypeSubtypes :: Traversal' (Datatype tyname name a) (Type tyname a)
 datatypeSubtypes f (Datatype a n vs m cs) = Datatype a n vs m <$> (traverse . varDeclSubtypes) f cs
 
+{-# INLINE bindingSubtypes #-}
 -- | Get all the direct child 'Type's of the given 'Binding'.
 bindingSubtypes :: Traversal' (Binding tyname name a) (Type tyname a)
 bindingSubtypes f = \case
@@ -162,6 +166,7 @@ instance TermLike (Term tyname name) tyname name where
     termLet x (Def vd bind) = Let x NonRec [TermBind x vd bind]
     typeLet x (Def vd bind) = Let x NonRec [TypeBind x vd bind]
 
+{-# INLINE termSubterms #-}
 -- | Get all the direct child 'Term's of the given 'Term', including those within 'Binding's.
 termSubterms :: Traversal' (Term tyname name a) (Term tyname name a)
 termSubterms f = \case
@@ -177,6 +182,7 @@ termSubterms f = \case
     c@Constant {} -> pure c
     b@Builtin {} -> pure b
 
+{-# INLINE termSubtypes #-}
 -- | Get all the direct child 'Type's of the given 'Term', including those within 'Binding's.
 termSubtypes :: Traversal' (Term tyname name a) (Type tyname a)
 termSubtypes f = \case

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
@@ -4,23 +4,23 @@
 -- | Functions for compiling let-bound PIR datatypes into PLC.
 module Language.PlutusIR.Compiler.Datatype (compileDatatype, compileRecDatatypes) where
 
-import           PlutusPrelude                         (showText)
+import           PlutusPrelude                          (showText)
 
 import           Language.PlutusIR
 import           Language.PlutusIR.Compiler.Error
 import           Language.PlutusIR.Compiler.Names
 import           Language.PlutusIR.Compiler.Provenance
 import           Language.PlutusIR.Compiler.Types
-import qualified Language.PlutusIR.MkPir               as PIR
+import qualified Language.PlutusIR.MkPir                as PIR
+import           Language.PlutusIR.Transform.Substitute
 
-import qualified Language.PlutusCore.MkPlc             as PLC
+import qualified Language.PlutusCore.MkPlc              as PLC
 import           Language.PlutusCore.Quote
-import qualified Language.PlutusCore.StdLib.Type       as Types
-import qualified Language.PlutusCore.Subst             as PLC
+import qualified Language.PlutusCore.StdLib.Type        as Types
 
 import           Control.Monad.Error.Lens
 
-import qualified Data.Text                             as T
+import qualified Data.Text                              as T
 import           Data.Traversable
 
 -- Utilities
@@ -50,7 +50,7 @@ constructorArgTypes = funTyArgs . varDeclType
 
 -- | "Unveil" a datatype definition in a type, by replacing uses of the name as a type variable with the concrete definition.
 unveilDatatype :: Eq (tyname a) => Type tyname a -> Datatype tyname name a -> Type tyname a -> Type tyname a
-unveilDatatype dty (Datatype _ tn _ _ _) = PLC.substTy (\n -> if n == tyVarDeclName tn then Just dty else Nothing)
+unveilDatatype dty (Datatype _ tn _ _ _) = typeSubstTyNames (\n -> if n == tyVarDeclName tn then Just dty else Nothing)
 
 resultTypeName :: Compiling m e a => Datatype TyName Name (Provenance a) -> m (TyName (Provenance a))
 resultTypeName (Datatype _ tn _ _ _) = getEnclosing >>= \p -> liftQuote $ freshTyName p $ "out_" <> (nameString $ unTyName $ tyVarDeclName tn)

--- a/plutus-ir/src/Language/PlutusIR/Transform/Substitute.hs
+++ b/plutus-ir/src/Language/PlutusIR/Transform/Substitute.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE ViewPatterns     #-}
 -- | Implements naive substitution functions for replacing type and term variables.
 module Language.PlutusIR.Transform.Substitute (
-      typeSubstTyNames
+      substVar
+    , substTyVar
+    , typeSubstTyNames
     , termSubstNames
     , termSubstTyNames
     , bindingSubstNames
@@ -11,21 +13,15 @@ module Language.PlutusIR.Transform.Substitute (
 
 import           Language.PlutusIR
 
+import           Language.PlutusCore.Subst (substTyVar, typeSubstTyNames)
+
 import           Control.Lens
 
--- | Replace a type variable using the given function.
-substTyVar :: (tyname a -> Maybe (Type tyname a)) -> Type tyname a -> Type tyname a
-substTyVar tynameF (TyVar _ (tynameF -> Just t)) = t
-substTyVar _ t                                   = t
-
+-- Needs to be different from the PLC version since we have different Terms
 -- | Replace a variable using the given function.
 substVar :: (name a -> Maybe (Term tyname name a)) -> Term tyname name a -> Term tyname name a
 substVar nameF (Var _ (nameF -> Just t)) = t
 substVar _ t                             = t
-
--- | Naively substitute type names (i.e. do not substitute binders).
-typeSubstTyNames :: (tyname a -> Maybe (Type tyname a)) -> Type tyname a -> Type tyname a
-typeSubstTyNames tynameF = transformOf typeSubtypes (substTyVar tynameF)
 
 -- | Naively substitute names using the given functions (i.e. do not substitute binders).
 termSubstNames :: (name a -> Maybe (Term tyname name a)) -> Term tyname name a -> Term tyname name a


### PR DESCRIPTION
Since I've learned how to do this, might as well push it a bit.

A few wrinkles have emerged:
- `transformMOf` is very nice, but it doesn't work well where you want to do something based on the current node before recursing, e.g. in the renamer with freshening names. So we need to keep the manual recursion there.
    - Possibly we could write a hairy function that did this. Maybe something like this [ADI stuff](http://www.newartisans.com/2018/04/win-for-recursion-schemes/).
- The traversals are type-preserving, so we can't e.g. change the type of names, so we cant' use this for `DeBruijn`, which would benefit a lot from it.
    - I think this is fundamental: using the `Traversable` instance for `TermF` we can have the subterms transformed to have a new name type, after which we fiddle with bound names at the current level to make them match. This requires having child nodes at a different type.

Overall it seems nice, though. I'm particularly proud of `normalizeTypesInM`, which IMO now says exactly what it does. (Although I do wish `transformOf` was called `bottomUp` or something).