### PR TITLE
ledger: handle machine exceptions

### DIFF
--- a/plutus-core-interpreter/bench/Bench.hs
+++ b/plutus-core-interpreter/bench/Bench.hs
@@ -4,7 +4,7 @@ import           Control.Monad                              (void)
 import           Criterion.Main
 import qualified Data.ByteString.Lazy                       as BSL
 import           Language.PlutusCore
-import           Language.PlutusCore.Interpreter.CekMachine (runCek)
+import           Language.PlutusCore.Interpreter.CekMachine (unsafeRunCek)
 
 main :: IO ()
 main =
@@ -16,8 +16,8 @@ main =
                     in
 
                     bgroup "runCek"
-                      [ bench "valid" $ nf (fmap (runCek mempty)) f'
-                      , bench "invalid" $ nf (fmap (runCek mempty)) g'
+                      [ bench "valid" $ nf (fmap (unsafeRunCek mempty)) f'
+                      , bench "invalid" $ nf (fmap (unsafeRunCek mempty)) g'
                       ]
 
                 ]

--- a/plutus-core-interpreter/src/Language/PlutusCore/Interpreter/CekMachine.hs
+++ b/plutus-core-interpreter/src/Language/PlutusCore/Interpreter/CekMachine.hs
@@ -20,6 +20,7 @@ module Language.PlutusCore.Interpreter.CekMachine
     , evaluateCekCatch
     , evaluateCek
     , readKnownCek
+    , runCekCatch
     , runCek
     ) where
 
@@ -223,6 +224,11 @@ readKnownCek means term = do
         EvaluationSuccess (Left err) -> Left $ MachineException appErr term where
             appErr = ConstAppMachineError $ UnreadableBuiltinConstAppError term err
         EvaluationSuccess (Right x)  -> Right $ EvaluationSuccess x
+
+-- | Run a program using the CEK machine.
+-- Calls 'evaluateCekCatch' under the hood.
+runCekCatch :: DynamicBuiltinNameMeanings -> Program TyName Name () -> Either CekMachineException EvaluationResultDef
+runCekCatch means (Program _ _ term) = evaluateCekCatch means term
 
 -- | Run a program using the CEK machine. May throw a 'CekMachineException'.
 -- Calls 'evaluateCek' under the hood.

--- a/plutus-core-interpreter/test/CekMachine.hs
+++ b/plutus-core-interpreter/test/CekMachine.hs
@@ -16,5 +16,5 @@ test_evaluateCek :: TestTree
 test_evaluateCek =
     testGroup "evaluateCek"
         [ testGroup "props" $ fromInterestingTermGens $ \name ->
-            testProperty name . propEvaluate (evaluateCek mempty)
+            testProperty name . propEvaluate (unsafeEvaluateCek mempty)
         ]

--- a/plutus-core-interpreter/test/DynamicBuiltins/Common.hs
+++ b/plutus-core-interpreter/test/DynamicBuiltins/Common.hs
@@ -28,7 +28,7 @@ typecheckAnd action meanings term = runQuoteT $ do
 typecheckEvaluateCek
     :: MonadError (Error ()) m
     => DynamicBuiltinNameMeanings -> Term TyName Name () -> m EvaluationResultDef
-typecheckEvaluateCek = typecheckAnd evaluateCek
+typecheckEvaluateCek = typecheckAnd unsafeEvaluateCek
 
 -- | Type check and convert a Plutus Core term to a Haskell value.
 typecheckReadKnownCek

--- a/plutus-core-interpreter/weigh/Bench.hs
+++ b/plutus-core-interpreter/weigh/Bench.hs
@@ -3,7 +3,7 @@ module Main (main) where
 import           Control.Monad                              (void)
 import qualified Data.ByteString.Lazy                       as BSL
 import           Language.PlutusCore
-import           Language.PlutusCore.Interpreter.CekMachine (runCek)
+import           Language.PlutusCore.Interpreter.CekMachine (unsafeRunCek)
 import           Weigh
 
 main :: IO ()
@@ -15,8 +15,8 @@ main = do
         g' = processor g
 
     mainWith $ sequence_
