### PR TITLE
ledger: move application of 'check' into 'wrapValidator'

### DIFF
--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -119,7 +119,7 @@ w1 = EM.Wallet 1
 
 someAddress :: Address
 someAddress = Ledger.scriptAddress $
-    Ledger.mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.Data) (_ :: PlutusTx.Data) (_ :: PlutusTx.Data) -> True ||])
+    Ledger.mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.Data) (_ :: PlutusTx.Data) (_ :: PlutusTx.Data) -> () ||])
 
 type Schema =
     BlockchainActions

--- a/plutus-use-cases/bench/Bench.hs
+++ b/plutus-use-cases/bench/Bench.hs
@@ -196,7 +196,7 @@ trivial = bgroup "trivial" [
         bench "typecheck" $ nf runScriptCheck (validationData1, validator, unitData, unitRedeemer)
     ]
     where
-        validator = mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.Data) (_ :: PlutusTx.Data) (_ :: PlutusTx.Data) -> True ||])
+        validator = mkValidatorScript $$(PlutusTx.compile [|| \(_ :: PlutusTx.Data) (_ :: PlutusTx.Data) (_ :: PlutusTx.Data) -> () ||])
 
 -- | The multisig contract is one of the simplest ones that we have. This runs a number of different scenarios.
 -- Note that multisig also does some signature verification!

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -100,7 +100,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100
 
 ==== Slot #2, Tx #0 ====
-TxId:       380fbc4c5efc421c4c6759c1cd07910cc83451f6adbbd1b08341a2679a55f34b
+TxId:       8c9de04ba4c14da0e6f50d27da5dfabb08e2301dd9d9541fb934aa36f922739a
 Fee:        -
 Forge:      -
 Inputs:
@@ -121,7 +121,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: 9f183818e6185e1892185318e918b8189e18d418...
+  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
   Value:
     Ada:      Lovelace:  10
 
@@ -167,12 +167,12 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f183818e6185e1892185318e918b8189e18d418...
+  Script: 9f18e71871183918900418260a1887181c185b18...
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #3, Tx #0 ====
-TxId:       c4963cd2405b52f7158e5980791f8fa88c6e17413c977e1e9918214b728c5496
+TxId:       9c5de2c287880317324f6332427267ce939482e021242420acf9afffa6380487
 Fee:        -
 Forge:      -
 Inputs:
@@ -193,7 +193,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: 9f183818e6185e1892185318e918b8189e18d418...
+  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
   Value:
     Ada:      Lovelace:  10
 
@@ -239,12 +239,12 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f183818e6185e1892185318e918b8189e18d418...
+  Script: 9f18e71871183918900418260a1887181c185b18...
   Value:
     Ada:      Lovelace:  20
 
 ==== Slot #4, Tx #0 ====
-TxId:       6c6850b0d16f92c460bcc62efd924850d62bd477a7303566d74dde45b53b909b
+TxId:       0550666bba41cbc584f0a6bcb1fab2ea109b134803417cf7c4b24f0c95772086
 Fee:        -
 Forge:      -
 Inputs:
@@ -265,7 +265,7 @@ Outputs:
     Ada:      Lovelace:  99
   
   ---- Output 1 ----
-  Destination:  Script: 9f183818e6185e1892185318e918b8189e18d418...
+  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
   Value:
     Ada:      Lovelace:  1
 
@@ -311,39 +311,39 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f183818e6185e1892185318e918b8189e18d418...
+  Script: 9f18e71871183918900418260a1887181c185b18...
   Value:
     Ada:      Lovelace:  21
 
 ==== Slot #23, Tx #0 ====
-TxId:       a6690562df608d989dd5d5b8424c95a2dd6b511c9437082a84da274677f683f1
+TxId:       4fb424a8b1d454c7a8ee5ff2b23882f4812d8229df503246f6a932e8d20f1422
 Fee:        -
 Forge:      -
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 9f183818e6185e1892185318e918b8189e18d418...
+  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
   Value:
-    Ada:      Lovelace:  10
+    Ada:      Lovelace:  1
   Source:
-    Tx:     380fbc4c5efc421c4c6759c1cd07910cc83451f6adbbd1b08341a2679a55f34b
+    Tx:     0550666bba41cbc584f0a6bcb1fab2ea109b134803417cf7c4b24f0c95772086
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
   
   ---- Input 1 ----
-  Destination:  Script: 9f183818e6185e1892185318e918b8189e18d418...
+  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
   Value:
-    Ada:      Lovelace:  1
+    Ada:      Lovelace:  10
   Source:
-    Tx:     6c6850b0d16f92c460bcc62efd924850d62bd477a7303566d74dde45b53b909b
+    Tx:     8c9de04ba4c14da0e6f50d27da5dfabb08e2301dd9d9541fb934aa36f922739a
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
   
   ---- Input 2 ----
-  Destination:  Script: 9f183818e6185e1892185318e918b8189e18d418...
+  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     c4963cd2405b52f7158e5980791f8fa88c6e17413c977e1e9918214b728c5496
+    Tx:     9c5de2c287880317324f6332427267ce939482e021242420acf9afffa6380487
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
 
@@ -396,6 +396,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f183818e6185e1892185318e918b8189e18d418...
+  Script: 9f18e71871183918900418260a1887181c185b18...
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -100,7 +100,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100
 
 ==== Slot #2, Tx #0 ====
-TxId:       89134456b9b6f772556b13c39472f1a2492173197f5f73512c891e7e5c0fa814
+TxId:       2bdbaa25a7bf049fe5324ae01f2713bf99593140460875c9717dfe8262e76ac7
 Fee:        -
 Forge:      -
 Inputs:
@@ -121,7 +121,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: 9f181c188518821824188c181f189518c3189818...
+  Destination:  Script: 9f184f181b1859185d18fa18f818d7185c18de18...
   Value:
     Ada:      Lovelace:  10
 
@@ -167,21 +167,21 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f181c188518821824188c181f189518c3189818...
+  Script: 9f184f181b1859185d18fa18f818d7185c18de18...
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #3, Tx #0 ====
-TxId:       c8db94ceb79c8c68387021b97c423420d4125f5c28a0b26abc284f41beb5d1cb
+TxId:       fec4beb9b56497c78c0108217b5386c33f855d7fd6a027f2bbd095bab88d56b6
 Fee:        -
 Forge:      -
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 9f181c188518821824188c181f189518c3189818...
+  Destination:  Script: 9f184f181b1859185d18fa18f818d7185c18de18...
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     89134456b9b6f772556b13c39472f1a2492173197f5f73512c891e7e5c0fa814
+    Tx:     2bdbaa25a7bf049fe5324ae01f2713bf99593140460875c9717dfe8262e76ac7
     Output #1
     Script: f6f6010000c3f6c3f6c5f6c1f6f664556e697419...
 
@@ -234,6 +234,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f181c188518821824188c181f189518c3189818...
+  Script: 9f184f181b1859185d18fa18f818d7185c18de18...
   Value:
     Ada:      Lovelace:  0


### PR DESCRIPTION
This finally makes the type of validators on-chain independent of our
datatype encoding scheme, since they can now return anything and must
signal failure via an error.

I haven't changed the type in the EUTXO spec, because that specifies the
type of the *interface* to validation, which can wrap up the error
handling and actually return a bool.

As a side effect, this removes the only use of the Plutus Tx plugin in
`plutus-wallet-api` (see https://github.com/input-output-hk/plutus/pull/1557
for why this is desirable).