### PR TITLE
Fix handling of type synonyms when generating `Lift`

### DIFF
--- a/plutus-tx/compiler/Language/PlutusTx/Lift/Class.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Lift/Class.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE ViewPatterns      #-}
-module Language.PlutusTx.Lift.Class (Typeable (..),  Lift (..), makeTypeable, makeLift)where
+module Language.PlutusTx.Lift.Class (Typeable (..),  Lift (..), makeTypeable, makeLift, withTyVars)where
 
 import           Language.PlutusTx.Lift.THUtils
 
@@ -22,6 +22,7 @@ import           Language.PlutusCore.Quote
 
 import           Control.Monad.Reader                   hiding (lift)
 import           Control.Monad.State                    hiding (lift)
+import qualified Control.Monad.Trans                    as Trans
 
 import qualified Language.Haskell.TH                    as TH
 import qualified Language.Haskell.TH.Datatype           as TH
@@ -38,8 +39,8 @@ import qualified Data.Text                              as T
 import           Data.Traversable
 
 -- Apparently this is how you're supposed to fail at TH time.
-die :: Monad m => String -> m a
-die message = fail $ "Generating Lift instances: " ++ message
+dieTH :: Monad m => String -> m a
+dieTH message = fail $ "Generating Lift instances: " ++ message
 
 {- Note [Compiling at TH time and runtime]
 We want to reuse PIR's machinery for defining datatypes. However, one cannot
@@ -47,8 +48,8 @@ get a PLC Type consisting of the compiled PIR type, because the compilation of t
 definitions is done by making a *term*.
 
 So we use the abstract support for handling definitions in PIR, MonadDefs. Typeable
-then has `typeRep :: (MonadDefs m, MonadQuote m) => Proxy a -> m (Type TyName Name ())`,
-which says that you can get the type in some context where you can make definitions (which
+then has `typeRep :: Proxy a -> RTCompile (Type TyName Name ())`,
+which says that you can get the type in some compilation monad (which
 you will later have to discharge yourself).
 
 This means that the TH expressions we are generating are not for `Type`s directly, but rather
@@ -68,6 +69,38 @@ instance are going to be different, and so we can't use reusable functions, inst
 inline all the definitions so that the overall expression can have the right constraints inferred.
 -}
 
+type RTCompile = DefT TH.Name () Quote
+type RTCompileScope = ReaderT LocalVars RTCompile
+type THCompile = StateT Deps (ReaderT THLocalVars TH.Q)
+
+{- Note [Type variables]
+We handle types in almost exactly the same way when we are constructing Typeable
+instances and when we are constructing Lift instances. However, there is one key difference
+in how we handle type variables.
+
+In the Typeable case, the type variables we see will be the type variables of the
+datatype, which we want to map into the variable declarations that we construct. This requires
+us to do some mapping between them at *runtime*, and keep a scope around to map between the TH names
+and the PLC types.
+
+In the Lift case, type variables will be free type variables in the instance, and should be handled
+by appropriate Typeable constraints for those variables. We get the PLC types by just calling
+typeRep.
+
+However, for simplicity we always act as though we have a local scope, and fall back to Typeable,
+but in the Lift case we will never populate the local scope.
+-}
+
+-- | A scope for type variables. See note [Type variables].
+type LocalVars = Map.Map TH.Name (Type TyName ())
+type THLocalVars = Set.Set TH.Name
+
+withTyVars :: (MonadReader LocalVars m) => [(TH.Name, TyVarDecl TyName ())] -> m a -> m a
+withTyVars mappings = local (\scope -> foldl' (\acc (n, tvd) -> Map.insert n (mkTyVar () tvd) acc) scope mappings)
+
+thWithTyVars :: (MonadReader THLocalVars m) => [TH.Name] -> m a -> m a
+thWithTyVars names = local (\scope -> foldr Set.insert scope names)
+
 {- Note [Lifting newtypes]
 Newtypes are handled differently in the compiler, in that we identify them with their underlying type.
 See Note [Coercions and newtypes] for details.
@@ -83,26 +116,6 @@ newtypes will hang a runtime. Don't do that. (This is worse than what we do in t
 Note [Occurrences of recursive names])
 -}
 
--- Constraints
-
--- | Make a 'Typeable' constraint.
-typeablePir :: TH.Type -> TH.Type
-typeablePir ty = TH.classPred ''Typeable [ty]
-
--- | Make a 'Lift' constraint.
-liftPir :: TH.Type -> TH.Type
-liftPir ty = TH.classPred ''Lift [ty]
-
-{- Note [Closed constraints]
-There is no point adding constraints that are "closed", i.e. don't mention any of the
-instance type variables. These will either be satisfied by other instances in scope
-(in which case GHC will complain at you), or be unsatisfied in which case the user will
-get a useful error anyway.
--}
-
-isClosedConstraint :: TH.Pred -> Bool
-isClosedConstraint = null . TH.freeVariables
-
 -- Dependencies at TH time
 
 {- Note [Tracking dependencies]
@@ -115,27 +128,53 @@ These are then cashed out into constraints on the instance.
 data Dep = TypeableDep TH.Type | LiftDep TH.Type deriving (Show, Eq, Ord)
 type Deps = Set.Set Dep
 
-toConstraint :: Dep -> TH.Pred
-toConstraint = \case
-    TypeableDep n -> typeablePir n
-    LiftDep ty -> liftPir ty
-
+-- | Get all the named types which we depend on to define the current type.
+-- Note that this relies on dependencies having been added with type synonyms
+-- resolved!
 getTyConDeps :: Deps -> Set.Set TH.Name
 getTyConDeps deps = Set.fromList $ mapMaybe typeableDep $ Set.toList deps
     where
         typeableDep (TypeableDep (TH.ConT n)) = Just n
         typeableDep _                         = Nothing
 
-addTypeableDep :: (THCompiling m) => TH.Type -> m ()
-addTypeableDep ty = modify $ Set.insert $ TypeableDep $ normalizeType ty
+addTypeableDep :: TH.Type -> THCompile ()
+addTypeableDep ty = do
+    ty' <- normalizeAndResolve ty
+    modify $ Set.insert $ TypeableDep ty'
 
-addLiftDep :: (THCompiling m) => TH.Type -> m ()
-addLiftDep ty = modify $ Set.insert $ LiftDep $ normalizeType ty
+addLiftDep :: TH.Type -> THCompile ()
+addLiftDep ty = do
+    ty' <- normalizeAndResolve ty
+    modify $ Set.insert $ LiftDep ty'
 
--- | The constraints when we are compiling at runtime. See note [Compiling at TH time and runtime].
-type RTCompiling m = (MonadDefs TH.Name () m, MonadQuote m)
--- | The constraints when we are compiling at TH time. See note [Compiling at TH time and runtime].
-type THCompiling m = (MonadState Deps m)
+-- Constraints
+
+-- | Make a 'Typeable' constraint.
+typeablePir :: TH.Type -> TH.Type
+typeablePir ty = TH.classPred ''Typeable [ty]
+
+-- | Make a 'Lift' constraint.
+liftPir :: TH.Type -> TH.Type
+liftPir ty = TH.classPred ''Lift [ty]
+
+toConstraint :: Dep -> TH.Pred
+toConstraint = \case
+    TypeableDep n -> typeablePir n
+    LiftDep ty -> liftPir ty
+
+{- Note [Closed constraints]
+There is no point adding constraints that are "closed", i.e. don't mention any of the
+instance type variables. These will either be satisfied by other instances in scope
+(in which case GHC will complain at you), or be unsatisfied in which case the user will
+get a useful error anyway.
+-}
+
+isClosedConstraint :: TH.Pred -> Bool
+isClosedConstraint = null . TH.freeVariables
+
+-- | Convenience wrapper around 'normalizeType' and 'TH.resolveTypeSynonyms'.
+normalizeAndResolve :: TH.Type -> THCompile TH.Type
+normalizeAndResolve ty = normalizeType <$> (Trans.lift $ Trans.lift $ TH.resolveTypeSynonyms ty)
 
 -- See Note [Ordering of constructors]
 sortedCons :: TH.DatatypeInfo -> [TH.ConstructorInfo]
@@ -144,108 +183,99 @@ sortedCons TH.DatatypeInfo{TH.datatypeName=tyName, TH.datatypeCons=cons} =
     let sorted = sortBy (\(TH.constructorName -> (TH.Name o1 _)) (TH.constructorName -> (TH.Name o2 _)) -> compare o1 o2) cons
     in if tyName == ''Bool || tyName == ''[] then reverse sorted else sorted
 
-tvNameAndKind :: (Monad m) => TH.Type -> m (TH.Name, Kind ())
+tvNameAndKind :: TH.Type -> THCompile (TH.Name, Kind ())
 tvNameAndKind = \case
     TH.SigT (TH.VarT name) kind -> do
-        kind' <- compileKind kind
+        kind' <- (compileKind <=< normalizeAndResolve) kind
         pure (name, kind')
-    _ -> die "Unknown sort of type variable"
+    _ -> dieTH "Unknown sort of type variable"
 
+------------------
 -- Types and kinds
+------------------
 
-{- Note [Type variables]
-We handle types in almost exactly the same way when we are constructing Typeable
-instances and when we are constructing Lift instances. However, there is one key difference
-in how we handle type variables.
-
-In the Typeable case, the type variables we see will be the type variables of the
-datatype, which we want to map into the variable declarations that we construct. This requires
-us to do some mapping between them at *runtime*, and keep a scope around to map between the TH names
-and the PLC types.
-
-In the Lift case, type variables will be free type variables in the instance, and should be handled
-by appropriate Typeable constraints for those variables. We get the PLC types by just calling
-typeRep.
--}
-
--- | A switch to indicate how to handle type variables. See note [Type variables].
-data VarsAs = Local | Typeable
-
--- | A scope for type variables. See note [Type variables].
-type LocalVars = Map.Map TH.Name (Type TyName ())
-
-getLocalName :: MonadReader LocalVars m => TH.Name -> m (Type TyName ())
-getLocalName name = do
-    vars <- ask
-    case Map.lookup name vars of
-        Just ty -> pure ty
-        Nothing -> die $ "Free type variable: " ++ show name
-
-withTyVars :: (MonadReader LocalVars m) => [(TH.Name, TyVarDecl TyName ())] -> m a -> m a
-withTyVars mappings = local (\scope -> foldl' (\acc (n, tvd) -> Map.insert n (mkTyVar () tvd) acc) scope mappings)
-
-compileKind :: (Monad m) => TH.Kind -> m (Kind ())
+-- Note: we can actually do this entirely at TH-time, which is nice
+compileKind :: TH.Kind -> THCompile (Kind ())
 compileKind = \case
     TH.StarT -> pure $ Type ()
     TH.AppT (TH.AppT TH.ArrowT k1) k2 -> KindArrow () <$> compileKind k1 <*> compileKind k2
-    k -> die $ "Unsupported kind: " ++ show k
+    k -> dieTH $ "Unsupported kind: " ++ show k
 
--- see note [Compiling at TH time and runtime]
-compileType :: THCompiling m => VarsAs -> TH.Type -> m (TH.Q TH.Exp)
-compileType vars = \case
+compileType :: TH.Type -> THCompile (TH.TExpQ (RTCompileScope (Type TyName ())))
+compileType = \case
     TH.AppT t1 t2 -> do
-        t1' <- compileType vars t1
-        t2' <- compileType vars t2
-        pure [| TyApp () <$> $(t1') <*> $(t2') |]
+        t1' <- compileType t1
+        t2' <- compileType t2
+        pure [|| TyApp () <$> $$t1' <*> $$t2' ||]
     t@(TH.ConT name) -> compileTypeableType t name
-    TH.LitT (TH.NumTyLit i) -> pure [| pure $ TyInt () i |]
     -- See note [Type variables]
-    t@(TH.VarT name) -> case vars of
-        Typeable -> compileTypeableType t name
-        Local    -> pure [| getLocalName name |]
-    t -> die $ "Unsupported type: " ++ show t
+    t@(TH.VarT name) -> do
+        isLocal <- asks (Set.member name)
+        if isLocal
+        then pure [||
+              do
+                  vars <- ask
+                  case Map.lookup name vars of
+                      Just ty -> pure ty
+                      -- TODO: better runtime failures
+                      Nothing -> fail $ "Unknown local variable: " ++ show name
+             ||]
+        else compileTypeableType t name
+    t -> dieTH $ "Unsupported type: " ++ show t
 
 -- | Compile a type with the given name using 'typeRep' and incurring a corresponding 'Typeable' dependency.
-compileTypeableType :: (THCompiling m) => TH.Type -> TH.Name -> m (TH.Q TH.Exp)
+compileTypeableType :: TH.Type -> TH.Name -> THCompile (TH.TExpQ (RTCompileScope (Type TyName ())))
 compileTypeableType ty name = do
     addTypeableDep ty
-    pure [|
-          do
+    -- We need the `unsafeTExpCoerce` since this will necessarily involve
+    -- types we don't know now: the type which this instance is for (which
+    -- appears in the proxy argument). However, since we know the type of
+    -- `typeRep` we can get back into typed land quickly.
+    let trep :: TH.TExpQ (RTCompile (Type TyName ()))
+        trep = TH.unsafeTExpCoerce [| typeRep (undefined :: Proxy $(pure ty)) |]
+    pure [||
+          let trep' :: RTCompile (Type TyName ())
+              trep' = $$trep
+          in do
               maybeType <- lookupType () name
               case maybeType of
                   Just t  -> pure t
                   -- this will need some additional constraints in scope
-                  Nothing -> typeRep (undefined :: Proxy $(pure ty))
-          |]
+                  Nothing -> Trans.lift trep'
+          ||]
 
+-----------
 -- Typeable
+-----------
 
 -- TODO: try and make this work with type applications
 -- | Class for types which have a corresponding Plutus IR type. Instances should always be derived, do not write
 -- your own instance!
 class Typeable (a :: k) where
     -- | Get the Plutus IR type corresponding to this type.
-    typeRep :: (RTCompiling m) => Proxy a -> m (Type TyName ())
+    typeRep :: Proxy a -> RTCompile (Type TyName ())
 
 -- TODO: there is an unpleasant amount of duplication between this and the main compiler, but
 -- I'm not sure how to unify them better
-compileTypeRep :: (THCompiling m) => TH.DatatypeInfo -> m (TH.Q TH.Exp)
+compileTypeRep :: TH.DatatypeInfo -> THCompile (TH.TExpQ (RTCompile (Type TyName ())))
 compileTypeRep dt@TH.DatatypeInfo{TH.datatypeName=tyName, TH.datatypeVars=tvs} = do
     tvNamesAndKinds <- traverse tvNameAndKind tvs
     -- annoyingly th-abstraction doesn't give us a kind we can compile here
     let typeKind = foldr (\(_, k) acc -> KindArrow () k acc) (Type ()) tvNamesAndKinds
     let cons = sortedCons dt
 
-    -- see note [Compiling at TH time and runtime]
-    if isNewtype dt
+    thWithTyVars (fmap fst tvNamesAndKinds) $ if isNewtype dt
     then do
         -- Extract the unique field of the unique constructor
         argTy <- case cons of
-            [ TH.ConstructorInfo {TH.constructorFields=[argTy]} ] -> compileType Local $ normalizeType argTy
-            _ -> die "Newtypes must have a single constructor with a single argument"
+            [ TH.ConstructorInfo {TH.constructorFields=[argTy]} ] -> (compileType <=< normalizeAndResolve) argTy
+            _ -> dieTH "Newtypes must have a single constructor with a single argument"
         deps <- gets getTyConDeps
-        pure [|
-            flip runReaderT mempty $ do
+        pure [||
+            let
+                argTy' :: RTCompileScope (Type TyName ())
+                argTy' = $$argTy
+            in flip runReaderT mempty $ do
                 maybeDefined <- lookupType () tyName
                 case maybeDefined of
                     Just ty -> pure ty
@@ -253,16 +283,19 @@ compileTypeRep dt@TH.DatatypeInfo{TH.datatypeName=tyName, TH.datatypeVars=tvs} =
                         (_, dtvd) <- mkTyVarDecl tyName typeKind
                         tvds <- traverse (uncurry mkTyVarDecl) tvNamesAndKinds
 
-                        alias <- withTyVars tvds $ mkIterTyLam (fmap snd tvds) <$> $(argTy)
+                        alias <- withTyVars tvds $ mkIterTyLam (fmap snd tvds) <$> argTy'
                         defineType tyName (PLC.Def dtvd alias) deps
                         recordAlias @TH.Name @() tyName
                         pure alias
-            |]
+            ||]
     else do
         constrExprs <- traverse compileConstructorDecl cons
         deps <- gets getTyConDeps
-        pure [|
-          flip runReaderT mempty $ do
+        pure [||
+          let
+              constrExprs' :: [Type TyName () -> RTCompileScope (VarDecl TyName Name ())]
+              constrExprs' = $$(tyListE constrExprs)
+          in flip runReaderT mempty $ do
               maybeDefined <- lookupType () tyName
               case maybeDefined of
                   Just ty -> pure ty
@@ -281,53 +314,60 @@ compileTypeRep dt@TH.DatatypeInfo{TH.datatypeName=tyName, TH.datatypeVars=tvs} =
                       withTyVars tvds $ do
                           -- The TH expressions are in fact all functions that take the result type, so
                           -- we need to apply them
-                          let constrActs = $(TH.listE constrExprs) <*> [resultType]
-                          constrs <- sequence constrActs
+                          let constrActs :: RTCompileScope [VarDecl TyName Name ()]
+                              constrActs = sequence $ constrExprs' <*> [resultType]
+                          constrs <- constrActs
 
                           let datatype = Datatype () dtvd (fmap snd tvds) matchName constrs
 
                           defineDatatype tyName (PLC.Def dtvd datatype) deps
                       pure $ mkTyVar () dtvd
-          |]
+          ||]
 
-compileConstructorDecl :: THCompiling m => TH.ConstructorInfo -> m (TH.Q TH.Exp)
+compileConstructorDecl
+    :: TH.ConstructorInfo
+    -> THCompile (TH.TExpQ (Type TyName () -> RTCompileScope (VarDecl TyName Name ())))
 compileConstructorDecl TH.ConstructorInfo{TH.constructorName=name, TH.constructorFields=argTys} = do
-    tyExprs <- traverse (compileType Local . normalizeType) argTys
-    -- see note [Compiling at TH time and runtime]
-    pure [|
+    tyExprs <- traverse (compileType <=< normalizeAndResolve) argTys
+    pure [||
+         let
+             tyExprs' :: [RTCompileScope (Type TyName ())]
+             tyExprs' = $$(tyListE tyExprs)
           -- we won't know the result type until runtime, so take it as an argument
-          \resultType -> do
-              tys' <- sequence $(TH.listE tyExprs)
+          in \resultType -> do
+              tys' <- sequence tyExprs'
               let constrTy = mkIterTyFun () tys' resultType
               constrName <- safeFreshName () $ showName name
               pure $ VarDecl () constrName constrTy
-          |]
+          ||]
 
 makeTypeable :: TH.Name -> TH.Q [TH.Dec]
 makeTypeable name = do
     requireExtension TH.ScopedTypeVariables
 
     info <- TH.reifyDatatype name
-    let (rhs, deps) = runState (compileTypeRep info) mempty
+    (rhs, deps) <- flip runReaderT mempty $ flip runStateT mempty $ (compileTypeRep info)
 
     -- See Note [Closed constraints]
     let constraints = filter (not . isClosedConstraint) $ toConstraint <$> Set.toList deps
 
-    decl <- TH.funD 'typeRep [TH.clause [TH.wildP] (TH.normalB rhs) []]
+    decl <- TH.funD 'typeRep [TH.clause [TH.wildP] (TH.normalB (TH.unTypeQ rhs)) []]
     pure [TH.InstanceD Nothing constraints (typeablePir (TH.ConT name)) [decl]]
 
+-------
 -- Lift
+-------
 
 -- | Class for types which can be lifted into Plutus IR. Instances should be derived, do not write your
 -- own instance!
 class Lift a where
     -- | Get a Plutus IR term corresponding to the given value.
-    lift :: (RTCompiling m) => a -> m (Term TyName Name ())
+    lift :: a -> RTCompile (Term TyName Name ())
 
-compileLift :: THCompiling m => TH.DatatypeInfo -> m [TH.Q TH.Clause]
+compileLift :: TH.DatatypeInfo -> THCompile [TH.Q TH.Clause]
 compileLift dt = traverse (uncurry (compileConstructorClause dt)) (zip [0..] (sortedCons dt))
 
-compileConstructorClause :: (THCompiling m) => TH.DatatypeInfo -> Int -> TH.ConstructorInfo -> m (TH.Q TH.Clause)
+compileConstructorClause :: TH.DatatypeInfo -> Int -> TH.ConstructorInfo -> THCompile (TH.Q TH.Clause)
 compileConstructorClause dt@TH.DatatypeInfo{TH.datatypeName=tyName, TH.datatypeVars=tvs} index TH.ConstructorInfo{TH.constructorName=name, TH.constructorFields=argTys} = do
     -- need to be able to lift the argument types
     traverse_ addLiftDep argTys
@@ -335,37 +375,55 @@ compileConstructorClause dt@TH.DatatypeInfo{TH.datatypeName=tyName, TH.datatypeV
     -- We need the actual type parameters for the non-newtype case, and we have to do
     -- it out here, but it will give us redundant constraints in the newtype case,
     -- so we fudge it.
-    typeExprs <- if isNewtype dt then pure [] else traverse (compileType Typeable . normalizeType) tvs
+    typeExprs <- if isNewtype dt then pure [] else traverse (compileType <=< normalizeAndResolve) tvs
     pure $ do
+        -- Build the patter for the clause definition. All the argument will be called "arg".
         patNames <- for argTys $ \_ -> TH.newName "arg"
-        let pats = fmap TH.varP patNames
-        let pat = TH.conP name pats
-        let liftExprs = fmap (\pn -> TH.varE 'lift `TH.appE` TH.varE pn) patNames
-        -- see note [Compiling at TH time and runtime]
-        expr <- if isNewtype dt
+        let pat = TH.conP name (fmap TH.varP patNames)
+
+        -- `lift arg` for each arg we bind in the pattern. We need the `unsafeTExpCoerce` since this will
+        -- necessarily involve types we don't know now: the types of each argument. However, since we
+        -- know the type of `lift arg` we can get back into typed land quickly.
+        let liftExprs :: [TH.TExpQ (RTCompile (Term TyName Name ()))]
+            liftExprs = fmap (\pn -> TH.unsafeTExpCoerce $ TH.varE 'lift `TH.appE` TH.varE pn) patNames
+        rhsExpr <- if isNewtype dt
             then case liftExprs of
-                    [arg] -> pure arg
-                    _     -> die "Newtypes must have a single constructor with a single argument"
+                    [argExpr] -> pure argExpr
+                    _     -> dieTH "Newtypes must have a single constructor with a single argument"
             else
-                pure [|
-                    do
+                pure [||
+                    -- We bind all the splices with explicit signatures to ensure we
+                    -- get type errors as soon as possible, and to aid debugging.
+                    let
+                        typeExprs' :: [RTCompileScope (Type TyName ())]
+                        typeExprs' = $$(tyListE typeExprs)
+                        liftExprs' :: [RTCompile (Term TyName Name ())]
+                        liftExprs' = $$(tyListE liftExprs)
+                        -- We need the `unsafeTExpCoerce` since this will necessarily involve
+                        -- types we don't know now: the type which this instance is for (which
+                        -- appears in the proxy argument). However, since we know the type of
+                        -- `typeRep` we can get back into typed land quickly.
+                        trep :: RTCompile (Type TyName ())
+                        trep = $$(TH.unsafeTExpCoerce [| typeRep (undefined :: Proxy $(TH.conT tyName)) |])
+                    in do
                         -- force creation of datatype
-                        _ <- typeRep (undefined :: Proxy $(TH.conT tyName))
+                        _ <- trep
 
                         -- get the right constructor
                         maybeConstructors <- lookupConstructors () tyName
                         constrs <- case maybeConstructors of
-                            Nothing -> die $ "Constructors not created for " ++ show tyName
+                            -- TODO: better runtime failures
+                            Nothing -> fail $ "Constructors not created for " ++ show tyName
                             Just cs -> pure cs
                         let constr = constrs !! index
 
-                        -- need to instantiate it to the right types and then lift all the arguments and apply it to them
-                        types <- sequence $(TH.listE typeExprs)
-                        lifts <- sequence $(TH.listE liftExprs)
+                        -- The types are compiled in an (empty) local scope.
+                        types <- flip runReaderT mempty $ sequence typeExprs'
+                        lifts <- sequence liftExprs'
 
                         pure $ mkIterApp () (mkIterInst () constr types) lifts
-                  |]
-        TH.clause [pat] (TH.normalB expr) []
+                  ||]
+        TH.clause [pat] (TH.normalB $ TH.unTypeQ rhsExpr) []
 
 makeLift :: TH.Name -> TH.Q [TH.Dec]
 makeLift name = do
@@ -377,7 +435,10 @@ makeLift name = do
 
     let datatypeType = TH.datatypeType info
 
-    let (clauses, deps) = runState (compileLift info) mempty
+    (clauses, deps) <-
+        flip runReaderT mempty $
+        flip runStateT mempty $
+        (compileLift info)
 
     {-
     Here we *do* need to add some constraints, because we're going to generate things like

--- a/plutus-tx/compiler/Language/PlutusTx/Lift/THUtils.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Lift/THUtils.hs
@@ -55,3 +55,7 @@ isNewtype :: TH.DatatypeInfo -> Bool
 isNewtype TH.DatatypeInfo{TH.datatypeVariant=variant} = case variant of
     TH.Newtype -> True
     _          -> False
+
+-- | "Safe" wrapper around 'TH.listE' for typed TH.
+tyListE :: [TH.TExpQ a] -> TH.TExpQ [a]
+tyListE texps = TH.unsafeTExpCoerce [| $(TH.listE (fmap TH.unTypeQ texps)) |]

--- a/plutus-tx/test/Lift/Spec.hs
+++ b/plutus-tx/test/Lift/Spec.hs
@@ -38,6 +38,14 @@ Lift.makeLift ''Newtype2
 newtype Newtype3 = Newtype3 { unNt3 :: Newtype2 }
 Lift.makeLift ''Newtype3
 
+-- 'Z' so it sorts late and this doesn't work by accident
+data Z = Z Integer
+Lift.makeLift ''Z
+type Syn = Z
+
+data SynExample = SynExample { unSE :: Syn }
+Lift.makeLift ''SynExample
+
 tests :: TestNested
 tests = testNested "Lift" [
     goldenPlc "int" (Lift.unsafeLiftProgram (1::Integer))
@@ -55,4 +63,5 @@ tests = testNested "Lift" [
     , goldenPlc "newtypeInt" (Lift.unsafeLiftProgram (NewtypeInt 1))
     , goldenPlc "newtypeInt2" (Lift.unsafeLiftProgram (Newtype2 $ NewtypeInt 1))
     , goldenPlc "newtypeInt3" (Lift.unsafeLiftProgram (Newtype3 $ Newtype2 $ NewtypeInt 1))
+    , goldenPlc "syn" (Lift.unsafeLiftProgram (SynExample $ Z $ 1))
  ]

--- a/plutus-tx/test/Lift/syn.plc.golden
+++ b/plutus-tx/test/Lift/syn.plc.golden
@@ -1,0 +1,77 @@
+(program 1.0.0
+  [
+    [
+      {
+        (abs
+          Lift_Spec_Z_i0
+          (type)
+          (lam
+            Lift_Spec_Z_i0
+            (fun (con integer) Lift_Spec_Z_i2)
+            (lam
+              match_Lift_Spec_Z_i0
+              (fun Lift_Spec_Z_i3 (all out_Lift_Spec_Z_i0 (type) (fun (fun (con integer) out_Lift_Spec_Z_i1) out_Lift_Spec_Z_i1)))
+              [
+                [
+                  {
+                    (abs
+                      Lift_Spec_SynExample_i0
+                      (type)
+                      (lam
+                        Lift_Spec_SynExample_i0
+                        (fun Lift_Spec_Z_i5 Lift_Spec_SynExample_i2)
+                        (lam
+                          match_Lift_Spec_SynExample_i0
+                          (fun Lift_Spec_SynExample_i3 (all out_Lift_Spec_SynExample_i0 (type) (fun (fun Lift_Spec_Z_i7 out_Lift_Spec_SynExample_i1) out_Lift_Spec_SynExample_i1)))
+                          [ Lift_Spec_SynExample_i2 [ Lift_Spec_Z_i5 (con 1) ] ]
+                        )
+                      )
+                    )
+                    (all out_Lift_Spec_SynExample_i0 (type) (fun (fun Lift_Spec_Z_i4 out_Lift_Spec_SynExample_i1) out_Lift_Spec_SynExample_i1))
+                  }
+                  (lam
+                    arg_0_i0
+                    Lift_Spec_Z_i4
+                    (abs
+                      out_Lift_Spec_SynExample_i0
+                      (type)
+                      (lam
+                        case_Lift_Spec_SynExample_i0
+                        (fun Lift_Spec_Z_i6 out_Lift_Spec_SynExample_i2)
+                        [ case_Lift_Spec_SynExample_i1 arg_0_i3 ]
+                      )
+                    )
+                  )
+                ]
+                (lam
+                  x_i0
+                  (all out_Lift_Spec_SynExample_i0 (type) (fun (fun Lift_Spec_Z_i5 out_Lift_Spec_SynExample_i1) out_Lift_Spec_SynExample_i1))
+                  x_i1
+                )
+              ]
+            )
+          )
+        )
+        (all out_Lift_Spec_Z_i0 (type) (fun (fun (con integer) out_Lift_Spec_Z_i1) out_Lift_Spec_Z_i1))
+      }
+      (lam
+        arg_0_i0
+        (con integer)
+        (abs
+          out_Lift_Spec_Z_i0
+          (type)
+          (lam
+            case_Lift_Spec_Z_i0
+            (fun (con integer) out_Lift_Spec_Z_i2)
+            [ case_Lift_Spec_Z_i1 arg_0_i3 ]
+          )
+        )
+      )
+    ]
+    (lam
+      x_i0
+      (all out_Lift_Spec_Z_i0 (type) (fun (fun (con integer) out_Lift_Spec_Z_i1) out_Lift_Spec_Z_i1))
+      x_i1
+    )
+  ]
+)

--- a/plutus-wallet-api/ledger/Ledger/Validation.hs
+++ b/plutus-wallet-api/ledger/Ledger/Validation.hs
@@ -126,7 +126,7 @@ toLedgerTxIn = fmap Just
 
 -- | A pending transaction. This is the view as seen by validator scripts, so some details are stripped out.
 data PendingTx' i = PendingTx
-    { pendingTxInputs     :: [PendingTxIn' (Maybe (ValidatorHash, RedeemerHash))] -- ^ Transaction inputs
+    { pendingTxInputs     :: [PendingTxIn] -- ^ Transaction inputs
     , pendingTxOutputs    :: [PendingTxOut] -- ^ Transaction outputs
     , pendingTxFee        :: Ada -- ^ The fee paid by this transaction.
     , pendingTxForge      :: Value -- ^ The 'Value' forged by this transaction.
@@ -141,7 +141,7 @@ data PendingTx' i = PendingTx
 instance Functor PendingTx' where
     fmap f p = p { pendingTxIn = f (pendingTxIn p) }
 
-type PendingTx = PendingTx' (PendingTxIn' (ValidatorHash, RedeemerHash))
+type PendingTx = PendingTx' PendingTxInScript
 
 {-# INLINABLE findDataScriptOutputs #-}
 -- | Look up a 'DataScriptHash' in the transaction outputs, returning the indexs of the outputs that have


### PR DESCRIPTION
I took the old approach of "refactor until the change you want to make is easy". In this case that involved quite a bit of chopping and changing, but I think the result is somewhat more comprehensible.

Probably not worth that much review, it took me about a day to load this back into my brain, I don't wish that on anyone else.

Fixes #1409.