### PR TITLE
Playground: Reemoving the editor's print marker.

### DIFF
--- a/web-common/src/Editor.purs
+++ b/web-common/src/Editor.purs
@@ -50,6 +50,7 @@ initEditor initialContents editor =
           contents = fromMaybe "" (savedContents <|> initialContents)
         void $ Editor.setValue contents (Just 1) editor
         Editor.setTheme "ace/theme/monokai" editor
+        Editor.setShowPrintMargin false editor
         --
         session <- Editor.getSession editor
         Session.setMode "ace/mode/haskell" session


### PR DESCRIPTION
The vertical line at column 80. Fixes #1440.