### PR TITLE
Performance enhancement for `abbreviate`.

### DIFF
--- a/plutus-playground-client/src/Data/String/Extra.purs
+++ b/plutus-playground-client/src/Data/String/Extra.purs
@@ -12,14 +12,14 @@ import Data.Int as Int
 import Data.Monoid (class Monoid, mempty)
 import Data.String as String
 import Data.String.CodeUnits as CodeUnits
-import Prelude (map, max, (-), (<=), (<>), (>>>))
+import Prelude (map, max, (-), (<>), (==), (>>>))
 
 abbreviate :: String -> String
 abbreviate str =
-  if String.length str <= 7 then
-    str
-  else
-    String.take 7 str <> "..."
+  let prefix = String.take 7 str
+  in if str == prefix
+     then str
+     else prefix <> "..."
 
 toHex :: String -> String
 toHex =


### PR DESCRIPTION
`String.length` is relatively slow in PureScript (compared to the
native JavaScript function) because unlike JavaScript, they take pains
to handle Unicode correctly.

Normally that wouldn't matter much, but the BlockchainExploration code
can end up calling `abbreviate` on some datascript hashes which can
get _very_ large (megabytes worth of strings). That just bit us in issue
1391. Chewing through all those megabytes (several times) just to
abbreviate them wa making some scenarios pathologically slow.

There are two solutions to this:

1) Use `Data.String.CodeUnits.length`, which is just the native
JavaScript call.
2) Only consider the first N characters in our abbreviation algorithm.

In practice they're both inperceptibly fast, so I'm going with 2 as
it's the more correct (unicode-aware) solution.

Fixes #1391.