### PR TITLE
Don't build updateClientDeps on darwin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -67,6 +67,15 @@ let
   latex = pkgs.callPackage ./nix/latex.nix {};
   sources = import ./nix/sources.nix;
 
+  # easy-purescript-nix has some kind of wacky internal IFD
+  # usage that breaks the logic that makes source fetchers
+  # use native dependencies. This isn't easy to fix, since
+  # the only places that need to use native dependencies
+  # are deep inside, and we don't want to build the whole 
+  # thing native. Fortunately, we only want to build the
+  # client on Linux, so that's okay. However, it does
+  # mean that e.g. we can't build the client dep updating
+  # script on Darwin.
   easyPS = pkgs.callPackage sources.easy-purescript-nix { }; 
 
   purty = pkgs.callPackage ./purty { };

--- a/release.nix
+++ b/release.nix
@@ -58,7 +58,8 @@ let
     papers = lib.mapAttrs (_: _: linux) packageSet.papers;  
     tests = lib.mapAttrs (_: _: supportedSystems) packageSet.tests;  
     dev.packages = lib.mapAttrs (_: _: supportedSystems) packageSet.dev.packages;  
-    dev.scripts = lib.mapAttrs (_: _: supportedSystems) packageSet.dev.scripts; 
+    # See note on 'easyPS' in 'default.nix'
+    dev.scripts = lib.mapAttrs (n: _: if n == "updateClientDeps" then linux else supportedSystems) packageSet.dev.scripts; 
   };
   
   testJobsets = mapTestOn systemMapping;


### PR DESCRIPTION
I thought this was all fixed now, but apparently I missed something.

The comment in the code sums it up, but essentially `easy-purescript-nix` is some kind of crazy abomination that doesn't work with cross-building very well (I assume because nobody else has tried it). Unfortunately the stuff that needs fixing is deep inside and after some poking I haven't been able to even figure out what's wrong, so I can't just do a patch.

In the end, the only thing I think we can do is not build the stuff that depends on `easy-purescript-nix` for darwin on Hydra. We already only built the clients for linux, so we just need to stop building `updateClientDeps`. Sorry :/

(Should make sure this actually fixes the issue on buildkite too!)