### PR TITLE
ledger: pass PendingTx as Data

### DIFF
--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -114,7 +114,7 @@ w1 = EM.Wallet 1
 
 someAddress :: Address
 someAddress = Ledger.scriptAddress $
-    Ledger.mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.Data) (_ :: PlutusTx.Data) (_ :: Ledger.PendingTx) -> True ||])
+    Ledger.mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.Data) (_ :: PlutusTx.Data) (_ :: PlutusTx.Data) -> True ||])
 
 type Schema =
     BlockchainActions

--- a/plutus-playground-server/test/Playground/Rollup/renderCrowdfunding.txt
+++ b/plutus-playground-server/test/Playground/Rollup/renderCrowdfunding.txt
@@ -51,7 +51,7 @@ Balances Carried Forward:
               EURToken:  30
 
 ==== Slot #2, Tx #0 ====
-TxId:       d687a0e01953bed5a4aa19b058b0783e3a80fc3ab961649ab9eb14ec6458cc3f
+TxId:       c22e46ca8feff921ccf3bbdfa30182f76d071aa1ca15ea263c859ecb6739d018
 Fee:        -
 Forge:      -
 Inputs:
@@ -76,7 +76,7 @@ Outputs:
               EURToken:  30
   
   ---- Output 1 ----
-  Destination:  Script: 9f18af182318be1890187b185e182c18ac183518...
+  Destination:  Script: 9f182e1118b8186b18db184f0c18e1184218a118...
   Value:
     Ada:      Lovelace:  8000000
 
@@ -100,12 +100,12 @@ Balances Carried Forward:
     b0b0:     USDToken:  20
               EURToken:  30
   
-  Script: 9f18af182318be1890187b185e182c18ac183518...
+  Script: 9f182e1118b8186b18db184f0c18e1184218a118...
   Value:
     Ada:      Lovelace:  8000000
 
 ==== Slot #3, Tx #0 ====
-TxId:       c4578014b6c2c8420f37ed9d4926668b316c3292ee750dbb7fae7e3059c29f05
+TxId:       c632375cac249e2a14bf7be16aa19de502f9c73a7a5405afa899b97183d89d94
 Fee:        -
 Forge:      -
 Inputs:
@@ -130,7 +130,7 @@ Outputs:
               EURToken:  30
   
   ---- Output 1 ----
-  Destination:  Script: 9f18af182318be1890187b185e182c18ac183518...
+  Destination:  Script: 9f182e1118b8186b18db184f0c18e1184218a118...
   Value:
     Ada:      Lovelace:  8000000
 
@@ -154,30 +154,30 @@ Balances Carried Forward:
     b0b0:     USDToken:  20
               EURToken:  30
   
-  Script: 9f18af182318be1890187b185e182c18ac183518...
+  Script: 9f182e1118b8186b18db184f0c18e1184218a118...
   Value:
     Ada:      Lovelace:  16000000
 
 ==== Slot #10, Tx #0 ====
-TxId:       922056b5085799abc9af5cbf1cc55c6884e6b7aceedd629386adcd19caa88929
+TxId:       6cbaa60c9d090a83150ca9df89b68d977578c67734f4cee362944f87b8f78789
 Fee:        -
 Forge:      -
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 9f18af182318be1890187b185e182c18ac183518...
+  Destination:  Script: 9f182e1118b8186b18db184f0c18e1184218a118...
   Value:
     Ada:      Lovelace:  8000000
   Source:
-    Tx:     c4578014b6c2c8420f37ed9d4926668b316c3292ee750dbb7fae7e3059c29f05
+    Tx:     c22e46ca8feff921ccf3bbdfa30182f76d071aa1ca15ea263c859ecb6739d018
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
   
   ---- Input 1 ----
-  Destination:  Script: 9f18af182318be1890187b185e182c18ac183518...
+  Destination:  Script: 9f182e1118b8186b18db184f0c18e1184218a118...
   Value:
     Ada:      Lovelace:  8000000
   Source:
-    Tx:     d687a0e01953bed5a4aa19b058b0783e3a80fc3ab961649ab9eb14ec6458cc3f
+    Tx:     c632375cac249e2a14bf7be16aa19de502f9c73a7a5405afa899b97183d89d94
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
 
