### PR TITLE
Style tweak to make it easier to read playground actions...

### DIFF
--- a/plutus-playground-client/src/Action.purs
+++ b/plutus-playground-client/src/Action.purs
@@ -15,7 +15,7 @@ import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\))
 import Halogen (HTML)
 import Halogen.Component (ParentHTML)
-import Halogen.HTML (ClassName(ClassName), IProp, br_, button, code_, div, div_, h2_, h3_, input, label, p_, small_, strong_, text)
+import Halogen.HTML (ClassName(ClassName), IProp, br_, button, code_, div, div_, h2_, h3_, hr_, input, label, p_, small_, strong_, text)
 import Halogen.HTML.Elements.Keyed as Keyed
 import Halogen.HTML.Events (input_, onClick, onDragEnd, onDragEnter, onDragLeave, onDragOver, onDragStart, onDrop, onValueInput)
 import Halogen.HTML.Events as HE
@@ -217,9 +217,11 @@ actionArgumentClass ancestors =
 actionArgumentForm :: forall p. Int -> Array SimpleArgument -> HTML p Query
 actionArgumentForm index arguments =
   div [ class_ wasValidated ]
-    (Array.mapWithIndex
-       (\i argument -> PopulateAction index i <$> actionArgumentField [ show i ] false argument)
-       arguments)
+    (Array.intercalate
+       [ hr_ ]
+       (Array.mapWithIndex
+          (\i argument -> [PopulateAction index i <$> actionArgumentField [ show i ] false argument])
+          arguments))
 
 actionArgumentField ::
   forall p. Warn (Text "We're still not handling the Unknowable case.")

--- a/plutus-playground-client/static/main.scss
+++ b/plutus-playground-client/static/main.scss
@@ -132,6 +132,11 @@ table.balance-map {
         .nested {
             margin-left: 1rem;
         }
+
+        hr {
+            border-top-style: dashed;
+            border-top-color: $gray-700;
+        }
     }
 
     .action-invalid-wallet {


### PR DESCRIPTION
... with many arguments. There's just a little dashed border separating them out:

<img width="400" alt="Screenshot 2019-07-31 at 17 32 44" src="https://user-images.githubusercontent.com/380756/62230205-39b51080-b3b9-11e9-9575-c6cbbcd28980.png">
