### PR TITLE
asciidoctor: fail if an error-level message is emitted

### DIFF
--- a/plutus-book/doc/default.nix
+++ b/plutus-book/doc/default.nix
@@ -5,12 +5,12 @@ stdenv.mkDerivation {
   src = lib.sourceFilesBySuffices ./. [ ".adoc" ".png" ".PNG" ".gif" ".jpg" ".ico" ".css" ];
   buildInputs = [ asciidoctor python2 ];
   buildPhase = ''
-    asciidoctor plutus.adoc -b html5 -o plutus.html
+    asciidoctor --failure-level ERROR plutus.adoc -b html5 -o plutus.html
 
-    asciidoctor-pdf plutus.adoc -o plutus.pdf
+    asciidoctor-pdf --failure-level ERROR plutus.adoc -o plutus.pdf
 
-    asciidoctor-epub3 plutus.adoc -o plutus.epub
-    asciidoctor-epub3 plutus.adoc -a ebook-format=kf8 -o plutus.mobi
+    asciidoctor-epub3 --failure-level ERROR plutus.adoc -o plutus.epub
+    asciidoctor-epub3 --failure-level ERROR plutus.adoc -a ebook-format=kf8 -o plutus.mobi
   '';
   installPhase = ''
     install -D -t $out/html plutus.html 

--- a/plutus-tutorial/doc/default.nix
+++ b/plutus-tutorial/doc/default.nix
@@ -6,7 +6,7 @@ in stdenv.mkDerivation {
   name = "plutus-tutorial";
   src = lib.sourceFilesBySuffices ./. [ ".adoc" ".png" ".PNG" ".gif" ".ico" ".css" ];
   buildInputs = [ asciidoctor python2 ];
-  buildPhase = "asciidoctor ${toString extraArgs} index.adoc";
+  buildPhase = "asciidoctor --failure-level ERROR ${toString extraArgs} index.adoc";
   installPhase = ''
     mkdir -p $out
     install -t $out *.html 


### PR DESCRIPTION
The default is FATAL, which is only for really bad stuff like the main
file not being there. We definitely want it to fail on ERROR, which
includes things like "you tried to include a nonexistent file".