### PR TITLE
plutus-tx: absorb Map and These modules

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -53926,6 +53926,7 @@ license = stdenv.lib.licenses.asl20;
 , mtl
 , playground-common
 , plutus-emulator
+, plutus-tx
 , plutus-wallet-api
 , QuickCheck
 , servant
@@ -53953,6 +53954,7 @@ memory
 mtl
 playground-common
 plutus-emulator
+plutus-tx
 plutus-wallet-api
 servant
 swagger2

--- a/plutus-emulator/test/Spec.hs
+++ b/plutus-emulator/test/Spec.hs
@@ -30,10 +30,10 @@ import qualified Hedgehog.Gen               as Gen
 import qualified Hedgehog.Range             as Range
 import qualified Language.PlutusTx.Builtins as Builtins
 import qualified Language.PlutusTx.Prelude  as PlutusTx
+import           Language.PlutusTx.AssocMap as AssocMap
 import           Ledger
 import qualified Ledger.Ada                 as Ada
 import qualified Ledger.Index               as Index
-import qualified Ledger.Map
 import qualified Ledger.Value               as Value
 import           Ledger.Value               (CurrencySymbol, Value (Value))
 import           LedgerBytes                as LedgerBytes

--- a/plutus-playground-lib/plutus-playground-lib.cabal
+++ b/plutus-playground-lib/plutus-playground-lib.cabal
@@ -50,6 +50,7 @@ library
     , template-haskell
     , text
     , transformers
+    , plutus-tx
     , plutus-wallet-api
     , plutus-emulator
   default-language: Haskell2010

