### PR TITLE
contract: WriteTx returns txID

### DIFF
--- a/plutus-contract/doc/contract-api.adoc
+++ b/plutus-contract/doc/contract-api.adoc
@@ -17,6 +17,7 @@ When you have a `PlutusContract` you can compile it to a contract bundle (a form
 {-# LANGUAGE TypeOperators    #-}
 {-# LANGUAGE MonoLocalBinds   #-}
 module ContractAPI where
+import           Control.Monad               (void)
 import           Language.Plutus.Contract
 import           Language.Plutus.Contract.Tx (UnbalancedTx)
 import           Ledger.AddressMap           (AddressMap)
@@ -65,9 +66,7 @@ The `UtxoAt` effect, available through `utxoAt {2c} HasUtxoAt s => Address -> Co
 
 === Transactions
 
-Contracts write transactions using `writeTx {2c} (HasWriteTx s) => UnbalancedTx -> Contract s ()`. The transactions produced that way are unbalanced and unsigned. When executing a `writeTx` instruction, the app platform forwards the transaction to the user's wallet to balance it (by adding appropriate public key inputs or outputs) and compute the gas cost of any scripts involved. The finished transaction is then signed by the signing process, and submitted to the wallet which sends it to the blockchain. `writeTx` returns when the transaction has been submitted to the blockchain.
-
-NOTE: In the future, `writeTx` will return some information about the transaction (status, gas fee, etc).
+Contracts write transactions using `writeTx {2c} (HasWriteTx s) => UnbalancedTx -> Contract s WriteTxResponse`. The transactions produced that way are unbalanced and unsigned. When executing a `writeTx` instruction, the app platform forwards the transaction to the user's wallet to balance it (by adding appropriate public key inputs or outputs) and compute the gas cost of any scripts involved. The finished transaction is then signed by the signing process, and submitted to the wallet which sends it to the blockchain. `writeTx` returns the final transaction's ID once it has been submitted to the blockchain (or an error if the balancing or signing failed).
 
 === Endpoints
 
@@ -123,7 +122,7 @@ mkTx = undefined
 spend :: HasBlockchainActions s => Contract s ()
 spend = do -- <1>
     (ins, pk) <- collectRec
-    writeTx (mkTx ins pk)
+    void (writeTx (mkTx ins pk))
 ----
 <1> We use Haskell's do notation to signal the start of a sequence of actions
 

--- a/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
@@ -121,9 +121,9 @@ addOutputs pk vl tx = tx & over Tx.outputs (pko :) where
 
 -- | Balance an unabalanced transaction, sign it, and submit
 --   it to the chain in the context of a wallet.
-handleTx :: MonadWallet m => UnbalancedTx -> m ()
+handleTx :: MonadWallet m => UnbalancedTx -> m Tx
 handleTx utx =
-    balanceWallet utx >>= addSignatures (view T.requiredSignatures utx) >>= WAPI.signTxAndSubmit_
+    balanceWallet utx >>= addSignatures (view T.requiredSignatures utx) >>= WAPI.signTxAndSubmit
 
 -- | Add signatures of the private keys belonging to the given
 --   public keys to the transaction, provided that they are

--- a/plutus-emulator/src/Wallet/Emulator/Types.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Types.hs
@@ -682,12 +682,12 @@ execTraceTxPool pl = snd . runTraceTxPool pl
 
 -- | Run an action as a wallet, subsequently process any pending transactions
 --   and notify wallets. Returns the new block
-runWalletActionAndProcessPending :: [Wallet] -> Wallet -> m () -> Trace m [Tx]
+runWalletActionAndProcessPending :: [Wallet] -> Wallet -> m a -> Trace m ([Tx], Either WalletAPIError a)
 runWalletActionAndProcessPending wallets wallet action = do
-    _ <- runWalletAction wallet action
+    (result, _) <- runWalletAction wallet action
     block <- processPending
     _ <- walletsNotifyBlock wallets block
-    pure block
+    pure (block, result)
 
 allWallets :: [Wallet]
 allWallets = Wallet <$> [1..10]

--- a/plutus-playground-lib/src/Playground/Contract.hs
+++ b/plutus-playground-lib/src/Playground/Contract.hs
@@ -48,6 +48,7 @@ import           GHC.Generics                (Generic)
 import           IOTS                        (IotsType (iotsDefinition))
 import           Ledger.Interval             (always)
 import           Ledger.Scripts              (ValidatorHash (ValidatorHash))
+import           Ledger.Tx                   (Tx)
 import           Ledger.Value                (TokenName (TokenName), Value)
 import           Playground.Interpreter.Util
 import           Playground.TH               (ensureIotsDefinitions, mkFunction, mkFunctions, mkIotsDefinitions,
@@ -55,11 +56,15 @@ import           Playground.TH               (ensureIotsDefinitions, mkFunction,
 import           Playground.Types            (FunctionSchema, KnownCurrency (KnownCurrency), adaCurrency)
 import           Schema                      (FormSchema, ToSchema)
 import           Wallet.API                  (WalletAPI, payToPublicKey_)
-import           Wallet.Emulator             (addBlocksAndNotify, runWalletActionAndProcessPending, walletPubKey)
-import           Wallet.Emulator.Types       (MockWallet, Wallet (..))
+import           Wallet.Emulator             (addBlocksAndNotify, walletPubKey)
+import qualified Wallet.Emulator             as Emulator
+import           Wallet.Emulator.Types       (MockWallet, Trace, Wallet (..))
 
 payToWallet_ :: (Monad m, WalletAPI m) => Value -> Wallet -> m ()
 payToWallet_ v = payToPublicKey_ always v . walletPubKey
+
+runWalletActionAndProcessPending :: [Wallet] -> Wallet -> m a -> Trace m [Tx]
+runWalletActionAndProcessPending wllts wllt a = fmap fst (Emulator.runWalletActionAndProcessPending wllts wllt a)
 
 -- We need to work with lazy 'ByteString's in contracts,
 -- but 'ByteArrayAccess' (which we need for hashing) is only defined for strict

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -171,7 +171,7 @@ contribute cmp = do
     let ds = Ledger.DataScript (Ledger.lifted ownPK)
         tx = payToScript contribution (campaignAddress cmp) ds
                 & validityRange .~ Ledger.interval 1 (campaignDeadline cmp)
-    writeTx tx
+    void (writeTx tx)
 
     utxo <- watchAddressUntil (campaignAddress cmp) (campaignCollectionDeadline cmp)
     -- 'utxo' is the set of unspent outputs at the campaign address at the
@@ -207,7 +207,7 @@ scheduleCollection cmp = do
 
     let tx = Typed.collectFromScriptFilter (\_ _ -> True) unspentOutputs (scriptInstance cmp) (PlutusTx.liftCode Collect)
             & validityRange .~ collectionRange cmp
-    writeTx tx
+    void $ writeTx tx
 
 -- | Call the "schedule collection" endpoint and instruct the campaign owner's
 --   wallet (wallet 1) to start watching the campaign address.


### PR DESCRIPTION
* `writeTx` now returns the ID of the final transaction that was submitted, or the `WalletAPI` error if balancing / signing failed.