### PR TITLE
Playgrounds: link to the master version of the changelog

### DIFF
--- a/plutus-playground-client/src/MainFrame.purs
+++ b/plutus-playground-client/src/MainFrame.purs
@@ -67,7 +67,6 @@ import MonadApp (class MonadApp, editorGetContents, editorGotoLine, editorSetAnn
 import Network.RemoteData (RemoteData(NotAsked, Loading, Failure, Success), _Success, isSuccess)
 import Playground.API (KnownCurrency(..), SimulatorWallet(SimulatorWallet), _CompilationResult, _FunctionSchema)
 import Playground.Server (SPParams_)
-import Playground.Usecases (gitRev)
 import Prelude (type (~>), Unit, Void, bind, const, discard, flip, join, map, pure, show, unit, unless, when, ($), (&&), (+), (-), (<$>), (<*>), (<<<), (<>), (==), (>>=))
 import Servant.PureScript.Settings (SPSettings_)
 import StaticData as StaticData
@@ -574,7 +573,7 @@ bannerMessage =
     ]
     [ text "Plutus Beta - Updated 11th April 2019 - See the "
     , a
-        [ href ("https://github.com/input-output-hk/plutus/blob/" <> gitRev <> "/CHANGELOG.md") ]
+        [ href ("https://github.com/input-output-hk/plutus/blob/master/CHANGELOG.md") ]
         [ text "CHANGELOG" ]
     ]
 


### PR DESCRIPTION
The changelog should be append-only, so it should be okay to just send
people to the latest one.

This also removes another usage of the baked-in git revision.

(I'm not 100% sure this is a good idea, but I think it is.)