### PR TITLE
EUTXO spec: more work

### DIFF
--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -481,17 +481,8 @@ is similar, but negative quantities are allowed.  As with \N{} and \Z{}, we rega
 \qty{} as a subtype of \qtypm{} and convert freely between them.
 
 \paragraph{Inputs and outputs. } Note that a transaction has a
-\textsf{Set} of inputs but a \textsf{List} of outputs. We use a list
-because any subsequent transaction attempting to use an unspent output
-$O$ as an input will have to be able to determine exactly where $O$
-came from: thus each input of a transaction refers to the output which
-it is trying to spend via an \s{OutputRef} which specifies the
-transaction which produced the output and an index which says which
-output of the transaction is required.
-
-%\todompj{Can we just cite one of the previous descriptions for this?
-%  Also: we should check this is still how they do it in the new ledger
-%  specs.}
+\textsf{Set} of inputs but a \textsf{List} of outputs. See
+note~\ref{note:inputs-and-outputs} for a discussion of why.
 
 \paragraph{Scripts.} Note that validation data are modelled as components
 of outputs, but validator scripts as components of inputs, even though
@@ -1025,6 +1016,23 @@ signature using a known public key: if the public key corresponds to
 the private key then validation succeeds, otherwise it fails.  Thus
 the output can only be spent by the owner of the relevant private key
 
+\note{Inputs and outputs}
+\label{note:inputs-and-outputs}
+A transaction has a \textsf{Set} of inputs but a \textsf{List} of outputs.
+This is for two reasons:
+\begin{itemize}
+  \item We need a way to uniquely identify a transaction output, so
+  that it can be referred to by a transaction input that spends it. The pair of
+  a transaction id and an output index is sufficient for this, but other schemes
+  are conceivable.
+  \item Equality of transaction outputs is defined structurally. But that means
+    that if we had two outputs paying $X$ to address $A$, then they would be
+    equal and therefore if we kept them in a \s{Set} one would be lost.
+\end{itemize}
+
+An alternative design would be to include a unique nonce in transaction outputs
+(effectively: their index in the list), and then we could use this to identify
+them (and distinguish them from each other), and so we could keep them in a \s{Set} instead.
 
 \note{Validation data}
 \label{note:valdata}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -276,13 +276,11 @@ conventions used in the remainder of the document.
 \item If $T$ is a type then $\FinSet{T}$ is the type of finite sets
   with elements of type $T$.
 
-\item A list $\lambda$ of type $\List{T}$ is either the empty list
-  $[]$ or a list $e :: \lambda'$ with $head$ $e$ of type $T$ and
-  $tail$ $\lambda'$ of type $\List{T}$. A list has only a finite
-  number of elements.  We denote the $i$th element of a list $\lambda$ by
-  $\lambda[i]$ and the length of $\lambda$ by $\left|\lambda\right|$.
-%The concatenation of two lists $\lambda_1$ and $\lambda_2$
-%  is denoted $\lambda_1 ::: \lambda_2$.
+\item A list $l$ of type $\List{T}$ is either the empty list
+  $[]$ or a list $e :: l$ with $head$ $e$ of type $T$ and
+  $tail$ $l$ of type $\List{T}$. A list has only a finite
+  number of elements.  We denote the $i$th element of a list $l$ by
+  $l[i]$ and the length of $l$ by $\left|l\right|$.
 
 \item $x \mapsto f(x)$ denotes an anonymous function.
 
@@ -596,14 +594,14 @@ for further discussion.
 \subsection{Validity of EUTXO-1 transactions}
 \label{sec:eutxo-1-validity}
 A number of conditions must be satisfied in order for a transaction
-$t$ to be considered valid with respect to a ledger $\lambda$.
+$t$ to be considered valid with respect to a ledger $l$.
 
 Fig.~\ref{fig:validation-functions-1} defines some auxiliary functions used in validation.
 \begin{ruledfigure}{H}
   \begin{displaymath}
   \begin{array}{lll}
   \multicolumn{3}{l}{\lookupTx{\_}{\_} : \s{Ledger} \times \TxId \rightarrow \eutxotx{}}\\
-  \lookupTx{\lambda}{id} &=& \textsf{find}(\lambda, tx \mapsto \txId(tx) = id)\\
+  \lookupTx{l}{id} &=& \textsf{find}(l, tx \mapsto \txId(tx) = id)\\
   \\
   \txunspent(t) &=& \{(\txId(t),1), \ldots, (\txId(id),\left|t.outputs\right|)\}\\
   \\
@@ -612,17 +610,17 @@ Fig.~\ref{fig:validation-functions-1} defines some auxiliary functions used in v
   \\
   \multicolumn{3}{l}{\unspent : \s{Ledger} \rightarrow \FinSet{\s{OutputRef}}}\\
   \unspent([]) &=& \emptymap \\
-  \unspent(t::\lambda) &=& (\unspent(\lambda) \setminus t.\inputs) \cup \txunspent(t)\\
+  \unspent(t::l) &=& (\unspent(l) \setminus t.\inputs) \cup \txunspent(t)\\
   \\
   \multicolumn{3}{l}{\getSpent : \s{Input} \times \s{Ledger} \rightarrow \s{Output}}\\
-  \getSpent(i,\lambda) &=& \lambda\langle i.\outputref.\id \rangle.\outputs[i.\outputref.\idx]
+  \getSpent(i,l) &=& l\langle i.\outputref.\id \rangle.\outputs[i.\outputref.\idx]
   \end{array}
   \end{displaymath}
   \caption{Auxiliary functions for EUTXO-1 validation}
   \label{fig:validation-functions-1}
 \end{ruledfigure}
 
-\noindent The function $\lookupTx{\lambda}{id}$ looks up the unique transaction
+\noindent The function $\lookupTx{l}{id}$ looks up the unique transaction
 $T$ whose $\TxId$ is $id$. This can of course fail, but we will assume it does
 not, since rule~\ref{rule:all-inputs-refer-to-unspent-outputs} ensures that all
 of the transaction inputs refer to existing unspent outputs, and hence that
@@ -642,21 +640,21 @@ the latter in rule~\ref{rule:all-inputs-validate}.
   \label{rule:all-inputs-refer-to-unspent-outputs}
   \textbf{All inputs refer to unspent outputs}
   \begin{displaymath}
-    t.\inputs \subseteq \unspent(\lambda).
+    t.\inputs \subseteq \unspent(l).
   \end{displaymath}
 
 \item
   \label{rule:forging}
   \textbf{Forging} \\
     A transaction with a non-zero \forge{}
-    field is only valid if the ledger $\lambda$ is empty (that
+    field is only valid if the ledger $l$ is empty (that
     is, if it is the initial transaction).
 
 \item
   \label{rule:value-is-preserved}
   \textbf{Value is preserved}
   \begin{displaymath}
-    t.\forge + \sum_{i \in t.\inputs} \getSpent(i, \lambda).\val = t.\fee + \sum_{o \in t.\outputs} o.\val
+    t.\forge + \sum_{i \in t.\inputs} \getSpent(i, l).\val = t.\fee + \sum_{o \in t.\outputs} o.\val
   \end{displaymath}
 
 \item
@@ -672,14 +670,14 @@ the latter in rule~\ref{rule:all-inputs-validate}.
   \textbf{All inputs validate}
   \begin{displaymath}
     \textrm{For all } i \in t.\inputs,\enspace \llbracket
-    i.\validator\rrbracket (\getSpent(i, \lambda).\valdata,\, i.\redeemer,\,  \delta(\tau(t,i))) = \true.
+    i.\validator\rrbracket (\getSpent(i, l).\valdata,\, i.\redeemer,\,  \delta(\tau(t,i))) = \true.
   \end{displaymath}
 
 \item
   \label{rule:validator-scripts-hash}
   \textbf{Validator scripts match output addresses}
   \begin{displaymath}
-    \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
+    \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, l).\addr
   \end{displaymath}
 
 \end{enumerate}
@@ -690,9 +688,9 @@ the latter in rule~\ref{rule:all-inputs-validate}.
 
 
 \noindent We say that a ledger
-$\lambda$ is \textit{valid} if either $\lambda$ is empty or
-$\lambda$ is of the form $t::\lambda^{\prime}$ with
-$\lambda^{\prime}$ valid and $t$ valid for $\lambda^{\prime}$.
+$l$ is \textit{valid} if either $l$ is empty or
+$l$ is of the form $t::l^{\prime}$ with
+$l^{\prime}$ valid and $t$ valid for $l^{\prime}$.
 
 
 In practice, validity imposes a limit on the size of the
@@ -893,7 +891,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
   \label{rule:all-inputs-refer-to-unspent-outputs-2}
   \textbf{All inputs refer to unspent outputs}
   \begin{displaymath}
-    t.\inputs \subseteq \unspent(\lambda).
+    t.\inputs \subseteq \unspent(l).
   \end{displaymath}
 
 \item
@@ -902,7 +900,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
   A transaction with a non-zero \forge{} field is only
   valid if either:
   \begin{enumerate}
-    \item the ledger $\lambda$ is empty (that is, if it is the initial transaction).
+    \item the ledger $l$ is empty (that is, if it is the initial transaction).
     \item \label{rule:custom-forge}
       for every key $h$ in $\support(t.\forge)$, there
       exists $i \in t.\inputs$ and $(a,v,d) \in i.\outputs$ with
@@ -914,7 +912,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
   \label{rule:value-is-preserved-2}
   \textbf{Values are preserved}
   \begin{displaymath}
-    t.\forge + \sum_{i \in t.\inputs} \getSpent(i, \lambda) = \injectNative(t.\fee) + \sum_{o \in t.\outputs} o.\val
+    t.\forge + \sum_{i \in t.\inputs} \getSpent(i, l) = \injectNative(t.\fee) + \sum_{o \in t.\outputs} o.\val
   \end{displaymath}
 
 \item
@@ -930,14 +928,14 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
   \textbf{All inputs validate}
   \begin{displaymath}
     \textrm{For all } i \in t.\inputs,\enspace \llbracket
-    i.\validator\rrbracket(\getSpent(i,\lambda).\valdata,\, i.\redeemer,\, \delta_2(\tau_2(t, i))) = \true
+    i.\validator\rrbracket(\getSpent(i,l).\valdata,\, i.\redeemer,\, \delta_2(\tau_2(t, i))) = \true
   \end{displaymath}
 
 \item
   \label{rule:validator-scripts-hash-2}
   \textbf{Validator scripts match output addresses}
   \begin{displaymath}
-    \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
+    \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, l).\addr
   \end{displaymath}
 
 \end{enumerate}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -452,6 +452,8 @@ the ledger.
   \label{fig:eutxo-1-types}
 \end{ruledfigure}
 
+\subsubsection{Remarks}
+\paragraph{ETUXO-1 on Cardano.}
 The Cardano implementation of EUTXO-1 uses the primitives given in
 Fig.~\ref{fig:eutxo-1-types-cardano}.
 
@@ -467,14 +469,14 @@ Fig.~\ref{fig:eutxo-1-types-cardano}.
     \script &=& \mbox{a Plutus Core program}\\
     \scriptAddr : \script \rightarrow \Address &=& s \mapsto \hash{s}\\
     \llbracket \cdots \rrbracket : \script \rightarrow \Data \times \Data \times
-    \Data \rightarrow \B &=& \mbox{typechecking the program and running the Plutus Core interpreter}\\
+    \Data \rightarrow \B &=& \mbox{typechecking the program and running}\\
+                             &&\mbox{the Plutus Core interpreter}\\
   \end{array}
   \end{displaymath}
   \caption{Cardano primitives for the EUTXO-1 model}
   \label{fig:eutxo-1-types-cardano}
 \end{ruledfigure}
 
-\subsubsection{Remarks}
 \paragraph{Quantities. }
 The \qty{} type represents a non-negative quantity of funds.  The \qtypm{} type
 is similar, but negative quantities are allowed.  As with \N{} and \Z{}, we regard
@@ -772,6 +774,8 @@ currency, as in EUTXO-1.
   \label{fig:eutxo-2-types}
 \end{ruledfigure}
 
+\subsubsection{Remarks}
+\paragraph{ETUXO-2 on Cardano.}
 The Cardano implementation of EUTXO-2 uses the primitives given in
 Fig.~\ref{fig:eutxo-2-types-cardano}.
 \begin{ruledfigure}{H}
@@ -787,7 +791,6 @@ Fig.~\ref{fig:eutxo-2-types-cardano}.
   \label{fig:eutxo-2-types-cardano}
 \end{ruledfigure}
 
-\subsubsection{Remarks}
 \paragraph{Quantity maps. }
 The \qtymap{} type represents a collection of funds from a
 number of currencies and their subcurrencies, with all quantities

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -460,7 +460,7 @@ Fig.~\ref{fig:eutxo-1-types-cardano}.
     \script &=& \mbox{a Plutus Core program}\\
     \scriptAddr : \script \rightarrow \Address &=& \mbox{the hash of the program}\\
     \llbracket \cdots \rrbracket : \script \rightarrow \Data \times \Data \times
-    \Data \rightarrow \B &=& \mbox{running the Plutus Core interpreter}\\
+    \Data \rightarrow \B &=& \mbox{typechecking the program and running the Plutus Core interpreter}\\
   \end{array}
   \end{displaymath}
   \caption{Cardano primitives for the EUTXO-1 model}
@@ -690,8 +690,6 @@ $\valdata$ fields and the result of $\delta$. The validation of a
 single transaction must take place within one slot, so the evaluation
 of $\llbracket ~ \rrbracket$ cannot take longer than one slot.
 \todokwxm{Do we need this $\uparrow$?}
-\todokwxm{We should probably point out somewhere that the validating node
-  typechecks scripts during validation.}
 
 %%\newpage
 \section{EUTXO-2: multicurrency support and non-fungible tokens}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -430,16 +430,16 @@ the ledger.
   \begin{displaymath}
   \begin{array}{rll}
     \multicolumn{3}{l}{\textsc{Ledger primitives}}\\
-    \qty{} &=& \mbox{an amount of currency, always non-negative}\\
-    \qtypm &=& \mbox{a possibly negative amount of currency}\\
-    \slotnum &=& \mbox{a slot number}\\
-    \Address &=& \mbox{the address of an object in the blockchain}\\
-    \TxId &=& \mbox{the identifier of a transaction}\\
-    \txId : \eutxotx \rightarrow \TxId &=& \mbox{a function computing the identifier of a transaction}\\
-    \script &=& \mbox{the (opaque) type of scripts}\\
-    \scriptAddr : \script \rightarrow \Address &=& \mbox{the address of a script}\\
+    \qty{} && \mbox{an amount of currency, always non-negative}\\
+    \qtypm && \mbox{a possibly negative amount of currency}\\
+    \slotnum && \mbox{a slot number}\\
+    \Address && \mbox{the address of an object in the blockchain}\\
+    \TxId && \mbox{the identifier of a transaction}\\
+    \txId : \eutxotx \rightarrow \TxId && \mbox{a function computing the identifier of a transaction}\\
+    \script && \mbox{the (opaque) type of scripts}\\
+    \scriptAddr : \script \rightarrow \Address && \mbox{the address of a script}\\
     \llbracket \cdots \rrbracket : \script \rightarrow \Data \times \Data \times
