### PR TITLE
plutus-wallet-api: typecheck scripts as we are supposed to

### DIFF
--- a/language-plutus-core/bench/Bench.hs
+++ b/language-plutus-core/bench/Bench.hs
@@ -8,6 +8,7 @@ import           Criterion.Main
 import           Crypto
 import qualified Data.ByteString.Lazy                     as BSL
 import           Language.PlutusCore
+import qualified Language.PlutusCore.Check.Normal     as Normal
 import           Language.PlutusCore.Constant.Dynamic
 import           Language.PlutusCore.Evaluation.CkMachine (runCk)
 import           Language.PlutusCore.Pretty
@@ -61,9 +62,11 @@ main =
 
                    bgroup "type-check" $ mkBench <$> [f, g, h]
                 , env largeTypeFiles $ \ ~(f, g, h) ->
-                   let mkBench = bench "check" . nf (fmap check) . parse
+                   let normalConcrete :: Program TyName Name AlexPosn -> Either (Error AlexPosn) ()
+                       normalConcrete = Normal.checkProgram
+                       mkBench = bench "normal-types check" . nf (normalConcrete =<<) . runQuoteT . parseScoped
                    in
-                   bgroup "normal-form check" $ mkBench <$> [f, g, h]
+                   bgroup "normal-types check" $ mkBench <$> [f, g, h]
 
                 , env sampleScript $ \ f ->
                     let renameConcrete :: Program TyName Name () -> Program TyName Name ()

--- a/language-plutus-core/bench/Bench.hs
+++ b/language-plutus-core/bench/Bench.hs
@@ -8,7 +8,7 @@ import           Criterion.Main
 import           Crypto
 import qualified Data.ByteString.Lazy                     as BSL
 import           Language.PlutusCore
-import qualified Language.PlutusCore.Check.Normal     as Normal
+import qualified Language.PlutusCore.Check.Normal         as Normal
 import           Language.PlutusCore.Constant.Dynamic
 import           Language.PlutusCore.Evaluation.CkMachine (runCk)
 import           Language.PlutusCore.Pretty

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
@@ -15,7 +15,7 @@ module Language.PlutusCore.Generators.Internal.TypeEvalCheck
     , unsafeTypeEvalCheck
     ) where
 
-import qualified Language.PlutusCore.Check.ValueRestriction              as VR
+import qualified Language.PlutusCore.Check.Value              as VR
 import           Language.PlutusCore.Constant
 import           Language.PlutusCore.Error
 import           Language.PlutusCore.Evaluation.CkMachine

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -40,7 +40,8 @@ library
         Language.PlutusCore.Evaluation.CkMachine
         Language.PlutusCore.Evaluation.MachineException
         Language.PlutusCore.Evaluation.Result
-        Language.PlutusCore.Check.ValueRestriction
+        Language.PlutusCore.Check.Value
+        Language.PlutusCore.Check.Normal
         Language.PlutusCore.CBOR
         Language.PlutusCore.Constant
         Language.PlutusCore.Constant.Dynamic
@@ -96,7 +97,6 @@ library
         Language.PlutusCore.Constant.Make
         Language.PlutusCore.Constant.Name
         Language.PlutusCore.Constant.Typed
-        Language.PlutusCore.Check.Normal
         Language.PlutusCore.Pretty.Classic
         Language.PlutusCore.Pretty.Plc
         Language.PlutusCore.Pretty.Readable

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -55,6 +55,8 @@ module Language.PlutusCore
     , fileTypeCfg
     , printType
     , printNormalizeType
+    , normalizeTypesFullIn
+    , normalizeTypesFullInProgram
     , InternalTypeError (..)
     , TypeError (..)
     , AsTypeError (..)
@@ -111,6 +113,7 @@ import           Language.PlutusCore.Evaluation.CkMachine
 import           Language.PlutusCore.Lexer
 import           Language.PlutusCore.Lexer.Type
 import           Language.PlutusCore.Name
+import           Language.PlutusCore.Normalize
 import           Language.PlutusCore.Parser
 import           Language.PlutusCore.Pretty
 import           Language.PlutusCore.Quote

--- a/language-plutus-core/src/Language/PlutusCore/Check/Normal.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Normal.hs
@@ -2,13 +2,11 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RankNTypes            #-}
 
