### PR TITLE
Build: fix issues with -O0

### DIFF
--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -11,6 +11,10 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns -Wno-name-shadowing #-}
 
+{-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+
 {-|
     Marlowe Mockchain client code.
 

--- a/marlowe/src/Language/Marlowe/Common.hs
+++ b/marlowe/src/Language/Marlowe/Common.hs
@@ -12,9 +12,12 @@
 {-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns -Wno-name-shadowing #-}
+
 {-# OPTIONS_GHC -fno-strictness #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
-{-# OPTIONS_GHC -Wno-incomplete-uni-patterns -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 
 {-| = Marlowe: financial contracts on Cardano Computation Layer
 

--- a/nix/overlays/required.nix
+++ b/nix/overlays/required.nix
@@ -15,6 +15,7 @@ let
     postCheck = "./Setup doctest --doctest-options=\"${opts}\"";
   });
   # cabal doctest doesn't seem to be clever enough to pick these up from the cabal file
+  # See Plutus Tx readme for information on the flags
   doctestOpts = "-pgmL markdown-unlit -XTemplateHaskell -XDeriveFunctor -XScopedTypeVariables -fno-ignore-interface-pragmas -fobject-code";
 in
 

--- a/plutus-emulator/test/Spec.hs
+++ b/plutus-emulator/test/Spec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Main(main) where
 
 

--- a/plutus-playground-server/plutus-playground-server.cabal
+++ b/plutus-playground-server/plutus-playground-server.cabal
@@ -94,6 +94,8 @@ library plutus-playground-usecases
         Vesting
     default-language: Haskell2010
     ghc-options: -Wincomplete-uni-patterns -Wincomplete-record-updates
+                 -- See Plutus Tx readme
+                 -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
     build-depends:
         aeson -any,
         base >=4.7 && <5,

--- a/plutus-playground-server/src/Playground/Interpreter.hs
+++ b/plutus-playground-server/src/Playground/Interpreter.hs
@@ -194,11 +194,9 @@ runghcOpts =
     , "-XTemplateHaskell"
     , "-XScopedTypeVariables"
     , "-XNoImplicitPrelude"
-    -- We need this to load unfoldings from interfaces with -O0, which is what we
-    -- get with runghc (higher optimization levels are just ignored).
+    -- See Plutus Tx readme
+    -- runghc is interpreting our code
     , "-fno-ignore-interface-pragmas"
-    -- We need this otherwise the bytecode interpreter can't deal with the code
-    -- it loads from the interfaces.
     , "-fobject-code"
     -- FIXME: stupid GHC bug still
     , "-package plutus-wallet-api"

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -42,7 +42,7 @@ spec = do
     knownCurrencySpec
 
 maxInterpretationTime :: Microsecond
-maxInterpretationTime = fromMicroseconds 10000000
+maxInterpretationTime = fromMicroseconds 40000000
 
 w1, w2, w3, w4, w5 :: Wallet
 w1 = Wallet 1

--- a/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground-server/usecases/CrowdFunding.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module CrowdFunding where
 -- TRIM TO HERE
 -- Crowdfunding contract implemented using the [[Plutus]] interface.

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Game where
 -- TRIM TO HERE
 -- A game with two players. Player 1 thinks of a secret word

--- a/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground-server/usecases/Vesting.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Vesting where
 -- TRIM TO HERE
 -- Vesting scheme as a PLC contract

--- a/plutus-tutorial/plutus-tutorial.cabal
+++ b/plutus-tutorial/plutus-tutorial.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.2
 name: plutus-tutorial
 version: 0.1.0.0
 license: Apache-2.0
-license-files: 
+license-files:
   LICENSE
   NOTICE
 maintainer: jann.mueller@iohk.io
@@ -38,8 +38,8 @@ common lang
     ghc-options: -Wall -Wnoncanonical-monad-instances
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
                  -Wredundant-constraints -Widentities
-                 -- Needed for GHCI to work with the plugin
-                 -fobject-code -fno-ignore-interface-pragmas
+                 -- See Plutus Tx readme
+                 -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
 
     if flag(defer-plugin-errors)
         ghc-options: -fplugin-opt Language.PlutusTx.Plugin:defer-errors
@@ -47,6 +47,7 @@ common lang
 library
     import: lang
     hs-source-dirs: tutorial
+    default-language: Haskell2010
     exposed-modules:
         Tutorial.TH
         Tutorial.Emulator
@@ -70,11 +71,10 @@ library
 test-suite tutorial-doctests
     type: exitcode-stdio-1.0
     hs-source-dirs: doctest
+    default-language: Haskell2010
     main-is: Main.hs
     ghc-options: -pgmL markdown-unlit -Wno-unused-imports
-    build-tool-depends: markdown-unlit:markdown-unlit -any
-    build-tool-depends: doctest:doctest -any
-    build-depends: plutus-tutorial
+    build-tool-depends: markdown-unlit:markdown-unlit -any, doctest:doctest -any
     other-modules:
       Tutorial.PlutusTx
       Tutorial.WalletAPI
@@ -87,7 +87,6 @@ test-suite tutorial-doctests
       plutus-tx -any,
       plutus-wallet-api -any,
       plutus-emulator -any,
+      plutus-tutorial -any,
       prettyprinter -any,
       containers -any
-
-

--- a/plutus-tutorial/tutorial/Tutorial/ExUtil.hs
+++ b/plutus-tutorial/tutorial/Tutorial/ExUtil.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 -- Some utility functions for the tutorials
 module Tutorial.ExUtil(
       initialTx

--- a/plutus-tutorial/tutorial/Tutorial/Solutions0.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions0.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -g #-}
 module Tutorial.Solutions0 where
 
 import           Data.Foldable                (traverse_)

--- a/plutus-tutorial/tutorial/Tutorial/Solutions0Mockchain.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions0Mockchain.hs
@@ -90,4 +90,3 @@ campaignFail = do
     _ <- EM.addBlocksAndNotify [ExUtil.w1, ExUtil.w2, ExUtil.w3] 20
 
     pure ()
-

--- a/plutus-tutorial/tutorial/Tutorial/Solutions1.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions1.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Tutorial.Solutions1 where
 
 -- Solutions to E2 and E4*

--- a/plutus-tutorial/tutorial/Tutorial/Solutions2.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions2.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Tutorial.Solutions2 where
 
 import qualified Data.Map                     as Map

--- a/plutus-tutorial/tutorial/Tutorial/Vesting.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Vesting.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 {-
     A vesting contract in Plutus
 

--- a/plutus-tx/README.md
+++ b/plutus-tx/README.md
@@ -52,7 +52,37 @@ The things that don't work broadly fall into a few categories:
 
 ## Building projects with `plutus-tx`
 
-Most build tools should work just fine with projects that use `plutus-tx`. However,
-if you want to use it in a project you are *intepreting* (e.g. loading into GHCI, using
-doctest), then you need to compile with `-fno-ignore-interface-pragmas`
-(which in turn requires `-fobject-code`).
+Most build tools should work just fine with projects that use `plutus-tx`.
+
+In some circumstances you may need some GHC compiler flags. To be safe, just add all of
+- `-fno-ignore-interface-pragmas`
+- `-fno-omit-interface-pragmas`
+- `-fobject-code`
+to all packages that either export functions to be used by the Plutus Tx compiler, or which
+use them. These flags should all be harmless, so enabling them is safe.
+Further explanation is given below.
+
+### Interface pragmas
+
+The Plutus Tx compiler relies on the bodies of functions being included in the *interface files*
+that GHC generates for dependencies. There are two flags that can inhibit this mechanism
+and prevent you from using functions from a dependency:
+- `-fignore-interface-pragmas` on the *consumer* of a function will prevent it from
+  loading the information from the interface files.
+- `-fomit-interface-pragmas` on the *producer* of a function will prevent it from
+  writing the information to the interface files at all.
+
+These flags are normally only implied by `-O0`, but if you want to support `-O0` (to allow
+faster compiles and use in GHCi) then you should disable them explicitly. Depending where the `-O0`
+comes from, you may need to explicitly include them in `OPTIONS_GHC` pragmas in the source file
+in order to prevent the being overridden.
+
+So on packages that produce functions you should pass `-fno-omit-interface-pragmas`, and
+on packages that consume functions you should pass `-fno-ignore-interface-pragmas`.
+
+### Object code
+
+GHCi will use interface files provided you have passed `-fno-ignore-interface-pragmas`
+(see above), but the information is designed for object code, not the interpreted bytecode
+that GHCi uses by default. To fix this, pass `-fobject-code` for projects using Plutus Tx
+which you want to load into GHCi.

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -32,6 +32,8 @@ common lang
     ghc-options: -Wall -Wnoncanonical-monad-instances
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
                  -Wredundant-constraints -Widentities
+                 -- See Plutus Tx readme
+                 -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
 
 library
     import: lang

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -1,6 +1,7 @@
 -- Need some extra imports from the Prelude for doctests, annoyingly
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Language.PlutusTx.Prelude (
     -- $prelude
     -- * String and tracing functions

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -45,8 +45,8 @@ library
     ghc-options: -Wall -Wnoncanonical-monad-instances
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
                  -Wredundant-constraints -Widentities
-                 -- Needed for GHCI to work with the plugin
-                 -fobject-code -fno-ignore-interface-pragmas
+                 -- See Plutus Tx readme
+                 -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
     build-depends:
         plutus-tx -any,
         plutus-wallet-api -any,

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Language.PlutusTx.Coordination.Contracts.CrowdFunding (
     -- * Campaign parameters
     Campaign(..)

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds       #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 -- | Implements a custom currency with a monetary policy that allows
 --   the forging of a fixed amount of units.
 module Language.PlutusTx.Coordination.Contracts.Currency(

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 -- | A futures contract in Plutus. This example illustrates three concepts.
 --   1. Maintaining a margin (a kind of deposit) during the duration of the contract to protect against breach of contract (see note [Futures in Plutus])
 --   2. Using oracle values to obtain current pricing information (see note [Oracles] in Language.PlutusTx.Coordination.Contracts)

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Language.PlutusTx.Coordination.Contracts.Game(
     lock,
     guess,

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 -- | A guessing game that
 --
 --   * Uses a state machine to keep track of the current secret word

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 -- | Implements an n-out-of-m multisig contract.
 module Language.PlutusTx.Coordination.Contracts.MultiSig
     ( MultiSig(..)

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 -- | A multisig contract written as a state machine.
 --   $multisig
 module Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine(

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 -- | A "pay-to-pubkey" transaction output implemented as a Plutus
 --   contract. This is useful if you need something that behaves like
 --   a pay-to-pubkey output, but is not (easily) identified by wallets

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Language.PlutusTx.Coordination.Contracts.Swap(
     Swap(..),
     -- * Script

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Language.PlutusTx.Coordination.Contracts.Vesting (
     Vesting(..),
     VestingTranche(..),

--- a/plutus-wallet-api/ledger/Ledger/Ada.hs
+++ b/plutus-wallet-api/ledger/Ledger/Ada.hs
@@ -6,6 +6,7 @@
 -- Otherwise we get a complaint about the 'fromIntegral' call in the generated instance of 'Integral' for 'Ada'
 {-# OPTIONS_GHC -Wno-identities #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 -- | Functions for working with 'Ada' in Template Haskell.
 module Ledger.Ada(
       Ada

--- a/plutus-wallet-api/ledger/Ledger/Interval.hs
+++ b/plutus-wallet-api/ledger/Ledger/Interval.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE MonoLocalBinds       #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 -- | A type for intervals and associated functions.
 module Ledger.Interval(
       Interval(..)

--- a/plutus-wallet-api/ledger/Ledger/Map.hs
+++ b/plutus-wallet-api/ledger/Ledger/Map.hs
@@ -11,6 +11,7 @@
 -- Prevent unboxing, which the plugin can't deal with
 {-# OPTIONS_GHC -fno-strictness #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 -- A map implementation that can be used in on-chain and off-chain code.
 module Ledger.Map(
     Map

--- a/plutus-wallet-api/ledger/Ledger/Scripts.hs
+++ b/plutus-wallet-api/ledger/Ledger/Scripts.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE ViewPatterns       #-}
 {-# LANGUAGE NoImplicitPrelude  #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 -- | Functions for working with scripts on the ledger.
 module Ledger.Scripts(
     -- * Scripts

--- a/plutus-wallet-api/ledger/Ledger/Slot.hs
+++ b/plutus-wallet-api/ledger/Ledger/Slot.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 -- Otherwise we get a complaint about the 'fromIntegral' call in the generated instance of 'Integral' for 'Ada'
 {-# OPTIONS_GHC -Wno-identities #-}
+{-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 -- | Slots and slot ranges.
 module Ledger.Slot(
       Slot(..)

--- a/plutus-wallet-api/ledger/Ledger/These.hs
+++ b/plutus-wallet-api/ledger/Ledger/These.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Ledger.These(
     These(..)
   , these

--- a/plutus-wallet-api/ledger/Ledger/Validation.hs
+++ b/plutus-wallet-api/ledger/Ledger/Validation.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Ledger.Validation
     (
     -- * Pending transactions and related types

--- a/plutus-wallet-api/ledger/Ledger/Value.hs
+++ b/plutus-wallet-api/ledger/Ledger/Value.hs
@@ -11,6 +11,7 @@
 -- Prevent unboxing, which the plugin can't deal with
 {-# OPTIONS_GHC -fno-strictness #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 -- | Functions for working with 'Value'.
 module Ledger.Value(
     -- ** Currency symbols

--- a/plutus-wallet-api/plutus-wallet-api.cabal
+++ b/plutus-wallet-api/plutus-wallet-api.cabal
@@ -32,8 +32,8 @@ common lang
     ghc-options: -Wall -Wnoncanonical-monad-instances
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
                  -Wredundant-constraints -Widentities
-                 -- Needed for GHCI to work with the plugin
-                 -fobject-code -fno-ignore-interface-pragmas
+                 -- See Plutus Tx readme
+                 -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
 
 flag development
     description:

--- a/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
+++ b/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 -- | On-chain code fragments for creating a state machine. First
 --   define a @StateMachine s i@ with input type @i@ and state type @s@. Then
 --   use 'mkValidator' in on-chain code to check the required hashes and

--- a/plutus-wallet-api/src/Wallet/API.hs
+++ b/plutus-wallet-api/src/Wallet/API.hs
@@ -10,6 +10,8 @@
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 -- | The interface between the wallet and Plutus client code.
 module Wallet.API(
     WalletAPI(..),


### PR DESCRIPTION
We also need `-fno-omit-interface-pragmas` otherwise GHC won't write out the information we need.

Weirdly, the `plutus-tx` tests don't work, it seems like the option is working for things that consume the `plutus-tx` package externally, but not internally. I'm a bit baffled, but it should work for the main use-case of building up to e.g. `plutus-playground-server` faster.

For me I can now `cabal new-build --disable-optimization plutus-playground-server` and have it work.