### PR TITLE
plutus-tx: improve some errors and handle an odd case

### DIFF
--- a/plutus-playground-server/test/Playground/Rollup/renderCrowdfunding.txt
+++ b/plutus-playground-server/test/Playground/Rollup/renderCrowdfunding.txt
@@ -51,7 +51,7 @@ Balances Carried Forward:
               EURToken:  30
 
 ==== Slot #2, Tx #0 ====
-TxId:       74c871f2035a8a9fa0e7149990cafab623df4cfeccca4bdf8201753444d73f1b
+TxId:       c7b51f10da5bf0dcaacd9448f2caa95c24bfeb2640e6af6d9de095345baa2059
 Fee:        -
 Forge:      -
 Inputs:
@@ -76,7 +76,7 @@ Outputs:
               EURToken:  30
   
   ---- Output 1 ----
-  Destination:  Script: 9f18ff188f186d120718cd1848188618461218f4...
+  Destination:  Script: 9f18ec18971880189418c318c718eb18a2182418...
   Value:
     Ada:      Lovelace:  8000000
 
@@ -100,12 +100,12 @@ Balances Carried Forward:
     b0b0:     USDToken:  20
               EURToken:  30
   
-  Script: 9f18ff188f186d120718cd1848188618461218f4...
+  Script: 9f18ec18971880189418c318c718eb18a2182418...
   Value:
     Ada:      Lovelace:  8000000
 
 ==== Slot #3, Tx #0 ====
-TxId:       b8378be79a54b782fd4ffeb2ab1cc54e43cb752a79f2019896e0d8b1c65f66a6
+TxId:       cb5fb8187f9a71d193ff4e6267e1899debf7ae96b6cf87f5014a853ed277d75c
 Fee:        -
 Forge:      -
 Inputs:
@@ -130,7 +130,7 @@ Outputs:
               EURToken:  30
   
   ---- Output 1 ----
-  Destination:  Script: 9f18ff188f186d120718cd1848188618461218f4...
+  Destination:  Script: 9f18ec18971880189418c318c718eb18a2182418...
   Value:
     Ada:      Lovelace:  8000000
 
@@ -154,30 +154,30 @@ Balances Carried Forward:
     b0b0:     USDToken:  20
               EURToken:  30
   
-  Script: 9f18ff188f186d120718cd1848188618461218f4...
+  Script: 9f18ec18971880189418c318c718eb18a2182418...
   Value:
     Ada:      Lovelace:  16000000
 
 ==== Slot #10, Tx #0 ====
-TxId:       b3765f51989d5528ece33277e9fce28a4639a2991c3bc68b0114ba78b2267375
+TxId:       d298407c2098d2c446335a18d0085b48ce5994ada8197739b4be8b96a0e8284f
 Fee:        -
 Forge:      -
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 9f18ff188f186d120718cd1848188618461218f4...
+  Destination:  Script: 9f18ec18971880189418c318c718eb18a2182418...
   Value:
     Ada:      Lovelace:  8000000
   Source:
-    Tx:     74c871f2035a8a9fa0e7149990cafab623df4cfeccca4bdf8201753444d73f1b
+    Tx:     c7b51f10da5bf0dcaacd9448f2caa95c24bfeb2640e6af6d9de095345baa2059
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
   
   ---- Input 1 ----
-  Destination:  Script: 9f18ff188f186d120718cd1848188618461218f4...
+  Destination:  Script: 9f18ec18971880189418c318c718eb18a2182418...
   Value:
     Ada:      Lovelace:  8000000
   Source:
-    Tx:     b8378be79a54b782fd4ffeb2ab1cc54e43cb752a79f2019896e0d8b1c65f66a6
+    Tx:     cb5fb8187f9a71d193ff4e6267e1899debf7ae96b6cf87f5014a853ed277d75c
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
 
@@ -208,6 +208,6 @@ Balances Carried Forward:
     b0b0:     USDToken:  20
               EURToken:  30
   
-  Script: 9f18ff188f186d120718cd1848188618461218f4...
+  Script: 9f18ec18971880189418c318c718eb18a2182418...
   Value:
     Ada:      Lovelace:  0

--- a/plutus-playground-server/test/Playground/Rollup/renderVestFunds.txt
+++ b/plutus-playground-server/test/Playground/Rollup/renderVestFunds.txt
@@ -19,7 +19,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       205f492ce1af99b09f542db09073d9f858645ad6465a476cb39bca6c001d3b7b
+TxId:       f654b5f59393e43fd602e015314a7d60755e7e596fb1fdb6e44d82b6578ba1b5
 Fee:        -
 Forge:      -
 Inputs:
