### PR TITLE
Mark .pir files as linguist-detectable=false

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 pkgs/default.nix linguist-generated=true
 meadow-client/yarn.nix linguist-generated=true
 plutus-playground-client/yarn.nix linguist-generated=true
+*.pir linguist-detectable=false


### PR DESCRIPTION
I think this will stop them contributing to our stats. Ideally I'd mark
them as "no language" but I can't find out how to do that.