### PR TITLE
nix: Docker image for development

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -306,6 +306,33 @@ let
           Cmd = ["${server-invoker}/bin/marlowe-playground" "--config" "${defaultPlaygroundConfig}/etc/playground.yaml" "webserver" "-b" "0.0.0.0" "-p" "8080" "${client}"];
         };
       };
+
+      development = pkgs.dockerTools.buildImage {
+        name = "plutus-development";
+        contents =         
+          let runtimeGhc = 
+                haskellPackages.ghcWithPackages (ps: [
+                  haskellPackages.language-plutus-core
+                  haskellPackages.plutus-core-interpreter
+                  haskellPackages.plutus-emulator
+                  haskellPackages.plutus-wallet-api
+                  haskellPackages.plutus-tx
+                  haskellPackages.plutus-use-cases
+                  haskellPackages.plutus-ir
+                  haskellPackages.plutus-contract
+                ]);
+          in  [ 
+                runtimeGhc
+                pkgs.binutils-unwrapped
+                pkgs.coreutils
+                pkgs.bash
+                pkgs.git # needed by cabal-install
+                haskellPackages.cabal-install 
+              ];
+        config = {
+          Cmd = ["bash"];
+        };
+      };
     };
 
     plutus-contract = rec {


### PR DESCRIPTION
* A docker image that can be used to build the example in `example/`

Output:
```
jann@iohk-dev-vm:~/plutus-example$ sudo docker run -w /app -v "$(pwd)":/app -v ~/tmp:/tmp --name dev plutus-development:iwhhac55vfnwgqff1v29scc6g2gdw2dw cabal new-build .
Config file path source is default config file.
Config file //.cabal/config not found.
Writing default configuration to //.cabal/config
Build profile: -w ghc-8.6.4 -O1
In order, the following will be built (use -v for more details):
 - example-0.1.0.0 (lib) (first run)
 - example-0.1.0.0 (exe:example-exe) (first run)
Preprocessing library for example-0.1.0.0..
Building library for example-0.1.0.0..
Configuring executable 'example-exe' for example-0.1.0.0..
Preprocessing executable 'example-exe' for example-0.1.0.0..
Building executable 'example-exe' for example-0.1.0.0..
[1 of 1] Compiling Main             ( app/Main.hs, /app/dist-newstyle/build/x86_64-linux/ghc-8.6.4/example-0.1.0.0/x/example-exe/build/example-exe/example-exe-tmp/Main.o )
Linking /app/dist-newstyle/build/x86_64-linux/ghc-8.6.4/example-0.1.0.0/x/example-exe/build/example-exe/example-exe ...
```