### PR TITLE
Improve the API for payment selection.

### DIFF
--- a/plutus-book/doc/auction/english.adoc
+++ b/plutus-book/doc/auction/english.adoc
@@ -603,7 +603,7 @@ start' = do
             []         -> go1 ref v
             (ref' : _) -> do
                 key <- ownPubKey
-                let i1 = pubKeyTxIn ref key
+                let i1 = pubKeyTxIn key ref
                     i2 = scriptTxIn
                             ref'
                             (mkAdminValidator admin)
@@ -644,7 +644,7 @@ start' = do
                 logMsg $ T.pack $
                     "starting tokens " ++ show nf
                 let v  = V.singleton s adminTokenName 1
-                    i  = pubKeyTxIn ref key
+                    i  = pubKeyTxIn key ref
                     o1 = scriptTxOut
                             v
                             (mkNonFungibleValidator nf)

--- a/plutus-book/doc/non-fungible/nonfungible8.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible8.adoc
@@ -195,10 +195,10 @@ hasAdminToken s (_, o) =
 Now we can write our endpoints. The biggest change is in `start`, where
 we now first have to forge the admin token before we can start our policy.
 
-We also rename `start` to `start'`, because for later use we want a version 
+We also rename `start` to `start'`, because for later use we want a version
 of `start` that _returns_ the symbol of our policy
 .
-It is not allowed to have wallet endpoints in the Playground return types other than `()`, though, 
+It is not allowed to have wallet endpoints in the Playground return types other than `()`, though,
 so afterwards we will define `start` in terms of `start'`.
 
 [source,haskell]
@@ -245,7 +245,7 @@ start' = do
             []         -> go1 ref v                        -- <4>
             (ref' : _) -> do
                 key <- ownPubKey
-                let i1 = pubKeyTxIn ref key                -- <5>
+                let i1 = pubKeyTxIn key ref                -- <5>
                     i2 = scriptTxIn                        -- <6>
                             ref'
                             (mkAdminValidator admin)
@@ -286,7 +286,7 @@ start' = do
                 logMsg $ T.pack $
                     "starting tokens " ++ show nf
                 let v  = V.singleton s adminTokenName 1
-                    i  = pubKeyTxIn ref key                -- <10>
+                    i  = pubKeyTxIn key ref                -- <10>
                     o1 = scriptTxOut                       -- <11>
                             v
                             (mkNonFungibleValidator nf)
@@ -344,7 +344,7 @@ forge s n = do
                 , adminCurrency = s
                 }
     logMsg $ T.pack $
-        "forging " ++ n ++ 
+        "forging " ++ n ++
         " (symbol " ++ show (nonFungibleSymbol nf) ++
         ") of " ++ show nf
 

--- a/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
@@ -106,7 +106,7 @@ addInputs mp pk vl tx = do
     let
 
         addTxIns  =
-            let ins = Set.fromList (flip Tx.pubKeyTxIn pk . fst <$> spend)
+            let ins = Set.fromList (Tx.pubKeyTxIn pk . fst <$> spend)
             in over Tx.inputs (Set.union ins)
 
         addTxOuts = if Value.isZero change

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -43,7 +43,7 @@ import qualified Ledger.Validation            as Validation
 import qualified Ledger.Ada                   as Ada
 import           Ledger.Ada                   (Ada)
 import qualified Wallet                       as W
-import           Wallet                       (WalletAPI (..), WalletAPIError, throwOtherError, createTxAndSubmit, defaultSlotRange)
+import           Wallet                       (WalletAPI (..), WalletAPIError, throwOtherError, createTxAndSubmit, defaultSlotRange, createPaymentWithChange)
 
 {- note [Futures in Plutus]
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -38,7 +38,7 @@ import qualified Ledger.Value                 as Value
 import qualified Ledger.Validation            as Validation
 import           Ledger.Validation            (PendingTx, PendingTx' (..), PendingTxIn'(..), PendingTxOut(..), getContinuingOutputs)
 import qualified Wallet                       as W
-import           Wallet                       (WalletAPI (..), WalletAPIError, throwOtherError, ownPubKeyTxOut, createTxAndSubmit, defaultSlotRange)
+import           Wallet                       (WalletAPI (..), WalletAPIError, throwOtherError, ownPubKeyTxOut, createTxAndSubmit, defaultSlotRange, createPaymentWithChange)
 
 -- | Tranche of a vesting scheme.
 data VestingTranche = VestingTranche {

--- a/plutus-wallet-api/ledger/Ledger/Tx.hs
+++ b/plutus-wallet-api/ledger/Ledger/Tx.hs
@@ -289,8 +289,8 @@ inAddress TxInOf{ txInType = t } = case t of
         LB.bytes (getPubKey pk)
 
 -- | A transaction input that spends a "pay to public key" output, given the witness.
-pubKeyTxIn :: TxOutRefOf h -> PubKey -> TxInOf h
-pubKeyTxIn r = TxInOf r . ConsumePublicKeyAddress
+pubKeyTxIn :: PubKey -> TxOutRefOf h -> TxInOf h
+pubKeyTxIn pubK r = TxInOf r (ConsumePublicKeyAddress pubK)
 
 -- | A transaction input that spends a "pay to script" output, given witnesses.
 scriptTxIn :: TxOutRefOf h -> ValidatorScript -> RedeemerScript -> TxInOf h

--- a/plutus-wallet-api/src/Wallet/API.hs
+++ b/plutus-wallet-api/src/Wallet/API.hs
@@ -22,6 +22,7 @@ module Wallet.API(
     MonadWallet,
     EventHandler(..),
     PubKey(..),
+    createPaymentWithChange,
     signTxn,
     signTxnWithKey,
     createTxAndSubmit,
@@ -287,8 +288,12 @@ class WalletAPI m where
     {- |
     Select enough inputs from the user's UTxOs to make a payment of the given value.
     Includes an output for any leftover funds, if there are any. Fails if we don't have enough funds.
+
+    This can also be used iteratively, by passing the outputs from this function as its inputs, and
+    a new value we want to spend. New inputs will be added to the input set to cover the new values,
+    as required.
     -}
-    createPaymentWithChange :: Value -> m (Set.Set TxIn, Maybe TxOut)
+    updatePaymentWithChange :: Value -> (Set.Set TxIn, Maybe TxOut) -> m (Set.Set TxIn, Maybe TxOut)
 
     {- |
     Register a 'EventHandler' in @m ()@ to be run a single time when the
@@ -328,6 +333,9 @@ class WalletAPI m where
     The current slot.
     -}
     slot :: m Slot
+
+createPaymentWithChange :: WalletAPI m => Value -> m (Set.Set TxIn, Maybe TxOut)
+createPaymentWithChange v = updatePaymentWithChange v (Set.empty, Nothing)
 
 throwInsufficientFundsError :: MonadError WalletAPIError m => Text -> m a
 throwInsufficientFundsError = throwError . InsufficientFunds

--- a/plutus-wallet-api/src/Wallet/Generators.hs
+++ b/plutus-wallet-api/src/Wallet/Generators.hs
@@ -156,7 +156,7 @@ genValidTransaction' g f (Mockchain bc ops) = do
                 then Gen.discard
                 else Gen.int (Range.linear 1 (Map.size ops))
     let ins = Set.fromList
-                    $ uncurry pubKeyTxIn
+                    $ uncurry (flip pubKeyTxIn)
                     <$> (catMaybes
                         $ traverse (pubKeyTxo [bc]) . (di . fst) <$> inUTXO)
         inUTXO = take nUtxo $ Map.toList ops


### PR DESCRIPTION
This improvement gives user an easy way to write contract code where
the value spent is specified in several iterations, giving more control
over the inputs used by the wallet (for example, to cover fees).

We tried to cover a couple of use cases (mostly used for covering
fees):

1) If we have a set of inputs specified, when we add a fee, we would
   like to make it easy to choose to cover fees from the remaining change,
   or to use new inputs to cover fees.

2) Make it easy to automate spending behaviors across all contract
   code where, for example, for each spending of funds, you need to
   add some extra book-keeping transactions.

3) In general, if we have a transaction where some inputs have already
   been specified, we need to provide a way to spend more without
   using the previously added inputs.

Overall I do think that these things are possible with the current
contract API, but they would require more code on the client side to
keep track of the inputs used so far and hack the code to choose new
inputs to cover some other fees.

This fixes #1381