-    \Data \rightarrow \B &=& \mbox{applying a script to its arguments}\\
+    \Data \rightarrow \B && \mbox{applying a script to its arguments}\\
     \\
     \multicolumn{3}{l}{\textsc{Defined types}}\\
     \s{Output } &=&(\addr: \s{Address},\\
@@ -461,7 +461,7 @@ the ledger.
      \s{Ledger } &=&\!\List{\eutxotx}\\
   \end{array}
   \end{displaymath}
-  \caption{Primitives for the EUTXO-1 model}
+  \caption{Primitives and basic types for the EUTXO-1 model}
   \label{fig:eutxo-1-types}
 \end{ruledfigure}
 
@@ -766,10 +766,10 @@ currency, as in EUTXO-1.
   \begin{displaymath}
     \begin{array}{rll}
     \multicolumn{3}{l}{\textsc{Ledger primitives}}\\
-    \currency  &=& \mbox{an identifier for a custom currency}\\
-    \nativeCur &=& \mbox{a distinguished \currency{} representing the native currency of the ledger}\\
-    \token     &=& \mbox{a type consisting of identifiers for individual tokens}\\
-    \nativeTok &=& \mbox{a distinguished \token{} representing the currency token of the native currency}\\
+    \currency  && \mbox{an identifier for a custom currency}\\
+    \nativeCur && \mbox{a distinguished \currency{} representing the native currency of the ledger}\\
+    \token     && \mbox{a type consisting of identifiers for individual tokens}\\
+    \nativeTok && \mbox{a distinguished \token{} representing the currency token of the native currency}\\
     \\
     \multicolumn{3}{l}{\textsc{Defined types}}\\
     \qtymap   &=& \FinSup{\currency}{\FinSup{\token}{\qty}}\\
@@ -791,7 +791,7 @@ currency, as in EUTXO-1.
     \s{Ledger}_2 &=&\!\List{\eutxotx_2}\\
     \end{array}
   \end{displaymath}
-  \caption{Extra types for the EUTXO-2 model}
+  \caption{Extra primitives and basic types for the EUTXO-2 model}
   \label{fig:eutxo-2-types}
 \end{ruledfigure}
 
@@ -806,7 +806,7 @@ Fig.~\ref{fig:eutxo-2-types-cardano}.
       \nativeTok &=& \mbox{the empty bytestring}\\
     \end{array}
   \end{displaymath}
-  \caption{Cardano primitives for the EUTXO-1 model}
+  \caption{Cardano primitives for the EUTXO-2 model}
   \label{fig:eutxo-2-types-cardano}
 \end{ruledfigure}
 

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -77,6 +77,8 @@
 \renewcommand{\i}{\textit}  % Just to speed up typing: replace these in the final version
 \renewcommand{\t}{\texttt}  % Just to speed up typing: replace these in the final version
 \newcommand{\s}{\textsf}  % Just to speed up typing: replace these in the final version
+\newcommand{\msf}[1]{\ensuremath{\mathsf{#1}}}
+\newcommand{\mi}[1]{\ensuremath{\mathit{#1}}}
 
 \newenvironment{arraydefs}[1]{\setlength{\arraycolsep}{0pt}\begin{array}{#1}}{\end{array}}
 %
@@ -102,7 +104,6 @@
 \newcommand\rfskip{7pt}
 \newenvironment{ruledfigure}[1]{\begin{figure}[#1]\hrule\vspace{\rfskip}}{\vspace{\rfskip}\hrule\end{figure}}
 
-
 %% Various text macros
 \newcommand{\true}{\textsf{true}}
 \newcommand{\false}{\textsf{false}}
@@ -113,14 +114,17 @@
 \newcommand{\Interval}[1]{\ensuremath{\s{Interval}[#1]}}
 \newcommand{\extended}[1]{#1^\updownarrow}
 \newcommand{\FinSup}[2]{\ensuremath{\s{FinSup}[#1,#2]}}
-\newcommand{\support}{\ensuremath{\mathrm{support}}}
+\newcommand{\support}{\msf{support}}
 
 \newcommand{\script}{\ensuremath{\s{Script}}}
+\newcommand{\scriptAddr}{\msf{scriptAddr}}
 \newcommand{\ptx}{\ensuremath{\s{PendingTx}}}
 
 % Macros for eutxo things.
-\newcommand{\mi}[1]{\ensuremath{\mathit{#1}}}
-\newcommand{\txid}{\mi{txid}}
+\newcommand{\TxId}{\ensuremath{\s{TxId}}}
+\newcommand{\txId}{\msf{txid}}
+\newcommand{\txrefid}{\mi{id}}
+\newcommand{\Address}{\ensuremath{\s{Address}}}
 \newcommand{\idx}{\mi{index}}
 \newcommand{\inputs}{\mi{inputs}}
 \newcommand{\outputs}{\mi{outputs}}
@@ -132,7 +136,7 @@
 \newcommand{\validator}{\mi{validator}}
 \newcommand{\redeemer}{\mi{redeemer}}
 \newcommand{\valdata}{\mi{valdata}}
-\newcommand{\Data}{\ensuremath{\mathsf{Data}}}
+\newcommand{\Data}{\ensuremath{\s{Data}}}
 
 \newcommand{\outputref}{\mi{outputRef}}
 \newcommand{\txin}{\mi{in}}
@@ -140,8 +144,7 @@
 \newcommand{\id}{\mi{id}}
 \newcommand{\getvalue}{\msf{getvalue}}
 
-\newcommand{\msf}[1]{\ensuremath{\mathsf{#1}}}
-\newcommand{\slotnum}{\msf{SlotNumber}}
+\newcommand{\slotnum}{\ensuremath{\s{SlotNumber}}}
 \newcommand{\spent}{\msf{spentOutputs}}
 \newcommand{\unspent}{\msf{unspentOutputs}}
 \newcommand{\txunspent}{\msf{unspentTxOutputs}}
@@ -247,78 +250,27 @@ notation established by \citep{Zahnentferner18-UTxO}, except that we make use
 of finitely-supported functions in most places that \citep{Zahnentferner18-UTxO}
 use maps.
 
-\subsection{Basic types}
-\noindent Throughout the document we assume a number of basic types.
-These are shown in Figure~\ref{fig:basic-types}.
-
-\begin{ruledfigure}{H}
-  \center{
-    \begin{tabular}{rl}
-      \B&: the type of booleans, $\{\false, \true\}$\\
-      \N&: the type of natural numbers, $\{0, 1, 2, \ldots\}$\\
-      \Z&: the type of integers, $\{,\ldots, -2, -1, 0, 1, 2, \ldots\}$\\
-      \H&: the type of \textit{bytestrings}, $\bigcup_{n=0}^{\infty}\{0,1\}^{8n}$\\
-      $\qty = \N$&: an amount of currency, always non-negative\\
-      $\qtypm = \Z$&: a possibly negative amount of currency\\
-      $\slotnum = \N$&: a slot number\\
-      $\s{Address} = \N$&: the address of an object in the blockchain\\
-      $\s{TxId} = \N$&: the identifier of a previous transaction on the chain\\
-    \end{tabular}
-  }
-  \caption{Basic types}
-  \label{fig:basic-types}
-\end{ruledfigure}
-
-\noindent We regard $\N$ as a subtype of $\Z$ and convert freely between
-natural numbers and non-negative integers (hence also \qty{} and \qtypm{}).
-A bytestring is a sequence
-of 8-bit bytes: the symbol $\H$ is used because bytestrings are often
-presented as sequences of hexadecimal digits.
-
-\medskip
-\noindent In practice an \textsf{Address} will be a
-collision-resistant hash of some object (so the address of an object
-$X$ is $X^{\#}$ in the notation of Figure~\ref{fig:basic-notation}),
-and the blockchain will provide an efficient way to retrieve the
-original object given its hash.  Compiled Plutus Core scripts are
-stored and transmitted in a serialised form, and when we talk about
-the hash of a Plutus Core script we mean the hash of the serialised
-version.
-
-% Accessing objects indirectly via addresses is helpful because it can
-% help to reduce memory and disk usage: for example, there may be
-% scripts for common validation scenarios used in many transactions, and
-% it is more efficient to store single copies of such scripts rather
-% than having hundreds of transactions each with their own copy.
-
-\medskip
-\noindent We assume that every transaction in a ledger has a unique identifier
-of type \s{TxId}: in an implementation this would probably be the
-hash of the transaction.
-
-\subsection{Basic notation}
-Figure~\ref{fig:basic-notation} describes some notation and
+\subsection{Basic types and operations}
+Figure~\ref{fig:basic-notation} describes some types, notation, and
 conventions used in the remainder of the document.
+
 \begin{ruledfigure}{H}
   \begin{itemize}
 \item Types are typeset in $\mathsf{sans~serif}$.
+
+\item \B{} denotes the type of booleans, $\{\false, \true\}$.
+\item \N{} denotes the type of natural numbers, $\{0, 1, 2, \ldots\}$.
+\item \Z{} denotes the type of integers, $\{,\ldots, -2, -1, 0, 1, 2, \ldots\}$.
+\item \H{} denotes the type of \textit{bytestrings}, $\bigcup_{n=0}^{\infty}\{0,1\}^{8n}$.
 
 \item If a type $M$ is a monoid, we use $+$ for the monoidal operation and $0$
   for the unit of the monoid. If $M$ is a group, we use $-$ for the group
   inverse operation. This should never be ambiguous.
 
-\item All scripts are of type \script{}.
-
-\item The only operation on \script{} from the ledger's
-  perspective is applying a validator script to three arguments,
-  which is denoted by $\llbracket \cdots \rrbracket :
-  \script \rightarrow \Data \times \Data
-    \times \Data \rightarrow \B$.
-
 \item A record type with fields $\phi_1, \ldots, \phi_n$ of types $T_1,
   \ldots, T_n$ is denoted by $(\phi_1 : T_1, \ldots, \phi_n : T_n)$.
 
-\item If $t$ is a value of a record type $T$ and $\phi$ is the name
+  If $t$ is a value of a record type $T$ and $\phi$ is the name
   of a field of $T$ then $t.\phi$ denotes the value of $\phi$ for
   $t$.
 
@@ -333,46 +285,51 @@ conventions used in the remainder of the document.
 %The concatenation of two lists $\lambda_1$ and $\lambda_2$
 %  is denoted $\lambda_1 ::: \lambda_2$.
 
-  \item For two types $K$ and $V$ where $V$ is a monoid, $\FinSup{K}{V}$ denotes the type of
-    \textit{finitely-supported functions} from $K$ to $V$. That is, there is a
-    function $\support : \FinSup{K}{V} \rightarrow \FinSet{K}$ such that
-    $k \in \support(f) \Leftrightarrow f(k) \neq 0$.
-    Equality on finitely-supported functions is defined as pointwise equality.
+\item For two types $K$ and $V$ where $V$ is a monoid, $\FinSup{K}{V}$ denotes the type of
+  \textit{finitely-supported functions} from $K$ to $V$. That is, there is a
+  function $\support : \FinSup{K}{V} \rightarrow \FinSet{K}$ such that
+  $k \in \support(f) \Leftrightarrow f(k) \neq 0$.
 
-  \item If the type $M$ is a monoid then we define the sum of two finitely-supported
-    functions
-    $f, g \in \FinSup{K}{M}$ to be the function $f+g \in \FinSup{K}{M}$ with
-    support $\support (f+g) = \support(f) \cup \support(g)$ given by
-    \[(f+g)(k) = f(k) + g(k) \]
-    We generalise this to the sum of a finite number of maps using
-    the $\sum$ notation in the usual way; care is required if
-    $+$ is non-commutative, since then the sum of a number of
-    functions will depend on the order in which they appear. Note that
-    the type $\FinSup{K}{M}$ itself becomes a monoid under the
-    operation $+$ which we have just defined, with the empty function as
-    identity element.
+  Equality on finitely-supported functions is defined as pointwise equality.
 
-  \item If the type $M$ is a group, then we can
-    similarly define the inverse of a finitely-supported function $f$ as
-    the function $(-f)$ with the same support, given by
-    \[ (-f)(k) = -f(k) \]
+  If the type $M$ is a monoid then we define the sum of two finitely-supported
+  functions
+  $f, g \in \FinSup{K}{M}$ to be the function $f+g \in \FinSup{K}{M}$ with
+  support $\support (f+g) = \support(f) \cup \support(g)$ given by
+  \[(f+g)(k) = f(k) + g(k) \]
+  We generalise this to the sum of a finite number of maps using
+  the $\sum$ notation in the usual way; care is required if
+  $+$ is non-commutative, since then the sum of a number of
+  functions will depend on the order in which they appear. Note that
+  the type $\FinSup{K}{M}$ itself becomes a monoid under the
+  operation $+$ which we have just defined, with the empty function as
+  identity element.
 
-  \item $x \mapsto f(x)$ denotes an anonymous function.
+  If the type $M$ is a group, then we can
+  similarly define the inverse of a finitely-supported function $f$ as
+  the function $(-f)$ with the same support, given by
+  \[ (-f)(k) = -f(k) \]
 
-  \item A cryptographic
-    collision-resistant hash of a value $c$ is denoted $c^{\#}$.
+\item $x \mapsto f(x)$ denotes an anonymous function.
 
-  \item For a type $A$ which forms a partial order, $\extended{A}$ is the same
-    type extended with a top element $\infty$ and a bottom element $-\infty$.
+\item A cryptographic collision-resistant hash of a value $c$ is denoted $c^{\#}$.
 
-  \item For a type $A$ which forms a total order,  $\Interval{A}$ is the type
-    of intervals over that type, whose endpoints may be either closed or open.
-    The type $\Interval{A}$ forms a lattice.
+\item For a type $A$ which forms a partial order, $\extended{A}$ is the same
+  type extended with a top element $\infty$ and a bottom element $-\infty$.
 
+\item For a type $A$ which forms a total order,  $\Interval{A}$ is the type
+  of intervals over that type, whose endpoints may be either closed or open.
+  The type $\Interval{A}$ forms a lattice.
 \end{itemize}
 \caption{Basic notation}
 \label{fig:basic-notation}
 \end{ruledfigure}
+
+\noindent We regard $\N$ as a subtype of $\Z$ and convert freely between
+natural numbers and non-negative integers (hence also \qty{} and \qtypm{}).
+A bytestring is a sequence
+of 8-bit bytes: the symbol $\H$ is used because bytestrings are often
+presented as sequences of hexadecimal digits.
 
 See note~\ref{note:finitely-supported-functions} for discussion of using
 finitely-supported functions computationally.
@@ -412,14 +369,13 @@ We assume that the scripting language has the ability to parse values
 of type \Data{}, converting them into a suitable internal representation.
 
 
-
-
-
-
 \section{EUTXO-1: Enhanced scripting}
 \label{sec:eutxo-1}
 The EUTXO-1 model adds the following new features to the model
 proposed in~\citep{Zahnentferner18-UTxO}:
+
+
+
 
 \begin{itemize}
 \item Every transaction has a \textit{validity interval}, of type $\Interval{\extended{\slotnum}}$.
@@ -485,18 +441,31 @@ features mentioned above (the validity interval, the validation data
 and the \ptx{} structure) and changed the type of the redeemer from
 \script{} to \Data{}.
 
-Figure~\ref{fig:eutxo-1-types} lists the types which
-describe transactions in the basic EUTXO model.
+Figure~\ref{fig:eutxo-1-types} lists the types and operations used in the
+the basic EUTXO model. Some of these are defined, the others must be provided by
+the ledger.
 %%
 \begin{ruledfigure}{H}
-  \[
-  \begin{arraydefs}{rll}
-
+  \begin{displaymath}
+  \begin{array}{rll}
+    \multicolumn{3}{l}{\textsc{Ledger primitives}}\\
+    \qty{} &=& \mbox{an amount of currency, always non-negative}\\
+    \qtypm &=& \mbox{a possibly negative amount of currency}\\
+    \slotnum &=& \mbox{a slot number}\\
+    \Address &=& \mbox{the address of an object in the blockchain}\\
+    \TxId &=& \mbox{the identifier of a transaction}\\
+    \txId : \eutxotx \rightarrow \TxId &=& \mbox{a function computing the identifier of a transaction}\\
+    \script &=& \mbox{the (opaque) type of scripts}\\
+    \scriptAddr : \script \rightarrow \Address &=& \mbox{the address of a script}\\
+    \llbracket \cdots \rrbracket : \script \rightarrow \Data \times \Data \times
+    \Data \rightarrow \B &=& \mbox{applying a script to its arguments}\\
+    \\
+    \multicolumn{3}{l}{\textsc{Defined types}}\\
     \s{Output } &= (&\addr: \s{Address},\\
     && \i{value}: \qty,\\
     &&  \valdata: \Data)\\
     \\
-    \s{OutputRef } &= (&\i{id}: \s{TxId}, \idx: \s{Int})\\
+    \s{OutputRef } &= (&\txrefid: \TxId, \idx: \s{Int})\\
     \\
     \s{Input } & = (&\i{outputRef}: \s{OutputRef},\\
                  && \i{validator}: \script,\\
@@ -509,13 +478,29 @@ describe transactions in the basic EUTXO model.
      &&\forge: \qty) \\
      \\
      \s{Ledger } &=&\!\List{\eutxotx}\\
-  \end{arraydefs}
-  \]
+  \end{array}
+  \end{displaymath}
   \caption{Types for the EUTXO-1 model}
   \label{fig:eutxo-1-types}
 \end{ruledfigure}
 
+\noindent A simple model of these primitives takes:
+\begin{itemize}
+  \item $\qty = \N$
+  \item $\qtypm = \Z$
+  \item $\slotnum = \N$
+  \item $\Address = \H$
+  \item $\TxId = \H$
+  \item $\txId = \textrm{the hash of the transaction}$
+  \item $\scriptAddr = \textrm{the hash of the script}$
+\end{itemize}
+
 \subsubsection{Remarks}
+\paragraph{Quantities. }
+The \qty{} type represents a non-negative quantity of funds.  The \qtypm{} type
+is similar, but negative quantities are allowed.  As with \N{} and \Z{}, we regard
+\qty{} as a subtype of \qtypm{} and convert freely between them.
+
 \paragraph{Inputs and outputs. } Note that a transaction has a
 \textsf{Set} of inputs but a \textsf{List} of outputs. We use a list
 because any subsequent transaction attempting to use an unspent output
@@ -564,9 +549,8 @@ EUTXO-1 is defined in Figure~\ref{fig:ptx-1-types}, along with some
 related types.
 
 \begin{ruledfigure}{H}
-  \[
-  \begin{arraydefs}{rll}
-
+  \begin{displaymath}
+  \begin{array}{rll}
     \s{OutputInfo } &= (& \i{value}: \qty,\\
     && \i{validatorHash}: \s{Address},\\
     &&  \valdata: \Data)\\
@@ -581,9 +565,12 @@ related types.
      &&\i{outputInfo}: \List{\s{OutputInfo}},\\
      &&\i{validityInterval}: \Interval{\extended{\slotnum}},\\
      && \fee: \qty,\\
-     &&\forge: \qty)
-   \end{arraydefs}
- \]
+     &&\forge: \qty)\\
+     \\
+     \tau: \eutxotx \times \N \rightarrow \ptx &=& \mbox{summarises a transaction}\\
+     \delta: \ptx \rightarrow \Data &=& \mbox{encodes a \ptx{}}
+  \end{array}
+  \end{displaymath}
   \caption{The \ptx{} type for the EUTXO-1 model}
   \label{fig:ptx-1-types}
 \end{ruledfigure}
@@ -607,18 +594,7 @@ relating to the input currently undergoing validation.
 % when we have pubkey inputs.  We're ignoring that special case here.
 
 \medskip
-\noindent We also require a function
-$$
-\tau: \eutxotx \times \N \rightarrow \ptx
-$$
-which produces the relevant \ptx{} for a transaction $t$ and an input
-$i$, and a function
-$$
-\delta: \ptx \rightarrow \Data
-$$
-which translates a \ptx{} object into a \Data{} value containing
-exactly the same information, encoded in some standard way enabling it
-to be accessed by a validator script.  Assuming we have an
+Assuming we have an
 appropriate hashing function, it is straightforward to define $\tau$.
 The function $\delta$ is implementation-dependent and we will not
 discuss it further.
@@ -650,7 +626,7 @@ $$
 $$
 \txunspent(t) = \{(id,1), \ldots, (\mathit{id},\left|t.outputs\right|)\}
 $$
-\noindent (where $\mathit{id}$ is $t$'s unique $\s{TxId}$), and
+\noindent (where $\mathit{id}$ is $t$'s unique \TxId{}), and
 %
 \[
   \unspent : \mathsf{Ledger} \rightarrow \FinSet{\s{OutputRef}}
@@ -669,7 +645,7 @@ the set of previously unspent outputs which were spent by $t$.
 \medskip
 \noindent Given a ledger $\lambda$ and a transaction id $\id$, we
 denote by $\lambda\langle\id\rangle$ the unique transaction $T$ in
-$\lambda$ with $T.\txid = \id$, if it exists. In our abstract model
+$\lambda$ with $\txId(T) = \id$, if it exists. In our abstract model
 where $\lambda$ consists of a list of transactions it would suffice to
 take $id$ to be the position of $T$ in $\lambda$, but in an
 implementation we would probably have $id = T^{\#}$.
@@ -678,7 +654,7 @@ implementation we would probably have $id = T^{\#}$.
 \noindent Now given an input $i$ to some transaction in a ledger
 $\lambda$ we define
 $$
-\getvalue(i,\lambda) = \lambda\langle i.\outputref.\txid \rangle.\outputs[i.\outputref.\idx].\val
+\getvalue(i,\lambda) = \lambda\langle i.\outputref.\id \rangle.\outputs[i.\outputref.\idx].\val
 $$
 This function simply returns the value of the input.
 
@@ -787,34 +763,57 @@ basic idea is that ordinary currencies have a single token whose
 sub-currency has an unlimited supply and NFTs have a number of tokens
 with the sub-currency for each token limited to a supply of one.
 
-
-\newcommand{\emspace}{\hspace{1em}}
-\newcommand{\espace}{\hspace{1en}}
-
+The changes to the basic EUTXO-1 types are now quite simple:
+see Figure~\ref{fig:eutxo-2-types}.  We change the type of the $\val$ field
+in the \s{Output} type to be \qtymap{}, representing values of all currencies;
+we also change the type of the \forge{} field on transactions to \qtymappm{}, to
+allow the creation and destruction of funds in all currencies; the
+supply of a currency can be reduced by forging a negative amount of that
+currency, as in EUTXO-1.
 \begin{ruledfigure}{H}
-  \center{
-  \begin{tabular}{rll}
-    \currency &: & an identifier for a custom currency. This is an alias
-                for the \s{Address} type\\
-             &  & from Figure~\ref{fig:basic-types}.\\
+  \begin{displaymath}
+    \begin{array}{rll}
+    \multicolumn{3}{l}{\textsc{Ledger primitives}}\\
+    \currency &=& \mbox{an identifier for a custom currency}\\
+    \nativeCur &=& \mbox{a distinguished \currency{} representing the native currency of the ledger}\\
+    \token   &=& \mbox{a type consisting of identifiers for individual tokens}\\
+    \nativeTok &=& \mbox{a distinguished \token{} representing the currency token of the native currency}\\
     \\
-    \nativeCur &: & a distinguished \currency{} representing the native currency of the ledger.\\
-    \\
-    \token   &: & a type consisting of identifiers for individual tokens.  These will probably\\
-             &  & be hashes in practice.\\
-    \\
-    \nativeTok &: & a distinguished \token{} representing the currency token of the native currency.\\
-    \\
+    \multicolumn{3}{l}{\textsc{Defined types}}\\
     \qtymap   &=& \FinSup{\currency}{\FinSup{\token}{\qty}}\\
-    \\
     \qtymappm &=& \FinSup{\currency}{\FinSup{\token}{\qtypm}}\\
-  \end{tabular}
-  }
-  \caption{Extra basic types for the EUTXO-2 model}
-  \label{fig:more-basic-types}
+    \\
+    \s{Output}_2 &= (&\addr: \s{Address},\\
+            && \val: \qtymap\\
+            && \valdata: \Data)\\
+    \s{OutputRef}_2 &= (&\txrefid: \s{TxId}, \idx: \s{Int})\\
+    \s{Input}_2 &= (& \i{outputRef}: \sf{OutputRef}_2,\\
+            && \i{validator}: \script,\\
+            & & \i{redeemer}: \Data)\\
+    \eutxotx_2 &= ( &\inputs: \FinSet{\s{Input}_2},\\
+            &&\outputs: \List{\s{Output}_2},\\
+            &&\i{validityInterval}: \Interval{\extended{\slotnum}},\\
+            &&\fee: \qty,\\
+            &&\forge: \qtymap^{\pm})\\
+    \\
+    \s{Ledger}_2 &=&\!\List{\eutxotx_2}\\
+    \end{array}
+  \end{displaymath}
+  \caption{Extra types for the EUTXO-2 model}
+  \label{fig:eutxo-2-types}
 \end{ruledfigure}
 
-\noindent The \qtymap{} type represents a collection of funds from a
+A simple implementation would take:
+\begin{itemize}
+\item $\currency = \H$
+\item $\token = \H$
+\item $\nativeCur = \textrm{empty bytestring}$
+\item $\nativeTok = \textrm{empty bytestring}$
+\end{itemize}
+
+\subsubsection{Remarks}
+\paragraph{Quantity maps. }
+The \qtymap{} type represents a collection of funds from a
 number of currencies and their subcurrencies, with all quantities
 being non-negative.  The \qtymappm{} type is similar, but
 negative quantities are allowed.  As with \qty{} and \qtypm{}, we regard
@@ -823,40 +822,7 @@ negative quantities are allowed.  As with \qty{} and \qtypm{}, we regard
 \qtymap{} is a finitely-supported function \emph{to} another finitely-supported
 function. This is well-defined, since finitely-supported functions form a monoid.
 
-\begin{ruledfigure}{H}
-  \[
-  \begin{arraydefs}{rll}
-    \s{Output}_2 &= (&\addr: \s{Address},\\
-    && \val: \qtymap\\
-    && \valdata: \Data)\\
-    \\
-    \s{OutputRef}_2 &= (&\i{id}: \s{TxId}, \idx: \s{Int})\\
-    \\
-    \s{Input}_2 &= (& \i{outputRef}: \sf{OutputRef}_2,\\
-                     && \i{validator}: \script,\\
-                     & & \i{redeemer}: \Data)\\
-    \\
-    \eutxotx_2 &= ( &\inputs: \FinSet{\s{Input}_2},\\
-    &&\outputs: \List{\s{Output}_2},\\
-    &&\i{validityInterval}: \Interval{\extended{\slotnum}},\\
-    &&\fee: \qty,\\
-    &&\forge: \qtymap^{\pm})\\
-    \\
-    \s{Ledger}_2 &=&\!\List{\eutxotx_2}\\
-\end{arraydefs}
-  \]
-  \caption{Types for the EUTXO-2 model}
-  \label{fig:eutxo-2-types}
-\end{ruledfigure}
-
-\noindent The changes to the basic EUTXO-1 types are now quite simple:
-see Figure~\ref{fig:eutxo-2-types}.  We change the type of the $\val$ field
-in the \s{Output} type to be \qtymap{}, representing values of all currencies;
-we also change the type of the \forge{} field on transactions to \qtymappm{}, to
-allow the creation and destruction of funds in all currencies; the
-supply of a currency can be reduced by forging a negative amount of that
-currency, as in EUTXO-1.
-
+\paragraph{Native currency. }
 Quantities of the native currency are represented just like any other currency,
 using \qtymap{}s with the \nativeCur{} identifier. The one exception is the
 \fee{} field, which continues to be a simple \qty{}. This represents a quantity
@@ -869,9 +835,8 @@ that is required is to replace \qty{} by \qtymap{} everywhere in
 Figure~\ref{fig:ptx-1-types} except for the \fee{} field: for reference
 the details are given in Figure~\ref{fig:ptx-2-types}.
 \begin{ruledfigure}{H}
-  \[
-  \begin{arraydefs}{rll}
-
+  \begin{displaymath}
+  \begin{array}{rll}
     \s{OutputInfo}_2\s{ } &= (& \i{value}: \qtymap,\\
     && \i{validatorHash}: \s{Address},\\
     &&  \i{datascriptHash}: \s{Address})\\
@@ -887,8 +852,8 @@ the details are given in Figure~\ref{fig:ptx-2-types}.
      &&\i{validityInterval}: \Interval{\extended{\slotnum}},\\
      &&\fee: \qty,\\
      &&\forge: \qtymap)
-   \end{arraydefs}
- \]
+  \end{array}
+  \end{displaymath}
   \caption{The \ptx{} type for the EUTXO-2 model}
   \label{fig:ptx-2-types}
 \end{ruledfigure}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -589,56 +589,35 @@ $t$ to be considered valid with respect to a ledger $\lambda$.  In
 order to define these we require a couple of auxiliary functions.
 Firstly, following~\citep{Zahnentferner18-UTxO} we define
 
-$$
-  \txunspent : \eutxotx \rightarrow \FinSet{\s{OutputRef}}
-  $$
-%
-  by
-%
-$$
-\txunspent(t) = \{(id,1), \ldots, (\mathit{id},\left|t.outputs\right|)\}
-$$
-\noindent (where $\mathit{id}$ is $t$'s unique \TxId{}), and
-%
-\[
-  \unspent : \mathsf{Ledger} \rightarrow \FinSet{\s{OutputRef}}
-\]
-%
-by
-%
-\begin{align*}
-   \unspent([]) &=\emptymap \\
-   \unspent(t::\lambda) &= (\unspent(\lambda) \setminus t.\inputs) \cup \txunspent(t).
-\end{align*}
-
-\noindent Note that for a completed transaction $t$, $t.\inputs$ is
-the set of previously unspent outputs which were spent by $t$.
-
-\medskip
-\noindent Given a ledger $\lambda$ and a transaction id $\id$, we
+Given a ledger $\lambda$ and a transaction id $\id$, we
 denote by $\lambda\langle\id\rangle$ the unique transaction $T$ in
-$\lambda$ with $\txId(T) = \id$, if it exists. In our abstract model
-where $\lambda$ consists of a list of transactions it would suffice to
-take $id$ to be the position of $T$ in $\lambda$, but in an
-implementation we would probably have $id = T^{\#}$.
+$\lambda$ with $\txId(T) = \id$, if it exists.
+\todompj{Make the failure handling explicit somehow.}
 
-\medskip
-\noindent Now given an input $i$ to some transaction in a ledger
-$\lambda$ we define
-$$
-\getvalue(i,\lambda) = \lambda\langle i.\outputref.\id \rangle.\outputs[i.\outputref.\idx].\val
-$$
-This function simply returns the value of the input.
-
-
-
-\bigskip
+Fig.~\ref{fig:validation-functions-1} defines some auxiliary functions used in validation.
+\begin{ruledfigure}{H}
+  \begin{displaymath}
+  \begin{array}{lll}
+  \multicolumn{3}{l}{\txunspent : \eutxotx \rightarrow \FinSet{\s{OutputRef}}}\\
+  \txunspent(t) &=& \{(\txId(t),1), \ldots, (\txId(id),\left|t.outputs\right|)\}\\
+  \\
+  \multicolumn{3}{l}{\unspent : \s{Ledger} \rightarrow \FinSet{\s{OutputRef}}}\\
+  \unspent([]) &=& \emptymap \\
+  \unspent(t::\lambda) &=& (\unspent(\lambda) \setminus t.\inputs) \cup \txunspent(t)\\
+  \\
+  \multicolumn{3}{l}{\getvalue : \TxId \times \s{Ledger} \rightarrow \eutxotx}\\
+  \getvalue(i,\lambda) &=& \lambda\langle i.\outputref.\id \rangle.\outputs[i.\outputref.\idx].\val
+  \end{array}
+  \end{displaymath}
+  \caption{Auxiliary functions for EUTXO-1 validation}
+  \label{fig:validation-functions-1}
+\end{ruledfigure}
 
 \noindent We can now define what it means for a transaction $t$ of
 type $\eutxotx$ to be valid for a ledger: see
 Figure~\ref{fig:eutxo-1-validity}.  Our definition combines
 Definitions 6 and 14 from \citep{Zahnentferner18-UTxO}, differing from
-the latter in condition \ref{rule:all-inputs-validate}.
+the latter in rule~\ref{rule:all-inputs-validate}.
 \todokwxm{Check this.}
 
 \begin{ruledfigure}{H}
@@ -856,17 +835,23 @@ Figure~\ref{fig:eutxo-1-validity} must also be updated to take account
 of multiple currencies.
 
 We use the definitions of \unspent{}  and
-\getvalue{} from Section~\ref{sec:eutxo-1-validity} unchanged,
+\getvalue{} from Figure~\ref{fig:validation-functions-1} unchanged,
 but we also require a function to inject a \qty{} of the native currency
-into \qtymap{}. We define:
+into \qtymap{}. We define it in Figure~\ref{fig:validation-functions-2}.
 \begin{displaymath}
-  \injectNative(q)(c)(t) = \left\{
+\end{displaymath}
+\begin{ruledfigure}{H}
+  \begin{displaymath}
+    \injectNative(q)(c)(t) = \left\{
     \begin{array}{ll}
       q & \mbox{if $c = \nativeCur$ and $t = \nativeTok$ }\\
       0 & \mbox{otherwise}
     \end{array}
-  \right\}
-\end{displaymath}
+    \right\}
+  \end{displaymath}
+  \caption{Auxiliary functions for EUTXO-2 validation}
+  \label{fig:validation-functions-2}
+\end{ruledfigure}
 
 We can now adapt the definition of validity for EUTXO-1
 (Figure~\ref{fig:eutxo-1-validity}) to obtain a definition of validity for

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -778,10 +778,13 @@ currency, as in EUTXO-1.
     \s{Output}_2 &=&(\addr: \s{Address},\\
                  & &\ \val: \qtymap\\
                  & &\ \valdata: \Data)\\
+    \\
     \s{OutputRef}_2 &= &(\txrefid: \s{TxId}, \idx: \s{Int})\\
+    \\
     \s{Input}_2 &=&( \i{outputRef}: \sf{OutputRef}_2,\\
                 & &\ \i{validator}: \script,\\
                 & &\ \i{redeemer}: \Data)\\
+    \\
     \eutxotx_2 &=&(\inputs: \FinSet{\s{Input}_2},\\
                & &\ \outputs: \List{\s{Output}_2},\\
                & &\ \i{validityInterval}: \Interval{\extended{\slotnum}},\\

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -650,7 +650,7 @@ the latter in rule~\ref{rule:all-inputs-validate}.
       \]
     \item\label{rule:validator-scripts-hash} \textbf{Validator scripts hash to their output addresses:}
     \[
-      \textrm{For all } i \in t.\inputs,\enspace i.\validator^{\#} = \txout(i, \lambda).\addr.
+      \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \txout(i, \lambda).\addr.
     \]
 \end{enumerate}
 \caption{Validity of a transaction $t$ in the EUTXO-1 model}
@@ -896,7 +896,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
       \]
     \item\label{rule:validator-scripts-hash-2} \textbf{Validator scripts hash to their output addresses:}
     \[
-      \textrm{For all } i \in t.\inputs,\enspace i.\validator^{\#} = \txout(i, \lambda).\addr.
+      \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \txout(i, \lambda).\addr.
     \]
   \end{enumerate}
   \caption{Validity of a transaction $t$ in the EUTXO-2 model}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -621,36 +621,51 @@ the latter in rule~\ref{rule:all-inputs-validate}.
 
 \begin{ruledfigure}{H}
 \begin{enumerate}
-    \item \label{rule:all-inputs-refer-to-unspent-outputs} \textbf{All
-      inputs refer to unspent outputs:}
-      \[
-        t.\inputs \subseteq \unspent(\lambda).
-      \]
-    \item\label{rule:forging} \textbf{Forging:}
-      \begin{center}
-        \parbox{0.8\textwidth}{ A transaction with a non-zero \forge{}
-          field is only valid if the ledger $\lambda$ is empty (that
-          is, if it is the initial transaction).}
-    \end{center}
 
-    \item \label{rule:value-is-preserved} \textbf{Value is preserved}:
-    \[
-      t.\forge + \sum_{i \in t.\inputs} \getSpent(i, \lambda).\val = t.\fee + \sum_{o \in t.\outputs} o.\val
-    \]
-    \item \label{rule:no-double-spending} \textbf{No output is double spent:}
-    \[
-     \textrm{If } i_1, i_2 \in t.\inputs \textrm{ and }  i_1.\outputref = i_2.\outputref
-     \textrm{ then } i_1 = i_2.
-    \]
-    \item\label{rule:all-inputs-validate} \textbf{All inputs validate:}
-    \[
+\item
+  \label{rule:all-inputs-refer-to-unspent-outputs}
+  \textbf{All inputs refer to unspent outputs:}
+  \begin{displaymath}
+    t.\inputs \subseteq \unspent(\lambda).
+  \end{displaymath}
+
+\item
+  \label{rule:forging}
+  \textbf{Forging:} \\
+    A transaction with a non-zero \forge{}
+    field is only valid if the ledger $\lambda$ is empty (that
+    is, if it is the initial transaction).
+
+\item
+  \label{rule:value-is-preserved}
+  \textbf{Value is preserved}:
+  \begin{displaymath}
+    t.\forge + \sum_{i \in t.\inputs} \getSpent(i, \lambda).\val = t.\fee + \sum_{o \in t.\outputs} o.\val
+  \end{displaymath}
+
+\item
+  \label{rule:no-double-spending}
+  \textbf{No output is double spent:}
+  \begin{displaymath}
+    \textrm{If } i_1, i_2 \in t.\inputs \textrm{ and }  i_1.\outputref = i_2.\outputref
+    \textrm{ then } i_1 = i_2.
+  \end{displaymath}
+
+\item
+  \label{rule:all-inputs-validate}
+  \textbf{All inputs validate:}
+  \begin{displaymath}
     \textrm{For all } i \in t.\inputs,\enspace \llbracket
     i.\validator\rrbracket (\getSpent(i, \lambda).\valdata,\, i.\redeemer,\,  \delta(\tau(t,i))) = \true.
-      \]
-    \item\label{rule:validator-scripts-hash} \textbf{Validator scripts hash to their output addresses:}
-    \[
-      \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
-    \]
+  \end{displaymath}
+
+\item
+  \label{rule:validator-scripts-hash}
+  \textbf{Validator scripts hash to their output addresses:}
+  \begin{displaymath}
+    \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
+  \end{displaymath}
+
 \end{enumerate}
 \caption{Validity of a transaction $t$ in the EUTXO-1 model}
 \label{fig:eutxo-1-validity}
@@ -857,50 +872,62 @@ We can now adapt the definition of validity for EUTXO-1
 EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
 
 \begin{ruledfigure}{H}
+\begin{enumerate}
+
+\item
+  \label{rule:all-inputs-refer-to-unspent-outputs-2}
+  \textbf{All inputs refer to unspent outputs:}
+  \begin{displaymath}
+    t.\inputs \subseteq \unspent(\lambda).
+  \end{displaymath}
+
+\item
+  \label{rule:forging-2}
+  \textbf{Forging:}\\
+  A transaction with a non-zero \forge{} field is only
+  valid if either:
   \begin{enumerate}
-    \item \label{rule:all-inputs-refer-to-unspent-outputs-2} \textbf{All
-      inputs refer to unspent outputs:}
-      \[
-        t.\inputs \subseteq \unspent(\lambda).
-      \]
-    \item \label{rule:forging-2} \textbf{Forging:}\\\\
-      \begin{minipage}{0.85\textwidth}
-        A transaction with a non-zero \forge{} field is only
-        valid if either:
-        \begin{enumerate}
-          \item the ledger $\lambda$ is empty (that is, if it is the initial transaction).
-          \item \label{rule:custom-forge}
-            for every key $h$ in $\support(t.\forge)$, there
-            exists $i \in t.\inputs$ and $(a,v,d) \in i.\outputs$ with
-            $a =h$; in other words, some input must spend an output
-            whose address is $h$.
-        \end{enumerate}
-      \end{minipage}
-    \item \textbf{Values are preserved}\\
-      \begin{minipage}{0.85\textwidth}
-          \label{rule:value-is-preserved-2}
-            \[
-            t.\forge + \sum_{i \in t.\inputs} \getSpent(i, \lambda) = \injectNative(t.\fee) + \sum_{o \in t.\outputs} o.\val
-            \]
-      \end{minipage}
-    \item \label{rule:no-double-spending-2} \textbf{No output is double spent:}
-    \[
-     \textrm{If } i_1, i_2 \in t.\inputs \textrm{ and }  i_1.\outputref = i_2.\outputref
-     \textrm{ then } i_1 = i_2.
-    \]
-    \item\label{rule:all-inputs-validate-2} \textbf{All inputs validate:}
-    \[
+    \item the ledger $\lambda$ is empty (that is, if it is the initial transaction).
+    \item \label{rule:custom-forge}
+      for every key $h$ in $\support(t.\forge)$, there
+      exists $i \in t.\inputs$ and $(a,v,d) \in i.\outputs$ with
+      $a =h$; in other words, some input must spend an output
+      whose address is $h$.
+  \end{enumerate}
+
+\item
+  \label{rule:value-is-preserved-2}
+  \textbf{Values are preserved}
+  \begin{displaymath}
+    t.\forge + \sum_{i \in t.\inputs} \getSpent(i, \lambda) = \injectNative(t.\fee) + \sum_{o \in t.\outputs} o.\val
+  \end{displaymath}
+
+\item
+  \label{rule:no-double-spending-2}
+  \textbf{No output is double spent:}
+  \begin{displaymath}
+    \textrm{If } i_1, i_2 \in t.\inputs \textrm{ and }  i_1.\outputref = i_2.\outputref
+    \textrm{ then } i_1 = i_2.
+  \end{displaymath}
+
+\item
+  \label{rule:all-inputs-validate-2}
+  \textbf{All inputs validate:}
+  \begin{displaymath}
     \textrm{For all } i \in t.\inputs,\enspace \llbracket
     i.\validator\rrbracket(\getSpent(i,\lambda).\valdata,\, i.\redeemer,\, \delta_2(\tau_2(t, i))) = \true
-      \]
-    \item\label{rule:validator-scripts-hash-2} \textbf{Validator scripts hash to their output addresses:}
-    \[
-      \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
-    \]
-  \end{enumerate}
-  \caption{Validity of a transaction $t$ in the EUTXO-2 model}
-  \label{fig:eutxo-2-validity}
+  \end{displaymath}
 
+\item
+  \label{rule:validator-scripts-hash-2}
+  \textbf{Validator scripts hash to their output addresses:}
+  \begin{displaymath}
+    \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
+  \end{displaymath}
+
+\end{enumerate}
+\caption{Validity of a transaction $t$ in the EUTXO-2 model}
+\label{fig:eutxo-2-validity}
 \end{ruledfigure}
 
 \noindent If any of the indexing operations here fail then the

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -102,7 +102,7 @@
 
 % Macros for eutxo things.
 \newcommand{\TxId}{\ensuremath{\s{TxId}}}
-\newcommand{\txId}{\msf{txid}}
+\newcommand{\txId}{\msf{txId}}
 \newcommand{\txrefid}{\mi{id}}
 \newcommand{\Address}{\ensuremath{\s{Address}}}
 \newcommand{\idx}{\mi{index}}
@@ -115,14 +115,14 @@
 
 \newcommand{\validator}{\mi{validator}}
 \newcommand{\redeemer}{\mi{redeemer}}
-\newcommand{\valdata}{\mi{valdata}}
+\newcommand{\valdata}{\mi{valData}}
 \newcommand{\Data}{\ensuremath{\s{Data}}}
 
 \newcommand{\outputref}{\mi{outputRef}}
 \newcommand{\txin}{\mi{in}}
 \newcommand{\txout}{\mi{out}}
 \newcommand{\id}{\mi{id}}
-\newcommand{\getvalue}{\msf{getvalue}}
+\newcommand{\getvalue}{\msf{getValue}}
 
 \newcommand{\slotnum}{\ensuremath{\s{SlotNumber}}}
 \newcommand{\spent}{\msf{spentOutputs}}
@@ -422,15 +422,15 @@ the ledger.
     \Data \rightarrow \B && \mbox{applying a script to its arguments}\\
     \\
     \multicolumn{3}{l}{\textsc{Defined types}}\\
-    \s{Output } &=&(\addr: \s{Address},\\
-                & &\ \i{value}: \qty,\\
+    \s{Output } &=&(\addr: Address,\\
+                & &\ \val: \qty,\\
                 & &\ \valdata: \Data)\\
     \\
     \s{OutputRef } &=&(\txrefid: \TxId, \idx: \s{Int})\\
     \\
-    \s{Input } &=&(\i{outputRef}: \s{OutputRef},\\
-               & &\ \i{validator}: \script,\\
-               & &\ \i{redeemer}: \Data)\\
+    \s{Input } &=&(\outputref: \s{OutputRef},\\
+               & &\ \validator: \script,\\
+               & &\ \redeemer: \Data)\\
      \\
      \eutxotx\s{ } &=&(\inputs: \FinSet{\s{Input}},\\
                    & &\ \outputs: \List{\s{Output}},\\
@@ -523,14 +523,14 @@ related types.
 \begin{ruledfigure}{H}
   \begin{displaymath}
   \begin{array}{rll}
-    \s{OutputInfo } &=&(\i{value}: \qty,\\
-                    & &\ \i{validatorHash}: \s{Address},\\
+    \s{OutputInfo } &=&(\val: \qty,\\
+                    & &\ \i{validatorHash}: \Address,\\
                     & &\ \valdata: \Data)\\
     \\
-    \s{InputInfo } &=&(\i{inputRef}: \s{OutputRef},\\
+    \s{InputInfo } &=&(\outputref: \s{OutputRef},\\
                    & &\ \i{validatorHash}: \s{Address},\\
                    & &\ \i{redeemerHash}: \s{Address},\\
-                   & &\ \i{value}: \qty)\\
+                   & &\ \val: \qty)\\
      \\
      \ptx\s{ } &=&(\i{inputInfo}: \List{\s{InputInfo}},\\
                & &\ \i{thisInput}: \N,\\
@@ -661,7 +661,7 @@ the latter in condition \ref{rule:all-inputs-validate}.
     \]
     \item \label{rule:no-double-spending} \textbf{No output is double spent:}
     \[
-     \textrm{If } i_1, i_2 \in t.\inputs \textrm{ and }  i_1.\mathit{outputRef} = i_2.\mathit{outputRef}
+     \textrm{If } i_1, i_2 \in t.\inputs \textrm{ and }  i_1.\outputref = i_2.\outputref
      \textrm{ then } i_1 = i_2.
     \]
     \item\label{rule:all-inputs-validate} \textbf{All inputs validate:}
@@ -755,15 +755,15 @@ currency, as in EUTXO-1.
     \qtymap   &=& \FinSup{\currency}{\FinSup{\token}{\qty}}\\
     \qtymappm &=& \FinSup{\currency}{\FinSup{\token}{\qtypm}}\\
     \\
-    \s{Output}_2 &=&(\addr: \s{Address},\\
+    \s{Output}_2 &=&(\addr: \Address,\\
                  & &\ \val: \qtymap\\
                  & &\ \valdata: \Data)\\
     \\
-    \s{OutputRef}_2 &= &(\txrefid: \s{TxId}, \idx: \s{Int})\\
+    \s{OutputRef}_2 &= &(\txrefid: \TxId, \idx: \s{Int})\\
     \\
-    \s{Input}_2 &=&( \i{outputRef}: \sf{OutputRef}_2,\\
-                & &\ \i{validator}: \script,\\
-                & &\ \i{redeemer}: \Data)\\
+    \s{Input}_2 &=&( \outputref: \sf{OutputRef}_2,\\
+                & &\ \validator: \script,\\
+                & &\ \redeemer: \Data)\\
     \\
     \eutxotx_2 &=&(\inputs: \FinSet{\s{Input}_2},\\
                & &\ \outputs: \List{\s{Output}_2},\\
@@ -823,14 +823,14 @@ the details are given in Figure~\ref{fig:ptx-2-types}.
 \begin{ruledfigure}{H}
   \begin{displaymath}
   \begin{array}{rll}
-    \s{OutputInfo}_2\s{ } &=&(\i{value}: \qtymap,\\
+    \s{OutputInfo}_2\s{ } &=&(\val: \qtymap,\\
                           & &\ \i{validatorHash}: \s{Address},\\
                           & &\ \i{datascriptHash}: \s{Address})\\
     \\
-    \s{InputInfo}_2\s{ } &=& (\i{inputRef}: \s{OutputRef},\\
+    \s{InputInfo}_2\s{ } &=& (\outputref: \s{OutputRef},\\
                          & &\ \i{validatorHash}: \s{Address},\\
                          & &\ \i{redeemerHash}: \s{Address}),\\
-                         & &\ \i{value}: \qtymap)\\
+                         & &\ \val: \qtymap)\\
      \\
      \ptx_2\s{ } &=&(\i{inputInfo}: \List{\s{InputInfo}_2},\\
                  & &\ \i{thisInput}: \N,\\
@@ -901,7 +901,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
       \end{minipage}
     \item \label{rule:no-double-spending-2} \textbf{No output is double spent:}
     \[
-     \textrm{If } i_1, i_2 \in t.\inputs \textrm{ and }  i_1.\mathit{outputRef} = i_2.\mathit{outputRef}
+     \textrm{If } i_1, i_2 \in t.\inputs \textrm{ and }  i_1.\outputref = i_2.\outputref
      \textrm{ then } i_1 = i_2.
     \]
     \item\label{rule:all-inputs-validate-2} \textbf{All inputs validate:}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -270,34 +270,6 @@ conventions used in the remainder of the document.
 %The concatenation of two lists $\lambda_1$ and $\lambda_2$
 %  is denoted $\lambda_1 ::: \lambda_2$.
 
-\item For two types $K$ and $V$ where $V$ is a monoid, $\FinSup{K}{V}$ denotes the type of
-  \textit{finitely-supported functions} from $K$ to $V$. That is, there is a
-  function $\support : \FinSup{K}{V} \rightarrow \FinSet{K}$ such that
-  $k \in \support(f) \Leftrightarrow f(k) \neq 0$.
-
-  Equality on finitely-supported functions is defined as pointwise equality.
-
-  If the type $M$ is a monoid then we define the sum of two finitely-supported
-  functions
-  $f, g \in \FinSup{K}{M}$ to be the function $f+g \in \FinSup{K}{M}$ with
-  support $\support (f+g) = \support(f) \cup \support(g)$ given by
-  \[(f+g)(k) = f(k) + g(k) \]
-  We generalise this to the sum of a finite number of maps using
-  the $\sum$ notation in the usual way; care is required if
-  $+$ is non-commutative, since then the sum of a number of
-  functions will depend on the order in which they appear. Note that
-  the type $\FinSup{K}{M}$ itself becomes a monoid under the
-  operation $+$ which we have just defined, with the empty function as
-  identity element.
-
-  If the type $M$ is a group, then we can
-  similarly define the inverse of a finitely-supported function $f$ as
-  the function $(-f)$ with the same support, given by
-  \[ (-f)(k) = -f(k) \]
-
-  See note~\ref{note:finitely-supported-functions} for discussion of using
-  finitely-supported functions computationally.
-
 \item $x \mapsto f(x)$ denotes an anonymous function.
 
 \item A cryptographic collision-resistant hash of a value $c$ is denoted $c^{\#}$.
@@ -309,6 +281,37 @@ conventions used in the remainder of the document.
   of intervals over that type, whose endpoints may be either closed or open.
   The type $\Interval{A}$ forms a lattice.
 \end{itemize}
+
+\subsection {Finitely supported functions}
+\label{sec:fsfs}
+
+For two types $K$ and $V$ where $V$ is a monoid, $\FinSup{K}{V}$ denotes the type of
+\textit{finitely-supported functions} from $K$ to $V$. That is, there is a
+function $\support : \FinSup{K}{V} \rightarrow \FinSet{K}$ such that
+$k \in \support(f) \Leftrightarrow f(k) \neq 0$.
+
+Equality on finitely-supported functions is defined as pointwise equality.
+
+If the type $M$ is a monoid then we define the sum of two finitely-supported
+functions
+$f, g \in \FinSup{K}{M}$ to be the function $f+g \in \FinSup{K}{M}$ with
+support $\support (f+g) = \support(f) \cup \support(g)$ given by
+\[(f+g)(k) = f(k) + g(k) \]
+We generalise this to the sum of a finite number of maps using
+the $\sum$ notation in the usual way; care is required if
+$+$ is non-commutative, since then the sum of a number of
+functions will depend on the order in which they appear. Note that
+the type $\FinSup{K}{M}$ itself becomes a monoid under the
+operation $+$ which we have just defined, with the empty function as
+identity element.
+
+If the type $M$ is a group, then we can
+similarly define the inverse of a finitely-supported function $f$ as
+the function $(-f)$ with the same support, given by
+\[ (-f)(k) = -f(k) \]
+
+See note~\ref{note:finitely-supported-functions} for discussion of using
+finitely-supported functions computationally.
 
 \subsection{The \Data{} type}
 We also define a type \Data{} which can be used to pass information
@@ -940,7 +943,7 @@ transaction is invalid.
 
 \paragraph{Note.} In rule~\ref{rule:value-is-preserved-2},
 $+$ and $\sum$ are the sum of finitely-supported functions as defined in
-Section~\ref{sec:basic-notation}. Essentially we require that the
+Section~\ref{sec:fsfs}. Essentially we require that the
 quantities of each of the individual custom currencies involved in the
 transaction are preserved. Recall that values in $\forge$ can
 be negative whereas values in outputs must be non-negative.  Thus

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -640,28 +640,28 @@ the latter in rule~\ref{rule:all-inputs-validate}.
 
 \item
   \label{rule:all-inputs-refer-to-unspent-outputs}
-  \textbf{All inputs refer to unspent outputs:}
+  \textbf{All inputs refer to unspent outputs}
   \begin{displaymath}
     t.\inputs \subseteq \unspent(\lambda).
   \end{displaymath}
 
 \item
   \label{rule:forging}
-  \textbf{Forging:} \\
+  \textbf{Forging} \\
     A transaction with a non-zero \forge{}
     field is only valid if the ledger $\lambda$ is empty (that
     is, if it is the initial transaction).
 
 \item
   \label{rule:value-is-preserved}
-  \textbf{Value is preserved}:
+  \textbf{Value is preserved}
   \begin{displaymath}
     t.\forge + \sum_{i \in t.\inputs} \getSpent(i, \lambda).\val = t.\fee + \sum_{o \in t.\outputs} o.\val
   \end{displaymath}
 
 \item
   \label{rule:no-double-spending}
-  \textbf{No output is double spent:}
+  \textbf{No output is double spent}
   \begin{displaymath}
     \textrm{If } i_1, i_2 \in t.\inputs \textrm{ and }  i_1.\outputref = i_2.\outputref
     \textrm{ then } i_1 = i_2.
@@ -669,7 +669,7 @@ the latter in rule~\ref{rule:all-inputs-validate}.
 
 \item
   \label{rule:all-inputs-validate}
-  \textbf{All inputs validate:}
+  \textbf{All inputs validate}
   \begin{displaymath}
     \textrm{For all } i \in t.\inputs,\enspace \llbracket
     i.\validator\rrbracket (\getSpent(i, \lambda).\valdata,\, i.\redeemer,\,  \delta(\tau(t,i))) = \true.
@@ -677,7 +677,7 @@ the latter in rule~\ref{rule:all-inputs-validate}.
 
 \item
   \label{rule:validator-scripts-hash}
-  \textbf{Validator scripts match output addresses:}
+  \textbf{Validator scripts match output addresses}
   \begin{displaymath}
     \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
   \end{displaymath}
@@ -891,14 +891,14 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
 
 \item
   \label{rule:all-inputs-refer-to-unspent-outputs-2}
-  \textbf{All inputs refer to unspent outputs:}
+  \textbf{All inputs refer to unspent outputs}
   \begin{displaymath}
     t.\inputs \subseteq \unspent(\lambda).
   \end{displaymath}
 
 \item
   \label{rule:forging-2}
-  \textbf{Forging:}\\
+  \textbf{Forging}\\
   A transaction with a non-zero \forge{} field is only
   valid if either:
   \begin{enumerate}
@@ -919,7 +919,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
 
 \item
   \label{rule:no-double-spending-2}
-  \textbf{No output is double spent:}
+  \textbf{No output is double spent}
   \begin{displaymath}
     \textrm{If } i_1, i_2 \in t.\inputs \textrm{ and }  i_1.\outputref = i_2.\outputref
     \textrm{ then } i_1 = i_2.
@@ -927,7 +927,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
 
 \item
   \label{rule:all-inputs-validate-2}
-  \textbf{All inputs validate:}
+  \textbf{All inputs validate}
   \begin{displaymath}
     \textrm{For all } i \in t.\inputs,\enspace \llbracket
     i.\validator\rrbracket(\getSpent(i,\lambda).\valdata,\, i.\redeemer,\, \delta_2(\tau_2(t, i))) = \true
@@ -935,7 +935,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
 
 \item
   \label{rule:validator-scripts-hash-2}
-  \textbf{Validator scripts match output addresses:}
+  \textbf{Validator scripts match output addresses}
   \begin{displaymath}
     \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
   \end{displaymath}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -80,26 +80,6 @@
 \newcommand{\msf}[1]{\ensuremath{\mathsf{#1}}}
 \newcommand{\mi}[1]{\ensuremath{\mathit{#1}}}
 
-\newenvironment{arraydefs}[1]{\setlength{\arraycolsep}{0pt}\begin{array}{#1}}{\end{array}}
-%
-% This is just the array environment with the column separation set to 0.
-% This is to enable us to get things like
-%
-%%   X = (field1: type1,
-%         field2: type2,
-%         ...
-%
-% without a space after the ')'. Unfortunately you have to manually insert a space
-% at the end of the X so you don't get X=
-% There's presumably a better way to do this.
-%
-% You can also use something like
-%
-%    \begin{tabular}{r@{ }l@{}l} ...
-%
-% but the spacing is arguably worse.
-
-
 %% A figure with rules above and below.
 \newcommand\rfskip{7pt}
 \newenvironment{ruledfigure}[1]{\begin{figure}[#1]\hrule\vspace{\rfskip}}{\vspace{\rfskip}\hrule\end{figure}}
@@ -326,7 +306,7 @@ conventions used in the remainder of the document.
 \end{ruledfigure}
 
 \noindent We regard $\N$ as a subtype of $\Z$ and convert freely between
-natural numbers and non-negative integers (hence also \qty{} and \qtypm{}).
+natural numbers and non-negative integers.
 A bytestring is a sequence
 of 8-bit bytes: the symbol $\H$ is used because bytestrings are often
 presented as sequences of hexadecimal digits.
@@ -438,8 +418,9 @@ The definitions in this section are essentially the definitions of
 UTXO-based cryptocurrencies with scripts from
 \citep{Zahnentferner18-UTxO}, except that we have added the new
 features mentioned above (the validity interval, the validation data
-and the \ptx{} structure) and changed the type of the redeemer from
-\script{} to \Data{}.
+and the \ptx{} structure), changed the type of the redeemer from
+\script{} to \Data{}, and used finitely-supported functions in place
+of maps.
 
 Figure~\ref{fig:eutxo-1-types} lists the types and operations used in the
 the basic EUTXO model. Some of these are defined, the others must be provided by
@@ -461,21 +442,21 @@ the ledger.
     \Data \rightarrow \B &=& \mbox{applying a script to its arguments}\\
     \\
     \multicolumn{3}{l}{\textsc{Defined types}}\\
-    \s{Output } &= (&\addr: \s{Address},\\
-    && \i{value}: \qty,\\
-    &&  \valdata: \Data)\\
+    \s{Output } &=&(\addr: \s{Address},\\
+                & &\ \i{value}: \qty,\\
+                & &\ \valdata: \Data)\\
     \\
-    \s{OutputRef } &= (&\txrefid: \TxId, \idx: \s{Int})\\
+    \s{OutputRef } &=&(\txrefid: \TxId, \idx: \s{Int})\\
     \\
-    \s{Input } & = (&\i{outputRef}: \s{OutputRef},\\
-                 && \i{validator}: \script,\\
-                 && \i{redeemer}: \Data)\\
+    \s{Input } &=&(\i{outputRef}: \s{OutputRef},\\
+               & &\ \i{validator}: \script,\\
+               & &\ \i{redeemer}: \Data)\\
      \\
-     \eutxotx\s{ } &= (&\inputs: \FinSet{\s{Input}},\\
-     &&\outputs: \List{\s{Output}},\\
-     &&\i{validityInterval}: \Interval{\extended{\slotnum}},\\
-     && \fee: \qty,\\
-     &&\forge: \qty) \\
+     \eutxotx\s{ } &=&(\inputs: \FinSet{\s{Input}},\\
+                   & &\ \outputs: \List{\s{Output}},\\
+                   & &\ \i{validityInterval}: \Interval{\extended{\slotnum}},\\
+                   & &\ \fee: \qty,\\
+                   & &\ \forge: \qty) \\
      \\
      \s{Ledger } &=&\!\List{\eutxotx}\\
   \end{array}
@@ -551,21 +532,21 @@ related types.
 \begin{ruledfigure}{H}
   \begin{displaymath}
   \begin{array}{rll}
-    \s{OutputInfo } &= (& \i{value}: \qty,\\
-    && \i{validatorHash}: \s{Address},\\
-    &&  \valdata: \Data)\\
+    \s{OutputInfo } &=&(\i{value}: \qty,\\
+                    & &\ \i{validatorHash}: \s{Address},\\
+                    & &\ \valdata: \Data)\\
     \\
-    \s{InputInfo } & = (&\i{inputRef}: \s{OutputRef},\\
-                 && \i{validatorHash}: \s{Address},\\
-                 && \i{redeemerHash}: \s{Address},\\
-                 && \i{value}: \qty)\\
+    \s{InputInfo } &=&(\i{inputRef}: \s{OutputRef},\\
+                   & &\ \i{validatorHash}: \s{Address},\\
+                   & &\ \i{redeemerHash}: \s{Address},\\
+                   & &\ \i{value}: \qty)\\
      \\
-     \ptx\s{ } &= (&\i{inputInfo}: \List{\s{InputInfo}},\\
-     &&\i{thisInput}: \N,\\
-     &&\i{outputInfo}: \List{\s{OutputInfo}},\\
-     &&\i{validityInterval}: \Interval{\extended{\slotnum}},\\
-     && \fee: \qty,\\
-     &&\forge: \qty)\\
+     \ptx\s{ } &=&(\i{inputInfo}: \List{\s{InputInfo}},\\
+               & &\ \i{thisInput}: \N,\\
+               & &\ \i{outputInfo}: \List{\s{OutputInfo}},\\
+               & &\ \i{validityInterval}: \Interval{\extended{\slotnum}},\\
+               & &\ \fee: \qty,\\
+               & &\ \forge: \qty)\\
      \\
      \tau: \eutxotx \times \N \rightarrow \ptx &=& \mbox{summarises a transaction}\\
      \delta: \ptx \rightarrow \Data &=& \mbox{encodes a \ptx{}}
@@ -774,27 +755,27 @@ currency, as in EUTXO-1.
   \begin{displaymath}
     \begin{array}{rll}
     \multicolumn{3}{l}{\textsc{Ledger primitives}}\\
-    \currency &=& \mbox{an identifier for a custom currency}\\
+    \currency  &=& \mbox{an identifier for a custom currency}\\
     \nativeCur &=& \mbox{a distinguished \currency{} representing the native currency of the ledger}\\
-    \token   &=& \mbox{a type consisting of identifiers for individual tokens}\\
+    \token     &=& \mbox{a type consisting of identifiers for individual tokens}\\
     \nativeTok &=& \mbox{a distinguished \token{} representing the currency token of the native currency}\\
     \\
     \multicolumn{3}{l}{\textsc{Defined types}}\\
     \qtymap   &=& \FinSup{\currency}{\FinSup{\token}{\qty}}\\
     \qtymappm &=& \FinSup{\currency}{\FinSup{\token}{\qtypm}}\\
     \\
-    \s{Output}_2 &= (&\addr: \s{Address},\\
-            && \val: \qtymap\\
-            && \valdata: \Data)\\
-    \s{OutputRef}_2 &= (&\txrefid: \s{TxId}, \idx: \s{Int})\\
-    \s{Input}_2 &= (& \i{outputRef}: \sf{OutputRef}_2,\\
-            && \i{validator}: \script,\\
-            & & \i{redeemer}: \Data)\\
-    \eutxotx_2 &= ( &\inputs: \FinSet{\s{Input}_2},\\
-            &&\outputs: \List{\s{Output}_2},\\
-            &&\i{validityInterval}: \Interval{\extended{\slotnum}},\\
-            &&\fee: \qty,\\
-            &&\forge: \qtymap^{\pm})\\
+    \s{Output}_2 &=&(\addr: \s{Address},\\
+                 & &\ \val: \qtymap\\
+                 & &\ \valdata: \Data)\\
+    \s{OutputRef}_2 &= &(\txrefid: \s{TxId}, \idx: \s{Int})\\
+    \s{Input}_2 &=&( \i{outputRef}: \sf{OutputRef}_2,\\
+                & &\ \i{validator}: \script,\\
+                & &\ \i{redeemer}: \Data)\\
+    \eutxotx_2 &=&(\inputs: \FinSet{\s{Input}_2},\\
+               & &\ \outputs: \List{\s{Output}_2},\\
+               & &\ \i{validityInterval}: \Interval{\extended{\slotnum}},\\
+               & &\ \fee: \qty,\\
+               & &\ \forge: \qtymap^{\pm})\\
     \\
     \s{Ledger}_2 &=&\!\List{\eutxotx_2}\\
     \end{array}
@@ -837,21 +818,21 @@ the details are given in Figure~\ref{fig:ptx-2-types}.
 \begin{ruledfigure}{H}
   \begin{displaymath}
   \begin{array}{rll}
-    \s{OutputInfo}_2\s{ } &= (& \i{value}: \qtymap,\\
-    && \i{validatorHash}: \s{Address},\\
-    &&  \i{datascriptHash}: \s{Address})\\
+    \s{OutputInfo}_2\s{ } &=&(\i{value}: \qtymap,\\
+                          & &\ \i{validatorHash}: \s{Address},\\
+                          & &\ \i{datascriptHash}: \s{Address})\\
     \\
-    \s{InputInfo}_2\s{ }& = (&\i{inputRef}: \s{OutputRef},\\
-                 && \i{validatorHash}: \s{Address},\\
-                 && \i{redeemerHash}: \s{Address}),\\
-                 && \i{value}: \qtymap)\\
+    \s{InputInfo}_2\s{ } &=& (\i{inputRef}: \s{OutputRef},\\
+                         & &\ \i{validatorHash}: \s{Address},\\
+                         & &\ \i{redeemerHash}: \s{Address}),\\
+                         & &\ \i{value}: \qtymap)\\
      \\
-     \ptx_2\s{ } &= (&\i{inputInfo}: \List{\s{InputInfo}_2},\\
-     &&\i{thisInput}: \N,\\
-     &&\i{outputInfo}: \List{\s{OutputInfo$_2$}},\\
-     &&\i{validityInterval}: \Interval{\extended{\slotnum}},\\
-     &&\fee: \qty,\\
-     &&\forge: \qtymap)
+     \ptx_2\s{ } &=&(\i{inputInfo}: \List{\s{InputInfo}_2},\\
+                 & &\ \i{thisInput}: \N,\\
+                 & &\ \i{outputInfo}: \List{\s{OutputInfo$_2$}},\\
+                 & &\ \i{validityInterval}: \Interval{\extended{\slotnum}},\\
+                 & &\ \fee: \qty,\\
+                 & &\ \forge: \qtymap)
   \end{array}
   \end{displaymath}
   \caption{The \ptx{} type for the EUTXO-2 model}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -120,9 +120,8 @@
 
 \newcommand{\outputref}{\mi{outputRef}}
 \newcommand{\txin}{\mi{in}}
-\newcommand{\txout}{\mi{out}}
 \newcommand{\id}{\mi{id}}
-\newcommand{\getvalue}{\msf{getValue}}
+\newcommand{\getSpent}{\msf{getSpentOutput}}
 
 \newcommand{\slotnum}{\ensuremath{\s{SlotNumber}}}
 \newcommand{\spent}{\msf{spentOutputs}}
@@ -605,8 +604,8 @@ Fig.~\ref{fig:validation-functions-1} defines some auxiliary functions used in v
   \unspent([]) &=& \emptymap \\
   \unspent(t::\lambda) &=& (\unspent(\lambda) \setminus t.\inputs) \cup \txunspent(t)\\
   \\
-  \multicolumn{3}{l}{\getvalue : \s{Input} \times \s{Ledger} \rightarrow \qty}\\
-  \getvalue(i,\lambda) &=& \lambda\langle i.\outputref.\id \rangle.\outputs[i.\outputref.\idx].\val
+  \multicolumn{3}{l}{\getSpent : \s{Input} \times \s{Ledger} \rightarrow \s{Output}}\\
+  \getSpent(i,\lambda) &=& \lambda\langle i.\outputref.\id \rangle.\outputs[i.\outputref.\idx]
   \end{array}
   \end{displaymath}
   \caption{Auxiliary functions for EUTXO-1 validation}
@@ -636,7 +635,7 @@ the latter in rule~\ref{rule:all-inputs-validate}.
 
     \item \label{rule:value-is-preserved} \textbf{Value is preserved}:
     \[
-      t.\forge + \sum_{i \in t.\inputs} \getvalue(i, \lambda) = t.\fee + \sum_{o \in t.\outputs} o.\val.
+      t.\forge + \sum_{i \in t.\inputs} \getSpent(i, \lambda).\val = t.\fee + \sum_{o \in t.\outputs} o.\val
     \]
     \item \label{rule:no-double-spending} \textbf{No output is double spent:}
     \[
@@ -646,11 +645,11 @@ the latter in rule~\ref{rule:all-inputs-validate}.
     \item\label{rule:all-inputs-validate} \textbf{All inputs validate:}
     \[
     \textrm{For all } i \in t.\inputs,\enspace \llbracket
-    i.\validator\rrbracket (\txout(i, \lambda).\valdata,\, i.\redeemer,\,  \delta(\tau(t,i))) = \true.
+    i.\validator\rrbracket (\getSpent(i, \lambda).\valdata,\, i.\redeemer,\,  \delta(\tau(t,i))) = \true.
       \]
     \item\label{rule:validator-scripts-hash} \textbf{Validator scripts hash to their output addresses:}
     \[
-      \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \txout(i, \lambda).\addr.
+      \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
     \]
 \end{enumerate}
 \caption{Validity of a transaction $t$ in the EUTXO-1 model}
@@ -835,7 +834,7 @@ Figure~\ref{fig:eutxo-1-validity} must also be updated to take account
 of multiple currencies.
 
 We use the definitions of \unspent{}  and
-\getvalue{} from Figure~\ref{fig:validation-functions-1} unchanged,
+\getSpent{} from Figure~\ref{fig:validation-functions-1} unchanged,
 but we also require a function to inject a \qty{} of the native currency
 into \qtymap{}. We define it in Figure~\ref{fig:validation-functions-2}.
 \begin{displaymath}
@@ -881,7 +880,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
       \begin{minipage}{0.85\textwidth}
           \label{rule:value-is-preserved-2}
             \[
-            t.\forge + \sum_{i \in t.\inputs} \getvalue(i, \lambda) = \injectNative(t.\fee) + \sum_{o \in t.\outputs} o.\val
+            t.\forge + \sum_{i \in t.\inputs} \getSpent(i, \lambda) = \injectNative(t.\fee) + \sum_{o \in t.\outputs} o.\val
             \]
       \end{minipage}
     \item \label{rule:no-double-spending-2} \textbf{No output is double spent:}
@@ -892,11 +891,11 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
     \item\label{rule:all-inputs-validate-2} \textbf{All inputs validate:}
     \[
     \textrm{For all } i \in t.\inputs,\enspace \llbracket
-    i.\validator\rrbracket(\txout(i,\lambda).\valdata,\, i.\redeemer,\, \delta_2(\tau_2(t, i))) = \true.
+    i.\validator\rrbracket(\getSpent(i,\lambda).\valdata,\, i.\redeemer,\, \delta_2(\tau_2(t, i))) = \true
       \]
     \item\label{rule:validator-scripts-hash-2} \textbf{Validator scripts hash to their output addresses:}
     \[
-      \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \txout(i, \lambda).\addr.
+      \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
     \]
   \end{enumerate}
   \caption{Validity of a transaction $t$ in the EUTXO-2 model}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -1120,7 +1120,7 @@ restrict the creation of the currency to owners of particular public
 keys.
 
 The idea is that a custom currency has a monetary policy which is
-defined by some script $H$, and the hash $h = H^{\#}$ is used as the
+defined by some script $H$, and the hash $h = \scriptAddr(H)$ is used as the
 identifier of the currency.
 
 Whenever a new quantity of the currency is forged,

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -605,7 +605,7 @@ Fig.~\ref{fig:validation-functions-1} defines some auxiliary functions used in v
   \unspent([]) &=& \emptymap \\
   \unspent(t::\lambda) &=& (\unspent(\lambda) \setminus t.\inputs) \cup \txunspent(t)\\
   \\
-  \multicolumn{3}{l}{\getvalue : \TxId \times \s{Ledger} \rightarrow \eutxotx}\\
+  \multicolumn{3}{l}{\getvalue : \s{Input} \times \s{Ledger} \rightarrow \qty}\\
   \getvalue(i,\lambda) &=& \lambda\langle i.\outputref.\id \rangle.\outputs[i.\outputref.\idx].\val
   \end{array}
   \end{displaymath}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -461,20 +461,31 @@ the ledger.
      \s{Ledger } &=&\!\List{\eutxotx}\\
   \end{array}
   \end{displaymath}
-  \caption{Types for the EUTXO-1 model}
+  \caption{Primitives for the EUTXO-1 model}
   \label{fig:eutxo-1-types}
 \end{ruledfigure}
 
-\noindent A simple model of these primitives takes:
-\begin{itemize}
-  \item $\qty = \N$
-  \item $\qtypm = \Z$
-  \item $\slotnum = \N$
-  \item $\Address = \H$
-  \item $\TxId = \H$
-  \item $\txId = \textrm{the hash of the transaction}$
-  \item $\scriptAddr = \textrm{the hash of the script}$
-\end{itemize}
+The Cardano implementation of EUTXO-1 uses the primitives given in
+Fig.~\ref{fig:eutxo-1-types-cardano}.
+
+\begin{ruledfigure}{H}
+  \begin{displaymath}
+  \begin{array}{rll}
+    \qty{} &=& \N\\
+    \qtypm &=& \Z\\
+    \slotnum &=& \N\\
+    \Address &=& \H\\
+    \TxId &=& \H\\
+    \txId : \eutxotx \rightarrow \TxId &=& \mbox{the hash of the transaction}\\
+    \script &=& \mbox{a Plutus Core program}\\
+    \scriptAddr : \script \rightarrow \Address &=& \mbox{the hash of the program}\\
+    \llbracket \cdots \rrbracket : \script \rightarrow \Data \times \Data \times
+    \Data \rightarrow \B &=& \mbox{running the Plutus Core interpreter}\\
+  \end{array}
+  \end{displaymath}
+  \caption{Cardano primitives for the EUTXO-1 model}
+  \label{fig:eutxo-1-types-cardano}
+\end{ruledfigure}
 
 \subsubsection{Remarks}
 \paragraph{Quantities. }
@@ -548,7 +559,7 @@ related types.
                & &\ \fee: \qty,\\
                & &\ \forge: \qty)\\
      \\
-     \tau: \eutxotx \times \N \rightarrow \ptx &=& \mbox{summarises a transaction}\\
+     \tau: \eutxotx \times \N \rightarrow \ptx &=& \mbox{summarises a transaction in the context of an input}\\
      \delta: \ptx \rightarrow \Data &=& \mbox{encodes a \ptx{}}
   \end{array}
   \end{displaymath}
@@ -784,13 +795,20 @@ currency, as in EUTXO-1.
   \label{fig:eutxo-2-types}
 \end{ruledfigure}
 
-A simple implementation would take:
-\begin{itemize}
-\item $\currency = \H$
-\item $\token = \H$
-\item $\nativeCur = \textrm{empty bytestring}$
-\item $\nativeTok = \textrm{empty bytestring}$
-\end{itemize}
+The Cardano implementation of EUTXO-2 uses the primitives given in
+Fig.~\ref{fig:eutxo-2-types-cardano}.
+\begin{ruledfigure}{H}
+  \begin{displaymath}
+    \begin{array}{rll}
+      \currency  &=& \H\\
+      \nativeCur &=& \mbox{the empty bytestring}\\
+      \token     &=& \H\\
+      \nativeTok &=& \mbox{the empty bytestring}\\
+    \end{array}
+  \end{displaymath}
+  \caption{Cardano primitives for the EUTXO-1 model}
+  \label{fig:eutxo-2-types-cardano}
+\end{ruledfigure}
 
 \subsubsection{Remarks}
 \paragraph{Quantity maps. }
@@ -808,6 +826,10 @@ Quantities of the native currency are represented just like any other currency,
 using \qtymap{}s with the \nativeCur{} identifier. The one exception is the
 \fee{} field, which continues to be a simple \qty{}. This represents a quantity
 in the native currency, as fees can only be paid in that.
+
+It may be desirable to choose \nativeCur{} outside the range
+of \scriptAddr{}, since this will prevent forging of the native currency
+except in the initial transaction (see rule~\ref{rule:forging-2}).
 
 \subsection{The \ptx{} type for EUTXO-2}
 \label{sec:pendingtx-2}
@@ -832,23 +854,15 @@ the details are given in Figure~\ref{fig:ptx-2-types}.
                  & &\ \i{outputInfo}: \List{\s{OutputInfo$_2$}},\\
                  & &\ \i{validityInterval}: \Interval{\extended{\slotnum}},\\
                  & &\ \fee: \qty,\\
-                 & &\ \forge: \qtymap)
+                 & &\ \forge: \qtymap)\\
+    \\
+    \tau_2: \eutxotx_2 \times \N \rightarrow \ptx_2 &=& \mbox{summarises a transaction in the context of an input}\\
+    \delta_2: \ptx_2 \rightarrow \Data &=& \mbox{encodes a $\ptx_2$}
   \end{array}
   \end{displaymath}
   \caption{The \ptx{} type for the EUTXO-2 model}
   \label{fig:ptx-2-types}
 \end{ruledfigure}
-
-\noindent Again we require functions
-$$
-\tau_2: \eutxotx_2 \times \N \rightarrow \ptx_2
-$$
-and
-$$
-\delta_2: \ptx_2 \rightarrow \Data
-$$
-which can be used to produce an appropriate script from a transaction
-and the index of an input.
 
 \subsection{Validity of EUTXO-2 transactions}
 \label{sec:eutxo-2-validity}
@@ -882,7 +896,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
       \[
         t.\inputs \subseteq \unspent(\lambda).
       \]
-    \item\textbf{Forging:}\\\\
+    \item \label{rule:forging-2} \textbf{Forging:}\\\\
       \begin{minipage}{0.85\textwidth}
         A transaction with a non-zero \forge{} field is only
         valid if either:

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -296,8 +296,12 @@ conventions used in the remainder of the document.
   The type $\Interval{A}$ forms a lattice.
 \end{itemize}
 
-\subsection {Finitely supported functions}
+\subsection {Finitely-supported functions}
 \label{sec:fsfs}
+
+Finitely-supported functions are a generalization of maps to monoidal values.
+They always return an answer (which will in all but finitely many cases be
+zero), and can be queried for the set of non-zero points in their domain.
 
 For two types $K$ and $V$ where $V$ is a monoid, $\FinSup{K}{V}$ denotes the type of
 \textit{finitely-supported functions} from $K$ to $V$. That is, there is a

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -550,8 +550,10 @@ related types.
   \caption{The \ptx{} type for the EUTXO-1 model}
   \label{fig:ptx-1-types}
 \end{ruledfigure}
-%%
-\noindent The \ptx{} type is essentially a summary of the information
+
+\subsection{Remarks}
+\paragraph{The contents of \ptx{}.}
+The \ptx{} type is essentially a summary of the information
 contained in the $\eutxotx$ type in
 Figure~\ref{fig:eutxo-1-types}. The \fee{}, \forge{}, and
 \i{validityInterval} fields are copied directly from the pending
@@ -569,17 +571,18 @@ relating to the input currently undergoing validation.
 % and redeemer scripts in inputInfo are allowed to be absent
 % when we have pubkey inputs.  We're ignoring that special case here.
 
-\medskip
+\paragraph{Defining $\tau$ and $\delta$.}
 Assuming we have an
 appropriate hashing function, it is straightforward to define $\tau$.
 The function $\delta$ is implementation-dependent and we will not
 discuss it further.
 
-\medskip\todokwxm{But with the advent of \Data{} we \textit{can}
+\todokwxm{But with the advent of \Data{} we \textit{can}
   specify $\delta$.  Maybe we should?}
 \todokwxm{... or even just do the whole translation in one step.}
 
-\paragraph{Determinism.}  The information provided in the \ptx{}
+\paragraph{Determinism.}
+The information provided in the \ptx{}
 structure is sufficiently limited that the validation process
 becomes \textit{deterministic},  which has important implications
 for fee calculations.  See Note~\ref{note:validation-determinism}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -128,7 +128,7 @@
 \newcommand{\spent}{\msf{spentOutputs}}
 \newcommand{\unspent}{\msf{unspentOutputs}}
 \newcommand{\txunspent}{\msf{unspentTxOutputs}}
-\newcommand{\eutxotx}{\msf{EUtxoTx}}
+\newcommand{\eutxotx}{\msf{Tx}}
 
 \newcommand{\qty}{\ensuremath{\s{Quantity}}}
 \newcommand{\qtypm}{\ensuremath{\s{Quantity}^{\pm}}}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -88,6 +88,8 @@
 \newcommand{\true}{\textsf{true}}
 \newcommand{\false}{\textsf{false}}
 
+\newcommand{\hash}[1]{\ensuremath{#1^{\#}}}
+
 \newcommand{\List}[1]{\ensuremath{\s{List}[#1]}}
 \newcommand{\Set}[1]{\ensuremath{\s{Set}[#1]}}
 \newcommand{\FinSet}[1]{\ensuremath{\s{FinSet}[#1]}}
@@ -272,7 +274,7 @@ conventions used in the remainder of the document.
 
 \item $x \mapsto f(x)$ denotes an anonymous function.
 
-\item A cryptographic collision-resistant hash of a value $c$ is denoted $c^{\#}$.
+\item A cryptographic collision-resistant hash of a value $c$ is denoted $\hash{c}$.
 
 \item For a type $A$ which forms a partial order, $\extended{A}$ is the same
   type extended with a top element $\infty$ and a bottom element $-\infty$.

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -256,8 +256,15 @@ conventions used in the remainder of the document.
   presented as sequences of hexadecimal digits.
 
 \item If a type $M$ is a monoid, we use $+$ for the monoidal operation and $0$
-  for the unit of the monoid. If $M$ is a group, we use $-$ for the group
-  inverse operation. This should never be ambiguous.
+  for the unit of the monoid.
+
+  If $M$ is a commutative monoid, we use $\sum$ for the extension of $+$ to a finite set of elements of
+  type $M$.
+
+  If $M$ is a group, we use $-$ for the group
+  inverse operation.
+
+  This should never be ambiguous.
 
 \item A record type with fields $\phi_1, \ldots, \phi_n$ of types $T_1,
   \ldots, T_n$ is denoted by $(\phi_1 : T_1, \ldots, \phi_n : T_n)$.
@@ -304,18 +311,15 @@ functions
 $f, g \in \FinSup{K}{M}$ to be the function $f+g \in \FinSup{K}{M}$ with
 support $\support (f+g) = \support(f) \cup \support(g)$ given by
 \[(f+g)(k) = f(k) + g(k) \]
-We generalise this to the sum of a finite number of maps using
-the $\sum$ notation in the usual way; care is required if
-$+$ is non-commutative, since then the sum of a number of
-functions will depend on the order in which they appear. Note that
-the type $\FinSup{K}{M}$ itself becomes a monoid under the
-operation $+$ which we have just defined, with the empty function as
+Note that the type $\FinSup{K}{M}$ is a monoid with this
+operation, and the empty function as
 identity element.
 
 If the type $M$ is a group, then we can
 similarly define the inverse of a finitely-supported function $f$ as
 the function $(-f)$ with the same support, given by
 \[ (-f)(k) = -f(k) \]
+Again, $\FinSup{K}{M}$ is a group with this operation.
 
 See note~\ref{note:finitely-supported-functions} for discussion of using
 finitely-supported functions computationally.

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -934,12 +934,20 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
 \label{fig:eutxo-2-validity}
 \end{ruledfigure}
 
-\paragraph{Note.} In rule~\ref{rule:value-is-preserved-2},
-$+$ and $\sum$ are the sum of finitely-supported functions as defined in
-Section~\ref{sec:fsfs}. Essentially we require that the
-quantities of each of the individual custom currencies involved in the
-transaction are preserved. Recall that values in $\forge$ can
-be negative whereas values in outputs must be non-negative.  Thus
+\subsection{Remarks}
+\paragraph{Preservation of value over \qtymap{}s.}
+In rule~\ref{rule:value-is-preserved-2},
+$+$ and $\sum$ operate over \qtymap{}s, which are
+finitely-supported functions (which, with their operations,
+are defined in Section~\ref{sec:fsfs}). Preservation of value
+in this model essentially requires that the
+quantities of each of the individual currencies involved in the
+transaction are preserved.
+
+\paragraph{Preservation of value and forging.}
+Recall that values in $\forge$ can
+be negative whereas values in outputs must be non-negative. This allows
+currency to be destroyed as well as created. The
 rule~\ref{rule:value-is-preserved-2} implies that a
 transaction is invalid if it attempts to destroy more of a currency
 than is actually available in its inputs.

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -976,7 +976,9 @@ aspects of the model.
 \label{note:finitely-supported-functions}
 
 We intend that finitely-supported functions are implemented as finite
-maps. However, there are two apparent difficulties:
+maps, with a failed map lookup corresponding to returning 0.
+
+However, there are two apparent difficulties:
 \begin{enumerate}
   \item The domain of a map does not correspond to the support of the function:
     values may be mapped to zero, thus appearing in the domain but not the support.

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -661,7 +661,7 @@ the latter in rule~\ref{rule:all-inputs-validate}.
 
 \item
   \label{rule:validator-scripts-hash}
-  \textbf{Validator scripts hash to their output addresses:}
+  \textbf{Validator scripts match output addresses:}
   \begin{displaymath}
     \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
   \end{displaymath}
@@ -920,7 +920,7 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
 
 \item
   \label{rule:validator-scripts-hash-2}
-  \textbf{Validator scripts hash to their output addresses:}
+  \textbf{Validator scripts match output addresses:}
   \begin{displaymath}
     \textrm{For all } i \in t.\inputs,\enspace \scriptAddr(i.\validator) = \getSpent(i, \lambda).\addr
   \end{displaymath}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -458,9 +458,9 @@ Fig.~\ref{fig:eutxo-1-types-cardano}.
     \slotnum &=& \N\\
     \Address &=& \H\\
     \TxId &=& \H\\
-    \txId : \eutxotx \rightarrow \TxId &=& \mbox{the hash of the transaction}\\
+    \txId : \eutxotx \rightarrow \TxId &=& t \mapsto \hash{t}\\
     \script &=& \mbox{a Plutus Core program}\\
-    \scriptAddr : \script \rightarrow \Address &=& \mbox{the hash of the program}\\
+    \scriptAddr : \script \rightarrow \Address &=& s \mapsto \hash{s}\\
     \llbracket \cdots \rrbracket : \script \rightarrow \Data \times \Data \times
     \Data \rightarrow \B &=& \mbox{typechecking the program and running the Plutus Core interpreter}\\
   \end{array}
@@ -1122,7 +1122,7 @@ restrict the creation of the currency to owners of particular public
 keys.
 
 The idea is that a custom currency has a monetary policy which is
-defined by some script $H$, and the hash $h = \scriptAddr(H)$ is used as the
+defined by some script $H$, and the address $h = \scriptAddr(H)$ is used as the
 identifier of the currency.
 
 Whenever a new quantity of the currency is forged,

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -353,52 +353,33 @@ of type \Data{}, converting them into a suitable internal representation.
 The EUTXO-1 model adds the following new features to the model
 proposed in~\citep{Zahnentferner18-UTxO}:
 
-
-
-
 \begin{itemize}
 \item Every transaction has a \textit{validity interval}, of type $\Interval{\extended{\slotnum}}$.
   A core node will only process the transaction if
   the current slot number lies within the transaction's validity
   interval.
 
-\item Each unspent output now has a (possibly empty) object $\valdata$ of type
+\item Each unspent output now has an object $\valdata$ of type
   \Data{} associated with it: we (\red{provisionally}) call this the output's
-  \textit{validation data}.  The introduction of the validation data
-  increases the expressivity of the model considerably. For example,
-  one can use the validation data to propagate state between
-  transactions, and this can be used to give a contract the structure
-  of a finite state machine; the fact that the validation data is part
-  of the output and not the transaction means that the state can
-  change without the transaction changing, which makes it easier to
-  have an ``identity'' for an ongoing contract.
+  \textit{validation data} (see note~\ref{note:valdata}).
 
 \item The redeemer script of~\citet{Zahnentferner18-UTxO} has been
-  replaced with a redeemer object of type \Data.
+  replaced with a redeemer object of type \Data{}.
+
+\item Validator scripts make use of information about the pending
+  transaction (ie, the transaction which is just about to take place, assuming that
+  validation succeeds). This information is contained in a structure
+  which we call \ptx{} (see Section~\ref{sec:pendingtx} for its definition).
 
 \item Validation of an output is performed by running the validator
-  script with the redeemer and validation data as input; the validator
-  is also provided with information about the pending transaction (ie,
-  the transaction which is just about to take place, assuming that
-  validation succeeds). This information is contained in a structure
-  (also encoded as \Data) which we call \ptx{}: this contains data
-  such as the validity interval of the pending transaction and
-  information about the inputs and outputs.  See
-  Section~\ref{sec:pendingtx} for more information on the \ptx{}
-  structure.
+  script with three inputs:
+  \begin{enumerate}
+  \item the validation data,
+  \item the redeemer,
+  \item the \ptx{}, encoded as \Data{}.
+  \end{enumerate}
 
 \end{itemize}
-
-
-\noindent At the ledger level, validator scripts now have the type
-$
-\Data \times \Data \times \Data \rightarrow \B
-$. At the Plutus level in Cardano, the validator is a program which
-consumes the redeemer, the validation data, and a \Data{} encoding
-of the \ptx{} structure as arguments.  The validator may
-expect these objects to have some specific form (a single bytestring
-or a list of integers, for example) and if it is supplied with data
-with an incorrect format it should fail and return \false.
 
 \todokwxm{There's the issue about whether validators return
   \texttt{true/false} or \texttt{()/Error}. Remember to fix this when things have settled down.}
@@ -1026,6 +1007,17 @@ signature using a known public key: if the public key corresponds to
 the private key then validation succeeds, otherwise it fails.  Thus
 the output can only be spent by the owner of the relevant private key
 
+
+\note{Validation data}
+\label{note:valdata}
+The introduction of the validation data
+increases the expressivity of the model considerably. For example,
+one can use the validation data to propagate state between
+transactions, and this can be used to give a contract the structure
+of a finite state machine; the fact that the validation data is part
+of the output and not the transaction means that the state can
+change without the transaction changing, which makes it easier to
+have an ``identity'' for an ongoing contract.
 
 \note{Fees and Costs.}
 \label{note:fees}

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -121,6 +121,7 @@
 \newcommand{\outputref}{\mi{outputRef}}
 \newcommand{\txin}{\mi{in}}
 \newcommand{\id}{\mi{id}}
+\newcommand{\lookupTx}[2]{#1\langle#2\rangle}
 \newcommand{\getSpent}{\msf{getSpentOutput}}
 
 \newcommand{\slotnum}{\ensuremath{\s{SlotNumber}}}
@@ -584,19 +585,17 @@ for further discussion.
 \subsection{Validity of EUTXO-1 transactions}
 \label{sec:eutxo-1-validity}
 A number of conditions must be satisfied in order for a transaction
-$t$ to be considered valid with respect to a ledger $\lambda$.  In
-order to define these we require a couple of auxiliary functions.
-Firstly, following~\citep{Zahnentferner18-UTxO} we define
-
-Given a ledger $\lambda$ and a transaction id $\id$, we
-denote by $\lambda\langle\id\rangle$ the unique transaction $T$ in
-$\lambda$ with $\txId(T) = \id$, if it exists.
-\todompj{Make the failure handling explicit somehow.}
+$t$ to be considered valid with respect to a ledger $\lambda$.
 
 Fig.~\ref{fig:validation-functions-1} defines some auxiliary functions used in validation.
 \begin{ruledfigure}{H}
   \begin{displaymath}
   \begin{array}{lll}
+  \multicolumn{3}{l}{\lookupTx{\_}{\_} : \s{Ledger} \times \TxId \rightarrow \eutxotx{}}\\
+  \lookupTx{\lambda}{id} &=& \textsf{find}(\lambda, tx \mapsto \txId(tx) = id)\\
+  \\
+  \txunspent(t) &=& \{(\txId(t),1), \ldots, (\txId(id),\left|t.outputs\right|)\}\\
+  \\
   \multicolumn{3}{l}{\txunspent : \eutxotx \rightarrow \FinSet{\s{OutputRef}}}\\
   \txunspent(t) &=& \{(\txId(t),1), \ldots, (\txId(id),\left|t.outputs\right|)\}\\
   \\
@@ -612,7 +611,13 @@ Fig.~\ref{fig:validation-functions-1} defines some auxiliary functions used in v
   \label{fig:validation-functions-1}
 \end{ruledfigure}
 
-\noindent We can now define what it means for a transaction $t$ of
+\noindent The function $\lookupTx{\lambda}{id}$ looks up the unique transaction
+$T$ whose $\TxId$ is $id$. This can of course fail, but we will assume it does
+not, since rule~\ref{rule:all-inputs-refer-to-unspent-outputs} ensures that all
+of the transaction inputs refer to existing unspent outputs, and hence that
+looking up the input cannot fail.
+
+We can now define what it means for a transaction $t$ of
 type $\eutxotx$ to be valid for a ledger: see
 Figure~\ref{fig:eutxo-1-validity}.  Our definition combines
 Definitions 6 and 14 from \citep{Zahnentferner18-UTxO}, differing from
@@ -929,9 +934,6 @@ EUTXO-2: see Figure~\ref{fig:eutxo-2-validity}.
 \caption{Validity of a transaction $t$ in the EUTXO-2 model}
 \label{fig:eutxo-2-validity}
 \end{ruledfigure}
-
-\noindent If any of the indexing operations here fail then the
-transaction is invalid.
 
 \paragraph{Note.} In rule~\ref{rule:value-is-preserved-2},
 $+$ and $\sum$ are the sum of finitely-supported functions as defined in

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -231,17 +231,22 @@ of finitely-supported functions in most places that \citep{Zahnentferner18-UTxO}
 use maps.
 
 \subsection{Basic types and operations}
-Figure~\ref{fig:basic-notation} describes some types, notation, and
+\label{sec:basic-notation}
+
+This section describes some types, notation, and
 conventions used in the remainder of the document.
 
-\begin{ruledfigure}{H}
-  \begin{itemize}
+\begin{itemize}
 \item Types are typeset in $\mathsf{sans~serif}$.
 
 \item \B{} denotes the type of booleans, $\{\false, \true\}$.
 \item \N{} denotes the type of natural numbers, $\{0, 1, 2, \ldots\}$.
 \item \Z{} denotes the type of integers, $\{,\ldots, -2, -1, 0, 1, 2, \ldots\}$.
-\item \H{} denotes the type of \textit{bytestrings}, $\bigcup_{n=0}^{\infty}\{0,1\}^{8n}$.
+\item We regard $\N$ as a subtype of $\Z$ and convert freely between
+  natural numbers and non-negative integers.
+\item \H{} denotes the type of bytestrings, $\bigcup_{n=0}^{\infty}\{0,1\}^{8n}$.
+  A bytestring is a sequence of 8-bit bytes: the symbol $\H$ is used because bytestrings are often
+  presented as sequences of hexadecimal digits.
 
 \item If a type $M$ is a monoid, we use $+$ for the monoidal operation and $0$
   for the unit of the monoid. If $M$ is a group, we use $-$ for the group
@@ -290,6 +295,9 @@ conventions used in the remainder of the document.
   the function $(-f)$ with the same support, given by
   \[ (-f)(k) = -f(k) \]
 
+  See note~\ref{note:finitely-supported-functions} for discussion of using
+  finitely-supported functions computationally.
+
 \item $x \mapsto f(x)$ denotes an anonymous function.
 
 \item A cryptographic collision-resistant hash of a value $c$ is denoted $c^{\#}$.
@@ -301,18 +309,6 @@ conventions used in the remainder of the document.
   of intervals over that type, whose endpoints may be either closed or open.
   The type $\Interval{A}$ forms a lattice.
 \end{itemize}
-\caption{Basic notation}
-\label{fig:basic-notation}
-\end{ruledfigure}
-
-\noindent We regard $\N$ as a subtype of $\Z$ and convert freely between
-natural numbers and non-negative integers.
-A bytestring is a sequence
-of 8-bit bytes: the symbol $\H$ is used because bytestrings are often
-presented as sequences of hexadecimal digits.
-
-See note~\ref{note:finitely-supported-functions} for discussion of using
-finitely-supported functions computationally.
 
 \subsection{The \Data{} type}
 We also define a type \Data{} which can be used to pass information
@@ -944,7 +940,7 @@ transaction is invalid.
 
 \paragraph{Note.} In rule~\ref{rule:value-is-preserved-2},
 $+$ and $\sum$ are the sum of finitely-supported functions as defined in
-Figure~\ref{fig:basic-notation}. Essentially we require that the
+Section~\ref{sec:basic-notation}. Essentially we require that the
 quantities of each of the individual custom currencies involved in the
 transaction are preserved. Recall that values in $\forge$ can
 be negative whereas values in outputs must be non-negative.  Thus

--- a/extended-utxo-spec/extended-utxo-specification.tex
+++ b/extended-utxo-spec/extended-utxo-specification.tex
@@ -149,6 +149,7 @@
 \newcommand\Z{\ensuremath{\mathbb{Z}}}
 \renewcommand\H{\ensuremath{\mathbb{H}}}
 %% \H is usually the Hungarian double acute accent
+\newcommand{\emptyBs}{\ensuremath{\emptyset}}
 
 \newcommand{\emptymap}{\ensuremath{\{\}}}
 
@@ -246,7 +247,11 @@ conventions used in the remainder of the document.
 \item \Z{} denotes the type of integers, $\{,\ldots, -2, -1, 0, 1, 2, \ldots\}$.
 \item We regard $\N$ as a subtype of $\Z$ and convert freely between
   natural numbers and non-negative integers.
-\item \H{} denotes the type of bytestrings, $\bigcup_{n=0}^{\infty}\{0,1\}^{8n}$.
+\item \H{} denotes the type of bytestrings,
+  $\bigcup_{n=0}^{\infty}\{0,1\}^{8n}$.
+
+  \emptyBs{} denotes the empty bytestring.
+
   A bytestring is a sequence of 8-bit bytes: the symbol $\H$ is used because bytestrings are often
   presented as sequences of hexadecimal digits.
 
@@ -782,9 +787,9 @@ Fig.~\ref{fig:eutxo-2-types-cardano}.
   \begin{displaymath}
     \begin{array}{rll}
       \currency  &=& \H\\
-      \nativeCur &=& \mbox{the empty bytestring}\\
+      \nativeCur &=& \emptyBs\\
       \token     &=& \H\\
-      \nativeTok &=& \mbox{the empty bytestring}\\
+      \nativeTok &=& \emptyBs\\
     \end{array}
   \end{displaymath}
   \caption{Cardano primitives for the EUTXO-2 model}


### PR DESCRIPTION
Based on https://github.com/input-output-hk/plutus/pull/1514. I'm not done yet, but this was already starting to get out of hand, and I wanted somewhere to refer to.

Ongoing work on the spec. It's difficult to break up into "features", so this is a bit of a mess. Should be lightly reviewable commit-by-commit (obviously start after the previous PR finishes, or just wait until it's merged), then I recommend just looking at the rendered new version.

Highlights:
- Fixed a few bugs in the validation rules.
- More explicit about a few things.
- Moved more notes out of the main text.
- Rearranged figures, so we have a single one for the non-ledger-specific types; with the ledger-specific ones per-section.
- Generally more consistency about macro usage.