### PR TITLE
plutus-tx: reverse GHC's OccName tidying

### DIFF
--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
@@ -29,8 +29,9 @@ import qualified TysPrim                                as GHC
 
 import qualified Language.PlutusIR                      as PIR
 import qualified Language.PlutusIR.Compiler.Definitions as PIR
-import           Language.PlutusIR.Compiler.Names
 import qualified Language.PlutusIR.MkPir                as PIR
+
+import qualified Language.PlutusCore.Name               as PLC
 
 import           Control.Monad.Extra
 import           Control.Monad.Reader
@@ -38,7 +39,6 @@ import           Control.Monad.Reader
 import           Data.List                              (reverse, sortBy)
 import qualified Data.List.NonEmpty                     as NE
 import qualified Data.Set                               as Set
-import qualified Data.Text                              as T
 import           Data.Traversable
 
 -- Types
@@ -108,7 +108,7 @@ compileTyCon tc
                     PIR.recordAlias @LexName @() (LexName tcName)
                     pure alias
                 Nothing -> do
-                    matchName <- safeFreshName () $ (T.pack $ GHC.getOccString $ GHC.getName tc) <> "_match"
+                    matchName <- PLC.mapNameString (<> "_match") <$> (compileNameFresh $ GHC.getName tc)
 
                     -- See Note [Occurrences of recursive names]
                     let fakeDatatype = PIR.Datatype () tvd [] matchName []

--- a/plutus-tx/test/Plugin/Data/monomorphic/defaultCase.plc.golden
+++ b/plutus-tx/test/Plugin/Data/monomorphic/defaultCase.plc.golden
@@ -6,9 +6,9 @@
         (tyvardecl MyMonoData (type))
         
         MyMonoData_match
-        (vardecl Mono1 (fun (con integer) (fun (con integer) MyMonoData)))
-        (vardecl Mono2 (fun (con integer) MyMonoData))
-        (vardecl Mono3 (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) (fun (con integer) MyMonoData)))
+        (vardecl Mono (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) MyMonoData))
       )
     )
     (lam

--- a/plutus-tx/test/Plugin/Data/monomorphic/enum.plc.golden
+++ b/plutus-tx/test/Plugin/Data/monomorphic/enum.plc.golden
@@ -6,9 +6,9 @@
         (tyvardecl MyEnum (type))
         
         MyEnum_match
-        (vardecl Enum1 MyEnum) (vardecl Enum2 MyEnum)
+        (vardecl Enum MyEnum) (vardecl Enum MyEnum)
       )
     )
-    Enum1
+    Enum
   )
 )

--- a/plutus-tx/test/Plugin/Data/monomorphic/irrefutableMatch.plc.golden
+++ b/plutus-tx/test/Plugin/Data/monomorphic/irrefutableMatch.plc.golden
@@ -6,9 +6,9 @@
         (tyvardecl MyMonoData (type))
         
         MyMonoData_match
-        (vardecl Mono1 (fun (con integer) (fun (con integer) MyMonoData)))
-        (vardecl Mono2 (fun (con integer) MyMonoData))
-        (vardecl Mono3 (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) (fun (con integer) MyMonoData)))
+        (vardecl Mono (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) MyMonoData))
       )
     )
     (let

--- a/plutus-tx/test/Plugin/Data/monomorphic/monoCase.plc.golden
+++ b/plutus-tx/test/Plugin/Data/monomorphic/monoCase.plc.golden
@@ -6,9 +6,9 @@
         (tyvardecl MyMonoData (type))
         
         MyMonoData_match
-        (vardecl Mono1 (fun (con integer) (fun (con integer) MyMonoData)))
-        (vardecl Mono2 (fun (con integer) MyMonoData))
-        (vardecl Mono3 (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) (fun (con integer) MyMonoData)))
+        (vardecl Mono (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) MyMonoData))
       )
     )
     (lam

--- a/plutus-tx/test/Plugin/Data/monomorphic/monoConstructed.plc.golden
+++ b/plutus-tx/test/Plugin/Data/monomorphic/monoConstructed.plc.golden
@@ -6,11 +6,11 @@
         (tyvardecl MyMonoData (type))
         
         MyMonoData_match
-        (vardecl Mono1 (fun (con integer) (fun (con integer) MyMonoData)))
-        (vardecl Mono2 (fun (con integer) MyMonoData))
-        (vardecl Mono3 (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) (fun (con integer) MyMonoData)))
+        (vardecl Mono (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) MyMonoData))
       )
     )