@@ -40,7 +40,7 @@ Outputs:
     Ada:      Lovelace:  8000000
   
   ---- Output 1 ----
-  Destination:  Script: 9f18b218ba18a3183b0118cf18b3183c13183a13...
+  Destination:  Script: 9f187a1875186a181d18e218b218bf18cd187618...
   Value:
     Ada:      Lovelace:  2000000
 
@@ -50,6 +50,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  8000000
   
-  Script: 9f18b218ba18a3183b0118cf18b3183c13183a13...
+  Script: 9f187a1875186a181d18e218b218bf18cd187618...
   Value:
     Ada:      Lovelace:  2000000

--- a/plutus-tx/README.md
+++ b/plutus-tx/README.md
@@ -35,7 +35,6 @@ The things that don't work broadly fall into a few categories:
 - Incompatible with the design of Plutus Core
     - `PolyKinds`, `DataKinds`, anything that moves towards "Dependent Haskell"
     - Literal patterns
-    - `StrictData` and bang patterns (may be allowed in future)
 - Requires access to function definitions
     - Normal function usage requires `INLINEABLE` or `-fexpose-all-unfoldings`
     - Typeclass dictionaries

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
@@ -367,14 +367,12 @@ compileExpr e = withContextM 2 (sdToTxt $ "Compiling expr:" GHC.<+> GHC.ppr e) $
             -- See Note [At patterns]
             scrutinee' <- compileExpr scrutinee
             let scrutineeType = GHC.varType b
-            -- This is something of a stop-gap error, we should use Integer everywhere
-            when (scrutineeType `GHC.eqType` GHC.intTy) $ throwPlain $ UnsupportedError "Case on Int"
 
             -- the variable for the scrutinee is bound inside the cases, but not in the scrutinee expression itself
             withVarScoped b $ \v -> do
                 (tc, argTys) <- case GHC.splitTyConApp_maybe scrutineeType of
                     Just (tc, argTys) -> pure (tc, argTys)
-                    Nothing      -> throwPlain $ CompilationError "Scrutinee's type was not a type constructor application"
+                    Nothing      -> throwSd UnsupportedError $ "Cannot case on a value of type:" GHC.<+> GHC.ppr scrutineeType
                 dcs <- getDataCons tc
 
                 -- See Note [Case expressions and laziness]

--- a/plutus-tx/plutus-tx.cabal
+++ b/plutus-tx/plutus-tx.cabal
@@ -139,6 +139,7 @@ test-suite plutus-tx-tests
     default-language: Haskell2010
     build-depends:
         base >=4.9 && <5,
+        integer-gmp -any,
         language-plutus-core -any,
         plutus-core-interpreter -any,
         plutus-tx -any,

--- a/plutus-tx/test/Plugin/Data/Spec.hs
+++ b/plutus-tx/test/Plugin/Data/Spec.hs
@@ -42,6 +42,7 @@ monoData = testNested "monomorphic" [
   , goldenPir "monoRecord" monoRecord
   , goldenPir "recordNewtype" recordNewtype
   , goldenPir "nonValueCase" nonValueCase
+  , goldenPir "strictPattern" strictPattern
   , goldenPir "synonym" synonym
   ]
 
@@ -88,6 +89,11 @@ recordNewtype = plc @"recordNewtype" (\(x :: RecordNewtype) -> x)
 -- must be compiled with a lazy case
 nonValueCase :: CompiledCode (MyEnum -> Integer)
 nonValueCase = plc @"nonValueCase" (\(x :: MyEnum) -> case x of { Enum1 -> 1::Integer ; Enum2 -> Builtins.error (); })
+
+data StrictPattern a = StrictPattern !a !a
+
+strictPattern :: CompiledCode (StrictPattern Integer)
+strictPattern = plc @"strictPattern" (StrictPattern 1 2)
 
 type Synonym = Integer
 

