### PR TITLE
ledger: refactor lots of things relating to addresses and hashes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -385,8 +385,6 @@ let
         fixStylishHaskell = pkgs.writeScript "fix-stylish-haskell" ''
           #!${pkgs.runtimeShell}
 
-          set -eou pipefail
-
           ${pkgs.git}/bin/git diff > pre-stylish.diff
           ${pkgs.fd}/bin/fd \
             --extension hs \

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -176,8 +176,8 @@ uniqueContractHash :: IO ()
 uniqueContractHash = do
     let pk1 = toPublicKey privateKey1
     let pk2 = toPublicKey privateKey2
-    let hash1 = plcValidatorHash $ validatorScript pk1
-    let hash2 = plcValidatorHash $ validatorScript pk2
+    let hash1 = validatorHash $ validatorScript pk1
+    let hash2 = validatorHash $ validatorScript pk2
     assertBool "Hashes must be different" (hash1 /= hash2)
 
 

--- a/plutus-book/doc/auction/english.adoc
+++ b/plutus-book/doc/auction/english.adoc
@@ -35,12 +35,12 @@ import qualified Data.Text                      as T
 -- The admin token is parameterized by a transaction
 -- output, which in turn is given by the hash of a
 -- transaction and the output index.
-type Admin = (TxHash, Integer)
+type Admin = (TxId, Integer)
 
 -- Convert the reference to an output to a hash-index
 -- pair.
 mkAdmin :: TxOutRef -> Admin
-mkAdmin (TxOutRef h i) = (plcTxHash h, i)
+mkAdmin (TxOutRef h i) = (h, i)
 
 -- We need no data in data- and redeemer-scripts,
 -- so both can be of unit type.
@@ -69,8 +69,7 @@ adminAddress :: Admin -> Address
 adminAddress = scriptAddress . mkAdminValidator
 
 adminSymbol :: Admin -> CurrencySymbol
-adminSymbol admin = case validatorScriptHash $ mkAdminValidator admin of
-    ValidatorHash h -> V.currencySymbol h
+adminSymbol admin = scriptCurrencySymbol $ mkAdminValidator admin
 
 adminTokenName :: TokenName
 adminTokenName = TokenName emptyByteString
@@ -132,8 +131,7 @@ nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator
 
 nonFungibleSymbol :: NonFungible -> CurrencySymbol
-nonFungibleSymbol nf = case validatorScriptHash $ mkNonFungibleValidator nf of
-    ValidatorHash h -> V.currencySymbol h
+nonFungibleSymbol nf = scriptCurrencySymbol $ mkNonFungibleValidator nf
 
 nonFungibleValue :: NonFungible -> String -> Value
 nonFungibleValue nf name = V.singleton

--- a/plutus-book/doc/non-fungible/nonfungible1.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible1.adoc
@@ -82,8 +82,7 @@ nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator
 
 nonFungibleSymbol :: NonFungible -> CurrencySymbol
-nonFungibleSymbol nf = case validatorScriptHash $ mkNonFungibleValidator nf of
-    ValidatorHash h -> V.currencySymbol h
+nonFungibleSymbol nf = scriptCurrencySymbol $ mkNonFungibleValidator nf
 
 -- Given a token name (represented by a string for convenience),
 -- return the value of the corresponding token.

--- a/plutus-book/doc/non-fungible/nonfungible2.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible2.adoc
@@ -63,8 +63,7 @@ nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator
 
 nonFungibleSymbol :: NonFungible -> CurrencySymbol
-nonFungibleSymbol nf = case validatorScriptHash $ mkNonFungibleValidator nf of
-    ValidatorHash h -> V.currencySymbol h
+nonFungibleSymbol nf = scriptCurrencySymbol $ mkNonFungibleValidator nf
 
 nonFungibleValue :: NonFungible -> String -> Value
 nonFungibleValue nf name = V.singleton

--- a/plutus-book/doc/non-fungible/nonfungible3.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible3.adoc
@@ -63,8 +63,7 @@ nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator
 
 nonFungibleSymbol :: NonFungible -> CurrencySymbol
-nonFungibleSymbol nf = case validatorScriptHash $ mkNonFungibleValidator nf of
-    ValidatorHash h -> V.currencySymbol h
+nonFungibleSymbol nf = scriptCurrencySymbol $ mkNonFungibleValidator nf
 
 nonFungibleValue :: NonFungible -> String -> Value
 nonFungibleValue nf name = V.singleton

--- a/plutus-book/doc/non-fungible/nonfungible4.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible4.adoc
@@ -63,8 +63,7 @@ nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator
 
 nonFungibleSymbol :: NonFungible -> CurrencySymbol
-nonFungibleSymbol nf = case validatorScriptHash $ mkNonFungibleValidator nf of
-    ValidatorHash h -> V.currencySymbol h
+nonFungibleSymbol nf = scriptCurrencySymbol $ mkNonFungibleValidator nf
 
 nonFungibleValue :: NonFungible -> String -> Value
 nonFungibleValue nf name = V.singleton

--- a/plutus-book/doc/non-fungible/nonfungible5.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible5.adoc
@@ -63,8 +63,7 @@ nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator
 
 nonFungibleSymbol :: NonFungible -> CurrencySymbol
-nonFungibleSymbol nf = case validatorScriptHash $ mkNonFungibleValidator nf of
-    ValidatorHash h -> V.currencySymbol h
+nonFungibleSymbol nf = scriptCurrencySymbol $ mkNonFungibleValidator nf
 
 nonFungibleValue :: NonFungible -> String -> Value
 nonFungibleValue nf name = V.singleton

--- a/plutus-book/doc/non-fungible/nonfungible6.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible6.adoc
@@ -99,8 +99,7 @@ nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator
 
 nonFungibleSymbol :: NonFungible -> CurrencySymbol
-nonFungibleSymbol nf = case validatorScriptHash $ mkNonFungibleValidator nf of
-    ValidatorHash h -> V.currencySymbol h
+nonFungibleSymbol nf = scriptCurrencySymbol $ mkNonFungibleValidator nf
 
 nonFungibleValue :: NonFungible -> String -> Value
 nonFungibleValue nf name = V.singleton

--- a/plutus-book/doc/non-fungible/nonfungible7.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible7.adoc
@@ -76,8 +76,7 @@ nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator
 
 nonFungibleSymbol :: NonFungible -> CurrencySymbol
-nonFungibleSymbol nf = case validatorScriptHash $ mkNonFungibleValidator nf of
-    ValidatorHash h -> V.currencySymbol h
+nonFungibleSymbol nf = scriptCurrencySymbol $ mkNonFungibleValidator nf
 
 nonFungibleValue :: NonFungible -> String -> Value
 nonFungibleValue nf name = V.singleton

--- a/plutus-book/doc/non-fungible/nonfungible8.adoc
+++ b/plutus-book/doc/non-fungible/nonfungible8.adoc
@@ -36,12 +36,12 @@ import qualified Data.Text                  as T
 -- The admin token is parameterized by a transaction
 -- output, which in turn is given by the hash of a
 -- transaction and the output index.
-type Admin = (TxHash, Integer)
+type Admin = (TxId, Integer)
 
 -- Convert the reference to an output to a hash-index
 -- pair.
 mkAdmin :: TxOutRef -> Admin
-mkAdmin (TxOutRef h i) = (plcTxHash h, i)
+mkAdmin (TxOutRef h i) = (h, i)
 
 -- We need no data in data- and redeemer-scripts,
 -- so both can be of unit type.
@@ -82,8 +82,7 @@ adminAddress :: Admin -> Address
 adminAddress = scriptAddress . mkAdminValidator
 
 adminSymbol :: Admin -> CurrencySymbol
-adminSymbol admin = case validatorScriptHash $ mkAdminValidator admin of
-    ValidatorHash h -> V.currencySymbol h
+adminSymbol admin = scriptCurrencySymbol $ mkAdminValidator admin
 
 adminTokenName :: TokenName
 adminTokenName = TokenName emptyByteString
@@ -165,8 +164,7 @@ nonFungibleAddress :: NonFungible -> Address
 nonFungibleAddress = scriptAddress . mkNonFungibleValidator
 
 nonFungibleSymbol :: NonFungible -> CurrencySymbol
-nonFungibleSymbol nf = case validatorScriptHash $ mkNonFungibleValidator nf of
-    ValidatorHash h -> V.currencySymbol h
+nonFungibleSymbol nf = scriptCurrencySymbol $ mkNonFungibleValidator nf
 
 nonFungibleValue :: NonFungible -> String -> Value
 nonFungibleValue nf name = V.singleton

--- a/plutus-book/doc/parameters/crowd.adoc
+++ b/plutus-book/doc/parameters/crowd.adoc
@@ -309,14 +309,14 @@ contribute campaign ada = do
 
     handler :: Tx -> EventHandler m
     handler tx = EventHandler $ const $ do
-        let txId = hashTx tx                                     -- <4>
-        logMsg $ pack $ "Reclaiming contribution " ++ show txId
+        let tid = txId tx                                     -- <4>
+        logMsg $ pack $ "Reclaiming contribution " ++ show tid
             ++ " from " ++ show campaign
         collectFromScriptTxn                                     -- <5>
             range
             (mkValidator campaign)
             (mkRedeemerScript Refund)                            -- <6>
-            txId
+            tid
 
 $(mkFunctions ['startCampaign, 'contribute])
 ----

--- a/plutus-book/doc/token/fungible.adoc
+++ b/plutus-book/doc/token/fungible.adoc
@@ -103,8 +103,7 @@ fungibleAddress :: Fungible -> Address
 fungibleAddress = scriptAddress . mkFungibleValidator
 
 fungibleSymbol :: Fungible -> CurrencySymbol
-fungibleSymbol f = case validatorScriptHash $ mkFungibleValidator f of
-    ValidatorHash h -> V.currencySymbol h
+fungibleSymbol f = scriptCurrencySymbol $ mkFungibleValidator f
 
 fungibleValue :: Fungible -> Integer -> Value
 fungibleValue f = V.singleton (fungibleSymbol f) (name f)
@@ -398,7 +397,7 @@ sell i c n v2 p2 dl = do
             (intervalFrom $ deadline t)
             (mkTradeValidator t)
             (mkTradeRedeemerScript Reclaim)
-            (hashTx tx)
+            (txId tx)
 ----
 
 <1> Lock the currency at the trade script.
@@ -464,7 +463,7 @@ buy i c n p1 v2 dl = do
             (intervalFrom $ deadline t)
             (mkTradeValidator t)
             (mkTradeRedeemerScript Reclaim)
