### PR TITLE
Restrict swagger2 library bounds

### DIFF
--- a/plutus-wallet-api/plutus-wallet-api.cabal
+++ b/plutus-wallet-api/plutus-wallet-api.cabal
@@ -139,7 +139,7 @@ library plutus-ledger
         operational -any,
         serialise -any,
         servant -any,
-        swagger2 -any,
+        swagger2 <2.4,
         template-haskell -any,
         text -any,
         transformers -any,


### PR DESCRIPTION
This is for the `cabal new-build` workflow I use, but serves a purpose if we release for Hackage.