### PR TITLE
plutus-tx: append -> ++

### DIFF
--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -47,7 +47,7 @@ module Language.PlutusTx.Prelude (
     length,
     all,
     any,
-    append,
+    (++),
     filter,
     -- * ByteStrings
     ByteString,
@@ -67,7 +67,7 @@ import           Language.PlutusTx.Builtins (ByteString, concatenate, dropByteSt
                                              sha2_256, sha3_256, takeByteString, verifySignature)
 import qualified Language.PlutusTx.Builtins as Builtins
 import           Prelude                    as Prelude hiding (all, any, error, filter, foldl, foldr, fst, length, map,
-                                                        max, maybe, min, not, null, snd, (&&), (||))
+                                                        max, maybe, min, not, null, snd, (&&), (++), (||))
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}
@@ -376,14 +376,14 @@ all p = foldr (\a acc -> acc && p a) True
 any :: (a -> Bool) -> [a] -> Bool
 any p = foldr (\a acc -> acc || p a) False
 
-{-# INLINABLE append #-}
+{-# INLINABLE (++) #-}
 -- | PlutusTx version of 'Data.List.(++)'.
 --
---   >>> append [0, 1, 2] [1, 2, 3, 4]
+--   >>> [0, 1, 2] ++ [1, 2, 3, 4]
 --   [0,1,2,1,2,3,4]
 --
-append :: [a] -> [a] -> [a]
-append l r = foldr (:) r l
+(++) :: [a] -> [a] -> [a]
+(++) l r = foldr (:) r l
 
 {-# INLINABLE filter #-}
 -- | PlutusTx version of 'Data.List.filter'.

--- a/plutus-wallet-api/ledger/Ledger/Map.hs
+++ b/plutus-wallet-api/ledger/Ledger/Map.hs
@@ -111,7 +111,7 @@ union eq (Map ls) (Map rs) =
         rs'' :: [(k, These v r)]
         rs'' = P.map (\(c, b) -> (c, That b)) rs'
 
-    in Map (append ls' rs'')
+    in Map (ls' ++ rs'')
 
 {-# INLINABLE all #-}
 -- | See 'Data.Map.all'


### PR DESCRIPTION
This is the last operator in the Prelude that should really be symbolic.

(Note that `gt`, `eq` etc should *not* be, since then they would shadow
the Haskell Preldue ones, but they're monomorphic and
not appropriate replacements for the Haskell Prelude's
typeclass-polymorphic functions.)