### PR TITLE
ledger: be fussier about the types of validator scripts

### DIFF
--- a/plutus-book/doc/auction/english.adoc
+++ b/plutus-book/doc/auction/english.adoc
@@ -61,9 +61,9 @@ adminRedeemer :: RedeemerScript
 adminRedeemer = RedeemerScript $ toData ()
 
 mkAdminValidator :: Admin -> ValidatorScript
-mkAdminValidator = ValidatorScript
-                       . applyScript $$(compileScript [|| \a -> wrapValidator (validateAdmin a) ||])
-                       . lifted
+mkAdminValidator = mkValidatorScript
+                       . applyCode $$(compile [|| \a -> wrapValidator (validateAdmin a) ||])
+                       . liftCode
 
 adminAddress :: Admin -> Address
 adminAddress = scriptAddress . mkAdminValidator
@@ -124,9 +124,9 @@ mkNonFungibleRedeemer :: String -> RedeemerScript
 mkNonFungibleRedeemer name = RedeemerScript $ toData $ TokenName $ C.pack name
 
 mkNonFungibleValidator :: NonFungible -> ValidatorScript
-mkNonFungibleValidator = ValidatorScript
-                       . applyScript $$(compileScript [|| \nf -> wrapValidator (validateNonFungible nf) ||])
-                       . lifted
+mkNonFungibleValidator = mkValidatorScript
+                       . applyCode $$(compile [|| \nf -> wrapValidator (validateNonFungible nf) ||])
+                       . liftCode
 
 nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator
@@ -550,7 +550,7 @@ eaStateMachine ea = StateMachine
     }
 
 mkEAValidator :: EnglishAuction -> ValidatorScript
-mkEAValidator ea = ValidatorScript $ $$(compileScript [|| v ||]) `applyScript` lifted ea
+mkEAValidator ea = mkValidatorScript $ $$(compile [|| v ||]) `applyCode` liftCode ea
     where v ea' = wrapValidator (mkValidator (eaStateMachine ea'))
 
 eaAddress :: EnglishAuction -> Address

--- a/plutus-book/doc/game/guess.adoc
+++ b/plutus-book/doc/game/guess.adoc
@@ -71,7 +71,7 @@ validate (HashedText hashed) (ClearText clear) _ =
     equalsByteString hashed (sha2_256 clear)
 
 gameValidator :: ValidatorScript
-gameValidator = ValidatorScript $$(compileScript [|| v ||])
+gameValidator = mkValidatorScript $$(compile [|| v ||])
     where v = wrapValidator validate
 ----
 

--- a/plutus-book/doc/multi/vesting.adoc
+++ b/plutus-book/doc/multi/vesting.adoc
@@ -104,10 +104,10 @@ validate v () () tx =
     in     (remaining >= unreleased)
         && (tx `txSignedBy` owner v)
 
-mkValidatorScript :: Vesting -> ValidatorScript
-mkValidatorScript = ValidatorScript
-                  . applyScript $$(compileScript [|| \v -> wrapValidator (validate v) ||])
-                  . lifted
+mkValidator :: Vesting -> ValidatorScript
+mkValidator = mkValidatorScript
+                  . applyCode $$(compile [|| \v -> wrapValidator (validate v) ||])
+                  . liftCode
 ----
 
 <1> Our validator hash.
@@ -127,7 +127,7 @@ Now we are ready to define our wallet endpoints, of which we need three:
 [source,haskell]
 ----
 vestingAddress :: Vesting -> Address
-vestingAddress = scriptAddress . mkValidatorScript
+vestingAddress = scriptAddress . mkValidator
 
 registerScheme :: MonadWallet m => Tranche -> Tranche -> m ()
 registerScheme t1 t2 = do
@@ -188,7 +188,7 @@ withdraw t1 t2 ada = do
             then [ o
                  , scriptTxOut
                     (toValue change)
-                    (mkValidatorScript v)
+                    (mkValidator v)
                     dataScript
                  ]
             else [o]
@@ -205,7 +205,7 @@ withdraw t1 t2 ada = do
     ins v utxos = Set.fromList
         [ scriptTxIn
             r
-            (mkValidatorScript v)
+            (mkValidator v)
             redeemerScript
         | r <- Map.keys utxos
         ]

--- a/plutus-book/doc/non-fungible/nonfungible1.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible1.adoc
@@ -74,9 +74,9 @@ mkNonFungibleRedeemer :: String -> RedeemerScript
 mkNonFungibleRedeemer name = RedeemerScript $ toData $ TokenName $ C.pack name
 
 mkNonFungibleValidator :: NonFungible -> ValidatorScript
-mkNonFungibleValidator = ValidatorScript
-                       . applyScript $$(compileScript [|| \nf -> wrapValidator (validateNonFungible nf) ||])
-                       . lifted
+mkNonFungibleValidator = mkValidatorScript
+                       . applyCode $$(compile [|| \nf -> wrapValidator (validateNonFungible nf) ||])
+                       . liftCode
 
 nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator

--- a/plutus-book/doc/non-fungible/nonfungible2.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible2.adoc
@@ -55,9 +55,9 @@ mkNonFungibleRedeemer :: String -> RedeemerScript
 mkNonFungibleRedeemer name = RedeemerScript $ toData $ TokenName $ C.pack name
 
 mkNonFungibleValidator :: NonFungible -> ValidatorScript
-mkNonFungibleValidator = ValidatorScript
-                       . applyScript $$(compileScript [|| \nf -> wrapValidator (validateNonFungible nf) ||])
-                       . lifted
+mkNonFungibleValidator = mkValidatorScript
+                       . applyCode $$(compile [|| \nf -> wrapValidator (validateNonFungible nf) ||])
+                       . liftCode
 
 nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator

--- a/plutus-book/doc/non-fungible/nonfungible3.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible3.adoc
@@ -55,9 +55,9 @@ mkNonFungibleRedeemer :: String -> RedeemerScript
 mkNonFungibleRedeemer name = RedeemerScript $ toData $ TokenName $ C.pack name
 
 mkNonFungibleValidator :: NonFungible -> ValidatorScript
-mkNonFungibleValidator = ValidatorScript
-                       . applyScript $$(compileScript [|| \nf -> wrapValidator (validateNonFungible nf) ||])
-                       . lifted
+mkNonFungibleValidator = mkValidatorScript
+                       . applyCode $$(compile [|| \nf -> wrapValidator (validateNonFungible nf) ||])
+                       . liftCode
 
 nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator

