### PR TITLE
contract: Add error handling

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract.hs
+++ b/plutus-contract/src/Language/Plutus/Contract.hs
@@ -3,7 +3,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeOperators    #-}
 module Language.Plutus.Contract(
-      Contract
+      Contract(..)
+    , ContractError(..)
     , HasBlockchainActions
     , BlockchainActions
     , both
@@ -11,6 +12,8 @@ module Language.Plutus.Contract(
     , select
     , (>>)
     , (<|>)
+    , checkpoint
+    , throwContractError
     -- * Dealing with time
     , HasAwaitSlot
     , AwaitSlot
@@ -56,7 +59,7 @@ import           Language.Plutus.Contract.Effects.WatchAddress
 import           Language.Plutus.Contract.Effects.WriteTx
 import           Language.Plutus.Contract.Util                   (both, selectEither)
 
-import           Language.Plutus.Contract.Request                (Contract, ContractRow, select)
+import           Language.Plutus.Contract.Request                (Contract(..), ContractError(..), ContractRow, select, checkpoint, throwContractError)
 
 import           Language.Plutus.Contract.Tx                     as Tx
 

--- a/plutus-contract/src/Language/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Request.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes  #-}
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE DerivingVia          #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
@@ -14,17 +15,33 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Language.Plutus.Contract.Request where
 
+import           Control.Applicative
+import           Control.Monad                      (MonadPlus)
+import           Control.Monad.Except               (MonadError (throwError))
 import qualified Data.Aeson                         as Aeson
 import           Data.Row
+import           Data.String                        (IsString)
+import           Data.Text                          (Text)
+import           GHC.Generics                       (Generic)
 
 import           Language.Plutus.Contract.Resumable
 import           Language.Plutus.Contract.Schema    (Event (..), Handlers (..), Input, Output)
 import qualified Language.Plutus.Contract.Schema    as Events
 
+-- | A list of errors produced by a `Contract`
+newtype ContractError = ContractError { unContractError :: Text }
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (Aeson.FromJSON, Aeson.ToJSON, IsString)
+
+-- | Throw a 'ContractError'
+throwContractError :: (MonadError ContractError m) => Text -> m a
+throwContractError = throwError . ContractError
+
 -- | @Contract s a@ is a contract with schema 's', producing a value of
---  type 'a'. See note [Contract Schema].
+--  type 'a' or a 'ContractError'. See note [Contract Schema].
 --
-type Contract s a = Resumable (Step (Maybe (Event s)) (Handlers s)) a
+newtype Contract s a = Contract { unContract :: Resumable ContractError (Step (Maybe (Event s)) (Handlers s)) a }
+  deriving newtype (Functor, Applicative, Monad, MonadError ContractError, Alternative, MonadPlus)
 
 -- | Constraints on the contract schema, ensuring that the requests produced
 --   by the contracts are 'Monoid's (so that we can produce a record with
@@ -49,7 +66,7 @@ request
     )
     => req
     -> Contract s resp
-request out = CStep (Step go) where
+request out = Contract $ CStep (Step go) where
   upd = Left $ Events.initialise @s @l out
   go Nothing = upd
   go (Just (Event rho)) = case trial rho (Label @l) of
@@ -77,7 +94,7 @@ requestMaybe out check = do
 --   one.
 --
 select :: forall s a. Contract s a -> Contract s a -> Contract s a
-select = CAlt
+select = (<|>)
 
-cJSONCheckpoint :: forall s a. (Aeson.FromJSON a, Aeson.ToJSON a) => Contract s a -> Contract s a
-cJSONCheckpoint = CJSONCheckpoint
+checkpoint :: forall s a. (Aeson.FromJSON a, Aeson.ToJSON a) => Contract s a -> Contract s a
+checkpoint = Contract . CJSONCheckpoint . unContract

--- a/plutus-contract/src/Language/Plutus/Contract/Schema.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Schema.hs
@@ -65,6 +65,7 @@ deriving via (JsonRec (Output s)) instance Forall (Output s) ToJSON => ToJSON (H
 deriving via (JsonRec (Output s)) instance (AllUniqueLabels (Output s), Forall (Output s) FromJSON) => FromJSON (Handlers s)
 
 deriving newtype instance Forall (Output s) Show => Show (Handlers s)
+deriving newtype instance Forall (Output s) Eq   => Eq (Handlers s)
 
 deriving via (MonoidRec (Output s)) instance (Forall (Output s) Semigroup) => Semigroup (Handlers s)
 

--- a/plutus-contract/src/Language/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Trace.hs
@@ -56,7 +56,8 @@ import           Data.Sequence                                   (Seq)
 import qualified Data.Sequence                                   as Seq
 import qualified Data.Set                                        as Set
 
-import           Language.Plutus.Contract                        (Contract, HasUtxoAt, HasWatchAddress, HasWriteTx)
+import           Language.Plutus.Contract                        (Contract (..), HasUtxoAt, HasWatchAddress, HasWriteTx)
+import           Language.Plutus.Contract.Request                (ContractError)
 import           Language.Plutus.Contract.Resumable              (ResumableError)
 import qualified Language.Plutus.Contract.Resumable              as State
 import           Language.Plutus.Contract.Schema                 (Event, Handlers, Input, Output)
@@ -119,9 +120,10 @@ getHooks
        , Forall (Output s) Semigroup
        , AllUniqueLabels (Output s)
        )
-    => Wallet -> ContractTrace s m (Either ResumableError (Handlers s))
+    => Wallet
+    -> ContractTrace s m (Either (ResumableError ContractError) (Handlers s))
 getHooks w = do
-    contract <- use ctsContract
+    contract <- unContract <$> use ctsContract
     evts <- gets (foldMap toList . view (at w) . _ctsEvents)
     return $ State.execResumable evts contract
 

--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE TemplateHaskell  #-}
-{-# LANGUAGE TypeOperators    #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE TypeApplications  #-}
 module Spec.Contract(tests) where
 
 import           Control.Monad                         (void)
@@ -99,6 +101,11 @@ tests =
             (void $ collectUntil (+) 0 (endpoint @"1") 10)
             (endpointAvailable @"1" w1 /\ waitingForSlot w1 10)
             (callEndpoint @"1" @Int w1 1)
+
+        , cp "throw an error"
+            (void $ throwContractError "error")
+            (assertContractError w1 "error" "failed to throw error")
+            (pure ())
         ]
 
 w1 :: EM.Wallet

--- a/plutus-contract/test/Spec/State.hs
+++ b/plutus-contract/test/Spec/State.hs
@@ -22,7 +22,7 @@ type Schema =
 
 tests :: TestTree
 tests =
-    let ep = Con.endpoint @"endpoint" @String @Schema
+    let ep = Con.unContract (Con.endpoint @"endpoint" @String @Schema)
         initRecord = fmap fst . fst . fromRight (error "initialise failed") . runExcept . runWriterT . S.initialise
         inp = Endpoint.event @"endpoint" "asd"
         run con =


### PR DESCRIPTION
* Add a `CError` constructor to deal with errors that happen during
  contract execution