### PR TITLE
Playground errors weren't working correctly

### DIFF
--- a/plutus-emulator/src/Wallet/Emulator/Types.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Types.hs
@@ -665,7 +665,7 @@ execTraceTxPool pl = snd . runTraceTxPool pl
 --   and notify wallets. Returns the new block
 runWalletActionAndProcessPending :: [Wallet] -> Wallet -> m () -> Trace m [Tx]
 runWalletActionAndProcessPending wallets wallet action = do
-    _ <- walletAction wallet action
+    _ <- runWalletAction wallet action
     block <- processPending
     _ <- walletsNotifyBlock wallets block
     pure block

--- a/plutus-playground-client/src/MonadApp.purs
+++ b/plutus-playground-client/src/MonadApp.purs
@@ -1,6 +1,7 @@
 module MonadApp where
 
 import Prelude
+
 import Ace (Annotation, Editor)
 import Ace.EditSession as Session
 import Ace.Editor as AceEditor
@@ -24,7 +25,7 @@ import Halogen (HalogenM)
 import Language.Haskell.Interpreter (InterpreterError, SourceCode(SourceCode), InterpreterResult)
 import LocalStorage as LocalStorage
 import Network.RemoteData as RemoteData
-import Playground.API (CompilationResult, Evaluation, EvaluationResult)
+import Playground.API (CompilationResult, Evaluation, EvaluationResult, PlaygroundError)
 import Playground.Server (SPParams_)
 import Playground.Server as Server
 import Servant.PureScript.Ajax (AjaxError)
@@ -50,7 +51,7 @@ class
   --
   getOauthStatus :: m (WebData AuthStatus)
   getGistByGistId :: GistId -> m (WebData Gist)
-  postEvaluation :: Evaluation -> m (WebData EvaluationResult)
+  postEvaluation :: Evaluation -> m (WebData (JsonEither PlaygroundError EvaluationResult))
   postGist :: NewGist -> m (WebData Gist)
   patchGistByGistId :: NewGist -> GistId -> m (WebData Gist)
   postContract :: SourceCode -> m (WebData (JsonEither InterpreterError (InterpreterResult CompilationResult)))

--- a/plutus-playground-client/src/Types.purs
+++ b/plutus-playground-client/src/Types.purs
@@ -1,6 +1,7 @@
 module Types where
 
 import Prelude
+
 import Ace.Halogen.Component (AceMessage, AceQuery)
 import Auth (AuthStatus)
 import Control.Comonad (class Comonad, extract)
@@ -40,7 +41,7 @@ import Ledger.TxId (TxIdOf)
 import Ledger.Value (CurrencySymbol, TokenName, Value, _CurrencySymbol, _TokenName, _Value)
 import Matryoshka (class Corecursive, class Recursive, Algebra, ana, cata)
 import Network.RemoteData (RemoteData)
-import Playground.API (CompilationResult, Evaluation(..), EvaluationResult, FunctionSchema, KnownCurrency, SimulatorWallet, _FunctionSchema, _SimulatorWallet)
+import Playground.API (CompilationResult, Evaluation(..), EvaluationResult, FunctionSchema, KnownCurrency, PlaygroundError, SimulatorWallet, _FunctionSchema, _SimulatorWallet)
 import Playground.API as API
 import Schema (FormSchema(..))
 import Servant.PureScript.Ajax (AjaxError)
@@ -326,7 +327,7 @@ newtype State
   , compilationResult :: WebData (JsonEither InterpreterError (InterpreterResult CompilationResult))
   , simulations :: Cursor Simulation
   , actionDrag :: Maybe Int
-  , evaluationResult :: WebData EvaluationResult
+  , evaluationResult :: WebData (JsonEither PlaygroundError EvaluationResult)
   , authStatus :: WebData AuthStatus
   , createGistResult :: WebData Gist
   , gistUrl :: Maybe String
