### PR TITLE
Modify reduction rules to include type instantiation

### DIFF
--- a/plutus-core-spec/figures/CkMachine.tex
+++ b/plutus-core-spec/figures/CkMachine.tex
@@ -18,7 +18,7 @@
     \end{array}\]
 
     \captionof{figure}{Grammar of CK Machine States}
-    \label{fig:ck_frames}
+    \label{fig:ck-frames}
 \end{subfigure}
 
 
@@ -53,10 +53,10 @@
     \end{alignat*}
 \end{minipage}
     \caption{CK Machine Transitions}
-    \label{fig:ck_machine}
+    \label{fig:ck-transitions}
 \end{subfigure}
-\label{fig:ck-machine}
 \caption{CK machine}
+\label{fig:ck-machine}
 \end{figure}
 
 \end{document}

--- a/plutus-core-spec/figures/TermReduction.tex
+++ b/plutus-core-spec/figures/TermReduction.tex
@@ -57,8 +57,8 @@
     \begin{prooftree}
         \AxiomC{\(\step{M}{M'}\)}
         \AxiomC{\(M' = \error{B}\)}
-        \RightLabel{\footnotesize(\textit{$A$ is the type of the frame, $B$ is the type of its hole})}
-        \BinaryInfC{\(\step{\ctxsubst{f}{M}}{\error{A}}\)}
+        \AxiomC{\(\ctxsubst{f}{M} : A\)}
+        \TrinaryInfC{\(\step{\ctxsubst{f}{M}}{\error{A}}\)}
     \end{prooftree}
 
     \begin{prooftree}

--- a/plutus-core-spec/figures/TermReduction.tex
+++ b/plutus-core-spec/figures/TermReduction.tex
@@ -31,7 +31,7 @@
 
     \begin{prooftree}
         \AxiomC{}
-        \UnaryInfC{\(\step{\inst{\abs{\alpha}{K}{V}}{A}}{V}\)}
+        \UnaryInfC{\(\step{\inst{\abs{\alpha}{K}{V}}{A}}{\{A/\alpha\}V}\)}
     \end{prooftree}
 
     \begin{prooftree}
@@ -57,7 +57,7 @@
     \begin{prooftree}
         \AxiomC{\(\step{M}{M'}\)}
         \AxiomC{\(M' = \error{B}\)}
-        \RightLabel{\footnotesize\textit{($A$ is the type of the frame, $B$ is the type of its hole)}}
+        \RightLabel{\footnotesize(\textit{$A$ is the type of the frame, $B$ is the type of its hole})}
         \BinaryInfC{\(\step{\ctxsubst{f}{M}}{\error{A}}\)}
     \end{prooftree}
 

--- a/plutus-core-spec/figures/TermReduction.tex
+++ b/plutus-core-spec/figures/TermReduction.tex
@@ -31,7 +31,7 @@
 
     \begin{prooftree}
         \AxiomC{}
-        \UnaryInfC{\(\step{\inst{\abs{\alpha}{K}{V}}{A}}{\{A/\alpha\}V}\)}
+        \UnaryInfC{\(\step{\inst{\abs{\alpha}{K}{V}}{A}}{[A/\alpha]V}\)}
     \end{prooftree}
 
     \begin{prooftree}

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -1,6 +1,6 @@
 % Plutus Core Specification
 \title{Formal Specification of\\the Plutus Core Language (version 2.0) }
-\date{15th June 2019}
+\date{22nd July 2019}
 
 \documentclass[a4paper]{article}
 
@@ -881,8 +881,8 @@ that the machine was incorrectly implemented or that it was attempting
 to evaluate an invalid program which should have been detected during
 parsing or typechecking.
 
-For efficiency reasons the semantics of the machine defined in
-Figure~\ref{fig:ck-machine} differ in two respects from the semantics
+For efficiency reasons the behaviour of the machine defined in
+Figure~\ref{fig:ck-machine} differs in two respects from the semantics
 defined in Figure~\ref{fig:term-reduction}:
 \begin{itemize}
 \item The CK machine does not perform type instantiation since this

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -934,25 +934,14 @@ at some time in the future.
   for integers.  These differ in their treatment of negative
   arguments.
 
-%%\footnote{The standard mathematical definition (the so-called
-%%\textit{division algorithm}, or \textit{Euclidean division}) is as
-%%follows: if $n,d \in \mathbb{Z}$ and $d \ne 0$ then there exist
-%%unique integers $q, r \in \mathbb{Z}$ such that $n=qb+r$ and
-%%$0 \le r < \lvert d \rvert$; $q$ is the \textit{quotient} and $r$
-%%is the \textit{remainder}.  Neither of our sets of operations
-%%implements this definition! For $d > 0$, \texttt{divideInteger}
-%%and \texttt{modInteger} give the correct results, but they can
-%%give negative remainders for $d<0$.  In any sensible computation
-%%we'd probably have $d>0$, but it's worth being careful.}:
-
   \begin{itemize}
   
   \item \texttt{divideInteger} and \texttt{modInteger} implement the
-    standard mathematical integer division operations (at least for
-    divisors greater than zero): \texttt{divideInteger}
-    rounds downwards and the sign of \texttt{modInteger} $n$ $d$ is
-    the same as the sign of $d$.  These correspond to Haskell's
-    \texttt{div} and \texttt{mod} operators.
+    standard mathematical integer division operations (at least when
+    the divisor is positive): \texttt{divideInteger} rounds
+    downwards and the sign of \texttt{modInteger} $n$ $d$ is the same
+    as the sign of $d$.  These correspond to Haskell's \texttt{div}
+    and \texttt{mod} operators.
 
   \item \texttt{quotientInteger} and \texttt{remainderInteger}
     represent the operations found in many computer languages and
@@ -961,11 +950,31 @@ at some time in the future.
     $n$.  These correspond to Haskell's \texttt{rem} and \texttt{quot}
     operators.  \end{itemize}
 
-  
-\item We use fixed Scott encodings for certain types and values, specifically for
-  the \textit{unit} and \textit{boolean} types.  Compilers targeting
-  Plutus Core must be aware of these encodings and use them
-  appropriately.
+% NOTE. The standard mathematical definition of integer
+% division/remainder (the so-called _division algorithm_, or
+% _Euclidean division_) is as follows: if n, d \in Z and d != 0
+% then there exist unique integers q, r \in Z such that n=qb+r and
+% 0 <= r < |d|; q is the _quotient_ and r is the _remainder_.
+% Neither of our sets of operations implements this definition!
+% For d>0, divideInteger and modInteger give the correct results,
+% but they can give negative remainders for d<0.  In any sensible
+% computation we'd probably have d>0, but it's worth being careful.
+
+% For comparison, here are the results for some sample inputs.
+% The last two columns give the results for Euclidean division.
+%
+%     n  d | div mod | quot rem |  q   r
+%   --------------------------------------
+%    41  5 |  8   1  |   8   1  |  8   1
+%   -41  5 | -9   4  |  -8  -1  | -9   4
+%    41 -5 | -9  -4  |  -8   1  | -8   1
+%   -41 -5 |  8  -1  |   8  -1  |  9   4 
+
+
+  \item We use fixed Scott encodings for certain types and values,
+    specifically for the \textit{unit} and \textit{boolean} types.
+    Compilers targeting Plutus Core must be aware of these encodings and
+    use them appropriately.
 \end{itemize}
 \subfile{figures/Builtins}
 

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -818,9 +818,10 @@ terminates, this allows us to perform normalisation (i.e., reduction
 to a form which cannot undergo any further reduction) statically,
 before execution begins.  Figure~\ref{fig:type-reduction} contains the
 rules for type reduction, and Figure~\ref{fig:type-equivalence}
-contains rules for type equivalence.  We use $[A/\alpha]V$ to denote
-the result of substituting a type $A$ for a type variable $\alpha$ in
-a value $V$.
+contains rules for type equivalence.  Here and elsewhere we use syntax
+of the form $[X/x]Y$ to denote (capture-avoiding) substitution of
+some entity (a type, term, or value) $X$ for all occurrences of a name
+$x$ within some other entity $Y$.
 
 \subfile{figures/TypeReduction}
 
@@ -830,10 +831,7 @@ a value $V$.
 Execution of Plutus Core programs is performed by (possibly
 non-terminating) reduction of well-typed terms.  The reduction rules
 are contained in Figure~\ref{fig:term-reduction}, and give us a fairly
-standard operational semantics.  We use $[V/x]M$ to denote
-substitution of a value for a variable in a term, and $\{A/\alpha\}V$
-to denote instantation of a polymorphic value (or term) $V$ at a
-particular type $A$. All substitutions are capture-avoiding, as usual.
+standard operational semantics.
 
 \subfile{figures/TermReduction}
 
@@ -969,7 +967,7 @@ at some time in the future.
 %   -41  5 | -9   4  |  -8  -1  | -9   4
 %    41 -5 | -9  -4  |  -8   1  | -8   1
 %   -41 -5 |  8  -1  |   8  -1  |  9   4 
-
+%
 
   \item We use fixed Scott encodings for certain types and values,
     specifically for the \textit{unit} and \textit{boolean} types.

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -335,7 +335,7 @@ may use the multi-argument forms.
 \item $\lam{x}{A}{M}$ is standard lambda-abstraction, $\lambda{}x{:}{A}.{M}$.
 \item $\app{M}{N}$ is standard function application.
 \item $\builtin{bn}{A^*}{M^*}$ is application of a built-in function: see Section~\ref{sec:builtins} for more information.
-\item $\error{A}$ causes an error, terminating computation immediately.
+\item $\error{A}$ causes an error, terminating computation.
 \end{itemize}
 
 %% Re the value restriction:  Phil says
@@ -814,11 +814,13 @@ typed lambda calculus, complex computations can take place at the
 level of types.  Reductions in the type system always transform a
 given type into an equivalent type, and so have no effect on the term
 level.  In conjunction with the fact that type reduction always
-terminates, this allows us to perform normalisation (i.e., reduction to
-a form which cannot undergo any further reduction) statically, before
-execution begins.  Figure~\ref{fig:type-reduction} contains the rules
-for type reduction, and Figure~\ref{fig:type-equivalence} contains
-rules for type equivalence.
+terminates, this allows us to perform normalisation (i.e., reduction
+to a form which cannot undergo any further reduction) statically,
+before execution begins.  Figure~\ref{fig:type-reduction} contains the
+rules for type reduction, and Figure~\ref{fig:type-equivalence}
+contains rules for type equivalence.  We use $[A/\alpha]V$ to denote
+the result of substituting a type $A$ for a type variable $\alpha$ in
+a value $V$.
 
 \subfile{figures/TypeReduction}
 
@@ -828,7 +830,10 @@ rules for type equivalence.
 Execution of Plutus Core programs is performed by (possibly
 non-terminating) reduction of well-typed terms.  The reduction rules
 are contained in Figure~\ref{fig:term-reduction}, and give us a fairly
-standard operational semantics.  
+standard operational semantics.  We use $[V/x]M$ to denote
+substitution of a value for a variable in a term, and $\{A/\alpha\}V$
+to denote instantation of a polymorphic value (or term) $V$ at a
+particular type $A$. All substitutions are capture-avoiding, as usual.
 
 \subfile{figures/TermReduction}
 
@@ -865,7 +870,7 @@ returns a value to the outside world.
 To evaluate a program $\texttt{(program } v\ M \texttt{)}$, we first
 check that the version number $v$ is valid, then start the machine in
 the state $\cdot \triangleright M$.  It can be proved that the
-transitions in Figure~\ref{fig:ck_machine} always preserve
+transitions in Figure~\ref{fig:ck-machine} always preserve
 validity of states, so that the machine can never enter a state such as
   $\cdot \triangleleft M$
 or
@@ -875,6 +880,27 @@ situation were to occur in an implementation then it would indicate
 that the machine was incorrectly implemented or that it was attempting
 to evaluate an invalid program which should have been detected during
 parsing or typechecking.
+
+For efficiency reasons the semantics of the machine defined in
+Figure~\ref{fig:ck-machine} differ in two respects from the semantics
+defined in Figure~\ref{fig:term-reduction}:
+\begin{itemize}
+\item The CK machine does not perform type instantiation since this
+  is irrelevant at run time.
+\item When it encounters an \texttt{error} term the machine terminates
+  immediately.  In Figure~\ref{fig:term-reduction} the \texttt{error}
+  term propagates to the top of the stack of reduction frames,
+  changing its type to match the surrounding context as it does so:
+  this is to ensure that the program has a well-defined type.
+\end{itemize}
+\noindent It can be proved that when the CK machine as defined in
+Figure~\ref{fig:ck-machine} evaluates a program $P$, the machine
+terminates in the $\blacklozenge$ state if and only if $P$ terminates
+with an \texttt{error} value according to the rules of
+Figure~\ref{fig:term-reduction}, and that the machine terminates with
+a non-error value $V$ if and only if $P$ terminates according to the
+reduction rules with a value $V^{\prime}$ which is equal to $V$
+modulo erasure of type annotations.
 
 
 \section{Built in types, functions, and values}
@@ -906,25 +932,27 @@ at some time in the future.
   the value \texttt{(error)}.
 \item We provide two versions of the division and remainder operations
   for integers.  These differ in their treatment of negative
-  arguments\footnote{The standard mathematical definition (the
-    so-called \textit{division algorithm}, or \textit{Euclidean
-      division}) is as follows: if $n,d \in \mathbb{Z}$ and $d \ne 0$
-    then there exist unique integers $q, r \in \mathbb{Z}$ such that
-    $n=qb+r$ and $0 \le r < \lvert d \rvert$; $q$ is the
-    \textit{quotient} and $r$ is the \textit{remainder}.  Neither of
-    our sets of operations implements this definition! For $d > 0$,
-    \texttt{divideInteger} and \texttt{modInteger} give the correct
-    results, but they can give negative remainders for $d<0$.  In any sensible
-  computation we'd probably have $d>0$, but it's worth being careful.}:
+  arguments.
+
+%%\footnote{The standard mathematical definition (the so-called
+%%\textit{division algorithm}, or \textit{Euclidean division}) is as
+%%follows: if $n,d \in \mathbb{Z}$ and $d \ne 0$ then there exist
+%%unique integers $q, r \in \mathbb{Z}$ such that $n=qb+r$ and
+%%$0 \le r < \lvert d \rvert$; $q$ is the \textit{quotient} and $r$
+%%is the \textit{remainder}.  Neither of our sets of operations
+%%implements this definition! For $d > 0$, \texttt{divideInteger}
+%%and \texttt{modInteger} give the correct results, but they can
+%%give negative remainders for $d<0$.  In any sensible computation
+%%we'd probably have $d>0$, but it's worth being careful.}:
 
   \begin{itemize}
   
   \item \texttt{divideInteger} and \texttt{modInteger} implement the
-    standard mathematical integer division
-    operations: \texttt{divideInteger} rounds downwards and the sign
-    of \texttt{modInteger} $n$ $d$ is the same as the sign of $d$.
-    These correspond to Haskell's \texttt{div} and \texttt{mod}
-    operators.
+    standard mathematical integer division operations (at least for
+    divisors greater than zero): \texttt{divideInteger}
+    rounds downwards and the sign of \texttt{modInteger} $n$ $d$ is
+    the same as the sign of $d$.  These correspond to Haskell's
+    \texttt{div} and \texttt{mod} operators.
 
   \item \texttt{quotientInteger} and \texttt{remainderInteger}
     represent the operations found in many computer languages and

--- a/plutus-core-spec/plutus-core-specification.tex
+++ b/plutus-core-spec/plutus-core-specification.tex
@@ -884,7 +884,7 @@ Figure~\ref{fig:ck-machine} differs in two respects from the semantics
 defined in Figure~\ref{fig:term-reduction}:
 \begin{itemize}
 \item The CK machine does not perform type instantiation since this
-  is irrelevant at run time.
+  is computationally irrelevant.
 \item When it encounters an \texttt{error} term the machine terminates
   immediately.  In Figure~\ref{fig:term-reduction} the \texttt{error}
   term propagates to the top of the stack of reduction frames,


### PR DESCRIPTION
As suggested a while ago, I've modified the evaluation rules in the PLC spec to include type instantiation.  I've left the CK machine unchanged and added some remarks pointing out the differences and claiming that we can prove that it doesn't make too much difference.  We may eventually want to modify the CK machine to match, and say that we do something different in practice (or even have two different versions of the machine).  See https://github.com/input-output-hk/plutus/issues/1145 in connection with this.

There are still a number of unresolved issues, like whether we want unsaturated builtins: see https://github.com/input-output-hk/plutus/pull/1162 . I was hoping for some input from Manuel, but he's away for a couple of weeks and will presumably have a lot of catching up to do when he gets back.  Maybe we should revisit these things before then.