### PR TITLE
plutus-tutorial: use callouts and admonitions

### DIFF
--- a/plutus-tutorial/doc/01-plutus-tx.adoc
+++ b/plutus-tutorial/doc/01-plutus-tx.adoc
@@ -14,7 +14,7 @@ in a transaction, hence the "Tx").
 This means that Plutus Tx _is just Haskell_. Strictly, only a subset of
 Haskell is supported, but most simple Haskell should work, and the
 compiler will tell you if you use something that is unsupported. (See
-link:../../../plutus-tx/README.md#haskell-language-support[Haskell
+link:../../plutus-tx/README.md#haskell-language-support[Haskell
 language support] for more details on what is supported.)
 
 The key technique that the Plutus Platform uses is called _staged
@@ -35,20 +35,20 @@ share types and defintions between the two.
 {-# LANGUAGE ScopedTypeVariables #-}
 module Tutorial.PlutusTx where
 
--- Main Plutus Tx module
-import Language.PlutusTx
--- Additional support for lifting
-import Language.PlutusTx.Lift
--- Builtin functions
-import Language.PlutusTx.Builtins
+import Language.PlutusTx -- <1>
+import Language.PlutusTx.Lift -- <2>
+import Language.PlutusTx.Builtins -- <3>
 
--- Used for examples
 import Language.PlutusCore
 import Language.PlutusCore.Pretty
 import Language.PlutusCore.Quote
 import Language.PlutusCore.Evaluation.CkMachine
-import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc -- <4>
 ----
+<1> Main Plutus Tx module.
+<2> Additional support for lifting.
+<3> Builtin functions.
+<4> Used for examples.
 
 Plutus Tx makes some use of Template Haskell. There are a few reasons
 for this: - Template Haskell allows us to do work at compile time, which
@@ -62,12 +62,12 @@ expression of type `a`, which lives in the `Q` type of quotes. You can
 splice a definition with this type into your program using the `$$`
 operator.
 
-(There is also an abbreviation `TExpQ a` for `Q (TExp a)`, which avoids
-some parentheses.)
+NOTE: There is also an abbreviation `TExpQ a` for `Q (TExp a)`, which avoids
+some parentheses.
 
 The key function we will use is the `compile` function. `compile` has
-type `Q (TExp a) -> Q (TExp (CompiledCode a))`. What does this mean? -
-`Q` and `TExp` we have already seen - `CompiledCode a` is a compiled
+type `TExpQ a -> TExpQ (CompiledCode a)`. What does this mean? -
+`TExpQ` we have already seen - `CompiledCode a` is a compiled
 Plutus Core program corresponding to a Haskell program of type `a`
 
 What this means is that `compile` lets you take a (quoted) Haskell
@@ -103,16 +103,16 @@ instructive to look at it to get a vague idea of what’s going on.
 )
 -}
 integerOne :: CompiledCode Integer
-integerOne = $$( -- The splice inserts the `Q (CompiledCode Integer)` into the program
-    -- compile turns the `Q Integer` into a `Q (CompiledCode Integer)`
-    compile
-        -- The quote has type `Q Integer`
-        [||
-          -- We always use unbounded integers in Plutus Core, so we have to pin
-          -- down this numeric literal to an `Integer` rather than an `Int`
-          (1 :: Integer)
-        ||])
+integerOne = $$(compile -- <3> <4>
+    [|| -- <2>
+        (1 :: Integer) -- <1>
+    ||])
 ----
+<1> We always use unbounded integers in Plutus Core, so we have to pin
+down this numeric literal to an `Integer` rather than an `Int`.
+<2> The quote has type `TExpQ Integer`.
+<3> `compile` turns the `TExpQ Integer` into a `TExpQ (CompiledCode Integer)`.
+<4> The splice inserts the `TExpQ (CompiledCode Integer)` into the program.
 
 We can see how the metaprogramming works here: the Haskell program `1`
 was turned into a `CompiledCode Integer` at compile time, which we
@@ -145,36 +145,33 @@ So far, so familiar: we compiled a lambda into a lambda (the "lam").
 == Functions and datatypes
 
 You can also use functions inside your expression. In practice, you may
-well want to define the entirety of your Plutus Tx program as a
+will usually want to define the entirety of your Plutus Tx program as a
 definition outside the quote, and then simply call it inside the quote.
 
 [source,haskell]
 ----