-            (hashTx tx)
+            (txId tx)
 
 $(mkFunctions ['forge, 'sell, 'buy])
 ----

--- a/plutus-book/test/Utils.hs
+++ b/plutus-book/test/Utils.hs
@@ -45,10 +45,10 @@ initialAda = lovelaceOf 100000
 initialChain :: Mockchain
 initialChain =
     let (txn, ot) = genInitialTransaction generatorModel
-        txId      = hashTx txn
+        tid      = txId txn
     in  Mockchain {
             mockchainInitialBlock = [txn],
-            mockchainUtxo = Map.fromList $ first (TxOutRef txId) <$> zip [0..] ot
+            mockchainUtxo = Map.fromList $ first (TxOutRef tid) <$> zip [0..] ot
         }
 
 updateWallets :: Trace MockWallet ()

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/WatchAddress.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/WatchAddress.hs
@@ -21,7 +21,7 @@ import qualified Data.Set                                   as Set
 import           Data.Text.Prettyprint.Doc                  (Pretty)
 import           Data.Text.Prettyprint.Doc.Extras
 import           GHC.Generics                               (Generic)
-import           Ledger                                     (Address, Slot, TxId, Value, hashTx)
+import           Ledger                                     (Address, Slot, TxId, Value, txId)
 import           Ledger.AddressMap                          (AddressMap)
 import qualified Ledger.AddressMap                          as AM
 import           Ledger.Tx                                  (Tx)
@@ -97,7 +97,7 @@ awaitTransactionConfirmed
 awaitTransactionConfirmed addr txid =
     flip loopM () $ \_ -> do
         tx' <- nextTransactionAt addr
-        if hashTx tx' == txid
+        if txId tx' == txid
         then pure $ Right tx'
         else pure $ Left ()
 

--- a/plutus-contract/src/Language/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Test.hs
@@ -71,10 +71,10 @@ import qualified Language.Plutus.Contract.Effects.WatchAddress   as WatchAddress
 import           Language.Plutus.Contract.Effects.WriteTx        (TxSymbol)
 import qualified Language.Plutus.Contract.Effects.WriteTx        as WriteTx
 
+import           Ledger.Address                        (Address)
 import qualified Ledger.Ada                            as Ada
 import qualified Ledger.AddressMap                     as AM
 import           Ledger.Slot                           (Slot)
-import           Ledger.Tx                             (Address)
 import           Ledger.Value                          (Value)
 import           Wallet.Emulator                       (EmulatorAction, EmulatorEvent, Wallet)
 import qualified Wallet.Emulator                       as EM
@@ -535,7 +535,7 @@ walletFundsChange w dlt = PredF $ \(initialDist, ContractTraceResult{_ctrEmulato
 assertNoFailedTransactions
     :: forall s e a.
     TracePredicate s e a
-assertNoFailedTransactions = PredF $ \(_, ContractTraceResult{_ctrEmulatorState = st}) -> 
+assertNoFailedTransactions = PredF $ \(_, ContractTraceResult{_ctrEmulatorState = st}) ->
     let failedTransactions = mapMaybe (\case { EM.TxnValidationFail txid err -> Just (txid, err); _ -> Nothing}) (EM.emLog st)
     in case failedTransactions of
         [] -> pure True

--- a/plutus-contract/src/Language/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Trace.hs
@@ -76,9 +76,10 @@ import qualified Language.Plutus.Contract.Effects.WriteTx        as WriteTx
 
 import           Ledger.Ada                                      (Ada)
 import qualified Ledger.Ada                                      as Ada
+import           Ledger.Address                                  (Address)
 import qualified Ledger.AddressMap                               as AM
 import           Ledger.Slot                                     (Slot)
-import           Ledger.Tx                                       (Address, Tx, hashTx)
+import           Ledger.Tx                                       (Tx, txId)
 
 import           Wallet.API                                      (WalletAPIError)
 import           Wallet.Emulator                                 (EmulatorAction, EmulatorState, MonadEmulator, Wallet)
@@ -217,7 +218,7 @@ submitUnbalancedTx
     -> ContractTrace s e m a [Tx]
 submitUnbalancedTx wllt tx = do
     (txns, res) <- lift (runWallet wllt (Wallet.handleTx tx))
-    addEvent wllt (WriteTx.event $ view (from WriteTx.writeTxResponse) $ fmap hashTx res)
+    addEvent wllt (WriteTx.event $ view (from WriteTx.writeTxResponse) $ fmap txId res)
     pure txns
 
 addInterestingTxEvents

--- a/plutus-contract/src/Language/Plutus/Contract/Tx.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Tx.hs
@@ -148,7 +148,7 @@ collectFromScriptFilter
     -> RedeemerScript
     -> UnbalancedTx
 collectFromScriptFilter flt am vls red =
-    let utxo       = fromMaybe Map.empty $ am ^. at (Tx.scriptAddress vls)
+    let utxo       = fromMaybe Map.empty $ am ^. at (L.scriptAddress vls)
         ourUtxo    = Map.toList $ Map.filterWithKey flt utxo
         mkTxIn ref = Tx.scriptTxIn ref vls red
         txInputs   = mkTxIn . fst  <$> ourUtxo

--- a/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
@@ -41,7 +41,7 @@ balanceWallet utx = do
     WAPI.logMsg $ "Balancing an unbalanced transaction: " <> fromString (show utx)
     pk <- WAPI.ownPubKey
     addr <- WAPI.watchedAddresses
-    let utxo = addr ^. at (Tx.pubKeyAddress pk) . to (fromMaybe mempty)
+    let utxo = addr ^. at (L.pubKeyAddress pk) . to (fromMaybe mempty)
     balanceTx utxo pk utx
 
 -- | Compute the difference between the value of the inputs consumed and the

--- a/plutus-emulator/src/Wallet/Rollup.hs
+++ b/plutus-emulator/src/Wallet/Rollup.hs
@@ -12,7 +12,7 @@ import           Control.Lens             (assign, ifoldr, makeLenses, over, use
 import           Control.Lens.Combinators (itraverse)
 import           Control.Monad.Except     (MonadError, throwError)
 import           Control.Monad.State      (StateT, evalStateT)
-import           Crypto.Hash              (Digest, SHA256)
+import qualified Data.ByteString.Lazy     as BSL
 import           Data.Map                 (Map)
 import qualified Data.Map                 as Map
 import qualified Data.Set                 as Set
@@ -29,7 +29,7 @@ import           Wallet.Rollup.Types      (AnnotatedTx (AnnotatedTx), Beneficial
 
 data TxKey =
     TxKey
-        { _txKeyTxId        :: Digest SHA256
+        { _txKeyTxId        :: BSL.ByteString
         , _txKeyTxOutRefIdx :: Integer
         }
     deriving (Show, Eq, Ord, Generic)

--- a/plutus-emulator/src/Wallet/Rollup/Render.hs
+++ b/plutus-emulator/src/Wallet/Rollup/Render.hs
@@ -32,8 +32,8 @@ import qualified Language.PlutusTx.Builtins            as Builtins
 import           Ledger                                (Address, PubKey, Tx (Tx), TxId, TxIn (TxIn, txInRef, txInType),
                                                         TxInType (ConsumePublicKeyAddress, ConsumeScriptAddress),
                                                         TxOut (TxOut), TxOutRef (TxOutRef, txOutRefId, txOutRefIdx),
-                                                        Value, getAddress, getPubKey, getTxId, txFee, txForge,
-                                                        txOutValue, txOutputs)
+                                                        Value, getPubKey, getTxId, txFee, txForge, txOutValue,
+                                                        txOutputs)
 import           Ledger.Ada                            (Ada (Lovelace))
 import qualified Ledger.Ada                            as Ada
 import           Ledger.Scripts                        (DataScript (getDataScript), Script, ValidatorScript,
@@ -159,7 +159,7 @@ instance Render Wallet where
     render (Wallet n) = pure $ "Wallet" <+> viaShow n
 
 instance Render Address where
-    render = render . getAddress
+    render = pure . pretty
 
 instance Render BeneficialOwner where
     render (OwnedByScript address) = ("Script:" <+>) <$> render address

--- a/plutus-emulator/test/Spec.hs
+++ b/plutus-emulator/test/Spec.hs
@@ -172,10 +172,10 @@ txnUpdateUtxo = property $ do
         -- Validate a pool that contains `txn` twice. It should succeed the
         -- first and fail the second time
         ValidatedBlock [t1] [e1, e2] [] _ = validateBlock slot idx [txn, txn]
-        txId = hashTx txn
+        tid = txId txn
     Hedgehog.assert (t1 == txn)
     Hedgehog.assert $ case (e1, e2) of
-        (TxnValidate i1, TxnValidationFail txi (Index.TxOutRefNotFound _)) -> i1 == txId && txi == txId
+        (TxnValidate i1, TxnValidationFail txi (Index.TxOutRefNotFound _)) -> i1 == tid && txi == tid
         _                                                                  -> False
 
 validTrace :: Property

--- a/plutus-playground-client/src/Chain/View.purs
+++ b/plutus-playground-client/src/Chain/View.purs
@@ -28,9 +28,10 @@ import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes, colSpan, rowSpan)
 import Language.PlutusTx.AssocMap as AssocMap
 import Ledger.Ada (Ada(..))
+import Ledger.Address (Address)
 import Ledger.Crypto (PubKey(..))
 import Ledger.Extra (humaniseInterval, adaToValue)
-import Ledger.Tx (Address(..), TxOut(..))
+import Ledger.Tx (TxOut(..))
 import Ledger.TxId (TxId)
 import Ledger.Value (CurrencySymbol(..), TokenName(..), Value(..))
 import Types (HAction(..), _value)
@@ -341,11 +342,11 @@ beneficialOwnerView walletKeys (OwnedByPubKey pubKey) = case Map.lookup pubKey w
           ]
       ]
 
-beneficialOwnerView _ (OwnedByScript (Address a)) =
+beneficialOwnerView _ (OwnedByScript a) =
   span_
     [ text "Script"
     , nbsp
-    , text a.getAddress
+    , text $ show a
     ]
 
 showPubKey :: forall p i. PubKey -> HTML p i

--- a/plutus-playground-server/src/Playground/Server.hs
+++ b/plutus-playground-server/src/Playground/Server.hs
@@ -19,7 +19,7 @@ import qualified Data.ByteString.Lazy.Char8   as BSL
 import           Data.Time.Units              (Microsecond, fromMicroseconds)
 import           Language.Haskell.Interpreter (InterpreterError (CompilationErrors),
                                                InterpreterResult (InterpreterResult), SourceCode (SourceCode))
-import           Ledger                       (hashTx)
+import           Ledger                       (txId)
 import           Playground.API               (API)
 import qualified Playground.Interpreter       as PI
 import           Playground.Interpreter.Util  (TraceResult)
@@ -58,7 +58,7 @@ postProcessEvaluation ::
 postProcessEvaluation interpreterResult = do
     (InterpreterResult _ (blockchain, emulatorLog, fundsDistribution, walletAddresses)) <-
         interpreterResult
-    let blockchainWithTxIds = fmap (\tx -> (hashTx tx, tx)) <$> blockchain
+    let blockchainWithTxIds = fmap (\tx -> (txId tx, tx)) <$> blockchain
     rollup <- first RollupError $ doAnnotateBlockchain blockchainWithTxIds
     pure $
         EvaluationResult

--- a/plutus-playground-server/usecases/CrowdFunding.hs
+++ b/plutus-playground-server/usecases/CrowdFunding.hs
@@ -23,7 +23,7 @@ import qualified Language.PlutusTx         as PlutusTx
 import           Language.PlutusTx.Prelude hiding (Applicative (..))
 import           Ledger                    (Address, DataScript (DataScript), PendingTx, PubKey,
                                             RedeemerScript (RedeemerScript), TxId, ValidatorScript, mkValidatorScript,
-                                            hashTx, pendingTxValidRange, scriptAddress, valueSpent)
+                                            txId, pendingTxValidRange, scriptAddress, valueSpent)
 import qualified Ledger.Interval           as Interval
 import           Ledger.Slot               (Slot, SlotRange)
 import           Ledger.Typed.Scripts      (wrapValidator)
@@ -164,7 +164,7 @@ contribute deadline target collectionDeadline ownerWallet value = do
     -- event. It instructs the wallet to start watching the addresses mentioned
     -- in the trigger definition and run the handler when the refund condition
     -- is true.
-    register (refundTrigger value cmp) (refundHandler (Ledger.hashTx tx) cmp)
+    register (refundTrigger value cmp) (refundHandler (Ledger.txId tx) cmp)
 
     logMsg "Registered refund trigger"
 

--- a/plutus-playground-server/usecases/Game.hs
+++ b/plutus-playground-server/usecases/Game.hs
@@ -24,7 +24,7 @@ import qualified Language.PlutusTx          as PlutusTx
 import           Language.PlutusTx.Prelude  hiding (Applicative (..))
 import           Ledger                     (Address, DataScript (DataScript), PendingTx,
                                              RedeemerScript (RedeemerScript), ValidatorScript, mkValidatorScript,
-                                             plcSHA2_256, scriptAddress)
+                                             scriptAddress)
 import           Ledger.Typed.Scripts       (wrapValidator)
 import           Ledger.Value               (Value)
 import           Playground.Contract
@@ -59,7 +59,7 @@ gameValidator =
 -- and lifting the hash to its on-chain representation
 gameDataScript :: String -> DataScript
 gameDataScript =
-    DataScript . PlutusTx.toData . HashedString . plcSHA2_256 . C.pack
+    DataScript . PlutusTx.toData . HashedString . sha2_256 . C.pack
 
 -- create a redeemer script for the guessing game by lifting the
 -- string to its on-chain representation

--- a/plutus-tutorial/doc/02-validator-scripts.adoc
+++ b/plutus-tutorial/doc/02-validator-scripts.adoc
@@ -99,7 +99,7 @@ PlutusTx.makeLift ''ClearText -- <.>
 
 mkDataScript :: String -> DataScript
 mkDataScript word =
-    let hashedWord = L.plcSHA2_256 (C.pack word)
+    let hashedWord = sha2_256 (C.pack word)
     in  DataScript (PlutusTx.toData (HashedText hashedWord)) -- <.>
 
 mkRedeemerScript :: String -> RedeemerScript

--- a/plutus-tutorial/doc/03-wallet-api.adoc
+++ b/plutus-tutorial/doc/03-wallet-api.adoc
@@ -561,14 +561,14 @@ contribute cmp adaAmount = do
     tx <- W.payToScript W.defaultSlotRange (campaignAddress cmp) amount dataScript -- <.>
     W.logMsg "Submitted contribution"
 
-    let txId = L.hashTx tx -- <.>
+    let tid = L.txId tx -- <.>
 
-    W.register (refundTrigger cmp) (refundHandler txId cmp)
+    W.register (refundTrigger cmp) (refundHandler tid cmp)
     W.logMsg "Registered refund trigger"
 ----
 <.> `payToScript` returns the transaction that was submitted
 (unlike `payToScript_` which returns unit).
-<.> `L.hashTx` gives the `TxId` of a transaction.
+<.> `L.txId` gives the `TxId` of a transaction.
 
 [#03-testing-contract]
 == Testing the contract

--- a/plutus-use-cases/bench/Bench.hs
+++ b/plutus-use-cases/bench/Bench.hs
@@ -14,7 +14,9 @@ import           Prelude                                           hiding (tail)
 import           Control.Lens.Indexed
 import           Criterion.Main
 import           Crypto.Hash
+import qualified Data.ByteArray                                    as BA
 import qualified Data.ByteString                                   as BS
+import qualified Data.ByteString.Lazy                              as BSL
 import qualified Language.PlutusTx.Coordination.Contracts.MultiSig as MS
 import qualified Language.PlutusTx.Prelude                         as P
 import           Ledger
@@ -231,7 +233,7 @@ multisig = bgroup "multisig" [
 -- Test functions and data
 
 verifySignature :: (PubKey, Digest SHA256, Signature) -> Bool
-verifySignature (PubKey (LedgerBytes k), m, Signature s) = P.verifySignature k (plcDigest m) s
+verifySignature (PubKey (LedgerBytes k), m, Signature s) = P.verifySignature k (BSL.fromStrict $ BA.convert m) s
 
 runScriptNoCheck :: (ValidationData, ValidatorScript, DataScript, RedeemerScript) -> Either ScriptError [String]
 runScriptNoCheck (vd, v, d, r) = runScript DontCheck vd v d r
@@ -271,7 +273,7 @@ mockPendingTx = PendingTx
     , pendingTxForge = PlutusTx.zero
     , pendingTxIn = PendingTxIn
         { pendingTxInRef = PendingTxOutRef
-            { pendingTxOutRefId = TxHash P.emptyByteString
+            { pendingTxOutRefId = TxId P.emptyByteString
             , pendingTxOutRefIdx = 0
             }
         , pendingTxInWitness = ("", "")
@@ -279,5 +281,5 @@ mockPendingTx = PendingTx
         }
     , pendingTxValidRange = defaultSlotRange
     , pendingTxSignatures = []
-    , pendingTxHash = TxHash P.emptyByteString
+    , pendingTxId = TxId P.emptyByteString
     }

--- a/plutus-use-cases/plutus-use-cases.cabal
+++ b/plutus-use-cases/plutus-use-cases.cabal
@@ -127,6 +127,7 @@ benchmark plutus-use-cases-bench
         cryptonite -any,
         language-plutus-core -any,
         lens -any,
+        memory -any,
         plutus-tx -any,
         plutus-use-cases -any,
         plutus-wallet-api -any,

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -32,7 +32,7 @@ import qualified Ledger.Validation          as V
 import qualified Ledger.Value               as Value
 import           Ledger.Scripts
 import qualified Ledger.Typed.Scripts       as Scripts
-import           Ledger                     (CurrencySymbol, PubKey, TxHash, TxOutRef(..), plcCurrencySymbol, txInRef)
+import           Ledger                     (CurrencySymbol, TxId, PubKey, TxOutRef(..), scriptCurrencySymbol, txInRef)
 import qualified Ledger                     as Ledger
 import           Ledger.Value               (TokenName, Value)
 
@@ -43,7 +43,7 @@ import qualified Language.PlutusTx.Coordination.Contracts.PubKey as PK
 {-# ANN module ("HLint: ignore Use uncurry" :: String) #-}
 
 data Currency = Currency
-  { curRefTransactionOutput :: (TxHash, Integer)
+  { curRefTransactionOutput :: (TxId, Integer)
   -- ^ Transaction input that must be spent when
   --   the currency is forged.
   , curAmounts              :: AssocMap.Map TokenName Integer
@@ -62,7 +62,7 @@ currencyValue s Currency{curAmounts = amts} =
 mkCurrency :: TxOutRef -> [(String, Integer)] -> Currency
 mkCurrency (TxOutRef h i) amts =
     Currency
-        { curRefTransactionOutput = (V.plcTxHash h, i)
+        { curRefTransactionOutput = (h, i)
         , curAmounts              = AssocMap.fromList (fmap (first fromString) amts)
         }
 
@@ -113,7 +113,7 @@ forgedValue :: Currency -> Value
 forgedValue cur =
     let
         -- see note [Obtaining the currency symbol]
-        a = plcCurrencySymbol (Ledger.scriptAddress (curValidator cur))
+        a = scriptCurrencySymbol (curValidator cur)
     in
         currencyValue a cur
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Escrow.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Escrow.hs
@@ -44,7 +44,6 @@ import           Ledger.Interval                (after, before, from)
 import qualified Ledger.Interval                as Interval
 import           Ledger.AddressMap              (values)
 import qualified Ledger.Typed.Scripts           as Scripts
-import qualified Ledger.Scripts                 as Scripts
 import           Ledger.Validation              (PendingTx, PendingTx' (..))
 import           Ledger.Value                   (Value, lt, geq)
 
@@ -95,8 +94,8 @@ payToPubKeyTarget = PubKeyTarget
 
 -- | An 'EscrowTarget' that pays the value to a script address, with the
 --   given data script.
-payToScriptTarget :: Address -> DataScript -> Value -> EscrowTarget
-payToScriptTarget (Ledger.Address hsh) = ScriptTarget (Scripts.plcValidatorDigest hsh)
+payToScriptTarget :: ValidatorHash -> DataScript -> Value -> EscrowTarget
+payToScriptTarget = ScriptTarget
 
 -- | Definition of an escrow contract, consisting of a deadline and a list of targets
 data EscrowParams =
@@ -126,7 +125,7 @@ targetValue = \case
 mkTxOutput :: EscrowTarget -> TxOut
 mkTxOutput = \case
     PubKeyTarget pk vl -> pubKeyTxOut vl pk
-    ScriptTarget hsh ds vl -> scriptTxOut' vl (Ledger.Address (Scripts.unsafePlcAddress hsh)) ds
+    ScriptTarget vs ds vl -> scriptTxOut' vl (Ledger.scriptHashAddress vs) ds
 
 data Action = Redeem | Refund
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -77,7 +77,7 @@ gameValidator = Ledger.mkValidatorScript $$(PlutusTx.compile [|| validator ||])
 
 gameDataScript :: String -> DataScript
 gameDataScript =
-    Ledger.DataScript . PlutusTx.toData . HashedString . Ledger.plcSHA2_256 . C.pack
+    Ledger.DataScript . PlutusTx.toData . HashedString . sha2_256 . C.pack
 
 gameRedeemerScript :: String -> RedeemerScript
 gameRedeemerScript =

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/GameStateMachine.hs
@@ -142,7 +142,7 @@ gameTokenVal :: Value
 gameTokenVal =
     let
         -- see note [Obtaining the currency symbol]
-        cur = plcCurrencySymbol (Scripts.scriptAddress scriptInstance)
+        cur = scriptCurrencySymbol (Scripts.validatorScript scriptInstance)
     in
         V.singleton cur gameToken 1
 
@@ -163,7 +163,7 @@ guess gss new keepVal restVal = do
 
     let addr = Scripts.scriptAddress scriptInstance
         guessedSecret = ClearString (C.pack gss)
-        newSecret = HashedString (plcSHA2_256 (C.pack new))
+        newSecret = HashedString (sha2_256 (C.pack new))
         input = Guess guessedSecret newSecret
         newState = Locked gameToken newSecret
         redeemer = RedeemerScript $ PlutusTx.toData input
@@ -189,7 +189,7 @@ guess gss new keepVal restVal = do
 --   when submitting a guess.
 lock :: (WalletAPI m, WalletDiagnostics m) => String -> Value -> m ()
 lock initialWord vl = do
-    let secret = HashedString (plcSHA2_256 (C.pack initialWord))
+    let secret = HashedString (sha2_256 (C.pack initialWord))
         addr = Scripts.scriptAddress scriptInstance
         state = Initialised secret
         ds   = DataScript $ PlutusTx.toData state
@@ -221,7 +221,7 @@ lock initialWord vl = do
                         , txSignatures = Map.empty
                         }
 
-            WAPI.logMsg $ Text.pack $ "The forging transaction is: " <> show (Ledger.hashTx tx)
+            WAPI.logMsg $ Text.pack $ "The forging transaction is: " <> show (Ledger.txId tx)
             WAPI.signTxAndSubmit_ tx
 
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/PubKey.hs
@@ -49,9 +49,9 @@ pubKeyContract
 pubKeyContract pk vl = do
     let address = Ledger.scriptAddress (pkValidator pk)
         tx = Contract.payToScript vl address (DataScript $ PlutusTx.toData ())
-    txId <- writeTxSuccess tx
+    tid <- writeTxSuccess tx
 
-    ledgerTx <- awaitTransactionConfirmed address txId
+    ledgerTx <- awaitTransactionConfirmed address tid
     let output = listToMaybe
                 $ fmap fst
                 $ filter ((==) address . txOutAddress . snd)

--- a/plutus-use-cases/test/Spec/MultiSig.hs
+++ b/plutus-use-cases/test/Spec/MultiSig.hs
@@ -19,7 +19,7 @@ import qualified Test.Tasty.HUnit                                  as HUnit
 import qualified Language.PlutusTx as PlutusTx
 
 import           Language.PlutusTx.Coordination.Contracts.MultiSig as MS
-import           Ledger                                            (PrivateKey, Tx, hashTx, signatures, toPublicKey)
+import           Ledger                                            (PrivateKey, Tx, txId, signatures, toPublicKey)
 import qualified Ledger.Ada                                        as Ada
 import qualified Ledger.Crypto                                     as Crypto
 import qualified Wallet.API                                        as WAPI
@@ -85,5 +85,5 @@ threeOutOfFive n = do
 -- | Attach a signature to a transaction.
 attachSignature :: PrivateKey -> Tx -> Tx
 attachSignature pk tx' =
-    let sig = Crypto.signTx (hashTx tx') pk
+    let sig = Crypto.signTx (txId tx') pk
     in  tx' & signatures . at (toPublicKey pk) ?~ sig

--- a/plutus-use-cases/test/Spec/Rollup.hs
+++ b/plutus-use-cases/test/Spec/Rollup.hs
@@ -39,7 +39,7 @@ render
 render con trace = do
     let (result, EmulatorState{_chainNewestFirst=blockchain, _walletStates=wallets}) = runTrace con trace
     let walletKeys = flip fmap (Map.toList wallets) $ \(w, ws) -> (toPublicKey (_ownPrivateKey ws), w)
-    let resultBlockchain = flip (fmap . fmap) blockchain $ \tx -> (hashTx tx, tx)
+    let resultBlockchain = flip (fmap . fmap) blockchain $ \tx -> (txId tx, tx)
     case result of
         Left err -> assertFailure $ show err
         Right _ ->

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -7,21 +7,21 @@ Events by wallet:
     • {slot:
        Slot: 27}
     • {utxo-at:
-       Utxo at 9f18e71871183918900418260a1887181c185b18a918911871189018d018511853181c18f3187a18bd18231868189a18f9185e0418c5184e188e18961834ff = TxId: 9f186e1718ee1877185e18ce181c184d188f182f18d418aa182f186c184418ac187d18cd18d5184018811823181c1884189918a918a318bb1834184f187118a1ff!1: PayToScript: "\248\US\181J\130_\206\217^\176\&3\175\205d1@u\171\251\n\189 \169p\137%\ETXCo4\184c" Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}
-         TxId: 9f18811883184e18ab18a618e0183e189a18361878185018bf18b3182d05061833187b183a184218e4187f0e18af18bc183900184618c718c9184018c4ff!1: PayToScript: "\152\165\227\163ng\170\186\137\136\139\240\147\222\SUB\217c\231t\SOH;9\STX\191\171\&5m\139\144\ETB\138c" Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-         TxId: 9f18cc18191873186a18c2188c189c185014184f1832189f18bf18df186f18e3182b187b0f1888187e18f5188f185c185118f61833186e1851183e18df184eff!1: PayToScript: "\252Q\205\142b\CAN\161\163\141\164~\208\STX0\240X\b\SYN\237\DC3\186\&3\ETX\172]\235\145\NAKH\144\128%" Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}
+       Utxo at 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff = TxId: 5f58204d2a1d9e8f43b4e8a4213b159c40c9afca8558b5a1012288473ed5a267d02a52ff!1: PayToScript: "\152\165\227\163ng\170\186\137\136\139\240\147\222\SUB\217c\231t\SOH;9\STX\191\171\&5m\139\144\ETB\138c" Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+         TxId: 5f58205f67ac958d592726b272aec1b71d9248f66842c82636f010ea08bae95c239b66ff!1: PayToScript: "\248\US\181J\130_\206\217^\176\&3\175\205d1@u\171\251\n\189 \169p\137%\ETXCo4\184c" Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}
+         TxId: 5f5820790286029e5601093629e141f5aeac975cdd03104a7b39e9dc34a97ce321259aff!1: PayToScript: "\252Q\205\142b\CAN\161\163\141\164~\208\STX0\240X\b\SYN\237\DC3\186\&3\ETX\172]\235\145\NAKH\144\128%" Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}
     • {tx:
-       WriteTxSuccess: TxId {getTxId = 92e32ac38b4bc425da22b0a0d083aacd30a07dd21e402f6b137f56a46a0bda04}}
+       WriteTxSuccess: TxId {getTxId = "\NAK\200O\DC3I\210\229\244\225\203u}CE\162\f\224\&7s6&\SO)b\NAK'M\255O\253\242\204"}}
   Events for W2:
     • {contribute:
        (PubKey {getPubKey = fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025},Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}})}
     • {tx:
-       WriteTxSuccess: TxId {getTxId = cc19736ac28c9c50144f329fbfdf6fe32b7b0f887ef58f5c51f6336e513edf4e}}
+       WriteTxSuccess: TxId {getTxId = "y\STX\134\STX\158V\SOH\t6)\225A\245\174\172\151\\\221\ETX\DLEJ{9\233\220\&4\169|\227!%\154"}}
     • {address:
-       ( 9f18e71871183918900418260a1887181c185b18a918911871189018d018511853181c18f3187a18bd18231868189a18f9185e0418c5184e188e18961834ff
-       , Tx TxId: 9f18cc18191873186a18c2188c189c185014184f1832189f18bf18df186f18e3182b187b0f1888187e18f5188f185c185118f61833186e1851183e18df184eff:
+       ( 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
+       , Tx TxId: 5f5820790286029e5601093629e141f5aeac975cdd03104a7b39e9dc34a97ce321259aff:
          {inputs:
-            - TxId: 9f18ce182218d1183018c617182d18a718db182b18b618a8183a1860188f189118ac1896186d18a018dd187218b61879185618f118ff01161850187d1838ff!8
+            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!8
               fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,90)]})]}} locked by
