### PR TITLE
fixed bug #1005

### DIFF
--- a/plutus-playground-client/src/Chain/BlockchainExploration.purs
+++ b/plutus-playground-client/src/Chain/BlockchainExploration.purs
@@ -197,7 +197,7 @@ toBalanceMap =
           = Tuple (Tuple (ScriptIx owner hash) row) (CurrencyBalance currencyBalances)
 
 adaCurrencySymbol :: CurrencySymbol
-adaCurrencySymbol = CurrencySymbol { unCurrencySymbol: "5fff" }
+adaCurrencySymbol = CurrencySymbol { unCurrencySymbol: "" }
 
 adaTokenName :: TokenName
 adaTokenName = TokenName { unTokenName: "" }

--- a/plutus-playground-client/src/ValueEditor.purs
+++ b/plutus-playground-client/src/ValueEditor.purs
@@ -54,7 +54,7 @@ balanceRow handler currencyIndex currencySymbol tokenIndex (Tuple tokenName amou
         [ label
             [ classes [ col, colFormLabel ] ]
             [ text $ case view _currencySymbol currencySymbol, view _tokenName tokenName of
-                       "5fff", "" -> "Ada"
+                       "", ""   -> "Ada"
                        _, other -> other
             ]
         , col_

--- a/plutus-playground-client/test/TypesTests.purs
+++ b/plutus-playground-client/test/TypesTests.purs
@@ -163,7 +163,7 @@ simpleArgumentToJsonTests = do
             ]
       equalJson
         (Just (encodeJSON (FO.singleton "getValue" [
-                              [ encode (FO.singleton "unCurrencySymbol" "5fff")
+                              [ encode (FO.singleton "unCurrencySymbol" "")
                               , encode [
                                    [ encode (FO.singleton "unTokenName" "")
                                    , encode 4
@@ -174,7 +174,7 @@ simpleArgumentToJsonTests = do
         (simpleArgumentToJson
           (ValueArgument
              valueSchema
-             (Value { getValue: (LedgerMap [CurrencySymbol { unCurrencySymbol: "5fff" } /\ LedgerMap [TokenName { unTokenName: "" } /\ 4]]) })))
+             (Value { getValue: (LedgerMap [CurrencySymbol { unCurrencySymbol: "" } /\ LedgerMap [TokenName { unTokenName: "" } /\ 4]]) })))
 
     test "Objects" $ do
       let objectSchema = SimpleObjectSchema [ JsonTuple $ Tuple "name" SimpleStringSchema

--- a/plutus-playground-client/test/compilation_response1.json
+++ b/plutus-playground-client/test/compilation_response1.json
@@ -4,7 +4,7 @@
     "result": {
       "knownCurrencies": [
         {
-          "hash": "5fff",
+          "hash": "",
           "friendlyName": "Ada",
           "knownTokens": [
             {

--- a/plutus-playground-client/test/evaluation_response1.json
+++ b/plutus-playground-client/test/evaluation_response1.json
@@ -93,7 +93,7 @@
                   ],
                   [
                     {
-                      "unCurrencySymbol": "5fff"
+                      "unCurrencySymbol": ""
                     },
                     [
                       [
@@ -140,7 +140,7 @@
                   ],
                   [
                     {
-                      "unCurrencySymbol": "5fff"
+                      "unCurrencySymbol": ""
                     },
                     [
                       [
@@ -216,7 +216,7 @@
               ],
               [
                 {
-                  "unCurrencySymbol": "5fff"
+                  "unCurrencySymbol": ""
                 },
                 [
                   [
@@ -254,7 +254,7 @@
                   ],
                   [
                     {
-                      "unCurrencySymbol": "5fff"
+                      "unCurrencySymbol": ""
                     },
                     [
                       [
@@ -301,7 +301,7 @@
                   ],
                   [
                     {
-                      "unCurrencySymbol": "5fff"
+                      "unCurrencySymbol": ""
                     },
                     [
                       [
@@ -433,7 +433,7 @@
           ],
           [
             {
-              "unCurrencySymbol": "5fff"
+              "unCurrencySymbol": ""
             },
             [
               [
@@ -474,7 +474,7 @@
           ],
           [
             {
-              "unCurrencySymbol": "5fff"
+              "unCurrencySymbol": ""
             },
             [
               [

--- a/plutus-playground-client/test/known_currency.json
+++ b/plutus-playground-client/test/known_currency.json
@@ -1,5 +1,5 @@
 {
-  "hash": "5fff",
+  "hash": "",
   "friendlyName": "Ada",
   "knownTokens": [
     {


### PR DESCRIPTION
The playground used currency symbol "5fff" for Ada, whereas `Ledger.Ada` used the empty string. I changed all occurences of "5fff" to "".