--- a/plutus-book/doc/non-fungible/nonfungible4.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible4.adoc
@@ -55,9 +55,9 @@ mkNonFungibleRedeemer :: String -> RedeemerScript
 mkNonFungibleRedeemer name = RedeemerScript $ toData $ TokenName $ C.pack name
 
 mkNonFungibleValidator :: NonFungible -> ValidatorScript
-mkNonFungibleValidator = ValidatorScript
-                       . applyScript $$(compileScript [|| \nf -> wrapValidator (validateNonFungible nf) ||])
-                       . lifted
+mkNonFungibleValidator = mkValidatorScript
+                       . applyCode $$(compile [|| \nf -> wrapValidator (validateNonFungible nf) ||])
+                       . liftCode
 
 nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator

--- a/plutus-book/doc/non-fungible/nonfungible5.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible5.adoc
@@ -55,9 +55,9 @@ mkNonFungibleRedeemer :: String -> RedeemerScript
 mkNonFungibleRedeemer name = RedeemerScript $ toData $ TokenName $ C.pack name
 
 mkNonFungibleValidator :: NonFungible -> ValidatorScript
-mkNonFungibleValidator = ValidatorScript
-                       . applyScript $$(compileScript [|| \nf -> wrapValidator (validateNonFungible nf) ||])
-                       . lifted
+mkNonFungibleValidator = mkValidatorScript
+                       . applyCode $$(compile [|| \nf -> wrapValidator (validateNonFungible nf) ||])
+                       . liftCode
 
 nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator

--- a/plutus-book/doc/non-fungible/nonfungible6.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible6.adoc
@@ -91,9 +91,9 @@ mkNonFungibleRedeemer :: String -> RedeemerScript
 mkNonFungibleRedeemer name = RedeemerScript $ toData $ TokenName $ C.pack name
 
 mkNonFungibleValidator :: NonFungible -> ValidatorScript
-mkNonFungibleValidator = ValidatorScript
-                       . applyScript $$(compileScript [|| \nf -> wrapValidator (validateNonFungible nf) ||])
-                       . lifted
+mkNonFungibleValidator = mkValidatorScript
+                       . applyCode $$(compile [|| \nf -> wrapValidator (validateNonFungible nf) ||])
+                       . liftCode
 
 nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator

--- a/plutus-book/doc/non-fungible/nonfungible7.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible7.adoc
@@ -68,9 +68,9 @@ mkNonFungibleRedeemer :: String -> RedeemerScript
 mkNonFungibleRedeemer name = RedeemerScript $ toData $ TokenName $ C.pack name
 
 mkNonFungibleValidator :: NonFungible -> ValidatorScript
-mkNonFungibleValidator = ValidatorScript
-                       . applyScript $$(compileScript [|| \nf -> wrapValidator (validateNonFungible nf) ||])
-                       . lifted
+mkNonFungibleValidator = mkValidatorScript
+                       . applyCode $$(compile [|| \nf -> wrapValidator (validateNonFungible nf) ||])
+                       . liftCode
 
 nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator

--- a/plutus-book/doc/non-fungible/nonfungible8.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible8.adoc
@@ -74,9 +74,9 @@ adminRedeemer :: RedeemerScript
 adminRedeemer = RedeemerScript $ toData ()
 
 mkAdminValidator :: Admin -> ValidatorScript
-mkAdminValidator = ValidatorScript
-                       . applyScript $$(compileScript [|| \a -> wrapValidator (validateAdmin a) ||])
-                       . lifted
+mkAdminValidator = mkValidatorScript
+                       . applyCode $$(compile [|| \a -> wrapValidator (validateAdmin a) ||])
+                       . liftCode
 
 adminAddress :: Admin -> Address
 adminAddress = scriptAddress . mkAdminValidator
@@ -157,9 +157,9 @@ mkNonFungibleRedeemer :: String -> RedeemerScript
 mkNonFungibleRedeemer name = RedeemerScript $ toData $ TokenName $ C.pack name
 
 mkNonFungibleValidator :: NonFungible -> ValidatorScript
-mkNonFungibleValidator = ValidatorScript
-                       . applyScript $$(compileScript [|| \nf -> wrapValidator (validateNonFungible nf) ||])
-                       . lifted
+mkNonFungibleValidator = mkValidatorScript
+                       . applyCode $$(compile [|| \nf -> wrapValidator (validateNonFungible nf) ||])
+                       . liftCode
 
 nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator

--- a/plutus-book/doc/parameters/crowd.adoc
+++ b/plutus-book/doc/parameters/crowd.adoc
@@ -229,9 +229,9 @@ parameters.
 
 [source,haskell]
 ----
-mkValidatorScript :: Campaign -> ValidatorScript
-mkValidatorScript campaign = ValidatorScript $
-    $$(compileScript [|| v ||]) `applyScript` lifted campaign
+mkValidator :: Campaign -> ValidatorScript
+mkValidator campaign = mkValidatorScript $
+    $$(compile [|| v ||]) `applyCode` liftCode campaign
     where v c = wrapValidator (validate c)
 ----
 
@@ -242,7 +242,7 @@ the script address for a campaign:
 [source,haskell]
 ----
 campaignAddress :: Campaign -> Address
-campaignAddress = scriptAddress . mkValidatorScript
+campaignAddress = scriptAddress . mkValidator
 ----
 
 Our first endpoint, `startCampaign`, will be run by the campaign owner.
@@ -280,7 +280,7 @@ startCampaign ft ed cd = do
         logMsg $ pack $ "collecting from " ++ show campaign
         collectFromScript
             (collectionRange campaign)
-            (mkValidatorScript campaign)
+            (mkValidator campaign)
             (mkRedeemerScript Collect)                      -- <3>
 ----
 
@@ -322,7 +322,7 @@ contribute campaign ada = do
             ++ " from " ++ show campaign
         collectFromScriptTxn                                     -- <5>
             range
-            (mkValidatorScript campaign)
+            (mkValidator campaign)
             (mkRedeemerScript Refund)                            -- <6>
             txId
 

