### PR TITLE
Fix serialisation of symbolic execution result

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -29,6 +29,8 @@ nixops host. You should always ssh using the `nixops ssh <host>` command on nixo
 
 The key for API Gateway (`apiGatewayKey` in the `secrets.json` file mentioned in next section) can be found in the AWS console in the API Gateway section, API Keys (left menu), then select the API Key in the list, and then click the `Show` hyperlink in the `API key` field on the right hand side.
 
+It seems currently the API Gateway end-point is not deployed automatically. It can also be deployed from the console by going to API Gateway, click in the API to deploy, and in the resources section resources click actions, and then Deploy API in the drop down menu ([related stack overflow question](https://stackoverflow.com/questions/38910937/terraform-not-deploying-api-gateway-stage)).
+
 ## Nixops
 
 The individual machines now exist but have nothing installed on them. We configure these machines and install services using nixops.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -27,6 +27,8 @@ We use `terraform` to manage the AWS infrastructure including networking, loadba
 You should now have a complete infrastructure however not much is installed on the machines. You can see the available machines and their addresses with `cat ~/.ssh/config.d/plutus_playground`. You can ssh to the machines as `root` in an emergency, but this should never ever be done unless the machine is completely unreachable from
 nixops host. You should always ssh using the `nixops ssh <host>` command on nixops host instead of directly logging in as root over ssh.
 
+The key for API Gateway (`apiGatewayKey` in the `secrets.json` file mentioned in next section) can be found in the AWS console in the API Gateway section, API Keys (left menu), then select the API Key in the list, and then click the `Show` hyperlink in the `API key` field on the right hand side.
+
 ## Nixops
 
 The individual machines now exist but have nothing installed on them. We configure these machines and install services using nixops.
@@ -40,7 +42,7 @@ The individual machines now exist but have nothing installed on them. We configu
 5. Enter the project `cd plutus`
 6. Switch to the branch you want to work with e.g. `git checkout master`
 7. Move into the nixops directory `cd deployment/nixops/`
-8. Create a file called `secrets.json` that is based on [the example file](./nixops/secrets.json.example)
+8. Create a file called `secrets.json` that is based on [the example file](./nixops/secrets.json.example).
 9. Create a new deployment `nixops create ./default.nix ./network.nix -d playgrounds`
 10. Deploy the new deployment `nixops deploy`
 11. You should now be able to reach the plutus playground at [https://myname.plutus.iohkdev.io] (https://myname.plutus.iohkdev.io) and marlowe playground at [https://myname.marlowe.iohkdev.io] (https://myname.marlowe.iohkdev.io)

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -64,6 +64,7 @@ variable "bastion_ssh_keys" {
     patrick = ["david", "kris"]
     david   = ["david"]
     kris    = ["kris"]
+    pablo   = ["pablo"]
     prod = [ "live-infra-staging", "david", "kris", "mpj" ]
   }
 
@@ -76,6 +77,7 @@ variable "nixops_ssh_keys" {
     patrick = ["david", "kris"]
     david   = ["david"]
     kris    = ["kris"]
+    pablo   = ["pablo"]
     prod = [ "live-infra-staging" ]
   }
 
@@ -88,6 +90,7 @@ variable "playground_ssh_keys" {
     patrick = ["david", "kris"]
     david   = ["david"]
     kris    = ["kris"]
+    pablo   = ["pablo"]
     prod = [ "live-infra-staging", "david", "kris", "mpj" ]
   }
 
@@ -100,6 +103,7 @@ variable "ssh_keys" {
     kris             = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJKNcFtDKX585wipRkoQvMxLofmoyquVRw0HoWf7zKTokc1e6G/4EpBu/klEqoIsQDCsZtkpWQU90GFc1cAnA2mvJcbJIz8efedrk6onnai/MLZjRzTAMIbjXoASK3sUXUH00W7UdKImox0nPRmmuZUk0g9lLPrt4rpWndrTOqc7H81GtxntZiQVvtjpMObBrKGaBlyt7b6P4M/x63Z55LYpUPcZ0V3ww7BD5xnop977vRvHB7fGv87jWsWlh7gXnC1p1Ykid9l7uVu0gWqZKWeNIqLIo5gCDeJLkH4crX+QLBJebs8GYrLIDqIo7PFfAXPMX7PPbGYbBgLjgH5SlN kris@MacBook-Pro"
     mpj = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC3Xw/OJSqbbcKoG2/FtiGrLlLcgB6gWb0OEN3fIfYMTMtMiDpknDliNoRdDZl794FicFmgvvdLtG40ITrxfxxxufP15uD/0yXLL+pA3IavKmV7g5Xn35cKtVEoIm/fIiWh1oLmHgyrC49Op19OxilCSsrJhaJjIE2cj3KFqCOsTMG/p2UjSdrYVSns7PxCUHTMZ/5uF/n9K7nbcHTvYUMBWnsBSaHRmdTDHQWeIuEIg730kIeFjqCNydZX/XeDjXoBAsJuH3YzRvjvneXyZqw4agS1cXQEye843/8SB76PgeSqGU6xxSaXegVE35JqWpO0tlfQ6Rx4aDq8fD23mJYGl3JTuARgVizk7Ot3I2kBEzn9Bm8VUgV+NW16oQjfYKjB0045G6+94e+N9bJKglHxrvZyMVjhGgWY7fqSblRckvYUkpK0C8NB5473J3kH+a59L4jcoelqU0rHe44x0t/RNHkf1gJ5kSHyz5+bmDDSa1pkNxcoxDWvP8c+t9ckFuYSt+7pPLBN99S1Ue3X5Vf/a5MYfel1n9fip/WL6K26RYmsifpYkqJRdpX2/1V13q+ZX7NrLNomvP4zQRpYCUK997K3hLUAVhhftLh/j78gNbmHcBdHVYiYSVAsw9WSf1FPnUPi42Bjx4vAc2WDoHFEmXSGeH/+b/jVvoNKXPTmrQ== michaelpj@gmail.com"
     live-infra-staging = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJI+ej2JpsbxyCtScmGZWseA+TeHica1a1hGtTgrX/mi cardano@ip-172-31-26-83.eu-central-1.compute.internal"
+    pablo = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCeNj/ZQL+nynseTe42O4G5rs4WqyJKEOMcuiVBki2XT/UuoLz40Lw4b54HtwFTaUQQa3zmSJN5u/5KC8TW8nIKF/7fYChqypX3KKBSqBJe0Gul9ncTqHmzpzrwERlh5GkYSH+nr5t8cUK1pBilscKbCxh5x6irOnUmosoKJDv68WKq8WLsjpRslV5/1VztBanFFOZdD3tfIph1Yn7j1DQP4NcT1cQGoBhO0b0vwHtz6vTY4SpHnYuwB1K4dQ3k+gYJUspn03byi/8KVvcerLKfXYFKR5uvRkHihlIwjlxL2FoXIkGhtlkFVFOx76CvEv8LU5AT1ueJ34C/qP6PSD//pezXkk3e4UGeQMLOUu507FjfjHjD4luxIInzBb1KLAjzxb+2B4JTHy2uUu1dpHXarqSyR3DAPcLqUjZajZ+6mQh7zNRgkwXyZqg9p2TOdfiH9dvrqPowocGJgfjsYnd9rfdQVc10h1zk4pP4pP/YhgMVzYYc/ytCqUP41zSsrtJI592PUS9/quDGfrUcuG4t06DJgevky5AGX2og+sR4e83UpgId/DdV/m1OIvuoS4iMrzN2XmZ7IaFxH03nWQPrndDJ3j9ZHiaZ9IyW0XwthJFXcaslL5w3c0+1y8blxhC0vHT4NUsf5vcY3pFrBsMbTt1yNIGcitnLhXC1k99JbQ=="
   }
 }
 

--- a/marlowe-symbolic/marlowe-symbolic.cabal
+++ b/marlowe-symbolic/marlowe-symbolic.cabal
@@ -35,4 +35,5 @@ library
                         servant,
                         servant-client -any,
                         template-haskell,
-                        utf8-string
+                        utf8-string,
+                        wl-pprint

--- a/marlowe-symbolic/src/App.hs
+++ b/marlowe-symbolic/src/App.hs
@@ -10,6 +10,7 @@ import           Data.ByteString.UTF8                  as BSU
 import           Data.Proxy                            (Proxy (Proxy))
 import           Language.Marlowe                      (Slot (Slot), TransactionInput, TransactionWarning)
 import           Language.Marlowe.Analysis.FSSemantics (warningsTrace)
+import           Language.Marlowe.Pretty
 import           Marlowe.Symbolic.Types.API            (API)
 import           Marlowe.Symbolic.Types.Request        (Request (Request, callbackUrl, contract))
 import qualified Marlowe.Symbolic.Types.Request        as Req
@@ -21,6 +22,7 @@ import           Servant.API                           (NoContent)
 import           Servant.Client                        (ClientEnv, ClientM, client, mkClientEnv, parseBaseUrl,
                                                         runClientM)
 import           System.Process                        (system)
+import           Text.PrettyPrint.Leijen               (displayS, renderCompact)
 
 notifyApi :: Proxy API
 notifyApi = Proxy
@@ -36,6 +38,9 @@ sendRequest cu resp = do
   res <- runClientM (notifyClient resp) clientEnv
   print res
 
+prettyToString :: Pretty a => a -> String
+prettyToString x = (displayS $ renderCompact $ prettyFragment x) ""
+
 makeResponse :: String ->
                 Either String (Maybe (Slot, [TransactionInput], [TransactionWarning]))
              -> Response
@@ -48,8 +53,8 @@ makeResponse u (Right res) =
                   Just (Slot sn, ti, tw) ->
                      CounterExample
                        { initialSlot = sn
-                       , transactionList = show ti
-                       , transactionWarning = show tw
+                       , transactionList = prettyToString ti
+                       , transactionWarning = prettyToString tw
                        }
      }
 

--- a/marlowe/src/Language/Marlowe/Pretty.hs
+++ b/marlowe/src/Language/Marlowe/Pretty.hs
@@ -13,6 +13,7 @@ import qualified Data.Text               as Text
 import           GHC.Generics            ((:*:) ((:*:)), (:+:) (L1, R1), C, Constructor, D, Generic, K1 (K1), M1 (M1),
                                           Rep, S, U1, conName, from)
 import           Ledger                  (PubKey (..), Slot (..))
+import           Ledger.Ada              (Ada, getLovelace)
 import           LedgerBytes
 import           Text.PrettyPrint.Leijen (Doc, comma, encloseSep, hang, lbracket, line, lparen, parens, rbracket,
                                           rparen, space, text)
@@ -133,3 +134,7 @@ instance Read Slot where
 
 instance Pretty BSL.ByteString where
     prettyFragment = text . show . BSL.toStrict
+
+instance Pretty Ada where
+    prettyFragment x = prettyFragment (getLovelace x)
+

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -42,7 +42,7 @@ import qualified Language.PlutusTx          as PlutusTx
 import           Language.PlutusTx.AssocMap (Map)
 import qualified Language.PlutusTx.AssocMap as Map
 import           Language.PlutusTx.Lift     (makeLift)
-import           Language.PlutusTx.Prelude
+import           Language.PlutusTx.Prelude  hiding ((<>))
 import           Ledger                     (PubKey (..), Slot (..))
 import           Ledger.Ada                 (Ada)
 import qualified Ledger.Ada                 as Ada
@@ -50,6 +50,7 @@ import           Ledger.Interval            (Extended (..), Interval (..), Lower
 import           Ledger.Scripts             (DataScript (..))
 import           Ledger.Validation
 import qualified Prelude                    as P
+import           Text.PrettyPrint.Leijen    (comma, hang, lbrace, line, rbrace, space, text, (<>))
 
 {-# ANN module ("HLint: ignore Avoid restricted function" :: String) #-}
 
@@ -336,8 +337,15 @@ data TransactionError = TEAmbiguousSlotIntervalError
 data TransactionInput = TransactionInput
     { txInterval :: SlotInterval
     , txInputs   :: [Input] }
-  deriving stock (Show, Generic)
-  deriving anyclass (Pretty)
+  deriving stock (Show)
+
+instance Pretty TransactionInput where
+    prettyFragment tInp = text "TransactionInput" <> space <> lbrace <> line <> txIntLine <> line <> txInpLine
+        where
+            txIntLine = hang 2 $ text "txInterval = " <> prettyFragment (txInterval tInp) <> comma
+            txInpLine = hang 2 $ text "txInputs = " <> prettyFragment (txInputs tInp) <> rbrace
+
+
 
 
 {-| Marlowe transaction output.

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -236,7 +236,8 @@ newtype Environment = Environment { slotInterval :: SlotInterval }
 data Input = IDeposit AccountId Party Money
            | IChoice ChoiceId ChosenNum
            | INotify
-  deriving stock (Show,P.Eq,P.Ord)
+  deriving stock (Show,P.Eq,P.Ord,Generic)
+  deriving anyclass (Pretty)
 
 
 {-| Slot interval errors.
@@ -318,7 +319,8 @@ data TransactionWarning = TransactionNonPositiveDeposit Party AccountId Integer
                                                -- ^ src    ^ dest ^ paid ^ expected
                         | TransactionShadowing ValueId Integer Integer
                                                 -- oldVal ^  newVal ^
-  deriving stock (Show)
+  deriving stock (Show, Generic)
+  deriving anyclass (Pretty)
 
 
 -- | Transaction error
@@ -334,7 +336,8 @@ data TransactionError = TEAmbiguousSlotIntervalError
 data TransactionInput = TransactionInput
     { txInterval :: SlotInterval
     , txInputs   :: [Input] }
-  deriving stock (Show)
+  deriving stock (Show, Generic)
+  deriving anyclass (Pretty)
 
 
 {-| Marlowe transaction output.


### PR DESCRIPTION
Extend pretty printing to include `TransactionInput` and `TransactionWarning` and modify symbolic execution result to use pretty-printing.