### PR TITLE
use-cases: Add escrow contract

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract.hs
+++ b/plutus-contract/src/Language/Plutus/Contract.hs
@@ -30,6 +30,7 @@ module Language.Plutus.Contract(
     -- * Transactions
     , HasWriteTx
     , WriteTx
+    , WalletAPIError
     , writeTx
     , writeTxSuccess
     -- * Blockchain events
@@ -66,6 +67,7 @@ import           Language.Plutus.Contract.Request                (Contract(..), 
 import           Language.Plutus.Contract.Tx                     as Tx
 
 import           Prelude                                         hiding (until)
+import           Wallet.API                                      (WalletAPIError)
 
 -- | Schema for contracts that can interact with the blockchain (via a node 
 --   client & signing process)

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -28,6 +28,7 @@ library
         Language.PlutusTx.Coordination.Contracts
         Language.PlutusTx.Coordination.Contracts.CrowdFunding
         Language.PlutusTx.Coordination.Contracts.Currency
+        Language.PlutusTx.Coordination.Contracts.Escrow
         Language.PlutusTx.Coordination.Contracts.Future
         Language.PlutusTx.Coordination.Contracts.Game
         Language.PlutusTx.Coordination.Contracts.GameStateMachine
@@ -72,6 +73,7 @@ test-suite plutus-use-cases-test
     other-modules:
         Spec.Crowdfunding
         Spec.Currency
+        Spec.Escrow
         Spec.Future
         Spec.Game
         Spec.GameStateMachine

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Escrow.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Escrow.hs
@@ -1,0 +1,285 @@
+{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeFamilies      #-}
+-- | An general-purpose escrow contract in Plutus
+module Language.PlutusTx.Coordination.Contracts.Escrow(
+    -- $escrow
+    Escrow
+    , EscrowParams(..)
+    , EscrowTarget(..)
+    , payToScriptTarget
+    , payToPubKeyTarget
+    , escrowAddress
+    , escrowScript
+    , targetValue
+    -- * Actions
+    , pay
+    , payEp
+    , redeem
+    , redeemEp
+    , refund
+    , refundEp
+    , RedeemFailReason(..)
+    , RedeemResult(..)
+    , RefundResult(..)
+    , EscrowSchema
+    ) where
+
+import           Control.Applicative            (Applicative (..))
+import           Control.Lens                   ((&), (^.), (.~), at, folded)
+import qualified Data.Set                       as Set
+import qualified Ledger
+import           Ledger                         (Address, DataScript(..), PubKey, Slot, ValidatorHash, scriptOutputsAt,
+                                                 txSignedBy, valuePaidTo, interval, TxId, TxOutRefOf(..), ValidatorScript, TxOut, pubKeyTxOut, scriptTxOut')
+import           Ledger.Interval                (after, before, from)
+import qualified Ledger.Interval                as Interval
+import           Ledger.AddressMap              (values)
+import qualified Ledger.Typed.Scripts           as Scripts
+import qualified Ledger.Scripts                 as Scripts
+import           Ledger.Validation              (PendingTx, PendingTx' (..))
+import           Ledger.Value                   (Value, lt)
+
+import qualified Language.Plutus.Contract.Typed.Tx as Typed
+import           Language.Plutus.Contract
+import qualified Language.PlutusTx              as PlutusTx
+import           Language.PlutusTx.Prelude      hiding (Applicative (..), check)
+
+import qualified Prelude                        as Haskell
+
+type EscrowSchema =
+    BlockchainActions
+        .\/ Endpoint "pay-escrow" (PubKey, Value)
+        .\/ Endpoint "redeem-escrow" ()
+        .\/ Endpoint "refund-escrow" ()
+
+-- $escrow
+-- The escrow contract implements the exchange of value between multiple 
+-- parties. It is defined by a list of targets (public keys and script 
+-- addresses, each associated with a value). It works similar to the 
+-- crowdfunding contract in that the contributions can be made independently,
+-- and the funds can be unlocked only by a transaction that pays the correct
+-- amount to each target. A refund is possible if the outputs locked by the 
+-- contract have not been spent by the deadline. (Compared to the crowdfunding
+-- contract, the refund policy is simpler because here because there is no
+-- "collection period" during which the outputs may be spent after the deadline
+-- has passed. This is because we're assuming that the participants in the escrow
+-- contract will make their deposits as quickly as possible after agreeing on a
+-- deal)
+-- 
+-- The contract supports two modes of operation, manual and automatic. In 
+-- manual mode, all actions are driven by endpoints that exposed via 'payEp'
+-- 'redeemEp' and 'refundEp'. In automatic mode, the 'pay', 'redeem' and 'refund'
+-- actions start immediately. This mode is useful when the escrow is called from
+-- within another contract, for example during setup (collection of the initial
+-- deposits).
+
+-- | Defines where the money should go.
+data EscrowTarget =
+    PubKeyTarget PubKey Value
+    | ScriptTarget ValidatorHash DataScript Value
+
+PlutusTx.makeLift ''EscrowTarget
+
+-- | An 'EscrowTarget' that pays the value to a public key address.
+payToPubKeyTarget :: PubKey -> Value -> EscrowTarget
+payToPubKeyTarget = PubKeyTarget
+
+-- | An 'EscrowTarget' that pays the value to a script address, with the
+--   given data script.
+payToScriptTarget :: Address -> DataScript -> Value -> EscrowTarget
+payToScriptTarget (Ledger.AddressOf hsh) = ScriptTarget (Scripts.plcValidatorDigest hsh)
+
+-- | Definition of an escrow contract, consisting of a deadline and a list of targets
+data EscrowParams =
+    EscrowParams
+        { escrowDeadline :: Slot
+        -- ^ Latest point at which the outputs may be spent.
+        , escrowTargets  :: [EscrowTarget]
+        -- ^ Where the money should go. For each target, the contract checks that
+        --   the output 'mkTxOutput' of the target is present in the spending
+        --   transaction.
+        }
+
+-- | The total 'Value' that must be paid into the escrow contract
+--   before it can be unlocked
+targetValue :: EscrowParams -> Value
+targetValue = foldl (\vl tgt -> vl + targetVal tgt) mempty . escrowTargets where
+    targetVal = \case
+        PubKeyTarget _ vl -> vl
+        ScriptTarget _ _ vl -> vl
+
+-- | Create a 'Ledger.TxOut' value for the target
+mkTxOutput :: EscrowTarget -> TxOut
+mkTxOutput = \case
+    PubKeyTarget pk vl -> pubKeyTxOut vl pk
+    ScriptTarget hsh ds vl -> scriptTxOut' vl (Ledger.AddressOf (Scripts.unsafePlcAddress hsh)) ds
+
+PlutusTx.makeLift ''EscrowParams
+
+data Action = Redeem | Refund
+
+instance PlutusTx.IsData Action where
+    toData Redeem = PlutusTx.Constr 0 []
+    toData Refund = PlutusTx.Constr 1 []
+    {-# INLINABLE fromData #-}
+    fromData (PlutusTx.Constr i [])
+        | i == 0 = Just Redeem
+        | i == 1 = Just Refund
+    fromData _ = Nothing
+
+PlutusTx.makeLift ''Action
+
+{-# INLINABLE meetsTarget #-}
+meetsTarget :: PendingTx -> EscrowTarget -> Bool
+meetsTarget ptx = \case
+    PubKeyTarget pk vl ->
+        valuePaidTo ptx pk == vl
+    ScriptTarget validatorHash dataScript vl ->
+        case scriptOutputsAt validatorHash ptx of
+            [(dataScript', vl')] -> dataScript' == dataScript && vl' == vl
+            _ -> False
+
+{-# INLINABLE validate #-}
+validate :: EscrowParams -> PubKey -> Action -> PendingTx -> Bool
+validate EscrowParams{escrowDeadline, escrowTargets} contributor action ptx@PendingTx{pendingTxValidRange} =
+    case action of
+        Redeem ->
+            traceIfFalseH "escrowDeadline-after" (escrowDeadline `after` pendingTxValidRange)
+            && traceIfFalseH "meetsTarget" (all (meetsTarget ptx) escrowTargets)
+        Refund ->
+            traceIfFalseH "escrowDeadline-before" (escrowDeadline `before` pendingTxValidRange)
+            && traceIfFalseH "txSignedBy" (ptx `txSignedBy` contributor)
+
+data Escrow
+instance Scripts.ScriptType Escrow where
+    type instance RedeemerType Escrow = Action
+    type instance DataType Escrow = PubKey
+
+escrowScript :: EscrowParams -> ValidatorScript
+escrowScript = Scripts.validatorScript . scriptInstance
+
+scriptInstance :: EscrowParams -> Scripts.ScriptInstance Escrow
+scriptInstance escrow = Scripts.Validator @Escrow
+    ($$(PlutusTx.compile [|| validate ||]) `PlutusTx.applyCode` PlutusTx.liftCode escrow)
+    $$(PlutusTx.compile [|| wrap ||])
+    where
+        wrap = Scripts.wrapValidator @PubKey @Action
+
+-- | The address of an escrow contract
+escrowAddress :: EscrowParams -> Ledger.Address
+escrowAddress = Scripts.scriptAddress . scriptInstance
+
+-- | 'pay' with an endpoint that gets the owner's public key and the
+--   contribution.
+payEp
+    ::
+    ( HasWriteTx s
+    , HasEndpoint "pay-escrow" (PubKey, Value) s
+    )
+    => EscrowParams
+    -> Contract s TxId
+payEp escrow = do
+    (ownPubKey, vl) <- endpoint @"pay-escrow"
+    pay escrow ownPubKey vl
+
+-- | Pay some money into the escrow contract.
+pay 
+    :: HasWriteTx s
+    => EscrowParams
+    -- ^ The escrow contract
+    -> PubKey
+    -- ^ Public key of the contributor (used for refunds)
+    -> Value
+    -- ^ How much money to pay in
+    -> Contract s TxId
+pay escrow ownPubKey vl = do
+    let ds = DataScript (PlutusTx.toData ownPubKey)
+        tx = payToScript vl (escrowAddress escrow) ds
+                & validityRange .~ Ledger.interval 1 (escrowDeadline escrow)
+    writeTxSuccess tx
+
+data RedeemFailReason = DeadlinePassed | NotEnoughFundsAtAddress
+  deriving (Haskell.Eq, Show)
+
+data RedeemResult =
+    RedeemSuccess TxId
+    | RedeemFail RedeemFailReason
+    deriving (Haskell.Eq, Show)
+
+-- | 'redeem' with an endpoint.
+redeemEp 
+    :: 
+    ( HasUtxoAt s 
+    , HasAwaitSlot s
+    , HasWriteTx s
+    , HasEndpoint "redeem-escrow" () s
+    )
+    => EscrowParams
+    -> Contract s RedeemResult
+redeemEp escrow = endpoint @"redeem-escrow" >> redeem escrow
+
+-- | Redeem all outputs at the contract address using a transaction that
+--   has all the outputs defined in the contract's list of targets.
+redeem 
+    :: 
+    ( HasUtxoAt s 
+    , HasAwaitSlot s
+    , HasWriteTx s
+    )
+    => EscrowParams
+    -> Contract s RedeemResult
+redeem escrow = do
+    currentSlot <- awaitSlot 0
+    unspentOutputs <- utxoAt (escrowAddress escrow)
+    let addr = escrowAddress escrow
+        valRange = 
+            let itvl = Interval.from 1
+                -- an upper bound that does not include the escrow 
+                -- deadline
+                upperBound = Interval.UpperBound (Interval.Finite $ escrowDeadline escrow) False
+            in itvl { Interval.ivTo = upperBound }
+        tx = Typed.collectFromScriptFilter (\_ _ -> True) unspentOutputs (scriptInstance escrow) Redeem
+            & validityRange .~ valRange
+            & outputs .~ fmap mkTxOutput (escrowTargets escrow)
+    if currentSlot >= escrowDeadline escrow
+    then pure $ RedeemFail DeadlinePassed
+    else if (values unspentOutputs ^. at addr . folded) `lt` targetValue escrow
+         then pure $ RedeemFail NotEnoughFundsAtAddress
+         else RedeemSuccess <$> writeTxSuccess tx
+
+data RefundResult = RefundOK TxId | RefundFailed 
+    deriving (Haskell.Eq, Show)
+
+-- | 'refund' with an endpoint.
+refundEp 
+    :: 
+    ( HasUtxoAt s 
+    , HasWriteTx s
+    , HasEndpoint "refund-escrow" () s
+    )
+    => EscrowParams
+    -> TxId
+    -> Contract s RefundResult
+refundEp escrow txid = endpoint @"refund-escrow" >> refund escrow txid
+
+-- | Claim a refund of the contribution.
+refund 
+    :: ( HasUtxoAt s
+       , HasWriteTx s )
+    => EscrowParams 
+    -> TxId
+    -> Contract s RefundResult
+refund escrow txId = do
+    unspentOutputs <- utxoAt (escrowAddress escrow)
+    let flt TxOutRefOf{txOutRefId} _ = txId Haskell.== txOutRefId
+        tx' = Typed.collectFromScriptFilter flt unspentOutputs (scriptInstance escrow) Refund
+                & validityRange .~ from (succ $ escrowDeadline escrow)
+    if not . Set.null $ tx' ^. inputs
+    then RefundOK <$> writeTxSuccess tx'
+    else pure $ RefundFailed

--- a/plutus-use-cases/test/Spec.hs
+++ b/plutus-use-cases/test/Spec.hs
@@ -3,6 +3,7 @@ module Main(main) where
 
 import qualified Spec.Crowdfunding
 import qualified Spec.Currency
+import qualified Spec.Escrow
 import qualified Spec.Future
 import qualified Spec.Game
 --import qualified Spec.GameStateMachine
@@ -32,6 +33,7 @@ tests = localOption limit $ testGroup "use cases" [
     Spec.MultiSig.tests,
     Spec.MultiSigStateMachine.tests,
     Spec.Currency.tests,
-    Spec.PubKey.tests
+    Spec.PubKey.tests,
+    Spec.Escrow.tests
     --Spec.GameStateMachine.tests
     ]

--- a/plutus-use-cases/test/Spec/Escrow.hs
+++ b/plutus-use-cases/test/Spec/Escrow.hs
@@ -45,7 +45,7 @@ tests = testGroup "escrow"
         >> handleBlockchainEvents (Wallet 2))
 
     , checkPredicate @EscrowSchema "can refund"
-        (payEp escrowParams >>= refundEp escrowParams)
+        (payEp escrowParams >> refundEp escrowParams (walletPubKey w1))
         ( walletFundsChange w1 mempty
           /\ assertDone w1 (\case { RefundOK _ -> True; _ -> False}) "refund should succeed")
         ( callEndpoint @"pay-escrow" (Wallet 1) (walletPubKey w1, Ada.lovelaceValueOf 20)

--- a/plutus-use-cases/test/Spec/Escrow.hs
+++ b/plutus-use-cases/test/Spec/Escrow.hs
@@ -44,6 +44,44 @@ tests = testGroup "escrow"
         >> handleBlockchainEvents (Wallet 1)
         >> handleBlockchainEvents (Wallet 2))
 
+    , checkPredicate @EscrowSchema "can redeem even if more money than required has been paid in"
+          (both (payEp escrowParams) (redeemEp escrowParams))
+
+          -- in this test case we pay in a total of 40 lovelace (10 more than required), for
+          -- the same contract as before, requiring 10 lovelace to go to wallet 1 and 20 to
+          -- wallet 2.
+          --
+          -- The scenario is
+          -- * Wallet 1 contributes 20
+          -- * Wallet 2 contributes 10
+          -- * Wallet 3 contributes 10
+          -- * Wallet 1 is going to redeem the payments
+          --
+
+          -- Wallet 1 pays 20 and receives 10 from the escrow contract and another 10
+          -- in excess inputs
+          ( walletFundsChange w1 (Ada.lovelaceValueOf 0)
+
+          -- Wallet 2 pays 10 and receives 20, as per the contract.
+            /\ walletFundsChange w2 (Ada.lovelaceValueOf 10)
+
+          -- Wallet 3 pays 10 and doesn't receive anything.
+            /\ walletFundsChange w3 (Ada.lovelaceValueOf (-10))
+          )
+
+          ( callEndpoint @"pay-escrow" (Wallet 1) (walletPubKey w1, Ada.lovelaceValueOf 20)
+          >> callEndpoint @"pay-escrow" (Wallet 2) (walletPubKey w2, Ada.lovelaceValueOf 10)
+          >> callEndpoint @"pay-escrow" (Wallet 3) (walletPubKey w3, Ada.lovelaceValueOf 10)
+          >> handleBlockchainEvents (Wallet 1)
+          >> handleBlockchainEvents (Wallet 2)
+          >> handleBlockchainEvents (Wallet 3)
+          >> callEndpoint @"redeem-escrow" (Wallet 1) ()
+          >> notifySlot w1
+          >> handleUtxoQueries (Wallet 1)
+          >> handleBlockchainEvents (Wallet 1)
+          >> handleBlockchainEvents (Wallet 3)
+          >> handleBlockchainEvents (Wallet 2))
+
     , checkPredicate @EscrowSchema "can refund"
         (payEp escrowParams >> refundEp escrowParams (walletPubKey w1))
         ( walletFundsChange w1 mempty

--- a/plutus-use-cases/test/Spec/Escrow.hs
+++ b/plutus-use-cases/test/Spec/Escrow.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE TypeApplications #-}
+module Spec.Escrow where
+
+import           Control.Monad                                   (void)
+
+import           Language.Plutus.Contract
+import           Language.Plutus.Contract.Test
+import qualified Ledger.Ada                                      as Ada
+import qualified Spec.Lib                                        as Lib
+
+import           Wallet.Emulator                                 (walletPubKey)
+
+import           Language.PlutusTx.Coordination.Contracts.Escrow
+import           Language.PlutusTx.Lattice
+
+import           Test.Tasty
+import qualified Test.Tasty.HUnit                                as HUnit
+
+tests :: TestTree
+tests = testGroup "escrow"
+    [ checkPredicate @EscrowSchema "can pay"
+        (void $ payEp escrowParams)
+        (assertDone w1 (const True) "escrow pay not done" /\ walletFundsChange w1 (Ada.lovelaceValueOf (-10)))
+        (callEndpoint @"pay-escrow" (Wallet 1) (walletPubKey w1, Ada.lovelaceValueOf 10)
+        >> handleBlockchainEvents (Wallet 1))
+
+    , checkPredicate @EscrowSchema "can redeem"
+        (void $ selectEither (payEp escrowParams) (redeemEp escrowParams))
+        ( assertDone w3 (const True) "escrow redeem not done"
+          /\ walletFundsChange w1 (Ada.lovelaceValueOf (-10))
+          /\ walletFundsChange w2  (Ada.lovelaceValueOf 10)
+          /\ walletFundsChange w3 mempty
+        )
+        ( callEndpoint @"pay-escrow" (Wallet 1) (walletPubKey w1, Ada.lovelaceValueOf 20)
+        >> callEndpoint @"pay-escrow" (Wallet 2) (walletPubKey w2, Ada.lovelaceValueOf 10)
+        >> handleBlockchainEvents (Wallet 1)
+        >> handleBlockchainEvents (Wallet 2)
+        >> callEndpoint @"redeem-escrow" (Wallet 3) ()
+        >> notifySlot w3
+        >> handleUtxoQueries (Wallet 3)
+        >> handleBlockchainEvents (Wallet 3)
+        >> handleBlockchainEvents (Wallet 1)
+        >> handleBlockchainEvents (Wallet 2))
+
+    , checkPredicate @EscrowSchema "can refund"
+        (payEp escrowParams >>= refundEp escrowParams)
+        ( walletFundsChange w1 mempty
+          /\ assertDone w1 (\case { RefundOK _ -> True; _ -> False}) "refund should succeed")
+        ( callEndpoint @"pay-escrow" (Wallet 1) (walletPubKey w1, Ada.lovelaceValueOf 20)
+        >> handleBlockchainEvents (Wallet 1)
+        >> addBlocks 200
+        >> callEndpoint @"refund-escrow" (Wallet 1) ()
+        >> handleUtxoQueries (Wallet 1)
+        >> handleBlockchainEvents (Wallet 1))
+
+    , HUnit.testCase "script size is reasonable" (Lib.reasonable (escrowScript escrowParams) 50000)
+    ]
+
+w1, w2, w3 :: Wallet
+w1 = Wallet 1
+w2 = Wallet 2
+w3 = Wallet 3
+
+escrowParams :: EscrowParams
+escrowParams =
+  EscrowParams
+    { escrowDeadline = 200
+    , escrowTargets  =
+        [ payToPubKeyTarget (walletPubKey w1) (Ada.lovelaceValueOf 10)
+        , payToPubKeyTarget (walletPubKey w2) (Ada.lovelaceValueOf 20)
+        ]
+    }
+

--- a/plutus-wallet-api/ledger/Ledger/Interval.hs
+++ b/plutus-wallet-api/ledger/Ledger/Interval.hs
@@ -29,6 +29,8 @@ module Ledger.Interval(
     , isEmpty
     , before
     , after
+    , strictLowerBound
+    , strictUpperBound
     ) where
 
 import           Codec.Serialise.Class     (Serialise)
@@ -121,6 +123,14 @@ instance Ord a => Ord (LowerBound a) where
         -- An open lower bound is bigger than a closed lower bound. This corresponds
         -- to the *reverse* of the normal order on Bool.
         EQ -> in2 `compare` in1
+
+{-# INLINABLE strictUpperBound #-}
+strictUpperBound :: a -> UpperBound a
+strictUpperBound a = UpperBound (Finite a) False
+
+{-# INLINABLE strictLowerBound #-}
+strictLowerBound :: a -> LowerBound a
+strictLowerBound a = LowerBound (Finite a) False
 
 {-# INLINABLE lowerBound #-}
 lowerBound :: a -> LowerBound a

--- a/plutus-wallet-api/ledger/Ledger/Scripts.hs
+++ b/plutus-wallet-api/ledger/Ledger/Scripts.hs
@@ -42,6 +42,8 @@ module Ledger.Scripts(
     plcValidatorDigest,
     plcValidatorHash,
     plcRedeemerHash,
+    plcAddress,
+    unsafePlcAddress,
     -- * Example scripts
     unitRedeemer,
     unitData
@@ -55,7 +57,7 @@ import           Codec.Serialise.Class                    (Serialise, encode)
 import           Control.Monad                            (unless)
 import           Control.Monad.Except                     (MonadError(..), runExcept)
 import           Control.DeepSeq                          (NFData)
-import           Crypto.Hash                              (Digest, SHA256)
+import           Crypto.Hash                              (Digest, SHA256, digestFromByteString)
 import           Data.Aeson                               (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import qualified Data.Aeson                               as JSON
 import qualified Data.Aeson.Extras                        as JSON
@@ -63,6 +65,7 @@ import qualified Data.ByteArray                           as BA
 import qualified Data.ByteString.Lazy                     as BSL
 import           Data.Functor                             (void)
 import           Data.Hashable                            (Hashable)
+import           Data.Maybe                               (fromJust)
 import           Data.String
 import           GHC.Generics                             (Generic)
 import qualified Language.PlutusCore                      as PLC
@@ -266,6 +269,19 @@ plcDataScriptHash = DataScriptHash . plcSHA2_256 . BSL.pack . BA.unpack
 -- | Compute the hash of a validator script.
 plcValidatorDigest :: Digest SHA256 -> ValidatorHash
 plcValidatorDigest = ValidatorHash . BSL.pack . BA.unpack
+
+{-# INLINABLE plcAddress #-}
+-- | Get the SHA256 hash (for use in off-chain code) from a 'ValidatorHash'
+--   (on-chain)
+plcAddress :: ValidatorHash -> Maybe (Digest SHA256)
+plcAddress (ValidatorHash hsh) = digestFromByteString $ BSL.toStrict hsh
+
+{-# INLINABLE unsafePlcAddress #-}
+-- | Get the SHA256 hash (for use in off-chain code) from a 'ValidatorHash'
+--   (on-chain). Should be safe if 'ValidatorHash' was constructed using 
+--   'plcValidatorDigest' or 'plcValidatorHash'.
+unsafePlcAddress :: ValidatorHash -> Digest SHA256
+unsafePlcAddress = fromJust . plcAddress
 
 -- TODO: Is this right? Make it obvious
 {-# INLINABLE plcValidatorHash #-}

--- a/plutus-wallet-api/ledger/Ledger/TxId.hs
+++ b/plutus-wallet-api/ledger/Ledger/TxId.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeApplications   #-}
-
 -- ToJSON/FromJSON/Serialise (Digest SHA256)
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -21,6 +20,7 @@ import qualified Data.Aeson.Extras      as JSON
 import qualified Data.ByteArray         as BA
 import qualified Data.ByteString        as BSS
 import           GHC.Generics           (Generic)
+import qualified Language.PlutusTx.Eq   as PlutusTx
 import           Language.PlutusTx.Lift (makeLift)
 import           Schema                 (ToSchema)
 
@@ -43,12 +43,12 @@ instance FromJSON (Digest SHA256) where
 newtype TxIdOf h = TxIdOf { getTxId :: h }
     deriving (Eq, Ord, Show, Generic)
     deriving anyclass (ToSchema)
-
 makeLift ''TxIdOf
 
 -- | A transaction id, using a SHA256 hash as the transaction id type.
 type TxId = TxIdOf (Digest SHA256)
 
 deriving newtype instance Serialise TxId
+deriving newtype instance PlutusTx.Eq h => PlutusTx.Eq (TxIdOf h)
 deriving anyclass instance ToJSON a => ToJSON (TxIdOf a)
 deriving anyclass instance FromJSON a => FromJSON (TxIdOf a)


### PR DESCRIPTION
* Adds an escrow contract that can be used not just on its own but also
  as part of the setup of another contract (collecting the initial
  contributions from the parties involved)
* The contract works like the crowdfunding one in that the contributions
  can be made in parallel