--- a/plutus-book/doc/token/fungible.adoc
+++ b/plutus-book/doc/token/fungible.adoc
@@ -95,9 +95,9 @@ mkFungibleRedeemerScript :: Integer -> RedeemerScript
 mkFungibleRedeemerScript = RedeemerScript . toData
 
 mkFungibleValidator :: Fungible -> ValidatorScript
-mkFungibleValidator = ValidatorScript
-                    . applyScript $$(compileScript [|| \f -> wrapValidator (validateFungible f) ||])
-                    . lifted
+mkFungibleValidator = mkValidatorScript
+                    . applyCode $$(compile [|| \f -> wrapValidator (validateFungible f) ||])
+                    . liftCode
 
 fungibleAddress :: Fungible -> Address
 fungibleAddress = scriptAddress . mkFungibleValidator
@@ -299,9 +299,9 @@ We write the usual helper functions and have completed the on-chain part:
 ----
 mkTradeValidator :: Trade -> ValidatorScript
 mkTradeValidator =
-      ValidatorScript
-    . applyScript $$(compileScript [|| v ||])
-    . lifted
+      mkValidatorScript
+    . applyCode $$(compile [|| v ||])
+    . liftCode
     where v t = wrapValidator (validateTrade t)
 
 tradeDataScript :: DataScript

--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -13,6 +13,7 @@ import           Language.Plutus.Contract              as Con
 import           Language.Plutus.Contract.Test
 import           Language.Plutus.Contract.Util         (loopM)
 import           Language.PlutusTx.Lattice
+import qualified Language.PlutusTx                     as PlutusTx
 import           Ledger                                (Address)
 import qualified Ledger                                as Ledger
 import qualified Ledger.Ada                            as Ada
@@ -22,7 +23,7 @@ import qualified Wallet.Emulator                       as EM
 import qualified Language.Plutus.Contract.Effects.AwaitSlot as AwaitSlot
 
 tests :: TestTree
-tests = 
+tests =
     let cp = checkPredicate @Schema in
     testGroup "contracts"
         [ cp "awaitSlot"
@@ -112,15 +113,11 @@ w1 :: EM.Wallet
 w1 = EM.Wallet 1
 
 someAddress :: Address
-someAddress =
-    -- this isn't the address of a valid validator script,
-    -- but it doesn't matter because we only need the address,
-    -- not the script
-    Ledger.scriptAddress $
-        Ledger.ValidatorScript $$(Ledger.compileScript [|| \(i :: Integer) -> i ||])
+someAddress = Ledger.scriptAddress $
+    Ledger.mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.Data) (_ :: PlutusTx.Data) (_ :: Ledger.PendingTx) -> True ||])
 
-type Schema = 
-    BlockchainActions 
+type Schema =
+    BlockchainActions
         .\/ Endpoint "1" Int
         .\/ Endpoint "2" Int
         .\/ Endpoint "3" Int

--- a/plutus-emulator/test/Spec.hs
+++ b/plutus-emulator/test/Spec.hs
@@ -28,6 +28,7 @@ import           Hedgehog                   (Property, forAll, property)
 import qualified Hedgehog
 import qualified Hedgehog.Gen               as Gen
 import qualified Hedgehog.Range             as Range
+import qualified Language.PlutusTx          as PlutusTx
 import qualified Language.PlutusTx.Numeric  as P
 import qualified Language.PlutusTx.Builtins as Builtins
 import qualified Language.PlutusTx.Prelude  as PlutusTx
@@ -236,7 +237,7 @@ invalidScript = property $ do
 
     where
         failValidator :: ValidatorScript
-        failValidator = ValidatorScript $ $$(compileScript [|| wrapValidator validator ||])
+        failValidator = mkValidatorScript $$(PlutusTx.compile [|| wrapValidator validator ||])
         validator :: () -> () -> PendingTx -> Bool
         validator _ _ _ = PlutusTx.traceErrorH "I always fail everything"
 

--- a/plutus-playground-lib/src/Playground/Rollup/Render.hs
+++ b/plutus-playground-lib/src/Playground/Rollup/Render.hs
@@ -41,8 +41,8 @@ import           Ledger                                (Address, PubKey, Tx (Tx)
                                                         txOutputs)
 import           Ledger.Ada                            (Ada (Lovelace))
 import qualified Ledger.Ada                            as Ada
-import           Ledger.Scripts                        (DataScript (getDataScript), Script,
-                                                        ValidatorScript (getValidator))
+import           Ledger.Scripts                        (DataScript (getDataScript), Script, ValidatorScript,
+                                                        unValidatorScript)
 import           Ledger.Value                          (CurrencySymbol (CurrencySymbol), TokenName (TokenName),
                                                         getValue)
 import qualified Ledger.Value                          as Value
@@ -200,7 +200,7 @@ instance Render Script where
          in "Script:" <+> pretty (abbreviate 40 v)
 
 instance Render ValidatorScript where
-    render = render . getValidator
+    render = render . unValidatorScript
 
 instance Render DataScript where
     render = render . getDataScript

--- a/plutus-playground-server/test/Playground/Rollup/renderCrowdfunding.txt
+++ b/plutus-playground-server/test/Playground/Rollup/renderCrowdfunding.txt
@@ -51,7 +51,7 @@ Balances Carried Forward:
               EURToken:  30
 
 ==== Slot #2, Tx #0 ====
-TxId:       12aa4d60b6cb922e4222483aa64071b96bd26d5df91f9c1600e87468ca8a0ba2
+TxId:       74c871f2035a8a9fa0e7149990cafab623df4cfeccca4bdf8201753444d73f1b
 Fee:        -
 Forge:      -
 Inputs:
@@ -76,7 +76,7 @@ Outputs:
               EURToken:  30
   
   ---- Output 1 ----
-  Destination:  Script: 9f186918461820187a185e185618da182a186718...
+  Destination:  Script: 9f18ff188f186d120718cd1848188618461218f4...
   Value:
     Ada:      Lovelace:  8000000
 
@@ -100,12 +100,12 @@ Balances Carried Forward:
     b0b0:     USDToken:  20
               EURToken:  30
   
-  Script: 9f186918461820187a185e185618da182a186718...
+  Script: 9f18ff188f186d120718cd1848188618461218f4...
   Value:
     Ada:      Lovelace:  8000000
 
 ==== Slot #3, Tx #0 ====
