### PR TITLE
plutus-tx: make the Plutus Tx Prelude a full Prelude replacement

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,7 +1,7 @@
 ---
 - functions:
   - {name: unsafePerformIO, within: [PlutusPrelude, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Constant.Dynamic.Call, Language.PlutusCore.Constant.Dynamic.Emit, Language.PlutusCore.Constant.Dynamic.Instances, Language.PlutusCore.StdLib.Type, Language.PlutusTx.Plugin, Language.PlutusTx.Evaluation]}
-  - {name: error, within: [Main, PlutusPrelude, Language.PlutusCore.StdLib.Meta, Evaluation.Constant.Success, Language.PlutusCore.Constant.Apply, Language.PlutusCore.Evaluation.CkMachine, Language.PlutusCore.TypeSynthesis, Language.PlutusCore.Generators.Internal.Dependent, Language.PlutusCore.Generators.Internal.Entity, Language.PlutusCore.Generators.Internal.TypeEvalCheck, Language.PlutusCore.Generators.Test, Language.PlutusCore.Constant.Make, DynamicBuiltins.Definition, DynamicBuiltins.MakeRead, Language.PlutusCore.TH, Language.PlutusTx.Utils, Language.PlutusIR.Compiler.Datatype, LedgerBytes, Language.PlutusTx.Builtins, Language.PlutusIR.Compiler.Definitions]}
+  - {name: error}
   - {name: undefined, within: [Language.PlutusCore.Constant.Apply, Language.PlutusTx.Lift.Class, Language.PlutusTx.Lift.Instances]}
   - {name: fromJust, within: [Language.PlutusTx.Lift]}
   - {name: foldl, within: []}

--- a/plutus-playground-server/src/Playground/Interpreter.hs
+++ b/plutus-playground-server/src/Playground/Interpreter.hs
@@ -193,6 +193,7 @@ runghcOpts =
     , "-XStandaloneDeriving"
     , "-XTemplateHaskell"
     , "-XScopedTypeVariables"
+    , "-XNoImplicitPrelude"
     -- We need this to load unfoldings from interfaces with -O0, which is what we
     -- get with runghc (higher optimization levels are just ignored).
     , "-fno-ignore-interface-pragmas"

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -372,6 +372,7 @@ knownCurrencySpec =
             , "import Ledger.Value (TokenName(TokenName))"
             , "import Ledger.Validation (ValidatorHash (..))"
             , "import Playground.API (KnownCurrency (..))"
+            , "import Language.PlutusTx.Prelude"
             , "myCurrency :: KnownCurrency"
             , "myCurrency = KnownCurrency (ValidatorHash \"\") \"MyCurrency\" (TokenName \"MyToken\" :| [])"
             , "$(mkKnownCurrencies ['myCurrency])"

--- a/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground-server/usecases/CrowdFunding.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
 module CrowdFunding where
 -- TRIM TO HERE
 -- Crowdfunding contract implemented using the [[Plutus]] interface.
@@ -15,11 +16,9 @@ module CrowdFunding where
 --
 -- Note [Transactions in the crowdfunding campaign] explains the structure of
 -- this contract on the blockchain.
-import           Prelude                      hiding ((&&))
 
 import qualified Language.PlutusTx            as PlutusTx
-import           Language.PlutusTx.Prelude    ((&&))
-import qualified Language.PlutusTx.Prelude    as P
+import           Language.PlutusTx.Prelude
 import           Ledger.Slot                  (SlotRange)
 import qualified Ledger.Slot                  as Slot
 import           Ledger
@@ -45,7 +44,6 @@ data Campaign = Campaign
     } deriving (Generic, ToJSON, FromJSON, ToSchema)
 
 PlutusTx.makeLift ''Campaign
-
 
 -- | Construct a 'Campaign' value from the campaign parameters,
 --   using the wallet's public key.

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
 module Game where
 -- TRIM TO HERE
 -- A game with two players. Player 1 thinks of a secret word
@@ -16,7 +17,7 @@ module Game where
 -- output. If the guess is correct, the validator script releases the funds.
 -- If it isn't, the funds stay locked.
 import qualified Language.PlutusTx            as PlutusTx
-import qualified Language.PlutusTx.Prelude    as P
+import           Language.PlutusTx.Prelude
 import           Ledger
 import qualified Ledger.Value                 as Value
 import           Ledger.Value                 (Value)
@@ -26,17 +27,17 @@ import           Playground.Contract
 
 import qualified Data.ByteString.Lazy.Char8   as C
 
-data HashedString = HashedString P.ByteString
+data HashedString = HashedString ByteString
 
 PlutusTx.makeLift ''HashedString
 
