### PR TITLE
language-plutus-core: add lessThanByteString and greaterThanByteString

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -73,6 +73,8 @@ instance Serialise BuiltinName where
                 EqByteString         -> 16
                 QuotientInteger      -> 17
                 ModInteger           -> 18
+                LtByteString         -> 19
+                GtByteString         -> 20
         in encodeTag i
 
     decode = go =<< decodeTag
@@ -95,6 +97,8 @@ instance Serialise BuiltinName where
               go 16 = pure EqByteString
               go 17 = pure QuotientInteger
               go 18 = pure ModInteger
+              go 19 = pure LtByteString
+              go 20 = pure GtByteString
               go _  = fail "Failed to decode BuiltinName"
 
 instance Serialise Unique where

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
@@ -213,6 +213,10 @@ applyBuiltinName VerifySignature      =
     applyTypedBuiltinName typedVerifySignature      verifySignature
 applyBuiltinName EqByteString         =
     applyTypedBuiltinName typedEqByteString         (==)
+applyBuiltinName LtByteString         =
+    applyTypedBuiltinName typedLtByteString         (<)
+applyBuiltinName GtByteString         =
+    applyTypedBuiltinName typedGtByteString         (>)
 
 -- | Apply a 'BuiltinName' to a list of 'Value's and evaluate the resulting computation usign the
 -- given evaluator.

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Name.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Name.hs
@@ -21,6 +21,8 @@ module Language.PlutusCore.Constant.Name
     , typedSHA3
     , typedVerifySignature
     , typedEqByteString
+    , typedLtByteString
+    , typedGtByteString
     ) where
 
 import           Language.PlutusCore.Constant.Dynamic.Instances ()
@@ -52,6 +54,8 @@ withTypedBuiltinName SHA2                 k = k typedSHA2
 withTypedBuiltinName SHA3                 k = k typedSHA3
 withTypedBuiltinName VerifySignature      k = k typedVerifySignature
 withTypedBuiltinName EqByteString         k = k typedEqByteString
+withTypedBuiltinName LtByteString         k = k typedLtByteString
+withTypedBuiltinName GtByteString         k = k typedGtByteString
 
 intIntInt :: TypeScheme (Integer -> Integer -> Integer) Integer
 intIntInt = Proxy `TypeSchemeArrow` Proxy `TypeSchemeArrow` TypeSchemeResult Proxy
@@ -154,4 +158,16 @@ typedVerifySignature =
 typedEqByteString :: TypedBuiltinName (BSL.ByteString -> BSL.ByteString -> Bool) Bool
 typedEqByteString =
     TypedBuiltinName EqByteString $
+        Proxy `TypeSchemeArrow` Proxy `TypeSchemeArrow` TypeSchemeResult Proxy
+
+-- | Typed 'LtByteString'.
+typedLtByteString :: TypedBuiltinName (BSL.ByteString -> BSL.ByteString -> Bool) Bool
+typedLtByteString =
+    TypedBuiltinName LtByteString $
+        Proxy `TypeSchemeArrow` Proxy `TypeSchemeArrow` TypeSchemeResult Proxy
+
+-- | Typed 'GtByteString'.
+typedGtByteString :: TypedBuiltinName (BSL.ByteString -> BSL.ByteString -> Bool) Bool
+typedGtByteString =
+    TypedBuiltinName GtByteString $
         Proxy `TypeSchemeArrow` Proxy `TypeSchemeArrow` TypeSchemeResult Proxy

--- a/language-plutus-core/src/Language/PlutusCore/Lexer.x
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer.x
@@ -87,6 +87,8 @@ tokens :-
     <0> takeByteString           { mkBuiltin TakeByteString }
     <0> dropByteString           { mkBuiltin DropByteString }
     <0> equalsByteString         { mkBuiltin EqByteString }
+    <0> lessThanByteString       { mkBuiltin LtByteString }
+    <0> greaterThanByteString    { mkBuiltin GtByteString }
     <0> "sha2_256"               { mkBuiltin SHA2 }
     <0> "sha3_256"               { mkBuiltin SHA3 }
     <0> verifySignature          { mkBuiltin VerifySignature }

--- a/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
@@ -50,6 +50,8 @@ data BuiltinName = AddInteger
                  | SHA3
                  | VerifySignature
                  | EqByteString