@@ -208,6 +208,6 @@ Balances Carried Forward:
     b0b0:     USDToken:  20
               EURToken:  30
   
-  Script: 9f18af182318be1890187b185e182c18ac183518...
+  Script: 9f182e1118b8186b18db184f0c18e1184218a118...
   Value:
     Ada:      Lovelace:  0

--- a/plutus-playground-server/test/Playground/Rollup/renderVestFunds.txt
+++ b/plutus-playground-server/test/Playground/Rollup/renderVestFunds.txt
@@ -19,7 +19,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000000
 
 ==== Slot #1, Tx #0 ====
-TxId:       846990a6bdeec394ae8ecdd54c91ba56fea3dca5af3a61d4a3277e517ecc6e23
+TxId:       55f28df328e3c09950cfb9d03aa7a23e720b24cf22f267c3f6067b0badedc60e
 Fee:        -
 Forge:      -
 Inputs:
@@ -40,7 +40,7 @@ Outputs:
     Ada:      Lovelace:  8000000
   
   ---- Output 1 ----
-  Destination:  Script: 9f0912188018b818d41833185f18c41879182518...
+  Destination:  Script: 9f187216188f18a518dc1864185c189218ec187d...
   Value:
     Ada:      Lovelace:  2000000
 
@@ -50,6 +50,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  8000000
   
-  Script: 9f0912188018b818d41833185f18c41879182518...
+  Script: 9f187216188f18a518dc1864185c189218ec187d...
   Value:
     Ada:      Lovelace:  2000000

--- a/plutus-use-cases/bench/Bench.hs
+++ b/plutus-use-cases/bench/Bench.hs
@@ -149,16 +149,16 @@ sumB = bgroup "sum" [
 tailB :: Benchmark
 tailB = bgroup "tail" [
         bgroup "5" [
-            bench "plutus" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () (_::PendingTx) -> tail [(), (), (), (), ()] ||])),
-            bench "plutus-opt" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () (_::PendingTx) -> tailOpt [(), (), (), (), ()] ||])),
+            bench "plutus" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tail [(), (), (), (), ()] ||])),
+            bench "plutus-opt" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tailOpt [(), (), (), (), ()] ||])),
             bench "native" $ nf tail (replicate 5 ()),
             bench "scott" $ nf tailScott (Scott.replicate 5 ()),
             bench "combinator" $ nf tailRec (replicate 5 ()),
             bench "scott-combinator" $ nf tailRecScott (Scott.replicate 5 ())
         ],
         bgroup "20" [
-            bench "plutus" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () (_::PendingTx) -> tail [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
-            bench "plutus-opt" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () (_::PendingTx) -> tailOpt [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
+            bench "plutus" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tail [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
+            bench "plutus-opt" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tailOpt [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
             bench "native" $ nf tail (replicate 20 ()),
             bench "scott" $ nf tailScott (Scott.replicate 20 ()),
             bench "combinator" $ nf tailRec (replicate 20 ()),
@@ -196,7 +196,7 @@ trivial = bgroup "trivial" [
         bench "typecheck" $ nf runScriptCheck (validationData1, validator, unitData, unitRedeemer)
     ]
     where
-        validator = mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.Data) (_ :: PlutusTx.Data) (_ :: PendingTx) -> True ||])
+        validator = mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.Data) (_ :: PlutusTx.Data) (_ :: PlutusTx.Data) -> True ||])
 
 -- | The multisig contract is one of the simplest ones that we have. This runs a number of different scenarios.
 -- Note that multisig also does some signature verification!
@@ -258,10 +258,10 @@ sig2 :: Signature
 sig2 = Crypto.sign txHash privk2
 
 validationData1 :: ValidationData
-validationData1 = ValidationData $ fromCompiledCode $ PlutusTx.liftCode $ mockPendingTx
+validationData1 = ValidationData $ PlutusTx.toData $ mockPendingTx
 
 validationData2 :: ValidationData
-validationData2 = ValidationData $ fromCompiledCode $ PlutusTx.liftCode $ mockPendingTx { pendingTxSignatures = [(pk1, sig1), (pk2, sig2)] }
+validationData2 = ValidationData $ PlutusTx.toData $ mockPendingTx { pendingTxSignatures = [(pk1, sig1), (pk2, sig2)] }
 
 mockPendingTx :: PendingTx
 mockPendingTx = PendingTx

