### PR TITLE
contract: Add UtxoAt effect

### DIFF
--- a/plutus-contract/doc/contract-api.adoc
+++ b/plutus-contract/doc/contract-api.adoc
@@ -59,6 +59,10 @@ Smart contracts often involve multiple participants that synchronise their actio
 
 Sometimes we want to see what outputs accumulate at an address, and spend all of them after a while. `watchAddressUntil {2c} (HasAwaitSlot s, HasWatchAddress s) => Address -> Slot -> Contract s AddressMap` keeps track of all changes to the address that happen between now and the given slot. It returns a value of `AddressMap` - a collection of outputs that can be used in transactions of the contract.
 
+=== Unspent outputs
+
+The `UtxoAt` effect, available through `utxoAt {2c} HasUtxoAt s => Address -> Contract s AddressMap`,  lets us query the node client for all unspent outputs at an address. The difference between `utxoAt` and `nextTransactionAt` is that the former returns right away with the current UTXO set at the address, and the latter only returns when the set of unspent outputs at the address has been changed (so it may not return at all, if there are no transactions that touch the address).
+
 === Transactions
 
 Contracts write transactions using `writeTx {2c} (HasWriteTx s) => UnbalancedTx -> Contract s ()`. The transactions produced that way are unbalanced and unsigned. When executing a `writeTx` instruction, the app platform forwards the transaction to the user's wallet to balance it (by adding appropriate public key inputs or outputs) and compute the gas cost of any scripts involved. The finished transaction is then signed by the signing process, and submitted to the wallet which sends it to the blockchain. `writeTx` returns when the transaction has been submitted to the blockchain.

--- a/plutus-contract/plutus-contract.cabal
+++ b/plutus-contract/plutus-contract.cabal
@@ -46,6 +46,7 @@ library
         Language.Plutus.Contract.App
         Language.Plutus.Contract.Effects.AwaitSlot
         Language.Plutus.Contract.Effects.ExposeEndpoint
+        Language.Plutus.Contract.Effects.UtxoAt
         Language.Plutus.Contract.Effects.WatchAddress
         Language.Plutus.Contract.Effects.WriteTx
         Language.Plutus.Contract.Request

