### PR TITLE
plutus-contract: generalize the error type

### DIFF
--- a/plutus-contract/doc/contract-api.adoc
+++ b/plutus-contract/doc/contract-api.adoc
@@ -31,10 +31,10 @@ The simplest contract is the one that produces no transactions, and does not int
 
 [source,haskell]
 ----
-c1 :: Contract Empty () -- <1>
+c1 :: Contract Empty e () -- <1>
 c1 = return () -- <2>
 ----
-<1> The type of `c1` is a Plutus contract that produces a unit value when it's finished. The fact that `s` is `Empty` tells us that `c1` does not have any effects.
+<1> The type of `c1` is a Plutus contract that produces a unit value when it's finished. The fact that `s` is `Empty` tells us that `c1` does not have any effects. The fact that `e` is unconstrained tells us that it does not throw any kind of error.
 <2> The implementation of `c1` returns the unit immediately.
 
 == Common effects
@@ -47,7 +47,7 @@ For example, `awaitSlot {2c} (HasAwaitSlot s) => Slot -> Contract s Slot` is a f
 
 [source,haskell]
 ----
-c2 :: (HasAwaitSlot s) => Contract s Slot
+c2 :: (HasAwaitSlot s) => Contract s e Slot
 c2 = awaitSlot 2765 -- <1>
 ----
 <1> `c2` waits until slot 2765 and then returns the current slot. The value returns may be greater than 2765, for example if execution of the contract was suspended for a while.
@@ -62,11 +62,11 @@ Sometimes we want to see what outputs accumulate at an address, and spend all of
 
 === Unspent outputs
 
-The `UtxoAt` effect, available through `utxoAt {2c} HasUtxoAt s => Address -> Contract s AddressMap`,  lets us query the node client for all unspent outputs at an address. The difference between `utxoAt` and `nextTransactionAt` is that the former returns right away with the current UTXO set at the address, and the latter only returns when the set of unspent outputs at the address has been changed (so it may not return at all, if there are no transactions that touch the address).
+The `UtxoAt` effect, available through `utxoAt {2c} HasUtxoAt s => Address -> Contract s e AddressMap`,  lets us query the node client for all unspent outputs at an address. The difference between `utxoAt` and `nextTransactionAt` is that the former returns right away with the current UTXO set at the address, and the latter only returns when the set of unspent outputs at the address has been changed (so it may not return at all, if there are no transactions that touch the address).
 
 === Transactions
 
-Contracts write transactions using `writeTx {2c} (HasWriteTx s) => UnbalancedTx -> Contract s WriteTxResponse`. The transactions produced that way are unbalanced and unsigned. When executing a `writeTx` instruction, the app platform forwards the transaction to the user's wallet to balance it (by adding appropriate public key inputs or outputs) and compute the gas cost of any scripts involved. The finished transaction is then signed by the signing process, and submitted to the wallet which sends it to the blockchain. `writeTx` returns the final transaction's ID once it has been submitted to the blockchain (or an error if the balancing or signing failed).
+Contracts write transactions using `writeTx {2c} (HasWriteTx s) => UnbalancedTx -> Contract s e WriteTxResponse`. The transactions produced that way are unbalanced and unsigned. When executing a `writeTx` instruction, the app platform forwards the transaction to the user's wallet to balance it (by adding appropriate public key inputs or outputs) and compute the gas cost of any scripts involved. The finished transaction is then signed by the signing process, and submitted to the wallet which sends it to the blockchain. `writeTx` returns the final transaction's ID once it has been submitted to the blockchain (or an error if the balancing or signing failed).
 
 === Endpoints
 
@@ -78,7 +78,7 @@ Let's say we write a contract that expects the user to enter an `Int` using an e
 
 [source,haskell]
 ----
-c3 :: (HasEndpoint "amount" Int s) => Contract s Int -- <1>
+c3 :: (HasEndpoint "amount" Int s) => Contract s e Int -- <1>
 c3 = endpoint @"amount" -- <2>
 ----
 <1> The `HasEndpoint` constraint describes user-defined endpoints. In this case, the contract exposes an endpoint called "amount" that requires the user to enter an 'Int'.
@@ -88,7 +88,7 @@ c3 = endpoint @"amount" -- <2>
 
 Given two contracts we can combine them by running them in parallel, in sequence, or by selecting the one that finishes first.
 