+                 | LtByteString
+                 | GtByteString
                  deriving (Show, Eq, Ord, Enum, Bounded, Generic, NFData, Lift)
 
 -- | The type of dynamic built-in functions. I.e. functions that exist on certain chains and do
@@ -174,6 +176,8 @@ instance Pretty BuiltinName where
     pretty TakeByteString       = "takeByteString"
     pretty DropByteString       = "dropByteString"
     pretty EqByteString         = "equalsByteString"
+    pretty LtByteString         = "lessThanByteString"
+    pretty GtByteString         = "greaterThanByteString"
     pretty SHA2                 = "sha2_256"
     pretty SHA3                 = "sha3_256"
     pretty VerifySignature      = "verifySignature"

--- a/plutus-core-spec/figures/Builtins.tex
+++ b/plutus-core-spec/figures/Builtins.tex
@@ -2,7 +2,7 @@
 
 \begin{document}
 
-\newcommand{\builtinoffset}{-3cm} 
+\newcommand{\builtinoffset}{-3cm}
 % Shift things left in the big table of builtins to make it fit on the page properly
 
 \newcommand\sep{4pt}
@@ -24,7 +24,7 @@
         \hline
         $\forall \alpha :: K.\ B$ & \(\allT{\alpha}{K}{B}\) \rule{0mm}{4mm} \\[\sep]
         $\integer$ & \(\conT{\conIntegerType{}}\)\\[\sep]
-        
+
         $\bytestring$ & \(\conT{\conBytestringType{}}\)\\[\sep]
 
         $\str$ & \(\conT{\conBytestringType{}}\)\\[\sep]
@@ -116,9 +116,11 @@
         \texttt{concatenate}   &   \sig{}{\str,\str}{\str}   &   - & b_0 , b_1   & b_0\cdot  b_1 & \\
         %&&\\
 
-        \texttt{equalsByteString}  &   \sig{}{\str,\str}{\boolean}   &   - & b_0 , b_1   & b_0 == b_1\\
-        \texttt{takeByteString}    &   \sig{}{\integer,\str}{\str}   & - &   i, b     & \texttt{take} \ i \  b\\
-        \texttt{dropByteString}    &   \sig{}{\integer,\str}{\str}   & - &   i, b     & \texttt{drop} \ i \  b\\
+        \texttt{equalsByteString}       &   \sig{}{\str,\str}{\boolean}   & - & b_0 , b_1 & b_0 == b_1\\
+        \texttt{lessThanByteString}     &   \sig{}{\str,\str}{\boolean}   & - & b_0 , b_1 & b_0 < b_1\\
+        \texttt{greaterThanByteString}  &   \sig{}{\str,\str}{\boolean}   & - & b_0 , b_1 & b_0 > b_1\\
+        \texttt{takeByteString}         &   \sig{}{\integer,\str}{\str}   & - &   i, b    & \texttt{take} \ i \  b\\
+        \texttt{dropByteString}         &   \sig{}{\integer,\str}{\str}   & - &   i, b    & \texttt{drop} \ i \  b\\
         %&&\\
 
         \texttt{sha2$\_256$}         &  \sig{}{\str}{\str}  & - &   b           & sha2\_256 \  b\\