--- | This module makes sure terms and types are well-formed according to Fig. 2
-module Language.PlutusCore.Check.Normal ( check
-                                        , checkProgram
+-- | This module makes sure types are normalized inside programs.
+module Language.PlutusCore.Check.Normal ( checkProgram
                                         , checkTerm
-                                        , NormalizationError
-                                        , isTypeValue
-                                        , isTermValue
+                                        , NormalizationError (..)
+                                        , isNormalType
                                         ) where
 
 import           Control.Monad.Except
@@ -21,86 +19,50 @@ import           Language.PlutusCore.Name
 import           Language.PlutusCore.Type
 import           PlutusPrelude
 
--- | Ensure that all terms and types are well-formed accoring to Fig. 2
+-- | Ensure that all types in the 'Program' are normalized.
 checkProgram :: (AsNormalizationError e TyName Name a, MonadError e m) => Program TyName Name a -> m ()
-checkProgram p = void $ throwingEither _NormalizationError $ preCheck p
+checkProgram (Program _ _ t) = checkTerm t
 
--- | Ensure that all terms and types are well-formed accoring to Fig. 2
+-- | Ensure that all types in the 'Term' are normalized.
 checkTerm :: (AsNormalizationError e TyName Name a, MonadError e m) => Term TyName Name a -> m ()
-checkTerm p = void $ throwingEither _NormalizationError $ checkTerm p
+checkTerm p = void $ throwingEither _NormalizationError $ checkT p
 
-check :: Program tyname name a -> Maybe (NormalizationError tyname name a)
-check = go . preCheck where
-    go Right{}  = Nothing
-    go (Left x) = Just x
-
--- | Ensure that all terms and types are well-formed accoring to Fig. 2
-preCheck :: Program tyname name a -> Either (NormalizationError tyname name a) (Program tyname name a)
-preCheck (Program l v t) = Program l v <$> checkT t
-
--- this basically ensures all type instatiations, etc. occur only with type *values*
 checkT :: Term tyname name a -> Either (NormalizationError tyname name a) (Term tyname name a)
-checkT (Error l ty)           = Error l <$> typeValue ty
-checkT (TyInst l t ty)        = TyInst l <$> checkT t <*> typeValue ty
-checkT (IWrap l pat arg term) = IWrap l <$> typeValue pat <*> typeValue arg <*> checkT term
+checkT (Error l ty)           = Error l <$> normalType ty
+checkT (TyInst l t ty)        = TyInst l <$> checkT t <*> normalType ty
+checkT (IWrap l pat arg term) = IWrap l <$> normalType pat <*> normalType arg <*> checkT term
 checkT (Unwrap l t)           = Unwrap l <$> checkT t
-checkT (LamAbs l n ty t)      = LamAbs l n <$> typeValue ty <*> checkT t
-checkT (Apply l t t')         = Apply l <$> checkT t <*> checkT t'
-checkT (TyAbs l tn k t)       = TyAbs l tn k <$> termValue t
+checkT (LamAbs l n ty t)      = LamAbs l n <$> normalType ty <*> checkT t
+checkT (Apply l t1 t2)        = Apply l <$> checkT t1 <*> checkT t2
+checkT (TyAbs l tn k t)       = TyAbs l tn k <$> checkT t
 checkT t@Var{}                = pure t
 checkT t@Constant{}           = pure t
 checkT t@Builtin{}            = pure t
 
-isTermValue :: Term tyname name a -> Bool
-isTermValue = isRight . termValue
-
--- ensure a term is a value
-termValue :: Term tyname name a -> Either (NormalizationError tyname name a) (Term tyname name a)
-termValue (LamAbs l n ty t)      = LamAbs l n ty <$> checkT t
-termValue (IWrap l pat arg term) = IWrap l pat arg <$> termValue term
-termValue (TyAbs l tn k t)       = TyAbs l tn k <$> termValue t
-termValue t                      = builtinValue t
-
 {- Note [Builtin applications and values]
-An older version of the specification had a special case for builtin applications being
-term values. This is important, because they obviously can't be reduced before runtime.
-However, it was missing a corresponding case for builtin *type* applications, which
-resulted in types like `[(con integer) (con 64)]` not being considered normalized, which
-effectively prevents you using integers anywhere.
+An older version of the specification had a special case for builtin type applications being
+normal types. This is important, because they obviously can't be reduced before runtime.
+This resulted in types like `[(con integer) (con 64)]` not being considered normalized, which
+effectively prevents you using integers anywhere (note: this isn't so much of a problem now
+integers aren't parameterized, but it's still wrong).
 
-The current version of the specification has moved to fully saturated builtins and builtin types,
-but the implementation is not there. Consequently we include the special cases for builtin applications
-and also consider builtin types and type level integers to be neutral types.
+The current version of the specification has moved to fully saturated builtins,
+but the implementation is not there. Consequently we consider builtin types to be neutral types.
 -}
 
--- See note [Builtin applications and values]
-builtinValue :: Term tyname name a -> Either (NormalizationError tyname name a) (Term tyname name a)
-builtinValue t@Constant{}    = pure t
-builtinValue (TyInst l t ty) = TyInst l <$> builtinValue t <*> pure ty
-builtinValue (Apply l t t')  = Apply l <$> builtinValue t <*> termValue t'
-builtinValue t               = Left $ BadTerm (termLoc t) t "builtin value"
+isNormalType :: Type tyname a -> Bool
+isNormalType = isRight . normalType
 
-isTypeValue :: Type tyname a -> Bool
-isTypeValue = isRight . typeValue
+normalType :: Type tyname a -> Either (NormalizationError tyname name a) (Type tyname a)
+normalType (TyFun l i o)        = TyFun l <$> normalType i <*> normalType o
+normalType (TyForall l tn k ty) = TyForall l tn k <$> normalType ty
+normalType (TyIFix l pat arg)   = TyIFix l <$> normalType pat <*> normalType arg
+normalType (TyLam l tn k ty)    = TyLam l tn k <$> normalType ty
+normalType ty                   = neutralType ty
 
--- ensure that a type is a type value
-typeValue :: Type tyname a -> Either (NormalizationError tyname name a) (Type tyname a)
-typeValue = cataM aM where
-
-    aM ty | isTyValue ty = pure (embed ty)
-          | otherwise    = neutralType (embed ty)
-
-    isTyValue TyFunF{}     = True
-    isTyValue TyForallF{}  = True
-    isTyValue TyIFixF{}    = True
-    isTyValue TyLamF{}     = True
-    isTyValue TyBuiltinF{} = True
-    isTyValue _            = False
-
--- ensure a type is a neutral type
 neutralType :: Type tyname a -> Either (NormalizationError tyname name a) (Type tyname a)
-neutralType ty@TyVar{}       = pure ty
-neutralType (TyApp x ty ty') = TyApp x <$> neutralType ty <*> typeValue ty'
+neutralType ty@TyVar{}        = pure ty
+neutralType (TyApp x ty1 ty2) = TyApp x <$> neutralType ty1 <*> normalType ty2
 -- See note [Builtin applications and values]
-neutralType ty@TyBuiltin{}   = pure ty
-neutralType ty               = Left (BadType (tyLoc ty) ty "neutral type")
+neutralType ty@TyBuiltin{}    = pure ty
+neutralType ty                = Left (BadType (tyLoc ty) ty "neutral type")

--- a/language-plutus-core/src/Language/PlutusCore/Check/Uniques.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Uniques.hs
@@ -1,4 +1,9 @@
-module Language.PlutusCore.Check.Uniques (checkProgram, checkTerm, checkType) where
+module Language.PlutusCore.Check.Uniques (
+    checkProgram
+    , checkTerm
+    , checkType
+    , UniqueError (..)
+    , AsUniqueError (..)) where
 
 import           Language.PlutusCore.Analysis.Definitions
 import           Language.PlutusCore.Error

--- a/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
@@ -34,9 +34,9 @@ checkProgram (Program _ _ term) = checkTerm term
 isTermValue :: Term tyname name a -> Bool
 isTermValue = isRight . termValue
 
-termValue :: Term tyname name a -> Either (NormalizationError tyname name a) (Term tyname name a)
-termValue (IWrap l pat arg term) = IWrap l pat arg <$> termValue term
-termValue (TyAbs l tn k t)       = TyAbs l tn k <$> termValue t
-termValue l@LamAbs {}            = pure l
-termValue c@Constant {}          = pure c
-termValue t                      = Left $ BadTerm (termLoc t) t "term value"
+termValue :: Term tyname name a -> Either (NormalizationError tyname name a) ()
+termValue (IWrap _ _ _ term) = termValue term
+termValue (TyAbs _ _ _ t)    = termValue t
+termValue LamAbs {}          = pure ()
+termValue Constant {}        = pure ()
+termValue t                  = Left $ BadTerm (termLoc t) t "term value"

--- a/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
@@ -5,6 +5,7 @@ module Language.PlutusCore.Check.Value
     , checkProgram
     , isTermValue
     , ValueRestrictionError(..)
+    , AsValueRestrictionError(..)
     ) where
 
 import           Language.PlutusCore.Error

--- a/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
@@ -1,18 +1,18 @@
--- | The value restriction check.
-
-{-# LANGUAGE LambdaCase #-}
-
-module Language.PlutusCore.Check.ValueRestriction
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Language.PlutusCore.Check.Value
     ( checkTerm
     , checkProgram
+    , isTermValue
+    , ValueRestrictionError(..)
     ) where
 
 import           Language.PlutusCore.Error
 import           Language.PlutusCore.Type
-import           Language.PlutusCore.View  (isTermValue)
 
 import           Control.Monad.Error.Lens
 import           Control.Monad.Except
+import           Data.Either
 import           Data.Foldable             (traverse_)
 import           Data.Functor.Foldable
 
@@ -21,8 +21,7 @@ checkTerm
     :: (AsValueRestrictionError e tyname ann, MonadError e m) => Term tyname name ann -> m ()
 checkTerm = para $ \case
     TyAbsF ann name _ (body, rest) -> do
-        unless (isTermValue body) $
-            throwing _ValueRestrictionError $ ValueRestrictionViolation ann name
+        unless (isTermValue body) $ throwing _ValueRestrictionError $ ValueRestrictionViolation ann name
         rest
     termF                          -> traverse_ snd termF
 
@@ -30,3 +29,13 @@ checkTerm = para $ \case
 checkProgram
     :: (AsValueRestrictionError e tyname ann, MonadError e m) => Program tyname name ann -> m ()
 checkProgram (Program _ _ term) = checkTerm term
+
+isTermValue :: Term tyname name a -> Bool
+isTermValue = isRight . termValue
+
+termValue :: Term tyname name a -> Either (NormalizationError tyname name a) (Term tyname name a)
+termValue (IWrap l pat arg term) = IWrap l pat arg <$> termValue term
+termValue (TyAbs l tn k t)       = TyAbs l tn k <$> termValue t
+termValue l@LamAbs {}            = pure l
+termValue c@Constant {}          = pure c
+termValue t                      = Left $ BadTerm (termLoc t) t "term value"

--- a/language-plutus-core/src/Language/PlutusCore/Normalize.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Normalize.hs
@@ -7,6 +7,7 @@ module Language.PlutusCore.Normalize
     , normalizeTypesIn
     , normalizeTypesFullIn
     , normalizeTypesGasIn
+    , normalizeTypesFullInProgram
     ) where
 
 import           Language.PlutusCore.Name
@@ -58,3 +59,9 @@ normalizeTypesGasIn
     :: (HasUnique (tyname ann) TypeUnique, HasUnique (name ann) TermUnique, MonadQuote m)
     => Gas -> Term tyname name ann -> m (Maybe (Term tyname name ann))
 normalizeTypesGasIn gas = rename >=> runNormalizeTypeGasM gas . normalizeTypesInM
+
+-- | Normalize every 'Type' in a 'Program' without dealing with gas.
+normalizeTypesFullInProgram
+    :: (HasUnique (tyname ann) TypeUnique, HasUnique (name ann) TermUnique, MonadQuote m)
+    => Program tyname name ann -> m (Program tyname name ann)
+normalizeTypesFullInProgram (Program x v t) = Program x v <$> normalizeTypesFullIn t

--- a/language-plutus-core/src/Language/PlutusCore/View.hs
+++ b/language-plutus-core/src/Language/PlutusCore/View.hs
@@ -12,7 +12,6 @@ module Language.PlutusCore.View
     , termAsBuiltin
     , termAsTermIterApp
     , termAsPrimIterApp
-    , isTermValue
     ) where
 
 import           Language.PlutusCore.Lexer.Type (StagedBuiltinName (..))
@@ -72,11 +71,3 @@ termAsPrimIterApp term = do
     -- TODO: resolve this.
     -- guard $ all isTermValue spine
     Just $ IterApp headName spine
-
--- | Check whether a 'Term' is a 'Value'. The term is assumed to be valid.
-isTermValue :: Term tyname name a -> Bool
-isTermValue (IWrap _ _ _ term) = isTermValue term
-isTermValue TyAbs{}            = True
-isTermValue LamAbs{}           = True
-isTermValue Constant{}         = True
-isTermValue term               = isJust $ termAsPrimIterApp term

--- a/language-plutus-core/test/Normalization/Check.hs
+++ b/language-plutus-core/test/Normalization/Check.hs
@@ -3,6 +3,7 @@
 module Normalization.Check ( test_normalizationCheck ) where
 
 import           Language.PlutusCore
+import           Language.PlutusCore.Check.Normal
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
@@ -15,7 +16,7 @@ test_applyToValue =
                     (KindArrow () (Type ()) (Type ()))
                     (TyApp () datVar aVar)
                 )
-    in isTypeValue ty @?= True
+    in isNormalType ty @?= True
 
     where recVar = TyVar () (TyName (Name () "rec" (Unique 0)))
           datVar = TyVar () datName

--- a/language-plutus-core/test/TypeSynthesis/Spec.hs
+++ b/language-plutus-core/test/TypeSynthesis/Spec.hs
@@ -5,17 +5,17 @@ module TypeSynthesis.Spec
     ) where
 
 import           Language.PlutusCore