@@ -34,10 +34,10 @@ Events by wallet:
            fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( 9f18e71871183918900418260a1887181c185b18a918911871189018d018511853181c18f3187a18bd18231868189a18f9185e0418c5184e188e18961834ff
-       , Tx TxId: 9f18811883184e18ab18a618e0183e189a18361878185018bf18b3182d05061833187b183a184218e4187f0e18af18bc183900184618c718c9184018c4ff:
+       ( 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
+       , Tx TxId: 5f58204d2a1d9e8f43b4e8a4213b159c40c9afca8558b5a1012288473ed5a267d02a52ff:
          {inputs:
-            - TxId: 9f18ce182218d1183018c617182d18a718db182b18b618a8183a1860188f189118ac1896186d18a018dd187218b61879185618f118ff01161850187d1838ff!3
+            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!3
               98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,90)]})]}} locked by
@@ -50,10 +50,10 @@ Events by wallet:
            98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( 9f18e71871183918900418260a1887181c185b18a918911871189018d018511853181c18f3187a18bd18231868189a18f9185e0418c5184e188e18961834ff
-       , Tx TxId: 9f186e1718ee1877185e18ce181c184d188f182f18d418aa182f186c184418ac187d18cd18d5184018811823181c1884189918a918a318bb1834184f187118a1ff:
+       ( 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
+       , Tx TxId: 5f58205f67ac958d592726b272aec1b71d9248f66842c82636f010ea08bae95c239b66ff:
          {inputs:
-            - TxId: 9f18ce182218d1183018c617182d18a718db182b18b618a8183a1860188f189118ac1896186d18a018dd187218b61879185618f118ff01161850187d1838ff!7
+            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!7
               f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,99)]})]}} locked by
