### PR TITLE
machinery to get a map of all holes from parser

### DIFF
--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -1,7 +1,6 @@
 module Marlowe.Blockly where
 
 import Prelude
-
 import Blockly (AlignDirection(..), Arg(..), BlockDefinition(..), block, blockType, category, colour, defaultBlockDefinition, getBlockById, initializeWorkspace, name, render, style, x, xml, y)
 import Blockly.Generator (Connection, Generator, Input, NewBlockFunction, clearWorkspace, connect, connectToOutput, connectToPrevious, fieldName, fieldRow, getBlockInputConnectedTo, getFieldValue, getInputWithName, inputList, inputName, inputType, insertGeneratorFunction, mkGenerator, nextBlock, nextConnection, previousConnection, setFieldText, statementToCode)
 import Blockly.Types (Block, BlocklyState, Workspace)

--- a/marlowe-playground-client/src/Marlowe/Semantics.purs
+++ b/marlowe-playground-client/src/Marlowe/Semantics.purs
@@ -273,7 +273,8 @@ ivTo (SlotInterval _ to) = to
 data BoundF f
   = Bound (f BigInteger) (f BigInteger)
 
-type Bound = BoundF IdentityF
+type Bound
+  = BoundF IdentityF
 
 derive instance genericBound :: Generic (BoundF f) _
 

--- a/marlowe-playground-client/src/MonadApp.purs
+++ b/marlowe-playground-client/src/MonadApp.purs
@@ -1,7 +1,6 @@
 module MonadApp where
 
 import Prelude
-
 import API (RunResult)
 import Ace (Annotation, Editor)
 import Ace.EditSession as Session
@@ -24,7 +23,6 @@ import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Tuple (Tuple(..), fst)
-import Debug.Trace (trace)
 import Editor as Editor
 import Effect (Effect)
 import Effect.Aff.Class (class MonadAff)
