### PR TITLE
plutus-tx: minor refactorings

### DIFF
--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Binders.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Binders.hs
@@ -29,65 +29,65 @@ first.
 variable *last* (so it is on the outside, so will be first when applying).
 -}
 
-withVarScoped :: Converting m => GHC.Var -> (PIR.VarDecl PIR.TyName PIR.Name () -> m a) -> m a
+withVarScoped :: Compiling m => GHC.Var -> (PIR.VarDecl PIR.TyName PIR.Name () -> m a) -> m a
 withVarScoped v k = do
     let ghcName = GHC.getName v
-    var <- convVarFresh v
+    var <- compileVarFresh v
     local (\c -> c {ccScopes=pushName ghcName var (ccScopes c)}) (k var)
 
-withVarsScoped :: Converting m => [GHC.Var] -> ([PIR.VarDecl PIR.TyName PIR.Name ()] -> m a) -> m a
+withVarsScoped :: Compiling m => [GHC.Var] -> ([PIR.VarDecl PIR.TyName PIR.Name ()] -> m a) -> m a
 withVarsScoped vs k = do
     vars <- for vs $ \v -> do
         let name = GHC.getName v
-        var' <- convVarFresh v
+        var' <- compileVarFresh v
         pure (name, var')
     local (\c -> c {ccScopes=pushNames vars (ccScopes c)}) (k (fmap snd vars))
 
-withTyVarScoped :: Converting m => GHC.Var -> (PIR.TyVarDecl PIR.TyName () -> m a) -> m a
+withTyVarScoped :: Compiling m => GHC.Var -> (PIR.TyVarDecl PIR.TyName () -> m a) -> m a
 withTyVarScoped v k = do
     let ghcName = GHC.getName v
-    var <- convTyVarFresh v
+    var <- compileTyVarFresh v
     local (\c -> c {ccScopes=pushTyName ghcName var (ccScopes c)}) (k var)
 
-withTyVarsScoped :: Converting m => [GHC.Var] -> ([PIR.TyVarDecl PIR.TyName ()] -> m a) -> m a
+withTyVarsScoped :: Compiling m => [GHC.Var] -> ([PIR.TyVarDecl PIR.TyName ()] -> m a) -> m a
 withTyVarsScoped vs k = do
     vars <- for vs $ \v -> do
         let name = GHC.getName v
-        var' <- convTyVarFresh v
+        var' <- compileTyVarFresh v
         pure (name, var')
     local (\c -> c {ccScopes=pushTyNames vars (ccScopes c)}) (k (fmap snd vars))
 
 -- | Builds a lambda, binding the given variable to a name that
 -- will be in scope when running the second argument.
-mkLamAbsScoped :: Converting m => GHC.Var -> m PIRTerm -> m PIRTerm
+mkLamAbsScoped :: Compiling m => GHC.Var -> m PIRTerm -> m PIRTerm
 mkLamAbsScoped v body = withVarScoped v $ \(PIR.VarDecl _ n t) -> PIR.LamAbs () n t <$> body
 
-mkIterLamAbsScoped :: Converting m => [GHC.Var] -> m PIRTerm -> m PIRTerm
+mkIterLamAbsScoped :: Compiling m => [GHC.Var] -> m PIRTerm -> m PIRTerm
 mkIterLamAbsScoped vars body = foldr (\v acc -> mkLamAbsScoped v acc) body vars
 
 -- | Builds a type abstraction, binding the given variable to a name that
 -- will be in scope when running the second argument.
-mkTyAbsScoped :: Converting m => GHC.Var -> m PIRTerm -> m PIRTerm
+mkTyAbsScoped :: Compiling m => GHC.Var -> m PIRTerm -> m PIRTerm
 mkTyAbsScoped v body = withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> do
     body' <- body
     checkTyAbsBody body'
     pure $ PIR.TyAbs () t k body'
 
-mkIterTyAbsScoped :: Converting m => [GHC.Var] -> m PIRTerm -> m PIRTerm
+mkIterTyAbsScoped :: Compiling m => [GHC.Var] -> m PIRTerm -> m PIRTerm
 mkIterTyAbsScoped vars body = foldr (\v acc -> mkTyAbsScoped v acc) body vars
 
 -- | Builds a forall, binding the given variable to a name that
 -- will be in scope when running the second argument.
-mkTyForallScoped :: Converting m => GHC.Var -> m PIRType -> m PIRType
+mkTyForallScoped :: Compiling m => GHC.Var -> m PIRType -> m PIRType
 mkTyForallScoped v body = withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> PIR.TyForall () t k <$> body
 
-mkIterTyForallScoped :: Converting m => [GHC.Var] -> m PIRType -> m PIRType
+mkIterTyForallScoped :: Compiling m => [GHC.Var] -> m PIRType -> m PIRType
 mkIterTyForallScoped vars body = foldr (\v acc -> mkTyForallScoped v acc) body vars
 
 -- | Builds a type lambda, binding the given variable to a name that
 -- will be in scope when running the second argument.
-mkTyLamScoped :: Converting m => GHC.Var -> m PIRType -> m PIRType
+mkTyLamScoped :: Compiling m => GHC.Var -> m PIRType -> m PIRType
 mkTyLamScoped v body = withTyVarScoped v $ \(PIR.TyVarDecl _ t k) -> PIR.TyLam () t k <$> body
 
-mkIterTyLamScoped :: Converting m => [GHC.Var] -> m PIRType -> m PIRType
+mkIterTyLamScoped :: Compiling m => [GHC.Var] -> m PIRType -> m PIRType
 mkIterTyLamScoped vars body = foldr (\v acc -> mkTyLamScoped v acc) body vars

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE OverloadedStrings      #-}
 {-# LANGUAGE TemplateHaskell        #-}
 module Language.PlutusTx.Compiler.Error (
-    ConvError
+    CompileError
     , Error (..)
     , WithContext (..)
     , withContext
@@ -31,7 +31,7 @@ data WithContext c e = NoContext e | WithContextC Int c (WithContext c e)
     deriving Functor
 makeClassyPrisms ''WithContext
 
-type ConvError = WithContext T.Text (Error ())
+type CompileError = WithContext T.Text (Error ())
 
 withContext :: (MonadError (WithContext c e) m) => Int -> c -> m a -> m a
 withContext p c act = catchError act $ \err -> throwError (WithContextC p c err)
@@ -70,13 +70,13 @@ makeClassyPrisms ''Error
 instance (PP.Pretty a) => PP.Pretty (Error a) where
     pretty = PLC.prettyPlcClassicDebug
 
-instance PLC.AsTypeError ConvError () where
+instance PLC.AsTypeError CompileError () where
     _TypeError = _NoContext . _PLCError . PLC._TypeError
 
-instance PLC.AsNormalizationError ConvError PLC.TyName PLC.Name () where
+instance PLC.AsNormalizationError CompileError PLC.TyName PLC.Name () where
     _NormalizationError = _NoContext . _PLCError . PLC._NormalizationError
 
-instance PIR.AsError ConvError (PIR.Provenance ()) where
+instance PIR.AsError CompileError (PIR.Provenance ()) where
     _Error = _NoContext . _PIRError
 
 instance (PP.Pretty a) => PLC.PrettyBy PLC.PrettyConfigPlc (Error a) where

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
@@ -27,8 +27,8 @@ import qualified PrelNames                              as GHC
 
 import qualified Language.PlutusIR                      as PIR
 import qualified Language.PlutusIR.Compiler.Definitions as PIR
-import qualified Language.PlutusIR.MkPir                as PIR
 import           Language.PlutusIR.Compiler.Names
+import qualified Language.PlutusIR.MkPir                as PIR
 import qualified Language.PlutusIR.Value                as PIR
 
 import qualified Language.PlutusCore                    as PLC
@@ -40,8 +40,8 @@ import qualified Data.ByteString.Lazy                   as BSL
 import           Data.List                              (elem, elemIndex)
 import qualified Data.List.NonEmpty                     as NE
 import qualified Data.Set                               as Set
-import           Data.Traversable
 import qualified Data.Text                              as T
+import           Data.Traversable
 
 {- Note [System FC and System FW]
 Haskell uses system FC, which includes type equalities and coercions.

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs-boot
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs-boot
@@ -1,14 +1,14 @@
 {-# LANGUAGE FlexibleContexts  #-}
 
-module Language.PlutusTx.Compiler.Expr (convExpr, convExprWithDefs, convDataConRef) where
+module Language.PlutusTx.Compiler.Expr (compileExpr, compileExprWithDefs, compileDataConRef) where
 
 import           Language.PlutusTx.Compiler.Types
 import           Language.PlutusTx.PIRTypes
 
 import qualified GhcPlugins                               as GHC
 
-convDataConRef :: Converting m => GHC.DataCon -> m PIRTerm
+compileDataConRef :: Compiling m => GHC.DataCon -> m PIRTerm
 
-convExpr :: Converting m => GHC.CoreExpr -> m PIRTerm
+compileExpr :: Compiling m => GHC.CoreExpr -> m PIRTerm
 
-convExprWithDefs :: Converting m => GHC.CoreExpr -> m PIRTerm
+compileExprWithDefs :: Compiling m => GHC.CoreExpr -> m PIRTerm

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Kind.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Kind.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ViewPatterns      #-}
 
 -- | Functions for compiling GHC kinds into PlutusCore kinds.
-module Language.PlutusTx.Compiler.Kind (convKind) where
+module Language.PlutusTx.Compiler.Kind (compileKind) where
 
 import           Language.PlutusTx.Compiler.Error
 import           Language.PlutusTx.Compiler.Types
@@ -14,9 +14,9 @@ import qualified Kind                             as GHC
 
 import qualified Language.PlutusCore              as PLC
 
-convKind :: Converting m => GHC.Kind -> m (PLC.Kind ())
-convKind k = withContextM 2 (sdToTxt $ "Converting kind:" GHC.<+> GHC.ppr k) $ case k of
+compileKind :: Compiling m => GHC.Kind -> m (PLC.Kind ())
+compileKind k = withContextM 2 (sdToTxt $ "Compiling kind:" GHC.<+> GHC.ppr k) $ case k of
     -- this is a bit weird because GHC uses 'Type' to represent kinds, so '* -> *' is a 'TyFun'
     (GHC.isLiftedTypeKind -> True)        -> pure $ PLC.Type ()
-    (GHC.splitFunTy_maybe -> Just (i, o)) -> PLC.KindArrow () <$> convKind i <*> convKind o
+    (GHC.splitFunTy_maybe -> Just (i, o)) -> PLC.KindArrow () <$> compileKind i <*> compileKind o
     _                                     -> throwSd UnsupportedError $ "Kind:" GHC.<+> GHC.ppr k

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Laziness.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Laziness.hs
@@ -26,28 +26,28 @@ with the standard library because it makes the generated terms simpler without t
 a simplifier pass. Also, PLC isn't lazy, so combinators work less well.
 -}
 
-delay :: Converting m => PIRTerm -> m PIRTerm
-delay body = PIR.LamAbs () <$> liftQuote (freshName () "thunk") <*> convType GHC.unitTy <*> pure body
+delay :: Compiling m => PIRTerm -> m PIRTerm
+delay body = PIR.LamAbs () <$> liftQuote (freshName () "thunk") <*> compileType GHC.unitTy <*> pure body
 
-delayType :: Converting m => PIRType -> m PIRType
-delayType orig = PIR.TyFun () <$> convType GHC.unitTy <*> pure orig
+delayType :: Compiling m => PIRType -> m PIRType
+delayType orig = PIR.TyFun () <$> compileType GHC.unitTy <*> pure orig
 
-delayVar :: Converting m => PIRVar -> m PIRVar
+delayVar :: Compiling m => PIRVar -> m PIRVar
 delayVar (PIR.VarDecl () n ty) = do
     ty' <- delayType ty
     pure $ PIR.VarDecl () n ty'
 
-force :: Converting m => PIRTerm -> m PIRTerm
-force thunk = PIR.Apply () thunk <$> convExpr (GHC.Var GHC.unitDataConId)
+force :: Compiling m => PIRTerm -> m PIRTerm
+force thunk = PIR.Apply () thunk <$> compileExpr (GHC.Var GHC.unitDataConId)
 
-maybeDelay :: Converting m => Bool -> PIRTerm -> m PIRTerm
+maybeDelay :: Compiling m => Bool -> PIRTerm -> m PIRTerm
 maybeDelay yes t = if yes then delay t else pure t
 
-maybeDelayVar :: Converting m => Bool -> PIRVar -> m PIRVar
+maybeDelayVar :: Compiling m => Bool -> PIRVar -> m PIRVar
 maybeDelayVar yes v = if yes then delayVar v else pure v
 
-maybeDelayType :: Converting m => Bool -> PIRType -> m PIRType
+maybeDelayType :: Compiling m => Bool -> PIRType -> m PIRType
 maybeDelayType yes t = if yes then delayType t else pure t
 
-maybeForce :: Converting m => Bool -> PIRTerm -> m PIRTerm
+maybeForce :: Compiling m => Bool -> PIRTerm -> m PIRTerm
 maybeForce yes t = if yes then force t else pure t

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Names.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Names.hs
@@ -26,31 +26,31 @@ import qualified Data.Text                        as T
 lookupName :: Scope -> GHC.Name -> Maybe PLCVar
 lookupName (Scope ns _) n = Map.lookup n ns
 
-convNameFresh :: MonadQuote m => GHC.Name -> m (PLC.Name ())
-convNameFresh n = safeFreshName () $ T.pack $ GHC.getOccString n
+compileNameFresh :: MonadQuote m => GHC.Name -> m (PLC.Name ())
+compileNameFresh n = safeFreshName () $ T.pack $ GHC.getOccString n
 
-convVarFresh :: Converting m => GHC.Var -> m PLCVar
-convVarFresh v = do
-    t' <- convType $ GHC.varType v
-    n' <- convNameFresh $ GHC.getName v
+compileVarFresh :: Compiling m => GHC.Var -> m PLCVar
+compileVarFresh v = do
+    t' <- compileType $ GHC.varType v
+    n' <- compileNameFresh $ GHC.getName v
     pure $ PLC.VarDecl () n' t'
 
 lookupTyName :: Scope -> GHC.Name -> Maybe PLCTyVar
 lookupTyName (Scope _ tyns) n = Map.lookup n tyns
 
-convTyNameFresh :: MonadQuote m => GHC.Name -> m (PLC.TyName ())
-convTyNameFresh n = safeFreshTyName () $ T.pack $ GHC.getOccString n
+compileTyNameFresh :: MonadQuote m => GHC.Name -> m (PLC.TyName ())
+compileTyNameFresh n = safeFreshTyName () $ T.pack $ GHC.getOccString n
 
-convTyVarFresh :: Converting m => GHC.TyVar -> m PLCTyVar
-convTyVarFresh v = do
-    k' <- convKind $ GHC.tyVarKind v
-    t' <- convTyNameFresh $ GHC.getName v
+compileTyVarFresh :: Compiling m => GHC.TyVar -> m PLCTyVar
+compileTyVarFresh v = do
+    k' <- compileKind $ GHC.tyVarKind v
+    t' <- compileTyNameFresh $ GHC.getName v
     pure $ PLC.TyVarDecl () t' k'
 
-convTcTyVarFresh :: Converting m => GHC.TyCon -> m PLCTyVar
-convTcTyVarFresh tc = do
-    k' <- convKind $ GHC.tyConKind tc
-    t' <- convTyNameFresh $ GHC.getName tc
+compileTcTyVarFresh :: Compiling m => GHC.TyCon -> m PLCTyVar
+compileTcTyVarFresh tc = do
+    k' <- compileKind $ GHC.tyConKind tc
+    t' <- compileTyNameFresh $ GHC.getName tc
     pure $ PLC.TyVarDecl () t' k'
 
 pushName :: GHC.Name -> PLCVar-> ScopeStack -> ScopeStack

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Primitives.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Primitives.hs
@@ -18,8 +18,8 @@ import qualified GhcPlugins                          as GHC
 import qualified PrimOp                              as GHC
 
 -- These never seem to come up, rather we get the typeclass operations. Not sure if we need them.
-convPrimitiveOp :: (Converting m) => GHC.PrimOp -> m PIRTerm
-convPrimitiveOp = \case
+compilePrimitiveOp :: Compiling m => GHC.PrimOp -> m PIRTerm
+compilePrimitiveOp = \case
     GHC.IntAddOp  -> lookupBuiltinTerm 'Builtins.addInteger
     GHC.IntSubOp  -> lookupBuiltinTerm 'Builtins.subtractInteger
     GHC.IntMulOp  -> lookupBuiltinTerm 'Builtins.multiplyInteger

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
@@ -7,15 +7,15 @@
 -- | Functions for compiling GHC types into PlutusCore types, as well as compiling constructors,
 -- matchers, and pattern match alternatives.
 module Language.PlutusTx.Compiler.Type (
-    convType,
-    convKind,
+    compileType,
+    compileKind,
     getDataCons,
     getConstructors,
     getConstructorsInstantiated,
     getMatch,
     getMatchInstantiated,
     findAlt,
-    convAlt) where
+    compileAlt) where
 
 import           Language.PlutusTx.Compiler.Binders
 import           Language.PlutusTx.Compiler.Builtins
@@ -47,20 +47,20 @@ import           Data.Traversable
 
 -- Types
 
-convType :: Converting m => GHC.Type -> m PIRType
-convType t = withContextM 2 (sdToTxt $ "Converting type:" GHC.<+> GHC.ppr t) $ do
+compileType :: Compiling m => GHC.Type -> m PIRType
+compileType t = withContextM 2 (sdToTxt $ "Compiling type:" GHC.<+> GHC.ppr t) $ do
     -- See Note [Scopes]
-    ConvertingContext {ccScopes=stack} <- ask
+    CompileContext {ccScopes=stack} <- ask
     let top = NE.head stack
     case t of
         -- in scope type name
         (GHC.getTyVar_maybe -> Just (lookupTyName top . GHC.getName -> Just (PIR.TyVarDecl _ name _))) -> pure $ PIR.TyVar () name
         (GHC.getTyVar_maybe -> Just v) -> throwSd FreeVariableError $ "Type variable:" GHC.<+> GHC.ppr v
-        (GHC.splitFunTy_maybe -> Just (i, o)) -> PIR.TyFun () <$> convType i <*> convType o
-        (GHC.splitTyConApp_maybe -> Just (tc, ts)) -> PIR.mkIterTyApp () <$> convTyCon tc <*> traverse convType ts
-        (GHC.splitForAllTy_maybe -> Just (tv, tpe)) -> mkTyForallScoped tv (convType tpe)
+        (GHC.splitFunTy_maybe -> Just (i, o)) -> PIR.TyFun () <$> compileType i <*> compileType o
+        (GHC.splitTyConApp_maybe -> Just (tc, ts)) -> PIR.mkIterTyApp () <$> compileTyCon tc <*> traverse compileType ts
+        (GHC.splitForAllTy_maybe -> Just (tv, tpe)) -> mkTyForallScoped tv (compileType tpe)
         -- I think it's safe to ignore the coercion here
-        (GHC.splitCastTy_maybe -> Just (tpe, _)) -> convType tpe
+        (GHC.splitCastTy_maybe -> Just (tpe, _)) -> compileType tpe
         _ -> throwSd UnsupportedError $ "Type" GHC.<+> GHC.ppr t
 
 {- Note [Occurrences of recursive names]
@@ -80,12 +80,12 @@ we just have to ban recursive newtypes, and we do this by blackholing the name w
 definition, and dying if we see it again.
 -}
 
-convTyCon :: (Converting m) => GHC.TyCon -> m PIRType
-convTyCon tc
+compileTyCon :: Compiling m => GHC.TyCon -> m PIRType
+compileTyCon tc
     | tc == GHC.intTyCon = throwPlain $ UnsupportedError "Int: use Integer instead"
     | tc == GHC.intPrimTyCon = throwPlain $ UnsupportedError "Int#: unboxed integers are not supported"
     -- See Note [Addr#]
-    | tc == GHC.addrPrimTyCon = convType GHC.stringTy
+    | tc == GHC.addrPrimTyCon = compileType GHC.stringTy
     -- this is Void#, see Note [Value restriction]
     | tc == GHC.voidPrimTyCon = errorTy
     | otherwise = do
@@ -100,14 +100,14 @@ convTyCon tc
             usedTcs <- getUsedTcs tc
             let deps = fmap GHC.getName usedTcs ++ fmap GHC.getName dcs
 
-            tvd <- convTcTyVarFresh tc
+            tvd <- compileTcTyVarFresh tc
 
             case GHC.unwrapNewTyCon_maybe tc of
                 Just (_, underlying, _) -> do
                     -- See Note [Coercions and newtypes]
                     -- See Note [Occurrences of recursive names]
                     -- Type variables are in scope for the rhs of the alias
-                    alias <- mkIterTyLamScoped (GHC.tyConTyVars tc) $ blackhole (GHC.getName tc) $ convType underlying
+                    alias <- mkIterTyLamScoped (GHC.tyConTyVars tc) $ blackhole (GHC.getName tc) $ compileType underlying
                     PIR.defineType (LexName tcName) (PIR.Def tvd alias) (Set.fromList $ LexName <$> deps)
                     PIR.recordAlias @LexName @() (LexName tcName)
                     pure alias
@@ -121,7 +121,7 @@ convTyCon tc
                     -- Type variables are in scope for the rest of the definition
                     withTyVarsScoped (GHC.tyConTyVars tc) $ \tvs -> do
                         constructors <- for dcs $ \dc -> do
-                            name <- convNameFresh (GHC.getName dc)
+                            name <- compileNameFresh (GHC.getName dc)
                             ty <- mkConstructorType dc
                             pure $ PIR.VarDecl () name ty
 
@@ -130,7 +130,7 @@ convTyCon tc
                         PIR.defineDatatype (LexName tcName) (PIR.Def tvd datatype) (Set.fromList $ LexName <$> deps)
                     pure $ PIR.mkTyVar () tvd
 
-getUsedTcs :: (Converting m) => GHC.TyCon -> m [GHC.TyCon]
+getUsedTcs :: Compiling m => GHC.TyCon -> m [GHC.TyCon]
 getUsedTcs tc = do
     dcs <- getDataCons tc
     let usedTcs = GHC.unionManyUniqSets $ (\dc -> GHC.unionManyUniqSets $ GHC.tyConsOfType <$> GHC.dataConOrigArgTys dc) <$> dcs
@@ -150,15 +150,15 @@ significantly better codegen a lot of the time.
 
 The check we do is:
 - Alternatives with arguments will be turned into lambdas by us, so will be values.
-- Otherwise, we convert the expression (we can do this easily since it doesn't need any variables in scope),
+- Otherwise, we compile the expression (we can do this easily since it doesn't need any variables in scope),
   and check whether it is a value.
 
-This is somewhat wasteful, since we may convert the expression twice, but it's difficult to avoid, and
+This is somewhat wasteful, since we may compile the expression twice, but it's difficult to avoid, and
 it's hard to tell if a GHC core expression will be a PLC value or not. Easiest to just try it.
 -}
 
 {- Note [Ordering of constructors]
-It is very important that we convert types and constructors consistently, especially between
+It is very important that we compile types and constructors consistently, especially between
 lifting at runtime and compilation via the plugin. The main place we can get bitten is ordering.
 
 GHC is under no obligation to give us any particular ordering of constructors, so we impose
@@ -194,7 +194,7 @@ sortConstructors tc cs =
     let sorted = sortBy (\dc1 dc2 -> compare (GHC.getOccName dc1) (GHC.getOccName dc2)) cs
     in if tc == GHC.boolTyCon || tc == GHC.listTyCon then reverse sorted else sorted
 
-getDataCons :: (Converting m) =>  GHC.TyCon -> m [GHC.DataCon]
+getDataCons :: Compiling m =>  GHC.TyCon -> m [GHC.DataCon]
 getDataCons tc' = sortConstructors tc' <$> extractDcs tc'
     where
         extractDcs tc
@@ -207,22 +207,22 @@ getDataCons tc' = sortConstructors tc' <$> extractDcs tc'
           | otherwise = throwSd UnsupportedError $ "Type constructor:" GHC.<+> GHC.ppr tc
 
 -- | Makes the type of the constructor corresponding to the given 'DataCon', with the type variables free.
-mkConstructorType :: Converting m => GHC.DataCon -> m PIRType
+mkConstructorType :: Compiling m => GHC.DataCon -> m PIRType
 mkConstructorType dc =
     let argTys = GHC.dataConOrigArgTys dc
     in
         -- See Note [Scott encoding of datatypes]
-        withContextM 3 (sdToTxt $ "Converting data constructor type:" GHC.<+> GHC.ppr dc) $ do
-            args <- mapM convType argTys
-            resultType <- convType (GHC.dataConOrigResTy dc)
+        withContextM 3 (sdToTxt $ "Compiling data constructor type:" GHC.<+> GHC.ppr dc) $ do
+            args <- mapM compileType argTys
+            resultType <- compileType (GHC.dataConOrigResTy dc)
             -- t_c_i_1 -> ... -> t_c_i_j -> resultType
             pure $ PIR.mkIterTyFun () args resultType
 
 -- | Get the constructors of the given 'TyCon' as PLC terms.
-getConstructors :: Converting m => GHC.TyCon -> m [PIRTerm]
+getConstructors :: Compiling m => GHC.TyCon -> m [PIRTerm]
 getConstructors tc = do
     -- make sure the constructors have been created
-    _ <- convTyCon tc
+    _ <- compileTyCon tc
     maybeConstrs <- PIR.lookupConstructors () (LexName $ GHC.getName tc)
     case maybeConstrs of
         Just constrs -> pure constrs
@@ -230,22 +230,22 @@ getConstructors tc = do
 
 -- | Get the constructors of the given 'Type' (which must be equal to a type constructor application) as PLC terms instantiated for
 -- the type constructor argument types.
-getConstructorsInstantiated :: Converting m => GHC.Type -> m [PIRTerm]
+getConstructorsInstantiated :: Compiling m => GHC.Type -> m [PIRTerm]
 getConstructorsInstantiated t = withContextM 3 (sdToTxt $ "Creating instantiated constructors for type:" GHC.<+> GHC.ppr t) $ case t of
     (GHC.splitTyConApp_maybe -> Just (tc, args)) -> do
         constrs <- getConstructors tc
 
         forM constrs $ \c -> do
-            args' <- mapM convType args
+            args' <- mapM compileType args
             pure $ PIR.mkIterInst () c args'
     -- must be a TC app
     _ -> throwSd CompilationError $ "Type was not a type constructor application:" GHC.<+> GHC.ppr t
 
 -- | Get the matcher of the given 'TyCon' as a PLC term
-getMatch :: Converting m => GHC.TyCon -> m PIRTerm
+getMatch :: Compiling m => GHC.TyCon -> m PIRTerm
 getMatch tc = do
     -- ensure the tycon has been compiled, which will create the matcher
-    _ <- convTyCon tc
+    _ <- compileTyCon tc
     maybeMatch <- PIR.lookupDestructor () (LexName $ GHC.getName tc)
     case maybeMatch of
         Just match -> pure match
@@ -253,12 +253,12 @@ getMatch tc = do
 
 -- | Get the matcher of the given 'Type' (which must be equal to a type constructor application) as a PLC term instantiated for
 -- the type constructor argument types.
-getMatchInstantiated :: Converting m => GHC.Type -> m PIRTerm
+getMatchInstantiated :: Compiling m => GHC.Type -> m PIRTerm
 getMatchInstantiated t = withContextM 3 (sdToTxt $ "Creating instantiated matcher for type:" GHC.<+> GHC.ppr t) $ case t of
     (GHC.splitTyConApp_maybe -> Just (tc, args)) -> do
         match <- getMatch tc
 
-        args' <- mapM convType args
+        args' <- mapM compileType args
         pure $ PIR.mkIterInst () match args'
     -- must be a TC app
     _ -> throwSd CompilationError $ "Type was not a type constructor application:" GHC.<+> GHC.ppr t
@@ -275,22 +275,22 @@ findAlt dc alts t = case GHC.findAlt (GHC.DataAlt dc) alts of
     Nothing  -> (GHC.DEFAULT, [], GHC.mkImpossibleExpr t)
 
 -- | Make the alternative for a given 'CoreAlt'.
-convAlt
-    :: Converting m
+compileAlt
+    :: Compiling m
     => Bool -- ^ Whether we must delay the alternative.
     -> [GHC.Type] -- ^ The instantiated type arguments for the data constructor.
     -> GHC.CoreAlt -- ^ The 'CoreAlt' representing the branch itself.
     -> m PIRTerm
-convAlt mustDelay instArgTys (alt, vars, body) = withContextM 3 (sdToTxt $ "Creating alternative:" GHC.<+> GHC.ppr alt) $ case alt of
+compileAlt mustDelay instArgTys (alt, vars, body) = withContextM 3 (sdToTxt $ "Creating alternative:" GHC.<+> GHC.ppr alt) $ case alt of
     GHC.LitAlt _  -> throwPlain $ UnsupportedError "Literal case"
     GHC.DEFAULT   -> do
-        body' <- convExpr body >>= maybeDelay mustDelay
+        body' <- compileExpr body >>= maybeDelay mustDelay
         -- need to consume the args
-        argTypes <- mapM convType instArgTys
+        argTypes <- mapM compileType instArgTys
         argNames <- forM [0..(length argTypes -1)] (\i -> safeFreshName () $ "default_arg" <> (T.pack $ show i))
         pure $ PIR.mkIterLamAbs (zipWith (PIR.VarDecl ()) argNames argTypes) body'
     -- We just package it up as a lambda bringing all the
     -- vars into scope whose body is the body of the case alternative.
     -- See Note [Iterated abstraction and application]
     -- See Note [Case expressions and laziness]
-    GHC.DataAlt _ -> mkIterLamAbsScoped vars (convExpr body >>= maybeDelay mustDelay)
+    GHC.DataAlt _ -> mkIterLamAbsScoped vars (compileExpr body >>= maybeDelay mustDelay)

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs-boot
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs-boot
@@ -7,6 +7,6 @@ import Language.PlutusTx.PIRTypes
 
 import qualified GhcPlugins                               as GHC
 
-convType :: Converting m => GHC.Type -> m PIRType
+compileType :: Compiling m => GHC.Type -> m PIRType
 
-getMatchInstantiated :: Converting m => GHC.Type -> m PIRTerm
+getMatchInstantiated :: Compiling m => GHC.Type -> m PIRTerm

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Utils.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Utils.hs
@@ -15,12 +15,12 @@ import           Control.Monad.Reader
 
 import qualified Data.Text                        as T
 
-sdToTxt :: (MonadReader ConvertingContext m) => GHC.SDoc -> m T.Text
+sdToTxt :: MonadReader CompileContext m => GHC.SDoc -> m T.Text
 sdToTxt sd = do
-  ConvertingContext { ccFlags=flags } <- ask
+  CompileContext { ccFlags=flags } <- ask
   pure $ T.pack $ GHC.showSDoc flags sd
 
-throwSd :: (MonadError ConvError m, MonadReader ConvertingContext m) => (T.Text -> Error ()) -> GHC.SDoc -> m a
+throwSd :: (MonadError CompileError m, MonadReader CompileContext m) => (T.Text -> Error ()) -> GHC.SDoc -> m a
 throwSd constr = (throwPlain . constr) <=< sdToTxt
 
 tyConsOfExpr :: GHC.CoreExpr -> GHC.UniqSet GHC.TyCon

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/ValueRestriction.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/ValueRestriction.hs
@@ -80,19 +80,19 @@ bit of a hack, though.
 -}
 
 -- See Note [Value restriction]
-mangleTyForall :: Converting m => PIRType -> m PIRType
+mangleTyForall :: Compiling m => PIRType -> m PIRType
 mangleTyForall = \case
     PIR.TyForall a t k body -> PIR.TyForall a t k <$> delayType body
     x -> pure x
 
 -- See Note [Value restriction]
-mangleTyAbs :: Converting m => PIRTerm -> m PIRTerm
+mangleTyAbs :: Compiling m => PIRTerm -> m PIRTerm
 mangleTyAbs = \case
     PIR.TyAbs a t k body -> PIR.TyAbs a t k <$> delay body
     x -> pure x
 
-checkTyAbsBody :: Converting m => PIRTerm -> m ()
+checkTyAbsBody :: Compiling m => PIRTerm -> m ()
 checkTyAbsBody t = do
-    ConvertingContext {ccOpts=opts} <- ask
+    CompileContext {ccOpts=opts} <- ask
     -- we sometimes need to turn this off, as checking for term values also checks for normalized types at the moment
     unless (not (coCheckValueRestriction opts) || PIR.isTermValue t) $ throwPlain ValueRestrictionError

--- a/plutus-tx/test/Plugin/Errors/machInt.plc.golden
+++ b/plutus-tx/test/Plugin/Errors/machInt.plc.golden
@@ -1,1 +1,1 @@
-Error: Unsupported feature: Int#: unboxed integers are not supported
+Error: Unsupported feature: Int: use Integer instead


### PR DESCRIPTION
- Refactor a couple of functions in `Type`
- Use "compile" uniformly instead of "convert". I don't know what past-me was thinking.
- Move a function to `Expr`

Mostly of interest to me, I suspect.