### PR TITLE
[Bug] [PlutusExe] Fixed looping 'plc example -a'

### DIFF
--- a/language-plutus-core/generate-evaluation-test/Main.hs
+++ b/language-plutus-core/generate-evaluation-test/Main.hs
@@ -9,20 +9,21 @@ import           Data.Foldable
 import           Data.Text                      (Text)
 import qualified Data.Text                      as Text
 import qualified Data.Text.IO                   as Text
+import qualified Hedgehog.Gen                   as Gen
 
 -- | Generate a test sample: a term of arbitrary type and what it computes to.
 -- Uses 'genTermLoose' under the hood.
-generateTerm :: IO (TermOf (Value TyName Name ()))
-generateTerm = runSampleSucceed $ withAnyTermLoose $ pure . unsafeTypeEvalCheck
+generateTerm :: IO (TermOf EvaluationResultDef)
+generateTerm = Gen.sample $ withAnyTermLoose $ pure . unsafeTypeEvalCheck
 
 oneline :: Text -> Text
 oneline = Text.unwords . Text.words
 
 main :: IO ()
 main = do
-    TermOf term value <- generateTerm
+    TermOf term result <- generateTerm
     traverse_ Text.putStrLn
         [ oneline . prettyPlcDefText $ Program () (Version () 0 1 0) term
         , ""
-        , oneline . prettyPlcDefText $ value
+        , oneline . prettyPlcDefText $ result
         ]

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Entity.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Entity.hs
@@ -22,6 +22,7 @@ module Language.PlutusCore.Generators.Internal.Entity
     ) where
 
 import           Language.PlutusCore.Constant
+import           Language.PlutusCore.Evaluation.Result
 import           Language.PlutusCore.Generators.Internal.Denotation
 import           Language.PlutusCore.Generators.Internal.Dependent
 import           Language.PlutusCore.Generators.Internal.TypedBuiltinGen
@@ -103,13 +104,13 @@ withTypedBuiltinGen k = Gen.choice
 withCheckedTermGen
     :: Monad m
     => TypedBuiltinGenT m
-    -> (forall a. AsKnownType a -> Maybe (TermOf (Value TyName Name ())) -> GenT m c)
+    -> (forall a. AsKnownType a -> TermOf EvaluationResultDef -> GenT m c)
     -> GenT m c
 withCheckedTermGen genTb k =
     withTypedBuiltinGen $ \akt@AsKnownType -> do
         termWithMetaValue <- genTb akt
-        let mayTermWithValue = unsafeTypeEvalCheck termWithMetaValue
-        k akt mayTermWithValue
+        let termWithResult = unsafeTypeEvalCheck termWithMetaValue
+        k akt termWithResult
 
 -- | Generate an 'IterAppValue' from a 'Denotation'.
 -- If the 'Denotation' has a functional type, then all arguments are generated and

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
@@ -94,7 +94,7 @@ typeEvalCheckBy eval (TermOf term x) = TermOf term <$> do
 -- | Type check and evaluate a term and check that the expected result is equal to the actual one.
 -- Throw an error in case something goes wrong.
 unsafeTypeEvalCheck
-    :: forall a. KnownType a => TermOf a -> Maybe (TermOf (Value TyName Name ()))
+    :: forall a. KnownType a => TermOf a -> TermOf EvaluationResultDef
 unsafeTypeEvalCheck termOfTbv = do
     let errOrRes = typeEvalCheckBy evaluateCk termOfTbv
     case errOrRes of
@@ -103,4 +103,4 @@ unsafeTypeEvalCheck termOfTbv = do
             , "\nin\n"
             , docString . prettyPlcClassicDebug $ _termOfTerm termOfTbv
             ]
-        Right termOfTecr -> traverse (reoption . _termCheckResultValue) termOfTecr
+        Right termOfTecr -> _termCheckResultValue <$> termOfTecr

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Utils.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Utils.hs
@@ -14,9 +14,6 @@ module Language.PlutusCore.Generators.Internal.Utils
     , forAllPrettyT
     , forAllPrettyPlc
     , forAllPrettyPlcT
-    , forAllPrettyPlcMaybe
-    , forAllPrettyPlcMaybeT
-    , runSampleSucceed
     , prettyPlcErrorString
     ) where
 
@@ -73,21 +70,6 @@ forAllPrettyPlc = forAllWith prettyPlcDefString
 -- A supplied generator has access to the 'Monad' the whole property has access to.
 forAllPrettyPlcT :: (Monad m, PrettyPlc a) => GenT m a -> PropertyT m a
 forAllPrettyPlcT = forAllWithT prettyPlcDefString