-        [ func "valid" (fmap (runCek mempty)) f'
-        , func "invalid" (fmap (runCek mempty)) g'
+        [ func "valid" (fmap (unsafeRunCek mempty)) f'
+        , func "invalid" (fmap (unsafeRunCek mempty)) g'
         ]
 
     where evalFile0 = BSL.readFile "../language-plutus-core/test/Evaluation/Golden/verifySignature.plc"

--- a/plutus-exe/src/Main.hs
+++ b/plutus-exe/src/Main.hs
@@ -138,7 +138,7 @@ runEval (EvalOptions inp mode) = do
     let bsContents = (BSL.fromStrict . encodeUtf8 . T.pack) contents
     let evalFn = case mode of
             CK  -> PLC.runCk
-            CEK -> PLC.runCek mempty
+            CEK -> PLC.unsafeRunCek mempty
             L   -> PLC.runL mempty
     case evalFn . void <$> PLC.runQuoteT (PLC.parseScoped bsContents) of
         Left (e :: PLC.Error PLC.AlexPosn) -> do

--- a/plutus-tx/src/Language/PlutusTx/Evaluation.hs
+++ b/plutus-tx/src/Language/PlutusTx/Evaluation.hs
@@ -1,9 +1,9 @@
-module Language.PlutusTx.Evaluation (evaluateCek, evaluateCekThrow, evaluateCekTrace, CekMachineException) where
+module Language.PlutusTx.Evaluation (evaluateCek, unsafeEvaluateCek, evaluateCekTrace, CekMachineException) where
 
 import           Language.PlutusCore
 import           Language.PlutusCore.Constant
 import           Language.PlutusCore.Constant.Dynamic
-import           Language.PlutusCore.Interpreter.CekMachine hiding (evaluateCek)
+import           Language.PlutusCore.Interpreter.CekMachine hiding (evaluateCek, unsafeEvaluateCek)
 
 import           Control.Exception
 
@@ -17,13 +17,13 @@ stringBuiltins =
 evaluateCek
     :: Program TyName Name ()
     -> Either CekMachineException EvaluationResultDef
-evaluateCek = runCekCatch stringBuiltins
+evaluateCek = runCek stringBuiltins
 
--- | Evaluate a program in the CEK machine with the usual string dynamic builtins.
-evaluateCekThrow
+-- | Evaluate a program in the CEK machine with the usual string dynamic builtins. May throw.
+unsafeEvaluateCek
     :: Program TyName Name ()
     -> EvaluationResultDef
-evaluateCekThrow = runCek stringBuiltins
+unsafeEvaluateCek = unsafeRunCek stringBuiltins
 
 -- TODO: pretty sure we shouldn't need the unsafePerformIOs here, we should expose a pure interface even if it has IO hacks under the hood
 
@@ -37,4 +37,4 @@ evaluateCekTrace p =
         let logName       = dynamicTraceName
             logDefinition = dynamicCallAssign logName emit
             env  = insertDynamicBuiltinNameDefinition logDefinition stringBuiltins
-        evaluate $ runCekCatch env p
+        evaluate $ runCek env p

--- a/plutus-tx/test/TH/Spec.hs
+++ b/plutus-tx/test/TH/Spec.hs
@@ -44,13 +44,16 @@ runPlcCek :: GetProgram a => [a] -> ExceptT SomeException IO EvaluationResultDef
 runPlcCek values = do
      ps <- Haskell.traverse getProgram values
      let p = foldl1 applyProgram ps
-     ExceptT $ try @SomeException $ evaluate $ evaluateCek p
+     let result = evaluateCek p
+     either (throwError . SomeException) Haskell.pure $ evaluateCek p
 
 runPlcCekTrace :: GetProgram a => [a] -> ExceptT SomeException IO ([String], EvaluationResultDef)
 runPlcCekTrace values = do
      ps <- Haskell.traverse getProgram values
      let p = foldl1 applyProgram ps
-     ExceptT $ try @SomeException $ evaluate $ evaluateCekTrace p
+     let (logOut, result) = evaluateCekTrace p
+     res <- either (throwError . SomeException) Haskell.pure result
+     Haskell.pure (logOut, res)
 
 goldenEvalCek :: GetProgram a => String -> [a] -> TestNested
 goldenEvalCek name values = nestedGoldenVsDocM name $ prettyPlcClassicDebug Haskell.<$> (rethrow $ runPlcCek values)

--- a/plutus-tx/test/TH/Spec.hs
+++ b/plutus-tx/test/TH/Spec.hs
@@ -44,7 +44,6 @@ runPlcCek :: GetProgram a => [a] -> ExceptT SomeException IO EvaluationResultDef
 runPlcCek values = do
      ps <- Haskell.traverse getProgram values
      let p = foldl1 applyProgram ps
-     let result = evaluateCek p
      either (throwError . SomeException) Haskell.pure $ evaluateCek p
 
 runPlcCekTrace :: GetProgram a => [a] -> ExceptT SomeException IO ([String], EvaluationResultDef)

--- a/plutus-use-cases/bench/Bench.hs
+++ b/plutus-use-cases/bench/Bench.hs
@@ -24,7 +24,7 @@ import           Wallet
 
 import qualified Language.PlutusTx                                 as PlutusTx
 import qualified Language.PlutusTx.Prelude                         as PlutusTx
-import           Language.PlutusTx.Evaluation                      (evaluateCekThrow)
+import           Language.PlutusTx.Evaluation                      (unsafeEvaluateCek)
 
 import qualified Recursion                                         as Rec
 import qualified Scott                                             as Scott
@@ -62,14 +62,14 @@ hashB = bgroup "hash" (imap (\i d -> bench ("hash-" <> show i) $ nf hashit d) ha
 fibB :: Benchmark
 fibB = bgroup "fib" [
         bgroup "5" [
-            bench "plutus" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| fib 5 ||])),
-            bench "plutus-opt" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| fibOpt 5 ||])),
+            bench "plutus" $ nf unsafeEvaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| fib 5 ||])),
+            bench "plutus-opt" $ nf unsafeEvaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| fibOpt 5 ||])),
             bench "native" $ nf fib 5,
             bench "combinator" $ nf fibRec 5
         ],
         bgroup "10" [
-            bench "plutus" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| fib 10 ||])),
-            bench "plutusOpt" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| fibOpt 10 ||])),
+            bench "plutus" $ nf unsafeEvaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| fib 10 ||])),
+            bench "plutusOpt" $ nf unsafeEvaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| fibOpt 10 ||])),
             bench "native" $ nf fib 10,
             bench "combinator" $ nf fibRec 10
         ]
