### PR TITLE
Starting to remove Sealed from the EUTXO spec

### DIFF
--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -293,45 +293,9 @@ version.
 of type \s{TxId}: in an implementation this would probably be the
 hash of the transaction.
 
-\subsection{The \Data{} type}
-We also define a type \Data{} which can be used to pass information
-into scripts in a type-safe manner: see Figure~\ref{fig:data-defn}. The
-definition is given here in EBNF form, but can easily be translated to
-a Haskell type, for instance.
-
-\begin{ruledfigure}{H}
-\begin{alltt}
-  \Data =
-      "I" \(\N\)
-    | "B" \(\H\)
-    | "Constr" \(\N (\List{\Data})\)
-    | "List" \(\List{\Data}\)
-    | "Map" \(\List{\Data\times\Data}\)
-\end{alltt}
-\caption{The \Data{} type}
-\label{fig:data-defn}
-\end{ruledfigure}
-
-\noindent Thus values of type \Data{} are nested sums and products built up
-recursively from the base types of integers and bytestrings. This
-allows one to encode a large variety of first-order data structures:
-for example, we could encode the list [11,22,33] as \texttt{Constr 1
-  (I 11, Constr 1 (I 22, Constr 1 (I 33, Constr 0)))}, using
-\texttt{Constr 0} to represent the \texttt{Nil} constructor of a list
-type, and \texttt{Constr 1} to represent the \texttt{Cons}
-constructor.
-
-The \texttt{List} and \texttt{Map} constructors are strictly
-redundant, but are included for convenience to allow straightforward
-encoding of lists and records.
-
-We assume that the scripting language has the ability to parse values
-of type \Data{}, converting them into a suitable internal representation.
-
-\subsection{Further notation}
-Figure~\ref{fig:basic-notation} presents some further notation for use in the
-sequel. 
-\todokwxm{Split this over the page break once things have stabilised.}
+\subsection{Basic notation}
+Figure~\ref{fig:basic-notation} describes some notation and
+conventions used in the remainder of the document.
 \begin{ruledfigure}{H}
   \begin{itemize}
 \item Types are typeset in $\mathsf{sans~serif}$.
@@ -404,6 +368,41 @@ sequel.
 \caption{Basic notation}
 \label{fig:basic-notation}
 \end{ruledfigure}
+
+\subsection{The \Data{} type}
+We also define a type \Data{} which can be used to pass information
+into scripts in a type-safe manner: see Figure~\ref{fig:data-defn}. The
+definition is given here in EBNF form, but can easily be translated to
+a Haskell type, for instance.
+
+\begin{ruledfigure}{H}
+\begin{alltt}
+  \Data =
+      "I" \(\N\)
+    | "B" \(\H\)
+    | "Constr" \(\N (\List{\Data})\)
+    | "List" \(\List{\Data}\)
+    | "Map" \(\List{\Data\times\Data}\)
+\end{alltt}
+\caption{The \Data{} type}
+\label{fig:data-defn}
+\end{ruledfigure}
+
+\noindent Thus values of type \Data{} are nested sums and products
+built up recursively from the base types of integers and
+bytestrings. This allows one to encode a large variety of first-order
+data structures: for example, we could encode values of Haskell's
+\verb|Maybe Integer| type using \verb|Constr 0| to represent
+\verb|Nothing| and \verb|Constr 1 [I 41]| to encode \verb|Just 41|.
+
+
+The \texttt{List} and \texttt{Map} constructors are strictly
+redundant, but are included for convenience to allow straightforward
+encoding of lists and records.
+
+We assume that the scripting language has the ability to parse values
+of type \Data{}, converting them into a suitable internal representation.
+
 
 
 

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -4,7 +4,7 @@
 \title{Formal Specification of the Extended UTXO Model (\red{\textsf{DRAFT}})}
 
 \pagestyle{plain}
-\date{12th September 2019}
+\date{9th October 2019}
 \author{}
 
 \documentclass[a4paper]{article}
@@ -34,7 +34,9 @@
 \usepackage{listings}
 \usepackage{xcolor}
 \usepackage{verbatim}
-\usepackage[disable]{todonotes}
+\usepackage{alltt}
+\usepackage{todonotes}
+%\usepackage[disable]{todonotes}
 
 \usepackage{hyperref}  % This has to go at the end of the packages.
 
@@ -132,7 +134,9 @@
 
 \newcommand{\validator}{\mi{validator}}
 \newcommand{\redeemer}{\mi{redeemer}}
-\newcommand{\datascript}{\mi{datascript}}
+\newcommand{\valdata}{\mi{valdata}}
+\newcommand{\Data}{\ensuremath{\mathsf{Data}}}
+
 \newcommand{\outputref}{\mi{outputRef}}
 \newcommand{\txin}{\mi{in}}
 \newcommand{\txout}{\mi{out}}
@@ -157,6 +161,8 @@
 \newcommand\B{\ensuremath{\mathbb{B}}}
 \newcommand\N{\ensuremath{\mathbb{N}}}
 \newcommand\Z{\ensuremath{\mathbb{Z}}}
+\renewcommand\H{\ensuremath{\mathbb{H}}}
+%% \H is usually the Hungarian double acute accent
 
 \newcommand{\emptymap}{\ensuremath{\{\}}}
 
@@ -165,23 +171,6 @@
 
 \begin{document}
 \maketitle