-
--- | Generate a value wrapped in 'Maybe' using the 'PrettyPlc' constraint
--- for getting its 'String' representation.
-forAllPrettyPlcMaybe :: (Monad m, PrettyPlc a) => Gen (Maybe a) -> PropertyT m (Maybe a)
-forAllPrettyPlcMaybe = forAllWith $ maybe "Nothing" prettyPlcDefString
-
--- | Generate a value wrapped in 'Maybe' using the 'PrettyPlc' constraint
--- for getting its 'String' representation.
--- A supplied generator has access to the 'Monad' the whole property has access to.
-forAllPrettyPlcMaybeT :: (Monad m, PrettyPlc a) => GenT m (Maybe a) -> PropertyT m (Maybe a)
-forAllPrettyPlcMaybeT = forAllWithT $ maybe "Nothing" prettyPlcDefString
-
--- | Run a generator until it succeeds with a 'Just'.
-runSampleSucceed :: Gen (Maybe a) -> IO a
-runSampleSucceed = Gen.sample . Gen.just
 
 -- | Pretty-print a PLC error.
 prettyPlcErrorString :: PrettyPlc err => err -> String

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Test.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Test.hs
@@ -28,18 +28,19 @@ import           Control.Monad.Except
 import           Data.Functor                                            ((<&>))
 import qualified Data.Text.IO                                            as Text
 import           Hedgehog                                                hiding (Size, Var, eval)
+import qualified Hedgehog.Gen                                            as Gen
 import           System.FilePath                                         ((</>))
 
 -- | Generate a term using a given generator and check that it's well-typed and evaluates correctly.
-getSampleTermValue :: KnownType a => TermGen a -> IO (TermOf (Value TyName Name ()))
-getSampleTermValue genTerm = runSampleSucceed $ unsafeTypeEvalCheck <$> genTerm
+getSampleTermValue :: KnownType a => TermGen a -> IO (TermOf EvaluationResultDef)
+getSampleTermValue genTerm = Gen.sample $ unsafeTypeEvalCheck <$> genTerm
 
 -- | Generate a program using a given generator and check that it's well-typed and evaluates correctly.
 getSampleProgramAndValue
-    :: KnownType a => TermGen a -> IO (Program TyName Name (), Value TyName Name ())
+    :: KnownType a => TermGen a -> IO (Program TyName Name (), EvaluationResultDef)
 getSampleProgramAndValue genTerm =
-    getSampleTermValue genTerm <&> \(TermOf term value) ->
-        (Program () (defaultVersion ()) term, value)
+    getSampleTermValue genTerm <&> \(TermOf term result) ->
+        (Program () (defaultVersion ()) term, result)
 
 -- | Generate a program using a given generator, check that it's well-typed and evaluates correctly
 -- and pretty-print it to stdout using the default pretty-printing mode.

--- a/language-plutus-core/language-plutus-core.cabal
+++ b/language-plutus-core/language-plutus-core.cabal
@@ -176,7 +176,8 @@ executable language-plutus-core-generate-evaluation-test
     build-depends:
         base -any,
         language-plutus-core -any,
-        text -any
+        text -any,
+        hedgehog -any
 
     if (flag(development) && impl(ghc <8.4))
         ghc-options: -Werror

--- a/language-plutus-core/test/Evaluation/Constant/Success.hs
+++ b/language-plutus-core/test/Evaluation/Constant/Success.hs
@@ -9,8 +9,6 @@ import           Evaluation.Constant.Apply
 
 import qualified Data.ByteString.Lazy           as BSL
 import qualified Data.ByteString.Lazy.Hash      as Hash
-import           Data.Maybe
-import           Hedgehog
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
 
@@ -145,17 +143,8 @@ test_applyBuiltinNameSuccess =
         , test_typedSHA3Success
         ]
 
--- | Generates in-bounds constants and checks that their evaluation results in an 'EvaluationSuccess'.
-test_evalInBounds :: TestTree
-test_evalInBounds =
-    testProperty "evalInBounds" . property $ do
-        mayTermWithValue <-
-            forAllPrettyPlcMaybeT $ withCheckedTermGen genTypedBuiltinDef $ const return
-        assert $ isJust mayTermWithValue
-
 test_constantSuccess :: TestTree
 test_constantSuccess =
     testGroup "constantSuccess"
        [ test_applyBuiltinNameSuccess
-       , test_evalInBounds
        ]

--- a/plutus-exe/src/Main.hs
+++ b/plutus-exe/src/Main.hs
@@ -69,7 +69,7 @@ plutusOpts :: Parser Command
 plutusOpts = hsubparser (
     command "typecheck" (info (Typecheck <$> typecheckOpts) (progDesc "Typecheck a Plutus Core program"))
     <> command "evaluate" (info (Eval <$> evalOpts) (progDesc "Evaluate a Plutus Core program"))
-    <> command "example" (info (Example <$> exampleOpts) (progDesc "Show a Plutus Core program example. Usage: first request the list of available examples (optional step), then request a particular example by the name of a type/term"))
+    <> command "example" (info (Example <$> exampleOpts) (progDesc "Show a Plutus Core program example. Usage: first request the list of available examples (optional step), then request a particular example by the name of a type/term. Note that evaluating a generated example may result in 'Failure'"))
   )
 
 normalizationMode :: Parser NormalizationMode


### PR DESCRIPTION
`plc example -a` was trying really hard to produce something that doesn't evaluate to `Failure`, but we have a test that always contains division by zero...

This PR allows `plc example` to generate a term that evaluates to `Failure`.