### PR TITLE
plutus-emulator: make walletAction assert success by default

### DIFF
--- a/marlowe/test/Spec/Common.hs
+++ b/marlowe/test/Spec/Common.hs
@@ -176,7 +176,7 @@ updateAll wallets = processPending >>= void . walletsNotifyBlock wallets
 
 performs :: Wallet -> m () -> Trace m Tx
 performs actor action = do
-    tx <- head <$> walletAction actor action
+    tx <- head . snd <$> walletAction actor action
     processPending >>= void . walletsNotifyBlock [actor]
     assertIsValidated tx
     return tx
@@ -188,13 +188,13 @@ withContract
     -> Trace MockWallet ()
 withContract wallets contract f = do
     let validator = marloweValidator (walletPubKey creator)
-    tx <- head <$> walletAction creator (createContract validator contract 12)
+    tx <- head . snd <$> walletAction creator (createContract validator contract 12)
     update
     assertIsValidated tx
 
     (tx1, state) <- f tx validator
 
-    tx <- head <$> walletAction creator (spendDeposit tx1 validator state)
+    tx <- head . snd <$> walletAction creator (spendDeposit tx1 validator state)
     update
     assertIsValidated tx
   where

--- a/plutus-book/test/NonFungible/NonFungible2Spec.hs
+++ b/plutus-book/test/NonFungible/NonFungible2Spec.hs
@@ -34,7 +34,7 @@ spec =
         updateWallets
         void $ walletAction w2 $ prank $ Wallet 1
         updateWallets
-        void $ walletAction w1 $ forge starryNight
+        void $ runFailingWalletAction w1 $ forge starryNight
         updateWallets
         assertOwnFundsEq w1 $
                A.toValue initialAda

--- a/plutus-book/test/NonFungible/NonFungible4Spec.hs
+++ b/plutus-book/test/NonFungible/NonFungible4Spec.hs
@@ -34,7 +34,7 @@ spec =
         updateWallets
         void $ walletAction w2 $ prank $ Wallet 1
         updateWallets
-        void $ walletAction w1 $ forge starryNight
+        void $ runFailingWalletAction w1 $ forge starryNight
         updateWallets
         assertOwnFundsEq w1 $
                A.toValue initialAda

--- a/plutus-emulator/test/Spec.hs
+++ b/plutus-emulator/test/Spec.hs
@@ -156,7 +156,7 @@ txnIndexValid = property $ do
 --   validated
 simpleTrace :: Tx -> Trace MockWallet ()
 simpleTrace txn = do
-    txn' <- head <$> (walletAction wallet1 $ signTxAndSubmit_ txn)
+    txn' <- head . snd <$> (walletAction wallet1 $ signTxAndSubmit_ txn)
     block <- processPending
     assertIsValidated txn'
 
@@ -273,7 +273,7 @@ eventTrace = property $ do
 
             -- schedule the `mkPayment` action to run when slot 3 is
             -- reached.
-            b1 <- walletAction wallet1 $ register trigger mkPayment
+            b1 <- snd <$> (walletAction wallet1 $ register trigger mkPayment)
             walletNotifyBlock w b1
 
             -- advance the clock to trigger `mkPayment`
@@ -342,9 +342,9 @@ watchFundsAtAddress = property $ do
                 t1 = slotRangeT (W.interval 3 4)
                 t2 = fundsAtAddressGtT (pubKeyAddress pkTarget) Value.zero
             walletNotifyBlock w =<<
-                (walletAction wallet1 $ do
+                (snd <$> (walletAction wallet1 $ do
                     register t1 mkPayment
-                    register t2 mkPayment)
+                    register t2 mkPayment))
 
             -- after 3 blocks, t1 should fire, triggering the first payment of 100 to PubKey 2
             -- after 4 blocks, t2 should fire, triggering the second payment of 100

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -52,12 +52,12 @@ tests = testGroup "futures" [
 
 init :: Wallet -> Trace MockWallet Ledger.TxOutRef
 init w = outp <$> walletAction w (F.initialise (walletPubKey wallet1) (walletPubKey wallet2) contract) where
-    outp = snd . head . filter (Ledger.isPayToScriptOut . fst) . Ledger.txOutRefs . head
+    outp = snd . head . filter (Ledger.isPayToScriptOut . fst) . Ledger.txOutRefs . head . snd
 
 adjustMargin :: Wallet -> [Ledger.TxOutRef] -> FutureData -> Ada -> Trace MockWallet Ledger.TxOutRef
 adjustMargin w refs fd vl =
     outp <$> walletAction w (F.adjustMargin refs contract fd vl) where
-        outp = snd . head . filter (Ledger.isPayToScriptOut . fst) . Ledger.txOutRefs . head
+        outp = snd . head . filter (Ledger.isPayToScriptOut . fst) . Ledger.txOutRefs . head . snd
 
 -- | Initialise the futures contract with contributions from wallets 1 and 2,
 --   and update all wallets. Running `initBoth` will increase the slot number

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -67,7 +67,7 @@ scen1 = VestingScenario{..} where
 --   script (and can be collected by the scheme's owner)
 commit :: Wallet -> Vesting -> Value -> Trace MockWallet Ledger.TxOutRef
 commit w vv vl = exScriptOut <$> walletAction w (void $ vestFunds vv vl) where
-    exScriptOut = snd . head . filter (Ledger.isPayToScriptOut . fst) . Ledger.txOutRefs . head
+    exScriptOut = snd . head . filter (Ledger.isPayToScriptOut . fst) . Ledger.txOutRefs . head . snd
 
 secureFunds :: Property
 secureFunds = checkVestingTrace scen1 $ do


### PR DESCRIPTION
This is usually what you want, and makes failing tests stop a lot
sooner. Users can explicitly say they want an action to fail, as well.