### PR TITLE
emulator: require only that assertions be injectable into the error type

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract/App.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/App.hs
@@ -26,7 +26,7 @@ import           Language.Plutus.Contract.Servant (Request (..), Response (..), 
 import           Language.Plutus.Contract.Trace   (ContractTrace, EmulatorAction, execTrace)
 import qualified Network.Wai.Handler.Warp         as Warp
 import           System.Environment               (getArgs)
-import           Wallet.Emulator                  (Wallet (..))
+import           Wallet.Emulator                  (AsAssertionError, Wallet (..))
 
 import           Language.Plutus.Contract.IOTS    (IotsRow, IotsType, rowSchema)
 
@@ -49,7 +49,7 @@ type AppSchema s =
 -- | Run the contract as an HTTP server with servant/warp
 run
     :: forall s e.
-       ( AppSchema s, Show e )
+       ( AppSchema s, Show e, AsAssertionError e )
     => Contract s e () -> IO ()
 run st = runWithTraces @s st []
 
@@ -57,9 +57,9 @@ run st = runWithTraces @s st []
 --   print the 'Request' values for the given traces.
 runWithTraces
     :: forall s e.
-       ( AppSchema s, Show e )
+       ( AppSchema s, Show e, AsAssertionError e )
     => Contract s e ()
-    -> [(String, (Wallet, ContractTrace s e EmulatorAction () ()))]
+    -> [(String, (Wallet, ContractTrace s e (EmulatorAction e) () ()))]
     -> IO ()
 runWithTraces con traces = do
     let mp = Map.fromList traces
@@ -90,11 +90,12 @@ printTrace
        , Forall (Output s) Monoid
        , Forall (Output s) Semigroup
        , Forall (Input s) ToJSON
+       , AsAssertionError e
        , Show e
        )
     => Contract s e ()
     -> Wallet
-    -> ContractTrace s e EmulatorAction () ()
+    -> ContractTrace s e (EmulatorAction e) () ()
     -> IO ()
 printTrace con wllt ctr = do
     let events = Map.findWithDefault [] wllt $ execTrace con ctr

--- a/plutus-contract/src/Language/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Request.hs
@@ -31,6 +31,7 @@ import qualified Language.PlutusTx.Applicative      as PlutusTx
 import qualified Language.PlutusTx.Functor          as PlutusTx
 import           Prelude                            as Haskell
 import           Wallet.API                         (WalletAPIError)
+import           Wallet.Emulator.Types              (AsAssertionError (..), AssertionError)
 
 -- | @Contract s a@ is a contract with schema 's', producing a value of
 --  type 'a' or a 'ContractError'. See note [Contract Schema].
@@ -47,13 +48,17 @@ instance PlutusTx.Applicative (Contract s e) where
 
 data ContractError =
     WalletError WalletAPIError
+    | EmulatorAssertionError AssertionError
     | OtherError T.Text
-    deriving Show
+    deriving (Show, Eq)
 makeClassyPrisms ''ContractError
 
 -- | This lets people use 'T.Text' as their error type.
 instance AsContractError T.Text where
     _ContractError = prism' (T.pack . show) (const Nothing)
