### PR TITLE
plutus-use-cases: add some benchmarks for crypto and multisig

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -54257,7 +54257,10 @@ license = stdenv.lib.licenses.asl20;
 , base
 , bytestring
 , containers
+, criterion
+, cryptonite
 , hedgehog
+, language-plutus-core
 , lens
 , mtl
 , plutus-emulator
@@ -54299,6 +54302,16 @@ tasty
 tasty-hedgehog
 tasty-hunit
 text
+];
+benchmarkHaskellDepends = [
+base
+bytestring
+criterion
+cryptonite
+language-plutus-core
+lens
+plutus-tx
+plutus-wallet-api
 ];
 doHaddock = false;
 description = "Collection of smart contracts to develop the plutus/wallet interface";

--- a/plutus-use-cases/bench/Bench.hs
+++ b/plutus-use-cases/bench/Bench.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DataKinds         #-}
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+module Main (main) where
+
+import           Prelude                                           hiding (tail)
+
+import           Control.Lens.Indexed
+import           Criterion.Main
+import           Crypto.Hash
+import qualified Data.ByteString                                   as BS
+import qualified Language.PlutusTx.Coordination.Contracts.MultiSig as MS
+import qualified Language.PlutusTx.Prelude                         as P
+import           Ledger
+import           Ledger.Ada                                        as Ada
+import qualified Ledger.Crypto                                     as Crypto
+import           Ledger.Value                                      as Value
+import           LedgerBytes
+import           Wallet
+
+main :: IO ()
+main = defaultMain [ expensive, plutus ]
+
+-- | Execution of some expensive operations that we can relevantly compare ourselves against.
+expensive :: Benchmark
+expensive = bgroup "expensive" [ verifySignatureB, hashB ]
+
+-- | Execution of signature verification, which is something that the validating nodes will have
+-- to do frequently, and typically >1 time per transaction.
+verifySignatureB :: Benchmark
+verifySignatureB = bgroup "verifySignature" (imap (\i d -> bench ("verifySignature-" <> show i) $ nf verifySignature d) signatureData)
+    where
+        signatureData :: [(PubKey, Digest SHA256, Signature)]
+        signatureData =
+            [ ( pk1 , txHash , sig1)
+            , ( pk2 , txHash , sig2)
+            ]
+
+-- | Hashing is also potentially expensive.
+hashB :: Benchmark
+hashB = bgroup "hash" (imap (\i d -> bench ("hash-" <> show i) $ nf hashit d) hashData)
+    where
+        -- TODO: check that this is the right hash function to check against
+        hashit :: BS.ByteString -> Digest SHA256
+        hashit = hash
+        hashData :: [BS.ByteString]
+        hashData = ["", "looooooooooooooooooooooooooooooooooooooooooooooooong"]
+
+-- | Execution of some Plutus programs.
+plutus :: Benchmark
+plutus = bgroup "plutus" [ trivial, fibB, sumB, tailB, multisig ]
+
+-- | The trivial validator script that just returns 'True'.
+trivial :: Benchmark
+trivial = bgroup "trivial" [
+        bench "nocheck" $ nf runScriptNoCheck (validationData1, validator, unitData, unitRedeemer),
+        bench "typecheck" $ nf runScriptCheck (validationData1, validator, unitData, unitRedeemer)
+    ]
+    where
+        validator = ValidatorScript $$(Ledger.compileScript [|| \() () (_::PendingTx) -> True ||])
+
+-- | The fibonnaci function.
+fibB :: Benchmark
+fibB = bgroup "fib" [
+        bench "5" $ nf runScriptNoCheck (validationData1, validator5, unitData, unitRedeemer),
+        bench "10" $ nf runScriptNoCheck (validationData1, validator10, unitData, unitRedeemer),
+        bench "typecheck" $ nf runScriptCheck (validationData1, validator5, unitData, unitRedeemer)
+    ]
+    where
+        fib :: Integer -> Integer
+        fib n =
+            if n P.== 0
+            then 0
+            else if n P.== 1
+            then 1
+            else fib (n `P.minus` 1) `P.plus` fib (n `P.minus` 2)
+        validator5 = ValidatorScript $$(Ledger.compileScript
+                                         [|| \() () (_::PendingTx) -> fib 5 P.== 5 ||])
+        validator10 = ValidatorScript $$(Ledger.compileScript
+                                         [|| \() () (_::PendingTx) -> fib 10 P.== 55 ||])
+
+-- | Summing a list.
+sumB :: Benchmark
+sumB = bgroup "sum" [
+        bench "5" $ nf runScriptNoCheck (validationData1, validator5, unitData, unitRedeemer),
+        bench "20" $ nf runScriptNoCheck (validationData1, validator20, unitData, unitRedeemer),
+        bench "typecheck" $ nf runScriptCheck (validationData1, validator5, unitData, unitRedeemer)
+    ]
+    where
+        fromTo :: Integer -> Integer -> [Integer]
+        fromTo f t =
+            if f P.== t then [f]
+            else f:(fromTo (f `P.plus` 1) t)
+
+        validator5 = ValidatorScript $$(Ledger.compileScript
+                                         [|| \() () (_::PendingTx) -> P.foldr P.plus 0 (fromTo 1 5) P.== 15 ||])
+        validator20 = ValidatorScript $$(Ledger.compileScript
+                                         [|| \() () (_::PendingTx) -> P.foldr P.plus 0 (fromTo 1 20) P.== 210 ||])
+
+-- | This aims to exercise some reasonably substantial computation *without* using any builtins.
+-- Hence we also provide explicitly constructed lists, rather than writing 'replicate', which would
+-- require integers.
+tailB :: Benchmark
+tailB = bgroup "tail" [
+        bench "5" $ nf runScriptNoCheck (validationData1, validator5, unitData, unitRedeemer),
+        bench "20" $ nf runScriptNoCheck (validationData1, validator20, unitData, unitRedeemer),
+        bench "typecheck" $ nf runScriptCheck (validationData1, validator5, unitData, unitRedeemer)
+    ]
+    where
+        tail :: [a] -> Maybe a
+        tail [] = Nothing
+        tail (x:[]) = Just x
+        tail (_:xs) = tail xs
+
+        validator5 = ValidatorScript $$(Ledger.compileScript
+                                         [|| \() () (_::PendingTx) -> tail [(), (), (), (), ()] P.== Just () ||])
+        validator20 = ValidatorScript $$(Ledger.compileScript
+                                         [|| \() () (_::PendingTx) -> tail [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] P.== Just () ||])
+
+-- | The multisig contract is one of the simplest ones that we have. This runs a number of different scenarios.
+-- Note that multisig also does some signature verification!
+multisig :: Benchmark
+multisig = bgroup "multisig" [
+        bench "1of1" $ nf runScriptNoCheck
+            (validationData2
+            , MS.msValidator msScen1of1
+            , MS.msDataScript
+            , MS.msRedeemer),
+        bench "1of2" $ nf runScriptNoCheck
+            (validationData2
+            , MS.msValidator msScen1of2
+            , MS.msDataScript
+            , MS.msRedeemer),
+        bench "2of2" $ nf runScriptNoCheck
+            (validationData2
+            , MS.msValidator msScen2of2
+            , MS.msDataScript
+            , MS.msRedeemer),
+        bench "typecheck" $ nf runScriptCheck
+            (validationData2
+            , MS.msValidator msScen1of1
+            , MS.msDataScript
+            , MS.msRedeemer)
+    ]
+    where
+        msScen1of1 = MS.MultiSig { MS.signatories = [pk1], MS.requiredSignatures = 1 }
+        msScen1of2 = MS.MultiSig { MS.signatories = [pk1, pk2], MS.requiredSignatures = 1 }
+        msScen2of2 = MS.MultiSig { MS.signatories = [pk1, pk2], MS.requiredSignatures = 2 }
+
+-- Test functions and data
+
+verifySignature :: (PubKey, Digest SHA256, Signature) -> Bool
+verifySignature (PubKey (LedgerBytes k), m, Signature s) = P.verifySignature k (plcDigest m) s
+
+runScriptNoCheck :: (ValidationData, ValidatorScript, DataScript, RedeemerScript) -> ([String], Bool)
+runScriptNoCheck (vd, v, d, r) = runScript DontCheck vd v d r
+runScriptCheck :: (ValidationData, ValidatorScript, DataScript, RedeemerScript) -> ([String], Bool)
+runScriptCheck (vd, v, d, r) = runScript Typecheck vd v d r
+
+privk1 :: PrivateKey
+privk1 = Crypto.knownPrivateKeys !! 0
+pk1 :: PubKey
+pk1 = Crypto.toPublicKey privk1
+
+privk2 :: PrivateKey
+privk2 = Crypto.knownPrivateKeys !! 1
+pk2 :: PubKey
+pk2 = Crypto.toPublicKey privk2
+
+txHash :: Digest SHA256
+txHash = hash (""::BS.ByteString)
+
+sig1 :: Signature
+sig1 = Crypto.sign txHash privk1
+
+sig2 :: Signature
+sig2 = Crypto.sign txHash privk2
+
+validationData1 :: ValidationData
+validationData1 = ValidationData $ lifted $ mockPendingTx
+
+validationData2 :: ValidationData
+validationData2 = ValidationData $ lifted $ mockPendingTx { pendingTxSignatures = [(pk1, sig1), (pk2, sig2)] }
+
+mockPendingTx :: PendingTx
+mockPendingTx = PendingTx
+    { pendingTxInputs = []
+    , pendingTxOutputs = []
+    , pendingTxFee = Ada.zero
+    , pendingTxForge = Value.zero
+    , pendingTxIn = PendingTxIn
+        { pendingTxInRef = PendingTxOutRef
+            { pendingTxOutRefId = TxHash P.emptyByteString
+            , pendingTxOutRefIdx = 0
+            }
+        , pendingTxInWitness = Nothing
+        , pendingTxInValue = Value.zero
+        }
+    , pendingTxValidRange = defaultSlotRange
+    , pendingTxSignatures = []
+    , pendingTxHash = TxHash P.emptyByteString
+    }

