### PR TITLE
typechecking tests `plc` vs `plc-agda`.

### DIFF
--- a/metatheory/Check.lagda.md
+++ b/metatheory/Check.lagda.md
@@ -222,17 +222,15 @@ inferTypeBuiltin modInteger [] []  = return ((con integer ⇒ con integer ⇒ co
 inferTypeBuiltin lessThanInteger [] [] = return ((con integer ⇒ con integer ⇒ booleanNf) ,, ƛ "" (ƛ "" (builtin lessThanInteger (λ()) (` (S (Z reflNf)) ,, ` (Z reflNf) ,, _) reflNf)))
 inferTypeBuiltin lessThanEqualsInteger [] [] = return ((con integer ⇒ con integer ⇒ booleanNf) ,, ƛ "" (ƛ "" (builtin lessThanEqualsInteger (λ()) (` (S (Z reflNf)) ,, ` (Z reflNf) ,, _) reflNf)))
 inferTypeBuiltin greaterThanInteger [] [] = return ((con integer ⇒ con integer ⇒ booleanNf) ,, ƛ "" (ƛ "" (builtin greaterThanInteger (λ()) (` (S (Z reflNf)) ,, ` (Z reflNf) ,, _) reflNf)))
-inferTypeBuiltin greaterThanEqualsInteger As ts = return ((con integer ⇒ con integer ⇒ booleanNf) ,, ƛ "" (ƛ "" (builtin greaterThanEqualsInteger (λ()) (` (S (Z reflNf)) ,, ` (Z reflNf) ,, _) reflNf)))
-inferTypeBuiltin equalsInteger As ts = return ((con integer ⇒ con integer ⇒ booleanNf) ,, ƛ "" (ƛ "" (builtin equalsInteger (λ()) (` (S (Z reflNf)) ,, ` (Z reflNf) ,, _) reflNf)))
+inferTypeBuiltin greaterThanEqualsInteger [] [] = return ((con integer ⇒ con integer ⇒ booleanNf) ,, ƛ "" (ƛ "" (builtin greaterThanEqualsInteger (λ()) (` (S (Z reflNf)) ,, ` (Z reflNf) ,, _) reflNf)))
+inferTypeBuiltin equalsInteger [] [] = return ((con integer ⇒ con integer ⇒ booleanNf) ,, ƛ "" (ƛ "" (builtin equalsInteger (λ()) (` (S (Z reflNf)) ,, ` (Z reflNf) ,, _) reflNf)))
 inferTypeBuiltin concatenate [] [] = return ((con bytestring ⇒ con bytestring ⇒ con bytestring) ,, ƛ "" (ƛ "" (builtin concatenate (λ()) (` (S (Z reflNf)) ,, ` (Z reflNf) ,, _) reflNf)))
 inferTypeBuiltin takeByteString [] [] = return ((con integer ⇒ con bytestring ⇒ con bytestring) ,, ƛ "" (ƛ "" (builtin takeByteString (λ()) (` (S (Z reflNf)) ,, ` (Z reflNf) ,, _) reflNf)))
 inferTypeBuiltin dropByteString [] [] = return ((con integer ⇒ con bytestring ⇒ con bytestring) ,, ƛ "" (ƛ "" (builtin dropByteString (λ()) (` (S (Z reflNf)) ,, ` (Z reflNf) ,, _) reflNf)))
-{-
-inferTypeBuiltin sha2-256 As ts = {!!}
-inferTypeBuiltin sha3-256 As ts = {!!}
-inferTypeBuiltin verifySignature As ts = {!!}
-inferTypeBuiltin equalsByteString As ts = {!!}
--}
+inferTypeBuiltin sha2-256 [] [] = return ((con bytestring ⇒ con bytestring) ,, ƛ "" (builtin sha2-256 (λ()) (` (Z reflNf) ,, _) reflNf))
+inferTypeBuiltin sha3-256 [] [] = return ((con bytestring ⇒ con bytestring) ,, ƛ "" (builtin sha3-256 (λ()) (` (Z reflNf) ,, _) reflNf))
+inferTypeBuiltin verifySignature [] [] = return ((con bytestring ⇒ con bytestring ⇒ con bytestring ⇒ booleanNf) ,, ƛ "" (ƛ "" (ƛ "" (builtin verifySignature (λ()) (` (S (S (Z reflNf))) ,, ` (S (Z reflNf)) ,, (` (Z reflNf)) ,, _) reflNf))))
+inferTypeBuiltin equalsByteString [] [] = return ((con bytestring ⇒ con bytestring ⇒ booleanNf) ,, ƛ "" (ƛ "" (builtin equalsByteString (λ()) (` (S (Z reflNf)) ,, ` (Z reflNf) ,, _) reflNf)))
 inferTypeBuiltin _ _ _ = inj₂ builtinError
 
 inferType Γ (` x)             =

--- a/metatheory/TestDetailed.hs
+++ b/metatheory/TestDetailed.hs
@@ -67,10 +67,9 @@ tcTestNames  = ["succInteger"
                ,"fibonacci"
                ,"NatRoundTrip"
                ,"ListSum"
-               -- these tests are currently unreliable:
-               --,"IfIntegers"
-               --,"ApplyAdd1"
-               --,"ApplyAdd2"
+               ,"IfIntegers"
+               ,"ApplyAdd1"
+               ,"ApplyAdd2"
                ]           
 
 mkTest :: String -> String -> TestInstance

--- a/metatheory/TestDetailed.hs
+++ b/metatheory/TestDetailed.hs
@@ -27,47 +27,67 @@ catchOutput act = do
   removeFile tmpFP
   return str
 
-compareResult :: String -> IO Progress
-compareResult test = do
+compareResult :: String -> String -> IO Progress
+compareResult mode test = do
   example <- readProcess "plc" ["example","-s",test] []
   writeFile "tmp" example
   putStrLn $ "test: " ++ test
-  plcOutput <- readProcess "plc" ["evaluate","--file","tmp"] []
+  plcOutput <- readProcess "plc" [mode,"--file","tmp"] []
   plcAgdaOutput <- catchOutput $ catch
-    (withArgs ["evaluate","--file","tmp"]  M.main)
+    (withArgs [mode,"--file","tmp"]  M.main)
     (\ e -> case e of
         ExitFailure _ -> exitFailure
         ExitSuccess   -> return ())
   return $ Finished $ if plcOutput == plcAgdaOutput then Pass else Fail "it failed!"
 
-testNames = ["succInteger"
-        ,"unitval"
-        ,"true"
-        ,"false"
-        ,"churchZero"
-        ,"churchSucc"
-        ,"overapplication"
-        ,"factorial"
-        ,"fibonacci"
-        ,"NatRoundTrip"
-        ,"ListSum"
-        ,"IfIntegers"
-        ,"ApplyAdd1"
-        ,"ApplyAdd2"
-        ]
+evalTestNames = ["succInteger"
+                ,"unitval"
+                ,"true"
+                ,"false"
+                ,"churchZero"
+                ,"churchSucc"
+                ,"overapplication"
+                ,"factorial"
+                ,"fibonacci"
+                ,"NatRoundTrip"
+                ,"ListSum"
+                ,"IfIntegers"
+                ,"ApplyAdd1"
+                ,"ApplyAdd2"
+                ]
 
-mkTest :: String -> TestInstance
-mkTest s = TestInstance
-        { run = compareResult s
-        , name = s
+tcTestNames  = ["succInteger"
+               ,"unitval"
+               ,"true"
+               ,"false"
+               ,"churchZero"
+               ,"churchSucc"
+               ,"overapplication"
+               ,"factorial"
+               ,"fibonacci"
+               ,"NatRoundTrip"
+               ,"ListSum"
+               -- these tests are currently unreliable:
+               --,"IfIntegers"
+               --,"ApplyAdd1"
+               --,"ApplyAdd2"
+               ]           
+
+mkTest :: String -> String -> TestInstance
+mkTest mode test = TestInstance
+        { run = compareResult mode test
+        , name = mode ++ " " ++ test
         , tags = []
         , options = []
-        , setOption = \_ _ -> Right (mkTest s)
+        , setOption = \_ _ -> Right (mkTest mode test)
         }
 
 tests :: IO [Test]
-tests = --return [ Test succeeds ] -- , Test fails ]
-  return $ map Test (map mkTest testNames)
+tests = do --return [ Test succeeds ] -- , Test fails ]
+  return $ map Test
+    (map (mkTest "evaluate") evalTestNames
+     ++
+     map (mkTest "typecheck") tcTestNames)
   where
     fails = TestInstance
         { run = return $ Finished $ Fail "Always fails!"

--- a/metatheory/TestDetailed.hs
+++ b/metatheory/TestDetailed.hs
@@ -70,7 +70,7 @@ tcTestNames  = ["succInteger"
                ,"IfIntegers"
                ,"ApplyAdd1"
                ,"ApplyAdd2"
-               ]           
+               ]
 
 mkTest :: String -> String -> TestInstance
 mkTest mode test = TestInstance

--- a/metatheory/TestSimple.hs
+++ b/metatheory/TestSimple.hs
@@ -38,10 +38,9 @@ succeedingTCTests = ["succInteger"
         ,"fibonacci"
         ,"NatRoundTrip"
         ,"ListSum"
-        -- these tests are currently unreliable:
-        --,"IfIntegers"
-        --,"ApplyAdd1"
-        --,"ApplyAdd2"
+        ,"IfIntegers"
+        ,"ApplyAdd1"
+        ,"ApplyAdd2"
         ]
 
 

--- a/metatheory/TestSimple.hs
+++ b/metatheory/TestSimple.hs
@@ -9,7 +9,7 @@ import           System.Process
 
 import qualified MAlonzo.Code.Main  as M
 
-succeedingTests = ["succInteger"
+succeedingEvalTests = ["succInteger"
         ,"unitval"
         ,"true"
         ,"false"
@@ -25,7 +25,25 @@ succeedingTests = ["succInteger"
         ,"ApplyAdd2"
         ]
 
-failingTests = ["DivideByZero"]
+failingEvalTests = ["DivideByZero"]
+
+succeedingTCTests = ["succInteger"
+        ,"unitval"
+        ,"true"
+        ,"false"
+        ,"churchZero"
+        ,"churchSucc"
+        ,"overapplication"
+        ,"factorial"
+        ,"fibonacci"
+        ,"NatRoundTrip"
+        ,"ListSum"
+        -- these tests are currently unreliable:
+        --,"IfIntegers"
+        --,"ApplyAdd1"
+        --,"ApplyAdd2"
+        ]
+
 
 
 -- this is likely to raise either an exitFailure or exitSuccess exception
@@ -53,8 +71,7 @@ runFailingTests mode (test:tests) = catch
       ExitSuccess   -> exitSuccess)
 
 main = do
-  runSucceedingTests "evaluate" succeedingTests
-  runFailingTests "evaluate" failingTests
-  -- all the examples are type correct:
-  runSucceedingTests "typecheck" (succeedingTests ++ failingTests)
+  runSucceedingTests "evaluate" succeedingEvalTests
+  runFailingTests "evaluate" failingEvalTests
+  runSucceedingTests "typecheck" succeedingTCTests
 


### PR DESCRIPTION
`IfIntegers`, `ApplyAdd1` and `ApplyAdd2` are disabled. In the process of creating this pull request I found that `plc-agda` _sometimes_ fails on them:
```
$ plc example -s ApplyAdd1 | plc-agda typecheck --stdin
(con integer)

$ plc example -s ApplyAdd1 | plc-agda typecheck --stdin
builtinError
```

Note: `plc example` generates slightly different examples each time.