### PR TITLE
contracts: Don't compute the handlers of a contract over and over again

### DIFF
--- a/plutus-use-cases/test/Spec/Rollup.hs
+++ b/plutus-use-cases/test/Spec/Rollup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 module Spec.Rollup where
 
 
@@ -11,6 +12,7 @@ import           Language.Plutus.Contract
 import           Language.Plutus.Contract.Trace
 import           Ledger
 
+import           Language.Plutus.Contract.Request                      (ContractRow)
 import           Language.PlutusTx.Coordination.Contracts.CrowdFunding
 import           Language.PlutusTx.Coordination.Contracts.Game
 
@@ -33,7 +35,8 @@ tests = testGroup "showBlockchain"
      ]
 
 render
-    :: Contract s T.Text a
+    :: ( ContractRow s )
+    => Contract s T.Text a
     -> ContractTrace s T.Text (EmulatorAction T.Text) a ()
     -> IO ByteString
 render con trace = do


### PR DESCRIPTION
* Cache the handlers that a contract has registered until a new event is added to the contract's trace
* This has a slight impact on the tests (122s down to 112s on my machine) but the primary target is the playground where we call `handleBlockchainEvents` much more frequently than we do in the tests