-import qualified Language.PlutusCore.Check.ValueRestriction as VR
-import           Language.PlutusCore.FsTree                 (foldPlcFolderContents)
+import qualified Language.PlutusCore.Check.Value         as VR
+import           Language.PlutusCore.FsTree              (foldPlcFolderContents)
 import           Language.PlutusCore.Pretty
 
-import           Language.PlutusCore.Examples.Everything    (examples)
-import           Language.PlutusCore.StdLib.Everything      (stdLib)
+import           Language.PlutusCore.Examples.Everything (examples)
+import           Language.PlutusCore.StdLib.Everything   (stdLib)
 
 import           Common
 
 import           Control.Monad.Except
-import           System.FilePath                            ((</>))
+import           System.FilePath                         ((</>))
 import           Test.Tasty
 import           Test.Tasty.HUnit
 

--- a/plutus-emulator/test/Spec.hs
+++ b/plutus-emulator/test/Spec.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Main(main) where
@@ -233,7 +234,9 @@ invalidScript = property $ do
 
     where
         failValidator :: ValidatorScript
-        failValidator = ValidatorScript $ $$(compileScript [|| \() () () -> PlutusTx.traceH "I always fail everything" (Builtins.error @()) ||])
+        failValidator = ValidatorScript $ $$(compileScript [|| validator ||])
+        validator :: () -> () -> PendingTx -> Bool
+        validator _ _ _ = PlutusTx.traceErrorH "I always fail everything"
 
 
 txnFlowsTest :: Property