-    [ Mono2 (con 1) ]
+    [ Mono (con 1) ]
   )
 )

--- a/plutus-tx/test/Plugin/Data/monomorphic/monoConstructor.plc.golden
+++ b/plutus-tx/test/Plugin/Data/monomorphic/monoConstructor.plc.golden
@@ -6,11 +6,11 @@
         (tyvardecl MyMonoData (type))
         
         MyMonoData_match
-        (vardecl Mono1 (fun (con integer) (fun (con integer) MyMonoData)))
-        (vardecl Mono2 (fun (con integer) MyMonoData))
-        (vardecl Mono3 (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) (fun (con integer) MyMonoData)))
+        (vardecl Mono (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) MyMonoData))
       )
     )
-    Mono1
+    Mono
   )
 )

--- a/plutus-tx/test/Plugin/Data/monomorphic/monoDataType.plc.golden
+++ b/plutus-tx/test/Plugin/Data/monomorphic/monoDataType.plc.golden
@@ -6,9 +6,9 @@
         (tyvardecl MyMonoData (type))
         
         MyMonoData_match
-        (vardecl Mono1 (fun (con integer) (fun (con integer) MyMonoData)))
-        (vardecl Mono2 (fun (con integer) MyMonoData))
-        (vardecl Mono3 (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) (fun (con integer) MyMonoData)))
+        (vardecl Mono (fun (con integer) MyMonoData))
+        (vardecl Mono (fun (con integer) MyMonoData))
       )
     )
     (lam ds MyMonoData ds)

--- a/plutus-tx/test/Plugin/Data/monomorphic/nonValueCase.plc.golden
+++ b/plutus-tx/test/Plugin/Data/monomorphic/nonValueCase.plc.golden
@@ -6,7 +6,7 @@
         (tyvardecl MyEnum (type))
         
         MyEnum_match
-        (vardecl Enum1 MyEnum) (vardecl Enum2 MyEnum)
+        (vardecl Enum MyEnum) (vardecl Enum MyEnum)
       )
     )
     (let

--- a/plutus-tx/test/Plugin/Data/polymorphic/defaultCasePoly.plc.golden
+++ b/plutus-tx/test/Plugin/Data/polymorphic/defaultCasePoly.plc.golden
@@ -6,8 +6,8 @@
         (tyvardecl MyPolyData (fun (type) (fun (type) (type))))
         (tyvardecl a (type)) (tyvardecl b (type))
         MyPolyData_match
-        (vardecl Poly1 (fun a (fun b [[MyPolyData a] b])))
-        (vardecl Poly2 (fun a [[MyPolyData a] b]))
+        (vardecl Poly (fun a (fun b [[MyPolyData a] b])))
+        (vardecl Poly (fun a [[MyPolyData a] b]))
       )
     )
     (lam

--- a/plutus-tx/test/Plugin/Data/polymorphic/polyConstructed.plc.golden
+++ b/plutus-tx/test/Plugin/Data/polymorphic/polyConstructed.plc.golden
@@ -6,10 +6,10 @@
         (tyvardecl MyPolyData (fun (type) (fun (type) (type))))
         (tyvardecl a (type)) (tyvardecl b (type))
         MyPolyData_match
-        (vardecl Poly1 (fun a (fun b [[MyPolyData a] b])))
-        (vardecl Poly2 (fun a [[MyPolyData a] b]))
+        (vardecl Poly (fun a (fun b [[MyPolyData a] b])))
+        (vardecl Poly (fun a [[MyPolyData a] b]))
       )
     )
-    [ [ { { Poly1 (con integer) } (con integer) } (con 1) ] (con 2) ]
+    [ [ { { Poly (con integer) } (con integer) } (con 1) ] (con 2) ]
   )
 )

--- a/plutus-tx/test/Plugin/Data/polymorphic/polyDataType.plc.golden
+++ b/plutus-tx/test/Plugin/Data/polymorphic/polyDataType.plc.golden
@@ -6,8 +6,8 @@
         (tyvardecl MyPolyData (fun (type) (fun (type) (type))))
         (tyvardecl a (type)) (tyvardecl b (type))
         MyPolyData_match