-\todokwxm{Michael suggests (and I agree) that we should try to make
-  clear the difference between the ledger layer and the script layer.
-  It would be good if we could make the EUTXO model independent of the
-  details of the scripting language, just saying ``We don't care what
-  the scripting language actually is: as long as you can do
-  \textsf{A},\textsf{B},\textsf{C}, and \textsf{D}, then we can make
-  the EUTXO model work'' (where
-  \textsf{A},\textsf{B},\textsf{C},\textsf{D} are things like encoding
-  the \textsf{PendingTx} data, performing validation, verifying the
-  content of the output data scripts, ...).  Then we can say separately
-  ``Here's how you can do \textsf{A},\textsf{B},\textsf{C}, and
-  \textsf{D} in Plutus Core''.  This would make things modular, giving
-  us a clear and well-defined interface between the EUTXO model and
-  Plutus Core, which would surely be a good thing.  However, the business
-  about validating data scripts \textit{really} messes this up.}
-
-\bigskip
 
 \section{Introduction: The Extended UTXO Model}
 \label{sec:intro}
@@ -205,7 +194,7 @@ to certain conditions being met.  A smart contract may involve
 multiple transactions, and our aim is to define a transaction model
 which enables the implementation of highly expressive contracts.
 
-An important component of our UTXO models are \textit{scripts},
+An important feature of our UTXO models is \textit{scripts},
 programs which run on the blockchain to check the validity of
 transactions.  In Cardano, scripts will be programs in the Plutus Core
 language~\citep{Plutus-Core-spec}. The Extended UTXO models are largely
@@ -214,8 +203,14 @@ agnostic as to the scripting language.
 
 \subsection{Structure of the document}
 \label{sec:doc-structure}
-This document proposes two extensions of the basic UTXO model (EUTXO
-stands for \textit{Extended UTXO}):
+The papers~\citep{Zahnentferner18-Chimeric} and
+\citep{Zahnentferner18-UTxO} give a formal specification of a basic
+UTXO model. See Note~\ref{note:basic-utxo} for some background on
+this model.
+
+\medskip
+\noindent This document proposes two extensions of the basic UTXO
+model (EUTXO stands for \textit{Extended UTXO}):
 
 \begin{itemize}
   \item \textbf{EUTXO-1} (Section~\ref{sec:eutxo-1}): this extends the
@@ -226,10 +221,6 @@ stands for \textit{Extended UTXO}):
     \textit{custom currencies} and \textit{non-fungible tokens}.
 \end{itemize}
 
-\noindent We give formal specifications of each of these versions,
-based on the models appearing in the
-papers~\citep{Zahnentferner18-Chimeric} and
-\citep{Zahnentferner18-UTxO}.
 
 \medskip
 
@@ -249,12 +240,94 @@ text.  Further explanation and many examples are contained in the
 book~\citep{Plutus-book}.
 
 
-
-\newpage
 \section{Notation}
 This section defines some basic notation.  We generally follow the
 notation established by \citep{Zahnentferner18-UTxO}.
 