--- a/plutus-tx/compiler/Language/PlutusTx/Code.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Code.hs
@@ -23,6 +23,9 @@ import qualified Data.ByteString.Lazy         as BSL
 -- | A compiled Plutus Tx program. The type parameter indicates
 -- the type of the Haskell expression that was compiled, and
 -- hence the type of the compiled code.
+--
+-- Note: the compiled PLC program does *not* have normalized types,
+-- if you want to put it on the chain you must normalize the types first.
 data CompiledCode a =
     -- | Serialized PLC code and possibly serialized PIR code.
     SerializedCode BS.ByteString (Maybe BS.ByteString)

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
@@ -13,16 +13,18 @@ module Language.PlutusTx.Compiler.Error (
     , throwPlain
     , pruneContext) where
 
-import qualified Language.PlutusIR.Compiler as PIR
+import qualified Language.PlutusIR.Compiler        as PIR
 
-import qualified Language.PlutusCore        as PLC
-import qualified Language.PlutusCore.Pretty as PLC
+import qualified Language.PlutusCore               as PLC
+import qualified Language.PlutusCore.Pretty        as PLC
+import qualified Language.PlutusCore.Check.Value   as PLC
+import qualified Language.PlutusCore.Check.Uniques as PLC
 
 import           Control.Lens
 import           Control.Monad.Except
 
