### PR TITLE
PlutusTx version of GHC.List.(!!)

### DIFF
--- a/plutus-tx/src/Language/PlutusTx/List.hs
+++ b/plutus-tx/src/Language/PlutusTx/List.hs
@@ -1,11 +1,11 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
-module Language.PlutusTx.List (null, map, foldr, foldl, length, all, any, elem, filter, listToMaybe, uniqueElement, findIndices, findIndex, (++)) where
+module Language.PlutusTx.List (null, map, foldr, foldl, length, all, any, elem, filter, listToMaybe, uniqueElement, findIndices, findIndex, (++), (!!)) where
 
 import           Language.PlutusTx.Bool
 import qualified Language.PlutusTx.Builtins as Builtins
 import           Language.PlutusTx.Eq
 import           Prelude                    hiding (Eq (..), all, any, elem, filter, foldl, foldr, length, map, null,
-                                             (&&), (++), (||))
+                                             (!!), (&&), (++), (||))
 
 {-# ANN module ("HLint: ignore"::String) #-}
 
@@ -133,3 +133,15 @@ findIndices p = go 0
 -- | PlutusTx version of 'Data.List.findIndex'.
 findIndex :: (a -> Bool) -> [a] -> Maybe Integer
 findIndex p l = listToMaybe (findIndices p l)
+
+{-# INLINABLE (!!) #-}
+-- | PlutusTx version of 'GHC.List.(!!)'.
+--
+--   >>> [10, 11, 12] !! 2
+--   12
+--
+(!!) :: [a] -> Integer -> a
+[]       !! _ = Builtins.error ()
+(x : xs) !! i = if Builtins.equalsInteger i 0
+    then x
+    else xs !! Builtins.subtractInteger i 1

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -65,8 +65,8 @@ import           Language.PlutusTx.Ord       as Ord
 import           Language.PlutusTx.Semigroup as Semigroup
 import           Prelude                     as Prelude hiding (Eq (..), Functor (..), Monoid (..), Ord (..),
                                                          Semigroup (..), all, any, const, elem, error, filter, foldl,
-                                                         foldr, fst, length, map, max, maybe, min, not, null, snd, (&&),
-                                                         (++), (<$>), (||))
+                                                         foldr, fst, length, map, max, maybe, min, not, null, snd, (!!),
+                                                         (&&), (++), (<$>), (||))
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}


### PR DESCRIPTION
I added `(!!) :: [a] -> Integer -> a` to `Language.PlutusTx.List`. The behavior should be the same as the one from `GHC.List` - in particular it is an error to have the index out of bound.