@@ -69,12 +69,12 @@ Events by wallet:
     • {contribute:
        (PubKey {getPubKey = 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63},Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}})}
     • {tx:
-       WriteTxSuccess: TxId {getTxId = 81834eaba6e03e9a367850bfb32d0506337b3a42e47f0eafbc390046c7c940c4}}
+       WriteTxSuccess: TxId {getTxId = "M*\GS\158\143C\180\232\164!;\NAK\156@\201\175\202\133X\181\161\SOH\"\136G>\213\162g\208*R"}}
     • {address:
-       ( 9f18e71871183918900418260a1887181c185b18a918911871189018d018511853181c18f3187a18bd18231868189a18f9185e0418c5184e188e18961834ff
-       , Tx TxId: 9f18811883184e18ab18a618e0183e189a18361878185018bf18b3182d05061833187b183a184218e4187f0e18af18bc183900184618c718c9184018c4ff:
+       ( 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
+       , Tx TxId: 5f58204d2a1d9e8f43b4e8a4213b159c40c9afca8558b5a1012288473ed5a267d02a52ff:
          {inputs:
-            - TxId: 9f18ce182218d1183018c617182d18a718db182b18b618a8183a1860188f189118ac1896186d18a018dd187218b61879185618f118ff01161850187d1838ff!3
+            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!3
               98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,90)]})]}} locked by
@@ -87,10 +87,10 @@ Events by wallet:
            98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( 9f18e71871183918900418260a1887181c185b18a918911871189018d018511853181c18f3187a18bd18231868189a18f9185e0418c5184e188e18961834ff
-       , Tx TxId: 9f186e1718ee1877185e18ce181c184d188f182f18d418aa182f186c184418ac187d18cd18d5184018811823181c1884189918a918a318bb1834184f187118a1ff:
+       ( 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
+       , Tx TxId: 5f58205f67ac958d592726b272aec1b71d9248f66842c82636f010ea08bae95c239b66ff:
          {inputs:
-            - TxId: 9f18ce182218d1183018c617182d18a718db182b18b618a8183a1860188f189118ac1896186d18a018dd187218b61879185618f118ff01161850187d1838ff!7
+            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!7
               f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,99)]})]}} locked by
@@ -106,12 +106,12 @@ Events by wallet:
     • {contribute:
        (PubKey {getPubKey = f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863},Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}})}
     • {tx:
-       WriteTxSuccess: TxId {getTxId = 6e17ee775ece1c4d8f2fd4aa2f6c44ac7dcdd54081231c8499a9a3bb344f71a1}}
+       WriteTxSuccess: TxId {getTxId = "_g\172\149\141Y'&\178r\174\193\183\GS\146H\246hB\200&6\240\DLE\234\b\186\233\\#\155f"}}
     • {address:
-       ( 9f18e71871183918900418260a1887181c185b18a918911871189018d018511853181c18f3187a18bd18231868189a18f9185e0418c5184e188e18961834ff
-       , Tx TxId: 9f186e1718ee1877185e18ce181c184d188f182f18d418aa182f186c184418ac187d18cd18d5184018811823181c1884189918a918a318bb1834184f187118a1ff:
+       ( 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
+       , Tx TxId: 5f58205f67ac958d592726b272aec1b71d9248f66842c82636f010ea08bae95c239b66ff:
          {inputs:
-            - TxId: 9f18ce182218d1183018c617182d18a718db182b18b618a8183a1860188f189118ac1896186d18a018dd187218b61879185618f118ff01161850187d1838ff!7
+            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!7
               f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,99)]})]}} locked by
@@ -128,7 +128,7 @@ Contract result by wallet:
     Done
     Wallet: W2
       Running, waiting for input:
