### PR TITLE
adoc2hs

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -53681,6 +53681,9 @@ license = stdenv.lib.licenses.mit;
 , hspec
 , language-plutus-core
 , mtl
+, optparse-generic
+, pipes
+, pipes-safe
 , plutus-emulator
 , plutus-playground-lib
 , plutus-tx
@@ -53697,6 +53700,8 @@ mkDerivation {
 pname = "plutus-book";
 version = "0.1.0.0";
 src = .././plutus-book;
+isLibrary = true;
+isExecutable = true;
 libraryHaskellDepends = [
 base
 bytestring
@@ -53715,12 +53720,19 @@ wl-pprint
 libraryToolDepends = [
 unlit
 ];
+executableHaskellDepends = [
+base
+optparse-generic
+pipes
+pipes-safe
+];
 testHaskellDepends = [
 base
 bytestring
 containers
 hspec
 plutus-emulator
+plutus-tx
 plutus-wallet-api
 text
 ];

--- a/plutus-book/plutus-book.cabal
+++ b/plutus-book/plutus-book.cabal
@@ -124,3 +124,13 @@ test-suite plutus-book-test
                      , text
   ghc-options:         -Wall
   default-language:    Haskell2010
+
+executable adoc2hs
+  hs-source-dirs:      tools/adoc2hs
+  main-is:             main.hs
+  build-depends:       base >= 4.7 && < 5
+                     , optparse-generic -any
+                     , pipes -any
+                     , pipes-safe -any
+  ghc-options:         -Wall -O2
+  default-language:    Haskell2010

--- a/plutus-book/tools/adoc2hs/main.hs
+++ b/plutus-book/tools/adoc2hs/main.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
+
+import           Data.List          (isInfixOf, isPrefixOf, isSuffixOf)
+import           Options.Generic
+import           Pipes
+import qualified Pipes.Prelude      as P
+import           Pipes.Safe
+import qualified Pipes.Safe.Prelude as S
+
+main :: IO ()
+main = do
+    p <- getRecord "adoc2hs" :: IO Params
+    let (prod, con) = fromParams p
+    runSafeT $ runEffect $ prod >-> process >-> con
+
+data Params = Params
+    { source :: Maybe FilePath
+    , target :: Maybe FilePath
+    } deriving (Show, Generic)
+
+instance ParseRecord Params
+
+fromParams :: MonadSafe m
+           => Params
+           -> ( Proxy x' x () String m ()
+              , Proxy () String y' y m ()
+              )
+fromParams p =
+    let prod = case source p of
+                Nothing -> P.stdinLn
+                Just s  -> S.readFile s
+        con  = case target p of
+                Nothing -> P.stdoutLn
+                Just t  -> S.writeFile t
+    in  (prod, con)
+
+data State = D | SH | H
+    deriving (Show, Eq, Ord)
+
+process :: Monad m => Pipe String String m ()
+process = go D
+  where
+    go x = do
+        s  <- await
+        s' <- case x of
+            D  -> if sh  s then return SH else            return D
+            SH -> if sep s then return H  else            return D
+            H  -> if sep s then return D  else yield s >> return H
+        go s'
+
+    sep = isPrefixOf "----"
+
+    sh s =
+        isPrefixOf "[" s &&
+        isInfixOf "source" s &&
+        isInfixOf "haskell" s &&
+        isSuffixOf "]" s


### PR DESCRIPTION
I added a small tool `adoc2hs` to extract the Haskell code from an adoc file (so that it is easy to paste it into the Playground). Until now, I did this by hand, but it's getting more and more tedious for long contracts.