-data ClearString = ClearString P.ByteString
+data ClearString = ClearString ByteString
 
 PlutusTx.makeLift ''ClearString
 
 correctGuess :: HashedString -> ClearString -> Bool
 correctGuess (HashedString actual) (ClearString guess') =
-    P.equalsByteString actual (P.sha2_256 guess')
+    equalsByteString actual (sha2_256 guess')
 
 validateGuess :: HashedString -> ClearString -> PendingTx -> Bool
 validateGuess dataScript redeemerScript _ = correctGuess dataScript redeemerScript

--- a/plutus-playground-server/usecases/Messages.hs
+++ b/plutus-playground-server/usecases/Messages.hs
@@ -1,17 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 module Messages where
 -- TRIM TO HERE
 -- Contract endpoints that generate different kinds of errors for the log:
 -- logAMessage produces a log message from a wallet
 -- submitInvalidTxn submits an invalid txn which should result in a "Validation failed" message
 -- throwWalletAPIError throws an error from a wallet (client)
-import qualified Data.Map            as Map
-import qualified Data.Set            as Set
-import           Data.Text           (Text)
+import           Language.PlutusTx.Prelude
+
+import qualified Data.Map                  as Map
+import qualified Data.Set                  as Set
+import           Data.Text                 (Text)
 
 import           Ledger
-import qualified Ledger.Ada          as Ada
+import qualified Ledger.Ada                as Ada
 import           Ledger.Validation
 import           Playground.Contract
 import           Wallet

--- a/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground-server/usecases/Vesting.hs
@@ -7,17 +7,16 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
 module Vesting where
 -- TRIM TO HERE
 -- Vesting scheme as a PLC contract
-import           Prelude                      hiding ((&&))
-
 import           Control.Monad             (void)
 import qualified Data.Map                  as Map
 import qualified Data.Set                  as Set
 
-import qualified Language.PlutusTx         as P
-import           Language.PlutusTx.Prelude ((&&))
+import qualified Language.PlutusTx         as PlutusTx
+import           Language.PlutusTx.Prelude
 import           Ledger                    (Address, DataScript(..), RedeemerScript(..), Signature, Slot, TxOutRef, TxIn, ValidatorScript(..))
 import qualified Ledger                    as Ledger
 import           Ledger.Value              (Value)
@@ -58,7 +57,7 @@ data VestingTranche = VestingTranche {
     -- ^ How much money is locked in this tranche
     } deriving (Generic, ToJSON, FromJSON, ToSchema)
 
-P.makeLift ''VestingTranche
+PlutusTx.makeLift ''VestingTranche
 
 -- | A vesting scheme consisting of two tranches. Each tranche defines a date
 --   (slot) after which an additional amount of money can be spent.
@@ -74,7 +73,7 @@ data Vesting = Vesting {
     --   it has been released)
     } deriving (Generic, ToJSON, FromJSON, ToSchema)
 
-P.makeLift ''Vesting
+PlutusTx.makeLift ''Vesting
 
 -- | The total value locked by a vesting scheme
 totalAmount :: Vesting -> Value

--- a/plutus-tutorial/doctest/Tutorial/02-validator-scripts.md
+++ b/plutus-tutorial/doctest/Tutorial/02-validator-scripts.md
@@ -27,14 +27,16 @@ We need some language extensions and imports:
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
 module Tutorial.ValidatorScripts where
 ```
 
 The language extensions fall into three categories. The first category is extensions required by the plugin that translates Haskell Core to Plutus IR (Intermediate Representation - a more abstract form of Plutus Core). This category includes [`DataKinds`](https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#datatype-promotion), [`TemplateHaskell`](https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#template-haskell) and [`ScopedTypeVariables`](https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#lexically-scoped-type-variables). The second category is extensions that contract endpoints to be automatically generated in the Plutus Playground, and it contains only the [`DeriveGeneric`](https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#deriving-representations) extension. The final category is extensions that make the code look nicer. These include [`RecordWildCards`](https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#record-wildcards), which lets us use write `Campaign{..}` in pattern matching to bring into scope all fields of a `Campaign` value, and [`OverloadedStrings`](https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#overloaded-string-literals) which allows us to write log messages as string literals without having to convert them to `Text` values first.
 
 ```haskell
-import qualified Language.PlutusTx            as P
-import qualified Ledger.Interval              as P
+import qualified Language.PlutusTx            as PlutusTx
+import           Language.PlutusTx.Prelude
+import qualified Ledger.Interval              as I
 import           Ledger                       (Address, DataScript(..), PubKey(..), RedeemerScript(..), Signature(..), Slot(..), TxId, ValidatorScript(..))
 import qualified Ledger                       as L
 import qualified Ledger.Ada                   as Ada
@@ -60,15 +62,15 @@ Both the hashed secret and the cleartext guess are represented as `ByteString` v
 To avoid any confusion between cleartext and hash we wrap them in data types called `HashedText` and `ClearText`, respectively.
 
 ```haskell
-data HashedText = HashedText P.ByteString
-data ClearText = ClearText P.ByteString
+data HashedText = HashedText ByteString
+data ClearText = ClearText ByteString
 ```
 
 One of the strengths of PlutusTx is the ability to use the same definitions for on-chain and off-chain code, which includes lifting values from Haskell to Plutus Core. To enable values of our string types to be lifted, we need to call `makeLift` from the `PlutusTx` module.
 
 ```haskell
-P.makeLift ''HashedText
-P.makeLift ''ClearText
+PlutusTx.makeLift ''HashedText
+PlutusTx.makeLift ''ClearText
 ```
 
 `mkDataScript` creates a data script for the guessing game by hashing the string and lifting the hash to its on-chain representation.
@@ -106,23 +108,23 @@ gameValidator = ValidatorScript ($$(L.compileScript [||
     \(HashedText actual) (ClearText guessed) (_ :: PendingTx) ->
 ```
 
-The actual game logic is very simple: We compare the hash of the `guessed` argument with the `actual` secret hash, and throw an error if the two don't match. In on-chain code, we can use the `$$()` splicing operator to access functions from the Plutus prelude, imported as `P`. For example, `P.equalsByteString :: ByteString -> ByteString -> Bool`  compares two `ByteString` values for equality.
+The actual game logic is very simple: We compare the hash of the `guessed` argument with the `actual` secret hash, and throw an error if the two don't match. In on-chain code, we can use the `$$()` splicing operator to access functions from the Plutus prelude, imported as `P`. For example, `equalsByteString :: ByteString -> ByteString -> Bool`  compares two `ByteString` values for equality.
 
 ```haskell
-    if P.equalsByteString actual (P.sha2_256 guessed)
-    then (P.traceH "RIGHT!" True)
-    else (P.traceH "WRONG!" False)
+    if equalsByteString actual (sha2_256 guessed)
+    then (traceH "RIGHT!" True)
+    else (traceH "WRONG!" False)
 
     ||])) -- marks the end of the quoted (on-chain) code
 ```
 
-`P.traceH :: String -> a -> a` returns its second argument after adding its first argument to the log output of this script. The log output is only available in the emulator and on the playground, and will be ignored when the code is run on the real blockchain.
+`traceH :: String -> a -> a` returns its second argument after adding its first argument to the log output of this script. The log output is only available in the emulator and on the playground, and will be ignored when the code is run on the real blockchain.
 
 TODO: The example doesn't use `error` anymore
 
-Before we move on to the wallet interactions that produces transactions for our game, let us look at the failure case more closely. There are two two subtle differences between on-chain and off-chain code that we need to be aware of. First, the signature of `P.error` is `forall a. () -> a` and therefore we alway have to apply it to a unit value. `P.error` is different from Haskell's `undefined :: forall a. a` because of differences in the type systems of the two languages.
+Before we move on to the wallet interactions that produces transactions for our game, let us look at the failure case more closely. There are two two subtle differences between on-chain and off-chain code that we need to be aware of. First, the signature of `error` is `forall a. () -> a` and therefore we alway have to apply it to a unit value. `error` is different from Haskell's `undefined :: forall a. a` because of differences in the type systems of the two languages.
 
-Second, `P.error` terminates evaluation of the script when it is encountered, but (due to the strict evaluation order of on-chain code) only *after* its argument has been evaluated. That is why we need to put the call to `P.traceH` as the argument to `P.error`. In regular Haskell we would write `traceH "WRONG!" undefined`.
+Second, `error` terminates evaluation of the script when it is encountered, but (due to the strict evaluation order of on-chain code) only *after* its argument has been evaluated. That is why we need to put the call to `traceH` as the argument to `error`. In regular Haskell we would write `traceH "WRONG!" undefined`.
 
 ## 1.3 Contract endpoints
 
@@ -198,7 +200,7 @@ If you change the word "plutus" in the third item of the trace to "pluto" and cl
 # 3. Problems / Questions
 
 1. Run traces for a successful game and a failed game in the Playground, and examine the logs after each trace.
-1. Change the error case of the validator script to `(P.traceH "WRONG!" (P.error ()))` and run the trace again with a wrong guess. Note how this time the log does not include the error message.
+1. Change the error case of the validator script to `(traceH "WRONG!" (error ()))` and run the trace again with a wrong guess. Note how this time the log does not include the error message.
 1. Look at the trace shown below. What will the logs say after running "Evaluate"?
 
 ![A trace for the guessing game](game-actions-2.PNG)

--- a/plutus-tutorial/tutorial/Tutorial/Solutions0.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions0.hs
@@ -4,14 +4,13 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
 module Tutorial.Solutions0 where
 
-import           Prelude                      hiding ((&&))
-
 import           Data.Foldable                (traverse_)
-import           Language.PlutusTx.Prelude    ((&&))
-import qualified Language.PlutusTx            as P
+import           Language.PlutusTx.Prelude
+import qualified Language.PlutusTx            as PlutusTx
 import           Ledger                       (Address, DataScript(..), PubKey(..), RedeemerScript(..), Slot(..), TxId, ValidatorScript(..))
 import qualified Ledger                       as L
 import qualified Ledger.Ada                   as Ada
@@ -37,7 +36,7 @@ import           GHC.Generics                 (Generic)
 
 -- 1. Run traces for a successful game and a failed game in the Playground, and examine the logs after each trace.
 -- (the logs should show the error message for the failed trace)
--- 2. Change the error case of the validator script to `($$(P.traceH) "WRONG!" ($$(P.error) ()))` and run the trace again with a wrong guess. Note how this time the log does not include the error message.
+-- 2. Change the error case of the validator script to `($$(traceH) "WRONG!" ($$(error) ()))` and run the trace again with a wrong guess. Note how this time the log does not include the error message.
 -- (there should be a failed transaction without log message)
 -- 1. Look at the trace shown below. What will the logs say after running "Evaluate"?
 -- Wallet 1's transaction attempts to unlock both outputs with the same redeemer ("plutus"). This fails for the second output (which expects "pluto"), making the entire transaction invalid.
@@ -51,7 +50,7 @@ import           GHC.Generics                 (Generic)
 --    should end with refunds being claimed after the `collectionDeadline` slot.
 
 -- 2. Change the validator script to produce more detailed log messages using
---    `P.traceH`
+--    `traceH`
 --    The log messages are only printed when validation of the script output
 --    fails. The triggers for both outcomes (successful campaign and refund)
 --    are set up to ensure that they only submit valid transactions to the
@@ -90,18 +89,18 @@ data Campaign = Campaign {
       campaignOwner      :: PubKey
  }
 
-P.makeLift ''Campaign
+PlutusTx.makeLift ''Campaign
 
 data CampaignAction = Collect | Refund
-P.makeLift ''CampaignAction
+PlutusTx.makeLift ''CampaignAction
 
 data Contributor = Contributor PubKey
-P.makeLift ''Contributor
+PlutusTx.makeLift ''Contributor
 
 mkValidatorScript :: Campaign -> ValidatorScript
 mkValidatorScript campaign = ValidatorScript val where
   val = L.applyScript mkValidator (L.lifted campaign)
-  mkValidator = L.fromCompiledCode $$(P.compile [||
+  mkValidator = L.fromCompiledCode $$(PlutusTx.compile [||
               \(c :: Campaign) (con :: Contributor) (act :: CampaignAction) (p :: PendingTx) ->
       let
         signedBy :: PendingTx -> PubKey -> Bool
@@ -122,7 +121,7 @@ mkValidatorScript campaign = ValidatorScript val where
 
               -- Apply "addToTotal" to each transaction input,
               -- summing up the results
-              in P.foldr addToTotal Ada.zero ins
+              in foldr addToTotal Ada.zero ins
 
         isValid = case act of
                     Refund ->
@@ -135,7 +134,7 @@ mkValidatorScript campaign = ValidatorScript val where
                                 Nothing -> False
                                 Just pk -> V.eqPubKey pk pkCon
 
-                            contributorOnly = P.all contribTxOut outs
+                            contributorOnly = all contribTxOut outs
 
                             refundable =
                               Slot.before collectionDeadline txnValidRange &&
@@ -163,18 +162,18 @@ mkValidatorScript campaign = ValidatorScript val where
                         minimumAda :: [Ada] -> Maybe Ada
                         minimumAda slts = case slts of
                                         []   -> Nothing
-                                        x:xs -> Just (P.foldr minAda x xs)
+                                        x:xs -> Just (foldr minAda x xs)
 
                         -- | The list of 'targets' filtered to those targets
                         --   that are in the future
                         futureTargets :: [(Slot, Ada)]
-                        futureTargets = P.filter (\(a, _) -> isFutureSlot a) targets
+                        futureTargets = filter (\(a, _) -> isFutureSlot a) targets
 
                         -- | The amount we have to exceed if we want to collect
                         --   all the contributions now. It is the smallest of
                         --   all target amounts that are in the future.
                         currentTarget :: Maybe Ada
-                        currentTarget = minimumAda (P.map (\(_, a) -> a) futureTargets)
+                        currentTarget = minimumAda (map (\(_, a) -> a) futureTargets)
 
                         -- We may collect the contributions if the
                         -- 'currentTarget' is defined and the sum of all

--- a/plutus-tutorial/tutorial/Tutorial/Solutions2.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Solutions2.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 module Tutorial.Solutions2 where
 
 import qualified Data.Map                     as Map
 
-import qualified Language.PlutusTx            as P
+import qualified Language.PlutusTx            as PlutusTx
+import           Language.PlutusTx.Prelude
 import           Ledger                       (Address, DataScript(..), RedeemerScript(..), ValidatorScript(..), Value)
 import qualified Ledger                       as L
 import           Ledger.Validation            (PendingTx)
@@ -41,8 +43,8 @@ import Tutorial.Emulator (SecretNumber(..), ClearNumber(..))
     >>> PL.sizePlc trickier10Light
     3799
 -}
-trickier10Light :: P.CompiledCode (Integer -> Integer)
-trickier10Light = $$(P.compile [|| $$(TH.trickierLight 10) ||])
+trickier10Light :: PlutusTx.CompiledCode (Integer -> Integer)
+trickier10Light = $$(PlutusTx.compile [|| $$(TH.trickierLight 10) ||])
 
 {-
 
@@ -51,7 +53,7 @@ trickier10Light = $$(P.compile [|| $$(TH.trickierLight 10) ||])
 -}
 intGameValidator :: ValidatorScript
 intGameValidator = ValidatorScript ($$(L.compileScript [||
-  \(SecretNumber actual) (ClearNumber guess') (_ :: PendingTx) -> P.eq actual ($$(TH.trickier 2) guess')
+  \(SecretNumber actual) (ClearNumber guess') (_ :: PendingTx) -> eq actual ($$(TH.trickier 2) guess')
   ||]))
 
 gameAddress :: Address

--- a/plutus-tutorial/tutorial/Tutorial/Vesting.hs
+++ b/plutus-tutorial/tutorial/Tutorial/Vesting.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE DataKinds       #-}
-{-# LANGUAGE DeriveGeneric   #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 {-
     A vesting contract in Plutus
@@ -16,14 +17,12 @@
 -}
 module Tutorial.Vesting where
 
-import           Prelude                      hiding ((&&))
-
 import           GHC.Generics              (Generic)
 import qualified Data.Map                  as Map
 import qualified Data.Set                  as Set
 
-import           Language.PlutusTx.Prelude ((&&))
-import qualified Language.PlutusTx         as P
+import           Language.PlutusTx.Prelude
+import qualified Language.PlutusTx         as PlutusTx
 import           Ledger                    (Address, DataScript(..), RedeemerScript(..), Slot, TxOutRef, TxIn, ValidatorScript(..))
 import qualified Ledger                    as L
 import           Ledger.Ada                (Ada)
@@ -70,7 +69,7 @@ data VestingTranche = VestingTranche {
     -- ^ How much money is locked in this tranche
     } deriving (Generic)
 
-P.makeLift ''VestingTranche
+PlutusTx.makeLift ''VestingTranche
 
 -- | A vesting scheme consisting of two tranches. Each tranche defines a date
 --   (slot) after which an additional amount of money can be spent.
@@ -86,7 +85,7 @@ data Vesting = Vesting {
     --   it has been released)
     } deriving (Generic)
 
-P.makeLift ''Vesting
+PlutusTx.makeLift ''Vesting
 
 -- | The total amount of Ada locked by a vesting scheme
 totalVested :: Vesting -> Ada

--- a/plutus-tx/src/Language/PlutusTx.hs
+++ b/plutus-tx/src/Language/PlutusTx.hs
@@ -8,7 +8,6 @@ module Language.PlutusTx (
     liftCode,
     unsafeLiftCode) where
 
-import           Language.PlutusTx.Code    (CompiledCode, applyCode, getPir, getPlc)
-import           Language.PlutusTx.Lift    (liftCode, makeLift, unsafeLiftCode)
-import           Language.PlutusTx.Prelude as Export
-import           Language.PlutusTx.TH      as Export
+import           Language.PlutusTx.Code (CompiledCode, applyCode, getPir, getPlc)
+import           Language.PlutusTx.Lift (liftCode, makeLift, unsafeLiftCode)
+import           Language.PlutusTx.TH   as Export

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -59,24 +59,31 @@ module Language.PlutusTx.Prelude (
     -- * Hashes and Signatures
     sha2_256,
     sha3_256,
-    verifySignature
+    verifySignature,
+    module Prelude
     ) where
 
 import           Language.PlutusTx.Builtins (ByteString, concatenate, dropByteString, emptyByteString, equalsByteString,
                                              sha2_256, sha3_256, takeByteString, verifySignature)
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Prelude                    (Bool (..), Integer, Maybe (..), String)
+import           Prelude                    as Prelude hiding (all, any, error, filter, foldl, foldr, fst, length, map,
+                                                        max, maybe, min, not, null, snd, (&&), (||))
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}
 
 -- $prelude
--- The PlutusTx Prelude is a collection of useful functions that work with
--- builtin Haskell data types such as 'Maybe' and @[]@ (list).
+-- The PlutusTx Prelude is a replacement for the Haskell Prelude that works
+-- better with Plutus Tx. You should use it if you're writing code that
+-- will be compiled with the Plutus Tx compiler.
+-- @
+--     {-# LANGUAGE NoImplicitPrelude #-}
+--     import Language.PlutusTx.Prelude
+-- @
 
 -- $setup
 -- >>> :set -XNoImplicitPrelude
--- >>> import Prelude (Bool (..), Integer, Maybe (..), String, (+), (==), (>))
+-- >>> import Language.PlutusTx.Prelude
 
 -- | Terminate the evaluation of the script with an error message.
 error :: () -> a
@@ -326,7 +333,7 @@ length as = foldr (\_ acc -> plus acc 1) 0 as
 --   True
 --
 all :: (a -> Bool) -> [a] -> Bool
-all pred = foldr (\a acc -> acc && pred a) True
+all p = foldr (\a acc -> acc && p a) True
 
 -- | PlutusTx version of 'Data.List.any'.
 --
@@ -334,7 +341,7 @@ all pred = foldr (\a acc -> acc && pred a) True
 --   True
 --
 any :: (a -> Bool) -> [a] -> Bool
-any pred = foldr (\a acc -> acc || pred a) False
+any p = foldr (\a acc -> acc || p a) False
 
 -- | PlutusTx version of 'Data.List.(++)'.
 --
@@ -350,7 +357,7 @@ append l r = foldr (:) r l
 --   [2,3,4]
 --
 filter :: (a -> Bool) -> [a] -> [a]
-filter pred = foldr (\e xs -> if pred e then e:xs else xs) []
+filter p = foldr (\e xs -> if p e then e:xs else xs) []
 
 -- | PlutusTx version of 'Data.Maybe.mapMaybe'.
 --
@@ -358,7 +365,7 @@ filter pred = foldr (\e xs -> if pred e then e:xs else xs) []
 --   "2"
 --
 mapMaybe :: (a -> Maybe b) -> [a] -> [b]
-mapMaybe pred = foldr (\e xs -> case pred e of { Just e' -> e':xs; Nothing -> xs}) []
+mapMaybe p = foldr (\e xs -> case p e of { Just e' -> e':xs; Nothing -> xs}) []
 
 -- | PlutusTx version of 'Data.Tuple.fst'
 fst :: (a, b) -> a

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE TypeApplications    #-}
 module Language.PlutusTx.Coordination.Contracts.CrowdFunding (
     -- * Campaign parameters
@@ -23,12 +24,10 @@ module Language.PlutusTx.Coordination.Contracts.CrowdFunding (
     , mkCampaign
     ) where
 
-import           Prelude                     hiding ((&&))
-
 import qualified Language.PlutusTx           as PlutusTx
 import           Ledger.Slot                 (SlotRange)
 import qualified Ledger.Slot                 as Slot
-import           Language.PlutusTx.Prelude   ((&&))
+import           Language.PlutusTx.Prelude
 import           Ledger
 import           Ledger.Validation           as V
 import           Ledger.Value                (Value)

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -1,6 +1,7 @@
 -- | A guessing game
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 module Language.PlutusTx.Coordination.Contracts.Game(
     lock,
     guess,
@@ -14,24 +15,24 @@ module Language.PlutusTx.Coordination.Contracts.Game(
     ) where
 
 import qualified Language.PlutusTx            as PlutusTx
-import qualified Language.PlutusTx.Prelude    as P
+import           Language.PlutusTx.Prelude
 import           Ledger
 import           Ledger.Value                 (Value)
 import           Wallet
 
 import qualified Data.ByteString.Lazy.Char8   as C
 
-data HashedString = HashedString P.ByteString
+data HashedString = HashedString ByteString
 
 PlutusTx.makeLift ''HashedString
 
-data ClearString = ClearString P.ByteString
+data ClearString = ClearString ByteString
 
 PlutusTx.makeLift ''ClearString
 
 correctGuess :: HashedString -> ClearString -> Bool
 correctGuess (HashedString actual) (ClearString guess') =
-    P.equalsByteString actual (P.sha2_256 guess')
+    equalsByteString actual (sha2_256 guess')
 
 validateGuess :: HashedString -> ClearString -> PendingTx -> Bool
 validateGuess dataScript redeemerScript _ = correctGuess dataScript redeemerScript

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 -- | A guessing game that
 --
 --   * Uses a state machine to keep track of the current secret word
@@ -16,15 +17,12 @@ module Language.PlutusTx.Coordination.Contracts.GameStateMachine(
     , gameValidator
     ) where
 
-import           Prelude                      hiding ((&&))
-
 import qualified Data.Map                     as Map
 import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
 import qualified Data.Text                    as Text
 import qualified Language.PlutusTx            as PlutusTx
-import           Language.PlutusTx.Prelude    ((&&))
-import qualified Language.PlutusTx.Prelude    as P
+import           Language.PlutusTx.Prelude
 import           Ledger                       hiding (to)
 import qualified Ledger.Ada                   as Ada
 import           Ledger.Value                 (TokenName)
@@ -38,11 +36,11 @@ import qualified Data.ByteString.Lazy.Char8   as C
 import qualified Language.PlutusTx.StateMachine as SM
 import           Language.PlutusTx.StateMachine ()
 
-data HashedString = HashedString P.ByteString
+data HashedString = HashedString ByteString
 
 PlutusTx.makeLift ''HashedString
 
-data ClearString = ClearString P.ByteString
+data ClearString = ClearString ByteString
 
 PlutusTx.makeLift ''ClearString
 
@@ -59,16 +57,16 @@ PlutusTx.makeLift ''GameState
 -- | Equality of 'GameState' valzes.
 stateEq :: GameState -> GameState -> Bool
 stateEq (Initialised (HashedString s)) (Initialised (HashedString s')) =
-    P.equalsByteString s s'
+    equalsByteString s s'
 stateEq (Locked (V.TokenName n) (HashedString s)) (Locked (V.TokenName n') (HashedString s')) =
-    P.equalsByteString s s' && P.equalsByteString n n'
-stateEq _ _ = P.traceIfFalseH "states not equal" False
+    equalsByteString s s' && equalsByteString n n'
+stateEq _ _ = traceIfFalseH "states not equal" False
 
 -- | Check whether a 'ClearString' is the preimage of a
 --   'HashedString'
 checkGuess :: HashedString -> ClearString -> Bool
 checkGuess (HashedString actual) (ClearString gss) =
-    P.equalsByteString actual (P.sha2_256 gss)
+    equalsByteString actual (sha2_256 gss)
 
 -- | Inputs (actions)
 data GameInput =
@@ -108,12 +106,12 @@ mkValidator ds vs p =
         trans (Initialised s) (ForgeToken tn) =
             if checkForge (tokenVal tn)
             then Locked tn s
-            else P.error ()
+            else error ()
         trans (Locked tn currentSecret) (Guess theGuess nextSecret) =
             if checkGuess currentSecret theGuess && tokenPresent tn && checkForge V.zero
             then Locked tn nextSecret
-            else P.error ()
-        trans _ _ = P.traceErrorH "Invalid SM.transition"
+            else error ()
+        trans _ _ = traceErrorH "Invalid SM.transition"
 
         sm = SM.StateMachine trans stateEq
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 -- | A multisig contract written as a state machine.
 --   $multisig
 module Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine(
@@ -18,8 +19,6 @@ module Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine(
     , makePayment
     ) where
 
-import           Prelude                      hiding ((&&))
-
 import           Data.Foldable                (foldMap)
 import qualified Data.Set                     as Set
 import           Ledger                       (DataScript(..), RedeemerScript(..), ValidatorScript(..))
@@ -34,8 +33,7 @@ import           Wallet
 import qualified Wallet                       as WAPI
 
 import qualified Language.PlutusTx              as PlutusTx
-import           Language.PlutusTx.Prelude      ((&&))
-import qualified Language.PlutusTx.Prelude      as P
+import           Language.PlutusTx.Prelude
 import           Language.PlutusTx.StateMachine (StateMachine(..))
 import qualified Language.PlutusTx.StateMachine as SM
 
@@ -104,11 +102,11 @@ PlutusTx.makeLift ''Input
 
 -- | Check if a public key is one of the signatories of the multisig contract.
 isSignatory :: PubKey -> Params -> Bool
-isSignatory pk (Params sigs _) = P.any (\pk' -> Validation.eqPubKey pk pk') sigs
+isSignatory pk (Params sigs _) = any (\pk' -> Validation.eqPubKey pk pk') sigs
 
 -- | Check whether a list of public keys contains a given key.
 containsPk :: PubKey -> [PubKey] -> Bool
-containsPk pk = P.any (\pk' -> Validation.eqPubKey pk' pk)
+containsPk pk = any (\pk' -> Validation.eqPubKey pk' pk)
 
 pkListEq :: [PubKey] -> [PubKey] -> Bool
 pkListEq [] []           = True
@@ -128,17 +126,17 @@ proposalExpired (PendingTx _ _ _ _ _ rng _ _) (Payment _ _ ddl) = Slot.before dd
 --   have signed a proposed payment.
 proposalAccepted :: Params -> [PubKey] -> Bool
 proposalAccepted (Params signatories numReq) pks =
-    let numSigned = P.length (P.filter (\pk -> containsPk pk pks) signatories)
-    in P.geq numSigned numReq
+    let numSigned = length (filter (\pk -> containsPk pk pks) signatories)
+    in geq numSigned numReq
 
 -- | @valuePreserved v p@ is true if the pending transaction @p@ pays the amount
 --   @v@ to a single pay-to-script output at this script's address.
 valuePreserved :: Value -> PendingTx -> Bool
 valuePreserved vl ptx =
     let ownHash = Validation.ownHash ptx
-        numOutputs = P.length (Validation.scriptOutputsAt ownHash ptx)
+        numOutputs = length (Validation.scriptOutputsAt ownHash ptx)
         valueLocked = Validation.valueLockedBy ptx ownHash
-    in P.eq 1 numOutputs && Value.eq valueLocked vl
+    in eq 1 numOutputs && Value.eq valueLocked vl
 
 -- | @valuePaid pm ptx@ is true if the pending transaction @ptx@ pays
 --   the amount specified in @pm@ to the public key address specified in @pm@
@@ -172,12 +170,12 @@ step s i = case (s, i) of
     (CollectingSignatures vl (Payment vp _ _) _, Pay) ->
         let vl' = Value.minus vl vp in
         InitialState vl'
-    _ -> P.error (P.traceH "invalid transition" ())
+    _ -> error (traceH "invalid transition" ())
 
 -- | @stepWithChecks params ptx state input@ computes the next state given
 --   current state @state@ and the input. It checks whether the pending
 --   transaction @ptx@ pays the expected amounts to script and public key
---   addresses. Fails with 'P.error' if an invalid transition is attempted.
+--   addresses. Fails with 'error' if an invalid transition is attempted.
 stepWithChecks :: Params -> PendingTx -> State -> Input -> State
 stepWithChecks p ptx s i =
     let newState = step s i in
@@ -186,28 +184,28 @@ stepWithChecks p ptx s i =
             if isValidProposal vl pmt &&
                 valuePreserved vl ptx
             then newState
-            else P.traceErrorH "ProposePayment invalid"
+            else traceErrorH "ProposePayment invalid"
         (CollectingSignatures vl _ pks, AddSignature pk) ->
             if Validation.txSignedBy ptx pk &&
                 isSignatory pk p &&
-                P.not (containsPk pk pks) &&
+                not (containsPk pk pks) &&
                 valuePreserved vl ptx
             then newState
-            else P.traceErrorH "AddSignature invalid"
+            else traceErrorH "AddSignature invalid"
         (CollectingSignatures vl pmt _, Cancel) ->
             if proposalExpired ptx pmt &&
                 valuePreserved vl ptx
             then InitialState vl
-            else P.traceErrorH "Cancel invalid"
+            else traceErrorH "Cancel invalid"
         (CollectingSignatures vl pmt@(Payment vp _ _) pks, Pay) ->
             let vl' = Value.minus vl vp in
-            if P.not (proposalExpired ptx pmt) &&
+            if not (proposalExpired ptx pmt) &&
                 proposalAccepted p pks &&
                 valuePreserved vl' ptx &&
                 valuePaid pmt ptx
             then newState
-            else P.traceErrorH "Pay invalid"
-        _ -> P.traceErrorH "invalid transition"
+            else traceErrorH "Pay invalid"
+        _ -> traceErrorH "invalid transition"
 
 mkValidator :: Params -> (State, Maybe Input) -> (State, Maybe Input) -> PendingTx -> Bool
 mkValidator p ds vs ptx =

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
@@ -15,7 +15,7 @@ import           Data.Maybe (listToMaybe)
 import qualified Data.Map   as Map
 import qualified Data.Text  as Text
 
-import qualified Language.PlutusTx            as P
+import qualified Language.PlutusTx            as PlutusTx
 import           Ledger                       as Ledger hiding (initialise, to)
 import           Ledger.Validation            as V
 import           Wallet.API                   as WAPI
@@ -25,7 +25,7 @@ mkValidator pk' () () p = V.txSignedBy p pk'
 
 pkValidator :: PubKey -> ValidatorScript
 pkValidator pk = ValidatorScript $
-    Ledger.fromCompiledCode $$(P.compile [|| mkValidator ||])
+    Ledger.fromCompiledCode $$(PlutusTx.compile [|| mkValidator ||])
         `Ledger.applyScript`
             Ledger.lifted pk
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 module Language.PlutusTx.Coordination.Contracts.Vesting (
     Vesting(..),
     VestingTranche(..),
@@ -23,7 +24,7 @@ import           Control.Monad.Error.Class    (MonadError (..))
 import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
 import           GHC.Generics                 (Generic)
-import           Language.PlutusTx.Prelude    ((&&))
+import           Language.PlutusTx.Prelude
 import qualified Language.PlutusTx            as PlutusTx
 import qualified Ledger                       as Ledger
 import           Ledger                       (DataScript (..), Slot(..), PubKey (..), TxOutRef, ValidatorScript (..), scriptTxIn, scriptTxOut)

--- a/plutus-wallet-api/ledger/Ledger/Ada.hs
+++ b/plutus-wallet-api/ledger/Ledger/Ada.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE NoImplicitPrelude  #-}
 {-# LANGUAGE TemplateHaskell    #-}
 -- Otherwise we get a complaint about the 'fromIntegral' call in the generated instance of 'Integral' for 'Ada'
 {-# OPTIONS_GHC -Wno-identities #-}
@@ -37,19 +38,19 @@ import           Data.Aeson                   (FromJSON, ToJSON)
 import           Data.Swagger.Internal.Schema (ToSchema)
 import           GHC.Generics                 (Generic)
 import           Language.PlutusTx.Lift       (makeLift)
+import           Language.PlutusTx.Prelude    hiding (divide, eq, geq, gt, leq, lt, minus, multiply, negate, plus)
 import qualified Language.PlutusTx.Prelude    as P
-import           Prelude                      hiding (negate)
 
 import           Ledger.Value                 (CurrencySymbol, TokenName, Value)
 import qualified Ledger.Value                 as TH
 
 -- | The 'CurrencySymbol' of the 'Ada' currency.
 adaSymbol :: CurrencySymbol
-adaSymbol = TH.currencySymbol P.emptyByteString
+adaSymbol = TH.currencySymbol emptyByteString
 
 -- | The 'TokenName' of the 'Ada' currency.
 adaToken :: TokenName
-adaToken = TH.tokenName P.emptyByteString
+adaToken = TH.tokenName emptyByteString
 
 -- | ADA, the special currency on the Cardano blockchain.
 --   See note [Currencies] in 'Ledger.Validation.Value.TH'.

--- a/plutus-wallet-api/ledger/Ledger/Map.hs
+++ b/plutus-wallet-api/ledger/Ledger/Map.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE MonoLocalBinds       #-}
+{-# LANGUAGE NoImplicitPrelude    #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
@@ -34,9 +35,8 @@ import           Data.Hashable                (Hashable)
 import           Data.Swagger.Internal.Schema (ToSchema)
 import           GHC.Generics                 (Generic)
 import           Language.PlutusTx.Lift       (makeLift)
-import           Language.PlutusTx.Prelude    ((&&))
+import           Language.PlutusTx.Prelude    hiding (all, lookup, map)
 import qualified Language.PlutusTx.Prelude    as P
-import           Prelude                      hiding (all, lookup, map, (&&), (||))
 
 import           Ledger.These
 
@@ -100,12 +100,12 @@ union eq (Map ls) (Map rs) =
         ls' = P.map (\(c, i) -> (c, f i (lookup eq c (Map rs)))) ls
 
         rs' :: [(k, r)]
-        rs' = P.filter (\(c, _) -> P.not (P.any (\(c', _) -> eq c' c) ls)) rs
+        rs' = filter (\(c, _) -> not (any (\(c', _) -> eq c' c) ls)) rs
 
         rs'' :: [(k, These v r)]
         rs'' = P.map (\(c, b) -> (c, That b)) rs'
 
-    in Map (P.append ls' rs'')
+    in Map (append ls' rs'')
 
 -- | See 'Data.Map.all'
 all :: (v -> Bool) -> Map k v -> Bool

--- a/plutus-wallet-api/ledger/Ledger/Scripts.hs
+++ b/plutus-wallet-api/ledger/Ledger/Scripts.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE ViewPatterns       #-}
+{-# LANGUAGE NoImplicitPrelude  #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- | Functions for working with scripts on the ledger.
 module Ledger.Scripts(
@@ -37,7 +38,6 @@ import           Data.Aeson                               (FromJSON (parseJSON),
 import qualified Data.Aeson                               as JSON
 import qualified Data.Aeson.Extras                        as JSON
 import qualified Data.ByteArray                           as BA
-import           Data.Maybe                               (isJust)
 import           GHC.Generics                             (Generic)
 import qualified Language.Haskell.TH                      as TH
 import qualified Language.PlutusCore                      as PLC
@@ -45,8 +45,8 @@ import           Language.PlutusTx.Evaluation             (evaluateCekTrace)
 import           Language.PlutusTx.Lift                   (unsafeLiftProgram)
 import           Language.PlutusTx.Lift.Class             (Lift)
 import           Language.PlutusTx                        (CompiledCode, compile, getPlc)
-import qualified Language.PlutusTx.Prelude                as P
-import           PlutusPrelude
+import           Language.PlutusTx.Prelude
+import           PlutusPrelude                            (reoption)
 
 -- | A script on the chain. This is an opaque type as far as the chain is concerned.
 newtype Script = Script { unScript :: PLC.Program PLC.TyName PLC.Name () }
@@ -223,4 +223,4 @@ unitRedeemer = RedeemerScript $ fromCompiledCode $$(compile [|| () ||])
 
 -- | @()@ as a redeemer.
 checker :: Script
-checker = fromCompiledCode $$(compile [|| P.check ||])
+checker = fromCompiledCode $$(compile [|| check ||])

--- a/plutus-wallet-api/ledger/Ledger/Slot.hs
+++ b/plutus-wallet-api/ledger/Ledger/Slot.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE MonoLocalBinds       #-}
+{-# LANGUAGE NoImplicitPrelude    #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- Otherwise we get a complaint about the 'fromIntegral' call in the generated instance of 'Integral' for 'Ada'
@@ -28,7 +29,8 @@ import           Data.Swagger.Internal.Schema (ToSchema)
 import           GHC.Generics                 (Generic)
 
 import           Language.PlutusTx.Lift       (makeLift)
-import           Language.PlutusTx.Prelude    as P
+import           Language.PlutusTx.Prelude    hiding (eq)
+import qualified Language.PlutusTx.Prelude    as P
 
 import           Ledger.Interval
 

--- a/plutus-wallet-api/ledger/Ledger/Value.hs
+++ b/plutus-wallet-api/ledger/Ledger/Value.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE NoImplicitPrelude  #-}
 -- Prevent unboxing, which the plugin can't deal with
 {-# OPTIONS_GHC -fno-strictness #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
@@ -61,10 +62,9 @@ import qualified Data.Text                    as Text
 import           GHC.Generics                 (Generic)
 import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Lift       (makeLift)
-import           Language.PlutusTx.Prelude    ((&&))
+import           Language.PlutusTx.Prelude    hiding (eq, plus, minus, negate, multiply, leq, lt, geq, gt)
 import qualified Language.PlutusTx.Prelude    as P
 import qualified Ledger.Map                   as Map
-import           Prelude                      hiding ((&&), (||), all, lookup, negate)
 import           LedgerBytes                  (LedgerBytes(LedgerBytes))
 import           Data.Function                ((&))
 
@@ -102,9 +102,9 @@ instance FromJSON CurrencySymbol where
 makeLift ''CurrencySymbol
 
 eqCurSymbol :: CurrencySymbol -> CurrencySymbol -> Bool
-eqCurSymbol (CurrencySymbol l) (CurrencySymbol r) = P.equalsByteString l r
+eqCurSymbol (CurrencySymbol l) (CurrencySymbol r) = equalsByteString l r
 
-currencySymbol :: P.ByteString -> CurrencySymbol
+currencySymbol :: ByteString -> CurrencySymbol
 currencySymbol = CurrencySymbol
 
 newtype TokenName = TokenName { unTokenName :: Builtins.ByteString }
@@ -138,9 +138,9 @@ instance FromJSON TokenName where
 makeLift ''TokenName
 
 eqTokenName :: TokenName -> TokenName -> Bool
-eqTokenName (TokenName l) (TokenName r) = P.equalsByteString l r
+eqTokenName (TokenName l) (TokenName r) = equalsByteString l r
 
-tokenName :: P.ByteString -> TokenName
+tokenName :: ByteString -> TokenName
 tokenName = TokenName
 
 -- | A cryptocurrency value. This is a map from 'CurrencySymbol's to a

--- a/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
+++ b/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
 -- | On-chain code fragments for creating a state machine. First
@@ -13,13 +14,10 @@ module Language.PlutusTx.StateMachine(
     ) where
 
 
-import           Prelude           hiding ((&&))
+import           Language.PlutusTx.Prelude
 
-import           Language.PlutusTx ((&&))
-import qualified Language.PlutusTx as P
-
-import           Ledger.Validation (PendingTx)
-import qualified Ledger.Validation as V
+import           Ledger.Validation         (PendingTx)
+import qualified Ledger.Validation         as V
 
 -- | Specification of a state machine
 data StateMachine s i = StateMachine {
@@ -46,16 +44,16 @@ mkValidator sm (currentState, _) (newState, Just input) p =
         expectedState = trans currentState input
 
         stateOk =
-            P.traceIfFalseH "State transition invalid - 'expectedState' not equal to 'newState'"
+            traceIfFalseH "State transition invalid - 'expectedState' not equal to 'newState'"
             (sEq expectedState newState)
 
         dataScriptHashOk =
             let relevantOutputs =
-                    P.map P.fst
+                    map fst
                     (V.scriptOutputsAt vh p)
-                dsHashOk (V.DataScriptHash dh) = P.equalsByteString dh rh
+                dsHashOk (V.DataScriptHash dh) = equalsByteString dh rh
             in
-                P.traceIfFalseH "State transition invalid - data script hash not equal to redeemer hash"
-                (P.all dsHashOk relevantOutputs)
+                traceIfFalseH "State transition invalid - data script hash not equal to redeemer hash"
+                (all dsHashOk relevantOutputs)
     in stateOk && dataScriptHashOk
 mkValidator _ _ _ _ = False


### PR DESCRIPTION
Implements the fourth suggestion in https://github.com/input-output-hk/plutus/issues/1070. Fixes #1070 if merged.

I think this makes the user-facing story pretty nice: if you're writing for Plutus Tx, use `NoImplicitPrelude` and import the Plutus Tx Prelude and just continue as normal.

(I'm aware we're building up a bunch of documentation debt, but I think we're going to need to basically rewrite the tutorials anyway)

One infelicity: we now need an import of the Plutus Tx Prelude to get `IO`, which the playground assumes we have. At the moment I'm just making sure we have one, possibly we should add it automatically.