@@ -90,16 +90,16 @@ fibB = bgroup "fib" [
 sumB :: Benchmark
 sumB = bgroup "sum" [
         bgroup "5" [
-            bench "plutus" $ nf evaluateCekThrow script5,
-            bench "plutus-opt" $ nf evaluateCekThrow script5Opt,
+            bench "plutus" $ nf unsafeEvaluateCek script5,
+            bench "plutus-opt" $ nf unsafeEvaluateCek script5Opt,
             bench "native" $ nf haskellNative 5,
             bench "scott" $ nf haskellScott 5,
             bench "combinator" $ nf haskellRec 5,
             bench "scott-combinator" $ nf haskellRecScott 5
         ],
         bgroup "20" [
-            bench "plutus" $ nf evaluateCekThrow script20,
-            bench "plutus-opt" $ nf evaluateCekThrow script20Opt,
+            bench "plutus" $ nf unsafeEvaluateCek script20,
+            bench "plutus-opt" $ nf unsafeEvaluateCek script20Opt,
             bench "native" $ nf haskellNative 20,
             bench "scott" $ nf haskellScott 20,
             bench "combinator" $ nf haskellRec 20,
@@ -149,16 +149,16 @@ sumB = bgroup "sum" [
 tailB :: Benchmark
 tailB = bgroup "tail" [
         bgroup "5" [
-            bench "plutus" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tail [(), (), (), (), ()] ||])),
-            bench "plutus-opt" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tailOpt [(), (), (), (), ()] ||])),
+            bench "plutus" $ nf unsafeEvaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tail [(), (), (), (), ()] ||])),
+            bench "plutus-opt" $ nf unsafeEvaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tailOpt [(), (), (), (), ()] ||])),
             bench "native" $ nf tail (replicate 5 ()),
             bench "scott" $ nf tailScott (Scott.replicate 5 ()),
             bench "combinator" $ nf tailRec (replicate 5 ()),
             bench "scott-combinator" $ nf tailRecScott (Scott.replicate 5 ())
         ],
         bgroup "20" [
-            bench "plutus" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tail [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
-            bench "plutus-opt" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tailOpt [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
+            bench "plutus" $ nf unsafeEvaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tail [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
+            bench "plutus-opt" $ nf unsafeEvaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tailOpt [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
             bench "native" $ nf tail (replicate 20 ()),
             bench "scott" $ nf tailScott (Scott.replicate 20 ()),
             bench "combinator" $ nf tailRec (replicate 20 ()),

--- a/plutus-use-cases/bench/Bench.hs
+++ b/plutus-use-cases/bench/Bench.hs
@@ -24,7 +24,7 @@ import           Wallet
 
 import qualified Language.PlutusTx                                 as PlutusTx
 import qualified Language.PlutusTx.Prelude                         as PlutusTx
-import           Language.PlutusTx.Evaluation                      (evaluateCek)
+import           Language.PlutusTx.Evaluation                      (evaluateCekThrow)
 
 import qualified Recursion                                         as Rec
 import qualified Scott                                             as Scott
@@ -62,14 +62,14 @@ hashB = bgroup "hash" (imap (\i d -> bench ("hash-" <> show i) $ nf hashit d) ha
 fibB :: Benchmark
 fibB = bgroup "fib" [
         bgroup "5" [
-            bench "plutus" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| fib 5 ||])),
-            bench "plutus-opt" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| fibOpt 5 ||])),
+            bench "plutus" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| fib 5 ||])),
+            bench "plutus-opt" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| fibOpt 5 ||])),
             bench "native" $ nf fib 5,
             bench "combinator" $ nf fibRec 5
         ],
         bgroup "10" [
-            bench "plutus" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| fib 10 ||])),
-            bench "plutusOpt" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| fibOpt 10 ||])),
+            bench "plutus" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| fib 10 ||])),
+            bench "plutusOpt" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| fibOpt 10 ||])),
             bench "native" $ nf fib 10,
             bench "combinator" $ nf fibRec 10
         ]