@@ -39,7 +37,7 @@ import Language.Haskell.Interpreter (InterpreterError, InterpreterResult, Source
 import LocalStorage as LocalStorage
 import Marlowe (SPParams_)
 import Marlowe as Server
-import Marlowe.Parser (MarloweHole(..), contract, contractTerm, fromTerm, getHoles, validateHoles)
+import Marlowe.Parser (MarloweHole(..), contractTerm, fromTerm, getHoles, validateHoles)
 import Marlowe.Semantics (ContractF(..), PubKey, SlotInterval(..), TransactionInputF(..), TransactionInput, TransactionOutput(..), choiceOwner, computeTransaction, extractRequiredActionsWithTxs, moneyInContract)
 import Network.RemoteData as RemoteData
 import Servant.PureScript.Ajax (AjaxError)
@@ -220,20 +218,26 @@ withMarloweEditor = HalogenApp <<< Editor.withEditor _marloweEditorSlot unit
 
 updateContractInStateP :: String -> MarloweState -> MarloweState
 updateContractInStateP text state = case runParser text contractTerm of
-  Right pcon -> 
-    let (Tuple duplicates holes) = validateHoles $ getHoles mempty pcon
-        mContract = fromTerm pcon
-    in case mContract of
+  Right pcon ->
+    let
+      (Tuple duplicates holes) = validateHoles $ getHoles mempty pcon
+
+      mContract = fromTerm pcon
+    in
+      case mContract of
         Just contract -> do
           set _editorErrors [] <<< set _contract (Just contract) $ state
         Nothing -> do
-          let holes' = fromFoldable $ Map.values holes
-              errors = map holeToAnnotation holes'
+          let
+            holes' = fromFoldable $ Map.values holes
+
+            errors = map holeToAnnotation holes'
           (set _editorErrors errors <<< set _holes holes') state
   Left error -> set _editorErrors [ errorToAnnotation error ] state
   where
   errorToAnnotation (ParseError msg (Position { line, column })) = { column: column, row: (line - 1), text: msg, "type": "error" }
-  holeToAnnotation (MarloweHole name marloweType (Position { column, line }) end) = { column: column, row: (line - 1), text: "Found hole ?" <> name, "type": "warning"}
+
+  holeToAnnotation (MarloweHole { name, marloweType, start: (Position { column, line }), end }) = { column: column, row: (line - 1), text: "Found hole ?" <> name, "type": "warning" }
 
 updatePossibleActions :: MarloweState -> MarloweState
 updatePossibleActions oldState =

--- a/marlowe-playground-client/src/Simulation.purs
+++ b/marlowe-playground-client/src/Simulation.purs
@@ -5,7 +5,7 @@ import Ace.EditSession as Session
 import Ace.Editor as Editor
 import Ace.Halogen.Component (Autocomplete(Live), aceComponent)
 import Ace.Types (Editor)
-import Bootstrap (btn, btnInfo, btnPrimary, btnSmall, card, cardBody_, card_, col6, col_, empty, listGroupItem_, listGroup_, row_)
+import Bootstrap (btn, btnInfo, btnPrimary, btnSmall, card, cardBody_, card_, col3_, col6, col_, empty, listGroupItem_, listGroup_, row_)
 import Control.Alternative (map, (<|>))
 import Data.Array (catMaybes)
 import Data.Array as Array
@@ -30,14 +30,14 @@ import Halogen.HTML (ClassName(..), ComponentHTML, HTML, PropName(..), b_, br_, 
 import Halogen.HTML.Events (onClick, onDragOver, onDrop, onValueChange)
 import Halogen.HTML.Properties (InputType(InputNumber), class_, classes, enabled, placeholder, prop, type_, value)
 import LocalStorage as LocalStorage
-import Marlowe.Parser (transactionInputList, transactionWarningList)
-import Marlowe.Semantics (AccountId, AccountIdF(..), Ada(..), Bound(..), ChoiceId, ChoiceIdF(..), ChosenNum, Input, InputF(..), Party, PayeeF(..), Payment(..), PubKey, Slot(..), SlotInterval(..), TransactionError, TransactionInput, TransactionInputF(..), TransactionWarning(..), ValueId, ValueIdF(..), _accounts, _boundValues, _choices, inBounds)
+import Marlowe.Parser (MarloweHole(..), transactionInputList, transactionWarningList)
+import Marlowe.Semantics (AccountId, AccountIdF(..), Ada(..), BoundF(..), Bound, ChoiceId, ChoiceIdF(..), ChosenNum, Input, InputF(..), Party, PayeeF(..), Payment(..), PubKey, Slot(..), SlotInterval(..), TransactionError, TransactionInput, TransactionInputF(..), TransactionWarning(..), ValueId, ValueIdF(..), _accounts, _boundValues, _choices, inBounds)
 import Marlowe.Symbolic.Types.Response as R
 import Network.RemoteData (RemoteData(..), isLoading)
 import Prelude (class Show, Unit, bind, const, discard, flip, identity, not, pure, show, unit, void, ($), (+), (<$>), (<<<), (<>), (>))
 import StaticData as StaticData
 import Text.Parsing.Parser (runParser)
-import Types (ActionInput(..), ActionInputId, ChildSlots, FrontendState, HAction(..), MarloweError(..), MarloweState, _Head, _analysisState, _contract, _editorErrors, _marloweCompileResult, _marloweEditorSlot, _marloweState, _moneyInContract, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError)
+import Types (ActionInput(..), ActionInputId, ChildSlots, FrontendState, HAction(..), MarloweError(..), MarloweState, _Head, _analysisState, _contract, _editorErrors, _holes, _marloweCompileResult, _marloweEditorSlot, _marloweState, _moneyInContract, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError)
 
 paneHeader :: forall p. String -> HTML p HAction
 paneHeader s = h2 [ class_ $ ClassName "pane-header" ] [ text s ]
@@ -80,8 +80,12 @@ simulationPane state =
               [ onDragOver $ Just <<< MarloweHandleDragEvent
               , onDrop $ Just <<< MarloweHandleDropEvent
               ]
-              [ slot _marloweEditorSlot unit (aceComponent initEditor (Just Live)) unit (Just <<< MarloweHandleEditorMessage)
-              ]
+              -- TODO: I am being taken off this project temporarily so I'm hiding this for now
+              [ row_ [ div [ class_ $ ClassName "col-12" ] [ slot _marloweEditorSlot unit (aceComponent initEditor (Just Live)) unit (Just <<< MarloweHandleEditorMessage) ] ] ]
+              -- [ row_ [ div [ class_ $ ClassName "col-9" ] [ slot _marloweEditorSlot unit (aceComponent initEditor (Just Live)) unit (Just <<< MarloweHandleEditorMessage) ]
+                    --  , holesPane (view (_marloweState <<< _Head <<< _holes) $ state)
+                    --  ]
+              -- ]
           , br_
           , errorList
           , analysisPane state
@@ -113,6 +117,12 @@ initEditor editor =
         Editor.setTheme "ace/theme/monokai" editor
         session <- Editor.getSession editor
         Session.setMode "ace/mode/haskell" session
+
+holesPane :: forall p. Array MarloweHole -> HTML p HAction
+holesPane holes = col3_ [ card_ [ cardBody_ (map displayHole holes)]]
+
+displayHole :: forall p. MarloweHole -> HTML p HAction
+displayHole (MarloweHole name marloweType _ _) = div [] [ text $ "Hole ?" <> name <> " of type " <> show marloweType ]
 
 demoScriptsPane :: forall p. HTML p HAction
 demoScriptsPane =

--- a/marlowe-playground-client/src/Simulation.purs
+++ b/marlowe-playground-client/src/Simulation.purs
@@ -37,7 +37,7 @@ import Network.RemoteData (RemoteData(..), isLoading)
 import Prelude (class Show, Unit, bind, const, discard, flip, identity, not, pure, show, unit, void, ($), (+), (<$>), (<<<), (<>), (>))
 import StaticData as StaticData
 import Text.Parsing.Parser (runParser)
-import Types (ActionInput(..), ActionInputId, ChildSlots, FrontendState, HAction(..), MarloweError(..), MarloweState, _Head, _analysisState, _contract, _editorErrors, _holes, _marloweCompileResult, _marloweEditorSlot, _marloweState, _moneyInContract, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError)
+import Types (ActionInput(..), ActionInputId, ChildSlots, FrontendState, HAction(..), MarloweError(..), MarloweState, _Head, _analysisState, _contract, _editorErrors, _marloweCompileResult, _marloweEditorSlot, _marloweState, _moneyInContract, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError)
 
 paneHeader :: forall p. String -> HTML p HAction
 paneHeader s = h2 [ class_ $ ClassName "pane-header" ] [ text s ]
@@ -82,10 +82,10 @@ simulationPane state =
               ]
               -- TODO: I am being taken off this project temporarily so I'm hiding this for now
               [ row_ [ div [ class_ $ ClassName "col-12" ] [ slot _marloweEditorSlot unit (aceComponent initEditor (Just Live)) unit (Just <<< MarloweHandleEditorMessage) ] ] ]
-              -- [ row_ [ div [ class_ $ ClassName "col-9" ] [ slot _marloweEditorSlot unit (aceComponent initEditor (Just Live)) unit (Just <<< MarloweHandleEditorMessage) ]
-                    --  , holesPane (view (_marloweState <<< _Head <<< _holes) $ state)
-                    --  ]
-              -- ]
+          -- [ row_ [ div [ class_ $ ClassName "col-9" ] [ slot _marloweEditorSlot unit (aceComponent initEditor (Just Live)) unit (Just <<< MarloweHandleEditorMessage) ]
+          --  , holesPane (view (_marloweState <<< _Head <<< _holes) $ state)
+          --  ]
+          -- ]
           , br_
           , errorList
           , analysisPane state
@@ -119,10 +119,10 @@ initEditor editor =
         Session.setMode "ace/mode/haskell" session
 
 holesPane :: forall p. Array MarloweHole -> HTML p HAction
-holesPane holes = col3_ [ card_ [ cardBody_ (map displayHole holes)]]
+holesPane holes = col3_ [ card_ [ cardBody_ (map displayHole holes) ] ]
 
 displayHole :: forall p. MarloweHole -> HTML p HAction
-displayHole (MarloweHole name marloweType _ _) = div [] [ text $ "Hole ?" <> name <> " of type " <> show marloweType ]
+displayHole (MarloweHole { name, marloweType }) = div [] [ text $ "Hole ?" <> name <> " of type " <> show marloweType ]
 
 demoScriptsPane :: forall p. HTML p HAction
 demoScriptsPane =


### PR DESCRIPTION
I am being temporarily re-assigned so I want to get this PR through as it deals with what should be most of the machinery required. After this it should just be a matter of front-end work.

Overall the idea will be to display a list of holes with their type which you can expand to give options for the constructors. You can then click on a constructor which will replace the hole in the editor. E.g. `?contract1` would appear in a card on the left, clicking on it would give options for `Close`, `Pay`, `If`, `When` and `Let`, each with some documentation. If you then click on `Let` then the hole will be replaced with `(Let ?valueId1 ?value1 ?contract1)` or something similar.