--- a/plutus-use-cases/bench/IFix.hs
+++ b/plutus-use-cases/bench/IFix.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE GADTs #-}
+module IFix where
+
+data IFix f a where
+    Wrap :: f (IFix f) a -> IFix f a

--- a/plutus-use-cases/bench/Recursion.hs
+++ b/plutus-use-cases/bench/Recursion.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators       #-}
+module Recursion where
+
+import           Data.Functor.Identity
+
+import           IFix
+
+newtype SelfF f a = SelfF (f a -> a)
+-- | Values that can be applied to themselves.
+type Self a = IFix SelfF a
+
+-- Some of these need to be NOINLINE to prevent a known
+-- loop in GHC's simplifier!
+
+{-# NOINLINE self #-}
+self :: forall a . (Self a -> a) -> Self a
+self f = Wrap $ SelfF f
+
+{-# NOINLINE unself #-}
+unself :: forall a . Self a -> Self a -> a
+unself (Wrap (SelfF s)) = s
+
+{-# NOINLINE selfApply #-}
+selfApply :: forall a . Self a -> a
+selfApply s = unself s s
+
+z :: forall a b . ((a -> b) -> (a -> b)) -> (a -> b)
+z f = let a r = f (\x -> selfApply r x) in a (self a)
+
+infixr 0 $$
+-- | Natural transformation. Reified to aid GHC's type inference.
+newtype f ~> g = NT { ($$) :: forall q . f q -> g q }
+
+(<.>) :: (b ~> c) -> (a ~> b) -> (a ~> c)
+NT f <.> NT g = NT (f . g)
+
+fixBy :: forall f .
+    ((f ~> Identity) -> (f ~> Identity)) ->
+    ((f ~> f) -> (f ~> Identity))
+fixBy by = z rr where
+    rr :: ((f ~> f) -> (f ~> Identity)) -> ((f ~> f) -> (f ~> Identity))
+    rr r g = by (r g) <.> g
+
+-- | Named type representing '\b . a -> b'. Reified to aid GHC's type inference.
+newtype Arr a b = Arr (a -> b)
+-- | Named type representing '\c . a -> b -> c'. Reified to aid GHC's type inference.
+newtype ArrArr a b c = ArrArr (a -> b -> c)
+
+by1z :: forall a1 b1 . (Arr (a1 -> b1) ~> Identity) -> (Arr (a1 -> b1) ~> Identity)
+by1z r = NT $ \(Arr k) -> Identity $ k
+    (\x -> runIdentity $ r $$ Arr (\f1 -> f1 x))
+
+fix1z :: forall a1 b1 . (Arr (a1 -> b1) ~> Arr (a1 -> b1)) -> (Arr (a1 -> b1) ~> Identity)
+fix1z = fixBy by1z
+
+fix1zSimple :: forall a b . ((a -> b) -> (a -> b)) -> (a -> b)
+fix1zSimple selfImpl a = runIdentity $ nt $$ Arr $ \f -> f a
+    where
+        nt :: Arr (a -> b) ~> Identity
+        nt = fix1z $ NT $ \(Arr sel) -> Arr $ \r -> sel $ selfImpl r
+
+by2z :: forall a1 b1 a2 b2 . (ArrArr (a1 -> b1) (a2 -> b2) ~> Identity) -> (ArrArr (a1 -> b1) (a2 -> b2) ~> Identity)
+by2z r = NT $ \(ArrArr k) -> Identity $ k
+    (\x -> runIdentity $ r $$ ArrArr (\f1 _f2 -> f1 x))
+    (\x -> runIdentity $ r $$ ArrArr (\_f1 f2 -> f2 x))
+
+fix2z :: forall a1 b1 a2 b2 . (ArrArr (a1 -> b1) (a2 -> b2) ~> ArrArr (a1 -> b1) (a2 -> b2)) -> (ArrArr (a1 -> b1) (a2 -> b2) ~> Identity)
+fix2z = fixBy by2z

--- a/plutus-use-cases/bench/Scott.hs
+++ b/plutus-use-cases/bench/Scott.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Scott where
+
+import           Prelude hiding (replicate, tail)
+
+import           IFix
+
+{-# ANN module "HLint: ignore" #-}
+
+newtype ScottListF f a = ScottListF (forall r . r -> (a -> f a -> r) -> r)
+type ScottList a = IFix ScottListF a
+
+nil :: ScottList a
+nil = Wrap $ ScottListF $ \z _c -> z
+
+cons :: a -> ScottList a -> ScottList a
+cons h t = Wrap $ ScottListF $ \_z c -> c h t
+
+matchList :: ScottList a -> r -> (a -> ScottList a -> r) -> r
+matchList (Wrap (ScottListF f)) = f
+
+fromTo :: Integer -> Integer -> ScottList Integer
+fromTo f t =
+    if f == t then f `cons` nil
+    else f `cons` fromTo (f + 1) t
+
+replicate :: Integer -> a -> ScottList a
+replicate n a = if n == 0 then nil else a `cons` replicate (n-1) a

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -101,6 +101,10 @@ benchmark plutus-use-cases-bench
     type: exitcode-stdio-1.0
     main-is: Bench.hs
     hs-source-dirs: bench
+    other-modules:
+        Scott
+        Recursion
+        IFix
     default-language: Haskell2010
     ghc-options: -Wall -Wincomplete-uni-patterns
                  -Wincomplete-record-updates -Wredundant-constraints -Widentities

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -51,14 +51,13 @@ library
                  -- See Plutus Tx readme
                  -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
     build-depends:
-        plutus-tx -any,
-        plutus-wallet-api -any,
-        plutus-emulator -any
-    build-depends:
         base -any,
         bytestring -any,
         containers -any,
         mtl -any,
+        plutus-tx -any,
+        plutus-wallet-api -any,
+        plutus-emulator -any,
         template-haskell -any,
         lens -any,
         text -any
@@ -85,16 +84,34 @@ test-suite plutus-use-cases-test
                  -Wincomplete-uni-patterns -Wincomplete-record-updates
                  -Wredundant-constraints -Widentities -rtsopts
     build-depends:
-        plutus-wallet-api -any,
-        plutus-use-cases -any,
-        plutus-emulator -any
-    build-depends:
         base >=4.9 && <5,
         containers -any,
         hedgehog -any,
+        plutus-wallet-api -any,
+        plutus-use-cases -any,
+        plutus-emulator -any,
         tasty -any,
         tasty-hunit -any,
         tasty-hedgehog >=0.2.0.0,
         text -any,
         lens -any,
         mtl -any
+
+benchmark plutus-use-cases-bench
+    type: exitcode-stdio-1.0
+    main-is: Bench.hs
+    hs-source-dirs: bench
+    default-language: Haskell2010
+    ghc-options: -Wall -Wincomplete-uni-patterns
+                 -Wincomplete-record-updates -Wredundant-constraints -Widentities
+                 -rtsopts
+    build-depends:
+        base -any,
+        criterion -any,
+        cryptonite -any,
+        language-plutus-core -any,
+        lens -any,
+        plutus-tx -any,
+        plutus-use-cases -any,
+        plutus-wallet-api -any,
+        bytestring -any

--- a/plutus-wallet-api/ledger/Ledger/Index.hs
+++ b/plutus-wallet-api/ledger/Ledger/Index.hs
@@ -238,7 +238,7 @@ checkMatch v = \case
             let v' = ValidationData
                     $ lifted
                     $ v { pendingTxIn = pTxIn }
-                (logOut, success) = runScript v' vl d r
+                (logOut, success) = runScript Typecheck v' vl d r
             if success
             then pure ()
             else throwError $ ScriptFailure logOut

--- a/plutus-wallet-api/ledger/Ledger/Validation.hs
+++ b/plutus-wallet-api/ledger/Ledger/Validation.hs
@@ -28,6 +28,7 @@ module Ledger.Validation
     , plcValidatorDigest
     , plcRedeemerHash
     , plcTxHash
+    , plcDigest
     , plcCurrencySymbol
     , validatorScriptHash
     -- * Oracles


### PR DESCRIPTION
This adds some very basic benchmarks comparing:
- Signature verification, which is the main cryptographic operation that
  we perform.
- Hashing.
- Execution of a trivial validator that returns `True`.
- Execution of `fib`.
- Execution of `sum`.
- Execution of `tail`.
- Execution of the multi-sig contract. Multi-sig is more-or-less the
  simplest contract that we have which does some reasonable work.

I haven't added any of the other use-cases yet, or other cryptographic
functions.

High-level takeaways:
- Both signature verification and simple script execution come out at
  ~50 microseconds on my machine.
- As scripts get more complex execution easily gets into 100s of
  microseconds.
    - Note that multi-sig does some signature validation, so is inflated
      by that.
    - Computing fibonnaci numbers can rapidly get out of hand. `fib 10`
      takes 1ms, `fib 20` (not included) takes 160ms! Not unexpected as the
      naive version is exponential without sharing.
    - Not all the slowdown is due to builtins: the tail benchmark also slows down a
      fair amount, so the "pure" computation is also quite expensive.
- Typechecking is *much* more expensive than everything else.
  Typechecking even the trivial script takes ~20ms.

Overall I would say this doesn't support the claim that script execution
is *dominated* by cryptographic operations. Perhaps there are other
expensive operations we should check against?

However, I don't think we're *problematically* slow. If we could sneak
out an order-of-magnitude speedup that would certianly be nice, though.