### PR TITLE
[PLC] [Builtin] Added the 'Sealed' gadget

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -44,11 +44,13 @@ instance Serialise TypeBuiltin where
         TyByteString -> encodeTag 0
         TyInteger    -> encodeTag 1
         TyString     -> encodeTag 2
+        TySealed     -> encodeTag 3
 
     decode = go =<< decodeTag
         where go 0 = pure TyByteString
               go 1 = pure TyInteger
               go 2 = pure TyString
+              go 3 = pure TySealed
               go _ = fail "Failed to decode TypeBuiltin"
 
 instance Serialise BuiltinName where

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/BuiltinName.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/BuiltinName.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
 
@@ -13,14 +14,19 @@ module Language.PlutusCore.Constant.Dynamic.BuiltinName
     , dynamicTraceName
     , dynamicTraceMeaningMock
     , dynamicTraceDefinitionMock
+    , dynamicSealMeaning
+    , dynamicSealDefinition
+    , dynamicUnsealMeaning
+    , dynamicUnsealDefinition
     ) where
 
-import           Language.PlutusCore.Constant.Dynamic.Instances ()
+import           Language.PlutusCore.Constant.Dynamic.Instances
 import           Language.PlutusCore.Constant.Make
 import           Language.PlutusCore.Constant.Typed
 import           Language.PlutusCore.Lexer.Type
 import           Language.PlutusCore.Type
 
+import           Data.Coerce
 import           Data.Proxy
 import           Debug.Trace                                    (trace)
 
@@ -69,3 +75,25 @@ dynamicTraceMeaningMock = DynamicBuiltinNameMeaning sch (flip trace ()) where
 dynamicTraceDefinitionMock :: DynamicBuiltinNameDefinition
 dynamicTraceDefinitionMock =
     DynamicBuiltinNameDefinition dynamicTraceName dynamicTraceMeaningMock
+
+dynamicSealMeaning :: DynamicBuiltinNameMeaning
+dynamicSealMeaning = DynamicBuiltinNameMeaning sch Sealed where
+    sch =
+        TypeSchemeAllType @"a" @0 Proxy $ \a@(_ :: Proxy a) ->
+        a `TypeSchemeArrow`
+        TypeSchemeResult (Proxy @(Sealed a))
+
+dynamicSealDefinition :: DynamicBuiltinNameDefinition
+dynamicSealDefinition =
+    DynamicBuiltinNameDefinition dynamicSealName dynamicSealMeaning
+
+dynamicUnsealMeaning :: DynamicBuiltinNameMeaning
+dynamicUnsealMeaning = DynamicBuiltinNameMeaning sch coerce where
+    sch =
+        TypeSchemeAllType @"a" @0 Proxy $ \a@(_ :: Proxy a) ->
+        Proxy @(CrossSealed a) `TypeSchemeArrow`
+        TypeSchemeResult a
+
+dynamicUnsealDefinition :: DynamicBuiltinNameDefinition
+dynamicUnsealDefinition =
+    DynamicBuiltinNameDefinition dynamicUnsealName dynamicUnsealMeaning

--- a/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
@@ -28,6 +28,7 @@ import           Numeric                            (showHex)
 data TypeBuiltin = TyByteString
                  | TyInteger
                  | TyString
+                 | TySealed
                  deriving (Show, Eq, Ord, Generic, NFData, Lift)
 
 -- | Builtin functions
@@ -193,6 +194,7 @@ instance Pretty TypeBuiltin where
     pretty TyInteger    = "integer"
     pretty TyByteString = "bytestring"
     pretty TyString     = "string"
+    pretty TySealed     = "sealed"
 
 instance Pretty (Version a) where
     pretty (Version _ i j k) = pretty i <> "." <> pretty j <> "." <> pretty k

--- a/language-plutus-core/src/Language/PlutusCore/TypeCheck/Internal.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeCheck/Internal.hs
@@ -241,6 +241,7 @@ kindOfTypeBuiltin = \case
     TyInteger    -> Type ()
     TyByteString -> Type ()
     TyString     -> Type ()
+    TySealed     -> KindArrow () (Type ()) $ Type ()
 
 -- | Infer the kind of a type.
 inferKindM :: Type TyName ann -> TypeCheckM ann (Kind ())


### PR DESCRIPTION
This adds the `Sealed` machinery by hardcoding the `sealed` type (which is just a few lines of code and is completely trivial) and adding the `seal` and `unseal` dynamic builtins, which is really far from being trivial. Read Note [Dynamic builtins as constructors], if you want to be terrified. But it seems to achieve the goal.