+
+instance AsAssertionError ContractError where
+    _AssertionError = _EmulatorAssertionError
 
 -- | Constraints on the contract schema, ensuring that the requests produced
 --   by the contracts are 'Monoid's (so that we can produce a record with

--- a/plutus-contract/src/Language/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Test.hs
@@ -122,11 +122,12 @@ not :: TracePredicate s e a -> TracePredicate s e a
 not = PredF . fmap (fmap Prelude.not) . unPredF
 
 checkPredicate
-    :: forall s e a.
-       String
+    :: forall s e a
+    . (EM.AsAssertionError e, Show e)
+    => String
     -> Contract s e a
     -> TracePredicate s e a
-    -> ContractTrace s e EmulatorAction a ()
+    -> ContractTrace s e (EmulatorAction e) a ()
     -> TestTree
 checkPredicate nm con predicate action =
     HUnit.testCaseSteps nm $ \step ->

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/CrowdFunding.hs
@@ -217,7 +217,7 @@ scheduleCollection cmp = do
 -- | Call the "schedule collection" endpoint and instruct the campaign owner's
 --   wallet (wallet 1) to start watching the campaign address.
 startCampaign
-    :: ( MonadEmulator m  )
+    :: ( MonadEmulator e m  )
     => ContractTrace CrowdfundingSchema e m () ()
 startCampaign =
     Trace.callEndpoint @"schedule collection" (Trace.Wallet 1)  ()
@@ -225,7 +225,7 @@ startCampaign =
 
 -- | Call the "contribute" endpoint, contributing the amount from the wallet
 makeContribution
-    :: ( MonadEmulator m )
+    :: ( MonadEmulator e m )
     => Wallet
     -> Value
     -> ContractTrace CrowdfundingSchema e m () ()
@@ -235,7 +235,7 @@ makeContribution w v =
 
 -- | Run a successful campaign with contributions from wallets 2, 3 and 4.
 successfulCampaign
-    :: ( MonadEmulator m )
+    :: ( MonadEmulator e m )
     => ContractTrace CrowdfundingSchema e m () ()
 successfulCampaign =
     startCampaign

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -16,6 +16,7 @@ module Language.PlutusTx.Coordination.Contracts.Game(
     lock,
     guess,
     game,
+    GameSchema,
     GuessParams(..),
     LockParams(..),
     -- * Scripts
@@ -126,7 +127,7 @@ game :: Contract GameSchema e ()
 game = guess <|> lock
 
 lockTrace
-    :: ( MonadEmulator m )
+    :: ( MonadEmulator e m )
     => ContractTrace GameSchema e m () ()
 lockTrace =
     let w1 = Trace.Wallet 1
@@ -136,7 +137,7 @@ lockTrace =
         >> Trace.handleBlockchainEvents w1
 
 guessTrace
-    :: ( MonadEmulator m )
+    :: ( MonadEmulator e m )
     => ContractTrace GameSchema e m () ()
 guessTrace =
     let w2 = Trace.Wallet 2 in
@@ -145,7 +146,7 @@ guessTrace =
         >> Trace.handleBlockchainEvents w2
 
 guessWrongTrace
-    :: ( MonadEmulator m )
+    :: ( MonadEmulator e m )
     => ContractTrace GameSchema e m () ()
 guessWrongTrace =
     let w2 = Trace.Wallet 2 in

--- a/plutus-use-cases/test/Spec/Game.hs
+++ b/plutus-use-cases/test/Spec/Game.hs
@@ -8,13 +8,12 @@ import qualified Language.Plutus.Contract.Effects.ExposeEndpoint as Endpoint
 import qualified Language.PlutusTx                             as PlutusTx
 import qualified Language.PlutusTx.Prelude                     as PlutusTx
 import           Language.PlutusTx.Lattice
-import           Language.PlutusTx.Coordination.Contracts.Game (LockParams (..), game, gameAddress,
-                                                                gameValidator, guessTrace, guessWrongTrace, lockTrace,
-                                                                validateGuess)
+import           Language.PlutusTx.Coordination.Contracts.Game
 import qualified Spec.Lib                                      as Lib
 import           Spec.Lib                                      (timesFeeAdjust)
 import           Test.Tasty
 import qualified Test.Tasty.HUnit                              as HUnit
+import           Wallet.Emulator.Types                         (AssertionError)
 
 w1, w2 :: Wallet
 w1 = Wallet 1
@@ -22,28 +21,28 @@ w2 = Wallet 2
 
 tests :: TestTree
 tests = testGroup "game"
-    [ checkPredicate "Expose 'lock' endpoint and watch game address"
+    [ checkPredicate @_ @AssertionError "Expose 'lock' endpoint and watch game address"
         game
         (endpointAvailable @"lock" w1 /\ interestingAddress w1 gameAddress)
         $ pure ()
 
-    , checkPredicate "'lock' endpoint submits a transaction"
+    , checkPredicate @_ @AssertionError "'lock' endpoint submits a transaction"
         game
         (anyTx w1)
         $ addEvent w1 (Endpoint.event @"lock" (LockParams "secret" 10))
 
-    , checkPredicate "'guess' endpoint is available after locking funds"
+    , checkPredicate @_ @AssertionError "'guess' endpoint is available after locking funds"
         game
         (endpointAvailable @"guess" w2)
         lockTrace
 
-    , checkPredicate "guess right (unlock funds)"
+    , checkPredicate @_ @AssertionError "guess right (unlock funds)"
         game
         (walletFundsChange w2 (1 `timesFeeAdjust` 10)
             /\ walletFundsChange w1 (1 `timesFeeAdjust` (-10)))
         guessTrace
 
-    , checkPredicate "guess wrong"
+    , checkPredicate @_ @AssertionError "guess wrong"
         game
         (walletFundsChange w2 PlutusTx.zero
             /\ walletFundsChange w1 (1 `timesFeeAdjust` (-10)))

--- a/plutus-use-cases/test/Spec/GameStateMachine.hs
+++ b/plutus-use-cases/test/Spec/GameStateMachine.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE TypeApplications         #-}
 module Spec.GameStateMachine(tests) where
 
 import           Control.Monad                                             (void)
@@ -36,11 +37,11 @@ tests =
     in
         testGroup "state machine tests" [
             HUnit.testCaseSteps "run a successful game trace"
-                (checkResult (EM.runEmulator initialState runGameSuccess)),
+                (checkResult (EM.runEmulator @EM.AssertionError initialState runGameSuccess)),
             HUnit.testCaseSteps "run a 2nd successful game trace"
-                (checkResult (EM.runEmulator initialState runGameSuccess2)),
+                (checkResult (EM.runEmulator @EM.AssertionError initialState runGameSuccess2)),
             HUnit.testCaseSteps "run a failed trace"
-                (checkResult (EM.runEmulator initialState runGameFailure)),
+                (checkResult (EM.runEmulator @EM.AssertionError initialState runGameFailure)),
             Lib.goldenPir "test/Spec/gameStateMachine.pir" $$(PlutusTx.compile [|| mkValidator ||])
         ]
 
@@ -62,7 +63,7 @@ processAndNotify = void (EM.addBlocksAndNotify [w1, w2, w3] 1)
 -- Wallet 1 locks some funds using the secret "hello". Then wallet 1
 -- transfers the token to wallet 2, and wallet 2 makes a correct guess
 -- and locks the remaining funds using the secret "new secret".
-runGameSuccess :: (EM.MonadEmulator m) => m ()
+runGameSuccess :: (EM.MonadEmulator e m) => m ()
 runGameSuccess = void $ EM.processEmulated $ do
         processAndNotify
         _   <- EM.runWalletAction w1 G.startGame
@@ -79,7 +80,7 @@ runGameSuccess = void $ EM.processEmulated $ do
 
 -- Runs 'runGameSuccess', then wallet 2 transfers the token to wallet 1, which takes
 -- out another couple of Ada.
-runGameSuccess2 :: (EM.MonadEmulator m) => m ()
+runGameSuccess2 :: (EM.MonadEmulator e m) => m ()
 runGameSuccess2 = do
     runGameSuccess
 
@@ -91,7 +92,7 @@ runGameSuccess2 = do
         EM.assertOwnFundsEq w1 (Ada.adaValueOf 4 <> G.gameTokenVal)
 
 -- Wallet 2 makes a wrong guess and fails to take out the funds
-runGameFailure :: (EM.MonadEmulator m) => m ()
+runGameFailure :: (EM.MonadEmulator e m) => m ()
 runGameFailure = void $ EM.processEmulated $ do
         processAndNotify
         _   <- EM.runWalletAction w1 G.startGame

--- a/plutus-use-cases/test/Spec/MultiSig.hs
+++ b/plutus-use-cases/test/Spec/MultiSig.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 module Spec.MultiSig(tests) where
 
 import           Control.Lens
 import           Control.Monad                                     (void)
-import           Control.Monad.Except
+import           Control.Monad.Error.Lens
 import           Data.Either                                       (isLeft, isRight)
 import qualified Data.Map                                          as Map
 import qualified Data.Text                                         as T
@@ -34,7 +35,7 @@ tests = testGroup "multisig" [
 nOutOfFiveTest :: Int -> HUnit.Assertion
 nOutOfFiveTest i = do
     let initialState = EM.emulatorStateInitialDist (Map.singleton (EM.walletPubKey (EM.Wallet 1)) (Ada.adaValueOf 10))
-        (result, _) = EM.runEmulator initialState (threeOutOfFive i)
+        (result, _) = EM.runEmulator @EM.AssertionError initialState (threeOutOfFive i)
         isOk = if i < 3 then isLeft result else isRight result
     HUnit.assertBool "transaction failed to validate" isOk
 
@@ -42,7 +43,7 @@ nOutOfFiveTest i = do
 --   contract, and attempts to spend them using the given number of signatures.
 --   @threeOutOfFive 3@ passes, @threeOutOfFive 2@ results in an
 --   'EM.AssertionError'.
-threeOutOfFive :: (EM.MonadEmulator m) => Int -> m ()
+threeOutOfFive :: (EM.MonadEmulator e m) => Int -> m ()
 threeOutOfFive n = do
 
     let
@@ -66,7 +67,7 @@ threeOutOfFive n = do
             processAndNotify
             EM.runWalletAction w2 (unlockTx ms)
 
-    tx <- either (throwError . EM.AssertionError . T.pack . show) pure r
+    tx <- either (throwing EM._AssertionError . EM.GenericAssertion . T.pack . show) pure r
 
     let
         -- Attach signatures of the first @n@ wallets' private keys to 'tx'.

--- a/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
+++ b/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
@@ -39,7 +39,7 @@ tests = testGroup "multi sig state machine tests" [
     HUnit.testCase "script size is reasonable" (Lib.reasonable (Scripts.validatorScript $ MS.scriptInstance params) 350000)
     ]
 
-runTrace :: EM.EmulatorAction a -> (Either EM.AssertionError a -> Bool) -> (String -> IO ()) -> IO ()
+runTrace :: EM.EmulatorAction EM.AssertionError a -> (Either EM.AssertionError a -> Bool) -> (String -> IO ()) -> IO ()
 runTrace t f step = do
     let initialState = EM.emulatorStateInitialDist (Map.singleton (EM.walletPubKey (EM.Wallet 1)) (Ada.adaValueOf 10))
         (result, st) = EM.runEmulator initialState t
@@ -110,7 +110,7 @@ makePayment'' st = processAndNotify >> fst <$> EM.walletAction w3 (makePayment' 
 proposeSignPay :: (WalletAPI m, WalletDiagnostics m) => Integer -> State -> EM.Trace m State
 proposeSignPay i = proposePayment'' >=> addSignature'' i >=> makePayment''
 
-lockProposeSignPay :: forall m . (EM.MonadEmulator m) => Integer -> Integer -> m ()
+lockProposeSignPay :: forall e m . (EM.MonadEmulator e m) => Integer -> Integer -> m ()
 lockProposeSignPay i j = EM.processEmulated $ do
 
     -- stX contain the state of the contract. See note [Current state of the

--- a/plutus-use-cases/test/Spec/Rollup.hs
+++ b/plutus-use-cases/test/Spec/Rollup.hs
@@ -34,7 +34,7 @@ tests = testGroup "showBlockchain"
 
 render
     :: Contract s T.Text a
-    -> ContractTrace s T.Text EmulatorAction a ()
+    -> ContractTrace s T.Text (EmulatorAction T.Text) a ()
     -> IO ByteString
 render con trace = do
     let (result, EmulatorState{_chainNewestFirst=blockchain, _walletStates=wallets}) = runTrace con trace


### PR DESCRIPTION
This is pretty grim, but I don't have a nicer solution.

We have a pervasive pair of `m` and `e` type arguments, representing the
base monad that the contract runs in and the error type. However, when
we run a trace, `m` has to do double duty as the emulator monad. This
means that we end up with two conflicting `MonadError` instances:
- One for the user's error type.
- One for the assertion errors that the emulator can throw.

What to do? This PR takes the route we're already using elsewhere, and
weakens the `MonadError` constraint from the emulator to only require
that `AssertionError` be injectable into the main error type.

The main downside of this is that the error type is now ambiguous if
it's unconstrained, which is a massive pain and requires type
annotations at the use site. But I don't have a better solution at the
moment.