### PR TITLE
Restrict symbolic execution to non-negative initial slot numbers

### DIFF
--- a/marlowe-symbolic/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe-symbolic/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -1116,6 +1116,6 @@ warningsTrace con =
         satCommand = proveWith (z3 {validateModel = True})
                                (forAll [snLabel, transListLabel]
                                    (\sn transList ->
-                                       (SL.length transList .<= literal (maxActs + 1)) .=>
+                                       (SL.length transList .<= literal (maxActs + 1)) .&& (sn .>= literal 0) .=>
                                        SL.null (warningsFunc sn transList)))
 


### PR DESCRIPTION
Add a restriction to symbolic execution mechanism that forces initial slot number of counter-example traces to be greater or equal to zero.