-TxId:       6663f4485ba69f7fdf531bc1725a1c36cd30e8e947dd0ef1d4af4c12f003e06f
+TxId:       b8378be79a54b782fd4ffeb2ab1cc54e43cb752a79f2019896e0d8b1c65f66a6
 Fee:        -
 Forge:      -
 Inputs:
@@ -130,7 +130,7 @@ Outputs:
               EURToken:  30
   
   ---- Output 1 ----
-  Destination:  Script: 9f186918461820187a185e185618da182a186718...
+  Destination:  Script: 9f18ff188f186d120718cd1848188618461218f4...
   Value:
     Ada:      Lovelace:  8000000
 
@@ -154,30 +154,30 @@ Balances Carried Forward:
     b0b0:     USDToken:  20
               EURToken:  30
   
-  Script: 9f186918461820187a185e185618da182a186718...
+  Script: 9f18ff188f186d120718cd1848188618461218f4...
   Value:
     Ada:      Lovelace:  16000000
 
 ==== Slot #10, Tx #0 ====
-TxId:       1aecdcda8607873ac664c897a49497f9eb072d6164e47ccf709a6dfb4452ece0
+TxId:       b3765f51989d5528ece33277e9fce28a4639a2991c3bc68b0114ba78b2267375
 Fee:        -
 Forge:      -
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 9f186918461820187a185e185618da182a186718...
+  Destination:  Script: 9f18ff188f186d120718cd1848188618461218f4...
   Value:
     Ada:      Lovelace:  8000000
   Source:
-    Tx:     12aa4d60b6cb922e4222483aa64071b96bd26d5df91f9c1600e87468ca8a0ba2
+    Tx:     74c871f2035a8a9fa0e7149990cafab623df4cfeccca4bdf8201753444d73f1b
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
   
   ---- Input 1 ----
-  Destination:  Script: 9f186918461820187a185e185618da182a186718...
+  Destination:  Script: 9f18ff188f186d120718cd1848188618461218f4...
   Value:
     Ada:      Lovelace:  8000000
   Source:
-    Tx:     6663f4485ba69f7fdf531bc1725a1c36cd30e8e947dd0ef1d4af4c12f003e06f
+    Tx:     b8378be79a54b782fd4ffeb2ab1cc54e43cb752a79f2019896e0d8b1c65f66a6
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
 
@@ -208,6 +208,6 @@ Balances Carried Forward:
     b0b0:     USDToken:  20
               EURToken:  30
   
-  Script: 9f186918461820187a185e185618da182a186718...
+  Script: 9f18ff188f186d120718cd1848188618461218f4...
   Value:
     Ada:      Lovelace:  0

--- a/plutus-playground-server/test/Playground/Rollup/renderVestFunds.txt
+++ b/plutus-playground-server/test/Playground/Rollup/renderVestFunds.txt
@@ -19,7 +19,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       118906465ae66fb3eb72f491957808194df4f0634b3937a5386dfc08ccadbbd2
+TxId:       205f492ce1af99b09f542db09073d9f858645ad6465a476cb39bca6c001d3b7b
 Fee:        -
 Forge:      -
 Inputs:
@@ -40,7 +40,7 @@ Outputs:
     Ada:      Lovelace:  8000000
   
   ---- Output 1 ----
-  Destination:  Script: 9f18e70818571822185c18f8182b18a2185218dd...
+  Destination:  Script: 9f18b218ba18a3183b0118cf18b3183c13183a13...
   Value:
     Ada:      Lovelace:  2000000
 
@@ -50,6 +50,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  8000000
   
-  Script: 9f18e70818571822185c18f8182b18a2185218dd...
+  Script: 9f18b218ba18a3183b0118cf18b3183c13183a13...
   Value:
     Ada:      Lovelace:  2000000

--- a/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground-server/usecases/CrowdFunding.hs
@@ -22,9 +22,8 @@ module CrowdFunding where
 import qualified Language.PlutusTx         as PlutusTx
 import           Language.PlutusTx.Prelude hiding (Applicative (..))
 import           Ledger                    (Address, DataScript (DataScript), PendingTx, PubKey,
-                                            RedeemerScript (RedeemerScript), TxId, ValidatorScript (ValidatorScript),
-                                            applyScript, compileScript, hashTx, lifted, pendingTxValidRange,
-                                            scriptAddress, valueSpent)
+                                            RedeemerScript (RedeemerScript), TxId, ValidatorScript, mkValidatorScript,
+                                            hashTx, pendingTxValidRange, scriptAddress, valueSpent)
 import qualified Ledger.Interval           as Interval
 import           Ledger.Slot               (Slot, SlotRange)
 import           Ledger.Typed.Scripts      (wrapValidator)
@@ -140,9 +139,9 @@ mkValidator c con act p = case act of
 --   retrieve the funds or the contributors can claim a refund.
 --
 contributionScript :: Campaign -> ValidatorScript
-contributionScript cmp  = ValidatorScript $
-    $$(Ledger.compileScript [|| \c -> wrap (mkValidator c) ||])
-        `Ledger.applyScript` Ledger.lifted cmp
+contributionScript cmp  = mkValidatorScript $
+    $$(PlutusTx.compile [|| \c -> wrap (mkValidator c) ||])
+        `PlutusTx.applyCode` PlutusTx.liftCode cmp
     where wrap = wrapValidator @PubKey @CampaignAction
 
 -- | The address of a [[Campaign]]

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -23,8 +23,8 @@ module Game where
 import qualified Language.PlutusTx          as PlutusTx
 import           Language.PlutusTx.Prelude  hiding (Applicative (..))
 import           Ledger                     (Address, DataScript (DataScript), PendingTx,
-                                             RedeemerScript (RedeemerScript), ValidatorScript (ValidatorScript),
-                                             compileScript, plcSHA2_256, scriptAddress)
+                                             RedeemerScript (RedeemerScript), ValidatorScript, mkValidatorScript,
+                                             plcSHA2_256, scriptAddress)
 import           Ledger.Typed.Scripts       (wrapValidator)
 import           Ledger.Value               (Value)
 import           Playground.Contract
@@ -52,7 +52,7 @@ validateGuess dataScript redeemerScript _ =
 -- | The validator script of the game.
 gameValidator :: ValidatorScript
 gameValidator =
-    ValidatorScript ($$(Ledger.compileScript [|| wrap validateGuess ||]))
+    mkValidatorScript $$(PlutusTx.compile [|| wrap validateGuess ||])
     where wrap = wrapValidator @HashedString @ClearString
 
 -- create a data script for the guessing game by hashing the string

