### PR TITLE
Add purescript-bridge to cabal.project matching stack.yaml

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -45,7 +45,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/shmish111/servant-purescript.git
-  tag: 18e1b61bf0aa3792285c6d8ecd0e4a72d76e34f5
+  tag: ab14502279c92084f06aa6222a17873275279e63
 
 source-repository-package
   type: git

--- a/cabal.project
+++ b/cabal.project
@@ -39,6 +39,11 @@ program-options
 
 source-repository-package
   type: git
+  location: https://github.com/shmish111/purescript-bridge.git
+  tag: a7069a515800135ce932742e995f3a96bc1c7129
+
+source-repository-package
+  type: git
   location: https://github.com/shmish111/servant-purescript.git
   tag: 18e1b61bf0aa3792285c6d8ecd0e4a72d76e34f5
 


### PR DESCRIPTION
cc @shmish111 but I do not believe this needs review

This makes `cabal new-build` work the same as `stack build`