### PR TITLE
Remove per-package shell.nix files

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -10,9 +10,9 @@ dependencies present, so is suitable for building the packages with
 e.g. `cabal v2-build`.
 
 An environment for developing a particular package in isolation can be
-entered by using `nix-shell` in the package directory. This has all the
-dependencies, including local ones, provided. This shouldn’t be
-necessary any more, but is useful if you need to use an old-style
+entered by using `nix-shell default.nix -A localPackages.<package name>.env`. 
+This has all the dependencies, *including* local ones, provided. 
+This shouldn’t be necessary unless you need to use an old-style
 `cabal` command that only works in a single package context.
 
 You can also use `cabal` and `stack` outside a Nix environment to build

--- a/default.nix
+++ b/default.nix
@@ -424,8 +424,6 @@ let
 
       withDevTools = env: env.overrideAttrs (attrs: { nativeBuildInputs = attrs.nativeBuildInputs ++ [ packages.cabal-install ]; });
     };
-
-    shellTemplate = name: dev.withDevTools haskellPackages."${name}".env;
   });
 
 

--- a/language-plutus-core/shell.nix
+++ b/language-plutus-core/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "language-plutus-core"

--- a/marlowe/shell.nix
+++ b/marlowe/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "marlowe"

--- a/playground-common/shell.nix
+++ b/playground-common/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "playground-common"

--- a/plutus-contract/shell.nix
+++ b/plutus-contract/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "plutus-contract"

--- a/plutus-core-interpreter/shell.nix
+++ b/plutus-core-interpreter/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "plutus-core-interpreter"

--- a/plutus-emulator/shell.nix
+++ b/plutus-emulator/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "plutus-emulator"

--- a/plutus-exe/shell.nix
+++ b/plutus-exe/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "plutus-exe"

--- a/plutus-ir/shell.nix
+++ b/plutus-ir/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "plutus-ir"

--- a/plutus-playground-lib/shell.nix
+++ b/plutus-playground-lib/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "plutus-playground-lib"

--- a/plutus-playground-server/shell.nix
+++ b/plutus-playground-server/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "plutus-playground-server"

--- a/plutus-tutorial/shell.nix
+++ b/plutus-tutorial/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "plutus-tutorial"

--- a/plutus-tx/shell.nix
+++ b/plutus-tx/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "plutus-tx"

--- a/plutus-use-cases/shell.nix
+++ b/plutus-use-cases/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "plutus-use-cases"

--- a/plutus-wallet-api/shell.nix
+++ b/plutus-wallet-api/shell.nix
@@ -1,1 +1,0 @@
-(import ../. {}).shellTemplate "plutus-wallet-api"


### PR DESCRIPTION
These were just confusing. There are instructions in `CONTRIBUTING.adoc`
for what to do if you really ned a per-package env.