### PR TITLE
Fix a semantic merge conflict in a copy (?!) of the Marlowe interpreter

### DIFF
--- a/marlowe-playground-server/test/Spec.hs
+++ b/marlowe-playground-server/test/Spec.hs
@@ -64,5 +64,5 @@ runBasicSpec = describe "Basic Contract" $
 |]
 
 runHaskell :: ByteString -> IO (Either InterpreterError (InterpreterResult RunResult))
-runHaskell = let maxInterpretationTime :: Microsecond = fromMicroseconds 5000000 in
+runHaskell = let maxInterpretationTime :: Microsecond = fromMicroseconds 10000000 in
                 runExceptT . Interpreter.runHaskell maxInterpretationTime . SourceCode . Text.pack . BSC.unpack

--- a/plutus-book/doc/marlowe/Language/Marlowe/common.adoc
+++ b/plutus-book/doc/marlowe/Language/Marlowe/common.adoc
@@ -38,6 +38,7 @@ import           Ledger.Ada                 (Ada)
 import qualified Ledger.Ada                 as Ada
 import           Ledger.Interval            (Interval (..))
 import           Ledger.Validation
+import           Ledger.Scripts             (DataScriptHash (..), RedeemerHash (..))
 import           LedgerBytes                (LedgerBytes (..))
 import           Text.PrettyPrint.Leijen    (text)
 

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -40,7 +40,7 @@ spec = do
     knownCurrencySpec
 
 maxInterpretationTime :: Microsecond
-maxInterpretationTime = fromMicroseconds 40000000
+maxInterpretationTime = fromMicroseconds 100000000
 
 w1, w2, w3, w4, w5 :: Wallet
 w1 = Wallet 1


### PR DESCRIPTION
I'm not sure this should be here at all, but anyway it had a conflict
after merging.