### PR TITLE
Frontend: Removing an obsolete constructor.

### DIFF
--- a/plutus-playground-client/src/Chain/Types.purs
+++ b/plutus-playground-client/src/Chain/Types.purs
@@ -2,30 +2,24 @@ module Chain.Types where
 
 import Prelude
 
-import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Data.Lens (Prism', Lens', prism)
+import Data.Lens (Iso', Lens', iso)
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
 import Data.Maybe (Maybe)
 import Data.Symbol (SProxy(..))
-import Ledger.Tx (AddressOf, TxOutOf(..), TxOutType(..))
+import Ledger.Tx (TxOutOf(..), TxOutType(..))
 import Playground.Types (AnnotatedTx, BeneficialOwner(..), SequenceId)
 
 data ChainFocus
   = FocusTx AnnotatedTx
-  | FocusAddress (AddressOf String)
 
-_FocusTx :: Prism' ChainFocus AnnotatedTx
-_FocusTx = prism FocusTx case _ of
-  FocusTx tx -> Right tx
-  other -> Left other
-
-_FocusAddress :: Prism' ChainFocus (AddressOf String)
-_FocusAddress = prism FocusAddress case _ of
-  FocusAddress address -> Right address
-  other -> Left other
+_FocusTx :: Iso' ChainFocus AnnotatedTx
+_FocusTx = iso get set
+  where
+    get (FocusTx annotatedTx) = annotatedTx
+    set = FocusTx
 
 derive instance genericChainFocus :: Generic ChainFocus _
 

--- a/plutus-playground-client/src/Chain/View.purs
+++ b/plutus-playground-client/src/Chain/View.purs
@@ -14,7 +14,7 @@ import Data.RawJson (JsonTuple(..))
 import Data.Tuple (fst)
 import Data.Tuple.Nested (type (/\), (/\))
 import Halogen (action)
-import Halogen.HTML (ClassName(..), HTML, br_, code_, div, div_, h2_, hr_, small_, span, span_, strong_, text)
+import Halogen.HTML (ClassName(..), HTML, br_, div, div_, h2_, hr_, small_, span, span_, strong_, text)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes)
 import Language.PlutusTx.AssocMap as AssocMap
@@ -140,8 +140,6 @@ detailView state@{ chainFocus:
     , balancesView sequenceId walletKeys (AssocMap.toDataMap balances)
     ]
 
-detailView state@{ chainFocus: Just (FocusAddress address) } _ _ = div_ [ code_ [ text $ show address ] ]
-
 detailView state@{ chainFocus: Nothing } _ _ = div_ []
 
 entryCardHeader :: forall i p. SequenceId -> HTML p i
@@ -216,15 +214,7 @@ formatSequenceId (SequenceId { slotIndex, txIndex }) = "Slot #" <> show slotInde
 txOutOfView :: forall p. Boolean -> Map PubKey Wallet -> TxOutOf String -> HTML p (Query Unit)
 txOutOfView showArrow walletKeys txOutOf@(TxOutOf { txOutAddress, txOutType, txOutValue }) =
   div
-    [ classes [ card, entry, beneficialOwnerClass beneficialOwner ]
-    , onClick
-        $ const
-        $ Just
-        $ action
-        $ SetChainFocus
-        $ Just
-        $ FocusAddress txOutAddress
-    ]
+    [ classes [ card, entry, beneficialOwnerClass beneficialOwner ] ]
     [ cardHeaderOwnerView showArrow walletKeys beneficialOwner
     , cardBody_
         [ valueView txOutValue ]


### PR DESCRIPTION
FocusAddress was something I'd planned in prototyping the new frontend
visualisation. But it ended up not being as useful as I'd thought.

Fixes #1451.