### PR TITLE
plutus-tx: support typeclasses and add some basic classes

### DIFF
--- a/plutus-emulator/src/Wallet/Emulator/Types.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Types.hs
@@ -273,7 +273,7 @@ instance WalletAPI MockWallet where
             pubK   =  toPublicKey privK
         (spend, change) <- selectCoin (second txOutValue <$> Map.toList fnds) vl
         let
-            txOutput = if Value.eq change Value.zero then Nothing else Just (pubKeyTxOut change pubK)
+            txOutput = if Value.isZero change then Nothing else Just (pubKeyTxOut change pubK)
             ins = Set.fromList (flip pubKeyTxIn pubK . fst <$> spend)
         pure (ins, txOutput)
 

--- a/plutus-emulator/test/Spec.hs
+++ b/plutus-emulator/test/Spec.hs
@@ -114,7 +114,7 @@ selectCoinProp = property $ do
         Left _ ->
             Hedgehog.assert $ not $ (fold $ snd <$> inputs) `Value.geq` target
         Right (ins, change) ->
-            Hedgehog.assert $ (fold $ snd <$> ins) `Value.eq` (target `Value.plus` change)
+            Hedgehog.assert $ (fold $ snd <$> ins) == (target `Value.plus` change)
 
 -- | Submits a transaction that is valid in the future, then adds a number of
 --   slots, then verifies that the transaction has been validated.

--- a/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground-server/usecases/CrowdFunding.hs
@@ -25,7 +25,7 @@ import qualified Ledger.Slot                  as Slot
 import           Ledger
 import           Ledger.Validation            as V
 import           Ledger.Value                 (Value)
-import qualified Ledger.Value                 as VTH
+import qualified Ledger.Value                 as Value
 import           Playground.Contract
 import           Wallet                       as W
 import qualified Wallet.Emulator              as EM
@@ -98,7 +98,7 @@ validCollection campaign p =
     (collectionRange campaign `Slot.contains` pendingTxValidRange p)
     -- Check that the transaction is trying to spend more money than the campaign
     -- target (and hence the target was reached)
-    && (valueSpent p `VTH.geq` campaignTarget campaign)
+    && (valueSpent p `Value.geq` campaignTarget campaign)
     -- Check that the transaction is signed by the campaign owner
     && (p `V.txSignedBy` campaignOwner campaign)
 

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -37,8 +37,7 @@ data ClearString = ClearString ByteString
 PlutusTx.makeLift ''ClearString
 
 correctGuess :: HashedString -> ClearString -> Bool
