### PR TITLE
ledger/contracts: Pretty instead of Show

### DIFF
--- a/plutus-contract/plutus-contract.cabal
+++ b/plutus-contract/plutus-contract.cabal
@@ -86,7 +86,8 @@ library
         mmorph -any,
         tasty -any,
         tasty-hunit -any,
-        row-types -any
+        row-types -any,
+        prettyprinter >=1.1.0.1
 
 test-suite contract-doctests
     type: exitcode-stdio-1.0

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/UtxoAt.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/UtxoAt.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE MonoLocalBinds      #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedLabels    #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
 module Language.Plutus.Contract.Effects.UtxoAt where
@@ -18,8 +19,9 @@ import qualified Data.Map                         as Map
 import           Data.Row
 import           Data.Set                         (Set)
 import qualified Data.Set                         as Set
+import           Data.Text.Prettyprint.Doc
 import           GHC.Generics                     (Generic)
-import           Ledger                           (Address)
+import           Ledger                           (Address, TxOutOf (..))
 import           Ledger.AddressMap                (AddressMap)
 import qualified Ledger.AddressMap                as AM
 import           Ledger.Tx                        (TxOut, TxOutRef)
@@ -41,6 +43,14 @@ data UtxoAtAddress =
     }
   deriving stock (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
+
+instance Pretty UtxoAtAddress where
+  pretty UtxoAtAddress{address, utxo} =
+    let
+      prettyTxOutPair (txoutref, TxOutOf{txOutValue, txOutType}) =
+        pretty txoutref <> colon <+> pretty txOutType <+> viaShow txOutValue
+      utxos = align $ hang 4 $ vsep $ fmap prettyTxOutPair (Map.toList utxo)
+    in "Utxo at" <+> pretty address <+> "=" <+> utxos
 
 type UtxoAt = UtxoAtSym .== (UtxoAtAddress, Set Address)
 

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/WriteTx.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/WriteTx.hs
@@ -1,18 +1,23 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveAnyClass      #-}
 {-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE MonoLocalBinds      #-}
 {-# LANGUAGE OverloadedLabels    #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
 module Language.Plutus.Contract.Effects.WriteTx where
 
+import           Control.Lens
 import           Control.Monad                    ((>=>))
 import           Control.Monad.Error.Lens         (throwing)
 import           Data.Aeson                       (FromJSON, ToJSON)
 import           Data.Row
+import           Data.Text.Prettyprint.Doc
 import           GHC.Generics                     (Generic)
 
 import           Language.Plutus.Contract.Request as Req
@@ -23,7 +28,22 @@ import           Ledger.TxId                      (TxId)
 import           Wallet.API                       (WalletAPIError)
 
 type TxSymbol = "tx"
-type WriteTxResponse = Either WalletAPIError TxId
+
+data WriteTxResponse =
+  WriteTxFailed WalletAPIError
+  | WriteTxSuccess TxId
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance Pretty WriteTxResponse where
+  pretty = \case
+    WriteTxFailed e -> "WriteTxFailed:" <+> pretty e
+    WriteTxSuccess i -> "WriteTxSuccess:" <+> viaShow i
+
+writeTxResponse :: Iso' WriteTxResponse (Either WalletAPIError TxId)
+writeTxResponse = iso f g where
+  f = \case { WriteTxFailed w -> Left w; WriteTxSuccess t -> Right t }
+  g = either WriteTxFailed WriteTxSuccess
 
 type HasWriteTx s =
     ( HasType TxSymbol WriteTxResponse (Input s)
@@ -46,7 +66,7 @@ writeTx t = request @TxSymbol @_ @_ @s (PendingTransactions [t])
 --    of the final transaction, throws an error on failure.
 writeTxSuccess :: forall s e. (HasWriteTx s, Req.AsContractError e) => UnbalancedTx -> Contract s e TxId
 -- See Note [Injecting errors into the user's error type]
-writeTxSuccess = writeTx >=> either (throwing Req._WalletError) pure
+writeTxSuccess = writeTx >=> either (throwing Req._WalletError) pure . view writeTxResponse
 
 event
   :: forall s. (HasType TxSymbol WriteTxResponse (Input s), AllUniqueLabels (Input s))

--- a/plutus-contract/src/Language/Plutus/Contract/Servant.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Servant.hs
@@ -18,6 +18,7 @@ module Language.Plutus.Contract.Servant(
     , Response(..)
     ) where
 
+import           Control.Lens                       (from, view)
 import           Control.Monad.Except               (MonadError (..), runExcept)
 import           Control.Monad.Writer               (runWriterT)
 import           Data.Aeson                         (FromJSON, ToJSON)
@@ -29,7 +30,8 @@ import           GHC.Generics                       (Generic)
 import           Servant                            ((:<|>) ((:<|>)), (:>), Get, JSON, Post, ReqBody, err500, errBody)
 import           Servant.Server                     (Application, ServantErr, Server, serve)
 
-import           Language.Plutus.Contract.Record
+import           Language.Plutus.Contract.Record    (Record)
+import qualified Language.Plutus.Contract.Record    as Rec
 import           Language.Plutus.Contract.Request   (Contract (..))
 import           Language.Plutus.Contract.Resumable (ResumableError)
 import qualified Language.Plutus.Contract.Resumable as Resumable
@@ -121,7 +123,7 @@ initialResponse
     => Contract s e ()
     -> Either (ResumableError e) (Response s)
 initialResponse =
-    fmap (uncurry Response . first (State . fmap fst))
+    fmap (uncurry Response . first (State . view (from Rec.record) . fmap fst))
     . runExcept
     . runWriterT
     . Resumable.initialise

--- a/plutus-contract/src/Language/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Test.hs
@@ -33,7 +33,7 @@ module Language.Plutus.Contract.Test(
     , checkPredicate
     ) where
 
-import           Control.Lens                          (at, folded, to, view, (^.))
+import           Control.Lens                          (at, folded, from, to, view, (^.))
 import           Control.Monad.Writer                  (MonadWriter (..), Writer, runWriter)
 import           Data.Bifunctor                        (Bifunctor(..))
 import           Data.Foldable                         (toList, traverse_)
@@ -52,6 +52,7 @@ import           Test.Tasty.Providers                  (TestTree)
 import qualified Language.PlutusTx.Prelude             as P
 
 import           Language.Plutus.Contract.Record       (Record)
+import qualified Language.Plutus.Contract.Record       as Rec
 import           Language.Plutus.Contract.Request      (Contract(..))
 import           Language.Plutus.Contract.Resumable    (ResumableError)
 import qualified Language.Plutus.Contract.Resumable    as State
@@ -116,7 +117,7 @@ record
     -> Either (ResumableError e) (Record (Event s))
 record w rs =
     let (evts, con) = contractEventsWallet rs w
-    in fmap (fmap fst . fst) (State.runResumable evts (unContract con))
+    in fmap (view (from Rec.record) . fmap fst . fst) (State.runResumable evts (unContract con))
 
 not :: TracePredicate s e a -> TracePredicate s e a
 not = PredF . fmap (fmap Prelude.not) . unPredF

--- a/plutus-contract/src/Language/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Trace.hs
@@ -216,7 +216,7 @@ submitUnbalancedTx
     -> ContractTrace s e m a [Tx]
 submitUnbalancedTx wllt tx = do
     (txns, res) <- lift (runWallet wllt (Wallet.handleTx tx))
-    addEvent wllt (WriteTx.event $ fmap hashTx res)
+    addEvent wllt (WriteTx.event $ view (from WriteTx.writeTxResponse) $ fmap hashTx res)
     pure txns
 
 -- | Add the 'LedgerUpdate' event for the given transaction to

--- a/plutus-contract/src/Language/Plutus/Contract/Tx.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Tx.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE NamedFieldPuns         #-}
+{-# LANGUAGE OverloadedStrings      #-}
 {-# LANGUAGE TemplateHaskell        #-}
 {-# LANGUAGE TypeApplications       #-}
 module Language.Plutus.Contract.Tx(
@@ -31,6 +33,8 @@ import qualified Data.Map                  as Map
 import           Data.Maybe                (fromMaybe)
 import           Data.Set                  (Set)
 import qualified Data.Set                  as Set
+import           Data.String               (IsString (fromString))
+import           Data.Text.Prettyprint.Doc
 import           GHC.Generics              (Generic)
 
 import           Language.PlutusTx.Lattice
@@ -58,6 +62,20 @@ data UnbalancedTx = UnbalancedTx
         deriving anyclass (Aeson.FromJSON, Aeson.ToJSON)
 
 Lens.TH.makeLenses ''UnbalancedTx
+
+instance Pretty UnbalancedTx where
+    pretty UnbalancedTx{_inputs, _outputs, _forge, _requiredSignatures, _validityRange} =
+        let lines' =
+                [ "inputs:" <+> prettyShowList (Set.toList _inputs)
+                , "outputs:" <+> prettyShowList _outputs
+                , "forge:" <+> viaShow _forge
+                , "required signatures:" <+> prettyShowList _requiredSignatures
+                , "validity range:" <+> viaShow _validityRange
+                ]
+        in braces (align (vsep lines'))
+
+prettyShowList :: Show a => [a] -> Doc ann
+prettyShowList = hsep . punctuate comma . fmap viaShow
 
 -- TODO: this is a bit of a hack, I'm not sure quite what the best way to avoid this is
 fromLedgerTx :: L.Tx -> UnbalancedTx

--- a/plutus-emulator/src/Wallet/Emulator/Types.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Types.hs
@@ -106,6 +106,7 @@ import qualified Data.Map                  as Map
 import           Data.Maybe
 import qualified Data.Set                  as Set
 import qualified Data.Text                 as T
+import           Data.Text.Prettyprint.Doc hiding (annotate)
 import           Data.Traversable          (for)
 import           GHC.Generics              (Generic)
 import           IOTS                      (IotsType (iotsDefinition))
@@ -134,6 +135,9 @@ newtype Wallet = Wallet { getWallet :: Integer }
     deriving (Show, Eq, Ord, Generic)
     deriving newtype (ToHttpApiData, FromHttpApiData, Hashable)
     deriving anyclass (Newtype, ToJSON, FromJSON, ToJSONKey, ToSchema, IotsType)
+
+instance Pretty Wallet where
+    pretty (Wallet i) = "W" <> pretty i
 
 -- | Get a wallet's public key.
 walletPubKey :: Wallet -> PubKey

--- a/plutus-wallet-api/ledger/Ledger/Crypto.hs
+++ b/plutus-wallet-api/ledger/Ledger/Crypto.hs
@@ -43,6 +43,7 @@ import qualified Data.ByteArray             as BA
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy       as BSL
 import qualified Data.ByteString.Lazy.Hash  as Hash
+import           Data.Text.Prettyprint.Doc
 import           GHC.Generics               (Generic)
 import           IOTS                       (IotsType)
 import qualified Language.PlutusTx          as PlutusTx
@@ -63,6 +64,9 @@ newtype PubKey = PubKey { getPubKey :: LedgerBytes }
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
 makeLift ''PubKey
 
+instance Pretty PubKey where
+    pretty pk = "PubKey:" <+> viaShow (getPubKey pk)
+
 -- | A cryptographic private key.
 newtype PrivateKey = PrivateKey { getPrivateKey :: LedgerBytes }
     deriving stock (Show, Eq, Ord, Generic)
@@ -70,6 +74,9 @@ newtype PrivateKey = PrivateKey { getPrivateKey :: LedgerBytes }
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
 
 makeLift ''PrivateKey
+
+instance Pretty PrivateKey where
+    pretty pk = "PrivateKey:" <+> viaShow (getPrivateKey pk)
 
 instance ToHttpApiData PrivateKey where
     toUrlPiece = toUrlPiece . getPrivateKey

--- a/plutus-wallet-api/ledger/Ledger/Slot.hs
+++ b/plutus-wallet-api/ledger/Ledger/Slot.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE MonoLocalBinds       #-}
 {-# LANGUAGE NoImplicitPrelude    #-}
+{-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- Otherwise we get a complaint about the 'fromIntegral' call in the generated instance of 'Integral' for 'Ada'
@@ -21,6 +22,7 @@ module Ledger.Slot(
 import           Codec.Serialise.Class     (Serialise)
 import           Data.Aeson                (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import           Data.Hashable             (Hashable)
+import           Data.Text.Prettyprint.Doc (Pretty (pretty), (<+>))
 import           GHC.Generics              (Generic)
 import           IOTS                      (IotsType)
 import qualified Prelude                   as Haskell
@@ -33,7 +35,7 @@ import           Language.PlutusTx.Prelude
 
 import           Ledger.Interval
 
-{-# ANN module "HLint: ignore Redundant if" #-}
+{-# ANN module ("HLint: ignore Redundant if" :: String) #-}
 
 -- | The slot number. This is a good proxy for time, since on the Cardano blockchain
 -- slots pass at a constant rate.
@@ -43,6 +45,9 @@ newtype Slot = Slot { getSlot :: Integer }
     deriving newtype (Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, Enum, Eq, Ord, Real, Integral, Serialise, Hashable, PlutusTx.IsData)
 
 makeLift ''Slot
+
+instance Pretty Slot where
+    pretty (Slot i) = "Slot:" <+> pretty i
 
 -- | An 'Interval' of 'Slot's.
 type SlotRange = Interval Slot

--- a/plutus-wallet-api/ledger/Ledger/Tx.hs
+++ b/plutus-wallet-api/ledger/Ledger/Tx.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RecordWildCards    #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Ledger.Tx(
@@ -63,6 +66,7 @@ import           Codec.Serialise.Class     (Serialise, encode)
 import           Control.Lens
 import           Crypto.Hash               (Digest, SHA256, hash)
 import           Data.Aeson                (FromJSON, FromJSONKey (..), ToJSON, ToJSONKey (..))
+import           Data.Aeson.Extras         (encodeSerialise)
 import qualified Data.ByteArray            as BA
 import qualified Data.ByteString.Char8     as BS8
 import qualified Data.ByteString.Lazy      as BSL
@@ -71,6 +75,7 @@ import           Data.Map                  (Map)
 import qualified Data.Map                  as Map
 import           Data.Maybe                (isJust)
 import qualified Data.Set                  as Set
+import           Data.Text.Prettyprint.Doc
 import           GHC.Generics              (Generic)
 import           Schema                    (ToSchema)
 
@@ -113,6 +118,9 @@ especially because we only need one direction (to binary).
 newtype AddressOf h = AddressOf { getAddress :: h }
     deriving stock (Eq, Ord, Show, Generic)
 
+instance Pretty (AddressOf (Digest SHA256)) where
+    pretty = pretty . encodeSerialise . getAddress
+
 -- | A payment address using a SHA256 hash as the address id type.
 type Address = AddressOf (Digest SHA256)
 
@@ -141,6 +149,22 @@ data Tx = Tx {
     -- ^ Signatures of this transaction
     } deriving stock (Show, Eq, Generic)
       deriving anyclass (ToJSON, FromJSON, Serialise)
+
+instance Pretty Tx where
+    pretty t@Tx{txInputs, txOutputs, txForge, txFee, txValidRange, txSignatures} =
+        let lines' =
+                [ "inputs:" <+> prettyShowList (Set.toList txInputs)
+                , "outputs:" <+> hsep (punctuate comma $ fmap (pretty . txOutType) txOutputs)
+                , "forge:" <+> viaShow txForge
+                , "fee:" <+> viaShow txFee
+                , "required signatures:" <+> hsep (punctuate comma $ fmap (pretty . fst) (Map.toList txSignatures))
+                , "validity range:" <+> viaShow txValidRange
+                ]
+            txid = hashTx t
+        in "Tx" <+> pretty txid <> colon <+> braces (nest 2 $ align (vsep lines'))
+
+prettyShowList :: Show a => [a] -> Doc ann
+prettyShowList = hsep . punctuate comma . fmap viaShow
 
 instance Semigroup Tx where
     tx1 <> tx2 = Tx {
@@ -227,6 +251,9 @@ data TxOutRefOf h = TxOutRefOf {
 -- | A reference to a transaction output, using a SHA256 hash.
 type TxOutRef = TxOutRefOf (Digest SHA256)
 
+instance Pretty (TxOutRefOf (Digest SHA256)) where
+    pretty TxOutRefOf{txOutRefId, txOutRefIdx} = pretty txOutRefId <> "!" <> pretty txOutRefIdx
+
 deriving instance Serialise TxOutRef
 deriving instance ToJSON TxOutRef
 deriving instance FromJSON TxOutRef
@@ -307,6 +334,11 @@ data TxOutType =
     PayToScript !DataScript -- ^ A pay-to-script output with the given data script.
     | PayToPubKey !PubKey -- ^ A pay-to-pubkey output.
     deriving (Show, Eq, Ord, Generic, Serialise, ToJSON, FromJSON, ToJSONKey)
+
+instance Pretty TxOutType where
+    pretty = \case
+        PayToScript (DataScript ds) -> "PayToScript:" <+> pretty ds
+        PayToPubKey pk -> "PayToPubKey:" <+> pretty pk
 
 -- | A transaction output, using the given transaction id type, consisting of a target address,
 -- a value, and an output type.

--- a/plutus-wallet-api/ledger/Ledger/TxId.hs
+++ b/plutus-wallet-api/ledger/Ledger/TxId.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeApplications   #-}
 -- ToJSON/FromJSON/Serialise (Digest SHA256)
@@ -12,17 +13,18 @@ module Ledger.TxId(
     , TxId
     ) where
 
-import           Codec.Serialise.Class  (Serialise, decode, encode)
-import           Crypto.Hash            (Digest, SHA256, digestFromByteString)
-import           Data.Aeson             (FromJSON (parseJSON), ToJSON (toJSON))
-import qualified Data.Aeson             as JSON
-import qualified Data.Aeson.Extras      as JSON
-import qualified Data.ByteArray         as BA
-import qualified Data.ByteString        as BSS
-import           GHC.Generics           (Generic)
-import qualified Language.PlutusTx.Eq   as PlutusTx
-import           Language.PlutusTx.Lift (makeLift)
-import           Schema                 (ToSchema)
+import           Codec.Serialise.Class     (Serialise, decode, encode)
+import           Crypto.Hash               (Digest, SHA256, digestFromByteString)
+import           Data.Aeson                (FromJSON (parseJSON), ToJSON (toJSON))
+import qualified Data.Aeson                as JSON
+import qualified Data.Aeson.Extras         as JSON
+import qualified Data.ByteArray            as BA
+import qualified Data.ByteString           as BSS
+import           Data.Text.Prettyprint.Doc (Pretty (pretty), (<+>))
+import           GHC.Generics              (Generic)
+import qualified Language.PlutusTx.Eq      as PlutusTx
+import           Language.PlutusTx.Lift    (makeLift)
+import           Schema                    (ToSchema)
 
 instance Serialise (Digest SHA256) where
     encode = encode . BA.unpack
@@ -52,3 +54,6 @@ deriving newtype instance Serialise TxId
 deriving newtype instance PlutusTx.Eq h => PlutusTx.Eq (TxIdOf h)
 deriving anyclass instance ToJSON a => ToJSON (TxIdOf a)
 deriving anyclass instance FromJSON a => FromJSON (TxIdOf a)
+
+instance Pretty (TxIdOf (Digest SHA256)) where
+    pretty t = "TxId:" <+> pretty (JSON.encodeSerialise $ getTxId t)

--- a/plutus-wallet-api/ledger/Ledger/Value.hs
+++ b/plutus-wallet-api/ledger/Ledger/Value.hs
@@ -52,6 +52,7 @@ import qualified Data.ByteString.Lazy.Char8   as C8
 import           Data.Hashable                (Hashable)
 import           Data.String                  (IsString(fromString))
 import qualified Data.Text                    as Text
+import           Data.Text.Prettyprint.Doc
 import           GHC.Generics                 (Generic)
 import qualified Language.PlutusTx            as PlutusTx
 import qualified Language.PlutusTx.Builtins   as Builtins
@@ -144,6 +145,9 @@ newtype Value = Value { getValue :: Map.Map CurrencySymbol (Map.Map TokenName In
     deriving stock (Show, Generic)
     deriving anyclass (ToJSON, FromJSON, Hashable, IotsType)
     deriving newtype (Serialise, PlutusTx.IsData)
+
+instance Pretty Value where
+    pretty = viaShow
 
 instance ToSchema Value where
     toSchema = FormSchemaValue

--- a/plutus-wallet-api/plutus-wallet-api.cabal
+++ b/plutus-wallet-api/plutus-wallet-api.cabal
@@ -93,7 +93,8 @@ library
         template-haskell -any,
         text -any,
         recursion-schemes -any,
-        deriving-compat -any
+        deriving-compat -any,
+        prettyprinter >=1.1.0.1
 
     if (flag(development) && impl(ghc <8.4))
         ghc-options: -Werror

--- a/plutus-wallet-api/src/Wallet/API.hs
+++ b/plutus-wallet-api/src/Wallet/API.hs
@@ -102,6 +102,7 @@ import qualified Data.Set                  as Set
 import           Data.Text                 (Text)
 
 import qualified Data.Text                 as Text
+import           Data.Text.Prettyprint.Doc hiding (width)
 import           GHC.Generics              (Generic, Generic1)
 import           Ledger                    (Address, DataScript, PubKey (..), RedeemerScript, Signature, Slot,
                                             SlotRange, Tx (..), TxId, TxIn, TxOut, TxOutOf (..), TxOutRef,
@@ -253,6 +254,15 @@ data WalletAPIError =
     | OtherError Text
     -- ^ Some other error occurred.
     deriving (Show, Eq, Ord, Generic)
+
+instance Pretty WalletAPIError where
+    pretty = \case
+        InsufficientFunds t ->
+            "Insufficient funds:" <+> pretty t
+        PrivateKeyNotFound pk ->
+            "Private key not found:" <+> viaShow pk
+        OtherError t ->
+            "Other error:" <+> pretty t
 
 instance FromJSON WalletAPIError
 instance ToJSON WalletAPIError


### PR DESCRIPTION
* Use `Pretty` instead of `Show` for all the debug output that's printed from the test predicated
* Add a number of `Pretty` instances to ledger types
* Also replace to occurrences of `Either` with proper datatypes 