### PR TITLE
Back out use of `-fexpose-all-unfoldings`

### DIFF
--- a/marlowe/src/Language/Marlowe/Common.hs
+++ b/marlowe/src/Language/Marlowe/Common.hs
@@ -15,7 +15,6 @@
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns -Wno-name-shadowing #-}
 
 {-# OPTIONS_GHC -fno-strictness #-}
-{-# OPTIONS_GHC -fexpose-all-unfoldings #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 
@@ -222,6 +221,7 @@ data State = State {
         stateChoices   :: [Choice]
     } deriving (Eq, Ord, Show)
 
+{-# INLINABLE emptyState #-}
 emptyState :: State
 emptyState = State { stateCommitted = [], stateChoices = [] }
 
@@ -270,10 +270,12 @@ makeLift ''MarloweData
 makeLift ''Input
 makeLift ''State
 
+{-# INLINABLE eqIdentCC #-}
 -- | 'IdentCC' equality
 eqIdentCC :: IdentCC -> IdentCC -> Bool
 eqIdentCC (IdentCC a) (IdentCC b) = a `Builtins.equalsInteger` b
 
+{-# INLINABLE equalValue #-}
 -- | 'Value' equality
 equalValue :: Value -> Value -> Bool
 equalValue = let
@@ -294,6 +296,7 @@ equalValue = let
             _ -> False
     in eq
 
+{-# INLINABLE equalObservation #-}
 -- | 'Observation' equality
 equalObservation :: (Value -> Value -> Bool) -> Observation -> Observation -> Bool
 equalObservation eqValue = let
@@ -312,6 +315,7 @@ equalObservation eqValue = let
             _ -> False
     in eq
 
+{-# INLINABLE equalContract #-}
 -- | 'Contract' equality
 equalContract :: (Value -> Value -> Bool) -> (Observation -> Observation -> Bool) -> Contract -> Contract -> Bool
 equalContract eqValue eqObservation =
@@ -344,15 +348,19 @@ equalContract eqValue eqObservation =
             _ -> False
    in eq
 
+{-# INLINABLE eqValue #-}
 eqValue :: Value -> Value -> Bool
 eqValue = equalValue
 
+{-# INLINABLE eqObservation #-}
 eqObservation :: Observation -> Observation -> Bool
 eqObservation = equalObservation eqValue
 
+{-# INLINABLE eqContract #-}
 eqContract :: Contract -> Contract -> Bool
 eqContract = equalContract eqValue eqObservation
 
+{-# INLINABLE validateContract #-}
 {-| Contract validation.
 
     * Check that 'IdentCC' and 'IdentPay' identifiers are unique.
@@ -404,6 +412,7 @@ validateContract State{stateCommitted} contract (Slot bn) actualMoney' = let
             in validIds
        else False
 
+{-# INLINABLE evaluateValue #-}
 {-|
     Evaluates 'Value' given current block number 'Slot', oracle values, and current 'State'.
 -}
@@ -450,6 +459,7 @@ evaluateValue pendingTxSlot inputOracles state value = let
 
         in evalValue state value
 
+{-# INLINABLE interpretObservation #-}
 -- | Interpret 'Observation' as 'Bool'.
 interpretObservation :: (State -> Value -> Integer) -> Integer -> State -> Observation -> Bool
 interpretObservation evalValue blockNumber state@(State _ choices) obs = let
@@ -474,6 +484,7 @@ interpretObservation evalValue blockNumber state@(State _ choices) obs = let
         FalseObs -> False
     in go obs
 
+{-# INLINABLE insertCommit #-}
 -- | Add a 'Commit', placing it in order by endTimeout per 'Person'
 insertCommit :: Commit -> [Commit] -> [Commit]
 insertCommit commit commits = let
@@ -487,6 +498,7 @@ insertCommit commit commits = let
             c : cs -> c : insert commit cs
     in insert commit commits
 
+{-# INLINABLE discountFromPairList #-}
 -- | Discounts the Cash from an initial segment of the list of pairs.
 discountFromPairList ::
     PubKey
@@ -512,6 +524,7 @@ discountFromPairList from (Slot currentBlockNumber) value' commits = let
         [] -> if value `Builtins.equalsInteger` 0 then Just [] else Nothing
     in discount value commits
 
+{-# INLINABLE findAndRemove #-}
 {-| Look for first 'Commit' satisfying @predicate@ and remove it.
     Returns 'Nothing' if the 'Commit' wasn't found,
     otherwise 'Just' modified @[Commit]@
@@ -530,6 +543,7 @@ findAndRemove predicate commits = let
 
     in findAndRemove False commits
 
+{-# INLINABLE evaluateContract #-}
 {-|
     Evaluates Marlowe Contract
     Returns contract 'State', remaining 'Contract', and validation result.
@@ -655,6 +669,7 @@ evaluateContract
         _ -> (state, Null, False)
     in eval inputCommand state contract
 
+{-# INLINABLE mergeChoices #-}
 {-| Merge lists of 'Choice's.
     Return a partialy ordered list of unique choices.
 -}
@@ -677,6 +692,7 @@ mergeChoices input choices = let
     merge (i:rest) choices = merge rest (insert i choices)
     in merge input choices
 
+{-# INLINABLE validatorScript #-}
 {-|
     Marlowe main Validator Script
 -}

--- a/plutus-playground-server/src/Playground/Server.hs
+++ b/plutus-playground-server/src/Playground/Server.hs
@@ -34,7 +34,7 @@ acceptSourceCode ::
     -> Handler (Either InterpreterError (InterpreterResult CompilationResult))
 acceptSourceCode sourceCode = do
     let maxInterpretationTime :: Microsecond =
-            fromMicroseconds (40 * 1000 * 1000)
+            fromMicroseconds (80 * 1000 * 1000)
     r <- liftIO . runExceptT $ PI.compile maxInterpretationTime sourceCode
     case r of
         Right vs -> pure . Right $ vs
@@ -51,7 +51,7 @@ throwJSONError err json =
 runFunction :: Evaluation -> Handler EvaluationResult
 runFunction evaluation = do
     let maxInterpretationTime :: Microsecond =
-            fromMicroseconds (40 * 1000 * 1000)
+            fromMicroseconds (80 * 1000 * 1000)
     result <-
         liftIO . runExceptT $ PI.runFunction maxInterpretationTime evaluation
     let pubKeys = PA.pubKeys evaluation

--- a/plutus-tutorial/doctest/Tutorial/01-plutus-tx.md
+++ b/plutus-tutorial/doctest/Tutorial/01-plutus-tx.md
@@ -170,8 +170,7 @@ The previous example marked the functions that we used using GHC's `INLINABLE`
 pragma. This is usually necessary for non-local functions to be usable
 in Plutus Tx blocks, as it instructs GHC to keep the information that the
 Plutus Tx compiler needs. While this is not always necessary, it is
-a good idea to simply mark all such functions as `INLINABLE`. An
-alternative is to use the `-fexpose-all-unfoldings` GHC option.
+a good idea to simply mark all such functions as `INLINABLE`.
 
 We can use normal Haskell datatypes and pattern matching freely:
 

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -1,6 +1,5 @@
 -- Need some extra imports from the Prelude for doctests, annoyingly
 {-# OPTIONS_GHC -Wno-unused-imports #-}
-{-# OPTIONS_GHC -fexpose-all-unfoldings #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Language.PlutusTx.Prelude (
     -- $prelude
@@ -86,20 +85,24 @@ import           Prelude                    as Prelude hiding (all, any, error, 
 -- >>> :set -XNoImplicitPrelude
 -- >>> import Language.PlutusTx.Prelude
 
+{-# INLINABLE error #-}
 -- | Terminate the evaluation of the script with an error message.
 error :: () -> a
 error = Builtins.error
 
+{-# INLINABLE check #-}
 -- | Checks a 'Bool' and aborts if it is false.
 check :: Bool -> ()
 check b = if b then () else error ()
 
+{-# INLINABLE toPlutusString #-}
 -- | Convert a Haskell 'String' into a PlutusTx 'Builtins.String'.
 toPlutusString :: String -> Builtins.String
 toPlutusString str = case str of
     []       -> Builtins.emptyString
     (c:rest) -> Builtins.charToString c `Builtins.appendString` toPlutusString rest
 
+{-# INLINABLE trace #-}
 -- | Emit the given string as a trace message before evaluating the argument.
 trace :: Builtins.String -> a -> a
 -- The builtin trace is just a side-effecting function that returns unit, so
@@ -107,22 +110,27 @@ trace :: Builtins.String -> a -> a
 -- thrown away by GHC or the PIR compiler.
 trace str a = case Builtins.trace str of () -> a
 
+{-# INLINABLE traceH #-}
 -- | A version of 'trace' that takes a Haskell 'String'.
 traceH :: String -> a -> a
 traceH str = trace (toPlutusString str)
 
+{-# INLINABLE traceErrorH #-}
 -- | Log a message and then terminate the evaluation with an error.
 traceErrorH :: String -> a
 traceErrorH str = error (traceH str ())
 
+{-# INLINABLE traceIfFalseH #-}
 -- | Emit the given Haskell 'String' only if the argument evaluates to 'False'.
 traceIfFalseH :: String -> Bool -> Bool
 traceIfFalseH str a = if a then True else traceH str False
 
+{-# INLINABLE traceIfTrueH #-}
 -- | Emit the given Haskell 'String' only if the argument evaluates to 'True'.
 traceIfTrueH :: String -> Bool -> Bool
 traceIfTrueH str a = if a then traceH str True else False
 
+{-# INLINABLE (&&) #-}
 -- | Logical AND
 --
 --   >>> True && False
@@ -132,6 +140,7 @@ infixr 3 &&
 (&&) :: Bool -> Bool -> Bool
 (&&) l r = if l then r else False
 
+{-# INLINABLE (||) #-}
 -- | Logical OR
 --
 --   >>> True || False
@@ -141,6 +150,7 @@ infixr 2 ||
 (||) :: Bool -> Bool -> Bool
 (||) l r = if l then True else r
 
+{-# INLINABLE not #-}
 -- | Logical negation
 --
 --   >>> not True
@@ -149,6 +159,7 @@ infixr 2 ||
 not :: Bool -> Bool
 not a = if a then False else True
 
+{-# INLINABLE gt #-}
 -- | Greater than
 --
 --   >>> gt 2 1
@@ -157,6 +168,7 @@ not a = if a then False else True
 gt :: Integer -> Integer -> Bool
 gt = Builtins.greaterThanInteger
 
+{-# INLINABLE geq #-}
 -- | Greater than or equal to
 --
 --   >>> geq 2 2
@@ -165,6 +177,7 @@ gt = Builtins.greaterThanInteger
 geq :: Integer -> Integer -> Bool
 geq = Builtins.greaterThanEqInteger
 
+{-# INLINABLE lt #-}
 -- | Less than
 --
 --   >>> lt 2 1
@@ -173,6 +186,7 @@ geq = Builtins.greaterThanEqInteger
 lt :: Integer -> Integer -> Bool
 lt = Builtins.lessThanInteger
 
+{-# INLINABLE leq #-}
 -- | Less than or equal to
 --
 --   >>> leq 2 2
@@ -181,6 +195,7 @@ lt = Builtins.lessThanInteger
 leq :: Integer -> Integer -> Bool
 leq = Builtins.lessThanEqInteger
 
+{-# INLINABLE eq #-}
 -- | Eq for 'Integer'
 --
 --   >>> eq 2 1
@@ -189,6 +204,7 @@ leq = Builtins.lessThanEqInteger
 eq :: Integer -> Integer -> Bool
 eq = Builtins.equalsInteger
 
+{-# INLINABLE plus #-}
 -- | Addition
 --
 --   >>> plus 2 1
@@ -197,6 +213,7 @@ eq = Builtins.equalsInteger
 plus :: Integer -> Integer -> Integer
 plus = Builtins.addInteger
 
+{-# INLINABLE minus #-}
 -- | Subtraction
 --
 --   >>> minus 2 1
@@ -205,6 +222,7 @@ plus = Builtins.addInteger
 minus :: Integer -> Integer -> Integer
 minus = Builtins.subtractInteger
 
+{-# INLINABLE multiply #-}
 -- | Multiplication
 --
 --   >>> multiply 2 1
@@ -213,6 +231,7 @@ minus = Builtins.subtractInteger
 multiply :: Integer -> Integer -> Integer
 multiply = Builtins.multiplyInteger
 
+{-# INLINABLE divide #-}
 -- | Integer division
 --
 --   >>> divide 3 2
@@ -221,6 +240,7 @@ multiply = Builtins.multiplyInteger
 divide :: Integer -> Integer -> Integer
 divide = Builtins.divideInteger
 
+{-# INLINABLE remainder #-}
 -- | Remainder (of integer division)
 --
 --   >>> remainder 3 2
@@ -229,6 +249,7 @@ divide = Builtins.divideInteger
 remainder :: Integer -> Integer -> Integer
 remainder = Builtins.remainderInteger
 
+{-# INLINABLE min #-}
 -- | The smaller of two 'Integer's
 --
 --   >>> min 10 5
@@ -237,6 +258,7 @@ remainder = Builtins.remainderInteger
 min :: Integer -> Integer -> Integer
 min a b = if Builtins.lessThanInteger a b then a else b
 
+{-# INLINABLE max #-}
 -- | The larger of two 'Integer's
 --
 --   >>> max 10 5
@@ -245,6 +267,7 @@ min a b = if Builtins.lessThanInteger a b then a else b
 max :: Integer -> Integer -> Integer
 max a b = if Builtins.greaterThanInteger a b then a else b
 
+{-# INLINABLE isJust #-}
 -- | Check if a 'Maybe' @a@ is @Just a@
 --
 --   >>> isJust Nothing
@@ -255,6 +278,7 @@ max a b = if Builtins.greaterThanInteger a b then a else b
 isJust :: Maybe a -> Bool
 isJust m = case m of { Just _ -> True; _ -> False; }
 
+{-# INLINABLE isNothing #-}
 -- | Check if a 'Maybe' @a@ is @Nothing@
 --
 --   >>> isNothing Nothing
@@ -265,6 +289,7 @@ isJust m = case m of { Just _ -> True; _ -> False; }
 isNothing :: Maybe a -> Bool
 isNothing m = case m of { Just _ -> False; _ -> True; }
 
+{-# INLINABLE maybe #-}
 -- | PlutusTx version of 'Prelude.maybe'.
 --
 --   >>> maybe "platypus" (\s -> s) (Just "plutus")
@@ -277,6 +302,7 @@ maybe b f m = case m of
     Nothing -> b
     Just a  -> f a
 
+{-# INLINABLE null #-}
 -- | PlutusTx version of 'Data.List.null'.
 --
 --   >>> null [1]
@@ -289,6 +315,7 @@ null l = case l of
     [] -> True
     _  -> False
 
+{-# INLINABLE map #-}
 -- | PlutusTx version of 'Data.List.map'.
 --
 --   >>> map (\i -> i + 1) [1, 2, 3]
@@ -299,6 +326,7 @@ map f l = case l of
     []   -> []
     x:xs -> f x : map f xs
 
+{-# INLINABLE foldr #-}
 -- | PlutusTx version of 'Data.List.foldr'.
 --
 --   >>> foldr (\i s -> s + i) 0 [1, 2, 3, 4]
@@ -309,6 +337,7 @@ foldr f acc l = case l of
     []   -> acc
     x:xs -> f x (foldr f acc xs)
 
+{-# INLINABLE foldl #-}
 -- | PlutusTx version of 'Data.List.foldl'.
 --
 --   >>> foldl (\s i -> s + i) 0 [1, 2, 3, 4]
@@ -319,6 +348,7 @@ foldl f acc l = case l of
     []   -> acc
     x:xs -> foldl f (f acc x) xs
 
+{-# INLINABLE length #-}
 -- | 'length' @xs@ is the number of elements in @xs@.
 --
 --   >>> length [1, 2, 3, 4]
@@ -328,6 +358,7 @@ length :: [a] -> Integer
 -- eta-expanded to avoid the value restriction
 length as = foldr (\_ acc -> plus acc 1) 0 as
 
+{-# INLINABLE all #-}
 -- | PlutusTx version of 'Data.List.all'.
 --
 --   >>> all (\i -> i > 5) [6, 8, 12]
@@ -336,6 +367,7 @@ length as = foldr (\_ acc -> plus acc 1) 0 as
 all :: (a -> Bool) -> [a] -> Bool
 all p = foldr (\a acc -> acc && p a) True
 
+{-# INLINABLE any #-}
 -- | PlutusTx version of 'Data.List.any'.
 --
 --   >>> any (\i -> i > 5) [6, 2, 1]
@@ -344,6 +376,7 @@ all p = foldr (\a acc -> acc && p a) True
 any :: (a -> Bool) -> [a] -> Bool
 any p = foldr (\a acc -> acc || p a) False
 
+{-# INLINABLE append #-}
 -- | PlutusTx version of 'Data.List.(++)'.
 --
 --   >>> append [0, 1, 2] [1, 2, 3, 4]
@@ -352,6 +385,7 @@ any p = foldr (\a acc -> acc || p a) False
 append :: [a] -> [a] -> [a]
 append l r = foldr (:) r l
 
+{-# INLINABLE filter #-}
 -- | PlutusTx version of 'Data.List.filter'.
 --
 --   >>> filter (> 1) [1, 2, 3, 4]
@@ -360,6 +394,7 @@ append l r = foldr (:) r l
 filter :: (a -> Bool) -> [a] -> [a]
 filter p = foldr (\e xs -> if p e then e:xs else xs) []
 
+{-# INLINABLE mapMaybe #-}
 -- | PlutusTx version of 'Data.Maybe.mapMaybe'.
 --
 --   >>> mapMaybe (\i -> if i == 2 then Just '2' else Nothing) [1, 2, 3, 4]
@@ -368,10 +403,12 @@ filter p = foldr (\e xs -> if p e then e:xs else xs) []
 mapMaybe :: (a -> Maybe b) -> [a] -> [b]
 mapMaybe p = foldr (\e xs -> case p e of { Just e' -> e':xs; Nothing -> xs}) []
 
+{-# INLINABLE fst #-}
 -- | PlutusTx version of 'Data.Tuple.fst'
 fst :: (a, b) -> a
 fst (a, _) = a
 
+{-# INLINABLE snd #-}
 -- | PlutusTx version of 'Data.Tuple.snd'
 snd :: (a, b) -> b
 snd (_, b) = b

--- a/plutus-tx/test/TH/all.plc.golden
+++ b/plutus-tx/test/TH/all.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  out_Bool_64
+  out_Bool_63
   (type)
-  (lam case_True_65 out_Bool_64 (lam case_False_66 out_Bool_64 case_True_65))
+  (lam case_True_64 out_Bool_63 (lam case_False_65 out_Bool_63 case_True_64))
 )

--- a/plutus-wallet-api/ledger/Ledger/Ada.hs
+++ b/plutus-wallet-api/ledger/Ledger/Ada.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE TemplateHaskell    #-}
 -- Otherwise we get a complaint about the 'fromIntegral' call in the generated instance of 'Integral' for 'Ada'
 {-# OPTIONS_GHC -Wno-identities #-}
-{-# OPTIONS_GHC -fexpose-all-unfoldings #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 -- | Functions for working with 'Ada' in Template Haskell.
 module Ledger.Ada(
@@ -45,10 +44,12 @@ import qualified Language.PlutusTx.Prelude    as P
 import           Ledger.Value                 (CurrencySymbol, TokenName, Value)
 import qualified Ledger.Value                 as TH
 
+{-# INLINABLE adaSymbol #-}
 -- | The 'CurrencySymbol' of the 'Ada' currency.
 adaSymbol :: CurrencySymbol
 adaSymbol = TH.currencySymbol emptyByteString
 
+{-# INLINABLE adaToken #-}
 -- | The 'TokenName' of the 'Ada' currency.
 adaToken :: TokenName
 adaToken = TH.tokenName emptyByteString
@@ -63,22 +64,27 @@ newtype Ada = Ada { getAda :: Integer }
 
 makeLift ''Ada
 
+{-# INLINABLE toValue #-}
 -- | Create a 'Value' containing only the given 'Ada'.
 toValue :: Ada -> Value
 toValue (Ada i) = TH.singleton adaSymbol adaToken i
 
+{-# INLINABLE fromValue #-}
 -- | Get the 'Ada' in the given 'Value'.
 fromValue :: Value -> Ada
 fromValue v = Ada (TH.valueOf v adaSymbol adaToken)
 
+{-# INLINABLE toInt #-}
 -- | Get the amount of 'Ada'.
 toInt :: Ada -> Integer
 toInt (Ada i) = i
 
+{-# INLINABLE fromInt #-}
 -- | Turn a quantity into 'Ada'.
 fromInt :: Integer -> Ada
 fromInt = Ada
 
+{-# INLINABLE adaValueOf #-}
 -- | A 'Value' with the given amount of 'Ada'.
 --
 --   @adaValueOf == toValue . fromInt@
@@ -86,50 +92,62 @@ fromInt = Ada
 adaValueOf :: Integer -> Value
 adaValueOf = TH.singleton adaSymbol adaToken
 
+{-# INLINABLE plus #-}
 -- | Add two 'Ada' values together.
 plus :: Ada -> Ada -> Ada
 plus (Ada a) (Ada b) = Ada (P.plus a b)
 
+{-# INLINABLE minus #-}
 -- | Subtract one 'Ada' value from another.
 minus :: Ada -> Ada -> Ada
 minus (Ada a) (Ada b) = Ada (P.minus a b)
 
+{-# INLINABLE multiply #-}
 -- | Multiply two 'Ada' values together.
 multiply :: Ada -> Ada -> Ada
 multiply (Ada a) (Ada b) = Ada (P.multiply a b)
 
+{-# INLINABLE divide #-}
 -- | Divide one 'Ada' value by another.
 divide :: Ada -> Ada -> Ada
 divide (Ada a) (Ada b) = Ada (P.divide a b)
 
+{-# INLINABLE zero #-}
 -- | The zero 'Ada' value.
 zero :: Ada
 zero = Ada 0
 
+{-# INLINABLE negate #-}
 -- | Negate an 'Ada' value.
 negate :: Ada -> Ada
 negate (Ada i) = Ada (P.multiply (-1) i)
 
+{-# INLINABLE isZero #-}
 -- | Check whether an 'Ada' value is zero.
 isZero :: Ada -> Bool
 isZero (Ada i) = P.eq i 0
 
+{-# INLINABLE geq #-}
 -- | Check whether one 'Ada' is greater than or equal to another.
 geq :: Ada -> Ada -> Bool
 geq (Ada i) (Ada j) = P.geq i j
 
+{-# INLINABLE gt #-}
 -- | Check whether one 'Ada' is strictly greater than another.
 gt :: Ada -> Ada -> Bool
 gt (Ada i) (Ada j) = P.gt i j
 
+{-# INLINABLE leq #-}
 -- | Check whether one 'Ada' is less than or equal to another.
 leq :: Ada -> Ada -> Bool
 leq (Ada i) (Ada j) = P.leq i j
 
+{-# INLINABLE lt #-}
 -- | Check whether one 'Ada' is strictly less than another.
 lt :: Ada -> Ada -> Bool
 lt (Ada i) (Ada j) = P.lt i j
 
+{-# INLINABLE eq #-}
 -- | Check whether one 'Ada' is equal to another.
 eq :: Ada -> Ada -> Bool
 eq (Ada i) (Ada j) = P.eq i j

--- a/plutus-wallet-api/ledger/Ledger/These.hs
+++ b/plutus-wallet-api/ledger/Ledger/These.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
-{-# OPTIONS_GHC -fexpose-all-unfoldings #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Ledger.These(
     These(..)
@@ -12,6 +11,7 @@ module Ledger.These(
 -- Plutus version of 'Data.These'.
 data These a b = This a | That b | These a b
 
+{-# INLINABLE theseWithDefault #-}
 -- | Consume a 'These a b' value.
 theseWithDefault :: a -> b -> (a -> b -> c) -> These a b -> c
 theseWithDefault a' b' f = \case
@@ -19,6 +19,7 @@ theseWithDefault a' b' f = \case
     That b -> f a' b
     These a b -> f a b
 
+{-# INLINABLE these #-}
 these :: (a -> c) -> (b -> c) -> (a -> b -> c) -> These a b -> c
 these f g h = \case
     This a -> f a

--- a/plutus-wallet-api/ledger/Ledger/Value.hs
+++ b/plutus-wallet-api/ledger/Ledger/Value.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE NoImplicitPrelude  #-}
 -- Prevent unboxing, which the plugin can't deal with
 {-# OPTIONS_GHC -fno-strictness #-}
-{-# OPTIONS_GHC -fexpose-all-unfoldings #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 -- | Functions for working with 'Value'.
 module Ledger.Value(
@@ -102,9 +101,11 @@ instance FromJSON CurrencySymbol where
 
 makeLift ''CurrencySymbol
 
+{-# INLINABLE eqCurSymbol #-}
 eqCurSymbol :: CurrencySymbol -> CurrencySymbol -> Bool
 eqCurSymbol (CurrencySymbol l) (CurrencySymbol r) = equalsByteString l r
 
+{-# INLINABLE currencySymbol #-}
 currencySymbol :: ByteString -> CurrencySymbol
 currencySymbol = CurrencySymbol
 
@@ -138,9 +139,11 @@ instance FromJSON TokenName where
 
 makeLift ''TokenName
 
+{-# INLINABLE eqTokenName #-}
 eqTokenName :: TokenName -> TokenName -> Bool
 eqTokenName (TokenName l) (TokenName r) = equalsByteString l r
 
+{-# INLINABLE tokenName #-}
 tokenName :: ByteString -> TokenName
 tokenName = TokenName
 
@@ -211,6 +214,7 @@ similar to 'Ledger.Ada' for their own currencies.
 
 -}
 
+{-# INLINABLE valueOf #-}
 -- | Get the quantity of the given currency in the 'Value'.
 valueOf :: Value -> CurrencySymbol -> TokenName -> Integer
 valueOf (Value mp) cur tn =
@@ -220,14 +224,17 @@ valueOf (Value mp) cur tn =
             Nothing -> 0
             Just v  -> v
 
+{-# INLINABLE symbols #-}
 -- | The list of 'CurrencySymbol's of a 'Value'.
 symbols :: Value -> [CurrencySymbol]
 symbols (Value mp) = Map.keys mp
 
+{-# INLINABLE singleton #-}
 -- | Make a 'Value' containing only the given quantity of the given currency.
 singleton :: CurrencySymbol -> TokenName -> Integer -> Value
 singleton c tn i = Value (Map.singleton c (Map.singleton tn i))
 
+{-# INLINABLE unionVal #-}
 -- | Combine two 'Value' maps
 unionVal :: Value -> Value -> Map.Map CurrencySymbol (Map.Map TokenName (Map.These Integer Integer))
 unionVal (Value l) (Value r) =
@@ -239,6 +246,7 @@ unionVal (Value l) (Value r) =
             Map.These a b -> Map.union eqTokenName a b
     in Map.map unThese combined
 
+{-# INLINABLE unionWith #-}
 unionWith :: (Integer -> Integer -> Integer) -> Value -> Value -> Value
 unionWith f ls rs =
     let
@@ -249,36 +257,44 @@ unionWith f ls rs =
             Map.These a b -> f a b
     in Value (Map.map (Map.map unThese) combined)
 
+{-# INLINABLE scale #-}
 -- | Multiply all the quantities in the 'Value' by the given scale factor.
 scale :: Integer -> Value -> Value
 scale i (Value xs) = Value (Map.map (Map.map (\i' -> P.multiply i i')) xs)
 
 -- Num operations
 
+{-# INLINABLE plus #-}
 -- | Add two 'Value's together. See 'Value' for an explanation of how operations on 'Value's work.
 plus :: Value -> Value -> Value
 plus = unionWith P.plus
 
+{-# INLINABLE negate #-}
 -- | Negate a 'Value's. See 'Value' for an explanation of how operations on 'Value's work.
 negate :: Value -> Value
 negate = scale (-1)
 
+{-# INLINABLE minus #-}
 -- | Subtract one 'Value' from another. See 'Value' for an explanation of how operations on 'Value's work.
 minus :: Value -> Value -> Value
 minus = unionWith P.minus
 
+{-# INLINABLE multiply #-}
 -- | Multiply two 'Value's together. See 'Value' for an explanation of how operations on 'Value's work.
 multiply :: Value -> Value -> Value
 multiply = unionWith P.multiply
 
+{-# INLINABLE zero #-}
 -- | The empty 'Value'.
 zero :: Value
 zero = Value (Map.empty ())
 
+{-# INLINABLE isZero #-}
 -- | Check whether a 'Value' is zero.
 isZero :: Value -> Bool
 isZero (Value xs) = Map.all (Map.all (\i -> P.eq 0 i)) xs
 
+{-# INLINABLE checkPred #-}
 checkPred :: (Map.These Integer Integer -> Bool) -> Value -> Value -> Bool
 checkPred f l r =
     let
@@ -287,6 +303,7 @@ checkPred f l r =
     in
       Map.all inner (unionVal l r)
 
+{-# INLINABLE checkBinRel #-}
 -- | Check whether a binary relation holds for value pairs of two 'Value' maps,
 --   supplying 0 where a key is only present in one of them.
 checkBinRel :: (Integer -> Integer -> Bool) -> Value -> Value -> Bool
@@ -298,26 +315,31 @@ checkBinRel f l r =
             Map.These a b -> f a b
     in checkPred unThese l r
 
+{-# INLINABLE geq #-}
 -- | Check whether one 'Value' is greater than or equal to another. See 'Value' for an explanation of how operations on 'Value's work.
 geq :: Value -> Value -> Bool
 -- If both are zero then checkBinRel will be vacuously true, but this is fine.
 geq = checkBinRel P.geq
 
+{-# INLINABLE gt #-}
 -- | Check whether one 'Value' is strictly greater than another. See 'Value' for an explanation of how operations on 'Value's work.
 gt :: Value -> Value -> Bool
 -- If both are zero then checkBinRel will be vacuously true. So we have a special case.
 gt l r = not (isZero l && isZero r) && checkBinRel P.gt l r
 
+{-# INLINABLE leq #-}
 -- | Check whether one 'Value' is less than or equal to another. See 'Value' for an explanation of how operations on 'Value's work.
 leq :: Value -> Value -> Bool
 -- If both are zero then checkBinRel will be vacuously true, but this is fine.
 leq = checkBinRel P.leq
 
+{-# INLINABLE lt #-}
 -- | Check whether one 'Value' is strictly less than another. See 'Value' for an explanation of how operations on 'Value's work.
 lt :: Value -> Value -> Bool
 -- If both are zero then checkBinRel will be vacuously true. So we have a special case.
 lt l r = not (isZero l && isZero r) && checkBinRel P.lt l r
 
+{-# INLINABLE eq #-}
 -- | Check whether one 'Value' is equal to another. See 'Value' for an explanation of how operations on 'Value's work.
 eq :: Value -> Value -> Bool
 -- If both are zero then checkBinRel will be vacuously true, but this is fine.

--- a/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
+++ b/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS_GHC -fexpose-all-unfoldings #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 -- | On-chain code fragments for creating a state machine. First
 --   define a @StateMachine s i@ with input type @i@ and state type @s@. Then
@@ -26,16 +25,19 @@ data StateMachine s i = StateMachine {
     , smStateEq    :: s -> s -> Bool
     }
 
+{-# INLINABLE initialState #-}
 -- | Create a transition script from an initial state of type
 --   @s@.
 initialState :: forall s i. s -> (s, Maybe i)
 initialState s = (s, Nothing)
 
+{-# INLINABLE transition #-}
 -- | Create a transition script from a new state of type @s@ and
 --   an input of type @i@.
 transition :: forall s i. s -> i -> (s, Maybe i)
 transition newState input = (newState, Just input)
 
+{-# INLINABLE mkValidator #-}
 -- | Turn a transition function 's -> i -> s' into a validator script.
 mkValidator :: StateMachine s i -> (s, Maybe i) -> (s, Maybe i) -> PendingTx -> Bool
 mkValidator sm (currentState, _) (newState, Just input) p =


### PR DESCRIPTION
This makes us more sensitive to compiler behaviour, which is undesirable.