### PR TITLE
Build: build a documentation site for the Playground

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -184,6 +184,16 @@ let
     };
 
     plutus-playground = rec {
+      documentation-site = let
+        # TODO: the playgroundUrl needs to be set to whatever will actually be appropriate when it's bundled
+        # with the playground
+        adjustedTutorial = docs.plutus-tutorial.override { playgroundUrl = "../.."; haddockUrl = "../haddock"; };
+      in pkgs.runCommand "documentation-site" {} ''
+        mkdir -p $out
+        cp -aR ${adjustedTutorial} $out/tutorial
+        cp -aR ${docs.public-combined-haddock}/share/doc $out/haddock
+      '';
+
       playground-exe = set-git-rev haskellPackages.plutus-playground-server;
       server-invoker = let
         # the playground uses ghc at runtime so it needs one packaged up with the dependencies it needs in one place

--- a/plutus-tutorial/doc/default.nix
+++ b/plutus-tutorial/doc/default.nix
@@ -1,10 +1,12 @@
-{ stdenv, lib, asciidoctor, python }:
+{ stdenv, lib, asciidoctor, python, playgroundUrl ? null, haddockUrl ? null }:
 
-stdenv.mkDerivation {
+let
+  extraArgs = (lib.optionals (playgroundUrl != null) [ "-a" "playground=${playgroundUrl}" ]) ++ (lib.optionals (haddockUrl != null) [ "-a" "haddock=${haddockUrl}" ]);
+in stdenv.mkDerivation {
   name = "plutus-tutorial";
   src = lib.sourceFilesBySuffices ./. [ ".adoc" ".png" ".PNG" ".gif" ];
   buildInputs = [ asciidoctor python ];
-  buildPhase = "asciidoctor index.adoc";
+  buildPhase = "asciidoctor ${toString extraArgs} index.adoc";
   installPhase = ''
     mkdir -p $out
     install -t $out *.html 


### PR DESCRIPTION
This is a self-contained site that can be deployed with the
Playground.

We need to set the relative URLs that correspond to how things are going
to be served, but this can adjusted when we actually start doing that.