--- a/plutus-wallet-api/ledger/Ledger/Index.hs
+++ b/plutus-wallet-api/ledger/Ledger/Index.hs
@@ -39,7 +39,7 @@ import qualified Data.Map                  as Map
 import           Data.Semigroup            (Semigroup)
 import qualified Data.Set                  as Set
 import           GHC.Generics              (Generic)
-import           Language.PlutusTx         (liftCode)
+import           Language.PlutusTx         (toData)
 import qualified Language.PlutusTx.Numeric as P
 import qualified Ledger.Ada                as Ada
 import           Ledger.Blockchain
@@ -245,7 +245,7 @@ checkMatch pendingTx = \case
             pTxIn <- pendingTxInScript (txInRef txin) vl r
             let
                 ptx' = pendingTx { pendingTxIn = pTxIn }
-                vd = ValidationData (fromCompiledCode $ liftCode ptx')
+                vd = ValidationData (toData ptx')
             case runExcept $ runScript Typecheck vd vl d r of
                 Left e  -> throwError $ ScriptFailure e
                 Right _ -> pure ()

--- a/plutus-wallet-api/ledger/Ledger/Scripts.hs-boot
+++ b/plutus-wallet-api/ledger/Ledger/Scripts.hs-boot
@@ -1,4 +1,0 @@
-module Ledger.Scripts where
-
-data ValidatorHash
-data RedeemerHash

--- a/plutus-wallet-api/ledger/Ledger/Typed/Scripts.hs
+++ b/plutus-wallet-api/ledger/Ledger/Typed/Scripts.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE TypeFamilies              #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE ViewPatterns              #-}
+{-# OPTIONS_GHC -fno-specialise #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Ledger.Typed.Scripts where
 
 import           Language.PlutusTx
@@ -28,7 +30,7 @@ class ScriptType (a :: Type) where
 -- | The type of validators for the given connection type.
 type ValidatorType (a :: Type) = DataType a -> RedeemerType a -> Validation.PendingTx -> Bool
 
-type WrappedValidatorType = Data -> Data -> Validation.PendingTx -> Bool
+type WrappedValidatorType = Data -> Data -> Data -> Bool
 
 -- | The type of a connection.
 data ScriptInstance (a :: Type) where
@@ -51,6 +53,6 @@ wrapValidator
     :: forall d r
     . (IsData d, IsData r)
     => (d -> r -> Validation.PendingTx -> Bool)
-    -> (Data -> Data -> Validation.PendingTx -> Bool)
-wrapValidator f (fromData -> Just d) (fromData -> Just r) p = f d r p
+    -> WrappedValidatorType
+wrapValidator f (fromData -> Just d) (fromData -> Just r) (fromData -> Just p) = f d r p
 wrapValidator _ _ _ _ = False

--- a/plutus-wallet-api/ledger/Ledger/Validation.hs
+++ b/plutus-wallet-api/ledger/Ledger/Validation.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 {-# OPTIONS_GHC -fno-strictness #-}
+{-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Ledger.Validation
     (

--- a/plutus-wallet-api/ledger/Ledger/Validation.hs-boot
+++ b/plutus-wallet-api/ledger/Ledger/Validation.hs-boot
@@ -1,9 +1,0 @@
-module Ledger.Validation where
-
-import {-# SOURCE #-} Ledger.Scripts
-
-data PendingTxIn' w
-type PendingTxIn = PendingTxIn' (Maybe (ValidatorHash, RedeemerHash))
-type PendingTxInScript = PendingTxIn' (ValidatorHash, RedeemerHash)
-data PendingTx' i
-type PendingTx = PendingTx' PendingTxInScript


### PR DESCRIPTION
Fixes #1481.

Thanks to the existing wrappers and so on, this is a pleasantly small PR.

The main question is: should we do this? I think so, mainly because it makes the specification simpler. Now the *only* thing that the validating node needs to be able to do is pass `Data` to a script. If we make `Data` a builtin type then we can actually specify how to write a validating process entirely independently of Haskell (you still need the PLC typechecker/evaluator, obviously), which seems pretty good.