-        {address: [ 9f18e71871183918900418260a1887181c185b18a918911871189018d018511853181c18f3187a18bd18231868189a18f9185e0418c5184e188e18961834ff ]
+        {address: [ 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff ]
          contribute: []
          schedule collection: ["schedule collection"]
          slot: WaitingForSlot {unWaitingForSlot = Just (Slot {getSlot = 30})}
@@ -136,7 +136,7 @@ Contract result by wallet:
          utxo-at: []}
     Wallet: W3
       Running, waiting for input:
-        {address: [ 9f18e71871183918900418260a1887181c185b18a918911871189018d018511853181c18f3187a18bd18231868189a18f9185e0418c5184e188e18961834ff ]
+        {address: [ 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff ]
          contribute: []
          schedule collection: ["schedule collection"]
          slot: WaitingForSlot {unWaitingForSlot = Just (Slot {getSlot = 30})}
@@ -144,7 +144,7 @@ Contract result by wallet:
          utxo-at: []}
     Wallet: W4
       Running, waiting for input:
-        {address: [ 9f18e71871183918900418260a1887181c185b18a918911871189018d018511853181c18f3187a18bd18231868189a18f9185e0418c5184e188e18961834ff ]
+        {address: [ 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff ]
          contribute: []
          schedule collection: ["schedule collection"]
          slot: WaitingForSlot {unWaitingForSlot = Just (Slot {getSlot = 30})}

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -1,5 +1,5 @@
 ==== Slot #0, Tx #0 ====
-TxId:       ce22d130c6172da7db2bb6a83a608f91ac966da0dd72b67956f1ff0116507d38
+TxId:       "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
 Fee:        -
 Forge:      Ada:      Lovelace:  1000
 Inputs:
@@ -100,7 +100,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100
 
 ==== Slot #2, Tx #0 ====
-TxId:       cc19736ac28c9c50144f329fbfdf6fe32b7b0f887ef58f5c51f6336e513edf4e
+TxId:       "y\STX\134\STX\158V\SOH\t6)\225A\245\174\172\151\\\221\ETX\DLEJ{9\233\220\&4\169|\227!%\154"
 Fee:        -
 Forge:      -
 Inputs:
@@ -109,7 +109,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     ce22d130c6172da7db2bb6a83a608f91ac966da0dd72b67956f1ff0116507d38
+    Tx:     "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
     Output #8
     PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
 
@@ -121,7 +121,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
+  Destination:  Script: 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
   Value:
     Ada:      Lovelace:  10
 
@@ -167,12 +167,12 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f18e71871183918900418260a1887181c185b18...
+  Script: 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #3, Tx #0 ====
-TxId:       81834eaba6e03e9a367850bfb32d0506337b3a42e47f0eafbc390046c7c940c4
+TxId:       "M*\GS\158\143C\180\232\164!;\NAK\156@\201\175\202\133X\181\161\SOH\"\136G>\213\162g\208*R"
 Fee:        -
 Forge:      -
 Inputs:
@@ -181,7 +181,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     ce22d130c6172da7db2bb6a83a608f91ac966da0dd72b67956f1ff0116507d38
+    Tx:     "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
     Output #3
     PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
 
@@ -193,7 +193,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
+  Destination:  Script: 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
   Value:
     Ada:      Lovelace:  10
 
@@ -239,12 +239,12 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f18e71871183918900418260a1887181c185b18...
+  Script: 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
   Value:
     Ada:      Lovelace:  20
 
 ==== Slot #4, Tx #0 ====
-TxId:       6e17ee775ece1c4d8f2fd4aa2f6c44ac7dcdd54081231c8499a9a3bb344f71a1
+TxId:       "_g\172\149\141Y'&\178r\174\193\183\GS\146H\246hB\200&6\240\DLE\234\b\186\233\\#\155f"
 Fee:        -
 Forge:      -
 Inputs:
@@ -253,7 +253,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     ce22d130c6172da7db2bb6a83a608f91ac966da0dd72b67956f1ff0116507d38
+    Tx:     "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
     Output #7
     PubKey: f81fb54a825fced95eb033afcd64314075abfb0a...
 
@@ -265,7 +265,7 @@ Outputs:
     Ada:      Lovelace:  99
   
   ---- Output 1 ----
-  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
+  Destination:  Script: 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
   Value:
     Ada:      Lovelace:  1
 
@@ -311,39 +311,39 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f18e71871183918900418260a1887181c185b18...
+  Script: 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
   Value:
     Ada:      Lovelace:  21
 
 ==== Slot #23, Tx #0 ====
-TxId:       92e32ac38b4bc425da22b0a0d083aacd30a07dd21e402f6b137f56a46a0bda04
+TxId:       "\NAK\200O\DC3I\210\229\244\225\203u}CE\162\f\224\&7s6&\SO)b\NAK'M\255O\253\242\204"
 Fee:        -
 Forge:      -
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
+  Destination:  Script: 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
   Value:
-    Ada:      Lovelace:  1
+    Ada:      Lovelace:  10
   Source:
-    Tx:     6e17ee775ece1c4d8f2fd4aa2f6c44ac7dcdd54081231c8499a9a3bb344f71a1
+    Tx:     "M*\GS\158\143C\180\232\164!;\NAK\156@\201\175\202\133X\181\161\SOH\"\136G>\213\162g\208*R"
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
   
   ---- Input 1 ----
-  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
+  Destination:  Script: 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
   Value:
-    Ada:      Lovelace:  10
+    Ada:      Lovelace:  1
   Source:
-    Tx:     81834eaba6e03e9a367850bfb32d0506337b3a42e47f0eafbc390046c7c940c4
+    Tx:     "_g\172\149\141Y'&\178r\174\193\183\GS\146H\246hB\200&6\240\DLE\234\b\186\233\\#\155f"
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
   
   ---- Input 2 ----
-  Destination:  Script: 9f18e71871183918900418260a1887181c185b18...
+  Destination:  Script: 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     cc19736ac28c9c50144f329fbfdf6fe32b7b0f887ef58f5c51f6336e513edf4e
+    Tx:     "y\STX\134\STX\158V\SOH\t6)\225A\245\174\172\151\\\221\ETX\DLEJ{9\233\220\&4\169|\227!%\154"
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
 
@@ -396,6 +396,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f18e71871183918900418260a1887181c185b18...
+  Script: 5f582006f0fa600099bd02622cdef6b874bd10d1b23aa9e7039a40b2b9085907246bb2ff
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -1,5 +1,5 @@
 ==== Slot #0, Tx #0 ====
-TxId:       ce22d130c6172da7db2bb6a83a608f91ac966da0dd72b67956f1ff0116507d38
+TxId:       "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
 Fee:        -
 Forge:      Ada:      Lovelace:  1000
 Inputs:
@@ -100,7 +100,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100
 
 ==== Slot #2, Tx #0 ====
-TxId:       0018bf85d530053d929813e64a9d3d922705e3a0c2bf9475cabc226c48dfb2c5
+TxId:       "\133\143y\139&\162\142E\ETX\185'\f\224\246\&60\SOH\STX\133\208\179C\132U\196_\143\f\163\217^b"
 Fee:        -
 Forge:      -
 Inputs:
@@ -109,7 +109,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     ce22d130c6172da7db2bb6a83a608f91ac966da0dd72b67956f1ff0116507d38
+    Tx:     "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
     Output #1
     PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
 
@@ -121,7 +121,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: 9f184f181b1859185d18fa18f818d7185c18de18...
+  Destination:  Script: 5f5820cfa11580db5f7039d6b9aea174f77fa06b469f0096d959e25cc47c2589249707ff
   Value:
     Ada:      Lovelace:  10
 
@@ -167,21 +167,21 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f184f181b1859185d18fa18f818d7185c18de18...
+  Script: 5f5820cfa11580db5f7039d6b9aea174f77fa06b469f0096d959e25cc47c2589249707ff
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #3, Tx #0 ====
-TxId:       20aae7827bcdd6c63ed8208b7ad981c273d381de28124912228d4a9d92492641
+TxId:       "\152\190\174\132Q!\185O\215V\232\ACK\171\v\NAKstz\233\f\172<H\\\240\DC2E\ESC\149e\217\173"
 Fee:        -
 Forge:      -
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 9f184f181b1859185d18fa18f818d7185c18de18...
+  Destination:  Script: 5f5820cfa11580db5f7039d6b9aea174f77fa06b469f0096d959e25cc47c2589249707ff
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     0018bf85d530053d929813e64a9d3d922705e3a0c2bf9475cabc226c48dfb2c5
+    Tx:     "\133\143y\139&\162\142E\ETX\185'\f\224\246\&60\SOH\STX\133\208\179C\132U\196_\143\f\163\217^b"
     Output #1
     Script: f6f6010000c3f6c3f6c5f6c1f6f664556e697419...
 
@@ -234,6 +234,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 9f184f181b1859185d18fa18f818d7185c18de18...
+  Script: 5f5820cfa11580db5f7039d6b9aea174f77fa06b469f0096d959e25cc47c2589249707ff
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/vesting.pir
+++ b/plutus-use-cases/test/Spec/vesting.pir
@@ -2138,7 +2138,7 @@
                                                                         VestingData_match
                                                                         (vardecl
                                                                           VestingData
-                                                                          (fun (con bytestring) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] VestingData))
+                                                                          (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] VestingData)
                                                                         )
                                                                       )
                                                                     )
