### PR TITLE
plutus-tx: add a version of $ that we can handle

### DIFF
--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -11,6 +11,8 @@ module Language.PlutusTx.Prelude (
     module Numeric,
     module Functor,
     module Lattice,
+    -- * Standard functions
+    ($),
     -- * String and tracing functions
     toPlutusString,
     trace,
@@ -69,7 +71,7 @@ import           Language.PlutusTx.Semigroup as Semigroup
 import           Prelude                     as Prelude hiding (Eq (..), Functor (..), Monoid (..), Num (..), Ord (..),
                                                          Semigroup (..), all, any, const, elem, error, filter, foldMap,
                                                          foldl, foldr, fst, length, map, max, maybe, min, not, null,
-                                                         snd, (!!), (&&), (++), (<$>), (||))
+                                                         snd, (!!), ($), (&&), (++), (<$>), (||))
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}
@@ -167,3 +169,10 @@ fold = foldr (<>) mempty
 {-# INLINABLE foldMap #-}
 foldMap :: Monoid m => (a -> m) -> [a] -> m
 foldMap f = foldr (\a m -> f a <> m) mempty
+
+infixr 0 $
+-- Normal $ is levity-polymorphic, which we can't handle.
+{-# INLINABLE ($) #-}
+-- | Plutus Tx version of 'Data.Function.($)'.
+($) :: (a -> b) -> a -> b
+f $ a = f a

--- a/plutus-tx/test/Plugin/Functions/Spec.hs
+++ b/plutus-tx/test/Plugin/Functions/Spec.hs
@@ -75,6 +75,7 @@ unfoldings = testNested "unfoldings" [
     -- on the outside of the let, which hit the value restriction. Now we hit the simplifier
     -- it seems to sometimes float these in, but we should keep an eye on these.
     , goldenPir "polyMap" polyMap
+    , goldenPir "applicationFunction" applicationFunction
   ]
 
 andDirect :: Bool -> Bool -> Bool
@@ -117,3 +118,9 @@ mapDirect f l = case l of
 
 polyMap :: CompiledCode ([Integer])
 polyMap = plc @"polyMap" (mapDirect (Builtins.addInteger 1) [0, 1])
+
+myDollar :: (a -> b) -> a -> b
+myDollar f a = f a
+
+applicationFunction :: CompiledCode (Integer)
+applicationFunction = plc @"applicationFunction" ((\x -> Builtins.addInteger 1 x) `myDollar` 1)

--- a/plutus-tx/test/Plugin/Functions/unfoldings/applicationFunction.plc.golden
+++ b/plutus-tx/test/Plugin/Functions/unfoldings/applicationFunction.plc.golden
@@ -1,0 +1,27 @@
+(program
+  (let
+    (nonrec)
+    (termbind
+      (strict)
+      (vardecl addInteger (fun (con integer) (fun (con integer) (con integer))))
+      (builtin addInteger)
+    )
+    (let
+      (nonrec)
+      (termbind
+        (strict)
+        (vardecl
+          myDollar (all a (type) (all b (type) (fun (fun a b) (fun a b))))
+        )
+        (abs a (type) (abs b (type) (lam f (fun a b) (lam a a [ f a ]))))
+      )
+      [
+        [
+          { { myDollar (con integer) } (con integer) }
+          (lam x (con integer) [ [ addInteger (con 1) ] x ])
+        ]
+        (con 1)
+      ]
+    )
+  )
+)


### PR DESCRIPTION
The real `$` has a scary levity-polymorphic type that we balk at. This
one is "boring" function application, which should work fine.

AFAIK, the only things that will go wrong if you use this instead of the
normal `$` are:
- Code that works with unlifted values (not much of that in what we're
writing).
- Code that uses `$` with `runST`, given that there's a special case for
that baked into GHC!

Fixes #1432. Also FYI @brunjlar who I know wanted this in the past.