--- a/plutus-tx/compiler/Language/PlutusTx/Builtins.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Builtins.hs
@@ -13,6 +13,8 @@ module Language.PlutusTx.Builtins (
                                 , dropByteString
                                 , emptyByteString
                                 , equalsByteString
+                                , lessThanByteString
+                                , greaterThanByteString
                                 , sha2_256
                                 , sha3_256
                                 , verifySignature
@@ -94,6 +96,16 @@ verifySignature pubKey message signature =
 -- | Check if two 'ByteString's are equal.
 equalsByteString :: ByteString -> ByteString -> Bool
 equalsByteString = (==)
+
+{-# NOINLINE lessThanByteString #-}
+-- | Check if one 'ByteString' is less than another.
+lessThanByteString :: ByteString -> ByteString -> Bool
+lessThanByteString = (<)
+
+{-# NOINLINE greaterThanByteString #-}
+-- | Check if one 'ByteString' is greater than another.
+greaterThanByteString :: ByteString -> ByteString -> Bool
+greaterThanByteString = (>)
 
 {-# NOINLINE addInteger #-}
 -- | Add two 'Integer's.

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Builtins.hs
@@ -135,6 +135,8 @@ builtinNames = [
     , 'Builtins.sha2_256
     , 'Builtins.sha3_256
     , 'Builtins.equalsByteString
+    , 'Builtins.lessThanByteString
+    , 'Builtins.greaterThanByteString
     , 'Builtins.emptyByteString
 
     , 'Builtins.verifySignature
@@ -214,6 +216,12 @@ defineBuiltinTerms = do
     do
         term <- wrapBsRel 2 $ mkBuiltin PLC.EqByteString
         defineBuiltinTerm 'Builtins.equalsByteString term [bs, bool]
+    do
+        term <- wrapBsRel 2 $ mkBuiltin PLC.LtByteString
+        defineBuiltinTerm 'Builtins.lessThanByteString term [bs, bool]
+    do
+        term <- wrapBsRel 2 $ mkBuiltin PLC.GtByteString
+        defineBuiltinTerm 'Builtins.greaterThanByteString term [bs, bool]
 
     do
         let term = PIR.Constant () $ PLC.BuiltinBS () BSL.empty

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -52,6 +52,8 @@ module Language.PlutusTx.Prelude (
     -- * ByteStrings
     ByteString,
     equalsByteString,
+    lessThanByteString,
+    greaterThanByteString,
     takeByteString,
     dropByteString,
     concatenate,
@@ -64,7 +66,8 @@ module Language.PlutusTx.Prelude (
     ) where
 
 import           Language.PlutusTx.Builtins (ByteString, concatenate, dropByteString, emptyByteString, equalsByteString,
-                                             sha2_256, sha3_256, takeByteString, verifySignature)
+                                             greaterThanByteString, lessThanByteString, sha2_256, sha3_256,
+                                             takeByteString, verifySignature)
 import qualified Language.PlutusTx.Builtins as Builtins
 import           Prelude                    as Prelude hiding (all, any, error, filter, foldl, foldr, fst, length, map,
                                                         max, maybe, min, not, null, snd, (&&), (++), (||))

--- a/plutus-tx/test/Plugin/Primitives/Spec.hs
+++ b/plutus-tx/test/Plugin/Primitives/Spec.hs
@@ -45,6 +45,7 @@ primitives = testNested "Primitives" [
   , goldenEval "bytestringApply" [ getPlc bytestring, unsafeLiftProgram ("hello"::Builtins.ByteString) ]
   , goldenEval "sha2_256" [ getPlc sha2, unsafeLiftProgram ("hello" :: Builtins.ByteString)]
   , goldenEval "equalsByteString" [ getPlc bsEquals, unsafeLiftProgram ("hello" :: Builtins.ByteString), unsafeLiftProgram ("hello" :: Builtins.ByteString)]
+  , goldenEval "ltByteString" [ getPlc bsLt, unsafeLiftProgram ("hello" :: Builtins.ByteString), unsafeLiftProgram ("world" :: Builtins.ByteString)]
   , goldenPir "verify" verify
   , goldenPir "trace" trace
   ]
@@ -106,6 +107,9 @@ sha2 = plc @"sha2" (\(x :: Builtins.ByteString) -> Builtins.sha2_256 x)
 
 bsEquals :: CompiledCode (Builtins.ByteString -> Builtins.ByteString -> Bool)
 bsEquals = plc @"bs32Equals" (\(x :: Builtins.ByteString) (y :: Builtins.ByteString) -> Builtins.equalsByteString x y)
+
+bsLt :: CompiledCode (Builtins.ByteString -> Builtins.ByteString -> Bool)
+bsLt = plc @"bsLt" (\(x :: Builtins.ByteString) (y :: Builtins.ByteString) -> Builtins.lessThanByteString x y)
 
 verify :: CompiledCode (Builtins.ByteString -> Builtins.ByteString -> Builtins.ByteString -> Bool)
 verify = plc @"verify" (\(x::Builtins.ByteString) (y::Builtins.ByteString) (z::Builtins.ByteString) -> Builtins.verifySignature x y z)

--- a/plutus-tx/test/Plugin/Primitives/ltByteString.plc.golden
+++ b/plutus-tx/test/Plugin/Primitives/ltByteString.plc.golden
@@ -1,0 +1,5 @@
+(abs
+  out_Bool_13
+  (type)
+  (lam case_True_14 out_Bool_13 (lam case_False_15 out_Bool_13 case_True_14))
+)


### PR DESCRIPTION
This means we can do `Ord`-like things with bytestrings, like use them
as the keys of binary search trees.

I don't think we can get away without adding more builtins for these things, alas.