### PR TITLE
setting version on api gateway causes issues

### DIFF
--- a/deployment/terraform/marlowe-symbolic-lambda.tf
+++ b/deployment/terraform/marlowe-symbolic-lambda.tf
@@ -135,10 +135,6 @@ resource "aws_api_gateway_deployment" "marlowe_symbolic_lambda" {
 
   rest_api_id = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.id}"
   stage_name  = "${var.env}"
-
-  variables {
-    version = "1"
-  }
 }
 
 resource "aws_lambda_permission" "marlowe_symbolic_lambda_api_gw" {


### PR DESCRIPTION
It seems that if you set the version then you need to manually go to the AWS console and redeploy the API. Otherwise you get 500 errors caused by some weird issue with the lambda permissions.