--- a/plutus-tx/test/Plugin/Data/monomorphic/strictPattern.plc.golden
+++ b/plutus-tx/test/Plugin/Data/monomorphic/strictPattern.plc.golden
@@ -1,0 +1,43 @@
+(program
+  (let
+    (nonrec)
+    (datatypebind
+      (datatype
+        (tyvardecl StrictPattern (fun (type) (type)))
+        (tyvardecl a (type))
+        StrictPattern_match
+        (vardecl StrictPattern (fun a (fun a [StrictPattern a])))
+      )
+    )
+    (let
+      (nonrec)
+      (termbind
+        (strict)
+        (vardecl WStrictPattern (all a (type) (fun a (fun a [StrictPattern a])))
+        )
+        (abs
+          a
+          (type)
+          (lam
+            dt
+            a
+            (lam
+              dt
+              a
+              (let
+                (nonrec)
+                (termbind (strict) (vardecl dt a) dt)
+                (let
+                  (nonrec)
+                  (termbind (strict) (vardecl dt a) dt)
+                  [ [ { StrictPattern a } dt ] dt ]
+                )
+              )
+            )
+          )
+        )
+      )
+      [ [ { WStrictPattern (con integer) } (con 1) ] (con 2) ]
+    )
+  )
+)

--- a/plutus-tx/test/Plugin/Errors/caseInt.plc.golden
+++ b/plutus-tx/test/Plugin/Errors/caseInt.plc.golden
@@ -1,0 +1,2 @@
+Error: Unsupported feature: Cannot case on a value on type: GHC.Integer.Type.Integer
+       Note: GHC can generate these unexpectedly, you may need '-fno-strictness', '-fno-specialise', or '-fno-spec-constr'

--- a/plutus-use-cases/test/Spec/crowdfunding.pir
+++ b/plutus-use-cases/test/Spec/crowdfunding.pir
@@ -3074,30 +3074,7 @@
                                                                                                                         (lam
                                                                                                                           thunk
                                                                                                                           Unit
-                                                                                                                          [
-                                                                                                                            [
-                                                                                                                              [
-                                                                                                                                {
-                                                                                                                                  [
-                                                                                                                                    Bool_match
-                                                                                                                                    ww
-                                                                                                                                  ]
-                                                                                                                                  (fun Unit Bool)
-                                                                                                                                }
-                                                                                                                                (lam
-                                                                                                                                  thunk
-                                                                                                                                  Unit
-                                                                                                                                  j
-                                                                                                                                )
-                                                                                                                              ]
-                                                                                                                              (lam
-                                                                                                                                thunk
-                                                                                                                                Unit
-                                                                                                                                j
-                                                                                                                              )
-                                                                                                                            ]
-                                                                                                                            Unit
-                                                                                                                          ]
+                                                                                                                          j
                                                                                                                         )
                                                                                                                       ]
                                                                                                                       (lam
@@ -3197,30 +3174,7 @@
                                                                                                                 (lam
                                                                                                                   thunk
                                                                                                                   Unit
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        {
-                                                                                                                          [
-                                                                                                                            Bool_match
-                                                                                                                            ww
-                                                                                                                          ]
-                                                                                                                          (fun Unit Bool)
-                                                                                                                        }
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          j
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      (lam
-                                                                                                                        thunk
-                                                                                                                        Unit
-                                                                                                                        j
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    Unit
-                                                                                                                  ]
+                                                                                                                  j
                                                                                                                 )
                                                                                                               ]
                                                                                                               (lam
@@ -3437,44 +3391,12 @@
                                                                                                           [
                                                                                                             [
                                                                                                               [
-                                                                                                                {
-                                                                                                                  [
-                                                                                                                    Bool_match
-                                                                                                                    ww
-                                                                                                                  ]
-                                                                                                                  (fun Unit Bool)
-                                                                                                                }
-                                                                                                                (lam
-                                                                                                                  thunk
-                                                                                                                  Unit
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        wtxSignedBy
-                                                                                                                        ww
-                                                                                                                      ]
-                                                                                                                      ww
-                                                                                                                    ]
-                                                                                                                    w
-                                                                                                                  ]
-                                                                                                                )
+                                                                                                                wtxSignedBy
+                                                                                                                ww
                                                                                                               ]
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      wtxSignedBy
-                                                                                                                      ww
-                                                                                                                    ]
-                                                                                                                    ww
-                                                                                                                  ]
-                                                                                                                  w
-                                                                                                                ]
-                                                                                                              )
+                                                                                                              ww
                                                                                                             ]
-                                                                                                            Unit
+                                                                                                            w
                                                                                                           ]
                                                                                                         )
                                                                                                       ]