-correctGuess (HashedString actual) (ClearString guess') =
-    equalsByteString actual (sha2_256 guess')
+correctGuess (HashedString actual) (ClearString guess') = actual == (sha2_256 guess')
 
 validateGuess :: HashedString -> ClearString -> PendingTx -> Bool
 validateGuess dataScript redeemerScript _ = correctGuess dataScript redeemerScript

--- a/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground-server/usecases/Vesting.hs
@@ -12,22 +12,21 @@
 module Vesting where
 -- TRIM TO HERE
 -- Vesting scheme as a PLC contract
+import qualified Prelude                   as Haskell
+import           Language.PlutusTx.Prelude
 import           Control.Monad             (void)
 import qualified Data.Map                  as Map
 import qualified Data.Set                  as Set
 
 import qualified Language.PlutusTx         as PlutusTx
-import           Language.PlutusTx.Prelude
 import           Ledger                    (Address, DataScript(..), RedeemerScript(..), Signature, Slot, TxOutRef, TxIn, ValidatorScript(..))
 import qualified Ledger                    as Ledger
 import           Ledger.Value              (Value)
 import qualified Ledger.Value              as Value
-import qualified Ledger.Value              as Value.TH
 import qualified Ledger.Interval           as Interval
 import qualified Ledger.Slot               as Slot
 import qualified Ledger.Validation         as V
 import           Ledger.Validation         (PendingTx(..))
-import qualified Ledger.Value              as Value
 import           Wallet                    (WalletAPI(..), WalletDiagnostics, PubKey)
 import qualified Wallet                    as W
 import qualified Wallet.API                as WAPI
@@ -202,7 +201,7 @@ withdraw vst vl = do
 
     -- The transaction's validity range should begin with the current slot and
     -- last indefinitely.
-    range <- fmap WAPI.intervalFrom WAPI.slot
+    range <- Haskell.fmap WAPI.intervalFrom WAPI.slot
 
     -- The input should be the UTXO of the vesting scheme. We can get the
     -- outputs at an address (as far as they are known by the wallet) with
@@ -236,7 +235,7 @@ withdraw vst vl = do
         currentlyLocked = Map.foldr (\txo vl' -> vl' `Value.plus` Ledger.txOutValue txo) Value.zero utxos
         remaining = currentlyLocked `Value.minus` vl
 
-        otherOutputs = if Value.eq Value.zero remaining
+        otherOutputs = if Value.isZero remaining
                        then []
                        else [Ledger.scriptTxOut remaining validator (DataScript (Ledger.lifted ()))]
 

--- a/plutus-tutorial/doc/02-validator-scripts.adoc
+++ b/plutus-tutorial/doc/02-validator-scripts.adoc
@@ -144,12 +144,11 @@ the two don’t match. We can use functions from the Plutus prelude, imported as
 [source,haskell]
 ----
 validator (HashedText actual) (ClearText guessed) _ =
-    if equalsByteString actual (sha2_256 guessed) -- <1>
+    if actual == (sha2_256 guessed) -- <1>
     then traceH "RIGHT!" True -- <2>
     else traceH "WRONG!" False
 ----
-<1> `equalsByteString {2c} ByteString -> ByteString -> Bool`
-compares two `ByteString` values for equality.
+<1> We have an instance of `Eq` for `ByteString`, so we can just use `==` here to compare for equality.
 <2> `traceH {2c} String -> a -> a` returns its second argument after adding
 its first argument to the log output of this script. The log output is
 only available in the emulator and on the playground, and will be

--- a/plutus-tutorial/doc/03-wallet-api.adoc
+++ b/plutus-tutorial/doc/03-wallet-api.adoc
@@ -274,7 +274,7 @@ predicate
                 contribTxOut o =
                   case V.pubKeyOutput o of
                     Nothing -> False
-                    Just pk -> V.eqPubKey pk pkCon
+                    Just pk -> pk == pkCon
 ----
 
 We check if `o` is a pay-to-pubkey output. If it isn’t, then the
@@ -317,7 +317,7 @@ has to be signed by the campaign owner.
 [source,haskell]
 ----
             S.contains (I.interval deadline collectionDeadline) txnValidRange && -- <1>
-            Ada.geq totalInputs target &&
+            totalInputs >= target &&
             p `V.txSignedBy` campaignOwner
 ----
 <1> We use

--- a/plutus-tutorial/doc/04-vesting.adoc
+++ b/plutus-tutorial/doc/04-vesting.adoc
@@ -23,6 +23,7 @@ xref:02-validator-scripts#validator-scripts[before]:
 module Tutorial.Vesting where
 
 import           Language.PlutusTx.Prelude
+import qualified Prelude                   as Haskell
 
 import qualified Language.PlutusTx         as PlutusTx
 
@@ -217,7 +218,7 @@ withdraw vst vl = do
 
     -- The transaction's validity range should begin with the current slot and
     -- last indefinitely.
-    range <- fmap WAPI.intervalFrom WAPI.slot
+    range <- Haskell.fmap WAPI.intervalFrom WAPI.slot
 
     -- The input should be the UTXO of the vesting scheme.
     utxos <- WAPI.outputsAt address -- <1>
@@ -253,7 +254,7 @@ that keeps the remaining value.
         currentlyLocked = Map.foldr (\txo vl' -> vl' `Value.plus` L.txOutValue txo) Value.zero utxos
         remaining = currentlyLocked `Value.minus` vl
 
-        otherOutputs = if Value.eq Value.zero remaining
+        otherOutputs = if Value.zero == remaining
                        then []
                        else [L.scriptTxOut remaining validator (DataScript (L.lifted ()))]
 

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
@@ -327,7 +327,7 @@ compileExpr e = withContextM 2 (sdToTxt $ "Compiling expr:" GHC.<+> GHC.ppr e) $
             let sel_names = fmap GHC.getName (GHC.classAllSelIds cls)
             val_index <- case elemIndex (GHC.getName n) sel_names of
                 Just i  -> pure i
-                Nothing -> throwPlain $ CompilationError "Id not in class method list"
+                Nothing -> throwSd CompilationError $ "Id not in class method list:" GHC.<+> GHC.ppr n
             let rhs = GHC.mkDictSelRhs cls val_index
 
             hoistExpr n rhs

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -43,6 +43,12 @@ library
         Language.PlutusTx.TH
         Language.PlutusTx.Prelude
         Language.PlutusTx.Evaluation
+        Language.PlutusTx.Bool
+        Language.PlutusTx.Eq
+        Language.PlutusTx.Functor
+        Language.PlutusTx.List
+        Language.PlutusTx.Ord
+        Language.PlutusTx.Maybe
     reexported-modules:
         Language.PlutusTx.Code,
         Language.PlutusTx.Lift,

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -115,6 +115,8 @@ test-suite plutus-tx-tests
         Plugin.Laziness.Spec
         Plugin.Primitives.Spec
         Plugin.ReadValue.Spec
+        Plugin.Typeclasses.Spec
+        Plugin.Typeclasses.Lib
         Plugin.Lib
         TH.Spec
         TH.TestTH

--- a/plutus-tx/src/Language/PlutusTx/Bool.hs
+++ b/plutus-tx/src/Language/PlutusTx/Bool.hs
@@ -1,0 +1,35 @@
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+module Language.PlutusTx.Bool ((&&), (||), not) where
+
+import           Prelude hiding (not, (&&), (||))
+
+{-# ANN module ("HLint: ignore"::String) #-}
+
+{-# INLINABLE (&&) #-}
+-- | Logical AND
+--
+--   >>> True && False
+--   False
+--
+infixr 3 &&
+(&&) :: Bool -> Bool -> Bool
+(&&) l r = if l then r else False
+
+{-# INLINABLE (||) #-}
+-- | Logical OR
+--
+--   >>> True || False
+--   True
+--
+infixr 2 ||
+(||) :: Bool -> Bool -> Bool
+(||) l r = if l then True else r
+
+{-# INLINABLE not #-}
+-- | Logical negation
+--
+--   >>> not True
+--   False
+--
+not :: Bool -> Bool
+not a = if a then False else True

--- a/plutus-tx/src/Language/PlutusTx/Eq.hs
+++ b/plutus-tx/src/Language/PlutusTx/Eq.hs
@@ -1,0 +1,61 @@
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+module Language.PlutusTx.Eq (Eq(..)) where
+
+import           Language.PlutusTx.Bool
+import qualified Language.PlutusTx.Builtins as Builtins
+import           Prelude                    hiding (Eq (..), not, (&&))
+
+{-# ANN module ("HLint: ignore"::String) #-}
+
+-- Copied from the GHC definition
+-- | The 'Eq' class defines equality ('==') and inequality ('/=').
+--
+-- Minimal complete definition: either '==' or '/='.
+--
+class Eq a where
+    (==), (/=)           :: a -> a -> Bool
+
+    {-# INLINABLE (/=) #-}
+    x /= y               = not (x == y)
+    {-# INLINABLE (==) #-}
+    x == y               = not (x /= y)
+
+instance Eq Integer where
+    {-# INLINABLE (==) #-}
+    (==) = Builtins.equalsInteger
+
+instance Eq Builtins.ByteString where
+    {-# INLINABLE (==) #-}
+    (==) = Builtins.equalsByteString
+
+instance Eq a => Eq [a] where
+    {-# INLINABLE (==) #-}
+    [] == [] = True
+    (x:xs) == (y:ys) = x == y && xs == ys
+    _ == _ = False
+
+instance Eq Bool where
+    {-# INLINABLE (==) #-}
+    True == True = True
+    False == False = True
+    _ == _ = False
+
+instance Eq a => Eq (Maybe a) where
+    {-# INLINABLE (==) #-}
+    (Just a1) == (Just a2) = a1 == a2
+    Nothing == Nothing = True
+    _ == _ = False
+
+instance (Eq a, Eq b) => Eq (Either a b) where
+    {-# INLINABLE (==) #-}
+    (Left a1) == (Left a2) = a1 == a2
+    (Right b1) == (Right b2) = b1 == b2
+    _ == _ = False
+
+instance Eq () where
+    {-# INLINABLE (==) #-}
+    _ == _ = True
+
+instance (Eq a, Eq b) => Eq (a, b) where
+    {-# INLINABLE (==) #-}
+    (a, b) == (a', b') = a == a' && b == b'

--- a/plutus-tx/src/Language/PlutusTx/Eq.hs
+++ b/plutus-tx/src/Language/PlutusTx/Eq.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module Language.PlutusTx.Eq (Eq(..)) where
+module Language.PlutusTx.Eq (Eq(..), (/=)) where
 
 import           Language.PlutusTx.Bool
 import qualified Language.PlutusTx.Builtins as Builtins
@@ -8,17 +8,16 @@ import           Prelude                    hiding (Eq (..), not, (&&))
 {-# ANN module ("HLint: ignore"::String) #-}
 
 -- Copied from the GHC definition
--- | The 'Eq' class defines equality ('==') and inequality ('/=').
---
--- Minimal complete definition: either '==' or '/='.
---
+-- | The 'Eq' class defines equality ('==').
 class Eq a where
-    (==), (/=)           :: a -> a -> Bool
+    (==) :: a -> a -> Bool
 
-    {-# INLINABLE (/=) #-}
-    x /= y               = not (x == y)
-    {-# INLINABLE (==) #-}
-    x == y               = not (x /= y)
+    -- (/=) deliberately omitted, to make this a one-method class which has a
+    -- simpler representation
+
+{-# INLINABLE (/=) #-}
+(/=) :: Eq a => a -> a -> Bool
+x /= y = not (x == y)
 
 instance Eq Integer where
     {-# INLINABLE (==) #-}

--- a/plutus-tx/src/Language/PlutusTx/Functor.hs
+++ b/plutus-tx/src/Language/PlutusTx/Functor.hs
@@ -1,0 +1,55 @@
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+module Language.PlutusTx.Functor (Functor(..), (<$>), (<$), const) where
+
+import           Prelude hiding (Functor (..), const, (<$), (<$>))
+
+{-# ANN module ("HLint: ignore"::String) #-}
+
+{- | The 'Functor' class is used for types that can be mapped over.
+Instances of 'Functor' should satisfy the following laws:
+
+> fmap id  ==  id
+> fmap (f . g)  ==  fmap f . fmap g
+-}
+class Functor f where
+    fmap :: (a -> b) -> f a -> f b
+
+    -- <$ deliberately omitted, to make this a one-method class which has a
+    -- simpler representation
+
+infixl 4 <$>
+-- | An infix synonym for 'fmap'.
+{-# INLINABLE (<$>) #-}
+(<$>) :: Functor f => (a -> b) -> f a -> f b
+(<$>) f fa = fmap f fa
+
+infixl 4 <$
+{-# INLINABLE (<$) #-}
+-- | Replace all locations in the input with the same value.
+(<$) :: Functor f => a -> f b -> f a
+(<$) a fb = fmap (const a) fb
+
+instance Functor [] where
+    {-# INLINABLE fmap #-}
+    fmap f l = case l of
+            []   -> []
+            x:xs -> f x : fmap f xs
+
+instance Functor Maybe where
+    {-# INLINABLE fmap #-}
+    fmap f (Just a) = Just (f a)
+    fmap _ Nothing  = Nothing
+
+instance Functor (Either c) where
+    {-# INLINABLE fmap #-}
+    fmap f (Right a) = Right (f a)
+    fmap _ (Left c)  = Left c
+
+instance Functor ((,) c) where
+    {-# INLINABLE fmap #-}
+    fmap f (c, a) = (c, f a)
+
+{-# INLINABLE const #-}
+-- | Plutus Tx version of 'Prelude.const'.
+const                   :: a -> b -> a
+const x _               =  x

--- a/plutus-tx/src/Language/PlutusTx/Functor.hs
+++ b/plutus-tx/src/Language/PlutusTx/Functor.hs
@@ -14,7 +14,7 @@ Instances of 'Functor' should satisfy the following laws:
 class Functor f where
     fmap :: (a -> b) -> f a -> f b
 
-    -- <$ deliberately omitted, to make this a one-method class which has a
+    -- (<$) deliberately omitted, to make this a one-method class which has a
     -- simpler representation
 
 infixl 4 <$>

--- a/plutus-tx/src/Language/PlutusTx/List.hs
+++ b/plutus-tx/src/Language/PlutusTx/List.hs
@@ -1,0 +1,100 @@
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+module Language.PlutusTx.List (null, map, foldr, foldl, length, all, any, filter, (++)) where
+
+import           Language.PlutusTx.Bool
+import qualified Language.PlutusTx.Builtins as Builtins
+import           Prelude                    hiding (all, any, filter, foldl, foldr, length, map, null, (&&), (++), (||))
+
+{-# ANN module ("HLint: ignore"::String) #-}
+
+{-# INLINABLE null #-}
+-- | PlutusTx version of 'Data.List.null'.
+--
+--   >>> null [1]
+--   False
+--   >>> null []
+--   True
+--
+null :: [a] -> Bool
+null l = case l of
+    [] -> True
+    _  -> False
+
+{-# INLINABLE map #-}
+-- | PlutusTx version of 'Data.List.map'.
+--
+--   >>> map (\i -> i + 1) [1, 2, 3]
+--   [2,3,4]
+--
+map :: (a -> b) -> [a] -> [b]
+map f l = case l of
+    []   -> []
+    x:xs -> f x : map f xs
+
+{-# INLINABLE foldr #-}
+-- | PlutusTx version of 'Data.List.foldr'.
+--
+--   >>> foldr (\i s -> s + i) 0 [1, 2, 3, 4]
+--   10
+--
+foldr :: (a -> b -> b) -> b -> [a] -> b
+foldr f acc l = case l of
+    []   -> acc
+    x:xs -> f x (foldr f acc xs)
+
+{-# INLINABLE foldl #-}
+-- | PlutusTx version of 'Data.List.foldl'.
+--
+--   >>> foldl (\s i -> s + i) 0 [1, 2, 3, 4]
+--   10
+--
+foldl :: (b -> a -> b) -> b -> [a] -> b
+foldl f acc l = case l of
+    []   -> acc
+    x:xs -> foldl f (f acc x) xs
+
+{-# INLINABLE length #-}
+-- | 'length' @xs@ is the number of elements in @xs@.
+--
+--   >>> length [1, 2, 3, 4]
+--   4
+--
+length :: [a] -> Integer
+-- eta-expanded to avoid the value restriction
+length as = foldr (\_ acc -> Builtins.addInteger acc 1) 0 as
+
+{-# INLINABLE all #-}
+-- | PlutusTx version of 'Data.List.all'.
+--
+--   >>> all (\i -> i > 5) [6, 8, 12]
+--   True
+--
+all :: (a -> Bool) -> [a] -> Bool
+all p = foldr (\a acc -> acc && p a) True
+
+{-# INLINABLE any #-}
+-- | PlutusTx version of 'Data.List.any'.
+--
+--   >>> any (\i -> i > 5) [6, 2, 1]
+--   True
+--
+any :: (a -> Bool) -> [a] -> Bool
+any p = foldr (\a acc -> acc || p a) False
+
+{-# INLINABLE (++) #-}
+-- | PlutusTx version of 'Data.List.(++)'.
+--
+--   >>> [0, 1, 2] ++ [1, 2, 3, 4]
+--   [0,1,2,1,2,3,4]
+--
+(++) :: [a] -> [a] -> [a]
+(++) l r = foldr (:) r l
+
+{-# INLINABLE filter #-}
+-- | PlutusTx version of 'Data.List.filter'.
+--
+--   >>> filter (> 1) [1, 2, 3, 4]
+--   [2,3,4]
+--
+filter :: (a -> Bool) -> [a] -> [a]
+filter p = foldr (\e xs -> if p e then e:xs else xs) []

--- a/plutus-tx/src/Language/PlutusTx/Maybe.hs
+++ b/plutus-tx/src/Language/PlutusTx/Maybe.hs
@@ -1,0 +1,51 @@
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+module Language.PlutusTx.Maybe (isJust, isNothing, maybe, mapMaybe) where
+
+import           Language.PlutusTx.List
+import           Prelude                hiding (foldr, maybe)
+
+{-# ANN module ("HLint: ignore"::String) #-}
+
+{-# INLINABLE isJust #-}
+-- | Check if a 'Maybe' @a@ is @Just a@
+--
+--   >>> isJust Nothing
+--   False
+--   >>> isJust (Just "plutus")
+--   True
+--
+isJust :: Maybe a -> Bool
+isJust m = case m of { Just _ -> True; _ -> False; }
+
+{-# INLINABLE isNothing #-}
+-- | Check if a 'Maybe' @a@ is @Nothing@
+--
+--   >>> isNothing Nothing
+--   True
+--   >>> isNothing (Just "plutus")
+--   False
+--
+isNothing :: Maybe a -> Bool
+isNothing m = case m of { Just _ -> False; _ -> True; }
+
+{-# INLINABLE maybe #-}
+-- | PlutusTx version of 'Prelude.maybe'.
+--
+--   >>> maybe "platypus" (\s -> s) (Just "plutus")
+--   "plutus"
+--   >>> maybe "platypus" (\s -> s) Nothing
+--   "platypus"
+--
+maybe :: b -> (a -> b) -> Maybe a -> b
+maybe b f m = case m of
+    Nothing -> b
+    Just a  -> f a
+
+{-# INLINABLE mapMaybe #-}
+-- | PlutusTx version of 'Data.Maybe.mapMaybe'.
+--
+--   >>> mapMaybe (\i -> if i == 2 then Just '2' else Nothing) [1, 2, 3, 4]
+--   "2"
+--
+mapMaybe :: (a -> Maybe b) -> [a] -> [b]
+mapMaybe p = foldr (\e xs -> case p e of { Just e' -> e':xs; Nothing -> xs}) []

--- a/plutus-tx/src/Language/PlutusTx/Ord.hs
+++ b/plutus-tx/src/Language/PlutusTx/Ord.hs
@@ -1,0 +1,101 @@
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+module Language.PlutusTx.Ord (Ord(..)) where
+
+import qualified Language.PlutusTx.Builtins as Builtins
+import           Language.PlutusTx.Eq
+import           Prelude                    hiding (Eq (..), Ord (..))
+
+{-# ANN module ("HLint: ignore"::String) #-}
+
+-- Copied from the GHC definition
+-- | The 'Ord' class is used for totally ordered datatypes.
+--
+-- Minimal complete definition: either 'compare' or '<='.
+-- Using 'compare' can be more efficient for complex types.
+--
+class Eq a => Ord a where
+    compare              :: a -> a -> Ordering
+    (<), (<=), (>), (>=) :: a -> a -> Bool
+    max, min             :: a -> a -> a
+
+    {-# INLINABLE compare #-}
+    compare x y = if x == y then EQ
+                  -- NB: must be '<=' not '<' to validate the
+                  -- above claim about the minimal things that
+                  -- can be defined for an instance of Ord:
+                  else if x <= y then LT
+                  else GT
+
+    {-# INLINABLE (<) #-}
+    x <  y = case compare x y of { LT -> True;  _ -> False }
+    {-# INLINABLE (<=) #-}
+    x <= y = case compare x y of { GT -> False; _ -> True }
+    {-# INLINABLE (>) #-}
+    x >  y = case compare x y of { GT -> True;  _ -> False }
+    {-# INLINABLE (>=) #-}
+    x >= y = case compare x y of { LT -> False; _ -> True }
+
+    -- These two default methods use '<=' rather than 'compare'
+    -- because the latter is often more expensive
+    {-# INLINABLE max #-}
+    max x y = if x <= y then y else x
+    {-# INLINABLE min #-}
+    min x y = if x <= y then x else y
+
+instance Ord Integer where
+    {-# INLINABLE (<) #-}
+    (<) = Builtins.lessThanInteger
+    {-# INLINABLE (<=) #-}
+    (<=) = Builtins.lessThanEqInteger
+    {-# INLINABLE (>) #-}
+    (>) = Builtins.greaterThanInteger
+    {-# INLINABLE (>=) #-}
+    (>=) = Builtins.greaterThanEqInteger
+
+instance Ord Builtins.ByteString where
+    {-# INLINABLE compare #-}
+    compare l r = if Builtins.lessThanByteString l r then LT else if Builtins.equalsByteString l r then EQ else GT
+
+instance Ord a => Ord [a] where
+    {-# INLINABLE compare #-}
+    compare []     []     = EQ
+    compare []     (_:_)  = LT
+    compare (_:_)  []     = GT
+    compare (x:xs) (y:ys) = case compare x y of
+                                EQ    -> compare xs ys
+                                other -> other
+
+instance Ord Bool where
+    {-# INLINABLE compare #-}
+    compare b1 b2 = case b1 of
+        False -> case b2 of
+            False -> EQ
+            True  -> LT
+        True -> case b2 of
+            False -> GT
+            True  -> EQ
+
+instance Ord a => Ord (Maybe a) where
+    {-# INLINABLE compare #-}
+    compare (Just a1) (Just a2) = compare a1 a2
+    compare Nothing (Just _)    = LT
+    compare (Just _) Nothing    = GT
+    compare Nothing Nothing     = EQ
+
+instance (Ord a, Ord b) => Ord (Either a b) where
+    {-# INLINABLE compare #-}
+    compare (Left a1) (Left a2)   = compare a1 a2
+    compare (Left _) (Right _)    = LT
+    compare (Right _) (Left _)    = GT
+    compare (Right b1) (Right b2) = compare b1 b2
+
+instance Ord () where
+    {-# INLINABLE compare #-}
+    compare _ _ = EQ
+
+instance (Ord a, Ord b) => Ord (a, b) where
+    {-# INLINABLE compare #-}
+    compare (a, b) (a', b') = case compare a a' of
+        LT -> LT
+        GT -> GT
+        EQ -> compare b b'

--- a/plutus-tx/test/Plugin/Lib.hs
+++ b/plutus-tx/test/Plugin/Lib.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Plugin.Lib where
 
@@ -29,7 +31,6 @@ andExternal :: Bool -> Bool -> Bool
 andExternal a b = if a then b else False
 
 data MyExternalRecord = MyExternalRecord { myExternal :: Integer }
-    deriving (Show, Eq)
 
 {-# INLINABLE evenDirect #-}
 evenDirect :: Integer -> Bool

--- a/plutus-tx/test/Plugin/Spec.hs
+++ b/plutus-tx/test/Plugin/Spec.hs
@@ -11,6 +11,7 @@ import           Plugin.Functions.Spec
 import           Plugin.Laziness.Spec
 import           Plugin.Primitives.Spec
 import           Plugin.ReadValue.Spec
+import           Plugin.Typeclasses.Spec
 
 tests :: TestNested
 tests = testNested "Plugin" [
@@ -21,4 +22,5 @@ tests = testNested "Plugin" [
   , pure readDyns
   , laziness
   , errors
+  , typeclasses
   ]

--- a/plutus-tx/test/Plugin/Typeclasses/Lib.hs
+++ b/plutus-tx/test/Plugin/Typeclasses/Lib.hs
@@ -1,0 +1,24 @@
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+{-# OPTIONS_GHC -ddump-simpl #-}
+module Plugin.Typeclasses.Lib where
+
+import qualified Language.PlutusTx.Builtins as Builtins
+
+data Animal = Dog | Cat
+data Person = Jim | Jane
+data Alien = AlienJim | AlienJane
+
+-- Needs to be in another file because of #978
+class DefaultMethods a where
+    method1 :: a -> Integer
+    {-# INLINABLE method2 #-}
+    method2 :: a -> Integer
+    method2 a = method1 a `Builtins.addInteger` 1
+
+instance DefaultMethods Integer where
+    {-# INLINABLE method1 #-}
+    method1 a = a
+
+instance DefaultMethods Person where
+    {-# INLINABLE method1 #-}
+    method1 _ = 1

--- a/plutus-tx/test/Plugin/Typeclasses/Spec.hs
+++ b/plutus-tx/test/Plugin/Typeclasses/Spec.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:no-context #-}
+
+module Plugin.Typeclasses.Spec where
+
+import           Common
+import           PlcTestUtils
+import           Plugin.Lib
+
+import           Plugin.Data.Spec
+
+import qualified Language.PlutusTx.Builtins as Builtins
+import           Language.PlutusTx.Code
+import           Language.PlutusTx.Plugin
+import qualified Language.PlutusTx.Prelude  as P
+
+import           Plugin.Typeclasses.Lib
+
+-- this module does lots of weird stuff deliberately
+{-# ANN module ("HLint: ignore"::String) #-}
+
+typeclasses :: TestNested
+typeclasses = testNested "Typeclasses" [
+    goldenPir "sizedBasic" sizedBasic
+    , goldenPir "sizedPair" sizedPair
+    , goldenPir "multiFunction" multiFunction
+    , goldenPir "defaultMethods" defaultMethods
+  ]
+
+class Sized a where
+    size :: a -> Integer
+
+instance Sized Integer where
+    size x = x
+
+instance (Sized a, Sized b) => Sized (a, b) where
+    {-# INLINABLE size #-}
+    size (a, b) = size a `Builtins.addInteger` size b
+
+sizedBasic :: CompiledCode (Integer -> Integer)
+sizedBasic = plc @"sizedBasic" (\(a::Integer) -> size a)
+
+sizedPair :: CompiledCode (Integer -> Integer -> Integer)
+sizedPair = plc @"sizedPair" (\(a::Integer) (b::Integer) -> size (a, b))
+
+-- This has multiple methods, so will have to be passed as a dictionary
+class PersonLike a where
+    age :: a -> Integer
+    likesAnimal :: a -> Animal -> Bool
+
+instance PersonLike Person where
+    {-# INLINABLE age #-}
+    age Jim  = 30
+    age Jane = 35
+    {-# INLINABLE likesAnimal #-}
+    likesAnimal Jane Cat = True
+    likesAnimal _ _      = False
+
+instance PersonLike Alien where
+    {-# INLINABLE age #-}
+    age AlienJim  = 300
+    age AlienJane = 350
+    {-# INLINABLE likesAnimal #-}
+    likesAnimal AlienJane Dog = True
+    likesAnimal _ _           = False
+
+multiFunction :: CompiledCode (Person -> Bool)
+multiFunction = plc @"multiFunction" (
+    let
+        {-# NOINLINE predicate #-}
+        predicate :: (PersonLike p) => p -> Bool
+        predicate p = likesAnimal p Cat P.&& (age p `Builtins.greaterThanInteger` 30)
+    in \(p::Person) -> predicate p)
+
+defaultMethods :: CompiledCode (Integer -> Integer)
+defaultMethods = plc @"defaultMethods" (
+    let
+        {-# NOINLINE f #-}
+        f :: (DefaultMethods a) => a -> Integer
+        f a = method2 a
+    in \(a::Integer) -> f a)

--- a/plutus-tx/test/Plugin/Typeclasses/defaultMethods.plc.golden
+++ b/plutus-tx/test/Plugin/Typeclasses/defaultMethods.plc.golden
@@ -1,0 +1,117 @@
+(program
+  (let
+    (nonrec
+    )
+    (termbind
+      (strict)
+      (vardecl fDefaultMethodsInteger_cmethod1 (fun (con integer) (con integer))
+      )
+      (lam a (con integer) a)
+    )
+    (let
+      (nonrec
+      )
+      (termbind
+        (strict)
+        (vardecl
+          addInteger (fun (con integer) (fun (con integer) (con integer)))
+        )
+        (builtin addInteger)
+      )
+      (let
+        (nonrec
+        )
+        (termbind
+          (strict)
+          (vardecl
+            fDefaultMethodsInteger_cmethod2 (fun (con integer) (con integer))
+          )
+          (lam a (con integer) [ [ addInteger a ] (con 1) ])
+        )
+        (let
+          (nonrec
+          )
+          (datatypebind
+            (datatype
+              (tyvardecl
+                DefaultMethods (fun (type) (type))
+              )
+              (tyvardecl a (type))
+              DefaultMethods_match
+              (vardecl
+                CConsDefaultMethods
+                (fun (fun a (con integer)) (fun (fun a (con integer)) [DefaultMethods a]))
+              )
+            )
+          )
+          (let
+            (nonrec
+            )
+            (termbind
+              (nonstrict)
+              (vardecl fDefaultMethodsInteger [DefaultMethods (con integer)])
+              [
+                [
+                  { CConsDefaultMethods (con integer) }
+                  fDefaultMethodsInteger_cmethod1
+                ]
+                fDefaultMethodsInteger_cmethod2
+              ]
+            )
+            (let
+              (nonrec
+              )
+              (termbind
+                (strict)
+                (vardecl
+                  method2
+                  (all a (type) (fun [DefaultMethods a] (fun a (con integer))))
+                )
+                (abs
+                  a
+                  (type)
+                  (lam
+                    v
+                    [DefaultMethods a]
+                    [
+                      { [ { DefaultMethods_match a } v ] (fun a (con integer)) }
+                      (lam
+                        v (fun a (con integer)) (lam v (fun a (con integer)) v)
+                      )
+                    ]
+                  )
+                )
+              )
+              (let
+                (nonrec
+                )
+                (termbind
+                  (strict
+                  )
+                  (vardecl
+                    f
+                    (all a (type) (fun [DefaultMethods a] (fun a (con integer))))
+                  )
+                  (abs
+                    a
+                    (type)
+                    (lam
+                      dDefaultMethods
+                      [DefaultMethods a]
+                      (lam a a [ [ { method2 a } dDefaultMethods ] a ])
+                    )
+                  )
+                )
+                (lam
+                  ds
+                  (con integer)
+                  [ [ { f (con integer) } fDefaultMethodsInteger ] ds ]
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/plutus-tx/test/Plugin/Typeclasses/multiFunction.plc.golden
+++ b/plutus-tx/test/Plugin/Typeclasses/multiFunction.plc.golden
@@ -1,0 +1,282 @@
+(program
+  (let
+    (nonrec
+    )
+    (datatypebind
+      (datatype
+        (tyvardecl Animal (type))
+        
+        Animal_match
+        (vardecl Cat Animal) (vardecl Dog Animal)
+      )
+    )
+    (let
+      (nonrec
+      )
+      (datatypebind
+        (datatype
+          (tyvardecl Person (type))
+          
+          Person_match
+          (vardecl Jane Person) (vardecl Jim Person)
+        )
+      )
+      (let
+        (nonrec
+        )
+        (datatypebind
+          (datatype
+            (tyvardecl Bool (type))
+            
+            Bool_match
+            (vardecl True Bool) (vardecl False Bool)
+          )
+        )
+        (let
+          (nonrec
+          )
+          (datatypebind
+            (datatype
+              (tyvardecl
+                PersonLike (fun (type) (type))
+              )
+              (tyvardecl a (type))
+              PersonLike_match
+              (vardecl
+                CConsPersonLike
+                (fun (fun a (con integer)) (fun (fun a (fun Animal Bool)) [PersonLike a]))
+              )
+            )
+          )
+          (let
+            (nonrec
+            )
+            (datatypebind
+              (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+            )
+            (let
+              (nonrec
+              )
+              (termbind
+                (strict)
+                (vardecl cage (fun Person (con integer)))
+                (lam
+                  ds
+                  Person
+                  [
+                    [ { [ Person_match ds ] (con integer) } (con 35) ] (con 30)
+                  ]
+                )
+              )
+              (let
+                (nonrec
+                )
+                (termbind
+                  (strict)
+                  (vardecl clikesAnimal (fun Person (fun Animal Bool)))
+                  (lam
+                    ds
+                    Person
+                    (lam
+                      ds
+                      Animal
+                      [
+                        [
+                          [
+                            { [ Person_match ds ] (fun Unit Bool) }
+                            (lam
+                              thunk
+                              Unit
+                              [
+                                [
+                                  [
+                                    { [ Animal_match ds ] (fun Unit Bool) }
+                                    (lam thunk Unit True)
+                                  ]
+                                  (lam thunk Unit False)
+                                ]
+                                Unit
+                              ]
+                            )
+                          ]
+                          (lam thunk Unit False)
+                        ]
+                        Unit
+                      ]
+                    )
+                  )
+                )
+                (let
+                  (nonrec
+                  )
+                  (termbind
+                    (nonstrict)
+                    (vardecl fPersonLikePerson [PersonLike Person])
+                    [ [ { CConsPersonLike Person } cage ] clikesAnimal ]
+                  )
+                  (let
+                    (nonrec
+                    )
+                    (termbind
+                      (strict
+                      )
+                      (vardecl
+                        age
+                        (all a (type) (fun [PersonLike a] (fun a (con integer))))
+                      )
+                      (abs
+                        a
+                        (type)
+                        (lam
+                          v
+                          [PersonLike a]
+                          [
+                            {
+                              [ { PersonLike_match a } v ] (fun a (con integer))
+                            }
+                            (lam
+                              v
+                              (fun a (con integer))
+                              (lam v (fun a (fun Animal Bool)) v)
+                            )
+                          ]
+                        )
+                      )
+                    )
+                    (let
+                      (nonrec
+                      )
+                      (termbind
+                        (strict
+                        )
+                        (vardecl
+                          likesAnimal
+                          (all a (type) (fun [PersonLike a] (fun a (fun Animal Bool))))
+                        )
+                        (abs
+                          a
+                          (type)
+                          (lam
+                            v
+                            [PersonLike a]
+                            [
+                              {
+                                [ { PersonLike_match a } v ]
+                                (fun a (fun Animal Bool))
+                              }
+                              (lam
+                                v
+                                (fun a (con integer))
+                                (lam v (fun a (fun Animal Bool)) v)
+                              )
+                            ]
+                          )
+                        )
+                      )
+                      (let
+                        (nonrec)
+                        (termbind
+                          (strict)
+                          (vardecl bad_name (fun Bool (fun Bool Bool)))
+                          (lam
+                            l
+                            Bool
+                            (lam
+                              r
+                              Bool
+                              [
+                                [
+                                  [
+                                    { [ Bool_match l ] (fun Unit Bool) }
+                                    (lam thunk Unit r)
+                                  ]
+                                  (lam thunk Unit False)
+                                ]
+                                Unit
+                              ]
+                            )
+                          )
+                        )
+                        (let
+                          (nonrec)
+                          (termbind
+                            (strict)
+                            (vardecl
+                              greaterThanInteger
+                              (fun (con integer) (fun (con integer) Bool))
+                            )
+                            (lam
+                              arg
+                              (con integer)
+                              (lam
+                                arg
+                                (con integer)
+                                [
+                                  (lam
+                                    b
+                                    (all a (type) (fun a (fun a a)))
+                                    [ [ { b Bool } True ] False ]
+                                  )
+                                  [ [ (builtin greaterThanInteger) arg ] arg ]
+                                ]
+                              )
+                            )
+                          )
+                          (let
+                            (nonrec)
+                            (termbind
+                              (strict)
+                              (vardecl
+                                predicate
+                                (all p (type) (fun [PersonLike p] (fun p Bool)))
+                              )
+                              (abs
+                                p
+                                (type)
+                                (lam
+                                  dPersonLike
+                                  [PersonLike p]
+                                  (lam
+                                    p
+                                    p
+                                    [
+                                      [
+                                        bad_name
+                                        [
+                                          [
+                                            [ { likesAnimal p } dPersonLike ] p
+                                          ]
+                                          Cat
+                                        ]
+                                      ]
+                                      [
+                                        [
+                                          greaterThanInteger
+                                          [ [ { age p } dPersonLike ] p ]
+                                        ]
+                                        (con 30)
+                                      ]
+                                    ]
+                                  )
+                                )
+                              )
+                            )
+                            (lam
+                              ds
+                              Person
+                              [ [ { predicate Person } fPersonLikePerson ] ds ]
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/plutus-tx/test/Plugin/Typeclasses/sizedBasic.plc.golden
+++ b/plutus-tx/test/Plugin/Typeclasses/sizedBasic.plc.golden
@@ -1,0 +1,36 @@
+(program
+  (let
+    (nonrec
+    )
+    (termbind
+      (strict)
+      (vardecl csize (fun (con integer) (con integer)))
+      (lam x (con integer) x)
+    )
+    (let
+      (nonrec
+      )
+      (termbind
+        (nonstrict)
+        (vardecl
+          fSizedInteger [(lam a (type) (fun a (con integer))) (con integer)]
+        )
+        csize
+      )
+      (let
+        (nonrec
+        )
+        (termbind
+          (strict
+          )
+          (vardecl
+            size
+            (all a (type) (fun [(lam a (type) (fun a (con integer))) a] (fun a (con integer))))
+          )
+          (abs a (type) (lam v [(lam a (type) (fun a (con integer))) a] v))
+        )
+        (lam ds (con integer) [ [ { size (con integer) } fSizedInteger ] ds ])
+      )
+    )
+  )
+)

--- a/plutus-tx/test/Plugin/Typeclasses/sizedPair.plc.golden
+++ b/plutus-tx/test/Plugin/Typeclasses/sizedPair.plc.golden
@@ -1,0 +1,147 @@
+(program
+  (let
+    (nonrec
+    )
+    (datatypebind
+      (datatype
+        (tyvardecl Tuple2 (fun (type) (fun (type) (type))))
+        (tyvardecl a (type)) (tyvardecl b (type))
+        Tuple2_match
+        (vardecl Tuple2 (fun a (fun b [[Tuple2 a] b])))
+      )
+    )
+    (let
+      (nonrec
+      )
+      (termbind
+        (strict)
+        (vardecl
+          addInteger (fun (con integer) (fun (con integer) (con integer)))
+        )
+        (builtin addInteger)
+      )
+      (let
+        (nonrec
+        )
+        (termbind
+          (strict
+          )
+          (vardecl
+            csize
+            (all a (type) (all b (type) (fun [(lam a (type) (fun a (con integer))) a] (fun [(lam a (type) (fun a (con integer))) b] (fun [[Tuple2 a] b] (con integer))))))
+          )
+          (abs
+            a
+            (type)
+            (abs
+              b
+              (type)
+              (lam
+                dSized
+                [(lam a (type) (fun a (con integer))) a]
+                (lam
+                  dSized
+                  [(lam a (type) (fun a (con integer))) b]
+                  (lam
+                    ds
+                    [[Tuple2 a] b]
+                    [
+                      { [ { { Tuple2_match a } b } ds ] (con integer) }
+                      (lam
+                        a
+                        a
+                        (lam b b [ [ addInteger [ dSized a ] ] [ dSized b ] ])
+                      )
+                    ]
+                  )
+                )
+              )
+            )
+          )
+        )
+        (let
+          (nonrec
+          )
+          (termbind
+            (nonstrict
+            )
+            (vardecl
+              fSizedTuple2
+              (all a (type) (all b (type) (fun [(lam a (type) (fun a (con integer))) a] (fun [(lam a (type) (fun a (con integer))) b] [(lam a (type) (fun a (con integer))) [[Tuple2 a] b]]))))
+            )
+            csize
+          )
+          (let
+            (nonrec
+            )
+            (termbind
+              (strict)
+              (vardecl csize (fun (con integer) (con integer)))
+              (lam x (con integer) x)
+            )
+            (let
+              (nonrec
+              )
+              (termbind
+                (nonstrict)
+                (vardecl
+                  fSizedInteger
+                  [(lam a (type) (fun a (con integer))) (con integer)]
+                )
+                csize
+              )
+              (let
+                (nonrec
+                )
+                (termbind
+                  (strict
+                  )
+                  (vardecl
+                    size
+                    (all a (type) (fun [(lam a (type) (fun a (con integer))) a] (fun a (con integer))))
+                  )
+                  (abs
+                    a (type) (lam v [(lam a (type) (fun a (con integer))) a] v)
+                  )
+                )
+                (let
+                  (nonrec
+                  )
+                  (termbind
+                    (nonstrict
+                    )
+                    (vardecl
+                      dSized
+                      [(lam a (type) (fun a (con integer))) [[Tuple2 (con integer)] (con integer)]]
+                    )
+                    [
+                      [
+                        { { fSizedTuple2 (con integer) } (con integer) }
+                        fSizedInteger
+                      ]
+                      fSizedInteger
+                    ]
+                  )
+                  (lam
+                    ds
+                    (con integer)
+                    (lam
+                      ds
+                      (con integer)
+                      [
+                        [
+                          { size [[Tuple2 (con integer)] (con integer)] } dSized
+                        ]
+                        [ [ { { Tuple2 (con integer) } (con integer) } ds ] ds ]
+                      ]
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/plutus-tx/test/TH/Spec.hs
+++ b/plutus-tx/test/TH/Spec.hs
@@ -2,23 +2,24 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE NoImplicitPrelude    #-}
 {-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:debug-context #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC   -g #-}
 
 module TH.Spec (tests) where
 
-import           Prelude                    hiding (all)
-
 import           Common
 import           PlcTestUtils
 
 import           TH.TestTH
 
+import qualified Prelude as Haskell
+
 import           Language.PlutusTx.TH
 import           Language.PlutusTx.Code
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Prelude as P hiding (fst)
+import           Language.PlutusTx.Prelude
 import           Language.PlutusTx.Evaluation
 
 import qualified Language.PlutusIR          as PIR
@@ -51,10 +52,10 @@ runPlcCekTrace values = do
      ExceptT $ try @SomeException $ evaluate $ evaluateCekTrace p
 
 goldenEvalCek :: GetProgram a => String -> [a] -> TestNested
-goldenEvalCek name values = nestedGoldenVsDocM name $ prettyPlcClassicDebug <$> (rethrow $ runPlcCek values)
+goldenEvalCek name values = nestedGoldenVsDocM name $ prettyPlcClassicDebug Haskell.<$> (rethrow $ runPlcCek values)
 
 goldenEvalCekLog :: GetProgram a => String -> [a] -> TestNested
-goldenEvalCekLog name values = nestedGoldenVsDocM name $ (pretty . fst) <$> (rethrow $ runPlcCekTrace values)
+goldenEvalCekLog name values = nestedGoldenVsDocM name $ (pretty . fst) Haskell.<$> (rethrow $ runPlcCekTrace values)
 
 tests :: TestNested
 tests = testNested "TH" [
@@ -79,7 +80,7 @@ andPlc :: CompiledCode Bool
 andPlc = $$(compile [|| $$(andTH) True False ||])
 
 allPlc :: CompiledCode Bool
-allPlc = $$(compile [|| all (\(x::Integer) -> gt x 5) [7, 6] ||])
+allPlc = $$(compile [|| all (\(x::Integer) -> x > 5) [7, 6] ||])
 
 convertString :: CompiledCode Builtins.String
 convertString = $$(compile [|| toPlutusString "test" ||])

--- a/plutus-tx/test/TH/TestTH.hs
+++ b/plutus-tx/test/TH/TestTH.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
 module TH.TestTH where
 
 import           Language.Haskell.TH

--- a/plutus-tx/test/TH/all.plc.golden
+++ b/plutus-tx/test/TH/all.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  out_Bool_65
+  out_Bool_59
   (type)
-  (lam case_True_66 out_Bool_65 (lam case_False_67 out_Bool_65 case_True_66))
+  (lam case_True_60 out_Bool_59 (lam case_False_61 out_Bool_59 case_True_60))
 )

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -36,6 +36,9 @@ library
         Language.PlutusTx.Coordination.Contracts.PubKey
         Language.PlutusTx.Coordination.Contracts.Vesting
         Language.PlutusTx.Coordination.Contracts.Swap
+    other-modules:
+        Language.PlutusTx.Coordination.Contracts.GameStateMachine.Types
+        Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine.Types
     hs-source-dirs: src
     default-language: Haskell2010
     default-extensions: ExplicitForAll ScopedTypeVariables

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -73,7 +73,7 @@ validate c@(Currency (refHash, refIdx) _) () () p =
         -- True if the pending transaction forges the amount of
         -- currency that we expect
         forgeOK =
-            let v = Value.eq expected forged
+            let v = expected == forged
             in traceIfFalseH "Value forged different from expected" v
 
         -- True if the pending transaction spends the output

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -32,8 +32,7 @@ data ClearString = ClearString ByteString
 PlutusTx.makeLift ''ClearString
 
 correctGuess :: HashedString -> ClearString -> Bool
-correctGuess (HashedString actual) (ClearString guess') =
-    equalsByteString actual (sha2_256 guess')
+correctGuess (HashedString actual) (ClearString guess') = actual == (sha2_256 guess')
 
 validateGuess :: HashedString -> ClearString -> PendingTx -> Bool
 validateGuess dataScript redeemerScript _ = correctGuess dataScript redeemerScript

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine/Types.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine/Types.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+module Language.PlutusTx.Coordination.Contracts.GameStateMachine.Types where
+
+
+import qualified Language.PlutusTx              as PlutusTx
+import           Language.PlutusTx.Prelude
+import           Ledger.Value                   (TokenName)
+import qualified Ledger.Value                   as V
+
+import           Language.PlutusTx.StateMachine ()
+
+newtype HashedString = HashedString ByteString
+
+PlutusTx.makeLift ''HashedString
+
+newtype ClearString = ClearString ByteString
+
+PlutusTx.makeLift ''ClearString
+
+-- | State of the guessing game
+data GameState =
+    Initialised HashedString
+    -- ^ Initial state. In this state only the 'ForgeTokens' action is allowed.
+    | Locked TokenName HashedString
+    -- ^ Funds have been locked. In this state only the 'Guess' action is
+    --   allowed.
+
+instance Eq GameState where
+    {-# INLINABLE (==) #-}
+    (Initialised (HashedString s)) == (Initialised (HashedString s')) = s == s'
+    (Locked (V.TokenName n) (HashedString s)) == (Locked (V.TokenName n') (HashedString s')) = s == s' && n == n'
+    _ == _ = traceIfFalseH "states not equal" False
+
+PlutusTx.makeLift ''GameState

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
@@ -42,7 +42,7 @@ PlutusTx.makeLift ''MultiSig
 validate :: MultiSig -> () -> () -> PendingTx -> Bool
 validate (MultiSig keys num) () () p =
     let present = length (filter (V.txSignedBy p) keys)
-    in present `geq` num
+    in present >= num
 
 msValidator :: MultiSig -> ValidatorScript
 msValidator sig = ValidatorScript $

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine/Types.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine/Types.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# OPTIONS_GHC -fno-specialise #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+module Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine.Types where
+
+import           Ledger.Slot               (Slot)
+import           Ledger.Value              (Value)
+import           Wallet
+
+import qualified Language.PlutusTx         as PlutusTx
+import           Language.PlutusTx.Prelude
+
+-- | A proposal for making a payment under the multisig scheme.
+data Payment = Payment
+    { paymentAmount    :: Value
+    -- ^ How much to pay out
+    , paymentRecipient :: PubKey
+    -- ^ Address to pay the value to
+    , paymentDeadline  :: Slot
+    -- ^ Time until the required amount of signatures has to be collected.
+    }
+
+instance Eq Payment where
+    {-# INLINABLE (==) #-}
+    (Payment vl pk sl) == (Payment vl' pk' sl') = vl == vl' && pk == pk' && sl == sl'
+
+PlutusTx.makeLift ''Payment
+
+data Params = Params
+    { mspSignatories  :: [PubKey]
+    -- ^ Public keys that are allowed to authorise payments
+    , mspRequiredSigs :: Integer
+    -- ^ How many signatures are required for a payment
+    }
+
+PlutusTx.makeLift ''Params
+
+-- | State of the multisig contract.
+data State =
+    InitialState Value
+    -- ^ Money is locked, anyone can make a proposal for a payment-
+
+    | CollectingSignatures Value Payment [PubKey]
+    -- ^ A payment has been proposed and is awaiting signatures.
+
+-- Needs to be in a different file due to #978
+instance Eq State where
+    {-# INLINABLE (==) #-}
+    (InitialState v) == (InitialState v') = v == v'
+    (CollectingSignatures vl pmt pks) == (CollectingSignatures vl' pmt' pks') =
+        vl == vl' && pmt == pmt' && pks == pks'
+    _ == _ = False
+
+PlutusTx.makeLift ''State
+
+data Input =
+    ProposePayment Payment
+    -- ^ Propose a payment. The payment can be made as soon as enough
+    --   signatures have been collected.
+
+    | AddSignature PubKey
+    -- ^ Add a signature to the sigs. that have been collected for the
+    --   current proposal.
+
+    | Cancel
+    -- ^ Cancel the current proposal if the deadline has passed
+
+    | Pay
+    -- ^ Make the payment.
+
+PlutusTx.makeLift ''Input

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -19,8 +19,6 @@ module Language.PlutusTx.Coordination.Contracts.Vesting (
     validatorScript
     ) where
 
-import           Prelude                      hiding ((&&))
-
 import           Control.Monad.Error.Class    (MonadError (..))
 import           Data.Maybe                   (maybeToList)
 import qualified Data.Set                     as Set
@@ -75,7 +73,11 @@ availableFrom (VestingTranche d v) range =
 data VestingData = VestingData {
     vestingDataHash    :: ValidatorHash, -- ^ Hash of the validator script
     vestingDataPaidOut :: Value          -- ^ How much of the vested value has already been retrieved
-    } deriving (Eq, Generic)
+    } deriving (Generic)
+
+instance Eq VestingData where
+    {-# INLINABLE (==) #-}
+    (VestingData h1 v1) == (VestingData h2 v2) = h1 == h2 && v1 == v2
 
 PlutusTx.makeLift ''VestingData
 
@@ -152,7 +154,7 @@ mkValidator d@Vesting{..} VestingData{..} () p@PendingTx{pendingTxValidRange = r
         -- script
         txnOutputsValid =
             let remaining = Validation.valueLockedBy p (Validation.ownHash p) in
-            remaining `Value.eq` (totalAmount d `Value.minus` newAmount)
+            remaining == (totalAmount d `Value.minus` newAmount)
 
     in amountsValid && txnOutputsValid
 

--- a/plutus-wallet-api/ledger/Ledger/Ada.hs
+++ b/plutus-wallet-api/ledger/Ledger/Ada.hs
@@ -24,21 +24,18 @@ module Ledger.Ada(
     , multiply
     , divide
     , negate
-    , geq
-    , gt
-    , leq
-    , lt
-    , eq
     -- * Etc.
     , isZero
     ) where
+
+import qualified Prelude                      as Haskell
 
 import           Codec.Serialise.Class        (Serialise)
 import           Data.Aeson                   (FromJSON, ToJSON)
 import           Data.Swagger.Internal.Schema (ToSchema)
 import           GHC.Generics                 (Generic)
 import           Language.PlutusTx.Lift       (makeLift)
-import           Language.PlutusTx.Prelude    hiding (divide, eq, geq, gt, leq, lt, minus, multiply, negate, plus)
+import           Language.PlutusTx.Prelude    hiding (divide, minus, multiply, negate, plus)
 import qualified Language.PlutusTx.Prelude    as P
 
 import           Ledger.Value                 (CurrencySymbol, TokenName, Value)
@@ -57,10 +54,10 @@ adaToken = TH.tokenName emptyByteString
 -- | ADA, the special currency on the Cardano blockchain.
 --   See note [Currencies] in 'Ledger.Validation.Value.TH'.
 newtype Ada = Ada { getAda :: Integer }
-    deriving (Eq, Ord, Show, Enum)
-    deriving stock (Generic)
+    deriving (Enum)
+    deriving stock (Haskell.Eq, Haskell.Ord, Show, Generic)
     deriving anyclass (ToSchema, ToJSON, FromJSON)
-    deriving newtype (Num, Integral, Real, Serialise)
+    deriving newtype (Eq, Ord, Num, Integral, Real, Serialise)
 
 makeLift ''Ada
 
@@ -125,29 +122,4 @@ negate (Ada i) = Ada (P.multiply (-1) i)
 {-# INLINABLE isZero #-}
 -- | Check whether an 'Ada' value is zero.
 isZero :: Ada -> Bool
-isZero (Ada i) = P.eq i 0
-
-{-# INLINABLE geq #-}
--- | Check whether one 'Ada' is greater than or equal to another.
-geq :: Ada -> Ada -> Bool
-geq (Ada i) (Ada j) = P.geq i j
-
-{-# INLINABLE gt #-}
--- | Check whether one 'Ada' is strictly greater than another.
-gt :: Ada -> Ada -> Bool
-gt (Ada i) (Ada j) = P.gt i j
-
-{-# INLINABLE leq #-}
--- | Check whether one 'Ada' is less than or equal to another.
-leq :: Ada -> Ada -> Bool
-leq (Ada i) (Ada j) = P.leq i j
-
-{-# INLINABLE lt #-}
--- | Check whether one 'Ada' is strictly less than another.
-lt :: Ada -> Ada -> Bool
-lt (Ada i) (Ada j) = P.lt i j
-
-{-# INLINABLE eq #-}
--- | Check whether one 'Ada' is equal to another.
-eq :: Ada -> Ada -> Bool
-eq (Ada i) (Ada j) = P.eq i j
+isZero (Ada i) = i == 0

--- a/plutus-wallet-api/ledger/Ledger/Crypto.hs
+++ b/plutus-wallet-api/ledger/Ledger/Crypto.hs
@@ -42,6 +42,7 @@ import           Data.Swagger.Internal
 import           GHC.Generics               (Generic)
 import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Lift     (makeLift)
+import qualified Language.PlutusTx.Prelude  as P
 import           Ledger.TxId
 import           LedgerBytes                (LedgerBytes)
 import qualified LedgerBytes                as KB
@@ -49,18 +50,16 @@ import           Servant.API                (FromHttpApiData (parseUrlPiece), To
 
 -- | A cryptographic public key.
 newtype PubKey = PubKey { getPubKey :: LedgerBytes }
-    deriving (Eq, Ord, Show)
-    deriving stock (Generic)
+    deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (ToSchema, ToJSON, FromJSON, Newtype, ToJSONKey, FromJSONKey)
-    deriving newtype (Serialise)
+    deriving newtype (P.Eq, P.Ord, Serialise)
 makeLift ''PubKey
 
 -- | A cryptographic private key.
 newtype PrivateKey = PrivateKey { getPrivateKey :: LedgerBytes }
-    deriving (Eq, Ord, Show)
-    deriving stock (Generic)
+    deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (ToSchema, ToJSON, FromJSON, Newtype, ToJSONKey, FromJSONKey)
-    deriving newtype (Serialise)
+    deriving newtype (P.Eq, P.Ord, Serialise)
 
 makeLift ''PrivateKey
 
@@ -72,9 +71,8 @@ instance FromHttpApiData PrivateKey where
 
 -- | A message with a cryptographic signature.
 newtype Signature = Signature { getSignature :: Builtins.ByteString }
-    deriving (Eq, Ord, Show)
-    deriving stock (Generic)
-    deriving newtype (Serialise)
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving newtype (P.Eq, P.Ord, Serialise)
 
 instance ToSchema Signature where
     declareNamedSchema _ = pure $ NamedSchema (Just "Signature") byteSchema

--- a/plutus-wallet-api/ledger/Ledger/Index.hs
+++ b/plutus-wallet-api/ledger/Ledger/Index.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE ConstraintKinds  #-}
-{-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE ConstraintKinds    #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE LambdaCase         #-}
 -- | An index of unspent transaction outputs, and some functions for validating
 --   transactions using the index.
 module Ledger.Index(
@@ -21,6 +22,9 @@ module Ledger.Index(
     -- * Actual validation
     validateTransaction
     ) where
+
+import           Prelude              hiding (lookup)
+
 
 import           Control.Lens         (at, (^.))
 import           Control.Monad
@@ -43,7 +47,6 @@ import           Ledger.TxId
 import           Ledger.Validation    (PendingTx (..))
 import qualified Ledger.Validation    as Validation
 import qualified Ledger.Value         as V
-import           Prelude              hiding (lookup)
 
 -- | Context for validating transactions. We need access to the unspent
 --   transaction outputs of the blockchain, and we can throw 'ValidationError's.
@@ -51,7 +54,8 @@ type ValidationMonad m = (MonadReader UtxoIndex m, MonadError ValidationError m)
 
 -- | The UTxOs of a blockchain indexed by their references.
 newtype UtxoIndex = UtxoIndex { getIndex :: Map.Map TxOutRef TxOut }
-    deriving (Eq, Show, Semigroup, Monoid)
+    deriving (Show, Semigroup, Monoid)
+    deriving newtype (Eq)
 
 -- | Create an index of all UTxOs on the chain.
 initialise :: Blockchain -> UtxoIndex

--- a/plutus-wallet-api/ledger/LedgerBytes.hs
+++ b/plutus-wallet-api/ledger/LedgerBytes.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -27,6 +28,7 @@ import           Data.Word                  (Word8)
 import           GHC.Generics               (Generic)
 import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Lift
+import qualified Language.PlutusTx.Prelude  as P
 import           Web.HttpApiData            (FromHttpApiData (..), ToHttpApiData (..))
 
 fromHex :: BSL.ByteString -> LedgerBytes
@@ -59,6 +61,7 @@ fromHex = LedgerBytes . asBSLiteral
 --   type for PureScript.
 newtype LedgerBytes = LedgerBytes { getLedgerBytes :: Builtins.ByteString } -- TODO: use strict bytestring
     deriving (Eq, Ord, Serialise, Generic)
+    deriving newtype (P.Eq, P.Ord)
 
 bytes :: LedgerBytes -> BSL.ByteString
 bytes = getLedgerBytes

--- a/plutus-wallet-api/src/Wallet/API.hs
+++ b/plutus-wallet-api/src/Wallet/API.hs
@@ -491,7 +491,7 @@ member v (Interval.Interval f t) =
 -- | Emit a warning if the value at an address is zero.
 warnEmptyTransaction :: (WalletDiagnostics m) => Value -> Address -> m ()
 warnEmptyTransaction value addr =
-    when (Value.eq Value.zero value)
+    when (Value.isZero value)
         $ logMsg
         $ Text.unwords [
               "Attempting to collect transaction outputs from"

--- a/plutus-wallet-api/test/Spec.hs
+++ b/plutus-wallet-api/test/Spec.hs
@@ -99,19 +99,19 @@ splitVal = property $ do
 valueAddIdentity :: Property
 valueAddIdentity = property $ do
     vl1 <- forAll Gen.genValue
-    Hedgehog.assert $ Value.eq vl1 (vl1 `Value.plus` Value.zero)
-    Hedgehog.assert $ Value.eq vl1 (Value.zero `Value.plus` vl1)
+    Hedgehog.assert $ vl1 == (vl1 `Value.plus` Value.zero)
+    Hedgehog.assert $ vl1 == (Value.zero `Value.plus` vl1)
 
 valueAddInverse :: Property
 valueAddInverse = property $ do
     vl1 <- forAll Gen.genValue
     let vl1' = Value.negate vl1
-    Hedgehog.assert $ Value.eq Value.zero (vl1 `Value.plus` vl1')
+    Hedgehog.assert $ Value.zero == (vl1 `Value.plus` vl1')
 
 valueScalarIdentity :: Property
 valueScalarIdentity = property $ do
     vl1 <- forAll Gen.genValue
-    Hedgehog.assert $ Value.eq vl1 (Value.scale 1 vl1)
+    Hedgehog.assert $ vl1 == Value.scale 1 vl1
 
 valueScalarDistrib :: Property
 valueScalarDistrib = property $ do
@@ -120,7 +120,7 @@ valueScalarDistrib = property $ do
     scalar <- forAll (Gen.integral (fromIntegral <$> Range.linearBounded @Int))
     let r1 = Value.scale scalar (Value.plus vl1 vl2)
         r2 = Value.plus (Value.scale scalar vl1) (Value.scale scalar vl2)
-    Hedgehog.assert $ Value.eq r1 r2
+    Hedgehog.assert $ r1 == r2
 
 intvlMember :: Property
 intvlMember = property $ do


### PR DESCRIPTION
Fixes #1109.

It turns out this works just fine. I'm sorry for putting you all through
the pain of not having typeclasses!

We can't use the classes from `base`, unsurprisingly, due to lack
of unfoldings for the instance definitions.

However, we can define our own replacements, which is a bit of
boilerplate but not too bad.

Delightfully, you seem to generally be able to get away with
newtype-deriving them:
- We *do* handle newtype coercions, so the generated instance
definitions are actually fine.
- They seem to be small enough that GHC always puts in an unfolding for
them even though we can't annotate them.
    - This is a little dicey, but seems to be okay so far.

The class operations themselves annoyingly don't have unfoldings, but we
can recreate the RHSs using GHC's functions. Antother annoyance is #978:
this bites us for e.g. the default method declarations in `Eq`, which
means that `(==)` and `(/=)` are mutually recursive! So you need to put
your `Eq` instances in a separate file from the final use site.

To demonstrate, I added `Eq`, `Ord`, and `Functor` and plumbed them
through. I think the result is a lot better!

We get a ~10% increase in script size and a comparable slowdown. I think
this is somewhat inevitable since we're not taking much advantage of
GHC's specializer, so we are paying a price from passing all the
dictionaries around.

TODO (but probably not in this PR):
- `Semigroup`/`Monoid`
- `Applicative`/`Monad`
    - With `RebindableSyntax` I think we could even do `do` notation!
- `Num`?
    - I'm unsure whether we want this, given that `Num` is kind of a
      dodgy class, but I would like to be able to use `+` and `-`...
    - Possibly we should define our own `Num`-like class.
- More tuple instances
    - I was lazy and only went to 2-tuples.