### PR TITLE
ledger: Fix JSON instances for ValidatorHash et al.

### DIFF
--- a/plutus-playground-lib/test/Playground/APISpec.hs
+++ b/plutus-playground-lib/test/Playground/APISpec.hs
@@ -4,6 +4,7 @@ module Playground.APISpec
     ( spec
     ) where
 
+import           Data.Aeson                   (encode, object, toJSON)
 import           Data.Proxy                   (Proxy (Proxy))
 import           Data.Swagger                 (toInlinedSchema)
 import           Language.Haskell.Interpreter (CompilationError (CompilationError, RawError), column, filename, row,
@@ -11,7 +12,8 @@ import           Language.Haskell.Interpreter (CompilationError (CompilationErro
 import           Ledger.Interval              (Interval)
 import           Ledger.Value                 (Value)
 import           Playground.API               (SimpleArgumentSchema (SimpleArraySchema, SimpleHexSchema, SimpleIntSchema, SimpleObjectSchema, SimpleStringSchema, SimpleTupleSchema, ValueSchema),
-                                               isSupportedByFrontend, parseErrorText, toSimpleArgumentSchema)
+                                               adaCurrency, isSupportedByFrontend, parseErrorText,
+                                               toSimpleArgumentSchema)
 import           Test.Hspec                   (Spec, describe, it, shouldBe)
 
 spec :: Spec
@@ -19,6 +21,7 @@ spec = do
     parseErrorTextSpec
     toSimpleArgumentSchemaSpec
     isSupportedByFrontendSpec
+    knownCurrenciesSpec
 
 parseErrorTextSpec :: Spec
 parseErrorTextSpec =
@@ -106,3 +109,20 @@ isSupportedByFrontendSpec =
     isSupportedByFrontend
         (toSimpleArgumentSchema (toInlinedSchema (Proxy :: Proxy Value))) `shouldBe`
     True
+
+knownCurrenciesSpec :: Spec
+knownCurrenciesSpec =
+    describe "mkKnownCurrencies" $
+    it "Should serialise Ada properly" $
+    encode adaCurrency
+        `shouldBe`
+    -- note that the object is the same as
+    -- plutus-playground-client\test\known_currency.json
+    encode (object
+                [ ("hash", "")
+                , ("friendlyName", "Ada")
+                , ("knownTokens"
+                  , toJSON [
+                    object [("unTokenName", "")]
+                    ])
+                ])

--- a/plutus-wallet-api/ledger/Ledger/Validation.hs
+++ b/plutus-wallet-api/ledger/Ledger/Validation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingVia          #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE DeriveGeneric        #-}
@@ -57,14 +58,14 @@ module Ledger.Validation
 
 import           Codec.Serialise              (Serialise)
 import           Crypto.Hash                  (Digest, SHA256)
-import           Data.Aeson                   (FromJSON, ToJSON (toJSON))
-import qualified Data.Aeson                   as JSON
-import qualified Data.Aeson.Extras            as JSON
+import           Data.Aeson                   (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import qualified Data.ByteArray               as BA
 import qualified Data.ByteString.Lazy         as BSL
 import qualified Data.ByteString.Lazy.Hash    as Hash
+import           Data.Hashable                (Hashable)
 import           Data.Proxy                   (Proxy (Proxy))
 import           Data.Swagger.Internal.Schema (ToSchema (declareNamedSchema), paramSchemaToSchema, plain)
+import           Data.String                  (IsString)
 import           GHC.Generics                 (Generic)
 import qualified Language.PlutusTx.Builtins   as Builtins
 import           Language.PlutusTx.Lift       (makeLift)
@@ -190,38 +191,33 @@ them from the correct types in Haskell, and for comparing them (in
 -- | Script runtime representation of a @Digest SHA256@.
 newtype ValidatorHash =
     ValidatorHash Builtins.ByteString
-    deriving stock (Haskell.Eq, Generic)
-    deriving newtype (Eq, Serialise)
-
-instance Show ValidatorHash where
-    show = show . JSON.encodeSerialise
+    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON) via LedgerBytes
+    deriving stock (Generic)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable)
 
 instance ToSchema ValidatorHash where
     declareNamedSchema _ = plain . paramSchemaToSchema $ (Proxy :: Proxy String)
 
-instance ToJSON ValidatorHash where
-    toJSON = JSON.String . JSON.encodeSerialise
-
-instance FromJSON ValidatorHash where
-    parseJSON = JSON.decodeSerialise
-
 -- | Script runtime representation of a @Digest SHA256@.
 newtype DataScriptHash =
     DataScriptHash Builtins.ByteString
-    deriving (Haskell.Eq, Generic)
-    deriving newtype (Eq)
+    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON) via LedgerBytes
+    deriving stock (Generic)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable)
 
 -- | Script runtime representation of a @Digest SHA256@.
 newtype RedeemerHash =
     RedeemerHash Builtins.ByteString
-    deriving (Haskell.Eq, Generic)
-    deriving newtype (Eq)
+    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON) via LedgerBytes
+    deriving stock (Generic)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable)
 
 -- | Script runtime representation of a @Digest SHA256@.
 newtype TxHash =
     TxHash Builtins.ByteString
-    deriving (Haskell.Eq, Generic)
-    deriving newtype (Eq)
+    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON) via LedgerBytes
+    deriving stock (Generic)
+    deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable)
 
 {-# INLINABLE plcDataScriptHash #-}
 plcDataScriptHash :: DataScript -> DataScriptHash


### PR DESCRIPTION
The reason for the spurious 5fff hash was that the `ToJSON` instance of `ValidatorHash` serialised the hash before `toJSON`ing it, so it included some extra bytes from the serialised representation.