--- a/plutus-playground-server/usecases/Starter.hs
+++ b/plutus-playground-server/usecases/Starter.hs
@@ -26,8 +26,8 @@ module Starter where
 import qualified Language.PlutusTx          as PlutusTx
 import           Language.PlutusTx.Prelude  hiding (Applicative (..))
 import           Ledger                     (Address, DataScript (DataScript), PendingTx,
-                                             RedeemerScript (RedeemerScript), ValidatorScript (ValidatorScript),
-                                             compileScript, scriptAddress)
+                                             RedeemerScript (RedeemerScript), ValidatorScript, mkValidatorScript,
+                                             scriptAddress)
 import           Ledger.Typed.Scripts       (wrapValidator)
 import           Ledger.Value               (Value)
 import           Playground.Contract
@@ -51,7 +51,7 @@ validateSpend _dataValue _redeemerValue _ = error () -- Please provide an implem
 --   the on-chain representation.
 contractValidator :: ValidatorScript
 contractValidator =
-    ValidatorScript ($$(Ledger.compileScript [|| wrap validateSpend ||]))
+    mkValidatorScript $$(PlutusTx.compile [|| wrap validateSpend ||])
     where wrap = wrapValidator @DataValue @RedeemerValue
 
 -- | Helper function used to build the DataScript.

--- a/plutus-playground-server/usecases/Vesting.hs
+++ b/plutus-playground-server/usecases/Vesting.hs
@@ -21,7 +21,7 @@ import           IOTS
 import qualified Language.PlutusTx         as PlutusTx
 import           Ledger                    (Address, DataScript(..),
                                             RedeemerScript(..),  Slot,
-                                            TxOutRef, TxIn, ValidatorScript(..), compileScript)
+                                            TxOutRef, TxIn, ValidatorScript, mkValidatorScript)
 import qualified Ledger                    as Ledger
 import           Ledger.Typed.Scripts      (wrapValidator)
 import           Ledger.Value              (Value)
@@ -161,10 +161,10 @@ mkValidator d@Vesting{..} () () p@PendingTx{pendingTxValidRange = range} =
     in con1 && con2
 
 validatorScript :: Vesting -> ValidatorScript
-validatorScript v = ValidatorScript $
-    $$(Ledger.compileScript [|| \vd -> wrapValidator (mkValidator vd) ||])
-        `Ledger.applyScript`
-            Ledger.lifted v
+validatorScript v = mkValidatorScript $
+    $$(PlutusTx.compile [|| \vd -> wrapValidator (mkValidator vd) ||])
+        `PlutusTx.applyCode`
+            PlutusTx.liftCode v
 
 contractAddress :: Vesting -> Address
 contractAddress vst = Ledger.scriptAddress (validatorScript vst)

--- a/plutus-tutorial/doc/02-validator-scripts.adoc
+++ b/plutus-tutorial/doc/02-validator-scripts.adoc
@@ -39,7 +39,7 @@ import           Language.PlutusTx.Prelude    hiding (Applicative (..)) -- <.>
 import qualified Language.PlutusTx            as PlutusTx -- <.>
 
 import           Ledger                       (Address, DataScript(..), RedeemerScript(..),
-                                               ValidatorScript(..))
+                                               ValidatorScript, mkValidatorScript)
 import qualified Ledger                       as L -- <.>
 import qualified Ledger.Ada                   as Ada
 import           Ledger.Ada                   (Ada)
@@ -167,12 +167,12 @@ Finally, we can compile this into on-chain code.
 ----
 -- | The validator script of the game.
 gameValidator :: ValidatorScript
-gameValidator = ValidatorScript $$(L.compileScript [|| v ||]) -- <.>
+gameValidator = mkValidatorScript $$(PlutusTx.compile [|| v ||]) -- <.>
     where v = wrapValidator validator
 ----
 <.> The reference to the validator script that we defined
 is wrapped in Template Haskell quotes, and then the