@@ -3267,289 +3267,160 @@
                                                                                                           }
                                                                                                           (lam
                                                                                                             ds
-                                                                                                            (con bytestring)
-                                                                                                            (lam
-                                                                                                              ds
-                                                                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                              (let
-                                                                                                                (nonrec
+                                                                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                            (let
+                                                                                                              (nonrec
+                                                                                                              )
+                                                                                                              (termbind
+                                                                                                                (strict
                                                                                                                 )
-                                                                                                                (termbind
-                                                                                                                  (strict
-                                                                                                                  )
-                                                                                                                  (vardecl
-                                                                                                                    wild
-                                                                                                                    [PendingTx [PendingTxIn [[Tuple2 (con bytestring)] (con bytestring)]]]
-                                                                                                                  )
-                                                                                                                  ptx
+                                                                                                                (vardecl
+                                                                                                                  wild
+                                                                                                                  [PendingTx [PendingTxIn [[Tuple2 (con bytestring)] (con bytestring)]]]
                                                                                                                 )
-                                                                                                                [
-                                                                                                                  {
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        PendingTx_match
-                                                                                                                        [PendingTxIn [[Tuple2 (con bytestring)] (con bytestring)]]
-                                                                                                                      }
-                                                                                                                      ptx
-                                                                                                                    ]
-                                                                                                                    Bool
-                                                                                                                  }
+                                                                                                                ptx
+                                                                                                              )
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  [
+                                                                                                                    {
+                                                                                                                      PendingTx_match
+                                                                                                                      [PendingTxIn [[Tuple2 (con bytestring)] (con bytestring)]]
+                                                                                                                    }
+                                                                                                                    ptx
+                                                                                                                  ]
+                                                                                                                  Bool
+                                                                                                                }
+                                                                                                                (lam
+                                                                                                                  ds
+                                                                                                                  [List [PendingTxIn [Maybe [[Tuple2 (con bytestring)] (con bytestring)]]]]
                                                                                                                   (lam
                                                                                                                     ds
-                                                                                                                    [List [PendingTxIn [Maybe [[Tuple2 (con bytestring)] (con bytestring)]]]]
+                                                                                                                    [List PendingTxOut]
                                                                                                                     (lam
                                                                                                                       ds
-                                                                                                                      [List PendingTxOut]
+                                                                                                                      (con integer)
                                                                                                                       (lam
                                                                                                                         ds
-                                                                                                                        (con integer)
+                                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                                                                         (lam
                                                                                                                           ds
-                                                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                          [PendingTxIn [[Tuple2 (con bytestring)] (con bytestring)]]
                                                                                                                           (lam
                                                                                                                             ds
-                                                                                                                            [PendingTxIn [[Tuple2 (con bytestring)] (con bytestring)]]
+                                                                                                                            [Interval (con integer)]
                                                                                                                             (lam
                                                                                                                               ds
-                                                                                                                              [Interval (con integer)]
+                                                                                                                              [List [[Tuple2 (con bytestring)] (con bytestring)]]
                                                                                                                               (lam
                                                                                                                                 ds
-                                                                                                                                [List [[Tuple2 (con bytestring)] (con bytestring)]]
-                                                                                                                                (lam
-                                                                                                                                  ds
-                                                                                                                                  (con bytestring)
-                                                                                                                                  (let
-                                                                                                                                    (nonrec
+                                                                                                                                (con bytestring)
+                                                                                                                                (let
+                                                                                                                                  (nonrec
+                                                                                                                                  )
+                                                                                                                                  (termbind
+                                                                                                                                    (nonstrict
                                                                                                                                     )
-                                                                                                                                    (termbind
-                                                                                                                                      (nonstrict
-                                                                                                                                      )
-                                                                                                                                      (vardecl
-                                                                                                                                        newAmount
-                                                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                      )
+                                                                                                                                    (vardecl
+                                                                                                                                      newAmount
+                                                                                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                    )
+                                                                                                                                    [
+                                                                                                                                      [
+                                                                                                                                        [
+                                                                                                                                          unionWith
+                                                                                                                                          addInteger
+                                                                                                                                        ]
+                                                                                                                                        ds
+                                                                                                                                      ]
                                                                                                                                       [
                                                                                                                                         [
                                                                                                                                           [
                                                                                                                                             unionWith
                                                                                                                                             addInteger
                                                                                                                                           ]
-                                                                                                                                          ds
+                                                                                                                                          [
+                                                                                                                                            {
+                                                                                                                                              [
+                                                                                                                                                {
+                                                                                                                                                  PendingTxIn_match
+                                                                                                                                                  [[Tuple2 (con bytestring)] (con bytestring)]
+                                                                                                                                                }
+                                                                                                                                                ds
+                                                                                                                                              ]
+                                                                                                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                            }
+                                                                                                                                            (lam
+                                                                                                                                              ds
+                                                                                                                                              PendingTxOutRef
+                                                                                                                                              (lam
+                                                                                                                                                ds
+                                                                                                                                                [[Tuple2 (con bytestring)] (con bytestring)]
+                                                                                                                                                (lam
+                                                                                                                                                  ds
+                                                                                                                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                  ds
+                                                                                                                                                )
+                                                                                                                                              )
+                                                                                                                                            )
+                                                                                                                                          ]
                                                                                                                                         ]
                                                                                                                                         [
                                                                                                                                           [
-                                                                                                                                            [
-                                                                                                                                              unionWith
-                                                                                                                                              addInteger
-                                                                                                                                            ]
-                                                                                                                                            [
-                                                                                                                                              {
-                                                                                                                                                [
-                                                                                                                                                  {
-                                                                                                                                                    PendingTxIn_match
-                                                                                                                                                    [[Tuple2 (con bytestring)] (con bytestring)]
-                                                                                                                                                  }
-                                                                                                                                                  ds
-                                                                                                                                                ]
-                                                                                                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                              }
-                                                                                                                                              (lam
-                                                                                                                                                ds
-                                                                                                                                                PendingTxOutRef
-                                                                                                                                                (lam
-                                                                                                                                                  ds
-                                                                                                                                                  [[Tuple2 (con bytestring)] (con bytestring)]
-                                                                                                                                                  (lam
-                                                                                                                                                    ds
-                                                                                                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                    ds
-                                                                                                                                                  )
-                                                                                                                                                )
-                                                                                                                                              )
-                                                                                                                                            ]
+                                                                                                                                            fAdditiveGroupValue_cscale
+                                                                                                                                            fAdditiveGroupValue
                                                                                                                                           ]
                                                                                                                                           [
                                                                                                                                             [
-                                                                                                                                              fAdditiveGroupValue_cscale
-                                                                                                                                              fAdditiveGroupValue
+                                                                                                                                              [
+                                                                                                                                                {
+                                                                                                                                                  {
+                                                                                                                                                    foldr
+                                                                                                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                  }
+                                                                                                                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                }
+                                                                                                                                                fMonoidValue_c
+                                                                                                                                              ]
+                                                                                                                                              {
+                                                                                                                                                Nil
+                                                                                                                                                [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                              }
                                                                                                                                             ]
                                                                                                                                             [
                                                                                                                                               [
-                                                                                                                                                [
-                                                                                                                                                  {
-                                                                                                                                                    {
-                                                                                                                                                      foldr
-                                                                                                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                    }
-                                                                                                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                  }
-                                                                                                                                                  fMonoidValue_c
-                                                                                                                                                ]
                                                                                                                                                 {
-                                                                                                                                                  Nil
-                                                                                                                                                  [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                  {
+                                                                                                                                                    map
+                                                                                                                                                    PendingTxOut
+                                                                                                                                                  }
+                                                                                                                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                                                                                                 }
+                                                                                                                                                pendingTxOutValue
                                                                                                                                               ]
                                                                                                                                               [
-                                                                                                                                                [
-                                                                                                                                                  {
-                                                                                                                                                    {
-                                                                                                                                                      map
-                                                                                                                                                      PendingTxOut
-                                                                                                                                                    }
-                                                                                                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                  }
-                                                                                                                                                  pendingTxOutValue
-                                                                                                                                                ]
-                                                                                                                                                [
-                                                                                                                                                  getContinuingOutputs
-                                                                                                                                                  wild
-                                                                                                                                                ]
+                                                                                                                                                getContinuingOutputs
+                                                                                                                                                wild
                                                                                                                                               ]
                                                                                                                                             ]
                                                                                                                                           ]
                                                                                                                                         ]
                                                                                                                                       ]
-                                                                                                                                    )
+                                                                                                                                    ]
+                                                                                                                                  )
+                                                                                                                                  [
                                                                                                                                     [
                                                                                                                                       [
-                                                                                                                                        [
-                                                                                                                                          {
-                                                                                                                                            [
-                                                                                                                                              Bool_match
-                                                                                                                                              [
-                                                                                                                                                [
-                                                                                                                                                  [
-                                                                                                                                                    checkBinRel
-                                                                                                                                                    lessThanEqInteger
-                                                                                                                                                  ]
-                                                                                                                                                  newAmount
-                                                                                                                                                ]
-                                                                                                                                                [
-                                                                                                                                                  [
-                                                                                                                                                    [
-                                                                                                                                                      unionWith
-                                                                                                                                                      addInteger
-                                                                                                                                                    ]
-                                                                                                                                                    [
-                                                                                                                                                      [
-                                                                                                                                                        availableFrom
-                                                                                                                                                        ds
-                                                                                                                                                      ]
-                                                                                                                                                      ds
-                                                                                                                                                    ]
-                                                                                                                                                  ]
-                                                                                                                                                  [
-                                                                                                                                                    [
-                                                                                                                                                      availableFrom
-                                                                                                                                                      ds
-                                                                                                                                                    ]
-                                                                                                                                                    ds
-                                                                                                                                                  ]
-                                                                                                                                                ]
-                                                                                                                                              ]
-                                                                                                                                            ]
-                                                                                                                                            (fun Unit Bool)
-                                                                                                                                          }
-                                                                                                                                          (lam
-                                                                                                                                            thunk
-                                                                                                                                            Unit
+                                                                                                                                        {
+                                                                                                                                          [
+                                                                                                                                            Bool_match
                                                                                                                                             [
                                                                                                                                               [
                                                                                                                                                 [
                                                                                                                                                   checkBinRel
-                                                                                                                                                  equalsInteger
+                                                                                                                                                  lessThanEqInteger
                                                                                                                                                 ]
-                                                                                                                                                [
-                                                                                                                                                  [
-                                                                                                                                                    [
-                                                                                                                                                      {
-                                                                                                                                                        {
-                                                                                                                                                          foldr
-                                                                                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                        }
-                                                                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                      }
-                                                                                                                                                      fMonoidValue_c
-                                                                                                                                                    ]
-                                                                                                                                                    {
-                                                                                                                                                      Nil
-                                                                                                                                                      [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                    }
-                                                                                                                                                  ]
-                                                                                                                                                  [
-                                                                                                                                                    [
-                                                                                                                                                      {
-                                                                                                                                                        {
-                                                                                                                                                          map
-                                                                                                                                                          [[Tuple2 Data] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                                                                                                                                                        }
-                                                                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                      }
-                                                                                                                                                      {
-                                                                                                                                                        {
-                                                                                                                                                          snd
-                                                                                                                                                          Data
-                                                                                                                                                        }
-                                                                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                      }
-                                                                                                                                                    ]
-                                                                                                                                                    [
-                                                                                                                                                      [
-                                                                                                                                                        scriptOutputsAt
-                                                                                                                                                        [
-                                                                                                                                                          {
-                                                                                                                                                            [
-                                                                                                                                                              {
-                                                                                                                                                                PendingTxIn_match
-                                                                                                                                                                [[Tuple2 (con bytestring)] (con bytestring)]
-                                                                                                                                                              }
-                                                                                                                                                              ds
-                                                                                                                                                            ]
-                                                                                                                                                            (con bytestring)
-                                                                                                                                                          }
-                                                                                                                                                          (lam
-                                                                                                                                                            ds
-                                                                                                                                                            PendingTxOutRef
-                                                                                                                                                            (lam
-                                                                                                                                                              ds
-                                                                                                                                                              [[Tuple2 (con bytestring)] (con bytestring)]
-                                                                                                                                                              (lam
-                                                                                                                                                                ds
-                                                                                                                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                                [
-                                                                                                                                                                  {
-                                                                                                                                                                    [
-                                                                                                                                                                      {
-                                                                                                                                                                        {
-                                                                                                                                                                          Tuple2_match
-                                                                                                                                                                          (con bytestring)
-                                                                                                                                                                        }
-                                                                                                                                                                        (con bytestring)
-                                                                                                                                                                      }
-                                                                                                                                                                      ds
-                                                                                                                                                                    ]
-                                                                                                                                                                    (con bytestring)
-                                                                                                                                                                  }
-                                                                                                                                                                  (lam
-                                                                                                                                                                    a
-                                                                                                                                                                    (con bytestring)
-                                                                                                                                                                    (lam
-                                                                                                                                                                      ds
-                                                                                                                                                                      (con bytestring)
-                                                                                                                                                                      a
-                                                                                                                                                                    )
-                                                                                                                                                                  )
-                                                                                                                                                                ]
-                                                                                                                                                              )
-                                                                                                                                                            )
-                                                                                                                                                          )
-                                                                                                                                                        ]
-                                                                                                                                                      ]
-                                                                                                                                                      wild
-                                                                                                                                                    ]
-                                                                                                                                                  ]
-                                                                                                                                                ]
+                                                                                                                                                newAmount
                                                                                                                                               ]
                                                                                                                                               [
                                                                                                                                                 [
@@ -3559,28 +3430,135 @@
                                                                                                                                                   ]
                                                                                                                                                   [
                                                                                                                                                     [
-                                                                                                                                                      [
-                                                                                                                                                        unionWith
-                                                                                                                                                        addInteger
-                                                                                                                                                      ]
+                                                                                                                                                      availableFrom
+                                                                                                                                                      ds
+                                                                                                                                                    ]
+                                                                                                                                                    ds
+                                                                                                                                                  ]
+                                                                                                                                                ]
+                                                                                                                                                [
+                                                                                                                                                  [
+                                                                                                                                                    availableFrom
+                                                                                                                                                    ds
+                                                                                                                                                  ]
+                                                                                                                                                  ds
+                                                                                                                                                ]
+                                                                                                                                              ]
+                                                                                                                                            ]
+                                                                                                                                          ]
+                                                                                                                                          (fun Unit Bool)
+                                                                                                                                        }
+                                                                                                                                        (lam
+                                                                                                                                          thunk
+                                                                                                                                          Unit
+                                                                                                                                          [
+                                                                                                                                            [
+                                                                                                                                              [
+                                                                                                                                                checkBinRel
+                                                                                                                                                equalsInteger
+                                                                                                                                              ]
+                                                                                                                                              [
+                                                                                                                                                [
+                                                                                                                                                  [
+                                                                                                                                                    {
+                                                                                                                                                      {
+                                                                                                                                                        foldr
+                                                                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                      }
+                                                                                                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                    }
+                                                                                                                                                    fMonoidValue_c
+                                                                                                                                                  ]
+                                                                                                                                                  {
+                                                                                                                                                    Nil
+                                                                                                                                                    [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                  }
+                                                                                                                                                ]
+                                                                                                                                                [
+                                                                                                                                                  [
+                                                                                                                                                    {
+                                                                                                                                                      {
+                                                                                                                                                        map
+                                                                                                                                                        [[Tuple2 Data] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                                                                                                                                      }
+                                                                                                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                    }
+                                                                                                                                                    {
+                                                                                                                                                      {
+                                                                                                                                                        snd
+                                                                                                                                                        Data
+                                                                                                                                                      }
+                                                                                                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                    }
+                                                                                                                                                  ]
+                                                                                                                                                  [
+                                                                                                                                                    [
+                                                                                                                                                      scriptOutputsAt
                                                                                                                                                       [
                                                                                                                                                         {
                                                                                                                                                           [
-                                                                                                                                                            VestingTranche_match
+                                                                                                                                                            {
+                                                                                                                                                              PendingTxIn_match
+                                                                                                                                                              [[Tuple2 (con bytestring)] (con bytestring)]
+                                                                                                                                                            }
                                                                                                                                                             ds
                                                                                                                                                           ]
-                                                                                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                          (con bytestring)
                                                                                                                                                         }
                                                                                                                                                         (lam
                                                                                                                                                           ds
-                                                                                                                                                          (con integer)
+                                                                                                                                                          PendingTxOutRef
                                                                                                                                                           (lam
                                                                                                                                                             ds
-                                                                                                                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                            ds
+                                                                                                                                                            [[Tuple2 (con bytestring)] (con bytestring)]
+                                                                                                                                                            (lam
+                                                                                                                                                              ds
+                                                                                                                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                              [
+                                                                                                                                                                {
+                                                                                                                                                                  [
+                                                                                                                                                                    {
+                                                                                                                                                                      {
+                                                                                                                                                                        Tuple2_match
+                                                                                                                                                                        (con bytestring)
+                                                                                                                                                                      }
+                                                                                                                                                                      (con bytestring)
+                                                                                                                                                                    }
+                                                                                                                                                                    ds
+                                                                                                                                                                  ]
+                                                                                                                                                                  (con bytestring)
+                                                                                                                                                                }
+                                                                                                                                                                (lam
+                                                                                                                                                                  a
+                                                                                                                                                                  (con bytestring)
+                                                                                                                                                                  (lam
+                                                                                                                                                                    ds
+                                                                                                                                                                    (con bytestring)
+                                                                                                                                                                    a
+                                                                                                                                                                  )
+                                                                                                                                                                )
+                                                                                                                                                              ]
+                                                                                                                                                            )
                                                                                                                                                           )
                                                                                                                                                         )
                                                                                                                                                       ]
+                                                                                                                                                    ]
+                                                                                                                                                    wild
+                                                                                                                                                  ]
+                                                                                                                                                ]
+                                                                                                                                              ]
+                                                                                                                                            ]
+                                                                                                                                            [
+                                                                                                                                              [
+                                                                                                                                                [
+                                                                                                                                                  unionWith
+                                                                                                                                                  addInteger
+                                                                                                                                                ]
+                                                                                                                                                [
+                                                                                                                                                  [
+                                                                                                                                                    [
+                                                                                                                                                      unionWith
+                                                                                                                                                      addInteger
                                                                                                                                                     ]
                                                                                                                                                     [
                                                                                                                                                       {
@@ -3601,27 +3579,45 @@
                                                                                                                                                       )
                                                                                                                                                     ]
                                                                                                                                                   ]
-                                                                                                                                                ]
-                                                                                                                                                [
                                                                                                                                                   [
-                                                                                                                                                    fAdditiveGroupValue_cscale
-                                                                                                                                                    fAdditiveGroupValue
+                                                                                                                                                    {
+                                                                                                                                                      [
+                                                                                                                                                        VestingTranche_match
+                                                                                                                                                        ds
+                                                                                                                                                      ]
+                                                                                                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                    }
+                                                                                                                                                    (lam
+                                                                                                                                                      ds
+                                                                                                                                                      (con integer)
+                                                                                                                                                      (lam
+                                                                                                                                                        ds
+                                                                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                        ds
+                                                                                                                                                      )
+                                                                                                                                                    )
                                                                                                                                                   ]
-                                                                                                                                                  newAmount
                                                                                                                                                 ]
                                                                                                                                               ]
+                                                                                                                                              [
+                                                                                                                                                [
+                                                                                                                                                  fAdditiveGroupValue_cscale
+                                                                                                                                                  fAdditiveGroupValue
+                                                                                                                                                ]
+                                                                                                                                                newAmount
+                                                                                                                                              ]
                                                                                                                                             ]
-                                                                                                                                          )
-                                                                                                                                        ]
-                                                                                                                                        (lam
-                                                                                                                                          thunk
-                                                                                                                                          Unit
-                                                                                                                                          False
+                                                                                                                                          ]
                                                                                                                                         )
                                                                                                                                       ]
-                                                                                                                                      Unit
+                                                                                                                                      (lam
+                                                                                                                                        thunk
+                                                                                                                                        Unit
+                                                                                                                                        False
+                                                                                                                                      )
                                                                                                                                     ]
-                                                                                                                                  )
+                                                                                                                                    Unit
+                                                                                                                                  ]
                                                                                                                                 )
                                                                                                                               )
                                                                                                                             )
@@ -3630,8 +3626,8 @@
                                                                                                                       )
                                                                                                                     )
                                                                                                                   )
-                                                                                                                ]
-                                                                                                              )
+                                                                                                                )
+                                                                                                              ]
                                                                                                             )
                                                                                                           )
                                                                                                         ]

--- a/plutus-wallet-api/ledger/Ledger.hs
+++ b/plutus-wallet-api/ledger/Ledger.hs
@@ -6,6 +6,7 @@ module Ledger (
     ) where
 
 import           Ledger.Ada        (Ada)
+import           Ledger.Address    as Export
 import           Ledger.Blockchain as Export
 import           Ledger.Crypto     as Export
 import           Ledger.Index      as Export

--- a/plutus-wallet-api/ledger/Ledger/Address.hs
+++ b/plutus-wallet-api/ledger/Ledger/Address.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DerivingVia     #-}
+module Ledger.Address (
+    -- Note that the constructor is not exported - generally people shouldn't be able
+    -- to look inside addresses
+    Address,
+    pubKeyAddress,
+    scriptAddress,
+    scriptHashAddress,
+    unsafeGetAddress
+    ) where
+
+import           Data.Aeson                (FromJSON, FromJSONKey (..), ToJSON, ToJSONKey (..))
+import           Data.Aeson.Extras         (encodeSerialise)
+import qualified Codec.CBOR.Write          as Write
+import           Codec.Serialise.Class     (Serialise, encode)
+import           Crypto.Hash               (Digest, SHA256, hash)
+import qualified Data.ByteArray            as BA
+import qualified Data.ByteString.Lazy      as BSL
+import           Data.Hashable             (Hashable, hashWithSalt)
+import           Data.Text.Prettyprint.Doc
+import           GHC.Generics              (Generic)
+
+import           Ledger.Crypto
+import qualified LedgerBytes               as LB
+import           Ledger.Scripts
+
+-- | A payment address using a hash as the id.
+newtype Address = Address { getAddress :: BSL.ByteString }
+    deriving stock (Eq, Ord, Show, Generic)
+
+instance Pretty Address where
+    pretty = pretty . encodeSerialise . getAddress
+
+instance Hashable Address where
+    hashWithSalt s (Address digest) = hashWithSalt s $ BSL.unpack digest
+
+deriving newtype instance Serialise Address
+deriving via LB.LedgerBytes instance ToJSON Address
+deriving via LB.LedgerBytes instance FromJSON Address
+deriving via LB.LedgerBytes instance ToJSONKey Address
+deriving via LB.LedgerBytes instance FromJSONKey Address
+
+-- | The address that should be targeted by a transaction output locked by the given public key.
+pubKeyAddress :: PubKey -> Address
+pubKeyAddress pk = Address $ BSL.fromStrict $ BA.convert h' where
+    h :: Digest SHA256 = hash $ Write.toStrictByteString e
+    h' :: Digest SHA256 = hash h
+    e = encode pk
+
+-- | The address that should be used by a transaction output locked by the given validator script.
+scriptAddress :: ValidatorScript -> Address
+scriptAddress vl = Address hsh where
+    (ValidatorHash hsh) = validatorHash vl
+
+-- | The address that should be used by a transaction output locked by the given validator script.
+scriptHashAddress :: ValidatorHash -> Address
+scriptHashAddress vh = Address hsh where
+    (ValidatorHash hsh) = vh
+
+-- | This function should not exist, and is only here transitionally. We need it to construct
+-- 'PendingTx', but this is because 'PendingTx' currently reveals too much information about
+-- what is in addresses.
+unsafeGetAddress :: Address -> BSL.ByteString
+unsafeGetAddress (Address h) = h

--- a/plutus-wallet-api/ledger/Ledger/AddressMap.hs
+++ b/plutus-wallet-api/ledger/Ledger/AddressMap.hs
@@ -36,7 +36,7 @@ import           Data.Semigroup        (Semigroup (..))
 import qualified Data.Set              as Set
 import           GHC.Generics          (Generic)
 
-import           Ledger                (Address, Tx (..), TxIn (..), TxOut (..), TxOutRef (..), Value, hashTx)
+import           Ledger                (Address, Tx (..), TxIn (..), TxOut (..), TxOutRef (..), Value, txId)
 import           Ledger.Index          (UtxoIndex)
 import qualified Ledger.Index          as Index
 import           Ledger.Tx             (outAddress)
@@ -106,7 +106,7 @@ fromTxOutputs :: Tx -> AddressMap
 fromTxOutputs tx =
     AddressMap . Map.fromListWith Map.union . fmap mkUtxo . zip [0..] . txOutputs $ tx where
     mkUtxo (i, t) = (txOutAddress t, Map.singleton (TxOutRef h i) t)
-    h = hashTx tx
+    h = txId tx
 
 -- | Take all unspent outputs from the 'UtxoIndex' and put them in
 --   an 'AddressMap'.

--- a/plutus-wallet-api/ledger/Ledger/Blockchain.hs
+++ b/plutus-wallet-api/ledger/Ledger/Blockchain.hs
@@ -45,8 +45,8 @@ lastSlot = Slot . fromIntegral . length
 
 -- | Lookup a transaction in a 'Blockchain' by its id.
 transaction :: Blockchain -> TxId -> Maybe Tx
-transaction bc txid = listToMaybe $ filter p  $ join bc where
-    p = (txid ==) . hashTx
+transaction bc tid = listToMaybe $ filter p  $ join bc where
+    p tx = tid == txId tx
 
 -- | Determine the unspent output that an input refers to
 out :: Blockchain -> TxOutRef -> Maybe TxOut

--- a/plutus-wallet-api/ledger/Ledger/Crypto.hs
+++ b/plutus-wallet-api/ledger/Ledger/Crypto.hs
@@ -13,10 +13,6 @@ module Ledger.Crypto(
     , signTx
     , fromHex
     , toPublicKey
-    -- * Hashes
-    , plcSHA2_256
-    , plcSHA3_256
-    , plcDigest
     -- $privateKeys
     , knownPrivateKeys
     , privateKey1
@@ -35,14 +31,12 @@ import           Codec.Serialise.Class      (Serialise)
 import           Control.Newtype.Generics   (Newtype)
 import qualified Crypto.ECC.Ed25519Donna    as ED25519
 import           Crypto.Error               (throwCryptoError)
-import           Crypto.Hash                (Digest, SHA256)
 import           Data.Aeson                 (FromJSON (parseJSON), FromJSONKey, ToJSON (toJSON), ToJSONKey, (.:))
 import qualified Data.Aeson                 as JSON
 import qualified Data.Aeson.Extras          as JSON
 import qualified Data.ByteArray             as BA
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy       as BSL
-import qualified Data.ByteString.Lazy.Hash  as Hash
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Extras
 import           GHC.Generics               (Generic)
@@ -113,11 +107,11 @@ signedBy :: Signature -> PubKey -> TxId -> Bool
 signedBy (Signature s) (PubKey k) txId =
     let k' = ED25519.publicKey $ BSL.toStrict $ KB.getLedgerBytes k
         s' = ED25519.signature $ BSL.toStrict s
-    in throwCryptoError $ ED25519.verify <$> k' <*> pure (getTxId txId) <*> s' -- TODO: is this what we want
+    in throwCryptoError $ ED25519.verify <$> k' <*> pure (BSL.toStrict $ getTxId txId) <*> s' -- TODO: is this what we want
 
 -- | Sign the hash of a transaction using a private key.
 signTx :: TxId -> PrivateKey -> Signature
-signTx (TxId txId) = sign txId
+signTx (TxId txId) = sign $ BSL.toStrict txId
 
 -- | Sign a message using a private key.
 sign :: BA.ByteArrayAccess a => a -> PrivateKey -> Signature
@@ -135,21 +129,6 @@ fromHex = PrivateKey . KB.fromHex
 toPublicKey :: PrivateKey -> PubKey
 toPublicKey = PubKey . KB.fromBytes . BSL.pack . BA.unpack . ED25519.toPublic . f . KB.bytes . getPrivateKey where
     f = throwCryptoError . ED25519.secretKey . BSL.toStrict
-
-{-# INLINABLE plcSHA2_256 #-}
--- | PLC-compatible SHA-256 hash of a hashable value
-plcSHA2_256 :: Builtins.ByteString -> Builtins.ByteString
-plcSHA2_256 = Hash.sha2
-
-{-# INLINABLE plcSHA3_256 #-}
--- | PLC-compatible SHA3-256 hash of a hashable value
-plcSHA3_256 :: Builtins.ByteString -> Builtins.ByteString
-plcSHA3_256 = Hash.sha3
-
-{-# INLINABLE plcDigest #-}
--- | Convert a `Digest SHA256` to a PLC `Hash`
-plcDigest :: Digest SHA256 -> Builtins.ByteString
-plcDigest = BSL.pack . BA.unpack
 
 -- $privateKeys
 -- 'privateKey1', 'privateKey2', ... 'privateKey10' are ten predefined 'PrivateKey' values.

--- a/plutus-wallet-api/ledger/Ledger/Orphans.hs
+++ b/plutus-wallet-api/ledger/Ledger/Orphans.hs
@@ -5,12 +5,33 @@
 
 module Ledger.Orphans where
 
-import           Crypto.Hash                (Digest, SHA256)
+import           Codec.Serialise.Class      (Serialise, decode, encode)
+import           Crypto.Hash                (Digest, SHA256, digestFromByteString)
+import           Data.Aeson                 (FromJSON (parseJSON), ToJSON (toJSON))
+import qualified Data.Aeson                 as JSON
+import qualified Data.Aeson.Extras          as JSON
+import qualified Data.ByteArray             as BA
+import qualified Data.ByteString            as BSS
 import           IOTS                       (IotsType (iotsDefinition))
 import qualified Language.PlutusTx.AssocMap as Map
 import qualified Language.PlutusTx.Prelude  as P
 import           Schema                     (FormSchema (FormSchemaHex), ToSchema (toSchema))
 import           Type.Reflection            (Typeable)
+
+instance Serialise (Digest SHA256) where
+    encode = encode . BA.unpack
+    decode = do
+      d <- decode
+      let md = digestFromByteString . BSS.pack $ d
+      case md of
+        Nothing -> fail "couldn't decode to Digest SHA256"
+        Just v  -> pure v
+
+instance ToJSON (Digest SHA256) where
+    toJSON = JSON.String . JSON.encodeSerialise
+
+instance FromJSON (Digest SHA256) where
+    parseJSON = JSON.decodeSerialise
 
 instance ToSchema (Digest SHA256) where
   toSchema = FormSchemaHex

--- a/plutus-wallet-api/ledger/Ledger/TxId.hs
+++ b/plutus-wallet-api/ledger/Ledger/TxId.hs
@@ -1,50 +1,38 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE OverloadedStrings  #-}
--- ToJSON/FromJSON/Serialise (Digest SHA256)
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DerivingVia       #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# OPTIONS_GHC -fno-strictness   #-}
 -- | The type of transaction IDs
 module Ledger.TxId(
     TxId (..)
     ) where
 
-import           Codec.Serialise.Class     (Serialise, decode, encode)
-import           Crypto.Hash               (Digest, SHA256, digestFromByteString)
-import           Data.Aeson                (FromJSON (parseJSON), ToJSON (toJSON))
-import qualified Data.Aeson                as JSON
+import           Codec.Serialise.Class     (Serialise)
+import           Data.Aeson                (FromJSON, ToJSON)
 import qualified Data.Aeson.Extras         as JSON
-import qualified Data.ByteArray            as BA
-import qualified Data.ByteString           as BSS
+import qualified Data.ByteString.Lazy      as BSL
 import           Data.Text.Prettyprint.Doc (Pretty (pretty), (<+>))
 import           GHC.Generics              (Generic)
+import qualified Language.PlutusTx         as PlutusTx
+import qualified Language.PlutusTx.Prelude as PlutusTx
 import           Ledger.Orphans            ()
+import           LedgerBytes               (LedgerBytes (..))
 import           Schema                    (ToSchema)
 
-instance Serialise (Digest SHA256) where
-    encode = encode . BA.unpack
-    decode = do
-      d <- decode
-      let md = digestFromByteString . BSS.pack $ d
-      case md of
-        Nothing -> fail "couldn't decode to Digest SHA256"
-        Just v  -> pure v
-
-instance ToJSON (Digest SHA256) where
-    toJSON = JSON.String . JSON.encodeSerialise
-
-instance FromJSON (Digest SHA256) where
-    parseJSON = JSON.decodeSerialise
-
 -- | A transaction ID, using a SHA256 hash as the transaction id.
-newtype TxId = TxId { getTxId :: Digest SHA256 }
+newtype TxId = TxId { getTxId :: BSL.ByteString }
     deriving (Eq, Ord, Show, Generic)
     deriving anyclass (ToSchema)
+    deriving newtype (PlutusTx.Eq, PlutusTx.Ord)
 
 deriving newtype instance Serialise TxId
-deriving anyclass instance ToJSON TxId
-deriving anyclass instance FromJSON TxId
+deriving via LedgerBytes instance ToJSON TxId
+deriving via LedgerBytes instance FromJSON TxId
 
 instance Pretty TxId where
     pretty t = "TxId:" <+> pretty (JSON.encodeSerialise $ getTxId t)
+
+PlutusTx.makeLift ''TxId
+PlutusTx.makeIsData ''TxId

--- a/plutus-wallet-api/ledger/Ledger/Typed/Scripts.hs
+++ b/plutus-wallet-api/ledger/Ledger/Typed/Scripts.hs
@@ -9,9 +9,8 @@ module Ledger.Typed.Scripts where
 import           Language.PlutusTx
 
 import           Language.PlutusTx.Prelude (check)
+import qualified Ledger.Address            as Addr
 import           Ledger.Scripts
-import           Ledger.Tx                 hiding (scriptAddress)
-import qualified Ledger.Tx                 as Tx
 import qualified Ledger.Validation         as Validation
 
 import           Data.Kind
@@ -42,8 +41,8 @@ data ScriptInstance (a :: Type) where
         -> ScriptInstance a
 
 -- | Get the address for a script instance.
-scriptAddress :: ScriptInstance a -> Address
-scriptAddress = Tx.scriptAddress . validatorScript
+scriptAddress :: ScriptInstance a -> Addr.Address
+scriptAddress = Addr.scriptAddress . validatorScript
 
 -- | Get the validator script for a script instance.
 validatorScript :: ScriptInstance a -> ValidatorScript

--- a/plutus-wallet-api/plutus-wallet-api.cabal
+++ b/plutus-wallet-api/plutus-wallet-api.cabal
@@ -63,6 +63,7 @@ library
         Data.Text.Prettyprint.Doc.Extras,
         Ledger,
         Ledger.Ada,
+        Ledger.Address,
         Ledger.AddressMap,
         Ledger.Blockchain,
         Ledger.Crypto,
@@ -112,6 +113,7 @@ library plutus-ledger
         Data.Text.Prettyprint.Doc.Extras
         Ledger
         Ledger.Ada
+        Ledger.Address
         Ledger.AddressMap
         Ledger.Blockchain
         Ledger.Crypto

--- a/plutus-wallet-api/src/Wallet/API.hs
+++ b/plutus-wallet-api/src/Wallet/API.hs
@@ -88,7 +88,6 @@ import           Control.Monad             (void, when)
 import           Control.Monad.Error.Class (MonadError (..))
 import           Data.Aeson                (FromJSON, FromJSON1, ToJSON, ToJSON1)
 import           Data.Bifunctor            (Bifunctor (bimap))
-import qualified Data.ByteArray            as BA
 import qualified Data.ByteString.Lazy      as BSL
 import           Data.Eq.Deriving          (deriveEq1)
 import           Data.Foldable             (fold)
@@ -106,8 +105,8 @@ import           Data.Text.Prettyprint.Doc hiding (width)
 import           GHC.Generics              (Generic, Generic1)
 import           Ledger                    (Address, DataScript, PubKey (..), RedeemerScript, Signature, Slot,
                                             SlotRange, Tx (..), TxId, TxIn, TxOut (..), TxOutRef, TxOutType (..),
-                                            ValidatorScript, Value, getTxId, hashTx, outValue, pubKeyTxOut,
-                                            scriptAddress, scriptTxIn, signatures, singleton, txOutRefId, width)
+                                            ValidatorScript, Value, getTxId, outValue, pubKeyTxOut, scriptAddress,
+                                            scriptTxIn, signatures, singleton, txId, txOutRefId, width)
 import           Ledger.AddressMap         (AddressMap)
 import           Ledger.Index              (minFee)
 import           Ledger.Interval           (Interval (..), after, always, before, contains, interval, isEmpty, member)
@@ -381,7 +380,7 @@ signTxnWithKey tx pubK = do
 signTxn   :: (WalletAPI m, Monad m) => Tx -> m Tx
 signTxn tx = do
     pubK <- ownPubKey
-    sig <- sign (BSL.pack $ BA.unpack $ getTxId $ hashTx tx)
+    sig <- sign (getTxId $ txId tx)
     pure $ tx & signatures . at pubK ?~ sig
 
 -- | Transfer some funds to a number of script addresses, returning the

--- a/plutus-wallet-api/src/Wallet/Generators.hs
+++ b/plutus-wallet-api/src/Wallet/Generators.hs
@@ -105,10 +105,10 @@ genMockchain' :: MonadGen m
     -> m Mockchain
 genMockchain' gm = do
     let (txn, ot) = genInitialTransaction gm
-        txId = hashTx txn
+        tid = txId txn
     pure Mockchain {
         mockchainInitialBlock = [txn],
-        mockchainUtxo = Map.fromList $ first (TxOutRef txId) <$> zip [0..] ot
+        mockchainUtxo = Map.fromList $ first (TxOutRef tid) <$> zip [0..] ot
         }
 
 -- | Generate a mockchain using the default 'GeneratorModel'.

--- a/plutus-wallet-api/src/Wallet/Graph.hs
+++ b/plutus-wallet-api/src/Wallet/Graph.hs
@@ -106,7 +106,7 @@ txnFlows keys bc = catMaybes (utxoLinks ++ foldMap extract bc')
 
     extract :: (UtxoLocation, Tx) -> [Maybe FlowLink]
     extract (loc, tx) =
-      let targetRef = mkRef $ hashTx tx in
+      let targetRef = mkRef $ txId tx in
       fmap (flow (Just loc) targetRef . txInRef) (Set.toList $ txInputs tx)
     -- make a flow for a TxOutRef
 


### PR DESCRIPTION
This is a big one. All of the action is in `plutus-wallet-api`, everything else is just fallout.

Highlights:
- Hide the constructor of `Address`, make it so that `Address`es can only be constructed in prescribed ways.
- Try and prevent people from making `ValidatorHash`es etc. in a random way.
    - I didn't quite manage this, since various things need access to the underlying hash, annoyingly.
- `TxId` and `Address` are backed by `ByteString` so can be used on-chain.
    - Consequently `TxHash` is gone. Probably `PendingTx` should use `Address` as well, but this will be easier after or in tandem with https://github.com/input-output-hk/plutus/issues/1575.
- `hashTx` -> `txId` since the fact that it's a hash is something of an implementation detail.
- There is (nearly) only one way to hash things.
    - There are still two: one using `Builtins.sha2_256` and one using `Crypto.hash`, see below.
- Many redundant things got deleted.

I'm not sure what to do about the two ways of hashing. They should really be the same otherwise things might go wrong (although we don't actually hash things on chain much). My inclination is probably to use the PLC builtin one everywhere and implement it in terms of `Crypto.hash` (which it currently isn't).

I'm also not done with `LedgerBytes`. I think it should probably not exist as a representation type but just be used with deriving via. However, there are funny things like it handles reading things via hex... There is also a bit more to do in `Ledger.Crypto` but it's tied to `LedgerBytes`.