+\subsection{Basic types}
+\noindent Throughout the document we assume a number of basic types.
+These are shown in Figure~\ref{fig:basic-types}.
+
+\begin{ruledfigure}{H}
+  \center{
+    \begin{tabular}{rl}
+      \B&: the type of booleans, $\{\false, \true\}$\\
+      \N&: the type of natural numbers, $\{0, 1, 2, \ldots\}$\\
+      \Z&: the type of integers, $\{,\ldots, -2, -1, 0, 1, 2, \ldots\}$\\
+      \H&: the type of \textit{bytestrings}, $\bigcup_{n=0}^{\infty}\{0,1\}^{8n}$\\
+      $\qty = \N$&: an amount of currency, always non-negative\\
+      $\qtypm = \Z$&: a possibly negative amount of currency\\
+      $\s{SlotNumber} = \N$&: a slot number\\
+      $\s{Address} = \N$&: the address of an object in the blockchain\\
+      $\s{TxId} = \N$&: the identifier of a previous transaction on the chain\\
+    \end{tabular}
+  }
+  \caption{Basic types}
+  \label{fig:basic-types}
+\end{ruledfigure}
+
+\noindent We regard $\N$ as a subtype of $\Z$ and convert freely between
+natural numbers and non-negative integers.  A bytestring is a sequence
+of 8-bit bytes.
+
+\medskip
+\noindent In practice an \textsf{Address} will be a
+collision-resistant hash of some object (so the address of an object
+$X$ is $X^{\#}$ in the notation of Figure~\ref{fig:basic-notation}),
+and the blockchain will provide an efficient way to retrieve the
+original object given its hash.  Compiled Plutus Core scripts are
+stored and transmitted in a serialised form, and when we talk about
+the hash of a Plutus Core script we mean the hash of the serialised
+version.
+
+% Accessing objects indirectly via addresses is helpful because it can
+% help to reduce memory and disk usage: for example, there may be
+% scripts for common validation scenarios used in many transactions, and
+% it is more efficient to store single copies of such scripts rather
+% than having hundreds of transactions each with their own copy.
+
+\medskip
+\noindent We assume that every transaction in a ledger has a unique identifier
+of type \s{TxId}: in an implementation this would probably be the
+hash of the transaction.
+
+\subsection{The \Data{} type}
+We also define a type \Data{} which can be used to pass information
+into scripts in a type-safe manner: see Figure~\ref{fig:data-defn}. The
+definition is given here in EBNF form, but can easily be translated to
+a Haskell type, for instance.
+
+\begin{ruledfigure}{H}
+\begin{alltt}
+  \Data =
+      "I" \(\N\)
+    | "B" \(\H\)
+    | "Constr" \(\N (\List{\Data})\)
+    | "Map" \(\List{\Data\times\Data}\)
+\end{alltt}
+\caption{The \Data{} type}
+\label{fig:data-defn}
+\end{ruledfigure}
+
+\noindent Thus values of type \Data{} are nested sums and products built up
+recursively from the base types of integers and bytestrings. This
+allows one to encode a large variety of first-order data structures:
+for example, we could encode the list [11,22,33] as \texttt{Constr 1
+  (I 11, Constr 1 (I 22, Constr 1 (I 33, Constr 0)))}, using
+\texttt{Constr 0} to represent the \texttt{Nil} constructor of a list
+type, and \texttt{Constr 1} to represent the \texttt{Cons}
+constructor.
+
+The \texttt{Map} constructor is strictly redundant, but is included for
+convenience to allow a straightforward encoding of records.
+
+We assume that the scripting language has the ability to parse values
+of type \Data{}, converting them into a suitable internal representation.
+
+\subsection{Further notation}
+Figure~\ref{fig:basic-notation} presents some further notation for use in the
+sequel. 
+\todokwxm{Split this over the page break once things have stabilised.}
 \begin{ruledfigure}{H}
   \begin{itemize}
 \item Types are typeset in $\mathsf{sans~serif}$.
@@ -264,8 +337,8 @@ notation established by \citep{Zahnentferner18-UTxO}.
 \item The only operation on $\mathsf{Script}$ from the ledger's
   perspective is applying a validator script to three arguments,
   which is denoted by $\llbracket \cdots \rrbracket :
-  \mathsf{Script} \rightarrow \mathsf{Script} \times \mathsf{Script}
-    \times \mathsf{Script} \rightarrow \B$.
+  \mathsf{Script} \rightarrow \Data \times \Data
+    \times \Data \rightarrow \B$.
 \item A record type with fields $\phi_1, \ldots, \phi_n$ of types $T_1,
   \ldots, T_n$ is denoted by $(\phi_1 : T_1, \ldots, \phi_n : T_n)$.
 
@@ -329,51 +402,6 @@ notation established by \citep{Zahnentferner18-UTxO}.
 \end{ruledfigure}
 
 
-\noindent Throughout the document we assume a number of basic types.
-These are shown in Figure~\ref{fig:basic-types}.
-
-\begin{ruledfigure}{H}
-  \center{
-    \begin{tabular}{rl}
-      \B&: the type of booleans, $\{\false, \true\}$\\
-      \N&: the type of natural numbers, $\{0, 1, 2, \ldots\}$\\
-      \Z&: the type of integers, $\{,\ldots, -2, -1, 0, 1, 2, \ldots\}$\\
-      $\qty = \N$&: an amount of currency, always non-negative\\
-      $\qtypm = \Z$&: a possibly negative amount of currency\\
-      $\s{SlotNumber} = \N$&: a slot number\\
-      $\s{Address} = \N$&: the address of an object in the blockchain\\
-      $\s{TxId} = \N$&: the identifier of a previous transaction on the chain\\
-    \end{tabular}
-  }
-  \caption{Basic types}
-  \label{fig:basic-types}
-\end{ruledfigure}
-
-\noindent We regard $\N$ as a subtype of $\Z$ and convert freely between
-natural numbers and non-negative integers.
-
-\medskip
-\noindent In practice an \textsf{Address} will be a
-collision-resistant hash of some object (so the address of an object
-$X$ is $X^{\#}$ in the notation of Figure~\ref{fig:basic-notation}),
-and the blockchain will provide an efficient way to retrieve the
-original object given its hash.  Compiled Plutus Core scripts are
-stored and transmitted in a serialised form, and when we talk about
-the hash of a Plutus Core script we mean the hash of the serialised
-version.
-
-% Accessing objects indirectly via addresses is helpful because it can
-% help to reduce memory and disk usage: for example, there may be
-% scripts for common validation scenarios used in many transactions, and
-% it is more efficient to store single copies of such scripts rather
-% than having hundreds of transactions each with their own copy.
-
-\medskip
-\noindent We assume that every transaction in a ledger has a unique identifier
-of type \s{TxId}: in an implementation this would probably be the
-hash of the transaction.
-
-
 
 
 
@@ -392,39 +420,44 @@ proposed in~\citep{Zahnentferner18-UTxO}:
   the current slot number lies within the transaction's validity
   interval.
 
-\item We introduce a new script called a \i{data script}, and each
-  unspent output has a (possibly empty) data script associated with
-  it.  The introduction of the data script increases the expressivity
-  of the model considerably. For example, one can use the data script
-  to propagate state between transactions, and this can be used to
-  give a contract the structure of a finite state machine; the fact
-  that the data script is part of the output and not the transaction
-  means that the state can change without the transaction changing,
-  which makes it easier to have an ``identity'' for an ongoing
-  contract: we will return to this issue in
-  Section~\ref{sec:validating-datascripts}.
+\item Each unspent output now has a (possibly empty) object $\valdata$ of type
+  \Data{} associated with it: we (\red{provisionally}) call this the output's
+  \textit{validation data}.  The introduction of the validation data
+  increases the expressivity of the model considerably. For example,
+  one can use the validation data to propagate state between
+  transactions, and this can be used to give a contract the structure
+  of a finite state machine; the fact that the validation data is part
+  of the output and not the transaction means that the state can
+  change without the transaction changing, which makes it easier to
+  have an ``identity'' for an ongoing contract.
+
+\item The redeemer script of~\citet{Zahnentferner18-UTxO} has been
+  replaced with a redeemer object of type \Data.
   
-\item Validation is performed by running the validator script with the
-  redeemer and data script as input; the validator is also provided
-  with information about the pending transaction (ie, the transaction
-  which is just about to take place, assuming that validation
-  succeeds); this information is contained in a structure which we call
-  \ptx{} which contains data such as the validity interval of the
-  pending transaction and information about the inputs and outputs.
-  See Section~\ref{sec:pendingtx} for more information on the $\ptx$
-  structure.
+\item Validation of an output is performed by running the validator
+  script with the redeemer and validation data as input; the validator
+  is also provided with information about the pending transaction (ie,
+  the transaction which is just about to take place, assuming that
+  validation succeeds); this information is contained in a structure
+  which we call \ptx{} which contains data such as the validity
+  interval of the pending transaction and information about the inputs
+  and outputs.  See Section~\ref{sec:pendingtx} for more information
+  on the $\ptx$ structure.
   
 \end{itemize}
 
 
 \noindent At the ledger level, validator scripts now have the type
-$$
-\script \times \script \times \script \rightarrow \B
-$$
-At the Plutus level in Cardano, the validator is a program which
-consumes the redeemer, the data script, and the Plutus Core encoding of
-the $\ptx$ structure as arguments: each script will have a Plutus type
-and the types will have to fit the types expected by the validator.
+$
+\Data \times \Data \times \Data \rightarrow \B
+$. At the Plutus level in Cardano, the validator is a program which
+consumes the redeemer, the validation data, and a \Data{} encoding
+of the $\ptx$ structure as arguments.  The validator may
+expect these objects to have some specific form (a single bytestring
+or a list of integers, for example) and if it is supplied with data
+with an incorrect format it should fail and return \false.
+
+\todokwxm{Fix the stuff above.}
 
 \subsection{A Formal Description of the EUTXO-1 Model}
 \label{section:eutxo-spec}
@@ -438,8 +471,10 @@ for automatic contract analysis.
 
 The definitions in this section are essentially the definitions of
 UTXO-based cryptocurrencies with scripts from
-\citep{Zahnentferner18-UTxO}, with the addition of the new features
-mentioned above: the validity interval and the $\ptx$ structure.
+\citep{Zahnentferner18-UTxO}, except that we have added the new
+features mentioned above (the validity interval, the validation data
+and the $\ptx$ structure) and changed the type of the redeemer from
+\textsf{Script} to \Data{}.
 
 Figure~\ref{fig:eutxo-1-types} lists the types which
 describe transactions in the basic EUTXO model.
@@ -450,13 +485,13 @@ describe transactions in the basic EUTXO model.
     
     \s{Output } &= (&\addr: \s{Address},\\
     && \i{value}: \qty,\\
-    &&  \i{datascript}: \s{Script})\\
+    &&  \valdata: \Data)\\
     \\
     \s{OutputRef } &= (&\i{id}: \s{TxId}, \idx: \s{Int})\\
     \\
     \s{Input } & = (&\i{outputRef}: \s{OutputRef},\\
                  && \i{validator}: \s{Script},\\
-                 && \i{redeemer}: \s{Script})\\
+                 && \i{redeemer}: \Data)\\
      \\
      \eutxotx\s{ } &= (&\inputs: \FinSet{\s{Input}},\\
      &&\outputs: \List{\s{Output}},\\
@@ -485,10 +520,10 @@ output of the transaction is required.
 %  Also: we should check this is still how they do it in the new ledger
 %  specs.}
 
-\paragraph{Scripts.} Note that data scripts are modelled as components
+\paragraph{Scripts.} Note that validation data are modelled as components
 of outputs, but validator scripts as components of inputs, even though
-a validator is conceptually part of an output.  The reasons for this are
-explained in Note~\ref{note:scripts}.
+a validator is conceptually part of an output.  The reasons for this
+are explained in Note~\ref{note:scripts}.
 
 \paragraph{Validity intervals.} We allow the second component of a
 validity interval to take the value $\infty$ to indicate that there is
@@ -531,11 +566,11 @@ related types.
     
     \s{OutputInfo } &= (& \i{value}: \qty,\\
     && \i{validatorHash}: \s{Address},\\
-    &&  \i{datascriptHash}: \s{Address})\\
+    &&  \valdata: \Data)\\
     \\
     \s{InputInfo } & = (&\i{inputRef}: \s{OutputRef},\\
                  && \i{validatorHash}: \s{Address},\\
-                 && \i{redeemerHash}: \s{Address}),\\
+                 && \i{redeemerHash}: \s{Address},\\
                  && \i{value}: \qty)\\
      \\
      \ptx\s{ } &= (&\i{inputInfo}: \List{\s{InputInfo}},\\
@@ -556,15 +591,16 @@ Figure~\ref{fig:eutxo-1-types}. The \fee, \forge, and
 \i{validityInterval} fields are copied directly from the pending
 transaction.  The \i{outputInfo} field contains information about the
 outputs which will be produced if the pending transaction validates
-successfully, but only contains the addresses (ie, hashes) of the
-relevant validator and data scripts, not the scripts themselves.
-
-Similarly the \i{inputInfo} field contains information about the
+successfully: it contains only the address of the relevant validator,
+but has the validation data for the output in full.\footnote{See
+  Note~\ref{note:validation-data} for further explanation.}
+The \i{inputInfo} field contains information about the
 inputs to the pending transaction, but provides only the hashes of the
 validator and redeemer scripts for the inputs.  The \i{thisInput}
 field is an index pointing to the element of \i{inputInfo}
 relating to the input currently undergoing validation.
-
+\todokwxm{In the code at the moment, the hashes of the validator
+and redeemer scripts in \i{inputInfo} are allowed to be absent.  Why?}
 \medskip
 \noindent We also require a function
 $$
@@ -573,14 +609,17 @@ $$
 which produces the relevant $\ptx$ for a transaction $t$ and an input
 $i$, and a function
 $$
-\sigma: \ptx \rightarrow \script
+\delta: \ptx \rightarrow \Data
 $$
-which translates a $\ptx$ object into a script containing exactly the
-same information, encoded in some standard way enabling it to be accessed
-by a validator script .  Assuming we have an appropriate hashing
-function, it is straightforward to define $\tau$.  The function
-$\sigma$ is implementation-dependent and we will not discuss it
-further.
+which translates a $\ptx$ object into a \Data{} value containing
+exactly the same information, encoded in some standard way enabling it
+to be accessed by a validator script.  Assuming we have an
+appropriate hashing function, it is straightforward to define $\tau$.
+The function $\delta$ is implementation-dependent and we will not
+discuss it further.
+
+\medskip\todokwxm{But with the advent of \Data{} we \textit{can}
+  specify $\delta$.  Maybe we should?}
 
 \paragraph{Determinism.}  The information provided in the $\ptx$
 structure is sufficiently limited that the validation process
@@ -641,13 +680,12 @@ This function simply returns the value of the input.
 
 \bigskip
 
-\noindent We can now define what it means for a transaction $t$ of type
-$\eutxotx$ to be
-valid for a ledger: see Figure~\ref{fig:eutxo-1-validity}.  Our
-definition combines Definitions 6 and 14 from
-\citep{Zahnentferner18-UTxO}, differing from the latter in condition
-\ref{rule:all-inputs-validate}.
-
+\noindent We can now define what it means for a transaction $t$ of
+type $\eutxotx$ to be valid for a ledger: see
+Figure~\ref{fig:eutxo-1-validity}.  Our definition combines
+Definitions 6 and 14 from \citep{Zahnentferner18-UTxO}, differing from
+the latter in condition \ref{rule:all-inputs-validate}.
+\todokwxm{Check this.}
 
 \begin{ruledfigure}{H}
 \begin{enumerate}
@@ -675,7 +713,7 @@ definition combines Definitions 6 and 14 from
     \item\label{rule:all-inputs-validate} \textbf{All inputs validate:}
     \[
     \textrm{For all } i \in t.\inputs,\enspace \llbracket
-    i.\validator(\txout(i, \lambda).\datascript,\, i.\redeemer,\,  \sigma(\tau(t,i))) \rrbracket = \true.
+    i.\validator\rrbracket (\txout(i, \lambda).\valdata,\, i.\redeemer,\,  \delta(\tau(t,i))) = \true.
       \]
     \item\label{rule:validator-scripts-hash} \textbf{Validator scripts hash to their output addresses:}
     \[
@@ -685,6 +723,8 @@ definition combines Definitions 6 and 14 from
 \caption{Validity of a transaction $t$ in the EUTXO-1 model}
 \label{fig:eutxo-1-validity}
 \end{ruledfigure}
+\todokwxm{Do we really needs the $\llbracket\cdots\rrbracket$ business?}
+
 
 \noindent We say that a ledger
 $\lambda$ is \textit{valid} if either $\lambda$ is empty or
@@ -694,170 +734,13 @@ $\lambda^{\prime}$ valid and $t$ valid for $\lambda^{\prime}$.
 
 In practice, validity imposes a limit on the size of the
 $\mathsf{Script}$ values of the $\validator$, $\redeemer$ and
-$\datascript$ fields and the result of $\sigma$. The validation of a
+$\valdata$ fields and the result of $\delta$. The validation of a
 single transaction must take place within one slot, so the evaluation
 of $\llbracket ~ \rrbracket$ cannot take longer than one slot.
-
+\todokwxm{Do we need this $\uparrow$?}
 \todokwxm{We should probably point out somewhere that the validating node
   typechecks scripts during validation.}
 
-\subsection{Validating pending data scripts}
-\label{sec:validating-datascripts}
-Suppose that a transaction $T$ is undergoing validation, and that $T$
-has outputs $O_1, \ldots, O_n$, with each $O_i$ having a data script
-$D_i$.  As part of the validation process we have to validate each
-input to $T$.  Consider a specific input $I$ with validator $V$.
-During the validation of $I$ it may be necessary for $V$ to check that
-some of $T$'s output data scripts $D_{i_1},\ldots,D_{i_k}$ are ``correct'' in
-some way (for example, the $D_i$ could be being used to propagate some
-state through an ongoing contract, and $V$ might need to check that
-the state has some expected form in order to be sure that the creator
-of $T$ is not attempting to cheat in some way).
-
-\noindent These considerations lead us to the following requirements:
-
-\begin{itemize}
-\item During validation of a contract $T$, a validator $V$ of an input
-  must be able to inspect the contents of the data scripts of some
-  selected subset of $T$'s outputs; this subset may vary with $V$.
-\item The contents of the data scripts must be obtained in such a way
-  that $V$ can be certain that they are genuine (if not, it might be
-  possible for some participant to lie about the contents and thus
-  subvert the transaction).
-\end{itemize}
-
-\noindent Exactly how this is done will depend on the properties of the
-scripting language.
-
-\paragraph{Pending data script validation in Plutus Core.} The above
-requirements present a problem for Plutus Core because Plutus Core is
-strongly typed and the $D_i$ are not required to have any fixed type.
-Furthermore, $V$ must exist when the input $I$ is created, but the
-$D_i$ need not be created until $T$ is prepared for submission to the
-blockchain, which may be long after $I$ is created; this means that
-the types of the $D_i$ are not even necessarily known when $V$ is
-created.  This prevents the $D_i$ from being supplied to $V$ as
-runtime arguments or included in the $\ptx$ structure, which has the
-fixed type described in Figure~\ref{fig:ptx-1-types}.
-
-There is a mechanism for solving this problem.  This depends on the
-fact that $I$'s redeemer, $R$, say, does not need to be
-created until $T$ is ready for submission to the chain, and the $D_i$
-are known at this point.
-
-As an initial attempt to deal with the problem, we could construct a
-redeemer $R$ containing the actual (deserialised) contents of
-the $D_{i_1},\ldots,D_{i_k}$ together with their hashes; during validation,
-$R$ could forward the contents of the $D_{i_j}$ to $V$ for examination.
-However, \textbf{this does not work}: the redeemer is constructed
-off-chain, probably in the wallet of the creator of the transaction
-$T$, and there is no reason for $V$ to trust the creator of $T$,
-who could lie about what is actually contained in $D_{i_j}$.
-
-However, this scheme can be modified to provide the contents of the
-data scripts in a trustworthy way.  The basic idea is to use a
-redeemer $R$ which takes the (contents of the) $D_{i_j}$ as arguments and
-forwards them to $V$, and for $R$ to be supplied with the true
-contents of the $D_{i_j}$ during validation; this is done by the
-validating node ($N$, say), and basic blockchain mechanisms mean that
-$V$ \textit{can} trust $N$.
-
-Some further refinements are required to ensure trustworthiness,
-because it is conceivable that $R$ might still be able to fake the
-contents of a data script.  The basic idea is for $N$ to wrap the data
-script contents in a special type \verb|Sealed| which can only be
-produced using an operation called \verb|Seal|, and then during
-validation is is checked that $R$ does not use the \verb|Seal|
-operation: it follows that any values of type \verb|Sealed| which
-$V$ receives can only have been provided by $N$, so $V$ can accept
-that these values are correct.
-
-
-\paragraph{The details.} We will now describe this process in more
-detail.  We define the following types (somewhat simplified and
-presented in Haskell syntax, but easily translatable to Plutus Core
-thanks to the latter's expressivity):
-
-\begin{verbatim}
-  type DataScriptHash = ByteString
-
-  type HashedDataScript a = a * DataScriptHash
-
-  data Sealed a = Seal a
-
-  newtype Sealer = 
-          Sealer (forall a . a -> DataScriptHash -> Sealed (HashedDataScript a))
-\end{verbatim}
-
-\noindent The type \verb|HashedDataScript a| represents a value of
-type \verb|a| together with a hash: in practice \verb|a| will be the
-Plutus Core type of the contents of a data script $D$ and the hash
-will be the hash of the serialised version of $D$ (ie, the version of
-$D$ stored on the blockchain).  The type \verb|Sealed a| simply wraps
-a value of type \verb|a|, and \verb|Sealer| gives a way to build a
-\verb|Sealed| value containing a value of type \verb|a| together with
-the hash of its serialised version.
-
-We assume during validation of the transaction $T$, the validator $V$
-for an input $I$ of $T$ needs to inspect the contents of data scripts
-$D_{i_1}, \ldots, D_{i_k}$ of the outputs $O_{i_1}, \ldots, O_{i_k}$
-of $T$, and that the (Plutus Core) type of $D_{i_j}$ is $\tau_{i_j}$
-($1\le j \le k$).  Recall from Section~\ref{sec:eutxo-1} that $V$
-takes as arguments (i) the data script for $I$, (ii) the redeemer for
-$I$, and (iii) a $\ptx$ structure for $I$ and $T$.  Assume that these
-have the Plutus Core types $\delta, \rho$ and $\pi$ respectively, so
-that the Plutus Core type of $V$ is
-$\delta \rightarrow \rho \rightarrow \pi \rightarrow \B$.  The creator
-of the validator $V$ will know in advance that $V$ requires access to
-objects of type $\tau_{i_1}, \ldots, \tau_{i_k}$, so the type $\rho$
-will describe an object which provides a means to access things of
-these types (for example, $\rho$ may be a tuple type involving
-(\verb|Sealed| versions of) the $\tau_{i_j}$, in addition to types
-of any other values which $V$ expects the redeemer to provide).
-
-\noindent We now proceed as follows:
-\begin{itemize}
-\item A ``pre-redeemer'' $R_0$ for $O$ is constructed (off-chain) with
-  the type
-  $\sealed\, \tau_{i_1} \rightarrow \sealed\, \tau_{i_2} \rightarrow \cdots
-  \rightarrow \sealed\, \tau_{i_k} \rightarrow \rho$
-\item On-chain, the validating node $N$ typechecks $R_0$ and makes
-  sure that it contains nothing of type \verb|Sealed ...| and no uses
-  of \verb|Seal| or \verb|Sealer|; if it does, then validation fails.
-\item  $N$ applies $R_0$ to the actual
-  data scripts and their hashes to obtain a full redeemer $R$ of type $\rho$:
-  \[
-    R = R_0\, (\sealer\, D_{i_1}\, D_{i_1}^{\#}) \cdots (\sealer\, D_{i_k}\, D_{i_k}^{\#})
-    \]
-  \item Validation is performed as usual to obtain a boolean value
-    $\llbracket V (D_I, R, P) \rrbracket$, where $D_I$ is $I$'s data script
-    and $P$ is the $\ptx$ object for $T$ and $I$.
-  \item During validation, $V$ can access the $D_{i_j}$ and check the hash
-    from the corresponding \verb|Sealed| object against the hash from
-    $P$ to make sure that $R_0$ has not replaced the expected $D_{i_j}$
-    with some other $D_{i_{j^{\prime}}}$ which happens to have the same type.
-    
-  \end{itemize}
-
-  \noindent This process has to be followed for every validator which needs to
-  inspect the contents of one or more pending data scripts.
-  \todokwxm{We don't really need the hashes now: we could just use the
-    index of the output.
-    
-    \medskip
-    [Later] Maybe having the hashes is good from the point of generality:
-    if your scripting language was Java bytecode or something you might be able to
-    load scripts/compute hashes dynamically and then the hash would be enough.}
-
-  \todokwxm{Damn. Now we need to apply
-    pre-redeemers to things as well in
-    Figure~\ref{fig:basic-notation}.}  \todokwxm{Also, this
-    Figure~\ref{fig:eutxo-1-validity} is now misleading because it
-    only gives the basic definition of validity and doesn't talk about
-    all these pending datascripts.  However, it would be intolerable
-    if we had to include all this stuff in something that's basically
-    pretty simple.}
-  
 %%\newpage
 \section{EUTXO-2: multicurrency support and non-fungible tokens}
 \label{sec:eutxo-2}
@@ -932,13 +815,13 @@ negative quantities are allowed.
     \s{Output}_2 &= (&\addr: \s{Address},\\
     && \val: \qty\\
     && \customvals: \qtymap,\\
-    && \i{datascript}: \s{Script})\\
+    && \valdata: \Data)\\
     \\
     \s{OutputRef}_2 &= (&\i{id}: \s{TxId}, \idx: \s{Int})\\
     \\
     \s{Input}_2 &= (& \i{outputRef}: \sf{OutputRef}_2,\\
                      && \i{validator}: \s{Script},\\
-                     & & \i{redeemer}: \s{Script})\\
+                     & & \i{redeemer}: \Data)\\
 \\
     \eutxotx_2 &= ( &\inputs: \FinSet{\s{Input}_2},\\
     &&\outputs: \List{\s{Output}_2},\\
@@ -1002,7 +885,7 @@ $$
 $$
 and
 $$
-\sigma_2: \ptx_2 \rightarrow \script
+\delta_2: \ptx_2 \rightarrow \Data
 $$
 which can be used to produce an appropriate script from a transaction
 and the index of an input.
@@ -1089,8 +972,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
     \item\label{rule:all-inputs-validate-2} \textbf{All inputs validate:}
     \[
     \textrm{For all } i \in t.\inputs,\enspace \llbracket
-    i.\validator(\txout(i,\lambda).\datascript,\, i.\redeemer,\, \sigma_2(\tau_2(t, i)))
-    \rrbracket = \true.
+    i.\validator\rrbracket(\txout(i,\lambda).\valdata,\, i.\redeemer,\, \delta_2(\tau_2(t, i))) = \true.
       \]
     \item\label{rule:validator-scripts-hash-2} \textbf{Validator scripts hash to their output addresses:}
     \[
@@ -1199,11 +1081,22 @@ the hash in the output can be used to check that the correct validator
 is in fact being used when validation occurs), but unspent outputs
 persist on-chain in the UTXO set until they are eventually spent.
 
-This strategy is not applied to data scripts since, as the name would
-suggest, we expect them to be small pieces of data (public keys, for
-example) which would not incur large storage charges.
-\todokwxm{Exactly what is the rationale for making the data script
-  part of the output and not just a hash?}
+This strategy is not applied to validation data since, as the name
+would suggest, we expect these to be small pieces of data (public
+keys, for example) which would not incur large storage charges.
+
+\note{Validation data in $\ptx$}
+\label{note:validation-data}
+In Figures~\ref{fig:ptx-1-types} and~\ref{fig:ptx-2-types} the
+\textsf{OutputInfo} type includes the validation data for the outputs
+of the pending transaction in full.  This allows a validator to
+inspect outgoing validation data, for example to confirm that its
+contents are correct in some sense. This can be useful when validation
+data is used to propagate information about the state of a contract to
+later transactions.  See~\cite{Plutus-book} for examples of this.
+\todokwxm{More specific reference?}
+
+
 
 \note{Determinism of the validation process.}
 \label{note:validation-determinism} The $\ptx$ type is the only

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -4,7 +4,7 @@
 \title{Formal Specification of the Extended UTXO Model (\red{\textsf{DRAFT}})}
 
 \pagestyle{plain}
-\date{9th October 2019}
+\date{11th October 2019}
 \author{}
 
 \documentclass[a4paper]{article}
@@ -35,8 +35,9 @@
 \usepackage{xcolor}
 \usepackage{verbatim}
 \usepackage{alltt}
-\usepackage{todonotes}
-%\usepackage[disable]{todonotes}
+
+%\usepackage{todonotes}
+\usepackage[disable]{todonotes}
 
 \usepackage{hyperref}  % This has to go at the end of the packages.
 
@@ -268,7 +269,8 @@ These are shown in Figure~\ref{fig:basic-types}.
 
 \noindent We regard $\N$ as a subtype of $\Z$ and convert freely between
 natural numbers and non-negative integers.  A bytestring is a sequence
-of 8-bit bytes.
+of 8-bit bytes: the symbol $\H$ is used because bytestrings are often
+presented as sequences of hexadecimal digits.
 
 \medskip
 \noindent In practice an \textsf{Address} will be a
@@ -303,6 +305,7 @@ a Haskell type, for instance.
       "I" \(\N\)
     | "B" \(\H\)
     | "Constr" \(\N (\List{\Data})\)
+    | "List" \(\List{\Data}\)
     | "Map" \(\List{\Data\times\Data}\)
 \end{alltt}
 \caption{The \Data{} type}
@@ -318,8 +321,9 @@ for example, we could encode the list [11,22,33] as \texttt{Constr 1
 type, and \texttt{Constr 1} to represent the \texttt{Cons}
 constructor.
 
-The \texttt{Map} constructor is strictly redundant, but is included for
-convenience to allow a straightforward encoding of records.
+The \texttt{List} and \texttt{Map} constructors are strictly
+redundant, but are included for convenience to allow straightforward
+encoding of lists and records.
 
 We assume that the scripting language has the ability to parse values
 of type \Data{}, converting them into a suitable internal representation.
@@ -438,11 +442,12 @@ proposed in~\citep{Zahnentferner18-UTxO}:
   script with the redeemer and validation data as input; the validator
   is also provided with information about the pending transaction (ie,
   the transaction which is just about to take place, assuming that
-  validation succeeds); this information is contained in a structure
-  which we call \ptx{} which contains data such as the validity
-  interval of the pending transaction and information about the inputs
-  and outputs.  See Section~\ref{sec:pendingtx} for more information
-  on the $\ptx$ structure.
+  validation succeeds). This information is contained in a structure
+  (also encoded as \Data) which we call \ptx{}: this contains data
+  such as the validity interval of the pending transaction and
+  information about the inputs and outputs.  See
+  Section~\ref{sec:pendingtx} for more information on the $\ptx$
+  structure.
   
 \end{itemize}
 
@@ -457,7 +462,8 @@ expect these objects to have some specific form (a single bytestring
 or a list of integers, for example) and if it is supplied with data
 with an incorrect format it should fail and return \false.
 
-\todokwxm{Fix the stuff above.}
+\todokwxm{There's the issue about whether validators return
+  \texttt{true/false} or \texttt{()/Error}. Remember to fix this when things have settled down.}
 
 \subsection{A Formal Description of the EUTXO-1 Model}
 \label{section:eutxo-spec}
@@ -599,8 +605,10 @@ inputs to the pending transaction, but provides only the hashes of the
 validator and redeemer scripts for the inputs.  The \i{thisInput}
 field is an index pointing to the element of \i{inputInfo}
 relating to the input currently undergoing validation.
-\todokwxm{In the code at the moment, the hashes of the validator
-and redeemer scripts in \i{inputInfo} are allowed to be absent.  Why?}
+% Note: in the code at the moment, the hashes of the validator
+% and redeemer scripts in inputInfo are allowed to be absent
+% when we have pubkey inputs.  We're ignoring that special case here.
+
 \medskip
 \noindent We also require a function
 $$
@@ -620,6 +628,7 @@ discuss it further.
 
 \medskip\todokwxm{But with the advent of \Data{} we \textit{can}
   specify $\delta$.  Maybe we should?}
+\todokwxm{... or even just do the whole translation in one step.}
 
 \paragraph{Determinism.}  The information provided in the $\ptx$
 structure is sufficiently limited that the validation process


### PR DESCRIPTION
This replaces validator and redeemer scripts with `Data` objects, getting rid of `Sealed` in the process.  I need to give it another pass before merging, but I hope it's approximately correct.  It says that `PendingTx` is translated into `Data` for validation, which is a bit premature, but we can change that back if need be.  

It has some todo notes which need to be hidden before merging.