--- a/plutus-contract/src/Language/Plutus/Contract.hs
+++ b/plutus-contract/src/Language/Plutus/Contract.hs
@@ -34,6 +34,9 @@ module Language.Plutus.Contract(
     , nextTransactionAt
     , watchAddressUntil
     , fundsAtAddressGt
+    -- * UTXO set
+    , HasUtxoAt
+    , utxoAt
     -- * Transactions
     , module Tx
     -- * Row-related things
@@ -48,6 +51,7 @@ import           Data.Row
 
 import           Language.Plutus.Contract.Effects.AwaitSlot
 import           Language.Plutus.Contract.Effects.ExposeEndpoint
+import           Language.Plutus.Contract.Effects.UtxoAt
 import           Language.Plutus.Contract.Effects.WatchAddress
 import           Language.Plutus.Contract.Effects.WriteTx
 import           Language.Plutus.Contract.Util                   (both, selectEither)
@@ -58,14 +62,17 @@ import           Language.Plutus.Contract.Tx                     as Tx
 
 import           Prelude                                         hiding (until)
 
--- | Schema for contracts that can interact with the blockchain (via a wallet)
+-- | Schema for contracts that can interact with the blockchain (via a node 
+--   client & signing process)
 type BlockchainActions =
   AwaitSlot
   .\/ WatchAddress
   .\/ WriteTx
+  .\/ UtxoAt
 
 type HasBlockchainActions s =
   ( HasAwaitSlot s
   , HasWatchAddress s
   , HasWriteTx s
+  , HasUtxoAt s
   )

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/UtxoAt.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/UtxoAt.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE MonoLocalBinds      #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedLabels    #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+module Language.Plutus.Contract.Effects.UtxoAt where
+
+import           Data.Aeson                       (FromJSON, ToJSON)
+import           Data.Map                         (Map)
+import qualified Data.Map                         as Map
+import           Data.Row
+import           Data.Set                         (Set)
+import qualified Data.Set                         as Set
+import           GHC.Generics                     (Generic)
+import           Ledger                           (Address)
+import           Ledger.AddressMap                (AddressMap)
+import qualified Ledger.AddressMap                as AM
+import           Ledger.Tx                        (TxOut, TxOutRef)
+
+import           Language.Plutus.Contract.Request (Contract, ContractRow, requestMaybe)
+import           Language.Plutus.Contract.Schema  (Event (..), Handlers (..), Input, Output)
+
+type HasUtxoAt s =
+    ( HasType "utxo-at" UtxoAtAddress (Input s)
+    , HasType "utxo-at" (Set Address) (Output s)
+    , ContractRow s)
+
+data UtxoAtAddress =
+  UtxoAtAddress
+    { address :: Address
+    , utxo    :: Map TxOutRef TxOut
+    }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+type UtxoAt = "utxo-at" .== (UtxoAtAddress, Set Address)
+
+-- | Get the unspent transaction outputs at an address.
+utxoAt :: forall s. HasUtxoAt s => Address -> Contract s AddressMap
+utxoAt address' =
+    let check :: UtxoAtAddress -> Maybe AddressMap
+        check UtxoAtAddress{address,utxo} =
+          if address' == address then Just (AM.AddressMap $ Map.singleton address utxo) else Nothing
+    in
+    requestMaybe @"utxo-at" @_ @_ @s (Set.singleton address') check
+
+event
+    :: forall s.
+    ( HasUtxoAt s )
+    => UtxoAtAddress
+    -> Event s
+event = Event . IsJust (Label @"utxo-at")
+
+addresses
+    :: forall s.
+    ( HasUtxoAt s )
+    => Handlers s
+    -> Set Address
+addresses (Handlers r) = r .! Label @"utxo-at"

--- a/plutus-contract/src/Language/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Trace.hs
@@ -286,8 +286,8 @@ addBlocks i =
 --   UTXO queries
 handleBlockchainEvents
     :: ( MonadEmulator m
-       , HasWatchAddress s
        , HasUtxoAt s
+       , HasWatchAddress s
        , HasWriteTx s
        )
     => Wallet

--- a/plutus-emulator/src/Wallet/Emulator/Types.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Types.hs
@@ -265,7 +265,7 @@ handleNotifications = mapM_ (updateState >=> runTriggers)  where
         traverse_ (uncurry (flip runEventHandler)) trueConditions
 
     -- Remove spent outputs and add unspent ones, for the addresses that we care about
-    update t = over addressMap (AM.updateAddresses t)
+    update t = over addressMap (\am -> AM.fromTxOutputs t <> AM.updateAddresses t am )
 
 -- Make a transaction output from a positive value.
 mkChangeOutput :: PubKey -> Value -> Maybe TxOut

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -239,5 +239,5 @@ successfulCampaign =
         >> makeContribution (Trace.Wallet 4) (Ada.lovelaceValueOf 1)
         >> Trace.addBlocks 18
         >> Trace.notifySlot (Trace.Wallet 1)
-        >> Trace.handleUtxoQueries (Trace.Wallet 1)
+        >> Trace.handleBlockchainEvents (Trace.Wallet 1)
         >> Trace.handleBlockchainEvents (Trace.Wallet 1)

--- a/plutus-wallet-api/ledger/Ledger/Tx.hs
+++ b/plutus-wallet-api/ledger/Ledger/Tx.hs
@@ -231,6 +231,8 @@ deriving instance Serialise TxOutRef
 deriving instance ToJSON TxOutRef
 deriving instance FromJSON TxOutRef
 deriving instance ToSchema TxOutRef
+deriving instance ToJSONKey TxOutRef
+deriving instance FromJSONKey TxOutRef
 
 -- | A list of a transaction's outputs paired with a 'TxOutRef's referring to them.
 txOutRefs :: Tx -> [(TxOut, TxOutRef)]


### PR DESCRIPTION
* Add the `UtxoAt` effect with
  `utxoAt :: HasUtxoAt s => Address -> Contract s AddressMap`, allowing
  contracts to query the UTXO set through the node client.

* Note that this also changes the way `WalletAPI` is implemented in the
  emulator: Wallets now keep track of the entire UTXO set, not just the
  subset of unspent outputs at the adddresses they are interested in. So
  the behaviour of `WalletAPI` in this regard is now that of a node
  client.

Implements #1468 