### PR TITLE
rolling deploy

### DIFF
--- a/deployment-server/app/Main.hs
+++ b/deployment-server/app/Main.hs
@@ -5,6 +5,7 @@ module Main where
 
 import           Control.Concurrent       (forkIO)
 import           Control.Concurrent.Chan  (newChan)
+import           Control.Monad            (void)
 import           Control.Newtype.Generics (unpack)
 import           Data.Aeson               (eitherDecodeFileStrict)
 import qualified Data.ByteString.Char8    as BS
@@ -33,6 +34,6 @@ main = do
         Right Secrets {..} -> do
             chan <- newChan
             slackConfig <- mkSlackConfig (unpack slackToken)
-            forkIO $ runWorker chan options slackConfig
+            void . forkIO $ runWorker chan options slackConfig
             putStrLn $ "start listening on port " <> show port
             run port $ app chan (gitHubKey . pure . BS.pack . Text.unpack . unpack $ githubWebhookKey)

--- a/deployment-server/src/Deploy/Types.hs
+++ b/deployment-server/src/Deploy/Types.hs
@@ -26,6 +26,7 @@ data Options = Options
     , keyfile        :: FilePath
     , slackChannel   :: SlackChannel
     , deploymentName :: Deployment
+    , environment    :: String
     } deriving (Generic, Show, ParseRecord)
 
 data Secrets = Secrets

--- a/deployment-server/src/Deploy/Worker.hs
+++ b/deployment-server/src/Deploy/Worker.hs
@@ -1,12 +1,16 @@
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Deploy.Worker where
 
 import           Control.Concurrent.Chan     (Chan, readChan)
-import           Control.Monad               (forever)
-import           Control.Monad.IO.Class      (liftIO)
+import           Control.Exception           (SomeException, displayException, handle)
+import           Control.Monad               (forever, void)
+import           Control.Monad.Except        (MonadError, runExceptT, throwError)
+import           Control.Monad.IO.Class      (MonadIO, liftIO)
 import           Control.Monad.Reader        (runReaderT)
 import           Control.Newtype.Generics    (unpack)
 import qualified Data.ByteString.Lazy.Char8  as BS