@@ -90,16 +90,16 @@ fibB = bgroup "fib" [
 sumB :: Benchmark
 sumB = bgroup "sum" [
         bgroup "5" [
-            bench "plutus" $ nf evaluateCek script5,
-            bench "plutus-opt" $ nf evaluateCek script5Opt,
+            bench "plutus" $ nf evaluateCekThrow script5,
+            bench "plutus-opt" $ nf evaluateCekThrow script5Opt,
             bench "native" $ nf haskellNative 5,
             bench "scott" $ nf haskellScott 5,
             bench "combinator" $ nf haskellRec 5,
             bench "scott-combinator" $ nf haskellRecScott 5
         ],
         bgroup "20" [
-            bench "plutus" $ nf evaluateCek script20,
-            bench "plutus-opt" $ nf evaluateCek script20Opt,
+            bench "plutus" $ nf evaluateCekThrow script20,
+            bench "plutus-opt" $ nf evaluateCekThrow script20Opt,
             bench "native" $ nf haskellNative 20,
             bench "scott" $ nf haskellScott 20,
             bench "combinator" $ nf haskellRec 20,
@@ -149,16 +149,16 @@ sumB = bgroup "sum" [
 tailB :: Benchmark
 tailB = bgroup "tail" [
         bgroup "5" [
-            bench "plutus" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tail [(), (), (), (), ()] ||])),
-            bench "plutus-opt" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tailOpt [(), (), (), (), ()] ||])),
+            bench "plutus" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tail [(), (), (), (), ()] ||])),
+            bench "plutus-opt" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tailOpt [(), (), (), (), ()] ||])),
             bench "native" $ nf tail (replicate 5 ()),
             bench "scott" $ nf tailScott (Scott.replicate 5 ()),
             bench "combinator" $ nf tailRec (replicate 5 ()),
             bench "scott-combinator" $ nf tailRecScott (Scott.replicate 5 ())
         ],
         bgroup "20" [
-            bench "plutus" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tail [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
-            bench "plutus-opt" $ nf evaluateCek (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tailOpt [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
+            bench "plutus" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tail [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
+            bench "plutus-opt" $ nf evaluateCekThrow (PlutusTx.getPlc $$(PlutusTx.compile [|| \() () () -> tailOpt [(), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), (), ()] ||])),
             bench "native" $ nf tail (replicate 20 ()),
             bench "scott" $ nf tailScott (Scott.replicate 20 ()),
             bench "combinator" $ nf tailRec (replicate 20 ()),


### PR DESCRIPTION
These should certainly fail validation.

Arguably, the validating node should just be catching all kinds of
exceptions and treating them as failures. I don't think this is right:
the exceptions we get here are *non-transient* errors determined by the
program we've been given, rather than e.g. ambient machine conditions.
So these really do indicate that the script is bad, whereas other
exceptions may not.

As mentioned in https://github.com/input-output-hk/plutus/issues/1524, this is more relevant if we start erasing things.