### PR TITLE
PLC spec: misc editing

### DIFF
--- a/plutus-core-spec/figures/CkMachine.tex
+++ b/plutus-core-spec/figures/CkMachine.tex
@@ -26,7 +26,7 @@
     \judgmentdef{\(\cksteps{\sigma}{\sigma'}\)}{Machine takes one step from state $\sigma$ to state $\sigma'$}
 
 %% Changed to alignat to align rules a bit more readably; unfortunately the &s have to go in macro invocations.
-\hspace{-1cm}\begin{minipage}{\linewidth}  
+\hspace{-1cm}\begin{minipage}{\linewidth}
 % To stop "bn computes to ...'' going over the edge of the page
 \begin{alignat*}{2}
         \cksteps{\ckforward{s&}{\con{cn}}&} {&\ckbackward{s}{\con{cn}}}\\
@@ -36,8 +36,8 @@
         \cksteps{\ckforward{s&}{\unwrap{M}}&} {&\ckforward{s, \inUnwrapFrame{}}{M}}\\
         \cksteps{\ckforward{s&}{\lam{x}{A}{M}}&} {&\ckbackward{s}{\lam{x}{A}{M}}}\\
         \cksteps{\ckforward{s&}{\app{M}{N}}&} {&\ckforward{s, \inAppLeftFrame{N}}{M}}\\
-        \cksteps{\ckforward{s&}{\builtin{bn}{\repetition{A}}{}}&} {&\ckforward{s}{M}} 
-              \quad (\textit{$bn$ computes on $\repetition{A}$ to $M$ according to Fig.~\ref{fig:builtins}})\\
+        \cksteps{\ckforward{s&}{\builtin{bn}{\repetition{A}}{}}&} {&\ckforward{s}{M}}
+              \quad (\textit{$bn$ computes on $\repetition{A}$ to $M$ according to \cref{fig:builtins}})\\
         \cksteps{\ckforward{s&}{\builtin{bn}{\repetition{A}}{M \repetition{M}}}&} {&\ckforward{s, \inBuiltin{bn}{\repetition{A}}{}{\_}{\repetition{M}}}{M}}\\
         \cksteps{\ckforward{s&}{\error{A}}&} {&\ckerror{}}\\
         \\[-10pt] %% Put some vertical space between compute and return rules, but not a whole line
@@ -47,8 +47,8 @@
         \cksteps{\ckbackward{s, \inUnwrapFrame{}&}{\wrap{A}{B}{V}}&} {&\ckbackward{s}{V}}\\
         \cksteps{\ckbackward{s, \inAppLeftFrame{N}&}{V}&} {&\ckforward{s, \inAppRightFrame{V}}{N}}\\
         \cksteps{\ckbackward{s, \inAppRightFrame{\lam{x}{A}{M}}&}{V}&} {&\ckforward{s}{\subst{V}{x}{M}}}\\
-        \cksteps{\ckbackward{s, \inBuiltin{bn}{\repetition{A}}{\repetition{V}}{\_}{}&}{V}&} {&\ckforward{s}{M}} 
-          \quad (\textit{$bn$ computes on $\repetition{A}$ and $\repetition{V}V$ to $M$ according to Fig.~\ref{fig:builtins}})\\
+        \cksteps{\ckbackward{s, \inBuiltin{bn}{\repetition{A}}{\repetition{V}}{\_}{}&}{V}&} {&\ckforward{s}{M}}
+          \quad (\textit{$bn$ computes on $\repetition{A}$ and $\repetition{V}V$ to $M$ according to \cref{fig:builtins}})\\
         \cksteps{\ckbackward{s, \inBuiltin{bn}{\repetition{A}}{\repetition{V}}{\_}{M \repetition{M}}&}{V}&} {&\ckforward{s, \inBuiltin{bn}{\repetition{A}}{\repetition{V} V}{\_}{\repetition{M}}}{M}}\\
     \end{alignat*}
 \end{minipage}

--- a/plutus-core-spec/figures/TermReduction.tex
+++ b/plutus-core-spec/figures/TermReduction.tex
@@ -45,7 +45,7 @@
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{$bn$ computes on $\repetition{A}$ and $\repetition{V}$ to $U$ according to Figure \ref{fig:builtins}}
+        \AxiomC{$bn$ computes on $\repetition{A}$ and $\repetition{V}$ to $U$ according to \cref{fig:builtins}}
         \UnaryInfC{\(\step{\builtin{bn}{\repetition{A}}{\repetition{V}}}{U}\)}
     \end{prooftree}
 

--- a/plutus-core-spec/figures/TermReduction.tex
+++ b/plutus-core-spec/figures/TermReduction.tex
@@ -57,8 +57,8 @@
     \begin{prooftree}
         \AxiomC{\(\step{M}{M'}\)}
         \AxiomC{\(M' = \error{B}\)}
-        \RightLabel{\footnotesize\textit{($A$ is the type of the frame, $B$ is the type of its hole)}}
-        \BinaryInfC{\(\step{\ctxsubst{f}{M}}{\error{A}}\)}
+        \AxiomC{\(\ctxsubst{f}{M} : A\)}
+        \TrinaryInfC{\(\step{\ctxsubst{f}{M}}{\error{A}}\)}
     \end{prooftree}
 
     \begin{prooftree}

--- a/plutus-core-spec/figures/TypeSynthesis-Algorithmic-Restricted.tex
+++ b/plutus-core-spec/figures/TypeSynthesis-Algorithmic-Restricted.tex
@@ -12,7 +12,7 @@
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{$cn$ has constant signature $\constsig{tcn}$ in Figure \ref{fig:constants}}
+        \AxiomC{$cn$ has constant signature $\constsig{tcn}$ in \cref{fig:constants}}
         \RightLabel{con}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{cn}{\conT{tcn}}}\)}
     \end{prooftree}
@@ -74,7 +74,7 @@
 \ContinuedFloat
     \begin{prooftree}
         \alwaysNoLine
-        \AxiomC{$bn$ has signature $\sig{\alpha_0 :: K_0, ..., \alpha_m :: K_m}{B_0, ..., B_n}{C}$ in Figure \ref{fig:builtins}}
+        \AxiomC{$bn$ has signature $\sig{\alpha_0 :: K_0, ..., \alpha_m :: K_m}{B_0, ..., B_n}{C}$ in \cref{fig:builtins}}
         \UnaryInfC{\(\diffbox{\typeBoundedMultistep{\textit{MAX}}{\subst{S_0, ..., S_m}{\alpha_0, ..., \alpha_m}{B_i}}{T_i}}\)}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{M_i}{T'_i}}\)}
         \UnaryInfC{\(\typeEqual{T_i}{T'_i}\)}

--- a/plutus-core-spec/figures/TypeSynthesis-Algorithmic-Unrestricted.tex
+++ b/plutus-core-spec/figures/TypeSynthesis-Algorithmic-Unrestricted.tex
@@ -24,7 +24,7 @@
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{$cn$ has constant signature $\constsig{tcn}$ in Figure \ref{fig:constants}}
+        \AxiomC{$cn$ has constant signature $\constsig{tcn}$ in \cref{fig:constants}}
         \RightLabel{con}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{cn}{\conT{tcn}}}\)}
     \end{prooftree}
@@ -87,7 +87,7 @@
   \ContinuedFloat
     \begin{prooftree}
         \alwaysNoLine
-        \AxiomC{$bn$ has signature $\sig{\alpha_0 :: K_0, ..., \alpha_m :: K_m}{B_0, ..., B_n}{C}$ in Figure \ref{fig:builtins}}
+        \AxiomC{$bn$ has signature $\sig{\alpha_0 :: K_0, ..., \alpha_m :: K_m}{B_0, ..., B_n}{C}$ in \cref{fig:builtins}}
         \UnaryInfC{\(\diffbox{\typeMultistep{\subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{B_i}}{T_i}}\)}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{M_i}{\diffbox{T'_i}}}\)}
         \UnaryInfC{\(\diffbox{\typeEqual{T_i}{T'_i}}\)}

--- a/plutus-core-spec/figures/TypeSynthesis.tex
+++ b/plutus-core-spec/figures/TypeSynthesis.tex
@@ -121,7 +121,7 @@
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{$tcn$ is a type constant in in Figure \ref{fig:type_constants}}
+        \AxiomC{$tcn$ is a type constant in in \cref{fig:type_constants}}
         \AxiomC{\(\hypJ{\Gamma}{\istypeJ{A}{\sizeK{}}}\)}
         \RightLabel{tycon}
         \BinaryInfC{\(\hypJ{\Gamma}{\istypeJ{\conT{tcn}{A}}{\typeK{}}}\)}
@@ -146,7 +146,7 @@
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{$cn$ has constant signature $\constsig{tcn}{s}$ in Figure \ref{fig:constants}}
+        \AxiomC{$cn$ has constant signature $\constsig{tcn}{s}$ in \cref{fig:constants}}
         \RightLabel{con}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{cn}{\conT{tcn}{s}}}\)}
     \end{prooftree}
@@ -202,7 +202,7 @@
 
     \begin{prooftree}
         \alwaysNoLine
-        \AxiomC{$bn$ has signature $\sig{\alpha_0 :: K_0, ..., \alpha_m :: K_m}{B_0, ..., B_n}{C}$ in Figure \ref{fig:builtins}}
+        \AxiomC{$bn$ has signature $\sig{\alpha_0 :: K_0, ..., \alpha_m :: K_m}{B_0, ..., B_n}{C}$ in \cref{fig:builtins}}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{M_i}{D_i}}\)}
         \UnaryInfC{\(\typeEquiv{D_i}{\subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{B_i}}\)}
         \alwaysSingleLine
@@ -215,7 +215,7 @@
         \RightLabel{error}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\error{A}}{A}}\)}
     \end{prooftree}
-    
+
     \begin{prooftree}
     	\AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{A}}\)}
 		\AxiomC{\(\typeEquiv{A}{A'}\)}

--- a/plutus-core-spec/figures/ValidatorExample.tex
+++ b/plutus-core-spec/figures/ValidatorExample.tex
@@ -48,24 +48,21 @@ and similarly
 \begin{lstlisting}
   |\case| : (all $a$ (type)
           (fun |\boolean|
-          (fun (fun |\unit| $a$) (fun (fun |\unit| $a$) $a$))))
+          (fun $a$ (fun $a$ $a$))))
   |\case| = (abs $a$ (type)
           (lam $b$ |\boolean|
-          (lam $t$ (fun |\unit| $a$)
-          (lam $f$ (fun |\unit| $a$)
-             [
-               [ {$b$ (fun |\unit| $a$)} $t$ $f$ ]
-               |\one|
-             ]
+          (lam $t$ $a$
+          (lam $f$ $a$
+            [ {$b$ $a$} $t$ $f$ ]
           ))))
 \end{lstlisting}
 The reader is encouraged to verify that
 \begin{lstlisting}
-  [{|\case| a} |\true| (lam |\unit| u x) (lam |\unit| u y)] $\stackrel{*}{\rightarrow}$ x
+  [{|\case| a} |\true| x y ] $\stackrel{*}{\rightarrow}$ x
 \end{lstlisting}
 and
 \begin{lstlisting}
-  [{|\case| a} |\false| (lam |\unit| u x) (lam |\unit| u y)] $\stackrel{*}{\rightarrow}$ y
+  [{|\case| a} |\false| x y ] $\stackrel{*}{\rightarrow}$ y
 \end{lstlisting}
 
 \noindent We can use \case{} to define the following function:
@@ -75,21 +72,27 @@ and
   verifyIdentity =
     (lam |\pubkey| (con bytestring)
     (lam |\signed| (con bytestring)
-  [ { |\case| |\unit| } [ (builtin verifySignature) |\signed| |\txhash| |\pubkey| ]
-        (lam u |\unit| |\one|)
-        (lam u |\unit| (error |\unit|))
-      ]))
+  [
+    { |\case| (fun |\unit| |\unit|) }
+    [ (builtin verifySignature) |\signed| |\txhash| |\pubkey| ]
+    (lam u |\unit| |\one|)
+    (lam u |\unit| (error |\unit|))
+    |\one|
+  ]))
 \end{lstlisting}
-the idea being that the first argument is a public key, and the second
+ Note that although we are producing a value of
+type \unit{} we instantiate \case{} at the type \texttt{(fun \unit \unit)} and
+pass the branches as functions from \unit{}. This
+is because Plutus Core is eagerly evaluated, so if we did not ``delay'' the
+branches of the case in this way, then the \texttt{(error)} in the second branch
+would be evaluated unconditionally, which is not what we want. This way the
+branch of the case is selected first, and then the body of the branch is
+evaluated.
+
+The idea is that first argument of \texttt{verifyIdentity} is a public key, and the second
 argument is the result of signing the hash of the current transaction
 (contained in $\mathit{txhash} : \texttt{(con bytestring)}$) with
-the corresponding private key\footnote{In practice $\mathit{txhash}$
-  is contained in a data structure supplied as an extra parameter to
-  the validator script at the start of the validation process.  The
-  Plutus Core code required to access $\mathit{txhash}$ is a (rather
-  complicated) implementation detail: we omit it here, regarding
-  $\mathit{txhash}$ as a value contained in some enclosing
-  environment.}.  The function terminates normally if and only if the
+the corresponding private key. The function terminates normally if and only if the
 signature is valid, returning \texttt{error} otherwise. Now, given
 Alice's public key we can apply our function to obtain one that
 verifies whether or not its input is the result of Alice signing the
@@ -97,26 +100,7 @@ current block number. Again, we stress that the Plutus Core expression
 corresponding to \texttt{verifyIdentity} is going to look something
 like \cref{fig:Continuized_Let_Example}.
 
-% The next bit no longer makes a lot of sense because
-
-%% With minimal modification we might turn our function into one that
-%% verifies a signature of the current block number; specifically, we
-%% could replace \txhash{} with
-%% \begin{lstlisting}
-%%   [ {intToByteString (con 16) (con 32)}
-%%     256
-%%     [{|\blocknum| (con 16)} 16]
-%%   ]
-%% \end{lstlisting}
-
-%% Notice that we must supply \blocknum{} with the size we wish to use to
-%% store the result twice, once at the type level and again at the term
-%% level. This is necessary because we want to have the size information
-%% available both at the type level, to facilitate gas calculations, and
-%% at the term level, so that once types are erased the runtime will know
-%% how much memory to allocate. This quirk is present in a number of the
-%% built in functions.
-
+\todompj{This is out of date. Not sure how useful it is.}
 \begin{figure*}[h]  % Using H here causes undefined references to this figure
 \begin{lstlisting}
 (lam |\pubkey| (con bytestring)

--- a/plutus-core-spec/figures/ValidatorExample.tex
+++ b/plutus-core-spec/figures/ValidatorExample.tex
@@ -10,13 +10,13 @@ for instance, we write
    |\one| : |\unit|
    |\one| = (abs $a$ (type) (lam $x$ $a$ $x$))
 \end{lstlisting}
-for the element of the type $unit$ (defined Figure~\ref{fig:type_abbreviations}).
+for the element of the type $unit$ (defined \cref{fig:type_abbreviations}).
 
 We stress that declarations in this style are not part of the Plutus
 Core language. We merely use the familiar syntax to present our
 example. If the high-level definitions in our example were compiled to
-a Plutus Core expression, it would result in something like Figure
-\ref{fig:Continuized_Let_Example}.
+a Plutus Core expression, it would result in something like
+\cref{fig:Continuized_Let_Example}.
 
 We proceed by defining the booleans. Like \textit{unit}, the type \textit{boolean}
 below is an abbreviation in the specification. Some built-in constants
@@ -95,9 +95,9 @@ Alice's public key we can apply our function to obtain one that
 verifies whether or not its input is the result of Alice signing the
 current block number. Again, we stress that the Plutus Core expression
 corresponding to \texttt{verifyIdentity} is going to look something
-like Figure \ref{fig:Continuized_Let_Example}.
+like \cref{fig:Continuized_Let_Example}.
 
-% The next bit no longer makes a lot of sense because 
+% The next bit no longer makes a lot of sense because
 
 %% With minimal modification we might turn our function into one that
 %% verifies a signature of the current block number; specifically, we
@@ -121,7 +121,7 @@ like Figure \ref{fig:Continuized_Let_Example}.
 \begin{lstlisting}
 (lam |\pubkey| (con bytestring)
 (lam |\signed| (con bytestring)
-    [ 
+    [
     {
         (abs $a$ (type)
         (lam $b$ (all $a$ (type) (fun $a$ (fun $a$ $a$)))
@@ -153,4 +153,3 @@ like Figure \ref{fig:Continuized_Let_Example}.
 \end{figure*}
 
 \end{document}
-

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -226,8 +226,8 @@ for use as a transaction validation language in blockchain
 systems. More precisely, Plutus Core is the system $F_\omega$ of
 Girard and Reynolds (see \citep{Girard-thesis},
 \citep{Reynolds-type-structure}, \citep[\S30]{Pierce:TAPL}) with a
-number of extensions (isorecursive types, higher kinds, and a library
-of basic types and functions).  Plutus Core is meant to be a
+number of extensions (isorecursive types, higher kinds, and additional
+builtin types and functions).  Plutus Core is meant to be a
 compilation target, and this is reflected in the design of the
 language: while writing large Plutus Core programs by hand is
 difficult, the language is relatively straightforward to formalise
@@ -244,14 +244,12 @@ to allow us to use standard combinators (for example the $Z$
 combinator and Church/Scott encoded booleans) for such purposes.
 
 
-\subsection{Blockchain issues}
-Plutus Core code (and code intended for execution on a blockchain in
-general) can be executed in two different environments:
-\textit{off-chain} and \textit{on-chain}.  As the name suggests,
-off-chain execution doesn't happen on the blockchain itself, but in
-some other environment, such as in an electronic wallet on a
-smartphone or PC.  In contrast, on-chain execution takes place on
-\textit{core nodes}, machines which are actually maintaining the
+\subsection{Running code on the blockchain}
+
+Plutus Core code is intended to be executed ``on'' a blockchain.
+This means that it is executed as part of a distributed block validation
+process, with the actual computation happening on
+\emph{core nodes}, machines which are actually maintaining the
 blockchain.
 
 It is important that core nodes process transactions quickly and
@@ -260,7 +258,7 @@ and compete with each other to do so.  Denial of service thus becomes
 an issue for on-chain code, and it is important that a malicious user
 cannot submit code which consumes excessive amounts of processor time
 or memory. To deal with this problem, a charge is levied when a core
-node runs on-chain code.  Units of so-called \textit{gas} are consumed
+node runs on-chain code.  Units of so-called \emph{gas} are consumed
 as a program runs, and users must pay a fee in advance to cover gas
 costs.  If at any point during execution the amount of gas consumed
 exceeds the amount than has been paid for then the program is
@@ -271,14 +269,6 @@ and verification.  We perform type checking prior to execution of
 Plutus Core Code, but no other validation.  Type checking itself takes
 time and requires memory, so there is also a gas charge for on-chain
 type checking.
-
-%% Because of these issues, it is important that the cost of on-chain
-%% code execution is easy to calculate, certainly during execution (so
-%% that gas consumption can be accounted for), but ideally also in
-%% advance so that a user has some idea of how much a contract is likely
-%% to cost and can make sure that they buy enough gas to allow their
-%% contract to run to completion.  The design of Plutus Core incorporates
-%% a number of features to facilitate cost analysis for this purpose.
 
 
 \section{Syntax}
@@ -316,11 +306,16 @@ For instance,
 All subsequent definitions assume iterated application and instantiation
 has been expanded out, and use only the binary form. Implementations
 may use the multi-argument forms.
+\todompj{We only use this in the examples, should we drop it?}
 
 
 \subfile{figures/LexicalGrammar}
 
 \subfile{figures/Grammar}
+
+\todompj{The syntax for builtins is ambiguous: we can't tell where the list of
+  types ends. There are a number of forms that could be either depending on
+  context, e.g. variables!}
 
 \newcommand\fixtype[1]{\mu\,\alpha.#1}  % Just for talking about the fix operator in the notes.
 

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -50,7 +50,8 @@
   escapeinside={|}{|}   %% Inside listings you can say things like |\textit{blah blah}|
 }
 
-
+\usepackage{hyperref}
+\usepackage{cleveref}
 
 
 % *** DEFINITIONS FOR PLUTUS LANGUAGE ***
@@ -274,8 +275,7 @@ type checking.
 \section{Syntax}
 
 The grammar of Plutus Core is given in
-Figures~\ref{fig:lexical_grammar} and
-\ref{fig:grammar}. This grammar describes the abstract
+\cref{fig:lexical_grammar,fig:grammar}. This grammar describes the abstract
 syntax trees of Plutus Core in a convenient notation which can also be
 used as concrete syntax for purposes such as experimentation and
 debugging.
@@ -324,7 +324,7 @@ may use the multi-argument forms.
 \begin{itemize}
 \item $\con{cn}$ represents a constant belonging to some built-in
   type: for example \texttt{(con 4)} is an integer with the value 127.
-  See Section~\ref{sec:builtins} for more on this.
+  See \cref{sec:builtins} for more on this.
 \item $\abs{\alpha}{K}{V}$ represents a polymorphic value abstracted
   over a type; this would often be donated by $\Lambda\alpha{::}K.V$.
   Note that we require the body of the abstraction to be a
@@ -333,7 +333,7 @@ may use the multi-argument forms.
 \item $\iwrap{A}{B}{M}$ and $\unwrap{M}$: see the note on recursive types below.
 \item $\lam{x}{A}{M}$ is standard lambda-abstraction, $\lambda{}x{:}{A}.{M}$.
 \item $\app{M}{N}$ is standard function application.
-\item $\builtin{bn}{A^*}{M^*}$ is application of a built-in function: see Section~\ref{sec:builtins} for more information.
+\item $\builtin{bn}{A^*}{M^*}$ is application of a built-in function: see \cref{sec:builtins} for more information.
 \item $\error{A}$ causes an error, terminating computation immediately.
 \end{itemize}
 
@@ -357,11 +357,11 @@ may use the multi-argument forms.
 \begin{itemize}
 \item $\funT{A}{B}$ is the type of functions from $A$ to $B$, $A \rightarrow B$.
 \item $\allT{\alpha}{K}{A}$ represents the type of a polymorphic term (eg a type abstraction), $\forall \alpha{::}K.A$.
-\item $\fixT{A}{B}$ represents a recursive type: see the note in Section~\ref{sec:ifix-note} below for more information.
+\item $\fixT{A}{B}$ represents a recursive type: see the note in \cref{sec:ifix-note} below for more information.
 \item $\lamT{\alpha}{K}{A}$ is abstraction of types over types, $\lambda \alpha{::}K.A$.
 \item $\appT{A}{B}$ is function application at the type level.
 \item $\conT{tcn}$ represents a built-in type: for example, $\conT{\textrm{integer}}$
-is the type of integers.  See Section~\ref{sec:builtins} for more information.
+is the type of integers.  See \cref{sec:builtins} for more information.
 \end{itemize}
 
 \paragraph{Type Values.} All types can be reduced to a type value (or
@@ -376,7 +376,7 @@ is the type of integers.  See Section~\ref{sec:builtins} for more information.
   opportunities for type reduction and thus have little effect on the
   proof.
 
-\paragraph{Kinds.} In Plutus Core we have a copy of the 
+\paragraph{Kinds.} In Plutus Core we have a copy of the
 simply typed lambda calculus at the type level. The types of the
 simply typed lambda calculus are lifted to the level of
 \textit{kinds} in Plutus Core, allowing the type system to talk about
@@ -394,7 +394,7 @@ Signatures are not used in the concrete syntax of Plutus Core, but we
 do use them later in this document, in typing rules and in the
 description of built-in values and functions.
 
-\paragraph{Programs and Versions.} A complete Plutus Core program 
+\paragraph{Programs and Versions.} A complete Plutus Core program
 consists of a standard version number (1.0.2, for example) indicating
 the Plutus Core version and a \textit{closed} term (i.e., a term with no
 free variables) forming the body of the program.  The version number
@@ -416,16 +416,16 @@ Plutus Core language.
 %% \subsubsection{Sizes and built-in types and functions}
 %% \label{sec:size-note}
 %% Details of built-in types and functions are given
-%% in Section~\ref{sec:builtins}, but a remark on sizes may be helpful at this
+%% in \cref{sec:builtins}, but a remark on sizes may be helpful at this
 %% point.  Plutus Core currently provides two types of built-in data with
 %% variable sizes: integers and bytestrings (blocks of binary data used
 %% for cryptographic purposes).  There is no fixed upper bound on the
 %% size of values of these types, but -- as mentioned in the introduction -- it
-%% could be problematic if users were allowed to create values of arbitrary size 
-%% at runtime. To avoid this, sizes are tracked in the type system so that 
-%% appropriate charges can be made. 
+%% could be problematic if users were allowed to create values of arbitrary size
+%% at runtime. To avoid this, sizes are tracked in the type system so that
+%% appropriate charges can be made.
 
-%% For integers, this works as follows (the system for 
+%% For integers, this works as follows (the system for
 %% bytestrings is similar).  Integers are signed values:
 %% there is no fixed upper bound, but values are represented as sequences
 %% of a specified number of 8-bit bytes.  For example, \texttt{1~!~100}
@@ -433,7 +433,7 @@ Plutus Core language.
 %% fit into the specified size: \texttt{1~!~200} gives a compile-time
 %% error. If a value overflows at runtime then an error occurs and
 %% execution is terminated.  Integers are manipulated using built-in
-%% functions (see Figure~\ref{fig:builtins}) whose types
+%% functions (see \cref{fig:builtins}) whose types
 %% include the size. This prevents users from writing programs which
 %% generate arbitrarily large values during execution; it also allows us
 %% to charge according to the actual amount of computation performed,
@@ -498,12 +498,12 @@ is required to avoid a number of problems when (implicit) type
 abstractions include non-values; other issues are explored
 in~\citep[2.4]{Ahmed:2017}. Plutus Core's restriction to values avoids
 these problems and is not very onerous in practice.
-  
+
 \section{Type Correctness}
 
 We define for Plutus Core a number of typing judgments which explain
-ways that a program can be well-formed. First, in Figure
-\ref{fig:contexts}, we define the grammar of contexts as
+ways that a program can be well-formed. First, in
+\cref{fig:contexts}, we define the grammar of contexts as
 contexts appear here for the first time. Contexts are sequences of
 variables. In System F there are two different sorts of variables:
 term variables and type variables. For succinctness of presentation we
@@ -517,11 +517,10 @@ not need a separate judgement for valid kinds. They are so simple that
 any kind that can be constructed according to the grammar is a valid
 kind.
 
-%We also consider variable judgements in Figure
-%\ref{fig:contexts}. Technically this judgement is defined
-%mutually with the typing and kinding judgement defined in Figures
-%\ref{fig:type_synthesis} and
-%\ref{fig:kind_synthesis}. We give axiomatic rules for term
+%We also consider variable judgements in
+%\cref{fig:contexts}. Technically this judgement is defined
+%mutually with the typing and kinding judgement defined in
+%\cref{fig:type_synthesis, fig:kind_synthesis}. We give axiomatic rules for term
 %and type variables at the right-hand end of the context. For term and
 %type variables defined further to the left in the context the
 %judgement is dependent on a judgement about a shorter context. These
@@ -590,7 +589,7 @@ kind.
 %
 %     \begin{prooftree}
 %        \AxiomC{\(\ctxni{\Gamma}{\termJ{x}{A}}\)}
-%        \AxiomC{\(x \not= y\)}        
+%        \AxiomC{\(x \not= y\)}
 %        \BinaryInfC{\(\ctxni{\Gamma, \termJ{y}{B}}{\termJ{x}{A}}\)}
 %    \end{prooftree}
 
@@ -600,8 +599,8 @@ kind.
     \label{fig:contexts}
 \end{figure}
 
-\newpage 
-\noindent Figure \ref{fig:kind_synthesis} defines what
+\newpage
+\noindent \cref{fig:kind_synthesis} defines what
 it means for a type to synthesise a kind. Plutus Core is a
 higher-kinded version of System F, so we have a number of standard
 System F rules (tyvar,tyall,tyfun) together with some extensions with
@@ -655,7 +654,7 @@ support integers and bytestrings.
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{$tcn$ is a type constant in in Figure \ref{fig:type_constants}}
+        \AxiomC{$tcn$ is a type constant in in \cref{fig:type_constants}}
         \RightLabel{tycon}
         \UnaryInfC{\(\hypJ{\Gamma}{\istypeJ{\conT{tcn}}{\typeK{}}}\)}
     \end{prooftree}
@@ -666,7 +665,7 @@ support integers and bytestrings.
 \end{figure}
 
 
-\noindent In Figure \ref{fig:type_synthesis}, we define the type
+\noindent In \cref{fig:type_synthesis}, we define the type
 synthesis judgment, which explains how a term synthesises a type. We
 have rules analogous to STLC (var,lam,app), extensions to System F
 (abs,inst). Higher-kinding introduces computation in types so we need
@@ -686,7 +685,7 @@ and builtins we have con, builtin and error.
     \end{prooftree}
 
     \begin{prooftree}
-        \AxiomC{$cn$ has constant signature $\constsig{tcn}$ in Figure \ref{fig:constants}}
+        \AxiomC{$cn$ has constant signature $\constsig{tcn}$ in \cref{fig:constants}}
         \RightLabel{con}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{cn}{\conT{tcn}}}\)}
     \end{prooftree}
@@ -742,7 +741,7 @@ and builtins we have con, builtin and error.
 
     \begin{prooftree}
         \alwaysNoLine
-        \AxiomC{$bn$ has signature $\sig{\alpha_0 :: K_0, ..., \alpha_m :: K_m}{B_0, ..., B_n}{C}$ in Figure \ref{fig:builtins}}
+        \AxiomC{$bn$ has signature $\sig{\alpha_0 :: K_0, ..., \alpha_m :: K_m}{B_0, ..., B_n}{C}$ in \cref{fig:builtins}}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{M_i}{D_i}}\)}
         \UnaryInfC{\(\typeEquiv{D_i}{\subst{A_0, ..., A_m}{\alpha_0, ..., \alpha_m}{B_i}}\)}
         \alwaysSingleLine
@@ -755,7 +754,7 @@ and builtins we have con, builtin and error.
         \RightLabel{error}
         \UnaryInfC{\(\hypJ{\Gamma}{\istermJ{\error{A}}{A}}\)}
     \end{prooftree}
-    
+
     \begin{prooftree}
     	\AxiomC{\(\hypJ{\Gamma}{\istermJ{M}{A}}\)}
 		\AxiomC{\(\typeEquiv{A}{A'}\)}
@@ -769,8 +768,8 @@ and builtins we have con, builtin and error.
 \end{figure}
 
 \noindent Finally, type synthesis for builtins are elaborated in tabular form
-rather than in inference rule form, in Figure
-\ref{fig:builtins}, which also gives the reduction
+rather than in inference rule form, in
+\cref{fig:builtins}, which also gives the reduction
 semantics. This table also specifies what conditions trigger an error.
 
 
@@ -781,12 +780,12 @@ In this section we define a standard eager,
 small-step contextual semantics~\citep[5.3]{Harper:PFPL} (or
 \textit{reduction semantics}~\citep[\S2]{Felleisen-Hieb}) for Plutus
 Core in terms of the reduction relation for types
-(\(\typeStep{A}{A'}\)) (Figure~\ref{fig:type-reduction}) 
-and terms (\(\step{M}{M'}\)) (Figure~\ref{fig:term-reduction}), which
+(\(\typeStep{A}{A'}\)) (\cref{fig:type-reduction})
+and terms (\(\step{M}{M'}\)) (\cref{fig:term-reduction}), which
 incorporates both $\beta$ reduction and contextual congruence. We make
 use of the transitive closure of these stepping relations via the
 usual Kleene star notation.
-% It seems that Harper talks about "contextual semactics" in the 
+% It seems that Harper talks about "contextual semactics" in the
 % first edition of his book, but changed it to "contextual dymanics"
 % in the second.  It doesn't seem to be a standard term elsewhere though.
 
@@ -811,8 +810,8 @@ given type into an equivalent type, and so have no effect on the term
 level.  In conjunction with the fact that type reduction always
 terminates, this allows us to perform normalisation (i.e., reduction to
 a form which cannot undergo any further reduction) statically, before
-execution begins.  Figure~\ref{fig:type-reduction} contains the rules
-for type reduction, and Figure~\ref{fig:type-equivalence} contains
+execution begins.  \Cref{fig:type-reduction} contains the rules
+for type reduction, and \cref{fig:type-equivalence} contains
 rules for type equivalence.
 
 \subfile{figures/TypeReduction}
@@ -822,15 +821,15 @@ rules for type equivalence.
 \subsection{Term reduction}
 Execution of Plutus Core programs is performed by (possibly
 non-terminating) reduction of well-typed terms.  The reduction rules
-are contained in Figure~\ref{fig:term-reduction}, and give us a fairly
-standard operational semantics.  
+are contained in \cref{fig:term-reduction}, and give us a fairly
+standard operational semantics.
 
 \subfile{figures/TermReduction}
 
 \subsection{An abstract machine for evaluating Plutus Core programs}
 This section contains a description of an abstract machine for
 executing Plutus Core.  This is based on the CK machine of Felleisen
-and Friedman~\citep{Felleisen-CK-CEK}. 
+and Friedman~\citep{Felleisen-CK-CEK}.
 
 This machine is intended as a reference implementation which is
 amenable to formalisation, ideally so that it can be proved to
@@ -850,7 +849,7 @@ purposes.
 \noindent The machine alternates between two main phases: the
 \textit{compute} phase ($\triangleright$), where it recurses down
 the AST looking for values, saving surrounding contexts as frames (or
-\textit{reduction contexts}) on a stack as it goes; and the 
+\textit{reduction contexts}) on a stack as it goes; and the
 \textit{return} phase ($\triangleleft$), where it has obtained a value and
 pops a frame off the stack to tell it how to proceed next.  In
 addition there is an error state $\blacklozenge$ which halts execution
@@ -860,7 +859,7 @@ returns a value to the outside world.
 To evaluate a program $\texttt{(program } v\ M \texttt{)}$, we first
 check that the version number $v$ is valid, then start the machine in
 the state $\cdot \triangleright M$.  It can be proved that the
-transitions in Figure~\ref{fig:ck_machine} always preserve
+transitions in \cref{fig:ck_machine} always preserve
 validity of states, so that the machine can never enter a state such as
   $\cdot \triangleleft M$
 or
@@ -881,21 +880,21 @@ to allow customisation for specialised blockchains.
 
 As mentioned earlier, there are two basic types: \texttt{integer} and
 \texttt{bytestring}.  These types are given in
-Figure~\ref{fig:type_constants}: for example \texttt{(con
+\cref{fig:type_constants}: for example \texttt{(con
   integer)} is the type of signed integers.
 We provide standard arithmetic and comparison operations for integers
 and a number of list-like functions for bytestrings. The details are
-given in Figure~\ref{fig:builtins}, using a number of
-abbreviations given in Figure~\ref{fig:type_abbreviations}.
+given in \cref{fig:builtins}, using a number of
+abbreviations given in \cref{fig:type_abbreviations}.
 
 
 Note the following:
 \begin{itemize}
-\item The built-in functions in Figure~\ref{fig:builtins}
-are all monomorphic, and hence the type arguments are all empty: []. 
+\item The built-in functions in \cref{fig:builtins}
+are all monomorphic, and hence the type arguments are all empty: [].
 It is possible that we may add some polymorphic built-in functions
 at some time in the future.
-\item Some of the entries in Figure~\ref{fig:builtins}
+\item Some of the entries in \cref{fig:builtins}
   contain \textit{success conditions}.  If a success condition is
   violated then the program terminates immediately and returns
   the value \texttt{(error)}.
@@ -913,7 +912,7 @@ at some time in the future.
   computation we'd probably have $d>0$, but it's worth being careful.}:
 
   \begin{itemize}
-  
+
   \item \texttt{divideInteger} and \texttt{modInteger} implement the
     standard mathematical integer division
     operations: \texttt{divideInteger} rounds downwards and the sign
@@ -928,7 +927,7 @@ at some time in the future.
     $n$.  These correspond to Haskell's \texttt{rem} and \texttt{quot}
     operators.  \end{itemize}
 
-  
+
 \item We use fixed Scott encodings for certain types and values, specifically for
   the \textit{unit} and \textit{boolean} types.  Compilers targeting
   Plutus Core must be aware of these encodings and use them
@@ -1016,8 +1015,7 @@ For implementation purposes it is useful to have a variant of the type
 system that is more algorithmic in its presentation. We give this
 here, showing the figures that have been changed (relative to the
 declarative version above), and highlighting the specific parts of
-each rule that is different, where possible (Figures~\ref{fig:contexts_algorithmic_unrestricted}
-and~\ref{fig:type_synthesis_algorithmic_unrestricted}) .
+each rule that is different, where possible (\cref{fig:contexts_algorithmic_unrestricted,fig:type_synthesis_algorithmic_unrestricted}) .
 
 \subfile{figures/TypeSynthesis-Algorithmic-Unrestricted.tex}
 
@@ -1032,7 +1030,7 @@ typecheck a program. It's also useful to have a way of bounding the
 amount of computation that can be done in type checking, for security
 purposes. To that end, we present a restricted grammar and type
 reduction, and a type system that reflects these.
-Figures~\ref{fig:grammar_algorithmic_restricted}--\ref{fig:type_synthesis_algorithmic_restricted}
+\Cref{fig:grammar_algorithmic_restricted, fig:type_synthesis_algorithmic_restricted}
 are additions with respect to the unrestricted version, and show only
 the new or changed figures and their respective highlighted
 differences.

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -438,7 +438,7 @@ mutually recursive data types.
   on than with standard \texttt{fix}.  With luck we'll soon have a publication
   to refer to.}
 
-Note that we have an \emph{isomporhism} of types here rather than
+Note that we have an \emph{isomorphism} of types here rather than
 equality: fixpoint types are
 \emph{isorecursive}~\citep[20.2]{Pierce:TAPL} with explicit maps
 
@@ -449,7 +449,7 @@ $$
 \noindent and
 
 $$
-\texttt{unwrap} : \texttt{ifix A B} \rightarrow  \texttt{A (ifix A) B}
+\texttt{unwrap} : \texttt{ifix A B} \rightarrow \texttt{A (ifix A) B}
 $$
 
 \noindent such that
@@ -479,35 +479,32 @@ abstractions include non-values; other issues are explored
 in~\citep[2.4]{Ahmed:2017}. Plutus Core's restriction to values avoids
 these problems and is not very onerous in practice.
 
+\todompj{Is it definitely a \emph{generalization} of the ML case? Shame there
+  isn't a better cite about why we do this.}
+
+\todompj{Include something about erasure: the fact that it lets us soundly erase
+  an abstraction to its body is important.}
+
 \section{Type Correctness}
 
 We define for Plutus Core a number of typing judgments which explain
-ways that a program can be well-formed. First, in
-\cref{fig:contexts}, we define the grammar of contexts as
-contexts appear here for the first time. Contexts are sequences of
+ways that a program can be well-formed.
+
+First, in \cref{fig:contexts}, we define the grammar of contexts, which
+appear here for the first time. Contexts are sequences of
 variables. In System F there are two different sorts of variables:
 term variables and type variables. For succinctness of presentation we
 keep information about both sorts of variables in the same
 context. Type variables carry their name and a kind and term variables
 carry their name and a type. The rules for context validity explain
-how valid contexts can be constructed, the empty context is valid,
+how valid contexts can be constructed: the empty context is valid;
 given valid context $\Gamma$, it can be extended with a fresh variable
-and kind or a fresh variable and a valid type in $\Gamma$. Note we do
-not need a separate judgement for valid kinds. They are so simple that
+and kind or a fresh variable and a valid type in $\Gamma$.
+
+Note that we do not need a separate judgement for kind validity.
+Our kinds are so simple that
 any kind that can be constructed according to the grammar is a valid
 kind.
-
-%We also consider variable judgements in
-%\cref{fig:contexts}. Technically this judgement is defined
-%mutually with the typing and kinding judgement defined in
-%\cref{fig:type_synthesis, fig:kind_synthesis}. We give axiomatic rules for term
-%and type variables at the right-hand end of the context. For term and
-%type variables defined further to the left in the context the
-%judgement is dependent on a judgement about a shorter context. These
-%two styles of rules for all combinations of term and type variables
-%allow us to give judgements for variables in all positions in the
-%context. This style of presentation is analogous to how one might
-%define instrinsically typed/kinded de Bruijn indices.
 
 %% ---------------- Contexts ---------------- %%
 
@@ -585,8 +582,7 @@ it means for a type to synthesise a kind. Plutus Core is a
 higher-kinded version of System F, so we have a number of standard
 System F rules (tyvar,tyall,tyfun) together with some extensions with
 extensions to higher kinds (tylam,tyapp) and to indexed
-recursive types (tyfix). We also introduce builtin types (tycon) to
-support integers and bytestrings.
+recursive types (tyfix). We also have the tycon rule to support builtin types.
 
 %% ---------------- Kind synthesis ---------------- %%
 
@@ -647,11 +643,13 @@ support integers and bytestrings.
 
 \noindent In \cref{fig:type_synthesis}, we define the type
 synthesis judgment, which explains how a term synthesises a type. We
-have rules analogous to STLC (var,lam,app), extensions to System F
-(abs,inst). Higher-kinding introduces computation in types so we need
+have rules analogous to those for the simply typed lambda calculus (var,lam,app),
+and System F (abs,inst). Higher kinds lead to computation in types, so we need
 the rule conv. Iso-recursive types introduce terms for wrapping and
 unwrapping recursive values (wrap,unwrap), and to support constants
 and builtins we have con, builtin and error.
+
+Type synthesis relies on type equivalence as defined in \cref{fig:type-equivalence}.
 
 %% ---------------- Type synthesis ---------------- %%
 
@@ -748,10 +746,7 @@ and builtins we have con, builtin and error.
 \end{figure}
 
 \noindent Finally, type synthesis for builtins are elaborated in tabular form
-rather than in inference rule form, in
-\cref{fig:builtins}, which also gives the reduction
-semantics. This table also specifies what conditions trigger an error.
-
+rather than in inference rule form, in \cref{fig:builtins}.
 
 \section{Reduction and Execution}
 \label{sec:reduction}
@@ -780,7 +775,12 @@ have. In this setting, we would pick some upper bound $\mathit{max}$
 and then perform steps of terms $M$ by computing which $M'$ is such
 that \(\multistepIndexed{M}{\mathit{max}}{M'}\).
 
-
+A version of the typesystem
+which incorporates such an upper bound on computation can be found in
+\cref{sec:algorithmic-restricted}.
+\todompj{What about bounded term reduction? We go as far as having a figure for
+  type reduction, why not for term reduction? Maybe put both in a section at the
+  end of the reduction section and then reference from the appendix?}
 
 \subsection{Type reduction}
 Because the Plutus Core type system contains a copy of the simply
@@ -791,8 +791,8 @@ level.  In conjunction with the fact that type reduction always
 terminates, this allows us to perform normalisation (i.e., reduction to
 a form which cannot undergo any further reduction) statically, before
 execution begins.  \Cref{fig:type-reduction} contains the rules
-for type reduction, and \cref{fig:type-equivalence} contains
-rules for type equivalence.
+for type reduction, giving a standard contextual semantics; and
+\cref{fig:type-equivalence} contains rules for type equivalence.
 
 \subfile{figures/TypeReduction}
 
@@ -801,8 +801,8 @@ rules for type equivalence.
 \subsection{Term reduction}
 Execution of Plutus Core programs is performed by (possibly
 non-terminating) reduction of well-typed terms.  The reduction rules
-are contained in \cref{fig:term-reduction}, and give us a fairly
-standard operational semantics.
+are contained in \cref{fig:term-reduction}, and give us a
+standard contextual semantics.
 
 \subfile{figures/TermReduction}
 
@@ -990,6 +990,7 @@ section.
 
 \begin{appendices}
 \section{Unrestricted Algorithmic Type System}
+\label{sec:algorithmic}
 
 For implementation purposes it is useful to have a variant of the type
 system that is more algorithmic in its presentation. We give this
@@ -1002,6 +1003,7 @@ each rule that is different, where possible (\cref{fig:contexts_algorithmic_unre
 \newpage
 
 \section{Restricted Algorithmic Type System}
+\label{sec:restricted-algorithmic}
 
 For blockchain purposes, it is useful to not only have an algorithmic
 system, but to require that no un-normalised types are present in

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -1010,7 +1010,7 @@ each rule that is different, where possible (\cref{fig:contexts_algorithmic_unre
 \newpage
 
 \section{Restricted Algorithmic Type System}
-\label{sec:restricted-algorithmic}
+\label{sec:algorithmic-restricted}
 
 For blockchain purposes, it is useful to not only have an algorithmic
 system, but to require that no non-normalised types are present in

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -329,7 +329,7 @@ may use the multi-argument forms.
 \item $\abs{\alpha}{K}{V}$ represents a polymorphic value abstracted
   over a type; this would often be donated by $\Lambda\alpha{::}K.V$.
   Note that we require the body of the abstraction to be a
-  \textit{value}, not a term: see the note on the value restriction below.
+  \emph{value}, not a term: see the note on the value restriction below.
 \item $\inst{M}{A}$ represents a polymorphic term instantiated at a particular type.
 \item $\iwrap{A}{B}{M}$ and $\unwrap{M}$: see \cref{sec:ifix-note}.
 \item $\lam{x}{A}{M}$ is standard lambda-abstraction, $\lambda{}x{:}{A}.{M}$.
@@ -366,7 +366,7 @@ is the type of integers.  See \cref{sec:builtins}.
 \end{itemize}
 
 \paragraph{Type Values.} All types can be reduced to a type value (or
-  \textit{normalised type}) which cannot undergo any further
+  \emph{normalised type}) which cannot undergo any further
   reduction: see section~\ref{sec:reduction}.  The type normalisation
   process always terminates: the proof is similar to the proof of the
   fact that reduction of terms in the simply typed lambda calculus
@@ -380,7 +380,7 @@ is the type of integers.  See \cref{sec:builtins}.
 \paragraph{Kinds.} In Plutus Core we have a copy of the
 simply typed lambda calculus at the type level. The types of the
 simply typed lambda calculus are lifted to the level of
-\textit{kinds} in Plutus Core, allowing the type system to talk about
+\emph{kinds} in Plutus Core, allowing the type system to talk about
 operations which themselves occur at the level of types.
 The basic kind (usually written as $\star$) is denoted by \texttt{(type)}.
 
@@ -397,7 +397,7 @@ description of built-in values and functions.
 
 \paragraph{Programs and Versions.} A complete Plutus Core program
 consists of a standard version number (1.0.2, for example) indicating
-the Plutus Core version and a \textit{closed} term (i.e., a term with no
+the Plutus Core version and a \emph{closed} term (i.e., a term with no
 free variables) forming the body of the program.  The version number
 is used by the Plutus Core evaluator and other tools to check that
 they are dealing with code conforming to the correct version of the
@@ -462,14 +462,14 @@ $$
 %% I really hate not having a full stop after the second equation, but it looks weird.
 
 \noindent The use of isorecursive types makes it somewhat more difficult to
-write \textit{terms}, but makes it much easier to reason about
-\textit{types}, and in particular simplifies the typechecking process
+write \emph{terms}, but makes it much easier to reason about
+\emph{types}, and in particular simplifies the typechecking process
 considerably.
 
 
 \subsubsection{The value restriction}
 In $\abs{\alpha}{K}{V}$ we require the body $V$ to be a value. We will
-refer to this restriction as the \textit{value restriction} because it
+refer to this restriction as the \emph{value restriction} because it
 can be regarded as a generalisation of the value restriction in
 Standard ML \citep[22.7]{Pierce:TAPL}. Experience has shown that
 allowing general terms as bodies of type abstractions can cause a
@@ -758,7 +758,7 @@ semantics. This table also specifies what conditions trigger an error.
 
 In this section we define a standard eager,
 small-step contextual semantics~\citep[5.3]{Harper:PFPL} (or
-\textit{reduction semantics}~\citep[\S2]{Felleisen-Hieb}) for Plutus
+\emph{reduction semantics}~\citep[\S2]{Felleisen-Hieb}) for Plutus
 Core in terms of the reduction relation for types
 (\(\typeStep{A}{A'}\)) (\cref{fig:type-reduction})
 and terms (\(\step{M}{M'}\)) (\cref{fig:term-reduction}), which
@@ -827,10 +827,10 @@ purposes.
 \subfile{figures/CkMachine}
 
 \noindent The machine alternates between two main phases: the
-\textit{compute} phase ($\triangleright$), where it recurses down
+\emph{compute} phase ($\triangleright$), where it recurses down
 the AST looking for values, saving surrounding contexts as frames (or
-\textit{reduction contexts}) on a stack as it goes; and the
-\textit{return} phase ($\triangleleft$), where it has obtained a value and
+\emph{reduction contexts}) on a stack as it goes; and the
+\emph{return} phase ($\triangleleft$), where it has obtained a value and
 pops a frame off the stack to tell it how to proceed next.  In
 addition there is an error state $\blacklozenge$ which halts execution
 with an error, and a stop state $\square$ which halts execution and
@@ -875,17 +875,17 @@ are all monomorphic, and hence the type arguments are all empty: [].
 It is possible that we may add some polymorphic built-in functions
 at some time in the future.
 \item Some of the entries in \cref{fig:builtins}
-  contain \textit{success conditions}.  If a success condition is
+  contain \emph{success conditions}.  If a success condition is
   violated then the program terminates immediately and returns
   the value \texttt{(error)}.
 \item We provide two versions of the division and remainder operations
   for integers.  These differ in their treatment of negative
   arguments\footnote{The standard mathematical definition (the
-    so-called \textit{division algorithm}, or \textit{Euclidean
+    so-called \emph{division algorithm}, or \emph{Euclidean
       division}) is as follows: if $n,d \in \mathbb{Z}$ and $d \ne 0$
     then there exist unique integers $q, r \in \mathbb{Z}$ such that
     $n=qb+r$ and $0 \le r < \lvert d \rvert$; $q$ is the
-    \textit{quotient} and $r$ is the \textit{remainder}.  Neither of
+    \emph{quotient} and $r$ is the \emph{remainder}.  Neither of
     our sets of operations implements this definition! For $d > 0$,
     \texttt{divideInteger} and \texttt{modInteger} give the correct
     results, but they can give negative remainders for $d<0$.  In any sensible
@@ -909,7 +909,7 @@ at some time in the future.
 
 
 \item We use fixed Scott encodings for certain types and values, specifically for
-  the \textit{unit} and \textit{boolean} types.  Compilers targeting
+  the \emph{unit} and \emph{boolean} types.  Compilers targeting
   Plutus Core must be aware of these encodings and use them
   appropriately.
 \end{itemize}
@@ -922,7 +922,7 @@ transactions taking place on the chain.  This section will give a
 brief description of the background which will be useful in a
 subsequent example.
 
-The Cardano blockchain uses a variant of Bitcoin's \textit{Unspent
+The Cardano blockchain uses a variant of Bitcoin's \emph{Unspent
   Transaction Output} (UTXO) model.  Transactions on the chain consume
 inputs and produce outputs consisting of cryptocurrency, and outputs
 from a transaction can be spent as inputs to a later transaction.
@@ -939,24 +939,24 @@ a particular output, or an output might not be spendable until a
 certain period of time has passed since its production.
 
 The process of verifying that an output can be spent is called
-\textit{validation}, and is performed by executing \textit{scripts},
+\emph{validation}, and is performed by executing \emph{scripts},
 which in our case will be Plutus Core programs.
 
 
-Cardano uses a validation strategy which we call the \textit{Extended
+Cardano uses a validation strategy which we call the \emph{Extended
   UTXO model}.  A full specification of the Extended UTXO model is
 currently being prepared: in the meantime the fundamental ideas can be
 found in~\citep{Zahnentferner18-Chimeric} and
 \citep{Zahnentferner18-UTxO}.
 
 The basic idea is that when a transaction wishes $T$ to consume an
-unspent output $U$, it applies a script called the \textit{validator}
-to another script called the \textit{redeemer}\footnote{The Extended
-  UTXO model also involves another script called the \textit{data
+unspent output $U$, it applies a script called the \emph{validator}
+to another script called the \emph{redeemer}\footnote{The Extended
+  UTXO model also involves another script called the \emph{data
     script}, but for simplicity we won't discuss this here}; the
 validator also has access to certain parts of the blockchain state,
-such as the current block number (\textit{blocknum}) and the hash
-\textit{txhash} of the current transaction.  If the result of applying
+such as the current block number (\emph{blocknum}) and the hash
+\emph{txhash} of the current transaction.  If the result of applying
 the validator to the redeemer is the Plutus Core \texttt{error} term
 then validation fails and the output cannot be spent; otherwise
 validation succeeds and the output can be spent.

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -57,6 +57,7 @@
 % *** DEFINITIONS FOR PLUTUS LANGUAGE ***
 
 \newcommand{\todompj}[1]{\todo[inline,color=yellow!40,author=Michael]{#1}}
+\newcommand{\todokwxm}[1]{\todo[inline,color=blue!40,author=Kenneth]{#1}}
 
 %%% General Misc. Definitions
 
@@ -324,16 +325,16 @@ may use the multi-argument forms.
 \begin{itemize}
 \item $\con{cn}$ represents a constant belonging to some built-in
   type: for example \texttt{(con 4)} is an integer with the value 127.
-  See \cref{sec:builtins} for more on this.
+  See \cref{sec:builtins}.
 \item $\abs{\alpha}{K}{V}$ represents a polymorphic value abstracted
   over a type; this would often be donated by $\Lambda\alpha{::}K.V$.
   Note that we require the body of the abstraction to be a
   \textit{value}, not a term: see the note on the value restriction below.
 \item $\inst{M}{A}$ represents a polymorphic term instantiated at a particular type.
-\item $\iwrap{A}{B}{M}$ and $\unwrap{M}$: see the note on recursive types below.
+\item $\iwrap{A}{B}{M}$ and $\unwrap{M}$: see \cref{sec:ifix-note}.
 \item $\lam{x}{A}{M}$ is standard lambda-abstraction, $\lambda{}x{:}{A}.{M}$.
 \item $\app{M}{N}$ is standard function application.
-\item $\builtin{bn}{A^*}{M^*}$ is application of a built-in function: see \cref{sec:builtins} for more information.
+\item $\builtin{bn}{A^*}{M^*}$ is application of a built-in function: see \cref{sec:builtins}.
 \item $\error{A}$ causes an error, terminating computation immediately.
 \end{itemize}
 
@@ -357,11 +358,11 @@ may use the multi-argument forms.
 \begin{itemize}
 \item $\funT{A}{B}$ is the type of functions from $A$ to $B$, $A \rightarrow B$.
 \item $\allT{\alpha}{K}{A}$ represents the type of a polymorphic term (eg a type abstraction), $\forall \alpha{::}K.A$.
-\item $\fixT{A}{B}$ represents a recursive type: see the note in \cref{sec:ifix-note} below for more information.
+\item $\fixT{A}{B}$ represents a recursive type: see \cref{sec:ifix-note}.
 \item $\lamT{\alpha}{K}{A}$ is abstraction of types over types, $\lambda \alpha{::}K.A$.
 \item $\appT{A}{B}$ is function application at the type level.
 \item $\conT{tcn}$ represents a built-in type: for example, $\conT{\textrm{integer}}$
-is the type of integers.  See \cref{sec:builtins} for more information.
+is the type of integers.  See \cref{sec:builtins}.
 \end{itemize}
 
 \paragraph{Type Values.} All types can be reduced to a type value (or
@@ -404,63 +405,42 @@ Plutus Core language.
 
 \subsection{More detailed remarks}
 \subsubsection{Type Normalisation}
- Type checking requires normalisation to be performed, for example to
- check that two types are equal.  This process can be expensive, so we
- require that code supplied for on-chain execution comes with all type
- annotations pre-normalised.  This can be done during off-chain type
- checking.  Another issue here is that normalisation can cause the
- size of a type to increase (in the worst case, exponentially), and
- requiring normalisation to be performed before a program is submitted
- to the chain reduces on-chain gas costs.
+Type checking requires normalising types, for example to
+check that two types are equal.  This process can be expensive, so we
+require that code supplied for on-chain execution comes with all type
+annotations pre-normalised, which allows the typechecker to perform
+normalizing substitutions and so only deal with normalised types.
+This can be done during off-chain type
+checking.  Another issue here is that normalisation can cause the
+size of a type to increase (in the worst case, exponentially),
+requiring normalisation to be performed before a program is submitted
+to the chain reduces on-chain gas costs.
 
-%% \subsubsection{Sizes and built-in types and functions}
-%% \label{sec:size-note}
-%% Details of built-in types and functions are given
-%% in \cref{sec:builtins}, but a remark on sizes may be helpful at this
-%% point.  Plutus Core currently provides two types of built-in data with
-%% variable sizes: integers and bytestrings (blocks of binary data used
-%% for cryptographic purposes).  There is no fixed upper bound on the
-%% size of values of these types, but -- as mentioned in the introduction -- it
-%% could be problematic if users were allowed to create values of arbitrary size
-%% at runtime. To avoid this, sizes are tracked in the type system so that
-%% appropriate charges can be made.
-
-%% For integers, this works as follows (the system for
-%% bytestrings is similar).  Integers are signed values:
-%% there is no fixed upper bound, but values are represented as sequences
-%% of a specified number of 8-bit bytes.  For example, \texttt{1~!~100}
-%% is the integer 100 stored as a single byte.  Literal constants must
-%% fit into the specified size: \texttt{1~!~200} gives a compile-time
-%% error. If a value overflows at runtime then an error occurs and
-%% execution is terminated.  Integers are manipulated using built-in
-%% functions (see \cref{fig:builtins}) whose types
-%% include the size. This prevents users from writing programs which
-%% generate arbitrarily large values during execution; it also allows us
-%% to charge according to the actual amount of computation performed,
-%% which will increase as the size of the integers involved increases.
-
+\todompj{I don't understand the last sentence. Why is it an issue to reduce
+  costs? Also, it reduces typechecking costs, but may well increase the cost for
+  the size of the program, which as you've pointed out can be exponential.}
 
 \subsubsection{Recursive types}
 \label{sec:ifix-note}
-\noindent
 The operator \texttt{ifix} allows one to define recursive types in
 Plutus Core: \texttt{ifix A B} is a type such that \texttt{ifix A B
-  $\cong$ A (ifix A) B} where \texttt{A} is a \textit{pattern
+  $\cong$ A (ifix A) B} where \texttt{A} is a \emph{pattern
   functor}~\citep[2.4]{backhouseetal98} and \texttt{B} is an
-index. Pattern functors that \texttt{ifix} receives bind two variables:
+index. Pattern functors bind two variables:
 one for building recursive occurrences and the other to act as an
-index. Indices can be used in order to get parameterised data types,
-but also in order to control the shape of the data type: depending on
+index. Indices can be used to encode parameterised data types,
+but also to control the shape of the data type: depending on
 an index, recursive occurrences can be instantiated differently.  This
 allows us to encode a wide variety of data types, including non-regular and
-mutually recursive data types\blue{\footnote{\blue{We could do with more detail (or perhaps an example) here, since
+mutually recursive data types.
+\todokwxm{We could do with more detail (or perhaps an example) here, since
   it'll be much more difficult for the reader to work out what's going
   on than with standard \texttt{fix}.  With luck we'll soon have a publication
-  to refer to.}}}.
+  to refer to.}
 
-Note that we have an \textit{isomporhism} of types here rather than
+Note that we have an \emph{isomporhism} of types here rather than
 equality: fixpoint types are
-\textit{isorecursive}~\citep[20.2]{Pierce:TAPL} with explicit maps
+\emph{isorecursive}~\citep[20.2]{Pierce:TAPL} with explicit maps
 
 $$
 \texttt{iwrap} : \texttt{A (fix A) B} \rightarrow \texttt{ifix A B}

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -32,6 +32,7 @@
 \usepackage{geometry}
 \usepackage{pdflscape}
 \usepackage[title]{appendix}
+\usepackage{todonotes}
 
 
 % *** IMPORTS FOR PLUTUS LANGUAGE ***
@@ -53,6 +54,8 @@
 
 
 % *** DEFINITIONS FOR PLUTUS LANGUAGE ***
+
+\newcommand{\todompj}[1]{\todo[inline,color=yellow!40,author=Michael]{#1}}
 
 %%% General Misc. Definitions
 
@@ -179,7 +182,8 @@
 % just put something like "integer" in math text.
 \newcommand\unit{\ensuremath{\mathit{unit}}}
 \newcommand\one{\ensuremath{\mathit{one}}}
-\newcommand\boolean{\ensuremath{\mathit{boolean}}}
+% clashes with something from ifthenelse
+\def\boolean{\ensuremath{\mathit{boolean}}}
 \newcommand\integer{\ensuremath{\mathit{integer}}}
 \newcommand\bytestring{\ensuremath{\mathit{bytestring}}}
 \newcommand\str{\ensuremath{\mathit{str}}}

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -821,7 +821,7 @@ considerable amounts of time and space.  More efficient machines are
 available (for example the CEK machine from~\citep{Felleisen-CK-CEK},
 which uses environments binding actual arguments to variables), and in
 practice we would use something based on such a machine; however, the
-CK machine will still provide a useful bridge for formalisation
+CK machine still provides a useful bridge for formalisation
 purposes.
 
 \subfile{figures/CkMachine}
@@ -853,12 +853,12 @@ parsing or typechecking.
 
 \section{Built in types, functions, and values}
 \label{sec:builtins}
-Plutus Core comes with a pre-defined set of built-in types and
-functions which will be useful for blockchain applications.  The set
-of built-ins is fixed, although in future we may provide a framework
-to allow customisation for specialised blockchains.
 
-As mentioned earlier, there are two basic types: \texttt{integer} and
+Plutus Core comes with a pre-defined set of built-in types and
+functions.  The set of built-ins is fixed, although in future
+we may allow extensible builtins.
+
+There are two builtin types: \texttt{integer} and
 \texttt{bytestring}.  These types are given in
 \cref{fig:type_constants}: for example \texttt{(con
   integer)} is the type of signed integers.
@@ -867,17 +867,19 @@ and a number of list-like functions for bytestrings. The details are
 given in \cref{fig:builtins}, using a number of
 abbreviations given in \cref{fig:type_abbreviations}.
 
+\todompj{We barely use the abbreviations: I suggest ditching them or at most
+  scoping them to the examples section.}
 
 Note the following:
 \begin{itemize}
 \item The built-in functions in \cref{fig:builtins}
-are all monomorphic, and hence the type arguments are all empty: [].
-It is possible that we may add some polymorphic built-in functions
-at some time in the future.
+  are all monomorphic, and hence the type arguments are all empty: [].
+  It is possible that we may add polymorphic built-in functions
+  in the future, or that they may be used for extensible builtins.
 \item Some of the entries in \cref{fig:builtins}
   contain \emph{success conditions}.  If a success condition is
   violated then the program terminates immediately and returns
-  the value \texttt{(error)}.
+  an error.
 \item We provide two versions of the division and remainder operations
   for integers.  These differ in their treatment of negative
   arguments\footnote{The standard mathematical definition (the
@@ -906,14 +908,16 @@ at some time in the future.
     of \texttt{remainderInteger $n$ $d$} is the same as the sign of
     $n$.  These correspond to Haskell's \texttt{rem} and \texttt{quot}
     operators.  \end{itemize}
-
-
-\item We use fixed Scott encodings for certain types and values, specifically for
-  the \emph{unit} and \emph{boolean} types.  Compilers targeting
-  Plutus Core must be aware of these encodings and use them
-  appropriately.
 \end{itemize}
+
+\todompj{I'm not sure what the footnote about division is trying to get across.}
 \subfile{figures/Builtins}
+\todompj{\Cref{fig:constants} is hard to understand.}
+\todompj{\texttt{verifySignature} needs to say something about what crypto it is
+  using.}
+\todompj{\texttt{takeByteString} and \texttt{dropByteString} should perhaps
+  fail if the bytestring is shorter than the amount to be taken?}
+\todompj{The sha functions don't have a very informative semantics.}
 
 \section{Transaction Validation}
 The primary use for Plutus Core is for executing code on blockchain
@@ -942,21 +946,24 @@ The process of verifying that an output can be spent is called
 \emph{validation}, and is performed by executing \emph{scripts},
 which in our case will be Plutus Core programs.
 
-
 Cardano uses a validation strategy which we call the \emph{Extended
   UTXO model}.  A full specification of the Extended UTXO model is
 currently being prepared: in the meantime the fundamental ideas can be
 found in~\citep{Zahnentferner18-Chimeric} and
 \citep{Zahnentferner18-UTxO}.
 
-The basic idea is that when a transaction wishes $T$ to consume an
+The basic idea is that when a transaction $T$ wishes to consume an
 unspent output $U$, it applies a script called the \emph{validator}
 to another script called the \emph{redeemer}\footnote{The Extended
   UTXO model also involves another script called the \emph{data
-    script}, but for simplicity we won't discuss this here}; the
-validator also has access to certain parts of the blockchain state,
-such as the current block number (\emph{blocknum}) and the hash
-\emph{txhash} of the current transaction.  If the result of applying
+    script}, but for simplicity we won't discuss that here.}.
+
+The validator also has access to certain information about the transaction
+currently being validated, such as the hash of the current transaction. This
+information is passed in via an additional argument which we will not discuss
+here, in the example we will assume that the transaction hash is in scope as \texttt{txhash}.
+
+If the result of applying
 the validator to the redeemer is the Plutus Core \texttt{error} term
 then validation fails and the output cannot be spent; otherwise
 validation succeeds and the output can be spent.
@@ -996,7 +1003,7 @@ For implementation purposes it is useful to have a variant of the type
 system that is more algorithmic in its presentation. We give this
 here, showing the figures that have been changed (relative to the
 declarative version above), and highlighting the specific parts of
-each rule that is different, where possible (\cref{fig:contexts_algorithmic_unrestricted,fig:type_synthesis_algorithmic_unrestricted}) .
+each rule that is different, where possible (\cref{fig:contexts_algorithmic_unrestricted,fig:type_synthesis_algorithmic_unrestricted}).
 
 \subfile{figures/TypeSynthesis-Algorithmic-Unrestricted.tex}
 
@@ -1006,7 +1013,7 @@ each rule that is different, where possible (\cref{fig:contexts_algorithmic_unre
 \label{sec:restricted-algorithmic}
 
 For blockchain purposes, it is useful to not only have an algorithmic
-system, but to require that no un-normalised types are present in
+system, but to require that no non-normalised types are present in
 programs, so as to reduce the amount of computation necessary to
 typecheck a program. It's also useful to have a way of bounding the
 amount of computation that can be done in type checking, for security


### PR DESCRIPTION
I just went through and edited, feel free to take whichever of the changes you want.

I've left a bunch of notes in the text for larger things that we should look at but I didn't want to just do.

A few notable changes:
- Use `hyperref` and `cleveref`.
    - Cross-references are nice, but drastically more useful when they're links.
    - `cleveref` gets rid of a bunch of noise.
- I moved the side condition about the type of frames and `error` into a hypothesis about the type of the framed term. I think this is both easier to read and makes it clearer that we have a dependency on type synthesis there.
- I changed the example a bit so that the way it does case expressions is closer to what we actually do.