### PR TITLE
Fix broken links on the main page.

### DIFF
--- a/plutus-tutorial/README.adoc
+++ b/plutus-tutorial/README.adoc
@@ -1,1 +1,3 @@
-doc/overview.adoc
+= Plutus tutorial
+
+This is the repository used to generate the tutorial. For reading, you can use the rendered  https://prod.playground.plutus.iohkdev.io/tutorial/[production version] or https://alpha.plutus.iohkdev.io/tutorial/[development version].


### PR DESCRIPTION
Linking the README.adoc file to the overview.adoc in the doc directory causes all links on the first page not to work.

My fix removes the overview.adoc, and moves it into the root as README.adoc with updated references (so the links still work). I also replaced filenames with a textual representation (ex: doc/intro.adoc with `Introduction`).

This is a very small change, but I think it is important not to have broken links on the first tutorial page, and would like to merge it sooner rather than later.