### PR TITLE
Turn off the todo notes in the eutxo spec

### DIFF
--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -44,7 +44,7 @@
 \usepackage{listings}
 \usepackage{xcolor}
 \usepackage{verbatim}
-\usepackage{todonotes}
+\usepackage[disable]{todonotes}
 
 \newcommand{\todochak}[1]{\todo[inline,color=purple!40,author=chak]{#1}}
 \newcommand{\todompj}[1]{\todo[inline,color=yellow!40,author=Michael]{#1}}


### PR DESCRIPTION
I accidentally merged a draft of the eutxo specification with the master branch a while ago. This PR is just to turn off the todo notes,  since it's publicly visible.  We could also delete it pending a final version, but this version isn't too bad.  