@@ -3523,30 +3445,7 @@
                                                                                                               (lam
                                                                                                                 thunk
                                                                                                                 Unit
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        [
-                                                                                                                          Bool_match
-                                                                                                                          ww
-                                                                                                                        ]
-                                                                                                                        (fun Unit Bool)
-                                                                                                                      }
-                                                                                                                      (lam
-                                                                                                                        thunk
-                                                                                                                        Unit
-                                                                                                                        j
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    (lam
-                                                                                                                      thunk
-                                                                                                                      Unit
-                                                                                                                      j
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  Unit
-                                                                                                                ]
+                                                                                                                j
                                                                                                               )
                                                                                                             ]
                                                                                                             (lam

--- a/plutus-use-cases/test/Spec/multisigStateMachine.pir
+++ b/plutus-use-cases/test/Spec/multisigStateMachine.pir
@@ -5757,30 +5757,7 @@
                                                                                                                                                                                                             (lam
                                                                                                                                                                                                               thunk
                                                                                                                                                                                                               Unit
-                                                                                                                                                                                                              [
-                                                                                                                                                                                                                [
-                                                                                                                                                                                                                  [
-                                                                                                                                                                                                                    {
-                                                                                                                                                                                                                      [
-                                                                                                                                                                                                                        Bool_match
-                                                                                                                                                                                                                        ww
-                                                                                                                                                                                                                      ]
-                                                                                                                                                                                                                      (fun Unit Bool)
-                                                                                                                                                                                                                    }
-                                                                                                                                                                                                                    (lam
-                                                                                                                                                                                                                      thunk
-                                                                                                                                                                                                                      Unit
-                                                                                                                                                                                                                      False
-                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                  ]
-                                                                                                                                                                                                                  (lam
-                                                                                                                                                                                                                    thunk
-                                                                                                                                                                                                                    Unit
-                                                                                                                                                                                                                    False
-                                                                                                                                                                                                                  )
-                                                                                                                                                                                                                ]
-                                                                                                                                                                                                                Unit
-                                                                                                                                                                                                              ]
+                                                                                                                                                                                                              False
                                                                                                                                                                                                             )
                                                                                                                                                                                                           ]
                                                                                                                                                                                                           (lam
@@ -5930,30 +5907,7 @@
                                                                                                                                                                                       (lam
                                                                                                                                                                                         thunk
                                                                                                                                                                                         Unit
-                                                                                                                                                                                        [
-                                                                                                                                                                                          [
-                                                                                                                                                                                            [
-                                                                                                                                                                                              {
-                                                                                                                                                                                                [
-                                                                                                                                                                                                  Bool_match
-                                                                                                                                                                                                  ww
-                                                                                                                                                                                                ]
-                                                                                                                                                                                                (fun Unit Bool)
-                                                                                                                                                                                              }
-                                                                                                                                                                                              (lam
-                                                                                                                                                                                                thunk
-                                                                                                                                                                                                Unit
-                                                                                                                                                                                                False
-                                                                                                                                                                                              )
-                                                                                                                                                                                            ]
-                                                                                                                                                                                            (lam
-                                                                                                                                                                                              thunk
-                                                                                                                                                                                              Unit
-                                                                                                                                                                                              False
-                                                                                                                                                                                            )
-                                                                                                                                                                                          ]
-                                                                                                                                                                                          Unit
-                                                                                                                                                                                        ]
+                                                                                                                                                                                        False
                                                                                                                                                                                       )
                                                                                                                                                                                     ]
                                                                                                                                                                                     (lam
@@ -6063,30 +6017,7 @@
                                                                                                                                                                                                       (lam
                                                                                                                                                                                                         thunk
                                                                                                                                                                                                         Unit
-                                                                                                                                                                                                        [
-                                                                                                                                                                                                          [
-                                                                                                                                                                                                            [
-                                                                                                                                                                                                              {
-                                                                                                                                                                                                                [
-                                                                                                                                                                                                                  Bool_match
-                                                                                                                                                                                                                  ww
-                                                                                                                                                                                                                ]
-                                                                                                                                                                                                                (fun Unit Bool)
-                                                                                                                                                                                                              }
-                                                                                                                                                                                                              (lam
-                                                                                                                                                                                                                thunk
-                                                                                                                                                                                                                Unit
-                                                                                                                                                                                                                False
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                            ]
-                                                                                                                                                                                                            (lam
-                                                                                                                                                                                                              thunk
-                                                                                                                                                                                                              Unit
-                                                                                                                                                                                                              False
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          ]
-                                                                                                                                                                                                          Unit
-                                                                                                                                                                                                        ]
+                                                                                                                                                                                                        False
                                                                                                                                                                                                       )
                                                                                                                                                                                                     ]
                                                                                                                                                                                                     (lam
@@ -6236,30 +6167,7 @@
                                                                                                                                                                                 (lam
                                                                                                                                                                                   thunk
                                                                                                                                                                                   Unit
-                                                                                                                                                                                  [
-                                                                                                                                                                                    [
-                                                                                                                                                                                      [
-                                                                                                                                                                                        {
-                                                                                                                                                                                          [
-                                                                                                                                                                                            Bool_match
-                                                                                                                                                                                            ww
-                                                                                                                                                                                          ]
-                                                                                                                                                                                          (fun Unit Bool)
-                                                                                                                                                                                        }
-                                                                                                                                                                                        (lam
-                                                                                                                                                                                          thunk
-                                                                                                                                                                                          Unit
-                                                                                                                                                                                          False
-                                                                                                                                                                                        )
-                                                                                                                                                                                      ]
-                                                                                                                                                                                      (lam
-                                                                                                                                                                                        thunk
-                                                                                                                                                                                        Unit
-                                                                                                                                                                                        False
-                                                                                                                                                                                      )
-                                                                                                                                                                                    ]
-                                                                                                                                                                                    Unit
-                                                                                                                                                                                  ]
+                                                                                                                                                                                  False
                                                                                                                                                                                 )
                                                                                                                                                                               ]
                                                                                                                                                                               (lam
@@ -6329,30 +6237,7 @@
                                                                                                                                                                 (lam
                                                                                                                                                                   thunk
                                                                                                                                                                   Unit
-                                                                                                                                                                  [
-                                                                                                                                                                    [
-                                                                                                                                                                      [
-                                                                                                                                                                        {
-                                                                                                                                                                          [
-                                                                                                                                                                            Bool_match
-                                                                                                                                                                            ww
-                                                                                                                                                                          ]
-                                                                                                                                                                          (fun Unit Bool)
-                                                                                                                                                                        }
-                                                                                                                                                                        (lam
-                                                                                                                                                                          thunk
-                                                                                                                                                                          Unit
-                                                                                                                                                                          False
-                                                                                                                                                                        )
-                                                                                                                                                                      ]
-                                                                                                                                                                      (lam
-                                                                                                                                                                        thunk
-                                                                                                                                                                        Unit
-                                                                                                                                                                        False
-                                                                                                                                                                      )
-                                                                                                                                                                    ]
-                                                                                                                                                                    Unit
-                                                                                                                                                                  ]
+                                                                                                                                                                  False
                                                                                                                                                                 )
                                                                                                                                                               ]
                                                                                                                                                               (lam
@@ -6489,30 +6374,7 @@
                                                                                                                                                                                                       (lam
                                                                                                                                                                                                         thunk
                                                                                                                                                                                                         Unit
-                                                                                                                                                                                                        [
-                                                                                                                                                                                                          [
-                                                                                                                                                                                                            [
-                                                                                                                                                                                                              {
-                                                                                                                                                                                                                [
-                                                                                                                                                                                                                  Bool_match
-                                                                                                                                                                                                                  ww
-                                                                                                                                                                                                                ]
-                                                                                                                                                                                                                (fun Unit Bool)
-                                                                                                                                                                                                              }
-                                                                                                                                                                                                              (lam
-                                                                                                                                                                                                                thunk
-                                                                                                                                                                                                                Unit
-                                                                                                                                                                                                                False
-                                                                                                                                                                                                              )
-                                                                                                                                                                                                            ]
-                                                                                                                                                                                                            (lam
-                                                                                                                                                                                                              thunk
-                                                                                                                                                                                                              Unit
-                                                                                                                                                                                                              False
-                                                                                                                                                                                                            )
-                                                                                                                                                                                                          ]
-                                                                                                                                                                                                          Unit
-                                                                                                                                                                                                        ]
+                                                                                                                                                                                                        False
                                                                                                                                                                                                       )
                                                                                                                                                                                                     ]
                                                                                                                                                                                                     (lam
@@ -6662,30 +6524,7 @@
                                                                                                                                                                                 (lam
                                                                                                                                                                                   thunk
                                                                                                                                                                                   Unit
-                                                                                                                                                                                  [
-                                                                                                                                                                                    [
-                                                                                                                                                                                      [
-                                                                                                                                                                                        {
-                                                                                                                                                                                          [
-                                                                                                                                                                                            Bool_match
-                                                                                                                                                                                            ww
-                                                                                                                                                                                          ]
-                                                                                                                                                                                          (fun Unit Bool)
-                                                                                                                                                                                        }
-                                                                                                                                                                                        (lam
-                                                                                                                                                                                          thunk
-                                                                                                                                                                                          Unit
-                                                                                                                                                                                          False
-                                                                                                                                                                                        )
-                                                                                                                                                                                      ]
-                                                                                                                                                                                      (lam
-                                                                                                                                                                                        thunk
-                                                                                                                                                                                        Unit
-                                                                                                                                                                                        False
-                                                                                                                                                                                      )
-                                                                                                                                                                                    ]
-                                                                                                                                                                                    Unit
-                                                                                                                                                                                  ]
+                                                                                                                                                                                  False
                                                                                                                                                                                 )
                                                                                                                                                                               ]
                                                                                                                                                                               (lam
@@ -6795,30 +6634,7 @@
                                                                                                                                                                                                 (lam
                                                                                                                                                                                                   thunk
                                                                                                                                                                                                   Unit
-                                                                                                                                                                                                  [
-                                                                                                                                                                                                    [
-                                                                                                                                                                                                      [
-                                                                                                                                                                                                        {
-                                                                                                                                                                                                          [
-                                                                                                                                                                                                            Bool_match
-                                                                                                                                                                                                            ww
-                                                                                                                                                                                                          ]
-                                                                                                                                                                                                          (fun Unit Bool)
-                                                                                                                                                                                                        }
-                                                                                                                                                                                                        (lam
-                                                                                                                                                                                                          thunk
-                                                                                                                                                                                                          Unit
-                                                                                                                                                                                                          False
-                                                                                                                                                                                                        )
-                                                                                                                                                                                                      ]
-                                                                                                                                                                                                      (lam
-                                                                                                                                                                                                        thunk
-                                                                                                                                                                                                        Unit
-                                                                                                                                                                                                        False
-                                                                                                                                                                                                      )
-                                                                                                                                                                                                    ]
-                                                                                                                                                                                                    Unit
-                                                                                                                                                                                                  ]
+                                                                                                                                                                                                  False
                                                                                                                                                                                                 )
                                                                                                                                                                                               ]
                                                                                                                                                                                               (lam
@@ -6968,30 +6784,7 @@
                                                                                                                                                                           (lam
                                                                                                                                                                             thunk
                                                                                                                                                                             Unit
-                                                                                                                                                                            [
-                                                                                                                                                                              [
-                                                                                                                                                                                [
-                                                                                                                                                                                  {
-                                                                                                                                                                                    [
-                                                                                                                                                                                      Bool_match
-                                                                                                                                                                                      ww
-                                                                                                                                                                                    ]
-                                                                                                                                                                                    (fun Unit Bool)
-                                                                                                                                                                                  }
-                                                                                                                                                                                  (lam
-                                                                                                                                                                                    thunk
-                                                                                                                                                                                    Unit
-                                                                                                                                                                                    False
-                                                                                                                                                                                  )
-                                                                                                                                                                                ]
-                                                                                                                                                                                (lam
-                                                                                                                                                                                  thunk
-                                                                                                                                                                                  Unit
-                                                                                                                                                                                  False
-                                                                                                                                                                                )
-                                                                                                                                                                              ]
-                                                                                                                                                                              Unit
-                                                                                                                                                                            ]
+                                                                                                                                                                            False
                                                                                                                                                                           )
                                                                                                                                                                         ]
                                                                                                                                                                         (lam

--- a/plutus-use-cases/test/Spec/vesting.pir
+++ b/plutus-use-cases/test/Spec/vesting.pir
@@ -1692,188 +1692,62 @@
                                                                             thunk
                                                                             Unit
                                                                             [
-                                                                              [
+                                                                              {
                                                                                 [
                                                                                   {
-                                                                                    [
-                                                                                      Bool_match
-                                                                                      ww
-                                                                                    ]
-                                                                                    (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
+                                                                                    UpperBound_match
+                                                                                    (con integer)
                                                                                   }
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
+                                                                                  ww
+                                                                                ]
+                                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                              }
+                                                                              (lam
+                                                                                ww
+                                                                                [Extended (con integer)]
+                                                                                (lam
+                                                                                  ww
+                                                                                  Bool
+                                                                                  [
                                                                                     [
-                                                                                      {
+                                                                                      [
                                                                                         [
                                                                                           {
-                                                                                            UpperBound_match
-                                                                                            (con integer)
+                                                                                            [
+                                                                                              {
+                                                                                                Extended_match
+                                                                                                (con integer)
+                                                                                              }
+                                                                                              ww
+                                                                                            ]
+                                                                                            (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
                                                                                           }
-                                                                                          ww
-                                                                                        ]
-                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                      }
-                                                                                      (lam
-                                                                                        ww
-                                                                                        [Extended (con integer)]
-                                                                                        (lam
-                                                                                          ww
-                                                                                          Bool
-                                                                                          [
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      {
-                                                                                                        Extended_match
-                                                                                                        (con integer)
-                                                                                                      }
-                                                                                                      ww
-                                                                                                    ]
-                                                                                                    (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    default_arg0
-                                                                                                    (con integer)
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      ww
-                                                                                                    )
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  ww
-                                                                                                )
-                                                                                              ]
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                [
-                                                                                                  [
-                                                                                                    [
-                                                                                                      {
-                                                                                                        [
-                                                                                                          Bool_match
-                                                                                                          ww
-                                                                                                        ]
-                                                                                                        (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
-                                                                                                      }
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        ww
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      ww
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  Unit
-                                                                                                ]
-                                                                                              )
-                                                                                            ]
-                                                                                            Unit
-                                                                                          ]
-                                                                                        )
-                                                                                      )
-                                                                                    ]
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
-                                                                                    {
-                                                                                      [
-                                                                                        {
-                                                                                          UpperBound_match
-                                                                                          (con integer)
-                                                                                        }
-                                                                                        ww
-                                                                                      ]
-                                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                    }
-                                                                                    (lam
-                                                                                      ww
-                                                                                      [Extended (con integer)]
-                                                                                      (lam
-                                                                                        ww
-                                                                                        Bool
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              [
-                                                                                                {
-                                                                                                  [
-                                                                                                    {
-                                                                                                      Extended_match
-                                                                                                      (con integer)
-                                                                                                    }
-                                                                                                    ww
-                                                                                                  ]
-                                                                                                  (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
-                                                                                                }
-                                                                                                (lam
-                                                                                                  default_arg0
-                                                                                                  (con integer)
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    ww
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                ww
-                                                                                              )
-                                                                                            ]
+                                                                                          (lam
+                                                                                            default_arg0
+                                                                                            (con integer)
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        Bool_match
-                                                                                                        ww
-                                                                                                      ]
-                                                                                                      (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      ww
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    ww
-                                                                                                  )
-                                                                                                ]
-                                                                                                Unit
-                                                                                              ]
+                                                                                              ww
                                                                                             )
-                                                                                          ]
-                                                                                          Unit
+                                                                                          )
                                                                                         ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          ww
+                                                                                        )
+                                                                                      ]
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        ww
                                                                                       )
-                                                                                    )
+                                                                                    ]
+                                                                                    Unit
                                                                                   ]
                                                                                 )
-                                                                              ]
-                                                                              Unit
+                                                                              )
                                                                             ]
                                                                           )
                                                                         ]
@@ -1949,30 +1823,7 @@
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        Bool_match
-                                                                                                        ww
-                                                                                                      ]
-                                                                                                      (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      ww
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    ww
-                                                                                                  )
-                                                                                                ]
-                                                                                                Unit
-                                                                                              ]
+                                                                                              ww
                                                                                             )
                                                                                           ]
                                                                                           Unit
@@ -2062,30 +1913,7 @@
                                                                         (lam
                                                                           thunk
                                                                           Unit
-                                                                          [
-                                                                            [
-                                                                              [
-                                                                                {
-                                                                                  [
-                                                                                    Bool_match
-                                                                                    ww
-                                                                                  ]
-                                                                                  (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
-                                                                                }
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  ww
-                                                                                )
-                                                                              ]
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                ww
-                                                                              )
-                                                                            ]
-                                                                            Unit
-                                                                          ]
+                                                                          ww
                                                                         )
                                                                       ]
                                                                       Unit


### PR DESCRIPTION
Improve the errors seen in https://github.com/input-output-hk/plutus/issues/1495 (I can't actually fix the issues directly, I don't think), and handle the odd case expressions introduced by bang patterns.