@@ -14,15 +18,21 @@ import           Data.Char                   (isSpace)
 import           Data.List                   (dropWhileEnd, isSuffixOf)
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
-import           Deploy.Types                (Options (Options, configDir, deploymentName, include, slackChannel, stateFile),
+import           Deploy.Types                (Options (Options, configDir, deploymentName, environment, include, slackChannel, stateFile),
                                               SlackChannel)
 import           GitHub.Data.Webhooks.Events (PullRequestEvent)
 import           System.Directory            (listDirectory)
 import           System.Exit                 (ExitCode (ExitFailure, ExitSuccess))
 import           System.IO.Temp              (withSystemTempDirectory)
-import           System.Process.Typed        (proc, readProcess, runProcess, setWorkingDir)
+import           System.Process.Typed        (proc, readProcess, setWorkingDir)
 import           Web.Slack                   (SlackConfig, chatPostMessage)
 import           Web.Slack.Chat              (mkPostMsgReq)
+
+newtype DeploymentError
+    = CommandError Text
+    deriving (Show)
+
+data AZ = A | B
 
 runWorker :: Chan PullRequestEvent -> Options -> SlackConfig -> IO ()
 runWorker chan options slackConfig =
@@ -32,57 +42,76 @@ runWorker chan options slackConfig =
 
 deploy :: PullRequestEvent -> Options -> SlackConfig -> IO ()
 deploy _ Options {..} slackConfig =
-    withSystemTempDirectory "deployment" $ \tempDir ->
-        liftIO $ do
+    withSystemTempDirectory "deployment" $ \tempDir -> do
             let plutusDir = tempDir <> "/plutus"
                 nixopsDir = plutusDir <> "/deployment/nixops"
-            putStrLn "Deploy origin/master"
-            _ <-
-                runIn
-                    tempDir
-                    "git"
-                    ["clone", "https://github.com/input-output-hk/plutus.git"]
-            _ <- runIn plutusDir "git" ["checkout", "origin/master"]
-            (_, stdout', _) <- readIn plutusDir "git" ["rev-parse", "HEAD"]
-            let gitHead = rstrip . BS.unpack $ stdout'
                 extraIncludesString = fmap (\s -> "-I" <> s) include
                 args =
-                    extraIncludesString <>
-                    [ "-s"
-                    , stateFile
-                    , "-d"
-                    , (Text.unpack . unpack) deploymentName
-                    ]
-            jsonFiles <- filter isJson <$> listDirectory configDir
-    -- we copy from the configDir in case someone has tried to be nasty by providing configDir like "/etc/passwd /proper/config/dir"
-    -- this means configDir must be a proper directory otherwise runIn will fail
-            _ <- runIn configDir "cp" $ ["-p"] <> jsonFiles <> [nixopsDir]
-            putStrLn $ "deploy " <> (Text.unpack . unpack) deploymentName
-            _ <-
-                runIn nixopsDir "nixops" $
-                ["modify", "./default.nix", "./network.nix"] <> args
-            exitCode <-
-                runIn nixopsDir "nixops" $
-                ["deploy", "--exclude", "nixops"] <> args
-            putStrLn $
-                "finished deployment of " <> gitHead <> " with exit code " <>
-                show exitCode
-            alert slackConfig slackChannel (Text.pack gitHead) exitCode
+                      extraIncludesString <>
+                      [ "-s"
+                      , stateFile
+                      , "-d"
+                      , (Text.unpack . unpack) deploymentName
+                      ]
+            putStrLn "Deploy origin/master"
+            result <- runExceptT $ do
+              void $ runIn tempDir "git" ["clone", "https://github.com/input-output-hk/plutus.git"]
+              void $ runIn plutusDir "git" ["checkout", "origin/master"]
+              (_, gitHeadStdout, _) <- runIn plutusDir "git" ["rev-parse", "HEAD"]
+              let gitHead = Text.pack . rstrip . BS.unpack $ gitHeadStdout
+              jsonFiles <- filter isJson <$> liftIO (listDirectory configDir)
+              -- we copy from the configDir in case someone has tried to be nasty by providing
+              -- configDir like "/etc/passwd /proper/config/dir", this means configDir must be
+              -- a proper directory otherwise runIn will fail
+              void $ runIn configDir "cp" $ ["-p"] <> jsonFiles <> [nixopsDir]
+              liftIO $ putStrLn $ "deploy " <> (Text.unpack . unpack) deploymentName
+              void $ runIn nixopsDir "nixops" $ ["modify", "./default.nix", "./network.nix"] <> args
+              -- We do a rolling deploy, if availability zone A fails to deploy or health check fails then we will
+              -- investigate and roll forward, rather than rolling back
+              void $ runIn nixopsDir "nixops" $ ["deploy", "--include", "playgroundA", "--include", "marlowePlaygroundA"] <> args
+              checkHealth nixopsDir A environment
+              void $ runIn nixopsDir "nixops" $ ["deploy", "--include", "playgroundB", "--include", "marlowePlaygroundB"] <> args
+              checkHealth nixopsDir B environment
+              pure gitHead
+            putStrLn $ "finished deployment with result: " <> show result
+            alert slackConfig slackChannel (showResult result)
   where
-    runIn dir bin = runProcess . setWorkingDir dir . proc bin
-    readIn dir bin = readProcess . setWorkingDir dir . proc bin
     rstrip = dropWhileEnd isSpace
     isJson = isSuffixOf "json"
 
-alert :: SlackConfig -> SlackChannel -> Text -> ExitCode -> IO ()
-alert config channel gitHead exitCode = do
+checkHealth :: (MonadIO m, MonadError DeploymentError m) => FilePath -> AZ -> String -> m ()
+checkHealth dir A environment = do
+    void $ runIn dir "curl" ["--max-time", "10", "http://marlowe-a.internal." <> environment <> ".plutus.iohkdev.io/api/health"]
+    void $ runIn dir "curl" ["--max-time", "10", "http://playground-a.internal." <> environment <> ".plutus.iohkdev.io/api/health"]
+    liftIO $ putStrLn "health check success"
+checkHealth dir B environment = do
+    void $ runIn dir "curl" ["--max-time", "10", "http://marlowe-b.internal." <> environment <> ".plutus.iohkdev.io/api/health"]
+    void $ runIn dir "curl" ["--max-time", "10", "http://playground-b.internal." <> environment <> ".plutus.iohkdev.io/api/health"]
+    liftIO $ putStrLn "health check success"
+
+runIn :: (MonadIO m, MonadError DeploymentError m) => FilePath -> String -> [String] -> m (ExitCode, BS.ByteString, BS.ByteString)
+runIn dir bin args = do
+    -- For some reason, readProcess fails to deal with all Exceptions, notably when `bin` does not exist
+    -- We need to catch this otherwise the worker thread will fail silently and all further requests will
+    -- result in a 200 but do nothing
+    (exitCode, stdout, stderr) <- liftIO . handle otherErrors . readProcess . setWorkingDir dir . proc bin $ args
+    case exitCode of
+        ExitSuccess -> pure (exitCode, stdout, stderr)
+        ExitFailure n -> do
+            liftIO $ print stderr
+            throwError $ CommandError ("Failed with exit code " <> (Text.pack . show) n <> " for command: " <> (Text.pack . unwords) ([dir, bin] <> args))
+    where
+        otherErrors :: SomeException -> IO (ExitCode, BS.ByteString, BS.ByteString)
+        otherErrors e = pure (ExitFailure 1, mempty, BS.pack (displayException e))
+
+showResult :: Either DeploymentError Text -> Text
+showResult (Left (CommandError err)) = "failed to deploy origin/master with error: " <> err
+showResult (Right gitHead)           = "origin/master (" <> gitHead <> ") deployed successfully"
+
+alert :: SlackConfig -> SlackChannel -> Text -> IO ()
+alert config channel message = do
     let msg =
-            mkPostMsgReq (unpack channel) $
-            case exitCode of
-                ExitSuccess ->
-                    "origin/master (" <> gitHead <> ") deployed successfully"
-                ExitFailure _ ->
-                    "failed to deploy origin/master (" <> gitHead <> ")"
+            mkPostMsgReq (unpack channel) message
     result <- flip runReaderT config $ chatPostMessage msg
     case result of
         Right _ -> pure ()

--- a/deployment/nixops/prometheus.nix
+++ b/deployment/nixops/prometheus.nix
@@ -107,7 +107,7 @@ in
         };
 
     environment.systemPackages = with pkgs;
-                    [ nixops vim tmux git ];
+                    [ nixops vim tmux git curl ];
 
     services.grafana = {
       enable = true;
@@ -196,7 +196,7 @@ in
 
     systemd.services.deploymentServer = {
       enable = enableGithubHooks;
-      path = ["${deploymentServer}" pkgs.git pkgs.nixops pkgs.nix pkgs.gnutar pkgs.gzip ];
+      path = ["${deploymentServer}" pkgs.git pkgs.nixops pkgs.nix pkgs.gnutar pkgs.gzip pkgs.curl ];
       script = ''deployment-server-exe \
       --slackChannel ${slackChannel} \
       --keyfile ${configDir}/secrets.json \
@@ -204,6 +204,7 @@ in
       --configDir ${configDir} \
       --stateFile ${nixopsStateFile} \
       --deploymentName ${deploymentName} \
+      --environment ${machines.environment} \
       --include nixos=${nixosLocation} \
       --include nixpkgs=${nixpkgsLocation}
       '';


### PR DESCRIPTION
This should give us lower risk deployment, if the health check endpoints fail on availability zone A then the deployment will stop and the playgrounds will still be running on availability zone B. When health checks fail then those instances will be removed from the AWS ALB so no traffic will be routed to them. The window of possible user errors should be the ALB health check interval which is 30 seconds.

This is difficult to test in any way other than end2end so I tested it on my own full environment, I can curl to the public facing url that github would talk to. I managed to deal with errors and also successfully redeploy master to my own environment so it looks good.