-Let's say we have two contracts `collect {2c} Contract r AddressMap` and `recipient {2c} Contract r PubKey'`. `collect` watches the blockchain for payments to a script address, and after a while returns an address map with all the inputs that are currently there. `recipient` asks the user for an address to make the payment to. Now we would like to build a contract that combines `collect` and `recipient` and then submits a transaction that spends all inputs and pays the value to the given address.
+Let's say we have two contracts `collect {2c} Contract r e AddressMap` and `recipient {2c} Contract r e PubKey'`. `collect` watches the blockchain for payments to a script address, and after a while returns an address map with all the inputs that are currently there. `recipient` asks the user for an address to make the payment to. Now we would like to build a contract that combines `collect` and `recipient` and then submits a transaction that spends all inputs and pays the value to the given address.
 
 === Parallel
 
@@ -96,13 +96,13 @@ Let's say we have two contracts `collect {2c} Contract r AddressMap` and `recipi
 
 [source,haskell]
 ----
-collect :: HasBlockchainActions s => Contract s AddressMap
+collect :: HasBlockchainActions s => Contract s e AddressMap
 collect = undefined
 
-recipient :: HasBlockchainActions s => Contract s PubKey
+recipient :: HasBlockchainActions s => Contract s e PubKey
 recipient = undefined
 
-collectRec :: HasBlockchainActions s => Contract s (AddressMap, PubKey) -- <1>
+collectRec :: HasBlockchainActions s => Contract s e (AddressMap, PubKey) -- <1>
 collectRec = both collect recipient -- <2>
 ----
 <1> `collectRec` is a contract that may use an endpoint asking for a public key. It returns two things: A list of transaction inputs and a public key.
@@ -119,7 +119,7 @@ After having obtained the inputs and the public key we can proceed to produce th
 mkTx :: AddressMap -> PubKey -> UnbalancedTx
 mkTx = undefined
 
-spend :: HasBlockchainActions s => Contract s ()
+spend :: HasBlockchainActions s => Contract s e ()
 spend = do -- <1>
     (ins, pk) <- collectRec
     void (writeTx (mkTx ins pk))
@@ -140,17 +140,17 @@ data Buy = Buy { buySymbol :: String, buyAmount :: Int }
 data Sell = Sell { sellSymbol :: String, sellAmount :: Int }
 ----
 
-Then we define two contracts, `buy {2c} Contract r Buy` and `sell {2c} Contract r Sell`. Now the combined contract is
+Then we define two contracts, `buy {2c} Contract r e Buy` and `sell {2c} Contract r e Sell`. Now the combined contract is
 
 [source, haskell]
 ----
-buy :: HasBlockchainActions s => Contract s Buy
+buy :: HasBlockchainActions s => Contract s e Buy
 buy = undefined
 
-sell :: HasBlockchainActions s => Contract s Sell
+sell :: HasBlockchainActions s => Contract s e Sell
 sell = undefined
 
-buyOrSell :: HasBlockchainActions r => Contract r (Either Buy Sell)
+buyOrSell :: HasBlockchainActions r => Contract r e (Either Buy Sell)
 buyOrSell = selectEither buy sell
 ----
 
@@ -160,7 +160,7 @@ NOTE: The `Alternative` instance of `Contract` is used to select one of two bran
 
 == Compiling Contracts
 