-{-# INLINABLE plusOne #-}
+{-# INLINABLE plusOne #-} -- <2>
 plusOne :: Integer -> Integer
-plusOne x = x `addInteger` 1
+plusOne x = x `addInteger` 1 -- <1>
 
-{-# INLINABLE myProgram #-}
+{-# INLINABLE myProgram #-} -- <2>
 myProgram :: Integer
 myProgram =
     let
         plusOneLocal :: Integer -> Integer
-        plusOneLocal x = x `addInteger` 1
+        plusOneLocal x = x `addInteger` 1 -- <1>
 
         localPlus = plusOneLocal 1
         externalPlus = plusOne 1
-    in localPlus `addInteger` externalPlus
+    in localPlus `addInteger` externalPlus -- <1>
 
 functions :: CompiledCode Integer
 functions = $$(compile [|| myProgram ||])
 ----
-
-Here we used the function `addInteger` from
-`Language.PlutusTx.Builtins`, which is mapped on the builtin integer
-addition in Plutus Core.
-
-The previous example marked the functions that we used using GHC’s
-`INLINABLE` pragma. This is usually necessary for non-local functions to
+<1> `addInteger` comes from `Language.PlutusTx.Builtins`, and is
+which is mapped to the builtin integer addition in Plutus Core.
+<2> Functions for reuse are marked with GHC’s `INLINABLE` pragma.
+This is usually necessary for non-local functions to
 be usable in Plutus Tx blocks, as it instructs GHC to keep the
 information that the Plutus Tx compiler needs. While this is not always
 necessary, it is a good idea to simply mark all such functions as
@@ -191,8 +188,9 @@ matchMaybe = $$(compile [|| \(x:: Maybe Integer) -> case x of
    ||])
 ----
 
-Unlike functions, datatypes do not need to be defined inside the
-expression, hence why we can use types like `Maybe` from the `Prelude`.
+Unlike functions, datatypes do not need any kind of special annotation to be
+used inside the
+expression, hence we can use types like `Maybe` from the `Prelude`.
 This works for your own datatypes too!
 
 Here’s a small example with a datatype of our own representing a
@@ -255,7 +253,8 @@ program that computes to `5`. Well, we need to _lift_ the argument (`4`)
 from Haskell to Plutus Core, and then we need to apply the function to
 it.
 
-....
+[source,haskell]
+----
 {- |
 >>> let program = addOneToN 4
 >>> pretty program
@@ -276,17 +275,22 @@ it.
 (con 8 ! 5)
 -}
 addOneToN :: Integer -> CompiledCode Integer
-addOneToN n = addOne `applyCode` unsafeLiftCode n
-....
+addOneToN n =
+    addOne
+    `applyCode` -- <1>
+    unsafeLiftCode n -- <2>
+----
+<1> `applyCode` applies one `CompiledCode` to another.
+<2> `unsafeLiftCode` lifts the argument `n` into a `CompiledCode Integer`.
 
-We lifted the argument `n` using the `unsafeLiftCode` function
-("unsafe" because we’re ignoring any errors that might occur from
-lifting something that we don’t support). In order to use this, a type
+We lifted the argument using the `unsafeLiftCode` function. In order to use this, a type
 must have an instance of the `Lift` class. In practice, you should
 generate these with the `makeLift` TH function from
 `Language.PlutusTx.Lift`. Lifting makes it easy to use the same types
 both inside your Plutus Tx program and in the external code that uses
 it.
+NOTE: `unsafeLiftCode` is "unsafe" because it ignores any errors that might occur from
+lifting something that isn't supported.
 
 The combined program applies the original compiled lambda to the lifted
 value (notice that the lambda is a bit complicated now since we have

--- a/plutus-tutorial/doc/02-validator-scripts.adoc
+++ b/plutus-tutorial/doc/02-validator-scripts.adoc
@@ -25,63 +25,47 @@ We need some language extensions and imports:
 ----
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE ScopedTypeVariables #-} -- <1>
+
+{-# LANGUAGE DeriveGeneric       #-} -- <2>
+
+{-# LANGUAGE OverloadedStrings   #-} -- <3>
+
+{-# LANGUAGE NoImplicitPrelude   #-} -- <4>
 module Tutorial.ValidatorScripts where
-----
 
-The language extensions fall into three categories. The first category
-is extensions required by the plugin that translates Haskell Core to
-Plutus IR (Intermediate Representation - a more abstract form of Plutus
-Core). This category includes
-https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#datatype-promotion[`DataKinds`],
-https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#template-haskell[`TemplateHaskell`],
-https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#lexically-scoped-type-variables[`ScopedTypeVariables`].
+import           Language.PlutusTx.Prelude -- <5>
 
-The second category is extensions that contract endpoints to be
-automatically generated in the Plutus Playground, and it contains only
-the
-https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#deriving-representations[`DeriveGeneric`]
-extension.
+import qualified Language.PlutusTx            as PlutusTx -- <6>
 
-The final category is extensions that make the code look nicer. These
-include
-https://downloads.haskell.org/~ghc/8.4.3/docs/html/users_guide/glasgow_exts.html#overloaded-string-literals[`OverloadedStrings`]
-which allows us to write log messages as string literals without having
-to convert them to `Text` values first.
-
-[source,haskell]
-----
-import           Language.PlutusTx.Prelude
-
-import qualified Language.PlutusTx            as PlutusTx
 import qualified Ledger.Interval              as I
 import           Ledger                       (Address, DataScript(..), PubKey(..), RedeemerScript(..),
                                                Signature(..), Slot(..), TxId, ValidatorScript(..))
-import qualified Ledger                       as L
+import qualified Ledger                       as L -- <7>
 import qualified Ledger.Ada                   as Ada
 import           Ledger.Ada                   (Ada)
 import           Ledger.Validation            (PendingTx(..), PendingTxIn(..), PendingTxOut)
-import qualified Ledger.Validation            as V
+import qualified Ledger.Validation            as V -- <8>
+
 import           Wallet                       (WalletAPI(..), WalletDiagnostics(..), MonadWallet,
                                                EventHandler(..), EventTrigger)
-import qualified Wallet                       as W
+import qualified Wallet                       as W -- <9>
+
 import           GHC.Generics                 (Generic)
 
 import qualified Data.ByteString.Lazy.Char8   as C
 ----
-
-The module
-{wallet-api-haddock}/Ledger-Validation.html[`Ledger.Validation`],
-imported as `V`, contains types and functions that can be used in
-on-chain code. `Language.PlutusTx` lets us translate code between
-Haskell and Plutus Core (see the xref:01-plutus-tx#plutus-tx[PlutusTx
-tutorial]).
-{wallet-api-haddock}/Ledger.html[`Ledger`]
-has data types for the ledger model and
-{wallet-api-haddock}/Wallet.html[`Wallet`]
+<1> Needed by the Plutus Tx compiler plugin.
+<2> Needed to allow contract endpoints to be automatically generated in the Plutus Playground.
+<3> Allows us to use string literals for log messages without having to convert them to `Text` first.
+<4> Allows us to use the Plutus Tx Prelude as a replacement for the Haskell Prelude.
+<5> The Plutus Tx Prelude.
+<6> `Language.PlutusTx` lets us translate code between
+Haskell and Plutus Core (see the xref:01-plutus-tx#plutus-tx[PlutusTx tutorial]).
+<7> {wallet-api-haddock}/Ledger.html[`Ledger`] has data types for the ledger model.
+<8> {wallet-api-haddock}/Ledger-Validation.html[`Ledger.Validation`] contains types and
+functions that can be used in on-chain code.
+<9> {wallet-api-haddock}/Wallet.html[`Wallet`]
 is the wallet API. It covers interactions with the wallet, for example
 generating the transactions that actually get the crowdfunding contract
 onto the blockchain.
@@ -98,47 +82,32 @@ Both the hashed secret and the cleartext guess are represented as
 `ByteString` values in on-chain code. `ByteString` represents the usual
 Haskell bytestrings in on-chain code.
 
-To avoid any confusion between cleartext and hash we wrap them in data
-types called `HashedText` and `ClearText`, respectively.
-
 [source,haskell]
 ----
 data HashedText = HashedText ByteString
-data ClearText = ClearText ByteString
-----
+data ClearText = ClearText ByteString -- <1>
 
-One of the strengths of PlutusTx is the ability to use the same
-definitions for on-chain and off-chain code, which includes lifting
-values from Haskell to Plutus Core. To enable values of our string types
-to be lifted, we need to call `makeLift` from the `PlutusTx` module.
-
-[source,haskell]
-----
 PlutusTx.makeLift ''HashedText
-PlutusTx.makeLift ''ClearText
-----
+PlutusTx.makeLift ''ClearText -- <2>
 
-`mkDataScript` creates a data script for the guessing game by hashing
-the string and lifting the hash to its on-chain representation.
-
-[source,haskell]
-----
 mkDataScript :: String -> DataScript
 mkDataScript word =
     let hashedWord = V.plcSHA2_256 (C.pack word)
-    in  DataScript (L.lifted (HashedText hashedWord))
-----
+    in  DataScript (L.lifted (HashedText hashedWord)) -- <3>
 
-`mkRedeemerScript` creates a redeemer script for the guessing game by
-lifting the string to its on-chain representation
-
-[source,haskell]
-----
 mkRedeemerScript :: String -> RedeemerScript
 mkRedeemerScript word =
     let clearWord = C.pack word
-    in RedeemerScript (L.lifted (ClearText clearWord))
+    in RedeemerScript (L.lifted (ClearText clearWord)) -- <4>
 ----
+<1> To avoid any confusion between cleartext and hash we wrap them in data
+types called `HashedText` and `ClearText`, respectively.
+<2> To enable values of our string types to be lifted to Plutus Core, we
+need to call `makeLift`.
+<3> `mkDataScript` creates a data script for the guessing game by hashing
+the string and lifting the hash to its on-chain representation.
+<4> `mkRedeemerScript` creates a redeemer script for the guessing game by
+lifting the string to its on-chain representation
 
 === The Validator Script
 
@@ -159,25 +128,29 @@ In our case, the data script is a `HashedText`, and the redeemer is a
 [source,haskell]
 ----
 -- | The validator script of the game.
-validator :: HashedText -> ClearText -> PendingTx -> Bool
-validator (HashedText actual) (ClearText guessed) _ =
+validator
+  :: HashedText -- <1>
+  -> ClearText -- <2>
+  -> PendingTx
+  -> Bool
 ----
+<1> The type of the data script is `HashedText`.
+<2> The type of the redeemer is `ClearText`.
 
 The actual game logic is very simple: We compare the hash of the
 `guessed` argument with the `actual` secret hash, and throw an error if
-the two don’t match. In on-chain code, we can use the `$$()` splicing
-operator to access functions from the Plutus prelude, imported as `P`.
-For example, `equalsByteString {2c} ByteString -> ByteString -> Bool`
-compares two `ByteString` values for equality.
+the two don’t match. We can use functions from the Plutus prelude, imported as `P`.
 
 [source,haskell]
 ----
-    if equalsByteString actual (sha2_256 guessed)
-    then (traceH "RIGHT!" True)
-    else (traceH "WRONG!" False)
+validator (HashedText actual) (ClearText guessed) _ =
+    if equalsByteString actual (sha2_256 guessed) -- <1>
+    then traceH "RIGHT!" True -- <2>
+    else traceH "WRONG!" False
 ----
-
-`traceH {2c} String -> a -> a` returns its second argument after adding
+<1> `equalsByteString {2c} ByteString -> ByteString -> Bool`
+compares two `ByteString` values for equality.
+<2> `traceH {2c} String -> a -> a` returns its second argument after adding
 its first argument to the log output of this script. The log output is
 only available in the emulator and on the playground, and will be
 ignored when the code is run on the real blockchain.
@@ -193,7 +166,7 @@ understand how Template Haskell works in detail.
 ----
 -- | The validator script of the game.
 gameValidator :: ValidatorScript
-gameValidator = ValidatorScript ($$(L.compileScript [|| validator ||]))
+gameValidator = ValidatorScript $$(L.compileScript [|| validator ||])
 ----
 
 === Contract endpoints
@@ -222,6 +195,11 @@ return a value of type `MonadWallet m => m ()`. This type indicates that
 the function uses the wallet API to produce and spend transaction
 outputs on the blockchain.
 
+Since `MonadWallet` is a sub-class of `Monad` we can use Haskell’s `do`
+notation, allowing us to list our instructions to the wallet in a
+sequence (see https://en.wikibooks.org/wiki/Haskell/do_notation[here]
+for more information).
+
 The first endpoint we need for our game is the function `lock`. It pays
 the specified amount of Ada to the script address. Paying to a script
 address is a common task at the beginning of a contract, and the wallet
@@ -232,11 +210,6 @@ The underscore is a Haskell naming convention, indicating that
 is a variant of
 {wallet-api-haddock}/Wallet-API.html#v:payToScript[`payToScript`]
 which ignores its return value and produces a `()` instead.
-
-Since `MonadWallet` is a sub-class of `Monad` we can use Haskell’s `do`
-notation, allowing us to list our instructions to the wallet in a
-sequence (see https://en.wikibooks.org/wiki/Haskell/do_notation[here]
-for more information).
 
 [source,haskell]
 ----
@@ -253,13 +226,12 @@ output using the guessed word as a redeemer.
 ----
 -- | The "guess" contract endpoint.
 guess :: MonadWallet m => String -> m ()
-guess word =
-    -- 'collectFromScript' is a function of the wallet API. It consumes the
-    -- unspent transaction outputs at a script address and pays them to a
-    -- public key address owned by this wallet. It takes the validator script
-    -- and the redeemer scripts as arguments.
-    W.collectFromScript W.defaultSlotRange gameValidator (mkRedeemerScript word)
+guess word = W.collectFromScript W.defaultSlotRange gameValidator (mkRedeemerScript word) -- <1>
 ----
+<1> `collectFromScript` is a function of the wallet API. It consumes the
+unspent transaction outputs at a script address and pays them to a
+public key address owned by this wallet. It takes the validator script
+and the redeemer scripts as arguments.
 
 If we run `guess` now, nothing will happen. Why? Because in order to
 spend all outputs at the script address, the wallet needs to be aware of
@@ -274,13 +246,13 @@ action:
 -- | The "startGame" contract endpoint, telling the wallet to start watching
 --   the address of the game script.
 startGame :: MonadWallet m => m ()
-startGame =
-    -- 'startWatching' is a function of the wallet API. It instructs the wallet
-    -- to keep track of all outputs at the address. Player 2 needs to call
-    -- 'startGame' before Player 1 uses the 'lock' endpoint, to ensure that
-    -- Player 2's wallet is aware of the game address.
-    W.startWatching gameAddress
+startGame = W.startWatching gameAddress -- <1>
 ----
+<1> `startWatching` is a function of the wallet API. It instructs the wallet
+to keep track of all outputs at the address.
+
+Player 2 needs to call `startGame` before Player 1 uses the `lock` endpoint,
+to ensure that Player 2's wallet is aware of the game address.
 
 Endpoints can have any number of parameters: `lock` has two parameters,
 `guess` has one and `startGame` has none. For each endpoint we include a
@@ -331,7 +303,7 @@ image:game-logs.PNG[Emulator log for a failed attempt]
 . Run traces for a successful game and a failed game in the Playground,
 and examine the logs after each trace.
 . Change the error case of the validator script to
-`(traceH "WRONG!" (error ()))` and run the trace again with a wrong
+`traceH "WRONG!" (error ())` and run the trace again with a wrong
 guess. Note how this time the log does not include the error message.
 . Look at the trace shown below. What will the logs say after running
 "Evaluate"?

--- a/plutus-tutorial/doc/03-wallet-api.adoc
+++ b/plutus-tutorial/doc/03-wallet-api.adoc
@@ -34,7 +34,6 @@ xref:02-validator-scripts#validator-scripts[before]:
 module Tutorial.WalletAPI where
 
 import           Language.PlutusTx.Prelude
-
 import qualified Language.PlutusTx            as PlutusTx
 import qualified Ledger.Interval              as I
 import qualified Ledger.Slot                  as S
@@ -73,27 +72,22 @@ In Haskell:
 [source,haskell]
 ----
 data Campaign = Campaign {
-      fundingTarget      :: Ada,
-      endDate            :: Slot,
-      collectionDeadline :: Slot,
-      campaignOwner      :: PubKey
+      fundingTarget      :: Ada, -- <1>
+      endDate            :: Slot, -- <2>
+      collectionDeadline :: Slot, -- <2>
+      campaignOwner      :: PubKey -- <3>
  }
-----
 
-The type of Ada values is
+PlutusTx.makeLift ''Campaign -- <4>
+----
+<1> The type of Ada values is
 {wallet-api-haddock}/Ledger-Ada.html#v:Ada[`Ada`].
-Dates are expressed in terms of slots, and their type is
+<2> Dates are expressed in terms of slots, and their type is
 {wallet-api-haddock}/Ledger-Slot.html#v:Slot[`Slot`].
-The campaign owner is identified by their public key.
-
-Just like we did in the xref:02-validator-scripts#validator-scripts[guessing game],
-we need to call `makeLift` for data types that we want to convert to
-Plutus at Haskell runtime:
-
-[source,haskell]
-----
-PlutusTx.makeLift ''Campaign
-----
+<3> The campaign owner is identified by their public key.
+<4> Just like we did in the xref:02-validator-scripts#validator-scripts[guessing game],
+we need to call `makeLift` for data types that we want to lift to
+Plutus Core.
 
 Now we need to figure out what the campaign will look like on the
 blockchain. Which transactions are involved, who submits them, and in
@@ -156,8 +150,14 @@ respectively, so the signature of the validator script is:
 
 [source,haskell]
 ----
-type CampaignValidator = Contributor -> CampaignAction -> PendingTx -> Bool
+type CampaignValidator =
+     Contributor -- <1>
+     -> CampaignAction -- <2>
+     -> PendingTx
+     -> Bool
 ----
+<1> The type of the data script is `Contributor`.
+<2> The type of the redeemer is `CampaignAction`.
 
 If we want to implement `CampaignValidator` we need to have access to
 the parameters of the campaign, so that we can check if the selected
@@ -166,22 +166,23 @@ function `mkValidator {2c} Campaign -> CampaignValidator` that takes a
 `Campaign` and produces a `CampaignValidator`.
 
 We then need to compile this into on-chain code using `L.compileScript`,
-which we do in `mkValidatorScript`. To apply the compiled `mkValidator`
-function to the `campaign {2c} Campaign` argument that is provided at
-runtime, we use `Ledger.lifted` to get the on-chain representation of
-`campaign`, and apply `mkValidator` to it with `Ledger.applyScript`:
+which we do in `mkValidatorScript`.
 
 [source,haskell]
 ----
 mkValidatorScript :: Campaign -> ValidatorScript
 mkValidatorScript campaign = ValidatorScript val where
-  val = $$(L.compileScript [|| mkValidator ||]) `L.applyScript` L.lifted campaign
+  val =
+      $$(L.compileScript [|| mkValidator ||])
+      `L.applyScript` -- <1>
+      L.lifted campaign -- <2>
 
 mkValidator :: Campaign -> CampaignValidator
-mkValidator campaign con act p =
 ----
+<1> `applyScript` applies one `Script` to another.
+<2> `Ledger.lifted campaign` gives us the on-chain representation of `campaign`.
 
-You may wonder why we use `L.applyScript` to supply the `Campaign`
+NOTE: You may wonder why we have to use `L.applyScript` to supply the `Campaign`
 argument. Why can we not write `$$(L.lifted campaign)` inside the
 validator script? The reason is that `campaign` is not known at the time
 the validator script is compiled. The names of `lifted` and `compile`
@@ -196,22 +197,29 @@ intermediate values that will make the checking code much more readable.
 These definitions are placed inside a `let` block, which is closed by a
 corresponding `in` below.
 
-First we pattern match on the structure of the
-{wallet-api-haddock}/Ledger-Validation.html#t:PendingTx[`PendingTx`]
-value `p` to get the Validation information we care about:
+In the declaration of the function we pattern match on the arguments
+to get the information we care about:
 
 [source,haskell]
 ----
-    let
-        PendingTx ins outs _ _ _ txnValidRange _  _ = p
-        -- p is bound to the pending transaction.
+mkValidator
+    (Campaign target deadline collectionDeadline campaignOwner) -- <3>
+    con
+    act
+    p@(PendingTx ins outs _ _ _ txnValidRange _ _) = -- <1> <2>
 ----
-
-This binds `ins` to the list of all inputs of the current transaction,
+<1> This binds `ins` to the list of all inputs of the current transaction,
 `outs` to the list of all its outputs, and `txnValidRange` to the
 validity interval of the pending transaction.
+<2> The underscores in the match stand for fields whose values are not
+we are not interested int. The fields are
+`pendingTxFee` (the fee of this transaction), `pendingTxForge` (how
+much, if any, value was forged) and `PendingTxIn` (the current
+{wallet-api-haddock}/Ledger-Validation.html#t:PendingTxIn[transaction
+input]) respectively.
+<3> This binds the parameters of the `Campaign`.
 
-In the extended UTXO model with scripts that underlies Plutus, each
+NOTE: In the extended UTXO model with scripts that underlies Plutus, each
 transaction has a validity range, an interval of slots during which it
 may be validated by core nodes. The validity interval is passed to
 validator scripts via the `PendingTx` argument, and it is the only
@@ -222,25 +230,10 @@ less than 20 (the interval is inclusive-exclusive). In terms of clock
 time we could say that the current time is between the beginning of slot
 10 and the end of slot 19.
 
-The three underscores in the match stand for fields whose values are not
-relevant for validating the crowdfunding transaction. The fields are
-`pendingTxFee` (the fee of this transaction), `pendingTxForge` (how
-much, if any, value was forged) and `PendingTxIn` (the current
-{wallet-api-haddock}/Ledger-Validation.html#t:PendingTxIn[transaction
-input]) respectively. You can click the link
-{wallet-api-haddock}/Ledger-Validation.html#t:PendingTx[`PendingTx`]
-to learn more about the data that is available.
-
-We also need the parameters of the campaign, which we can get by pattern
-matching on `campaign`.
-
-[source,haskell]
-----
-        Campaign target deadline collectionDeadline campaignOwner = campaign
-----
-
 Then we compute the total value of all transaction inputs, using `foldr`
-on the list of inputs `ins`. Note that there is a limit on the number of
+on the list of inputs `ins`.
+
+NOTE: There is a limit on the number of
 inputs a transaction may have, and thus on the number of contributions
 in this crowdfunding campaign. In this tutorial we ignore that limit,
 because it depends on the details of the implementation of Plutus on the
@@ -248,18 +241,18 @@ Cardano chain, and that implementation has not happened yet.
 
 [source,haskell]
 ----
+    let
         totalInputs :: Ada
         totalInputs =
-            -- define a function "addToTotal" that adds the ada
-            -- value of a 'PendingTxIn' to the total
-            let addToTotal (PendingTxIn _ _ vl) total =
+            let addToTotal (PendingTxIn _ _ vl) total = -- <1>
                   let adaVl = Ada.fromValue vl
                   in Ada.plus total adaVl
-
-            -- Apply "addToTotal" to each transaction input,
-            -- summing up the results
-            in foldr addToTotal Ada.zero ins
+            in foldr addToTotal Ada.zero ins -- <2>
 ----
+<1> Defines a function that adds the Ada
+value of a `PendingTxIn` to the total.
+<2> Applies `addToTotal` to each transaction input,
+summing up the results.
 
 We now have all the information we need to check whether the action
 `act` is allowed. This will be computed as
@@ -300,17 +293,16 @@ transaction:
 For the contribution to be refundable, three conditions must hold. The
 collection deadline must have passed, all outputs of this transaction
 must go to the contributor `con`, and the transaction was signed by the
-contributor. To check whether the collection deadline has passed, we use
-`S.before {2c} Slot -> SlotRange -> Bool`. `before` is exported by the
-`Ledger.Slot` module, alongside other useful functions for working with
-`SlotRange` values.
+contributor.
 
 [source,haskell]
 ----
-            in S.before collectionDeadline txnValidRange &&
+            in S.before collectionDeadline txnValidRange && -- <1>
                contributorOnly &&
                p `V.txSignedBy` pkCon
 ----
+<1> To check whether the collection deadline has passed, we use
+`before {2c} Slot -> SlotRange -> Bool`.
 
 The second branch represents a successful campaign.
 
@@ -321,19 +313,21 @@ The second branch represents a successful campaign.
 
 In the `Collect` case, the current slot must be between `deadline` and
 `collectionDeadline`, the target must have been met, and and transaction
-has to be signed by the campaign owner. We use
-`interval {2c} Slot -> Slot -> SlotRange` and
-`contains {2c} SlotRange -> SlotRange -> Bool` from the `Ledger.Slot`
-module to ensure that the spending transactions validity range,
-`txnValidRange`, is completely contained in the time between campaign
-deadline and collection deadline.
+has to be signed by the campaign owner.
 
 [source,haskell]
 ----
-            S.contains (I.interval deadline collectionDeadline) txnValidRange &&
+            S.contains (I.interval deadline collectionDeadline) txnValidRange && -- <1>
             Ada.geq totalInputs target &&
             p `V.txSignedBy` campaignOwner
 ----
+<1> We use
+`interval {2c} Slot -> Slot -> SlotRange` and
+`contains {2c} SlotRange -> SlotRange -> Bool`
+to ensure that the transaction's validity range,
+`txnValidRange`, is completely contained in the time between campaign
+deadline and collection deadline.
+
 
 === Contract Endpoints
 
@@ -410,23 +404,18 @@ target has been reached. The function `collectFundsTrigger` gives us the
 ----
 collectFundsTrigger :: Campaign -> EventTrigger
 collectFundsTrigger c = W.andT
-    -- We use `W.intervalFrom` to create an open-ended interval that starts
-    -- at the funding target.
-    (W.fundsAtAddressGeqT (campaignAddress c) (Ada.toValue (fundingTarget c)))
-
-    -- With `W.interval` we create an interval from the campaign's end date
-    -- (inclusive) to the collection deadline (exclusive)
-    (W.slotRangeT (W.interval (endDate c) (collectionDeadline c)))
+    (W.fundsAtAddressGeqT (campaignAddress c) (Ada.toValue (fundingTarget c))) -- <1>
+    (W.slotRangeT (W.interval (endDate c) (collectionDeadline c))) -- <2>
 ----
+<1> We use `W.intervalFrom` to create an open-ended interval that starts
+at the funding target.
+<2> With `W.interval` we create an interval from the campaign's end date
+(inclusive) to the collection deadline (exclusive).
 
 `fundsAtAddressGeqT` and `slotRangeT` take `Value` and `Interval Slot`
 arguments respectively. The
 {wallet-api-haddock}/Wallet-API.html#t:Interval[`Interval`]
-type is part of the `wallet-api` package. The
-{wallet-api-haddock}/Ledger-Interval.html#v:Interval[`Ledger.Interval`]
-module that originally defines it illustrates how to write a data type
-and associated operations that can be used both in off-chain and in
-on-chain code.
+type is part of the `wallet-api` package.
 
 The campaign owner can collect contributions when two conditions hold:
 The funds at the address must have reached the target, and the current
@@ -438,7 +427,7 @@ Now we can define an event handler that collects the contributions:
 [source,haskell]
 ----
 collectionHandler :: MonadWallet m => Campaign -> EventHandler m
-collectionHandler cmp = EventHandler (\_ -> do
+collectionHandler cmp = EventHandler $ \_ -> do
 ----
 
 `EventHandler` is a function of one argument, which we ignore in this
@@ -454,19 +443,19 @@ conditions hold when the event handler is run, so we can call
 {wallet-api-haddock}/Wallet-API.html#v:collectFromScript[`collectFromScript`]
 immediately.
 
-To collect the funds we use
-{wallet-api-haddock}/Wallet-API.html#v:collectFromScript[`collectFromScript`],
-which expects a validator script and a redeemer script.
 
 [source,haskell]
 ----
     W.logMsg "Collecting funds"
     let redeemerScript = mkRedeemer Collect
         range          = W.interval (endDate cmp) (collectionDeadline cmp)
-    W.collectFromScript range (mkValidatorScript cmp) redeemerScript)
+    W.collectFromScript range (mkValidatorScript cmp) redeemerScript -- <1>
 ----
+<1> To collect the funds we use
+{wallet-api-haddock}/Wallet-API.html#v:collectFromScript[`collectFromScript`],
+which expects a validator script and a redeemer script.
 
-Note that the trigger mechanism is a feature of the wallet, not of the
+NOTE: The trigger mechanism is a feature of the wallet, not of the
 blockchain. That means that the wallet needs to be running when the
 condition becomes true, so that it can react to it and submit
 transactions. Anything that happens in an
@@ -530,15 +519,15 @@ do with
 [source,haskell]
 ----
 refundHandler :: MonadWallet m => TxId -> Campaign -> EventHandler m
-refundHandler txid cmp = EventHandler (\_ -> do
+refundHandler txid cmp = EventHandler $ \_ -> do
     W.logMsg "Claiming refund"
     let redeemer  = mkRedeemer Refund
         range     = W.intervalFrom (collectionDeadline cmp)
-    W.collectFromScriptTxn range (mkValidatorScript cmp) redeemer txid)
+    W.collectFromScriptTxn range (mkValidatorScript cmp) redeemer txid
 ----
 
 Now we can register the refund handler when we make the contribution.
-The condition for being able to claim a refund is
+The condition for being able to claim a refund is:
 
 [source,haskell]
 ----
@@ -560,17 +549,17 @@ contribute cmp adaAmount = do
     let dataScript = mkDataScript pk
         amount = Ada.toValue adaAmount
 
-    -- payToScript returns the transaction that was submitted
-    -- (unlike payToScript_ which returns unit)
-    tx <- W.payToScript W.defaultSlotRange (campaignAddress cmp) amount dataScript
+    tx <- W.payToScript W.defaultSlotRange (campaignAddress cmp) amount dataScript -- <1>
     W.logMsg "Submitted contribution"
 
-    -- L.hashTx gives the `TxId` of a transaction
-    let txId = L.hashTx tx
+    let txId = L.hashTx tx -- <2>
 
     W.register (refundTrigger cmp) (refundHandler txId cmp)
     W.logMsg "Registered refund trigger"
 ----
+<1> `payToScript` returns the transaction that was submitted
+(unlike `payToScript_` which returns unit).
+<2> `L.hashTx` gives the `TxId` of a transaction.
 
 [#testing-contract-03]
 == Testing the Contract
@@ -597,12 +586,12 @@ for the endpoints to the end of the script:
 $(mkFunctions ['scheduleCollection, 'contribute])
 ....
 
-(We can’t use the usual Haskell syntax highlighting for this line
+NOTE: We can’t use the usual Haskell syntax highlighting for this line
 because the entire script is compiled and executed as part of the test
 suite for the `wallet-api` project. The Playground-specific
 {haddock}/plutus-playground-lib-0.1.0.0/html/Playground-Contract.html#v:mkFunctions[`mkFunctions`]
 is defined in a different library (`plutus-playground-lib`) and it is
-not available for this tutorial.)
+not available for this tutorial.
 
 Alternatively, you can click the "Crowdfunding" button in the
 Playground to load the sample contract including the `mkFunctions` line.

--- a/plutus-tutorial/doc/index.adoc
+++ b/plutus-tutorial/doc/index.adoc
@@ -3,6 +3,7 @@
 :numbered:
 :source-highlighter: pygments
 :imagesdir: images
+:icons: font
 
 // unfortunately, asciidoctor likes to parse these as definition lists :(
 // https://github.com/asciidoctor/asciidoctor/issues/1066

--- a/plutus-tutorial/doc/overview.adoc
+++ b/plutus-tutorial/doc/overview.adoc
@@ -4,18 +4,18 @@ This document is a series of tutorials that explain various
 aspects of the Plutus smart contract platform.
 
 [arabic]
-. xref:intro#intro[Introduction to Plutus] introduces smart
+. xref:intro#intro[] introduces smart
 contracts and related terms
-. xref:01-plutus-tx#plutus-tx[Plutus Tx] explains the basics of using
+. xref:01-plutus-tx#plutus-tx[] explains the basics of using
 the Plutus Tx compiler to create embedded (on-chain) programs
-. xref:02-validator-scripts#validator-scripts[A guessing game] implements a
+. xref:02-validator-scripts#validator-scripts[] implements a
 guessing game. Topics covered:
     * Signature of validator script
     * `Ledger.makeLift`, `Ledger.compileScript`
     * Contract endpoints
     * `Wallet.payToScript_`, `Wallet.collectFromScript`
     * Playground
-. xref:03-wallet-api#wallet-api[A crowdfunding campaign] implements a
+. xref:03-wallet-api#wallet-api[] implements a
 crowdfunding campaign. Topics covered:
     * Parameterising a contract through partial application using
     `Ledger.applyScript`
@@ -35,7 +35,7 @@ a vesting scheme. Topics covered:
 Note that (5) and (6) are written as regular Haskell modules and include
 exercises (marked by `error`). They are intended to be edited
 interactively with the help of GHCi. See
-link:../tutorial/Tutorial/Emulator.hs[4.1] for details. Solutions for the
+link:../tutorial/Tutorial/Emulator.hs[the first such tutorial] for details. Solutions for the
 exercises are located in `Solutions0.hs`.
 
 Additional documentation will be added for the following
@@ -47,8 +47,8 @@ work-in-progress features, when they are available on the mockchain:
 
 == Prerequisites
 
-To follow the xref:02-validator-scripts#validator-scripts[Wallet API, Part I]
-and xref:03-wallet-api#wallet-api[Wallet API, Part II] tutorials you
+To follow the xref:02-validator-scripts#validator-scripts[]
+and xref:03-wallet-api#wallet-api[] tutorials you
 should have access to a recent version of the Plutus Playground.
 
 To follow the link:../tutorial/Tutorial/Emulator.hs[mockchain tutorial], you should
@@ -70,8 +70,8 @@ To install the emulator (not the Playground) locally, follow these steps.
 . Install the nix package manager following the instructions on
 https://nixos.org/nix/.
 +
-IMPORTANT: Add the IOHK binary cache to your Nix configuration. See
-link:../README.md#binary-caches[here] for details.
+IMPORTANT: Make sure to add the IOHK binary cache to your Nix configuration. See
+link:../README.md#binary-caches[the repository README] for details.
 . Move to the plutus-tutorial folder.
 . Type `nix-shell`. This will download all of the dependencies and
 populate the PATH with a correctly configured cabal. If `nix-shell`


### PR DESCRIPTION
These can help where we are explaining several bits of a piece of code.
The alternative can require breaking it up painfully small, and
sometimes having to order things weirdly in order to get the text in a
logical order. Callouts don't have this problem.

Admonitions are nice for asides that would otherwise break up the flow
of the text.

I may have gone a bit overboard with both.