### PR TITLE
plutus-tx: 'and' -> '&&', 'or' -> '||'

### DIFF
--- a/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground-server/usecases/CrowdFunding.hs
@@ -15,10 +15,13 @@ module CrowdFunding where
 --
 -- Note [Transactions in the crowdfunding campaign] explains the structure of
 -- this contract on the blockchain.
+import           Prelude                      hiding ((&&))
+
 import qualified Language.PlutusTx            as PlutusTx
+import           Language.PlutusTx.Prelude    ((&&))
+import qualified Language.PlutusTx.Prelude    as P
 import           Ledger.Slot                  (SlotRange)
 import qualified Ledger.Slot                  as Slot
-import qualified Language.PlutusTx.Prelude    as P
 import           Ledger
 import           Ledger.Validation            as V
 import           Ledger.Value                 (Value)
@@ -88,7 +91,7 @@ validRefund campaign contributor ptx =
     -- Check that the transaction falls in the refund range of the campaign
     Slot.contains (refundRange campaign) (pendingTxValidRange ptx)
     -- Check that the transaction is signed by the contributor
-    `P.and` (ptx `V.txSignedBy` contributor)
+    && (ptx `V.txSignedBy` contributor)
 
 validCollection :: Campaign -> PendingTx -> Bool
 validCollection campaign p =
@@ -96,9 +99,9 @@ validCollection campaign p =
     (collectionRange campaign `Slot.contains` pendingTxValidRange p)
     -- Check that the transaction is trying to spend more money than the campaign
     -- target (and hence the target was reached)
-    `P.and` (valueSpent p `VTH.geq` campaignTarget campaign)
+    && (valueSpent p `VTH.geq` campaignTarget campaign)
     -- Check that the transaction is signed by the campaign owner
-    `P.and` (p `V.txSignedBy` campaignOwner campaign)
+    && (p `V.txSignedBy` campaignOwner campaign)
 
 -- | The validator script is of type 'CrowdfundingValidator', and is additionally parameterized by a
 -- 'Campaign' definition. This argument is provided by the Plutus client, using 'Ledger.applyScript'.

--- a/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground-server/usecases/Vesting.hs
@@ -10,11 +10,14 @@
 module Vesting where
 -- TRIM TO HERE
 -- Vesting scheme as a PLC contract
-import           Control.Monad                (void)
+import           Prelude                      hiding ((&&))
+
+import           Control.Monad             (void)
 import qualified Data.Map                  as Map
 import qualified Data.Set                  as Set
 
 import qualified Language.PlutusTx         as P
+import           Language.PlutusTx.Prelude ((&&))
 import           Ledger                    (Address, DataScript(..), RedeemerScript(..), Signature, Slot, TxOutRef, TxIn, ValidatorScript(..))
 import qualified Ledger                    as Ledger
 import           Ledger.Value              (Value)
@@ -144,7 +147,7 @@ mkValidator d@Vesting{..} () () p@PendingTx{pendingTxValidRange = range} =
         -- transaction 'p'.
         con2 :: Bool
         con2 = p `V.txSignedBy` vestingOwner
-    in con1 `P.and` con2
+    in con1 && con2
 
 validatorScript :: Vesting -> ValidatorScript
 validatorScript v = ValidatorScript $

