### PR TITLE
plutus-tx: rename some functions

### DIFF
--- a/plutus-tutorial/doc/plutus-tx.adoc
+++ b/plutus-tutorial/doc/plutus-tx.adoc
@@ -326,7 +326,7 @@ addOneToN :: Integer -> CompiledCode Integer
 addOneToN n =
     addOne
     `applyCode` -- <.>
-    unsafeLiftCode n -- <.>
+    liftCode n -- <.>
 
 {- |
 >>> pretty $ getPlc addOne
@@ -360,15 +360,16 @@ addOneToN n =
 -}
 ----
 <.> `applyCode` applies one `CompiledCode` to another.
-<.> `unsafeLiftCode` lifts the argument `n` into a `CompiledCode Integer`.
+<.> `liftCode` lifts the argument `n` into a `CompiledCode Integer`.
 
-We lifted the argument using the `unsafeLiftCode` function. In order to use this, a type
+We lifted the argument using the `liftCode` function. In order to use this, a type
 must have an instance of the `Lift` class. In practice, you should
 generate these with the `makeLift` TH function from
 `Language.PlutusTx.Lift`.
 
-NOTE: `unsafeLiftCode` is "unsafe" because it ignores any errors that might occur from
-lifting something that isn't supported.
+NOTE: `liftCode` is a little "unsafe" because it ignores any errors that might occur from
+lifting something that isn't supported. There is a `safeLiftCode` if you want to explicitly
+handle these.
 
 The combined program applies the original compiled lambda to the lifted
 value (notice that the lambda is a bit complicated now since we have
@@ -385,9 +386,9 @@ pastEndAt :: EndDate -> Integer -> CompiledCode Bool
 pastEndAt end current =
     pastEnd
     `applyCode`
-    unsafeLiftCode end
+    liftCode end
     `applyCode`
-    unsafeLiftCode current
+    liftCode current
 
 {- |
 >>> let program = getPlc $ pastEndAt Never 5

--- a/plutus-tx/src/Language/PlutusTx.hs
+++ b/plutus-tx/src/Language/PlutusTx.hs
@@ -7,11 +7,11 @@ module Language.PlutusTx (
     Lift,
     Typeable,
     makeLift,
+    safeLiftCode,
     liftCode,
-    unsafeLiftCode,
-    unsafeConstCode) where
+    constCode) where
 
 import           Language.PlutusTx.Code       (CompiledCode, applyCode, getPir, getPlc)
-import           Language.PlutusTx.Lift       (liftCode, makeLift, unsafeConstCode, unsafeLiftCode)
+import           Language.PlutusTx.Lift       (constCode, liftCode, makeLift, safeLiftCode)
 import           Language.PlutusTx.Lift.Class (Lift, Typeable)
 import           Language.PlutusTx.TH         as Export

--- a/plutus-tx/test/Lift/Spec.hs
+++ b/plutus-tx/test/Lift/Spec.hs
@@ -48,20 +48,20 @@ Lift.makeLift ''SynExample
 
 tests :: TestNested
 tests = testNested "Lift" [
-    goldenPlc "int" (Lift.unsafeLiftProgram (1::Integer))
-    , goldenPlc "tuple" (Lift.unsafeLiftProgram (1::Integer, 2::Integer))
-    , goldenPlc "mono" (Lift.unsafeLiftProgram (Mono2 2))
-    , goldenEval "monoInterop" [ getPlc monoCase, Lift.unsafeLiftProgram (Mono1 1 2) ]
-    , goldenPlc "poly" (Lift.unsafeLiftProgram (Poly1 (1::Integer) (2::Integer)))
-    , goldenEval "polyInterop" [ getPlc defaultCasePoly, Lift.unsafeLiftProgram (Poly1 (1::Integer) (2::Integer)) ]
-    , goldenPlc "record" (Lift.unsafeLiftProgram (MyMonoRecord 1 2))
-    , goldenEval "boolInterop" [ getPlc andPlc, Lift.unsafeLiftProgram True, Lift.unsafeLiftProgram True ]
-    , goldenPlc "list" (Lift.unsafeLiftProgram ([1]::[Integer]))
-    , goldenEval "listInterop" [ getPlc listMatch, Lift.unsafeLiftProgram ([1]::[Integer]) ]
-    , goldenPlc "nested" (Lift.unsafeLiftProgram (NestedRecord (Just (1, 2))))
-    , goldenPlc "bytestring" (Lift.unsafeLiftProgram (WrappedBS "hello"))
-    , goldenPlc "newtypeInt" (Lift.unsafeLiftProgram (NewtypeInt 1))
-    , goldenPlc "newtypeInt2" (Lift.unsafeLiftProgram (Newtype2 $ NewtypeInt 1))
-    , goldenPlc "newtypeInt3" (Lift.unsafeLiftProgram (Newtype3 $ Newtype2 $ NewtypeInt 1))
-    , goldenPlc "syn" (Lift.unsafeLiftProgram (SynExample $ Z $ 1))
+    goldenPlc "int" (Lift.liftProgram (1::Integer))
+    , goldenPlc "tuple" (Lift.liftProgram (1::Integer, 2::Integer))
+    , goldenPlc "mono" (Lift.liftProgram (Mono2 2))
+    , goldenEval "monoInterop" [ getPlc monoCase, Lift.liftProgram (Mono1 1 2) ]
+    , goldenPlc "poly" (Lift.liftProgram (Poly1 (1::Integer) (2::Integer)))
+    , goldenEval "polyInterop" [ getPlc defaultCasePoly, Lift.liftProgram (Poly1 (1::Integer) (2::Integer)) ]
+    , goldenPlc "record" (Lift.liftProgram (MyMonoRecord 1 2))
+    , goldenEval "boolInterop" [ getPlc andPlc, Lift.liftProgram True, Lift.liftProgram True ]
+    , goldenPlc "list" (Lift.liftProgram ([1]::[Integer]))
+    , goldenEval "listInterop" [ getPlc listMatch, Lift.liftProgram ([1]::[Integer]) ]
+    , goldenPlc "nested" (Lift.liftProgram (NestedRecord (Just (1, 2))))
+    , goldenPlc "bytestring" (Lift.liftProgram (WrappedBS "hello"))
+    , goldenPlc "newtypeInt" (Lift.liftProgram (NewtypeInt 1))
+    , goldenPlc "newtypeInt2" (Lift.liftProgram (Newtype2 $ NewtypeInt 1))
+    , goldenPlc "newtypeInt3" (Lift.liftProgram (Newtype3 $ Newtype2 $ NewtypeInt 1))
+    , goldenPlc "syn" (Lift.liftProgram (SynExample $ Z $ 1))
  ]

--- a/plutus-tx/test/Plugin/Primitives/Spec.hs
+++ b/plutus-tx/test/Plugin/Primitives/Spec.hs
@@ -40,12 +40,12 @@ primitives = testNested "Primitives" [
   , goldenPir "ifThenElse" ifThenElse
   , goldenEval "ifThenElseApply" [ getProgram ifThenElse, getProgram int, getProgram int2 ]
   , goldenPir "emptyByteString" emptyByteString
-  , goldenEval "emptyByteStringApply" [ getPlc emptyByteString, unsafeLiftProgram Builtins.emptyByteString ]
+  , goldenEval "emptyByteStringApply" [ getPlc emptyByteString, liftProgram Builtins.emptyByteString ]
   , goldenPir "bytestring" bytestring
-  , goldenEval "bytestringApply" [ getPlc bytestring, unsafeLiftProgram ("hello"::Builtins.ByteString) ]
-  , goldenEval "sha2_256" [ getPlc sha2, unsafeLiftProgram ("hello" :: Builtins.ByteString)]
-  , goldenEval "equalsByteString" [ getPlc bsEquals, unsafeLiftProgram ("hello" :: Builtins.ByteString), unsafeLiftProgram ("hello" :: Builtins.ByteString)]
-  , goldenEval "ltByteString" [ getPlc bsLt, unsafeLiftProgram ("hello" :: Builtins.ByteString), unsafeLiftProgram ("world" :: Builtins.ByteString)]
+  , goldenEval "bytestringApply" [ getPlc bytestring, liftProgram ("hello"::Builtins.ByteString) ]
+  , goldenEval "sha2_256" [ getPlc sha2, liftProgram ("hello" :: Builtins.ByteString)]
+  , goldenEval "equalsByteString" [ getPlc bsEquals, liftProgram ("hello" :: Builtins.ByteString), liftProgram ("hello" :: Builtins.ByteString)]
+  , goldenEval "ltByteString" [ getPlc bsLt, liftProgram ("hello" :: Builtins.ByteString), liftProgram ("world" :: Builtins.ByteString)]
   , goldenPir "verify" verify
   , goldenPir "trace" trace
   ]

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -117,7 +117,7 @@ instance Typed.ScriptType CrowdFunding where
     type instance DataType CrowdFunding = PubKey
 
 scriptInstance :: Campaign -> Typed.ScriptInstance CrowdFunding
-scriptInstance cmp = Typed.Validator $ $$(PlutusTx.compile [|| mkValidator ||]) `PlutusTx.applyCode` PlutusTx.unsafeLiftCode cmp
+scriptInstance cmp = Typed.Validator $ $$(PlutusTx.compile [|| mkValidator ||]) `PlutusTx.applyCode` PlutusTx.liftCode cmp
 
 {-# INLINABLE validRefund #-}
 validRefund :: Campaign -> PubKey -> PendingTx -> Bool
@@ -182,7 +182,7 @@ contribute cmp = do
     -- ID of 'tx'. So we use `collectFromScriptFilter` to collect only those
     -- outputs whose data script is our own public key (in 'ds')
     let flt _ txOut = Ledger.txOutData txOut == Just ds
-        tx' = Typed.collectFromScriptFilter flt utxo (scriptInstance cmp) (PlutusTx.unsafeLiftCode Refund)
+        tx' = Typed.collectFromScriptFilter flt utxo (scriptInstance cmp) (PlutusTx.liftCode Refund)
                 & validityRange .~ refundRange cmp
     if not . Set.null $ tx' ^. inputs
     then void (writeTx tx')
@@ -210,7 +210,7 @@ scheduleCollection cmp = do
     -- campaign collection deadline, so we use the 'timeout' combinator.
     void $ timeout (campaignCollectionDeadline cmp) $ do
         (outxo, _) <- trg
-        let tx = Typed.collectFromScriptFilter (\_ _ -> True) outxo (scriptInstance cmp) (PlutusTx.unsafeLiftCode Collect)
+        let tx = Typed.collectFromScriptFilter (\_ _ -> True) outxo (scriptInstance cmp) (PlutusTx.liftCode Collect)
                     & validityRange .~ collectionRange cmp
         writeTx tx
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine.hs
@@ -213,7 +213,7 @@ mkValidator :: Params -> SM.StateMachineValidator State Input
 mkValidator p = SM.mkValidator $ StateMachine step (check p) final
 
 validatorCode :: Params -> PlutusTx.CompiledCode (Typed.ValidatorType MultiSigSym)
-validatorCode params = $$(PlutusTx.compile [|| mkValidator ||]) `PlutusTx.applyCode` PlutusTx.unsafeLiftCode params
+validatorCode params = $$(PlutusTx.compile [|| mkValidator ||]) `PlutusTx.applyCode` PlutusTx.liftCode params
 
 type MultiSigSym = StateMachine State Input
 scriptInstance :: Params -> Typed.ScriptInstance MultiSigSym

--- a/plutus-wallet-api/ledger/Ledger/Scripts.hs
+++ b/plutus-wallet-api/ledger/Ledger/Scripts.hs
@@ -74,7 +74,7 @@ import qualified Language.PlutusCore.Pretty               as PLC
 import qualified Language.PlutusCore.Constant.Dynamic     as PLC
 import qualified Language.PlutusCore.Evaluation.Result    as PLC
 import           Language.PlutusTx.Evaluation             (evaluateCekTrace)
-import           Language.PlutusTx.Lift                   (unsafeLiftCode)
+import           Language.PlutusTx.Lift                   (liftCode)
 import           Language.PlutusTx.Lift.Class             (Lift)
 import           Language.PlutusTx                        (CompiledCode, compile, getPlc, makeLift)
 import           Language.PlutusTx.Prelude
@@ -193,7 +193,7 @@ instance FromJSON Script where
 -- | Lift a Haskell value into the corresponding 'Script'. This allows you to create
 -- 'Script's at runtime, whereas 'compileScript' allows you to do so at compile time.
 lifted :: Lift a => a -> Script
-lifted = fromCompiledCode . unsafeLiftCode
+lifted = fromCompiledCode . liftCode
 
 -- | 'ValidatorScript' is a wrapper around 'Script's which are used as validators in transaction outputs.
 newtype ValidatorScript = ValidatorScript { getValidator :: Script }

--- a/plutus-wallet-api/ledger/Ledger/Typed/Tx.hs
+++ b/plutus-wallet-api/ledger/Ledger/Typed/Tx.hs
@@ -124,7 +124,7 @@ ignoreArgs
     -> CompiledCode r
     -> CompiledCode (Uncurry args r)
 ignoreArgs NilSpine _ c = c
-ignoreArgs (ConsSpine tspine) p c = Lift.unsafeConstCode Proxy $ ignoreArgs tspine p c
+ignoreArgs (ConsSpine tspine) p c = Lift.constCode Proxy $ ignoreArgs tspine p c
 
 -- | A 'TxIn' tagged by two phantom types: a list of the types of the data scripts in the transaction; and the connection type of the input.
 newtype TypedScriptTxIn (outs :: [Type]) a = TypedScriptTxIn { unTypedScriptTxIn :: TxIn }

--- a/plutus-wallet-api/src/Wallet/Typed/StateMachine.hs
+++ b/plutus-wallet-api/src/Wallet/Typed/StateMachine.hs
@@ -27,7 +27,7 @@ mkInitialise
     -> m (Typed.TypedTx '[] '[SM.StateMachine s i], s)
     -- ^ The initalizing transaction and the initial state of the contract.
 mkInitialise (SM.StateMachineInstance _ si _ _) state vl = do
-    let dataScript = PlutusTx.unsafeLiftCode state
+    let dataScript = PlutusTx.liftCode state
 
     tx <- WAPITyped.makeScriptPayment si WAPI.defaultSlotRange vl dataScript
 
@@ -56,9 +56,9 @@ mkStep (SM.StateMachineInstance (SM.StateMachine step _ _) si stepRedeemer _) cu
         Just s  -> pure s
         Nothing -> WAPI.throwOtherError "Invalid transition"
     let redeemer :: PlutusTx.CompiledCode (Typed.RedeemerFunctionType '[SM.StateMachine s i] (SM.StateMachine s i))
-        redeemer = stepRedeemer `PlutusTx.applyCode` PlutusTx.unsafeLiftCode input
+        redeemer = stepRedeemer `PlutusTx.applyCode` PlutusTx.liftCode input
         dataScript :: PlutusTx.CompiledCode s
-        dataScript = PlutusTx.unsafeLiftCode newState
+        dataScript = PlutusTx.liftCode newState
 
     -- TODO: This needs to check that all the inputs have exactly the state we specify as the argument here,
     -- otherwise you can poison the contract by adding a state machine output that's not in the same state.
@@ -94,7 +94,7 @@ mkHalt (SM.StateMachineInstance (SM.StateMachine step _ final) si _ haltRedeemer
         Nothing -> WAPI.throwOtherError "Invalid transition"
     unless (final newState) $ WAPI.throwOtherError $ "Cannot halt when transitioning to a non-final state: " <> (T.pack $ show newState)
     let redeemer :: PlutusTx.CompiledCode (Typed.RedeemerFunctionType '[] (SM.StateMachine s i))
-        redeemer = haltRedeemer `PlutusTx.applyCode` PlutusTx.unsafeLiftCode input
+        redeemer = haltRedeemer `PlutusTx.applyCode` PlutusTx.liftCode input
 
     -- TODO: This needs to check that all the inputs have exactly the state we specify as the argument here,
     -- otherwise you can poison the contract by adding a state machine output that's not in the same state.


### PR DESCRIPTION
In practice the "unsafe" variants were the ones that everyone used
anyway, and having the prefix made it look more dangerous than it
actually is.

Fixes #1430.