-result of `L.compileScript` is spliced in (see xref:01-plutus-tx#plutus-tx[PlutusTx tutorial] for further explanation of this pattern).
+result of `PlutusTx.compile` is spliced in (see xref:01-plutus-tx#plutus-tx[PlutusTx tutorial] for further explanation of this pattern).
 
 === Contract endpoints
 

--- a/plutus-tutorial/doc/03-wallet-api.adoc
+++ b/plutus-tutorial/doc/03-wallet-api.adoc
@@ -41,7 +41,7 @@ import qualified Language.PlutusTx            as PlutusTx
 import qualified Ledger.Interval              as I
 import           Ledger                       (Address, DataScript(..), PubKey(..),
                                                RedeemerScript(..), Slot(..),
-                                               TxId, ValidatorScript(..))
+                                               TxId, ValidatorScript, mkValidatorScript)
 import qualified Ledger                       as L
 import qualified Ledger.Ada                   as Ada
 import           Ledger.Ada                   (Ada)
@@ -170,26 +170,25 @@ type CampaignValidator =
 If we want to implement `CampaignValidator` we need to have access to
 the parameters of the campaign, so that we can check if the selected
 `CampaignAction` is allowed. In Haskell we can do this by writing a
-function `mkValidator {2c} Campaign -> CampaignValidator` that takes a
+function `validator {2c} Campaign -> CampaignValidator` that takes a
 `Campaign` and produces a `CampaignValidator`.
 
-We then need to compile this into on-chain code using `L.compileScript`,
-which we do in `mkValidatorScript`.
+We then need to compile this into on-chain code using `PlutusTx.compile`,
+which we do in `mkValidator`.
 
 [source,haskell]
 ----
-mkValidatorScript :: Campaign -> ValidatorScript
-mkValidatorScript campaign = ValidatorScript val where
-  val =
-      $$(L.compileScript [|| v ||])
-      `L.applyScript` -- <1>
-      L.lifted campaign -- <2>
-  v c = wrapValidator (mkValidator c)
+mkValidator :: Campaign -> ValidatorScript
+mkValidator campaign = mkValidatorScript $
+  $$(PlutusTx.compile [|| v ||])
+  `PlutusTx.applyCode` -- <1>
+  PlutusTx.liftCode campaign -- <2>
+  where v c = wrapValidator (validator c)
 
-mkValidator :: Campaign -> CampaignValidator
+validator :: Campaign -> CampaignValidator
 ----
-<1> `applyScript` applies one `Script` to another.
-<2> `Ledger.lifted campaign` gives us the on-chain representation of `campaign`.
+<1> `applyCode` applies one `CompiledCode` to another.
+<2> `liftCode campaign` gives us the on-chain representation of `campaign`.
 
 [NOTE]
 .Parameterizing validators
@@ -198,10 +197,10 @@ You may wonder why we have to use `L.applyScript` to supply the `Campaign`
 argument. Why can we not write `L.lifted campaign` inside the
 validator script? The reason is that `campaign` is not known at the time
 the validator script is compiled. The names of `lifted` and `compile`
-indicate their chronological order: `mkValidator` is compiled (via a
+indicate their chronological order: `validator` is compiled (via a
 compiler plugin) to Plutus Core when GHC compiles the contract module,
 and the `campaign` value is lifted to Plutus Core at runtime, when the
-contract module is executed. But we know that `mkValidator` is a
+contract module is executed. But we know that `validator` is a
 function, and that is why we can apply it to the campaign definition.
 ====
 
@@ -215,7 +214,7 @@ to get the information we care about:
 
 [source,haskell]
 ----
-mkValidator
+validator
     Campaign {fundingTarget, endDate, collectionDeadline, campaignOwner} -- <.>
     con
     act
@@ -385,12 +384,12 @@ link:{wallet-api-haddock}/Wallet-API.html#v:notT[`notT`]
 to describe more complex conditions.
 
 We will need to know the address of a campaign, which amounts to hashing
-the output of `mkValidatorScript`:
+the output of `mkValidator`:
 
 [source,haskell]
 ----
 campaignAddress :: Campaign -> Address
-campaignAddress cmp = L.scriptAddress (mkValidatorScript cmp)
+campaignAddress cmp = L.scriptAddress (mkValidator cmp)
 ----
 
 Contributors put their public key in a data script:
@@ -467,7 +466,7 @@ immediately.
     W.logMsg "Collecting funds"
     let redeemerScript = mkRedeemer Collect
         range          = W.interval (endDate cmp) (collectionDeadline cmp)
-    W.collectFromScript range (mkValidatorScript cmp) redeemerScript -- <.>
+    W.collectFromScript range (mkValidator cmp) redeemerScript -- <.>
 ----
 <.> To collect the funds we use
 link:{wallet-api-haddock}/Wallet-API.html#v:collectFromScript[`collectFromScript`],
@@ -541,7 +540,7 @@ refundHandler txid cmp = EventHandler $ \_ -> do
     W.logMsg "Claiming refund"
     let redeemer  = mkRedeemer Refund
         range     = W.intervalFrom (collectionDeadline cmp)
-    W.collectFromScriptTxn range (mkValidatorScript cmp) redeemer txid
+    W.collectFromScriptTxn range (mkValidator cmp) redeemer txid
 ----
 
 Now we can register the refund handler when we make the contribution.

--- a/plutus-tutorial/doc/04-vesting.adoc
+++ b/plutus-tutorial/doc/04-vesting.adoc
@@ -29,7 +29,7 @@ import qualified Prelude                   as Haskell
 
 import qualified Language.PlutusTx         as PlutusTx
 
-import           Ledger                    (Address, DataScript(..), RedeemerScript(..), Slot, TxOutRef, TxIn, ValidatorScript(..))
+import           Ledger                    (Address, DataScript(..), RedeemerScript(..), Slot, TxOutRef, TxIn, ValidatorScript, mkValidatorScript)
 import qualified Ledger                    as L
 import qualified Ledger.Interval           as Interval
 import qualified Ledger.Slot               as Slot
@@ -125,8 +125,8 @@ That gives our validator script the signature: `Vesting -> () -> () -> PendingTx
 [source,haskell]
 ----
 vestingValidatorScript :: Vesting -> ValidatorScript
-vestingValidatorScript v = ValidatorScript $
-    $$(L.compileScript [|| \vd -> wrapValidator (vestingValidator vd) ||]) `L.applyScript` L.lifted v
+vestingValidatorScript v = mkValidatorScript $
+    $$(PlutusTx.compile [|| \vd -> wrapValidator (vestingValidator vd) ||]) `PlutusTx.applyCode` PlutusTx.liftCode v
 
 vestingValidator :: Vesting -> () -> () -> PendingTx -> Bool
 vestingValidator v@(Vesting {vestingTranche1, vestingTranche2, vestingOwner}) _ _ p@PendingTx{pendingTxValidRange = range} =

--- a/plutus-use-cases/bench/Bench.hs
+++ b/plutus-use-cases/bench/Bench.hs
@@ -196,7 +196,7 @@ trivial = bgroup "trivial" [
         bench "typecheck" $ nf runScriptCheck (validationData1, validator, unitData, unitRedeemer)
     ]
     where
-        validator = ValidatorScript $$(Ledger.compileScript [|| \() () (_::PendingTx) -> True ||])
+        validator = mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.Data) (_ :: PlutusTx.Data) (_ :: PendingTx) -> True ||])
 
 -- | The multisig contract is one of the simplest ones that we have. This runs a number of different scenarios.
 -- Note that multisig also does some signature verification!
@@ -258,10 +258,10 @@ sig2 :: Signature
 sig2 = Crypto.sign txHash privk2
 
 validationData1 :: ValidationData
-validationData1 = ValidationData $ lifted $ mockPendingTx
+validationData1 = ValidationData $ fromCompiledCode $ PlutusTx.liftCode $ mockPendingTx
 
 validationData2 :: ValidationData
-validationData2 = ValidationData $ lifted $ mockPendingTx { pendingTxSignatures = [(pk1, sig1), (pk2, sig2)] }
+validationData2 = ValidationData $ fromCompiledCode $ PlutusTx.liftCode $ mockPendingTx { pendingTxSignatures = [(pk1, sig1), (pk2, sig2)] }
 
 mockPendingTx :: PendingTx
 mockPendingTx = PendingTx

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -28,7 +28,7 @@ import           Language.PlutusTx.Prelude  hiding (Applicative (..))
 import qualified Ledger.Ada                 as Ada
 import qualified Language.PlutusTx          as PlutusTx
 import qualified Language.PlutusTx.AssocMap as AssocMap
-import           Ledger.Scripts             (ValidatorScript(..))
+import           Ledger.Scripts             (ValidatorScript, mkValidatorScript)
 import qualified Ledger.Validation          as V
 import qualified Ledger.Value               as Value
 import qualified Ledger.Typed.Scripts       as Scripts
@@ -88,10 +88,10 @@ validate c@(Currency (refHash, refIdx) _) _ _ p =
     in forgeOK && txOutputSpent
 
 curValidator :: Currency -> ValidatorScript
-curValidator cur = ValidatorScript $
-    Ledger.fromCompiledCode $$(PlutusTx.compile [|| \c -> Scripts.wrapValidator (validate c) ||])
-        `Ledger.applyScript`
-            Ledger.lifted cur
+curValidator cur = mkValidatorScript $
+    $$(PlutusTx.compile [|| \c -> Scripts.wrapValidator (validate c) ||])
+        `PlutusTx.applyCode`
+            PlutusTx.liftCode cur
 
 {- note [Obtaining the currency symbol]
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -37,7 +37,7 @@ import           GHC.Generics                 (Generic)
 import           Language.PlutusTx.Prelude    hiding (Applicative (..))
 import qualified Language.PlutusTx.Applicative as PlutusTx
 import qualified Language.PlutusTx            as PlutusTx
-import           Ledger                       (DataScript (..), Slot(..), PubKey, TxOutRef, RedeemerScript (..), ValidatorScript (..), scriptTxIn, scriptTxOut)
+import           Ledger                       (DataScript (..), Slot(..), PubKey, TxOutRef, RedeemerScript (..), ValidatorScript, scriptTxIn, scriptTxOut)
 import qualified Ledger                       as Ledger
 import qualified Ledger.Interval              as Interval
 import qualified Ledger.Typed.Scripts         as Scripts
@@ -299,10 +299,10 @@ mkValidator ft@Future{..} FutureData{..} r p@PendingTx{pendingTxOutputs=outs, pe
                     vl > (futureDataMarginShort + futureDataMarginLong)
 
 validatorScript :: Future -> ValidatorScript
-validatorScript ft = ValidatorScript $
-    $$(Ledger.compileScript [|| validatorParam ||])
-        `Ledger.applyScript`
-            Ledger.lifted ft
+validatorScript ft = Ledger.mkValidatorScript $
+    $$(PlutusTx.compile [|| validatorParam ||])
+        `PlutusTx.applyCode`
+            PlutusTx.liftCode ft
     where validatorParam f = Scripts.wrapValidator (mkValidator f)
 
 PlutusTx.makeLift ''Future

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -71,7 +71,7 @@ validateGuess :: HashedString -> ClearString -> PendingTx -> Bool
 validateGuess (HashedString actual) (ClearString guess') _ = actual == sha2_256 guess'
 
 gameValidator :: ValidatorScript
-gameValidator = Ledger.ValidatorScript ($$(Ledger.compileScript [|| validator ||]))
+gameValidator = Ledger.mkValidatorScript $$(PlutusTx.compile [|| validator ||])
     where validator = wrapValidator validateGuess
 
 gameDataScript :: String -> DataScript

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
@@ -44,10 +44,10 @@ validate (MultiSig keys num) _ _ p =
     in present >= num
 
 msValidator :: MultiSig -> ValidatorScript
-msValidator sig = ValidatorScript $
-    Ledger.fromCompiledCode $$(PlutusTx.compile [|| validatorParam ||])
-        `Ledger.applyScript`
-            Ledger.lifted sig
+msValidator sig = mkValidatorScript $
+    $$(PlutusTx.compile [|| validatorParam ||])
+        `PlutusTx.applyCode`
+            PlutusTx.liftCode sig
     where validatorParam s = Scripts.wrapValidator (validate s)
 
 -- | Multisig data script (unit value).

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
@@ -26,10 +26,10 @@ mkValidator :: PubKey -> () -> () -> PendingTx -> Bool
 mkValidator pk' _ _ p = V.txSignedBy p pk'
 
 pkValidator :: PubKey -> ValidatorScript
-pkValidator pk = ValidatorScript $
-    Ledger.fromCompiledCode $$(PlutusTx.compile [|| validatorParam ||])
-        `Ledger.applyScript`
-            Ledger.lifted pk
+pkValidator pk = mkValidatorScript $
+    $$(PlutusTx.compile [|| validatorParam ||])
+        `PlutusTx.applyCode`
+            PlutusTx.liftCode pk
     where validatorParam k = Scripts.wrapValidator (mkValidator k)
 
 -- | Lock some funds in a 'PayToPubKey' contract, returning the output's address

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Swap.hs
@@ -16,7 +16,7 @@ module Language.PlutusTx.Coordination.Contracts.Swap(
 import qualified Language.PlutusTx         as PlutusTx
 import qualified Language.PlutusTx.Applicative as PlutusTx
 import           Language.PlutusTx.Prelude
-import           Ledger                    (Slot, PubKey, ValidatorScript (..))
+import           Ledger                    (Slot, PubKey, ValidatorScript)
 import qualified Ledger                    as Ledger
 import qualified Ledger.Typed.Scripts      as Scripts
 import           Ledger.Validation         (OracleValue (..), PendingTx, PendingTx' (..), PendingTxIn, PendingTxIn' (..), PendingTxOut (..))
@@ -198,10 +198,10 @@ mkValidator Swap{..} SwapOwners{..} redeemer p =
 --   See note [Contracts and Validator Scripts] in
 --       Language.Plutus.Coordination.Contracts
 swapValidator :: Swap -> ValidatorScript
-swapValidator swp = ValidatorScript $
-    $$(Ledger.compileScript [|| validatorParam ||])
-        `Ledger.applyScript`
-            Ledger.lifted swp
+swapValidator swp = Ledger.mkValidatorScript $
+    $$(PlutusTx.compile [|| validatorParam ||])
+        `PlutusTx.applyCode`
+            PlutusTx.liftCode swp
     where validatorParam s = Scripts.wrapValidator (mkValidator s)
 
 {- Note [Swap Transactions]

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Vesting.hs
@@ -31,7 +31,7 @@ import           Language.PlutusTx.Prelude    hiding (Applicative (..))
 import qualified Language.PlutusTx            as PlutusTx
 import qualified Language.PlutusTx.Applicative as PlutusTx
 import qualified Ledger                       as Ledger
-import           Ledger                       (DataScript (..), Slot(..), PubKey (..), TxOutRef, RedeemerScript (..), ValidatorScript (..), scriptTxIn, scriptTxOut)
+import           Ledger                       (DataScript (..), Slot(..), PubKey (..), TxOutRef, RedeemerScript (..), ValidatorScript, scriptTxIn, scriptTxOut)
 import qualified Ledger.Ada                   as Ada
 import qualified Ledger.Interval              as Interval
 import qualified Ledger.Slot                  as Slot
@@ -189,8 +189,8 @@ mkValidator d@Vesting{..} VestingData{..} _ ptx@PendingTx{pendingTxValidRange = 
     in amountsValid && txnOutputsValid
 
 validatorScript :: Vesting -> ValidatorScript
-validatorScript v = ValidatorScript $
-    $$(Ledger.compileScript [|| validatorParam ||])
-        `Ledger.applyScript`
-            Ledger.lifted v
+validatorScript v = Ledger.mkValidatorScript $
+    $$(PlutusTx.compile [|| validatorParam ||])
+        `PlutusTx.applyCode`
+            PlutusTx.liftCode v
     where validatorParam vd = Scripts.wrapValidator (mkValidator vd)

--- a/plutus-use-cases/test/Spec/Lib.hs
+++ b/plutus-use-cases/test/Spec/Lib.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ViewPatterns #-}
 module Spec.Lib
     ( reasonable
     , goldenPir
@@ -24,7 +25,7 @@ import           Ledger.Value              (Value)
 -- | Assert that the size of a 'ValidatorScript' is below
 --   the maximum.
 reasonable :: ValidatorScript -> Integer -> Assertion
-reasonable (Ledger.ValidatorScript s) maxSize = do
+reasonable (Ledger.unValidatorScript -> s) maxSize = do
     let sz = Ledger.scriptSize s
         msg = "Script too big! Max. size: " <> show maxSize <> ". Actual size: " <> show sz
     -- so the actual size is visible in the log

--- a/plutus-wallet-api/ledger/Ledger/Index.hs
+++ b/plutus-wallet-api/ledger/Ledger/Index.hs
@@ -39,6 +39,7 @@ import qualified Data.Map                  as Map
 import           Data.Semigroup            (Semigroup)
 import qualified Data.Set                  as Set
 import           GHC.Generics              (Generic)
+import           Language.PlutusTx         (liftCode)
 import qualified Language.PlutusTx.Numeric as P
 import qualified Ledger.Ada                as Ada
 import           Ledger.Blockchain
@@ -244,7 +245,7 @@ checkMatch pendingTx = \case
             pTxIn <- pendingTxInScript (txInRef txin) vl r
             let
                 ptx' = pendingTx { pendingTxIn = pTxIn }
-                vd = ValidationData (lifted ptx')
+                vd = ValidationData (fromCompiledCode $ liftCode ptx')
             case runExcept $ runScript Typecheck vd vl d r of
                 Left e  -> throwError $ ScriptFailure e
                 Right _ -> pure ()

--- a/plutus-wallet-api/ledger/Ledger/Scripts.hs-boot
+++ b/plutus-wallet-api/ledger/Ledger/Scripts.hs-boot
@@ -1,0 +1,4 @@
+module Ledger.Scripts where
+
+data ValidatorHash
+data RedeemerHash

--- a/plutus-wallet-api/ledger/Ledger/Typed/Scripts.hs
+++ b/plutus-wallet-api/ledger/Ledger/Typed/Scripts.hs
@@ -44,7 +44,7 @@ scriptAddress = Tx.scriptAddress . validatorScript
 
 -- | Get the validator script for a script instance.
 validatorScript :: ScriptInstance a -> ValidatorScript
-validatorScript (Validator vc wrapper) = ValidatorScript $ fromCompiledCode $ wrapper `applyCode` vc
+validatorScript (Validator vc wrapper) = mkValidatorScript $ wrapper `applyCode` vc
 
 {-# INLINABLE wrapValidator #-}
 wrapValidator

--- a/plutus-wallet-api/ledger/Ledger/Typed/Tx.hs
+++ b/plutus-wallet-api/ledger/Ledger/Typed/Tx.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE TypeFamilies              #-}
 {-# LANGUAGE TypeOperators             #-}
 {-# LANGUAGE UndecidableInstances      #-}
+{-# LANGUAGE ViewPatterns              #-}
 -- | Typed transactions. This module defines typed versions of various ledger types. The ultimate
 -- goal is to make sure that the script types attached to inputs and outputs line up, to avoid
 -- type errors at validation time.
@@ -227,7 +228,7 @@ checkValidatorScript
     => ScriptInstance a
     -> ValidatorScript
     -> m (CompiledCode WrappedValidatorType)
-checkValidatorScript _ (ValidatorScript (Script prog)) =
+checkValidatorScript _ (unValidatorScript -> (Script prog)) =
     case PLC.runQuote $ runExceptT @(PIR.Error (PIR.Provenance ())) $ Lift.typeCode (Proxy @WrappedValidatorType) prog of
         Right code -> pure code
         Left e     -> throwError $ WrongValidatorType $ show $ PLC.prettyPlcDef e

--- a/plutus-wallet-api/ledger/Ledger/Validation.hs-boot
+++ b/plutus-wallet-api/ledger/Ledger/Validation.hs-boot
@@ -1,0 +1,9 @@
+module Ledger.Validation where
+
+import {-# SOURCE #-} Ledger.Scripts
+
+data PendingTxIn' w
+type PendingTxIn = PendingTxIn' (Maybe (ValidatorHash, RedeemerHash))
+type PendingTxInScript = PendingTxIn' (ValidatorHash, RedeemerHash)
+data PendingTx' i
+type PendingTx = PendingTx' PendingTxInScript


### PR DESCRIPTION
Now that validator scripts all have the same type, we can insist that
you only make a `ValidatorScript` from something that has that type.
This spots a few invalid validators - but not in our real examples, fortunately.

This has some knock-on effects: we need to use `CompiledCode` instead of
`Script`, since only the former still has the type around.

However, I think this is good. `CompiledCode` is more type-safe, and we had a bit
of a problem where there were two ways to do things: with
`CompiledCode`, or with `Script`. Now there is only one.