-Once we've written our conract we can compile it into a form that can be run by the application platform. To this end the `Language.Plutus.Contract.App` module exposes a `run` function, which takes a `Contract s ()` and turns it into an `IO ()` action. The contracts we've seen so far have been parameterised over the schema (that is, they were of the form `contract {2c} c s => Contract s ()` for some set of constraints `s`). When we call `run contract` we need to commit to a specific value for the schema `s`, because it can't be inferred by the compiler. As the schema describes all possible interactions between the contract and the outside world, it usually consists of two parts: Interactions with the blockchain (via the wallet), and interactions with the user (via endpoints). The first part of the schema is always the same: The `BlockchainActions` type found in `Language.Plutus.Contract`. The second part depends on the specific set of user-facing endpoints that the contract has. We use the `Endpoint` type constructor to describe the name and type of each endpoint. The `.\/` operator combines two schemas. So a contract with a single endpoint called "amount" of type `Int` would have the following schema type:
+Once we've written our conract we can compile it into a form that can be run by the application platform. To this end the `Language.Plutus.Contract.App` module exposes a `run` function, which takes a `Contract s e ()` and turns it into an `IO ()` action. The contracts we've seen so far have been parameterised over the schema (that is, they were of the form `contract {2c} c s => Contract s e ()` for some set of constraints `s`). When we call `run contract` we need to commit to a specific value for the schema `s`, because it can't be inferred by the compiler. As the schema describes all possible interactions between the contract and the outside world, it usually consists of two parts: Interactions with the blockchain (via the wallet), and interactions with the user (via endpoints). The first part of the schema is always the same: The `BlockchainActions` type found in `Language.Plutus.Contract`. The second part depends on the specific set of user-facing endpoints that the contract has. We use the `Endpoint` type constructor to describe the name and type of each endpoint. The `.\/` operator combines two schemas. So a contract with a single endpoint called "amount" of type `Int` would have the following schema type:
 
 [source, haskell]
 ----