@@ -352,7 +353,7 @@ _actions = _Newtype <<< prop (SProxy :: SProxy "actions")
 _wallets :: Lens' Simulation (Array SimulatorWallet)
 _wallets = _Newtype <<< prop (SProxy :: SProxy "wallets")
 
-_evaluationResult :: Lens' State (WebData EvaluationResult)
+_evaluationResult :: Lens' State (WebData (JsonEither PlaygroundError EvaluationResult))
 _evaluationResult = _Newtype <<< prop (SProxy :: SProxy "evaluationResult")
 
 _compilationResult :: Lens' State (WebData (JsonEither InterpreterError (InterpreterResult CompilationResult)))

--- a/plutus-playground-lib/src/Playground/API.hs
+++ b/plutus-playground-lib/src/Playground/API.hs
@@ -40,7 +40,7 @@ import           Wallet.Graph                 (FlowGraph)
 
 type API
      = "contract" :> ReqBody '[ JSON] SourceCode :> Post '[ JSON] (Either HI.InterpreterError (InterpreterResult CompilationResult))
-       :<|> "evaluate" :> ReqBody '[ JSON] Evaluation :> Post '[ JSON] EvaluationResult
+       :<|> "evaluate" :> ReqBody '[ JSON] Evaluation :> Post '[ JSON] (Either PlaygroundError EvaluationResult)
        :<|> "health" :> Get '[ JSON] ()
 
 data KnownCurrency =

--- a/plutus-playground-server/app/PSGenerator.hs
+++ b/plutus-playground-server/app/PSGenerator.hs
@@ -52,7 +52,7 @@ import           Ledger.Slot                                (Slot)
 import           Ledger.Value                               (CurrencySymbol, TokenName, Value)
 import           Playground.API                             (CompilationResult, Evaluation, EvaluationResult,
                                                              Expression, Fn, FunctionSchema, KnownCurrency,
-                                                             SimulatorWallet)
+                                                             PlaygroundError, SimulatorWallet)
 import qualified Playground.API                             as API
 import           Playground.Usecases                        (crowdfunding, game, messages, starter, vesting)
 import           Schema                                     (FormSchema)
@@ -246,6 +246,7 @@ myTypes =
     , mkSumType (Proxy @Evaluation)
     , mkSumType (Proxy @EvaluationResult)
     , mkSumType (Proxy @EmulatorEvent)
+    , mkSumType (Proxy @PlaygroundError)
     , (genericShow <*> mkSumType) (Proxy @ValidationError)
     , (genericShow <*> mkSumType) (Proxy @ScriptError)
     , (genericShow <*> mkSumType) (Proxy @Slot)

--- a/plutus-playground-server/src/Playground/Interpreter.hs
+++ b/plutus-playground-server/src/Playground/Interpreter.hs
@@ -214,6 +214,7 @@ runghcOpts =
     , "-fobject-code"
     -- FIXME: stupid GHC bug still
     , "-package plutus-tx"
+    -- , "-package plutus-wallet-api"
     ]
 
 jsonToString :: ToJSON a => a -> String


### PR DESCRIPTION
This should fix https://github.com/input-output-hk/plutus/issues/1365

I have done 2 things:

1. Made the `/evaluate` endpoint return errors correctly, previously if any errors occurred we got a decoding error as we were trying to decode to a successful evaluation. We shouldn't really get any errors here but if we do we can deal with them in a better way, for example I've dealt with a timeout error with a proper message.
2. `runWalletActionAndProcessPending` was creating a `Failure` action if an error is thrown in the wallet action. This was caused by https://github.com/input-output-hk/plutus/pull/1329 but I don't think it's what we want in this particular function as it causes the whole trace to fail. Rather we want  the function to carry on if the wallet action has a failure in it so that the rest of the trace can complete. The error ends up in the trace logs anyway so the user is informed of this in the correct place (on the transactions tab logs section).

I would like some review on this change (other than the code itself) to make sure 2. is in fact the correct thing to do.