--- a/plutus-playground-lib/src/Playground/API.hs
+++ b/plutus-playground-lib/src/Playground/API.hs
@@ -35,9 +35,9 @@ import           Language.Haskell.Interpreter (CompilationError (CompilationErro
                                                SourceCode, column, filename, row, text)
 import qualified Language.Haskell.Interpreter as HI
 import qualified Language.Haskell.TH.Syntax   as TH
+import qualified Language.PlutusTx.AssocMap   as Map
 import           Ledger                       (Blockchain, PubKey, Tx, TxId)
 import qualified Ledger.Ada                   as Ada
-import qualified Ledger.Map                   as Map
 import           Ledger.Validation            (ValidatorHash, fromSymbol)
 import           Ledger.Value                 (TokenName)
 import qualified Ledger.Value                 as V

--- a/plutus-playground-server/app/PSGenerator.hs
+++ b/plutus-playground-server/app/PSGenerator.hs
@@ -89,7 +89,7 @@ integerBridge = do
 ledgerMapBridge :: BridgePart
 ledgerMapBridge = do
     typeName ^== "Map"
-    typeModule ^== "Ledger.Map"
+    typeModule ^== "Language.PlutusTx.AssocMap"
     psLedgerMap
 
 ledgerBytesBridge :: BridgePart

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -51,6 +51,8 @@ library
         Language.PlutusTx.Maybe
         Language.PlutusTx.Semigroup
         Language.PlutusTx.Monoid
+        Language.PlutusTx.AssocMap
+        Language.PlutusTx.These
     reexported-modules:
         Language.PlutusTx.Code,
         Language.PlutusTx.Lift,

--- a/plutus-tx/src/Language/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/Language/PlutusTx/AssocMap.hs
@@ -11,8 +11,8 @@
 -- Prevent unboxing, which the plugin can't deal with
 {-# OPTIONS_GHC -fno-strictness #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
--- A map implementation that can be used in on-chain and off-chain code.
-module Ledger.Map(
+-- | A map represented as an "association list" of key-value pairs.
+module Language.PlutusTx.AssocMap (
     Map
     , singleton
     , empty
@@ -22,23 +22,13 @@ module Ledger.Map(
     , lookup
     , union
     , all
-    -- * These
-    , These(..)
-    , these
     ) where
 
-import qualified Prelude                      as Haskell
-
-import           Codec.Serialise.Class        (Serialise)
-import           Data.Aeson                   (FromJSON (parseJSON), ToJSON (toJSON))
-import           Data.Hashable                (Hashable)
-import           Data.Swagger.Internal.Schema (ToSchema)
-import           GHC.Generics                 (Generic)
-import           Language.PlutusTx.Lift       (makeLift)
-import           Language.PlutusTx.Prelude    hiding (all, lookup)
-import qualified Language.PlutusTx.Prelude    as P
-
-import           Ledger.These
+import           GHC.Generics              (Generic)
+import           Language.PlutusTx.Lift    (makeLift)
+import           Language.PlutusTx.Prelude hiding (all, lookup)
+import qualified Language.PlutusTx.Prelude as P
+import           Language.PlutusTx.These
 
 {-# ANN module ("HLint: ignore Use newtype instead of data"::String) #-}
 
@@ -47,7 +37,6 @@ newtype Map k v = Map { unMap :: [(k, v)] }
     deriving (Show)
     deriving stock (Generic)
     deriving newtype (Eq, Ord)
-    deriving anyclass (ToSchema, Serialise, Hashable)
 
 instance Functor (Map k) where
     {-# INLINABLE fmap #-}
@@ -65,12 +54,6 @@ instance (Eq k, Semigroup v) => Semigroup (Map k v) where
 
 instance (Eq k, Semigroup v) => Monoid (Map k v) where
     mempty = empty ()
-
-instance (ToJSON v, ToJSON k) => ToJSON (Map k v) where
-    toJSON = toJSON . unMap
-
-instance (FromJSON v, FromJSON k) => FromJSON (Map k v) where
-    parseJSON v = Map Haskell.<$> parseJSON v
 
 {-# INLINABLE fromList #-}
 fromList :: [(k, v)] -> Map k v

--- a/plutus-tx/src/Language/PlutusTx/These.hs
+++ b/plutus-tx/src/Language/PlutusTx/These.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module Ledger.These(
+module Language.PlutusTx.These(
     These(..)
   , these
   , theseWithDefault

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -13,25 +13,25 @@ module Language.PlutusTx.Coordination.Contracts.Currency(
     , forgedValue
     ) where
 
-import           Control.Lens              ((^.), at, to)
-import           Data.Bifunctor            (Bifunctor(first))
-import qualified Data.Set                  as Set
-import qualified Data.Map                  as Map
-import           Data.Maybe                (fromMaybe)
-import           Data.String               (IsString(fromString))
-import qualified Data.Text                 as Text
+import           Control.Lens               ((^.), at, to)
+import           Data.Bifunctor             (Bifunctor(first))
+import qualified Data.Set                   as Set
+import qualified Data.Map                   as Map
+import           Data.Maybe                 (fromMaybe)
+import           Data.String                (IsString(fromString))
+import qualified Data.Text                  as Text
 
 import           Language.PlutusTx.Prelude
-import qualified Language.PlutusTx         as PlutusTx
+import qualified Language.PlutusTx          as PlutusTx
 
-import qualified Ledger.Ada                as Ada
-import qualified Ledger.Map                as LMap
-import           Ledger.Scripts            (ValidatorScript(..))
-import qualified Ledger.Validation         as V
-import qualified Ledger.Value              as Value
-import           Ledger                    as Ledger hiding (to)
-import           Ledger.Value              (TokenName, Value)
-import           Wallet.API                as WAPI
+import qualified Ledger.Ada                 as Ada
+import qualified Language.PlutusTx.AssocMap as AssocMap
+import           Ledger.Scripts             (ValidatorScript(..))
+import qualified Ledger.Validation          as V
+import qualified Ledger.Value               as Value
+import           Ledger                     as Ledger hiding (to)
+import           Ledger.Value               (TokenName, Value)
+import           Wallet.API                 as WAPI
 
 import qualified Language.PlutusTx.Coordination.Contracts.PubKey as PK
 
@@ -41,7 +41,7 @@ data Currency = Currency
   { curRefTransactionOutput :: (TxHash, Integer)
   -- ^ Transaction input that must be spent when
   --   the currency is forged.
-  , curAmounts              :: LMap.Map TokenName Integer
+  , curAmounts              :: AssocMap.Map TokenName Integer
   -- ^ How many units of each 'TokenName' are to
   --   be forged.
   }
@@ -51,14 +51,14 @@ PlutusTx.makeLift ''Currency
 currencyValue :: CurrencySymbol -> Currency -> Value
 currencyValue s Currency{curAmounts = amts} =
     let
-        values = map (\(tn, i) -> (Value.singleton s tn i)) (LMap.toList amts)
+        values = map (\(tn, i) -> (Value.singleton s tn i)) (AssocMap.toList amts)
     in foldr Value.plus Value.zero values
 
 mkCurrency :: TxOutRef -> [(String, Integer)] -> Currency
 mkCurrency (TxOutRefOf h i) amts =
     Currency
         { curRefTransactionOutput = (V.plcTxHash h, i)
-        , curAmounts              = LMap.fromList (fmap (first fromString) amts)
+        , curAmounts              = AssocMap.fromList (fmap (first fromString) amts)
         }
 
 validate :: Currency -> () -> () -> V.PendingTx -> Bool

--- a/plutus-wallet-api/plutus-wallet-api.cabal
+++ b/plutus-wallet-api/plutus-wallet-api.cabal
@@ -61,8 +61,6 @@ library
         Ledger,
         Ledger.Ada,
         Ledger.AddressMap,
-        Ledger.Map,
-        Ledger.These,
         Ledger.Blockchain,
         Ledger.Crypto,
         Ledger.Slot,
@@ -108,8 +106,6 @@ library plutus-ledger
         Ledger
         Ledger.Ada
         Ledger.AddressMap
-        Ledger.Map
-        Ledger.These
         Ledger.Blockchain
         Ledger.Crypto
         Ledger.Slot

--- a/plutus-wallet-api/test/Spec.hs
+++ b/plutus-wallet-api/test/Spec.hs
@@ -23,12 +23,12 @@ import           Hedgehog                   (Property, forAll, property)
 import qualified Hedgehog
 import qualified Hedgehog.Gen               as Gen
 import qualified Hedgehog.Range             as Range
+import qualified Language.PlutusTx.AssocMap as AssocMap
 import qualified Language.PlutusTx.Builtins as Builtins
 import qualified Language.PlutusTx.Prelude  as PlutusTx
 import           Ledger
 import qualified Ledger.Ada                 as Ada
 import qualified Ledger.Index               as Index
-import qualified Ledger.Map
 import           Ledger.Value               (CurrencySymbol, Value (Value))
 import qualified Ledger.Value               as Value
 import           LedgerBytes


### PR DESCRIPTION
I found myself moving these in a couple of other branches, so I thought
I'd just do it on master.

`plutus-tx` feels like a more natural home for these, since that's where
our "standard library" lives, and they're pretty general data
structures, rather than being ledger-specific.