-        (vardecl Poly1 (fun a (fun b [[MyPolyData a] b])))
-        (vardecl Poly2 (fun a [[MyPolyData a] b]))
+        (vardecl Poly (fun a (fun b [[MyPolyData a] b])))
+        (vardecl Poly (fun a [[MyPolyData a] b]))
       )
     )
     (lam ds [[MyPolyData (con integer)] (con integer)] ds)

--- a/plutus-tx/test/Plugin/Functions/unfoldings/recordSelector.plc.golden
+++ b/plutus-tx/test/Plugin/Functions/unfoldings/recordSelector.plc.golden
@@ -21,7 +21,7 @@
           MyMonoRecord
           [
             { [ MyMonoRecord_match ds ] (con integer) }
-            (lam ds1 (con integer) (lam ds2 (con integer) ds1))
+            (lam ds (con integer) (lam ds (con integer) ds))
           ]
         )
       )

--- a/plutus-tx/test/Plugin/Functions/unfoldings/recordSelectorExternal.plc.golden
+++ b/plutus-tx/test/Plugin/Functions/unfoldings/recordSelectorExternal.plc.golden
@@ -19,7 +19,7 @@
           MyExternalRecord
           [
             { [ MyExternalRecord_match ds ] (con integer) }
-            (lam ds1 (con integer) ds1)
+            (lam ds (con integer) ds)
           ]
         )
       )

--- a/plutus-tx/test/Plugin/Laziness/joinError.plc.golden
+++ b/plutus-tx/test/Plugin/Laziness/joinError.plc.golden
@@ -13,7 +13,7 @@
       )
       (let
         (nonrec)
-        (termbind (nonstrict) (vardecl joinError1 Unit) [ { error Unit } Unit ])
+        (termbind (nonstrict) (vardecl joinError Unit) [ { error Unit } Unit ])
         (let
           (nonrec)
           (datatypebind
@@ -46,7 +46,7 @@
                             [
                               [
                                 { [ Bool_match y ] (fun Unit Unit) }
-                                (lam thunk Unit joinError1)
+                                (lam thunk Unit joinError)
                               ]
                               (lam thunk Unit Unit)
                             ]

--- a/plutus-tx/test/Plugin/Typeclasses/defaultMethods.plc.golden
+++ b/plutus-tx/test/Plugin/Typeclasses/defaultMethods.plc.golden
@@ -4,8 +4,7 @@
     )
     (termbind
       (strict)
-      (vardecl fDefaultMethodsInteger_cmethod1 (fun (con integer) (con integer))
-      )
+      (vardecl fDefaultMethodsInteger_cmethod (fun (con integer) (con integer)))
       (lam a (con integer) a)
     )
     (let
@@ -24,7 +23,7 @@
         (termbind
           (strict)
           (vardecl
-            fDefaultMethodsInteger_cmethod2 (fun (con integer) (con integer))
+            fDefaultMethodsInteger_cmethod (fun (con integer) (con integer))
           )
           (lam a (con integer) [ [ addInteger a ] (con 1) ])
         )
@@ -53,9 +52,9 @@
               [
                 [
                   { CConsDefaultMethods (con integer) }
-                  fDefaultMethodsInteger_cmethod1
+                  fDefaultMethodsInteger_cmethod
                 ]
-                fDefaultMethodsInteger_cmethod2
+                fDefaultMethodsInteger_cmethod
               ]
             )
             (let
@@ -64,7 +63,7 @@
               (termbind
                 (strict)
                 (vardecl
-                  method2
+                  method
                   (all a (type) (fun [DefaultMethods a] (fun a (con integer))))
                 )
                 (abs
@@ -98,7 +97,7 @@
                     (lam
                       dDefaultMethods
                       [DefaultMethods a]
-                      (lam a a [ [ { method2 a } dDefaultMethods ] a ])
+                      (lam a a [ [ { method a } dDefaultMethods ] a ])
                     )
                   )
                 )


### PR DESCRIPTION
I've observed these being nondeterministic on bigger examples (possibly
related to the order in which modules are processed). So we kind of have
to strip them.

This has two annoying downsides:
- We strip "real" trailing digits from names (witness the diffs in the
  `plutus-tx` tests).
- We lose the disambiguation they provide. This is especially annoying
  for generated names like the many occurrences of `ds`.

We could regain the disambiguation by running our *own* disambiguation
pass, which would be deterministic. Not sure if this is worth it, I'll
probably just see how annoying it is in practice.

I hope this will fix https://github.com/input-output-hk/plutus/pull/1167.