### PR TITLE
remove gitRev from purescript

### DIFF
--- a/marlowe-playground-server/app/PSGenerator.hs
+++ b/marlowe-playground-server/app/PSGenerator.hs
@@ -23,15 +23,12 @@ import           Control.Applicative                        (empty, (<|>))
 import           Control.Lens                               (set, (&))
 import           Control.Monad.Reader                       (MonadReader)
 import qualified Data.ByteString                            as BS
-import qualified Data.ByteString.Char8                      as CBS
 import           Data.Monoid                                ()
 import           Data.Proxy                                 (Proxy (Proxy))
 import qualified Data.Set                                   as Set ()
-import qualified Data.Text                                  as T (unpack)
 import qualified Data.Text.Encoding                         as T ()
 import qualified Data.Text.IO                               as T ()
 import           Gist                                       (Gist, GistFile, GistId, NewGist, NewGistFile, Owner)
-import           Git                                        (gitRev)
 import           Language.Haskell.Interpreter               (CompilationError, InterpreterError, InterpreterResult,
                                                              SourceCode, Warning)
 import           Language.PureScript.Bridge                 (BridgePart, Language (Haskell), PSType, SumType,
@@ -166,8 +163,7 @@ psModule name body = "module " <> name <> " where" <> body
 writeUsecases :: FilePath -> IO ()
 writeUsecases outputDir = do
     let usecases =
-            multilineString "gitRev" (CBS.pack . T.unpack $ gitRev)
-         <> multilineString "escrow" escrow
+            multilineString "escrow" escrow
          <> multilineString "zeroCouponBond" zeroCouponBond
          <> multilineString "couponBondGuaranteed" couponBondGuaranteed
         usecasesModule = psModule "Haskell.Contracts" usecases

--- a/plutus-playground-server/app/PSGenerator.hs
+++ b/plutus-playground-server/app/PSGenerator.hs
@@ -29,7 +29,6 @@ import qualified Data.Text                                  as T ()
 import qualified Data.Text.Encoding                         as T (encodeUtf8)
 import qualified Data.Text.IO                               as T ()
 import           Gist                                       (Gist, GistFile, GistId, NewGist, NewGistFile, Owner)
-import           Git                                        (gitRev)
 import           Language.Haskell.Interpreter               (CompilationError, InterpreterError, InterpreterResult,
                                                              SourceCode, Warning)
 import           Language.PureScript.Bridge                 (BridgePart, Language (Haskell), PSType, SumType,
@@ -294,7 +293,7 @@ psModule name body = "module " <> name <> " where" <> body
 writeUsecases :: FilePath -> IO ()
 writeUsecases outputDir = do
     let usecases =
-            multilineString "gitRev" gitRev <> multilineString "vesting" vesting <>
+            multilineString "vesting" vesting <>
             multilineString "game" game <>
             multilineString "crowdfunding" crowdfunding <>
             multilineString "messages" messages


### PR DESCRIPTION
`gitRev` is not used in any purescript code any more so this should avoid the need to rebuild the purescript code on every git commit.