### PR TITLE
Only put "public" packages into the published Haddock

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -152,7 +152,7 @@ let
       shellcheck = pkgs.callPackage localLib.iohkNix.tests.shellcheck { inherit src; };
       hlint = pkgs.callPackage localLib.iohkNix.tests.hlint {
         inherit src;
-        projects = localLib.plutusHaskellPkgList;
+        projects = localLib.plutusPkgList;
       };
       stylishHaskell = pkgs.callPackage localLib.iohkNix.tests.stylishHaskell {
         inherit (self.haskellPackages) stylish-haskell;
@@ -165,11 +165,16 @@ let
       multi-currency = pkgs.callPackage ./docs/multi-currency {};
       extended-utxo-spec = pkgs.callPackage ./extended-utxo-spec {};
       lazy-machine = pkgs.callPackage ./docs/fomega/lazy-machine {};
-      combined-haddock = (pkgs.callPackage ./nix/haddock-combine.nix {}) {
-        hspkgs = builtins.attrValues localPackages;
-        prologue = pkgs.writeTextFile {
-          name = "prologue";
-          text = "Combined documentation for all the Plutus libraries.";
+      public-combined-haddock = let
+        haddock-combine = pkgs.callPackage ./nix/haddock-combine.nix {};
+        publicPackages = localLib.getPackages {
+          inherit (self) haskellPackages; filter = localLib.isPublicPlutus;
+        };
+        in haddock-combine {
+          hspkgs = builtins.attrValues publicPackages;
+          prologue = pkgs.writeTextFile {
+            name = "prologue";
+            text = "Combined documentation for all the public Plutus libraries.";
         };
       };
     };

--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -30,7 +30,7 @@ git fetch $UPSTREAM $BRANCH
 git worktree add -B $BRANCH $WORKTREE_NAME $UPSTREAM/$BRANCH
 
 echo "Generating"
-nix build -f default.nix docs.combined-haddock
+nix build -f default.nix docs.public-combined-haddock
 cp -ar result/share/doc/* $WORKTREE_NAME
 # The results are copied from the store so have read-only permissions, which
 # will upset git. We will own the files, so we can change the perms.

--- a/lib.nix
+++ b/lib.nix
@@ -21,28 +21,30 @@ let
   lib = pkgs.lib;
   getPackages = iohkNix.getPackages;
 
-  # List of all plutus pkgs. This is used for `isPlutus` filter and `mapTestOn`
-  plutusPkgList = [
+  # List of all public (i.e. published Haddock, will go on Hackage) Plutus pkgs
+  plutusPublicPkgList = [
     "language-plutus-core"
     "plutus-contract-exe"
     "plutus-core-interpreter"
-    "plutus-playground-server"
     "plutus-playground-lib"
-    "plutus-playground-client"
-    "plutus-server-invoker"
     "plutus-exe"
     "plutus-ir"
     "plutus-tx"
+    "plutus-wallet-api"
+    "plutus-emulator"
+  ];
+
+  isPublicPlutus = name: builtins.elem name plutusPublicPkgList;
+
+  # List of all Plutus packges in this repository.
+  plutusPkgList = plutusPublicPkgList ++ [
+    "plutus-playground-server"
     "plutus-tutorial"
     "plutus-use-cases"
     "playground-common"
     "marlowe"
     "meadow"
-    "plutus-wallet-api"
-    "plutus-emulator"
   ];
-
-  plutusHaskellPkgList = lib.filter (v: v != "plutus-playground-client" && v != "plutus-server-invoker") plutusPkgList;
 
   isPlutus = name: builtins.elem name plutusPkgList;
 
@@ -54,7 +56,8 @@ in lib // {
   getPackages 
   iohkNix 
   isPlutus 
-  plutusHaskellPkgList 
+  isPublicPlutus 
+  plutusPublicPkgList 
   plutusPkgList 
   regeneratePackages 
   nixpkgs 

--- a/shell.nix
+++ b/shell.nix
@@ -3,5 +3,5 @@
 , localPackages ? import ./. { inherit config system; rev = "in-nix-shell"; }
 }:
 localPackages.dev.withDevTools (localPackages.haskellPackages.shellFor {
-    packages = p: (map (x: p.${x}) localPackages.localLib.plutusHaskellPkgList);
+    packages = p: (map (x: p.${x}) localPackages.localLib.plutusPkgList);
 })


### PR DESCRIPTION
We don't want to e.g. have all the tutorial modules appearing in the
published Haddock.

Also having a list of "public" packages may be useful for publishing to
Hackage later.