@@ -179,6 +179,6 @@ To avoid keeping old events around for longer than necessary we can use the `jso
 
 `jsonCheckpoint` is a unary operator that takes a `PlutusContract` with a result that can be written to and read from JSON. The bookeeping system that is used behind the scenes to keep track of contract state will, upon encountering a contract wrapped in `jsonCheckpoint`, run the contract once and then store the result of that contract as a JSON object. The next time we restore the contract's state, the system will _not_ replay the events for that contract, but instead use the `FromJSON` instance to restore the state.
 
-NOTE: Contracts that don't use `jsonCheckpoint` are still able to have their state saved and restored. This will take the form of the `[Event]` sequence of inputs that have been seen so far. 
+NOTE: Contracts that don't use `jsonCheckpoint` are still able to have their state saved and restored. This will take the form of the `[Event]` sequence of inputs that have been seen so far.
 
 NOTE: To handle things like the loop in the `sharedealing` example we probably need something more explicit, like a notion of cells that can be written to and read from. But we could implement that in the same manner as the `jsonCheckpoint` (the important bit is how the JSON constraints are embedded in the contract definition)

--- a/plutus-contract/src/Language/Plutus/Contract.hs
+++ b/plutus-contract/src/Language/Plutus/Contract.hs
@@ -5,6 +5,7 @@
 module Language.Plutus.Contract(
       Contract(..)
     , ContractError(..)
+    , AsContractError(..)
     , HasBlockchainActions
     , BlockchainActions
     , both
@@ -13,7 +14,6 @@ module Language.Plutus.Contract(
     , (>>)
     , (<|>)
     , checkpoint
-    , throwContractError
     -- * Dealing with time
     , HasAwaitSlot
     , AwaitSlot
@@ -62,8 +62,8 @@ import           Language.Plutus.Contract.Effects.WatchAddress
 import           Language.Plutus.Contract.Effects.WriteTx
 import           Language.Plutus.Contract.Util                   (both, selectEither)
 
-import           Language.Plutus.Contract.Request                (Contract (..), ContractError (..), ContractRow,
-                                                                  checkpoint, select, throwContractError)
+import           Language.Plutus.Contract.Request                (AsContractError (..), Contract (..),
+                                                                  ContractError (..), ContractRow, checkpoint, select)
 
 import           Language.Plutus.Contract.Tx                     as Tx
 

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/ExposeEndpoint.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/ExposeEndpoint.hs
@@ -44,9 +44,9 @@ type Endpoint l a = l .== (a, ActiveEndpoints)
 
 -- | Expose an endpoint, return the data that was entered
 endpoint
-  :: forall l a s.
+  :: forall l a s e.
      ( HasEndpoint l a s )
-  => Contract s a
+  => Contract s e a
 endpoint = request @l @_ @_ @s s where
   s = ActiveEndpoints $ Set.singleton $ EndpointDescription $ symbolVal (Proxy @l)
 

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/UtxoAt.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/UtxoAt.hs
@@ -45,7 +45,7 @@ data UtxoAtAddress =
 type UtxoAt = UtxoAtSym .== (UtxoAtAddress, Set Address)
 
 -- | Get the unspent transaction outputs at an address.
-utxoAt :: forall s. HasUtxoAt s => Address -> Contract s AddressMap
+utxoAt :: forall s e. HasUtxoAt s => Address -> Contract s e AddressMap
 utxoAt address' =
     let check :: UtxoAtAddress -> Maybe AddressMap
         check UtxoAtAddress{address,utxo} =

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/WriteTx.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/WriteTx.hs
@@ -10,9 +10,9 @@
 module Language.Plutus.Contract.Effects.WriteTx where
 
 import           Control.Monad                    ((>=>))
+import           Control.Monad.Error.Lens         (throwing)
 import           Data.Aeson                       (FromJSON, ToJSON)
 import           Data.Row
-import qualified Data.Text                        as Text
 import           GHC.Generics                     (Generic)
 
 import           Language.Plutus.Contract.Request as Req
@@ -37,15 +37,16 @@ newtype PendingTransactions =
     deriving stock (Eq, Generic, Show)
     deriving newtype (Semigroup, Monoid, ToJSON, FromJSON)
 
---  | Send an unbalanced transaction to be balanced and signed. Returns the ID
+-- | Send an unbalanced transaction to be balanced and signed. Returns the ID
 --    of the final transaction, or an error.
-writeTx :: forall s. HasWriteTx s => UnbalancedTx -> Contract s WriteTxResponse
+writeTx :: forall s e. HasWriteTx s => UnbalancedTx -> Contract s e WriteTxResponse
 writeTx t = request @TxSymbol @_ @_ @s (PendingTransactions [t])
 
---  | Send an unbalanced transaction to be balanced and signed. Returns the ID
+-- | Send an unbalanced transaction to be balanced and signed. Returns the ID
 --    of the final transaction, throws an error on failure.
-writeTxSuccess :: forall s. HasWriteTx s => UnbalancedTx -> Contract s TxId
-writeTxSuccess = writeTx >=> either (Req.throwContractError . Text.pack . show) pure
+writeTxSuccess :: forall s e. (HasWriteTx s, Req.AsContractError e) => UnbalancedTx -> Contract s e TxId
+-- See Note [Injecting errors into the user's error type]
+writeTxSuccess = writeTx >=> either (throwing Req._WalletError) pure
 
 event
   :: forall s. (HasType TxSymbol WriteTxResponse (Input s), AllUniqueLabels (Input s))

--- a/plutus-contract/src/Language/Plutus/Contract/Servant.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Servant.hs
@@ -30,7 +30,7 @@ import           Servant                            ((:<|>) ((:<|>)), (:>), Get,
 import           Servant.Server                     (Application, ServantErr, Server, serve)
 
 import           Language.Plutus.Contract.Record
-import           Language.Plutus.Contract.Request   (Contract (..), ContractError)
+import           Language.Plutus.Contract.Request   (Contract (..))
 import           Language.Plutus.Contract.Resumable (ResumableError)
 import qualified Language.Plutus.Contract.Resumable as Resumable
 import           Language.Plutus.Contract.Schema    (Event, Handlers, Input, Output)
@@ -63,20 +63,21 @@ type ContractAPI s =
 
 -- | Serve a 'PlutusContract' via the contract API.
 contractServer
-    :: forall s.
+    :: forall s e.
        ( AllUniqueLabels (Output s)
        , Forall (Output s) Monoid
        , Forall (Output s) Semigroup
+       , Show e
        )
-    => Contract s ()
+    => Contract s e ()
     -> Server (ContractAPI s)
 contractServer con = initialise :<|> run where
     initialise = servantResp (initialResponse con)
     run req = servantResp (runUpdate con req)
 
 servantResp
-    :: MonadError ServantErr m
-    => Either (ResumableError ContractError) (Response s)
+    :: (Show e, MonadError ServantErr m)
+    => Either (ResumableError e) (Response s)
     -> m (Response s)
 servantResp = \case
         Left err ->
@@ -86,38 +87,39 @@ servantResp = \case
 
 -- | A servant 'Application' that serves a Plutus contract
 contractApp
-    :: forall s.
+    :: forall s e.
        ( AllUniqueLabels (Output s)
        , AllUniqueLabels (Input s)
        , Forall (Output s) Monoid
        , Forall (Output s) Semigroup
        , Forall (Input s) FromJSON
        , Forall (Input s) ToJSON
-       , Forall (Output s) ToJSON )
-    => Contract s () -> Application
+       , Forall (Output s) ToJSON
+       , Show e)
+    => Contract s e () -> Application
 contractApp = serve (Proxy @(ContractAPI s)) . contractServer @s
 
 runUpdate
-    :: forall s.
+    :: forall s e.
        (AllUniqueLabels (Output s)
        , Forall (Output s) Monoid
        , Forall (Output s) Semigroup
        )
-    => Contract s ()
+    => Contract s e ()
     -> Request s
-    -> Either (ResumableError ContractError) (Response s)
+    -> Either (ResumableError e) (Response s)
 runUpdate con (Request o e) =
     (\(r, h) -> Response (State r) h)
     <$> Resumable.insertAndUpdate (unContract con) (record o) e
 
 initialResponse
-    :: forall s.
+    :: forall s e.
        ( AllUniqueLabels (Output s)
        , Forall (Output s) Monoid
        , Forall (Output s) Semigroup
        )
-    => Contract s ()
-    -> Either (ResumableError ContractError) (Response s)
+    => Contract s e ()
+    -> Either (ResumableError e) (Response s)
 initialResponse =
     fmap (uncurry Response . first (State . fmap fst))
     . runExcept

--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -4,9 +4,12 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeOperators     #-}
 {-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 module Spec.Contract(tests) where
 
 import           Control.Monad                         (void)
+import           Control.Monad.Except                  (throwError)
 import           Test.Tasty
 
 import           Language.Plutus.Contract              as Con
@@ -89,7 +92,9 @@ tests =
         , cp "select either"
             (let l = endpoint @"1" >> endpoint @"2"
                  r = endpoint @"3" >> endpoint @"4"
-            in (void $ selectEither l r))
+                 s :: Contract _ () _
+                 s = selectEither l r
+            in void s)
             (assertDone w1 (const True) "left branch should finish")
             (callEndpoint @"3" w1 3 >> callEndpoint @"1" w1 1 >> callEndpoint @"2" w1 2)
 
@@ -104,7 +109,7 @@ tests =
             (callEndpoint @"1" @Int w1 1)
 
         , cp "throw an error"
-            (void $ throwContractError "error")
+            (void $ throwError ("error"::String))
             (assertContractError w1 "error" "failed to throw error")
             (pure ())
         ]

--- a/plutus-contract/test/Spec/State.hs
+++ b/plutus-contract/test/Spec/State.hs
@@ -22,7 +22,10 @@ type Schema =
 
 tests :: TestTree
 tests =
-    let ep = Con.unContract (Con.endpoint @"endpoint" @String @Schema)
+    let
+        epCon :: Con.Contract Schema () String
+        epCon = Con.endpoint @"endpoint" @String @Schema
+        ep = Con.unContract epCon
         initRecord = fmap fst . fst . fromRight (error "initialise failed") . runExcept . runWriterT . S.initialise
         inp = Endpoint.event @"endpoint" "asd"
         run con =

--- a/plutus-use-cases/exe/crowdfunding/Main.hs
+++ b/plutus-use-cases/exe/crowdfunding/Main.hs
@@ -1,11 +1,13 @@
+{-# LANGUAGE TypeApplications #-}
 -- | Contract interface for the crowdfunding contract
 module Main where
 
+import           Language.Plutus.Contract                              (ContractError)
 import qualified Language.Plutus.Contract.App                          as App
 import           Language.PlutusTx.Coordination.Contracts.CrowdFunding (crowdfunding, successfulCampaign, theCampaign)
 
 main :: IO ()
-main = App.runWithTraces (crowdfunding theCampaign)
+main = App.runWithTraces (crowdfunding @ContractError theCampaign)
         [ ("success-w1", (App.Wallet 1, successfulCampaign))
         , ("success-w2", (App.Wallet 2, successfulCampaign))
         , ("success-w3", (App.Wallet 3, successfulCampaign))

--- a/plutus-use-cases/exe/game/Main.hs
+++ b/plutus-use-cases/exe/game/Main.hs
@@ -1,11 +1,13 @@
+{-# LANGUAGE TypeApplications #-}
 -- | Contract interface for the guessing game
 module Main where
 
+import           Language.Plutus.Contract                      (ContractError)
 import qualified Language.Plutus.Contract.App                  as App
 import           Language.PlutusTx.Coordination.Contracts.Game (game, guessTrace, lockTrace)
 
 main :: IO ()
-main = App.runWithTraces game
+main = App.runWithTraces (game @ContractError)
           [ ("lock", (App.Wallet 1, lockTrace))
           , ("guess", (App.Wallet 2, guessTrace)) ]
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -121,12 +121,13 @@ forgedValue cur =
 --   @k@ token names, forging @c_i@ units of each token @n_i@.
 --   If @k == 0@ then no value is forged.
 forgeContract
-    :: forall s.
+    :: forall s e.
     ( HasWatchAddress s
-    , HasWriteTx s)
+    , HasWriteTx s
+    , AsContractError e)
     => PubKey
     -> [(String, Integer)]
-    -> Contract s Currency
+    -> Contract s e Currency
 forgeContract pk amounts = do
     refTxIn <- PK.pubKeyContract pk (Ada.lovelaceValueOf 1)
     let theCurrency = mkCurrency (txInRef refTxIn) amounts

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -100,7 +100,7 @@ newtype GuessParams = GuessParams
     deriving stock (Prelude.Eq, Prelude.Ord, Prelude.Show, Generic)
     deriving anyclass (Aeson.FromJSON, Aeson.ToJSON, IotsType)
 
-guess :: Contract GameSchema ()
+guess :: Contract GameSchema e ()
 guess = do
     st <- nextTransactionAt gameAddress
     let mp = AM.fromTxOutputs st
@@ -112,7 +112,7 @@ guess = do
         tx         = unbalancedTx inp []
     void (writeTx tx)
 
-lock :: Contract GameSchema ()
+lock :: Contract GameSchema e ()
 lock = do
     LockParams secret amt <- endpoint @"lock" @LockParams
     let
@@ -122,12 +122,12 @@ lock = do
         tx         = unbalancedTx [] [output]
     void (writeTx tx)
 
-game :: Contract GameSchema ()
+game :: Contract GameSchema e ()
 game = guess <|> lock
 
 lockTrace
     :: ( MonadEmulator m )
-    => ContractTrace GameSchema m () ()
+    => ContractTrace GameSchema e m () ()
 lockTrace =
     let w1 = Trace.Wallet 1
         w2 = Trace.Wallet 2 in
@@ -137,7 +137,7 @@ lockTrace =
 
 guessTrace
     :: ( MonadEmulator m )
-    => ContractTrace GameSchema m () ()
+    => ContractTrace GameSchema e m () ()
 guessTrace =
     let w2 = Trace.Wallet 2 in
     lockTrace
@@ -146,7 +146,7 @@ guessTrace =
 
 guessWrongTrace
     :: ( MonadEmulator m )
-    => ContractTrace GameSchema m () ()
+    => ContractTrace GameSchema e m () ()
 guessWrongTrace =
     let w2 = Trace.Wallet 2 in
     lockTrace

--- a/plutus-use-cases/test/Spec/Currency.hs
+++ b/plutus-use-cases/test/Spec/Currency.hs
@@ -32,7 +32,7 @@ tests = testGroup "currency"
 w1 :: Wallet
 w1 = Wallet 1
 
-theContract :: Contract BlockchainActions Currency
+theContract :: Contract BlockchainActions ContractError Currency
 theContract =
     let amounts = [("my currency", 1000), ("my token", 1)] in
     Cur.forgeContract (walletPubKey w1) amounts

--- a/plutus-use-cases/test/Spec/PubKey.hs
+++ b/plutus-use-cases/test/Spec/PubKey.hs
@@ -17,7 +17,7 @@ import           Test.Tasty
 w1 :: Wallet
 w1 = Wallet 1
 
-theContract :: Contract BlockchainActions ()
+theContract :: Contract BlockchainActions ContractError ()
 theContract = do
   txin <- pubKeyContract (walletPubKey w1) (Ada.lovelaceValueOf 10)
   void $ writeTx $ mempty & inputs .~ Set.singleton txin


### PR DESCRIPTION
This lets users pick what they want to put here, which is important
since it's supposed to be a carrier for user errors too. The old version
handled this by turning everything into `Text`, which is also non-ideal.

Really, we should do this with more types and an approach like the
various `As*Error` classes used in the compiler. But this is a lot more
machinery for something we're barely using yet, so for now I've stuck to
abusing `IsString`.