-import qualified Data.Text                  as T
-import qualified Data.Text.Prettyprint.Doc  as PP
+import qualified Data.Text                         as T
+import qualified Data.Text.Prettyprint.Doc         as PP
 import           Data.Typeable
 
 -- | An error with some (nested) context. The integer argument to 'WithContextC' represents
@@ -75,6 +77,12 @@ instance PLC.AsTypeError CompileError () where
 
 instance PLC.AsNormalizationError CompileError PLC.TyName PLC.Name () where
     _NormalizationError = _NoContext . _PLCError . PLC._NormalizationError
+
+instance PLC.AsValueRestrictionError CompileError PLC.TyName () where
+    _ValueRestrictionError = _NoContext . _PLCError . PLC._ValueRestrictionError
+
+instance PLC.AsUniqueError CompileError () where
+    _UniqueError = _NoContext . _PLCError . PLC._UniqueError
 
 instance PIR.AsError CompileError (PIR.Provenance ()) where
     _Error = _NoContext . _PIRError

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Types.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Types.hs
@@ -26,7 +26,8 @@ import qualified Language.Haskell.TH.Syntax             as TH
 
 type BuiltinNameInfo = Map.Map TH.Name GHC.TyThing
 
-newtype CompileOptions = CompileOptions { coCheckValueRestriction :: Bool }
+-- | Compilation options. Empty currently.
+data CompileOptions = CompileOptions {}
 
 data CompileContext = CompileContext {
     ccOpts            :: CompileOptions,

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/ValueRestriction.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/ValueRestriction.hs
@@ -92,7 +92,4 @@ mangleTyAbs = \case
     x -> pure x
 
 checkTyAbsBody :: Compiling m => PIRTerm -> m ()
-checkTyAbsBody t = do
-    CompileContext {ccOpts=opts} <- ask
-    -- we sometimes need to turn this off, as checking for term values also checks for normalized types at the moment
-    unless (not (coCheckValueRestriction opts) || PIR.isTermValue t) $ throwPlain ValueRestrictionError
+checkTyAbsBody t = unless (PIR.isTermValue t) $ throwPlain ValueRestrictionError

--- a/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
@@ -249,7 +249,7 @@ compileCoreExpr opts locStr codeTy origE = do
     -- We need to do this out here, since it has to run in CoreM
     nameInfo <- makePrimitiveNameInfo builtinNames
     let context = CompileContext {
-            ccOpts=CompileOptions { coCheckValueRestriction=poDoTypecheck opts },
+            ccOpts=CompileOptions {},
             ccFlags=flags,
             ccBuiltinNameInfo=nameInfo,
             ccScopes=initialScopeStack,
@@ -301,8 +301,5 @@ runCompiler opts expr = do
     -- We do this after dumping the programs so that if we fail typechecking we still get the dump
     when (poDoTypecheck opts) $ void $ do
         stringBuiltinTypes <- PLC.getStringBuiltinTypes ()
-        checkVr <- asks (coCheckValueRestriction.ccOpts)
-        if checkVr
-              then PLC.typecheckPipeline (PLC.offChainConfig stringBuiltinTypes) plcP
-              else PLC.inferTypeOfProgram (PLC.offChainConfig stringBuiltinTypes) plcP
+        PLC.typecheckPipeline (PLC.offChainConfig stringBuiltinTypes) plcP
     pure (pirP, plcP)


### PR DESCRIPTION
This started off as an attempt to finish off https://github.com/input-output-hk/plutus/pull/925, but the rabbit hole became rather deeper than I expected.

Commit messages should explain each in turn.

Overall this:
- Disentangles term value checking and type normalization checking.
- Normalizes types in `plutus-wallet-api`.
- Makes `plutus-wallet-api` actually do the typechecking as it's supposed to do it in the real implementation.

Notes:
- There were several things that were suspicious about value checking. One notable one is that I asserted in the note that builtin application should be a value. This is precisely the confusion I mentioned: they are in *normal form*, but they are *not* values. In particular, they can evaluate to `error`, so have visibly different behaviour under a type abstraction. So: not values.
- I suspect I know what the problem Vanessa was having is: you need to also normalize types when lifting, which was missing from the previous PR.
- I *think* the right place to do normalization is on the boundary of `plutus-wallet-api` rather than in `plutus-tx`, but I could be persuaded otherwise.
- This doesn't seem to have had much effect on script sizes. I suspect this is because the Plutus Tx compiler will tend to create type lambdas for datatypes only, in which case they will be type-abstracted out and so will not actually appear as redexes. That does somewhat make me question how much we're actually saving by doing type normalization.
- At the moment we don't do anything with the error if the checks fail. It is very useful for debugging if we put it in the log, however. I think we probably should do this, since logging is explicitly an off-chain only thing, so it's okay to leak more information there. But I'll leave that for a follow-up PR.