--- a/plutus-tutorial/doctest/Tutorial/03-wallet-api.md
+++ b/plutus-tutorial/doctest/Tutorial/03-wallet-api.md
@@ -29,6 +29,9 @@ We need the same language extensions and imports as [before](./02-validator-scri
 {-# LANGUAGE OverloadedStrings   #-}
 module Tutorial.WalletAPI where
 
+import           Prelude                      hiding ((&&))
+
+import           Language.PlutusTx.Prelude    ((&&))
 import qualified Language.PlutusTx            as P
 import qualified Ledger.Interval              as P
 import qualified Ledger.Slot                  as P
@@ -42,7 +45,6 @@ import           Ledger.Validation            (PendingTx(..), PendingTxIn(..), P
 import qualified Ledger.Validation            as V
 import           Wallet                       (WalletAPI(..), WalletDiagnostics(..), MonadWallet, EventHandler(..), EventTrigger)
 import qualified Wallet                       as W
-import           Prelude                      hiding ((&&))
 import           GHC.Generics                 (Generic)
 ```
 
@@ -122,11 +124,6 @@ Before we check whether `act` is permitted, we define a number of intermediate v
 
 ```haskell
               let
-                  infixr 3 &&
-                  (&&) :: Bool -> Bool -> Bool
-                  (&&) = P.and
-
-
                   signedBy :: PendingTx -> PubKey -> Bool
                   signedBy = V.txSignedBy
 ```

--- a/plutus-tutorial/tutorial/Tutorial/Solutions0.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions0.hs
@@ -7,7 +7,10 @@
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
 module Tutorial.Solutions0 where
 
+import           Prelude                      hiding ((&&))
+
 import           Data.Foldable                (traverse_)
+import           Language.PlutusTx.Prelude    ((&&))
 import qualified Language.PlutusTx            as P
 import           Ledger                       (Address, DataScript(..), PubKey(..), RedeemerScript(..), Slot(..), TxId, ValidatorScript(..))
 import qualified Ledger                       as L
@@ -21,7 +24,6 @@ import           Ledger.Validation            (PendingTx(..), PendingTxIn(..), P
 import qualified Ledger.Validation            as V
 import           Wallet                       (WalletAPI(..), WalletDiagnostics(..), MonadWallet, EventHandler(..), EventTrigger)
 import qualified Wallet                       as W
-import           Prelude                      hiding ((&&))
 import           GHC.Generics                 (Generic)
 
 {-
@@ -102,11 +104,6 @@ mkValidatorScript campaign = ValidatorScript val where
   mkValidator = L.fromCompiledCode $$(P.compile [||
               \(c :: Campaign) (con :: Contributor) (act :: CampaignAction) (p :: PendingTx) ->
       let
-        infixr 3 &&
-        (&&) :: Bool -> Bool -> Bool
-        (&&) = P.and
-
-
         signedBy :: PendingTx -> PubKey -> Bool
         signedBy = V.txSignedBy
 

--- a/plutus-tutorial/tutorial/Tutorial/Vesting.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Vesting.hs
@@ -16,16 +16,19 @@
 -}
 module Tutorial.Vesting where
 
+import           Prelude                      hiding ((&&))
+
 import           GHC.Generics              (Generic)
 import qualified Data.Map                  as Map
 import qualified Data.Set                  as Set
 
+import           Language.PlutusTx.Prelude ((&&))
 import qualified Language.PlutusTx         as P
 import           Ledger                    (Address, DataScript(..), RedeemerScript(..), Slot, TxOutRef, TxIn, ValidatorScript(..))
 import qualified Ledger                    as L
 import           Ledger.Ada                (Ada)
 import qualified Ledger.Ada                as Ada
-import qualified Ledger.Ada             as ATH
+import qualified Ledger.Ada                as ATH
 import qualified Ledger.Interval           as Interval
 import qualified Ledger.Slot               as Slot
 import qualified Ledger.Validation         as V
@@ -199,7 +202,7 @@ vestingValidator v = ValidatorScript val where
             con2 :: Bool
             con2 = V.txSignedBy p owner
 
-        in con1 `P.and` con2
+        in con1 && con2
         ||])
 
 contractAddress :: Vesting -> Address

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -14,8 +14,8 @@ module Language.PlutusTx.Prelude (
     error,
     check,
     -- * Boolean operators
-    and,
-    or,
+    (&&),
+    (||),
     not,
     -- * Int operators
     gt,
@@ -117,19 +117,21 @@ traceIfTrueH str a = if a then traceH str True else False
 
 -- | Logical AND
 --
---   >>> and True False
+--   >>> True && False
 --   False
 --
-and :: Bool -> Bool -> Bool
-and l r = if l then r else False
+infixr 3 &&
+(&&) :: Bool -> Bool -> Bool
+(&&) l r = if l then r else False
 
 -- | Logical OR
 --
---   >>> or True False
+--   >>> True || False
 --   True
 --
-or :: Bool -> Bool -> Bool
-or l r = if l then True else r
+infixr 2 ||
+(||) :: Bool -> Bool -> Bool
+(||) l r = if l then True else r
 
 -- | Logical negation
 --
@@ -324,7 +326,7 @@ length as = foldr (\_ acc -> plus acc 1) 0 as
 --   True
 --
 all :: (a -> Bool) -> [a] -> Bool
-all pred = foldr (\a acc -> acc `and` pred a) True
+all pred = foldr (\a acc -> acc && pred a) True
 
 -- | PlutusTx version of 'Data.List.any'.
 --
@@ -332,7 +334,7 @@ all pred = foldr (\a acc -> acc `and` pred a) True
 --   True
 --
 any :: (a -> Bool) -> [a] -> Bool
-any pred = foldr (\a acc -> acc `or` pred a) False
+any pred = foldr (\a acc -> acc || pred a) False
 
 -- | PlutusTx version of 'Data.List.(++)'.
 --

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -23,10 +23,12 @@ module Language.PlutusTx.Coordination.Contracts.CrowdFunding (
     , mkCampaign
     ) where
 
+import           Prelude                     hiding ((&&))
+
 import qualified Language.PlutusTx           as PlutusTx
 import           Ledger.Slot                 (SlotRange)
 import qualified Ledger.Slot                 as Slot
-import qualified Language.PlutusTx.Prelude   as P
+import           Language.PlutusTx.Prelude   ((&&))
 import           Ledger
 import           Ledger.Validation           as V
 import           Ledger.Value                (Value)
@@ -34,8 +36,6 @@ import qualified Ledger.Value                as VTH
 import           Wallet                      as W
 import qualified Wallet.Emulator             as EM
 import           Wallet.Emulator             (Wallet)
-
-import           Prelude                     hiding ((&&))
 
 -- | A crowdfunding campaign.
 data Campaign = Campaign
@@ -86,13 +86,13 @@ type CrowdfundingValidator = PubKey -> CampaignAction -> PendingTx -> Bool
 validRefund :: Campaign -> PubKey -> PendingTx -> Bool
 validRefund campaign contributor ptx =
     Slot.contains (refundRange campaign) (pendingTxValidRange ptx)
-    `P.and` (ptx `V.txSignedBy` contributor)
+    && (ptx `V.txSignedBy` contributor)
 
 validCollection :: Campaign -> PendingTx -> Bool
 validCollection campaign p =
     (collectionRange campaign `Slot.contains` pendingTxValidRange p)
-    `P.and` (valueSpent p `VTH.geq` campaignTarget campaign)
-    `P.and` (p `V.txSignedBy` campaignOwner campaign)
+    && (valueSpent p `VTH.geq` campaignTarget campaign)
+    && (p `V.txSignedBy` campaignOwner campaign)
 
 mkValidator :: Campaign -> CrowdfundingValidator
 mkValidator c con act p = case act of

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -11,6 +11,8 @@ module Language.PlutusTx.Coordination.Contracts.Currency(
     , forgedValue
     ) where
 
+import           Prelude                   hiding ((&&))
+
 import           Control.Lens              ((^.), at, to)
 import           Data.Bifunctor            (Bifunctor(first))
 import qualified Data.Set                  as Set
@@ -19,6 +21,7 @@ import           Data.Maybe                (fromMaybe)
 import           Data.String               (IsString(fromString))
 import qualified Data.Text                 as Text
 
+import           Language.PlutusTx.Prelude ((&&))
 import qualified Language.PlutusTx         as P
 
 import qualified Ledger.Ada                as Ada
@@ -79,7 +82,7 @@ validate c@(Currency (refHash, refIdx) _) () () p =
             let v = V.spendsOutput p refHash refIdx
             in  P.traceIfFalseH "Pending transaction does not spend the designated transaction output" v
 
-    in forgeOK `P.and` txOutputSpent
+    in forgeOK && txOutputSpent
 
 curValidator :: Currency -> ValidatorScript
 curValidator cur = ValidatorScript $

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -17,10 +17,13 @@ module Language.PlutusTx.Coordination.Contracts.Vesting (
     validatorScript
     ) where
 
+import           Prelude                      hiding ((&&))
+
 import           Control.Monad.Error.Class    (MonadError (..))
 import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
 import           GHC.Generics                 (Generic)
+import           Language.PlutusTx.Prelude    ((&&))
 import qualified Language.PlutusTx            as PlutusTx
 import qualified Ledger                       as Ledger
 import           Ledger                       (DataScript (..), Slot(..), PubKey (..), TxOutRef, ValidatorScript (..), scriptTxIn, scriptTxOut)
@@ -149,7 +152,7 @@ mkValidator d@Vesting{..} VestingData{..} () p@PendingTx{pendingTxValidRange = r
             let remaining = Validation.valueLockedBy p (Validation.ownHash p) in
             remaining `Value.eq` (totalAmount d `Value.minus` newAmount)
 
-    in amountsValid `PlutusTx.and` txnOutputsValid
+    in amountsValid && txnOutputsValid
 
 validatorScript :: Vesting -> ValidatorScript
 validatorScript v = ValidatorScript $

--- a/plutus-wallet-api/ledger/Ledger/Map.hs
+++ b/plutus-wallet-api/ledger/Ledger/Map.hs
@@ -34,8 +34,9 @@ import           Data.Hashable                (Hashable)
 import           Data.Swagger.Internal.Schema (ToSchema)
 import           GHC.Generics                 (Generic)
 import           Language.PlutusTx.Lift       (makeLift)
+import           Language.PlutusTx.Prelude    ((&&))
 import qualified Language.PlutusTx.Prelude    as P
-import           Prelude                      hiding (all, lookup, map)
+import           Prelude                      hiding (all, lookup, map, (&&), (||))
 
 import           Ledger.These
 
@@ -111,7 +112,7 @@ all :: (v -> Bool) -> Map k v -> Bool
 all p (Map mps) =
     let go xs = case xs of
             []              -> True
-            (_ :: k, x):xs' -> P.and (p x) (go xs')
+            (_ :: k, x):xs' -> p x && go xs'
     in go mps
 
 -- | A singleton map.

--- a/plutus-wallet-api/ledger/Ledger/Validation.hs
+++ b/plutus-wallet-api/ledger/Ledger/Validation.hs
@@ -71,7 +71,9 @@ import           Data.Swagger.Internal.Schema (ToSchema (declareNamedSchema), pa
 import           GHC.Generics                 (Generic)
 import qualified Language.PlutusTx.Builtins   as Builtins
 import           Language.PlutusTx.Lift       (makeLift)
+import           Language.PlutusTx.Prelude    ((&&), (||))
 import qualified Language.PlutusTx.Prelude    as P
+import           Prelude                      hiding ((&&), (||))
 
 import           Ledger.Ada                   (Ada)
 import qualified Ledger.Ada                   as Ada
@@ -272,7 +274,7 @@ txSignedBy PendingTx{pendingTxSignatures=sigs, pendingTxHash=hash} k =
                     (pk, sig):r ->
                         if eqPubKey k pk
                         then  signedBy' sig
-                              `P.or` P.traceH "matching pub key with invalid signature" (go r)
+                              || P.traceH "matching pub key with invalid signature" (go r)
                         else go r
                     []  -> False
     in
@@ -379,7 +381,7 @@ spendsOutput p h i =
     let spendsOutRef inp =
             let outRef = pendingTxInRef inp
             in eqTx h (pendingTxOutRefId outRef)
-                `P.and` P.eq i (pendingTxOutRefIdx outRef)
+                && P.eq i (pendingTxOutRefIdx outRef)
 
     in P.any spendsOutRef (pendingTxInputs p)
 

--- a/plutus-wallet-api/ledger/Ledger/Value.hs
+++ b/plutus-wallet-api/ledger/Ledger/Value.hs
@@ -61,9 +61,10 @@ import qualified Data.Text                    as Text
 import           GHC.Generics                 (Generic)
 import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Lift       (makeLift)
+import           Language.PlutusTx.Prelude    ((&&))
 import qualified Language.PlutusTx.Prelude    as P
 import qualified Ledger.Map                   as Map
-import           Prelude                      hiding (all, lookup, negate)
+import           Prelude                      hiding ((&&), (||), all, lookup, negate)
 import           LedgerBytes                  (LedgerBytes(LedgerBytes))
 import           Data.Function                ((&))
 
@@ -304,7 +305,7 @@ geq = checkBinRel P.geq
 -- | Check whether one 'Value' is strictly greater than another. See 'Value' for an explanation of how operations on 'Value's work.
 gt :: Value -> Value -> Bool
 -- If both are zero then checkBinRel will be vacuously true. So we have a special case.
-gt l r = not (isZero l `P.and` isZero r) `P.and` checkBinRel P.gt l r
+gt l r = not (isZero l && isZero r) && checkBinRel P.gt l r
 
 -- | Check whether one 'Value' is less than or equal to another. See 'Value' for an explanation of how operations on 'Value's work.
 leq :: Value -> Value -> Bool
@@ -314,7 +315,7 @@ leq = checkBinRel P.leq
 -- | Check whether one 'Value' is strictly less than another. See 'Value' for an explanation of how operations on 'Value's work.
 lt :: Value -> Value -> Bool
 -- If both are zero then checkBinRel will be vacuously true. So we have a special case.
-lt l r = not (isZero l `P.and` isZero r) `P.and` checkBinRel P.lt l r
+lt l r = not (isZero l && isZero r) && checkBinRel P.lt l r
 
 -- | Check whether one 'Value' is equal to another. See 'Value' for an explanation of how operations on 'Value's work.
 eq :: Value -> Value -> Bool

--- a/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
+++ b/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
@@ -13,6 +13,9 @@ module Language.PlutusTx.StateMachine(
     ) where
 
 
+import           Prelude           hiding ((&&))
+
+import           Language.PlutusTx ((&&))
 import qualified Language.PlutusTx as P
 
 import           Ledger.Validation (PendingTx)
@@ -54,5 +57,5 @@ mkValidator sm (currentState, _) (newState, Just input) p =
             in
                 P.traceIfFalseH "State transition invalid - data script hash not equal to redeemer hash"
                 (P.all dsHashOk relevantOutputs)
-    in stateOk `P.and` dataScriptHashOk
+    in stateOk && dataScriptHashOk
 mkValidator _ _ _ _ = False


### PR DESCRIPTION
As discussed on Slack. This is significantly better, although only really when imported unqualified. That means a few more instances of `import Prelude hiding`.