### PR TITLE
[PLC] [Refac] Changed some indentation, renamed annotation variables

### DIFF
--- a/language-plutus-core/prelude/PlutusPrelude.hs
+++ b/language-plutus-core/prelude/PlutusPrelude.hs
@@ -4,100 +4,96 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-module PlutusPrelude ( -- * Reëxports from base
-                       (&)
-                     , (&&&)
-                     , (<&>)
-                     , toList
-                     , bool
-                     , first
-                     , second
-                     , on
-                     , isNothing
-                     , isJust
-                     , fromMaybe
-                     , guard
-                     , foldl'
-                     , fold
-                     , for
-                     , throw
-                     , join
-                     , (<=<)
-                     , (>=>)
-                     , ($>)
-                     , fromRight
-                     , isRight
-                     , void
-                     , through
-                     , coerce
-                     , Generic
-                     , NFData
-                     , Natural
-                     , NonEmpty (..)
-                     , Word8
-                     , Alternative (..)
-                     , Exception
-                     , PairT (..)
-                     , Coercible
-                     , Typeable
-                     -- * Lens
-                     , Lens'
-                     , lens
-                     , (^.)
-                     , view
-                     , (.~)
-                     , set
-                     , (%~)
-                     , over
-                     -- * Debugging
-                     , traceShowId
-                     , trace
-                     -- * Reëxports from "Control.Composition"
-                     , (.*)
-                     -- * Custom functions
-                     , (<<$>>)
-                     , (<<*>>)
-                     , forBind
-                     , foldMapM
-                     , reoption
-                     , repeatM
-                     , (?)
-                     , hoist
-                     -- * Reëxports from "Data.Text.Prettyprint.Doc"
-                     , (<+>)
-                     , parens
-                     , brackets
-                     , hardline
-                     , squotes
-                     , list
-                     , Doc
-                     , strToBs
-                     , bsToStr
-                     , indent
-                     -- * Pretty-printing
-                     , Pretty (..)
-                     , DefaultPrettyBy (..)
-                     , PrettyBy (..)
-                     , PrettyConfigIgnore (..)
-                     , PrettyConfigAttach (..)
-                     , docString
-                     , docText
-                     , prettyString
-                     , prettyText
-                     , prettyStringBy
-                     , prettyTextBy
-                     -- * Custom pretty-printing functions
-                     , module X
-                     -- * Integer arithmetic
-                     , isqrt
-                     , iasqrt
-                     , ilogFloor
-                     , ilogRound
-                     -- * GHCi
-                     , printPretty
-                     -- * Text
-                     , showText
-                     ) where
+module PlutusPrelude
+    ( -- * Reëxports from base
+                 (&)
+    , (&&&)
+    , (<&>)
+    , toList
+    , bool
+    , first
+    , second
+    , on
+    , isNothing
+    , isJust
+    , fromMaybe
+    , guard
+    , foldl'
+    , fold
+    , for
+    , throw
+    , join
+    , (<=<)
+    , (>=>)
+    , ($>)
+    , fromRight
+    , isRight
+    , void
+    , through
+    , coerce
+    , Generic
+    , NFData
+    , Natural
+    , NonEmpty (..)
+    , Word8
+    , Alternative (..)
+    , Exception
+    , PairT (..)
+    , Coercible
+    , Typeable
+    -- * Lens
+    , Lens'
+    , lens
+    , (^.)
+    , view
+    , (.~)
+    , set
+    , (%~)
+    , over
+    -- * Debugging
+    , traceShowId
+    , trace
+    -- * Reëxports from "Control.Composition"
+    , (.*)
+    -- * Custom functions
+    , (<<$>>)
+    , (<<*>>)
+    , forBind
+    , foldMapM
+    , reoption
+    , repeatM
+    , (?)
+    , hoist
+    -- * Reëxports from "Data.Text.Prettyprint.Doc"
+    , (<+>)
+    , parens
+    , brackets
+    , hardline
+    , squotes
+    , list
+    , Doc
+    , strToBs
+    , bsToStr
+    , indent
+    -- * Pretty-printing
+    , Pretty (..)
+    , DefaultPrettyBy (..)
+    , PrettyBy (..)
+    , PrettyConfigIgnore (..)
+    , PrettyConfigAttach (..)
+    , docString
+    , docText
+    , prettyString
+    , prettyText
+    , prettyStringBy
+    , prettyTextBy
+    -- * Custom pretty-printing functions
+    , module X
+    -- * GHCi
+    , printPretty
+    -- * Text
+    , showText
+    ) where
 
 import           Control.Applicative                     (Alternative (..))
 import           Control.Arrow                           ((&&&))
@@ -256,45 +252,6 @@ strToBs = BSL.fromStrict . TE.encodeUtf8 . T.pack
 
 bsToStr :: BSL.ByteString -> String
 bsToStr = T.unpack . TE.decodeUtf8 . BSL.toStrict
-
--- | The integer square root.
--- Throws an 'error' on negative input.
-isqrt :: Integer -> Integer
-isqrt n
-    | n < 0     = error "isqrt: negative number"
-    | n <= 1    = n
-    | otherwise = head $ dropWhile (not . isRoot) iters
-    where
-        sqr = (^ (2 :: Int))
-        twopows = iterate sqr 2
-        (lowerRoot, lowerN) = last . takeWhile ((n >=) . snd) $ zip (1 : twopows) twopows
-        newtonStep x = (x + n `div` x) `div` 2
-        iters = iterate newtonStep $ isqrt (n `div` lowerN) * lowerRoot
-        isRoot r = sqr r <= n && n < sqr (r + 1)
-
--- | The integer square root that acts on negative numbers like this:
---
--- >>> iasqrt (-4)
--- -2
-iasqrt :: Integer -> Integer
-iasqrt n = signum n * isqrt (abs n)
-
--- | Compute the maximal @p@ such that @b ^ p <= x@.
-ilogFloor :: Integer -> Integer -> Integer
-ilogFloor b x
-    | x < b     = 0
-    | otherwise = go (x `div` (b ^ l)) l
-    where
-        l = 2 * ilogFloor (b * b) x
-        go x' l' = if x' < b then l' else go (x' `div` b) (l' + 1)
-
--- | Compute the minimal @p@ such that @x <= b ^ p@.
-ilogRound :: Integer -> Integer -> Integer
--- That's a really stupid implementation.
-ilogRound b x
-    | b ^ p == x = p
-    | otherwise  = p + 1
-    where p = ilogFloor b x
 
 -- For GHCi to use this properly it needs to be in a registered package, hence
 -- why we're naming such a trivial thing.

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -66,7 +66,7 @@ module Language.PlutusCore
     -- * Errors
     , Error (..)
     , AsError (..)
-    , AsNormalizationError (..)
+    , AsNormCheckError (..)
     , UnknownDynamicBuiltinNameError (..)
     , UniqueError (..)
     -- * Base functors
@@ -180,7 +180,7 @@ parseTypecheck
     :: (AsParseError e AlexPosn,
         AsValueRestrictionError e TyName AlexPosn,
         AsUniqueError e AlexPosn,
-        AsNormalizationError e TyName Name AlexPosn,
+        AsNormCheckError e TyName Name AlexPosn,
         AsTypeError e AlexPosn,
         MonadError e m,
         MonadQuote m)
@@ -190,7 +190,7 @@ parseTypecheck cfg = typecheckPipeline cfg <=< parseScoped
 -- | Typecheck a program.
 typecheckPipeline
     :: (AsValueRestrictionError e TyName a,
-        AsNormalizationError e TyName Name a,
+        AsNormCheckError e TyName Name a,
         AsTypeError e a,
         MonadError e m,
         MonadQuote m)

--- a/language-plutus-core/src/Language/PlutusCore/Check/Uniques.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Uniques.hs
@@ -1,9 +1,10 @@
-module Language.PlutusCore.Check.Uniques (
-    checkProgram
+module Language.PlutusCore.Check.Uniques
+    ( checkProgram
     , checkTerm
     , checkType
     , UniqueError (..)
-    , AsUniqueError (..)) where
+    , AsUniqueError (..)
+    ) where
 
 import           Language.PlutusCore.Analysis.Definitions
 import           Language.PlutusCore.Error
@@ -16,36 +17,36 @@ import           Control.Monad.Except
 import           Data.Foldable
 
 checkProgram
-    :: (Ord a,
-        HasUnique (name a) TermUnique,
-        HasUnique (tyname a) TypeUnique,
-        AsUniqueError e a,
+    :: (Ord ann,
+        HasUnique (name ann) TermUnique,
+        HasUnique (tyname ann) TypeUnique,
+        AsUniqueError e ann,
         MonadError e m)
-    => (UniqueError a -> Bool)
-    -> Program tyname name a
+    => (UniqueError ann -> Bool)
+    -> Program tyname name ann
     -> m ()
 checkProgram p (Program _ _ t) = checkTerm p t
 
 checkTerm
-    :: (Ord a,
-        HasUnique (name a) TermUnique,
-        HasUnique (tyname a) TypeUnique,
-        AsUniqueError e a,
+    :: (Ord ann,
+        HasUnique (name ann) TermUnique,
+        HasUnique (tyname ann) TypeUnique,
+        AsUniqueError e ann,
         MonadError e m)
-    => (UniqueError a -> Bool)
-    -> Term tyname name a
+    => (UniqueError ann -> Bool)
+    -> Term tyname name ann
     -> m ()
 checkTerm p t = do
     (_, errs) <- runTermDefs t
     for_ errs $ \e -> when (p e) $ throwing _UniqueError e
 
 checkType
-    :: (Ord a,
-        HasUnique (tyname a) TypeUnique,
-        AsUniqueError e a,
+    :: (Ord ann,
+        HasUnique (tyname ann) TypeUnique,
+        AsUniqueError e ann,
         MonadError e m)
-    => (UniqueError a -> Bool)
-    -> Type tyname a
+    => (UniqueError ann -> Bool)
+    -> Type tyname ann
     -> m ()
 checkType p t = do
     (_, errs) <- runTypeDefs t

--- a/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
@@ -4,8 +4,8 @@ module Language.PlutusCore.Check.Value
     ( checkTerm
     , checkProgram
     , isTermValue
-    , ValueRestrictionError(..)
-    , AsValueRestrictionError(..)
+    , ValueRestrictionError (..)
+    , AsValueRestrictionError (..)
     ) where
 
 import           Language.PlutusCore.Error
@@ -22,7 +22,8 @@ checkTerm
     :: (AsValueRestrictionError e tyname ann, MonadError e m) => Term tyname name ann -> m ()
 checkTerm = para $ \case
     TyAbsF ann name _ (body, rest) -> do
-        unless (isTermValue body) $ throwing _ValueRestrictionError $ ValueRestrictionViolation ann name
+        unless (isTermValue body) $
+            throwing _ValueRestrictionError $ ValueRestrictionViolation ann name
         rest
     termF                          -> traverse_ snd termF
 
@@ -31,10 +32,10 @@ checkProgram
     :: (AsValueRestrictionError e tyname ann, MonadError e m) => Program tyname name ann -> m ()
 checkProgram (Program _ _ term) = checkTerm term
 
-isTermValue :: Term tyname name a -> Bool
+isTermValue :: Term tyname name ann -> Bool
 isTermValue = isRight . termValue
 
-termValue :: Term tyname name a -> Either (NormalizationError tyname name a) ()
+termValue :: Term tyname name ann -> Either (NormCheckError tyname name ann) ()
 termValue (IWrap _ _ _ term) = termValue term
 termValue (TyAbs _ _ _ t)    = termValue t
 termValue LamAbs {}          = pure ()

--- a/language-plutus-core/src/Language/PlutusCore/Error.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Error.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings      #-}
 {-# LANGUAGE TemplateHaskell        #-}
 {-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
 -- appears in the generated instances
 {-# OPTIONS_GHC -Wno-overlapping-patterns #-}
@@ -14,8 +15,8 @@ module Language.PlutusCore.Error
     , AsParseError (..)
     , ValueRestrictionError (..)
     , AsValueRestrictionError (..)
-    , NormalizationError (..)
-    , AsNormalizationError (..)
+    , NormCheckError (..)
+    , AsNormCheckError (..)
     , UniqueError (..)
     , AsUniqueError (..)
     , UnknownDynamicBuiltinNameError (..)
@@ -49,30 +50,30 @@ throwingEither r e = case e of
     Right v -> pure v
 
 -- | An error encountered during parsing.
-data ParseError a
+data ParseError ann
     = LexErr String
-    | Unexpected (Token a)
-    | Overflow a Natural Integer
+    | Unexpected (Token ann)
+    | Overflow ann Natural Integer
     deriving (Show, Eq, Generic, NFData)
 makeClassyPrisms ''ParseError
 
-data ValueRestrictionError tyname a
-    = ValueRestrictionViolation a (tyname a)
+data ValueRestrictionError tyname ann
+    = ValueRestrictionViolation ann (tyname ann)
     deriving (Show, Eq, Generic, NFData)
 makeClassyPrisms ''ValueRestrictionError
 
-data UniqueError a
-    = MultiplyDefined Unique a a
-    | IncoherentUsage Unique a a
-    | FreeVariable Unique a
+data UniqueError ann
+    = MultiplyDefined Unique ann ann
+    | IncoherentUsage Unique ann ann
+    | FreeVariable Unique ann
     deriving (Show, Eq, Generic, NFData)
 makeClassyPrisms ''UniqueError
 
-data NormalizationError tyname name a
-    = BadType a (Type tyname a) T.Text
-    | BadTerm a (Term tyname name a) T.Text
+data NormCheckError tyname name ann
+    = BadType ann (Type tyname ann) T.Text
+    | BadTerm ann (Term tyname name ann) T.Text
     deriving (Show, Eq, Generic, NFData)
-makeClassyPrisms ''NormalizationError
+makeClassyPrisms ''NormCheckError
 
 -- | This error is returned whenever scope resolution of a 'DynamicBuiltinName' fails.
 newtype UnknownDynamicBuiltinNameError
@@ -82,79 +83,86 @@ newtype UnknownDynamicBuiltinNameError
 makeClassyPrisms ''UnknownDynamicBuiltinNameError
 
 -- | An internal error occurred during type checking.
-data InternalTypeError a
+data InternalTypeError ann
     = OpenTypeOfBuiltin (Type TyName ()) (Builtin ())
     deriving (Show, Eq, Generic, NFData)
 makeClassyPrisms ''InternalTypeError
 
-data TypeError a
-    = KindMismatch a (Type TyName ()) (Kind ()) (Kind ())
-    | TypeMismatch a (Term TyName Name ())
-                     (Type TyName ())
-                     (Normalized (Type TyName ()))
-    | UnknownDynamicBuiltinName a UnknownDynamicBuiltinNameError
-    | InternalTypeErrorE a (InternalTypeError a)
-    | FreeTypeVariableE (TyName a)
-    | FreeVariableE (Name a)
+data TypeError ann
+    = KindMismatch ann (Type TyName ()) (Kind ()) (Kind ())
+    | TypeMismatch ann
+        (Term TyName Name ())
+        (Type TyName ())
+        (Normalized (Type TyName ()))
+    | UnknownDynamicBuiltinName ann UnknownDynamicBuiltinNameError
+    | InternalTypeErrorE ann (InternalTypeError ann)
+    | FreeTypeVariableE (TyName ann)
+    | FreeVariableE (Name ann)
     | OutOfGas
     deriving (Show, Eq, Generic, NFData)
 makeClassyPrisms ''TypeError
 
-data Error a
-    = ParseErrorE (ParseError a)
-    | ValueRestrictionErrorE (ValueRestrictionError TyName a)
-    | UniqueCoherencyErrorE (UniqueError a)
-    | TypeErrorE (TypeError a)
-    | NormalizationErrorE (NormalizationError TyName Name a)
+data Error ann
+    = ParseErrorE (ParseError ann)
+    | ValueRestrictionErrorE (ValueRestrictionError TyName ann)
+    | UniqueCoherencyErrorE (UniqueError ann)
+    | TypeErrorE (TypeError ann)
+    | NormCheckErrorE (NormCheckError TyName Name ann)
     deriving (Show, Eq, Generic, NFData)
 makeClassyPrisms ''Error
 
-instance AsParseError (Error a) a where
+instance AsParseError (Error ann) ann where
     _ParseError = _ParseErrorE
 
-instance tyname ~ TyName => AsValueRestrictionError (Error a) tyname a where
+instance tyname ~ TyName => AsValueRestrictionError (Error ann) tyname ann where
     _ValueRestrictionError = _ValueRestrictionErrorE
 
-instance AsUniqueError (Error a) a where
+instance AsUniqueError (Error ann) ann where
     _UniqueError = _UniqueCoherencyErrorE
 
-instance AsTypeError (Error a) a where
+instance AsTypeError (Error ann) ann where
     _TypeError = _TypeErrorE
 
-instance (tyname ~ TyName, name ~ Name) => AsNormalizationError (Error a) tyname name a where
-    _NormalizationError = _NormalizationErrorE
+instance (tyname ~ TyName, name ~ Name) =>
+            AsNormCheckError (Error ann) tyname name ann where
+    _NormCheckError = _NormCheckErrorE
 
 asInternalError :: Doc ann -> Doc ann
 asInternalError doc =
     "An internal error has occurred:" <+> doc <> hardline <>
     "Please report this as a bug."
 
-instance Pretty a => Pretty (ParseError a) where
+instance Pretty ann => Pretty (ParseError ann) where
     pretty (LexErr s)         = "Lexical error:" <+> Text (length s) (T.pack s)
     pretty (Unexpected t)     = "Unexpected" <+> squotes (pretty t) <+> "at" <+> pretty (loc t)
-    pretty (Overflow pos _ _) = "Integer overflow at" <+> pretty pos <> "."
+    pretty (Overflow ann _ _) = "Integer overflow at" <+> pretty ann <> "."
 
-instance (Pretty a, PrettyBy config (tyname a)) => PrettyBy config (ValueRestrictionError tyname a) where
+instance (Pretty ann, PrettyBy config (tyname ann)) =>
+            PrettyBy config (ValueRestrictionError tyname ann) where
     prettyBy config (ValueRestrictionViolation ann name) =
         "Value restriction violation at" <+> pretty ann <+>
         "after the binding for this name:" <+> prettyBy config name
 
-instance Pretty a => Pretty (UniqueError a) where
+instance Pretty ann => Pretty (UniqueError ann) where
     pretty (MultiplyDefined u def redef) =
-        "Variable" <+> pretty u <+> "defined at" <+> pretty def <+> "is redefined at" <+> pretty redef
+        "Variable" <+> pretty u <+> "defined at" <+> pretty def <+>
+        "is redefined at" <+> pretty redef
     pretty (IncoherentUsage u def use) =
-        "Variable" <+> pretty u <+> "defined at" <+> pretty def <+> "is used in a different scope at" <+> pretty use
+        "Variable" <+> pretty u <+> "defined at" <+> pretty def <+>
+        "is used in a different scope at" <+> pretty use
     pretty (FreeVariable u use) =
         "Variable" <+> pretty u <+> "is free at" <+> pretty use
 
-instance (Pretty a, PrettyBy config (Type tyname a), PrettyBy config (Term tyname name a)) =>
-        PrettyBy config (NormalizationError tyname name a) where
-    prettyBy config (BadType l ty expct) =
-        "Malformed type at" <+> pretty l <>
+instance ( Pretty ann
+         , PrettyBy config (Type tyname ann)
+         , PrettyBy config (Term tyname name ann)
+         ) => PrettyBy config (NormCheckError tyname name ann) where
+    prettyBy config (BadType ann ty expct) =
+        "Malformed type at" <+> pretty ann <>
         ". Type" <+>  squotes (prettyBy config ty) <+>
         "is not a" <+> pretty expct <> "."
-    prettyBy config (BadTerm l t expct) =
-        "Malformed term at" <+> pretty l <>
+    prettyBy config (BadTerm ann t expct) =
+        "Malformed term at" <+> pretty ann <>
         ". Term" <+> squotes (prettyBy config t) <+>
         "is not a" <+> pretty expct <> "."
 
@@ -162,21 +170,21 @@ instance Pretty UnknownDynamicBuiltinNameError where
     pretty (UnknownDynamicBuiltinNameErrorE dbn) =
         "Scope resolution failed on a dynamic built-in name:" <+> pretty dbn
 
-instance PrettyBy PrettyConfigPlc (InternalTypeError a) where
+instance PrettyBy PrettyConfigPlc (InternalTypeError ann) where
     prettyBy config (OpenTypeOfBuiltin ty bi)        =
         asInternalError $
             "The type" <+> prettyBy config ty <+>
             "of the" <+> prettyBy config bi <+>
             "built-in is open"
 
-instance Pretty a => PrettyBy PrettyConfigPlc (TypeError a) where
-    prettyBy config (KindMismatch x ty k k')          =
-        "Kind mismatch at" <+> pretty x <+>
+instance Pretty ann => PrettyBy PrettyConfigPlc (TypeError ann) where
+    prettyBy config (KindMismatch ann ty k k')          =
+        "Kind mismatch at" <+> pretty ann <+>
         "in type" <+> squotes (prettyBy config ty) <>
         ". Expected kind" <+> squotes (prettyBy config k) <+>
         ", found kind" <+> squotes (prettyBy config k')
-    prettyBy config (TypeMismatch x t ty ty')         =
-        "Type mismatch at" <+> pretty x <>
+    prettyBy config (TypeMismatch ann t ty ty')         =
+        "Type mismatch at" <+> pretty ann <>
         (if _pcpoCondensedErrors (_pcpOptions config) == CondensedErrorsYes
             then mempty
             else " in term" <> hardline <> indent 2 (squotes (prettyBy config t)) <> ".") <>
@@ -188,17 +196,17 @@ instance Pretty a => PrettyBy PrettyConfigPlc (TypeError a) where
         "Free type variable:" <+> prettyBy config name
     prettyBy config (FreeVariableE name)              =
         "Free variable:" <+> prettyBy config name
-    prettyBy config (InternalTypeErrorE x err)        =
+    prettyBy config (InternalTypeErrorE ann err)        =
         prettyBy config err <> hardline <>
-        "Error location:" <+> pretty x
-    prettyBy _      (UnknownDynamicBuiltinName x err) =
-        "Unknown dynamic built-in name at" <+> pretty x <>
+        "Error location:" <+> pretty ann
+    prettyBy _      (UnknownDynamicBuiltinName ann err) =
+        "Unknown dynamic built-in name at" <+> pretty ann <>
         ":" <+> pretty err
     prettyBy _      OutOfGas                          = "Type checker ran out of gas."
 
-instance Pretty a => PrettyBy PrettyConfigPlc (Error a) where
+instance Pretty ann => PrettyBy PrettyConfigPlc (Error ann) where
     prettyBy _      (ParseErrorE e)            = pretty e
     prettyBy config (ValueRestrictionErrorE e) = prettyBy config e
     prettyBy _      (UniqueCoherencyErrorE e)  = pretty e
     prettyBy config (TypeErrorE e)             = prettyBy config e
-    prettyBy config (NormalizationErrorE e)    = prettyBy config e
+    prettyBy config (NormCheckErrorE e)        = prettyBy config e

--- a/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
@@ -2,18 +2,19 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings  #-}
 
-module Language.PlutusCore.Lexer.Type ( BuiltinName (..)
-                                      , DynamicBuiltinName (..)
-                                      , StagedBuiltinName (..)
-                                      , Version (..)
-                                      , Keyword (..)
-                                      , Special (..)
-                                      , Token (..)
-                                      , TypeBuiltin (..)
-                                      , prettyBytes
-                                      , allBuiltinNames
-                                      , defaultVersion
-                                      ) where
+module Language.PlutusCore.Lexer.Type
+    ( TypeBuiltin (..)
+    , BuiltinName (..)
+    , DynamicBuiltinName (..)
+    , StagedBuiltinName (..)
+    , Version (..)
+    , Keyword (..)
+    , Special (..)
+    , Token (..)
+    , prettyBytes
+    , allBuiltinNames
+    , defaultVersion
+    ) where
 
 import           Language.PlutusCore.Name
 import           PlutusPrelude
@@ -25,34 +26,36 @@ import           Language.Haskell.TH.Syntax         (Lift)
 import           Numeric                            (showHex)
 
 -- | A builtin type
-data TypeBuiltin = TyByteString
-                 | TyInteger
-                 | TyString
-                 deriving (Show, Eq, Ord, Generic, NFData, Lift)
+data TypeBuiltin
+    = TyByteString
+    | TyInteger
+    | TyString
+    deriving (Show, Eq, Ord, Generic, NFData, Lift)
 
 -- | Builtin functions
-data BuiltinName = AddInteger
-                 | SubtractInteger
-                 | MultiplyInteger
-                 | DivideInteger
-                 | QuotientInteger
-                 | RemainderInteger
-                 | ModInteger
-                 | LessThanInteger
-                 | LessThanEqInteger
-                 | GreaterThanInteger
-                 | GreaterThanEqInteger
-                 | EqInteger
-                 | Concatenate
-                 | TakeByteString
-                 | DropByteString
-                 | SHA2
-                 | SHA3
-                 | VerifySignature
-                 | EqByteString
-                 | LtByteString
-                 | GtByteString
-                 deriving (Show, Eq, Ord, Enum, Bounded, Generic, NFData, Lift)
+data BuiltinName
+    = AddInteger
+    | SubtractInteger
+    | MultiplyInteger
+    | DivideInteger
+    | QuotientInteger
+    | RemainderInteger
+    | ModInteger
+    | LessThanInteger
+    | LessThanEqInteger
+    | GreaterThanInteger
+    | GreaterThanEqInteger
+    | EqInteger
+    | Concatenate
+    | TakeByteString
+    | DropByteString
+    | SHA2
+    | SHA3
+    | VerifySignature
+    | EqByteString
+    | LtByteString
+    | GtByteString
+    deriving (Show, Eq, Ord, Enum, Bounded, Generic, NFData, Lift)
 
 -- | The type of dynamic built-in functions. I.e. functions that exist on certain chains and do
 -- not exist on others. Each 'DynamicBuiltinName' has an associated type and operational semantics --
@@ -63,65 +66,70 @@ newtype DynamicBuiltinName = DynamicBuiltinName
       deriving newtype (NFData, Lift)
 
 -- | Either a 'BuiltinName' (known statically) or a 'DynamicBuiltinName' (known dynamically).
-data StagedBuiltinName = StaticStagedBuiltinName  BuiltinName
-                       | DynamicStagedBuiltinName DynamicBuiltinName
-                       deriving (Show, Eq, Generic, NFData, Lift)
+data StagedBuiltinName
+    = StaticStagedBuiltinName  BuiltinName
+    | DynamicStagedBuiltinName DynamicBuiltinName
+    deriving (Show, Eq, Generic, NFData, Lift)
 
 -- | Version of Plutus Core to be used for the program.
-data Version a = Version a Natural Natural Natural
-               deriving (Show, Eq, Functor, Generic, NFData, Lift)
+data Version ann
+    = Version ann Natural Natural Natural
+    deriving (Show, Eq, Functor, Generic, NFData, Lift)
 
 -- | A keyword in Plutus Core.
-data Keyword = KwAbs
-             | KwLam
-             | KwIFix
-             | KwFun
-             | KwAll
-             | KwByteString
-             | KwInteger
-             | KwType
-             | KwProgram
-             | KwCon
-             | KwIWrap
-             | KwBuiltin
-             | KwUnwrap
-             | KwError
-             deriving (Show, Eq, Generic, NFData)
+data Keyword
+    = KwAbs
+    | KwLam
+    | KwIFix
+    | KwFun
+    | KwAll
+    | KwByteString
+    | KwInteger
+    | KwType
+    | KwProgram
+    | KwCon
+    | KwIWrap
+    | KwBuiltin
+    | KwUnwrap
+    | KwError
+    deriving (Show, Eq, Generic, NFData)
 
 -- | A special character. This type is only used internally between the lexer
 -- and the parser.
-data Special = OpenParen
-             | CloseParen
-             | OpenBracket
-             | CloseBracket
-             | Dot
-             | Exclamation
-             | OpenBrace
-             | CloseBrace
-             deriving (Show, Eq, Generic, NFData)
+data Special
+    = OpenParen
+    | CloseParen
+    | OpenBracket
+    | CloseBracket
+    | Dot
+    | Exclamation
+    | OpenBrace
+    | CloseBrace
+    deriving (Show, Eq, Generic, NFData)
 
 -- | A token generated by the lexer.
-data Token a = LexName { loc        :: a
-                       , name       :: T.Text
-                       , identifier :: Unique -- ^ A 'Unique' assigned to the identifier during lexing.
-                       }
-             | LexInt { loc :: a, tkInt :: Integer }
-             | LexBS { loc :: a, tkBytestring :: BSL.ByteString }
-             | LexBuiltin { loc :: a, tkBuiltin :: BuiltinName }
-             | LexNat { loc :: a, tkNat :: Natural }
-             | LexKeyword { loc :: a, tkKeyword :: Keyword }
-             | LexSpecial { loc :: a, tkSpecial :: Special }
-             | EOF { loc :: a }
-             deriving (Show, Eq, Generic, NFData)
+data Token ann
+    = LexName { loc        :: ann
+              , name       :: T.Text
+              , identifier :: Unique -- ^ A 'Unique' assigned to the identifier during lexing.
+              }
+    | LexInt { loc :: ann, tkInt :: Integer }
+    | LexBS { loc :: ann, tkBytestring :: BSL.ByteString }
+    | LexBuiltin { loc :: ann, tkBuiltin :: BuiltinName }
+    | LexNat { loc :: ann, tkNat :: Natural }
+    | LexKeyword { loc :: ann, tkKeyword :: Keyword }
+    | LexSpecial { loc :: ann, tkSpecial :: Special }
+    | EOF { loc :: ann }
+    deriving (Show, Eq, Generic, NFData)
 
-asBytes :: Word8 -> Doc a
+asBytes :: Word8 -> Doc ann
 asBytes x = Text 2 $ T.pack $ addLeadingZero $ showHex x mempty
     where addLeadingZero :: String -> String
           addLeadingZero
               | x < 16    = ('0' :)
               | otherwise = id
 
-prettyBytes :: BSL.ByteString -> Doc a
+prettyBytes :: BSL.ByteString -> Doc ann
 prettyBytes b = "#" <> fold (asBytes <$> BSL.unpack b)
 instance Pretty Special where
     pretty OpenParen    = "("
@@ -149,7 +157,7 @@ instance Pretty Keyword where
     pretty KwUnwrap     = "unwrap"
     pretty KwError      = "error"
 
-instance Pretty (Token a) where
+instance Pretty (Token ann) where
     pretty (LexName _ n _)   = pretty n
     pretty (LexInt _ i)      = pretty i
     pretty (LexNat _ n)      = pretty n
@@ -194,7 +202,7 @@ instance Pretty TypeBuiltin where
     pretty TyByteString = "bytestring"
     pretty TyString     = "string"
 
-instance Pretty (Version a) where
+instance Pretty (Version ann) where
     pretty (Version _ i j k) = pretty i <> "." <> pretty j <> "." <> pretty k
 
 -- | The list of all 'BuiltinName's.
@@ -204,5 +212,5 @@ allBuiltinNames = [minBound .. maxBound]
 -- automatically handled by tests and other stuff that deals with all built-in names at once.
 
 -- | The default version of Plutus Core supported by this library.
-defaultVersion :: a -> Version a
-defaultVersion a = Version a 1 0 0
+defaultVersion :: ann -> Version ann
+defaultVersion ann = Version ann 1 0 0

--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -1,58 +1,62 @@
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE LambdaCase             #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
 
-module Language.PlutusCore.MkPlc ( TermLike (..)
-                                 , VarDecl (..)
-                                 , TyVarDecl (..)
-                                 , TyDecl (..)
-                                 , mkVar
-                                 , mkTyVar
-                                 , tyDeclVar
-                                 , Def (..)
-                                 , embed
-                                 , TermDef
-                                 , TypeDef
-                                 , FunctionType (..)
-                                 , FunctionDef (..)
-                                 , functionTypeToType
-                                 , functionDefToType
-                                 , functionDefVarDecl
-                                 , mkFunctionDef
-                                 , mkImmediateLamAbs
-                                 , mkImmediateTyAbs
-                                 , mkIterTyForall
-                                 , mkIterTyLam
-                                 , mkIterApp
-                                 , mkIterTyFun
-                                 , mkIterLamAbs
-                                 , mkIterInst
-                                 , mkIterTyAbs
-                                 , mkIterTyApp
-                                 , mkIterKindArrow
-                                 ) where
+module Language.PlutusCore.MkPlc
+    ( TermLike (..)
+    , VarDecl (..)
+    , TyVarDecl (..)
+    , TyDecl (..)
+    , mkVar
+    , mkTyVar
+    , tyDeclVar
+    , Def (..)
+    , embed
+    , TermDef
+    , TypeDef
+    , FunctionType (..)
+    , FunctionDef (..)
+    , functionTypeToType
+    , functionDefToType
+    , functionDefVarDecl
+    , mkFunctionDef
+    , mkImmediateLamAbs
+    , mkImmediateTyAbs
+    , mkIterTyForall
+    , mkIterTyLam
+    , mkIterApp
+    , mkIterTyFun
+    , mkIterLamAbs
+    , mkIterInst
+    , mkIterTyAbs
+    , mkIterTyApp
+    , mkIterKindArrow
+    ) where
 
-import           Prelude                  hiding (error)
+import           Prelude                               hiding (error)
 
 import           Language.PlutusCore.Type
 
-import           Data.List                (foldl')
-import           GHC.Generics             (Generic)
+import           Data.List                             (foldl')
+import           GHC.Generics                          (Generic)
 
+--- TODO: add @con@.
 -- | A final encoding for Term, to allow PLC terms to be used transparently as PIR terms.
-class TermLike term tyname name | term -> tyname, term -> name where
-    var      :: a -> name a -> term a
-    tyAbs    :: a -> tyname a -> Kind a -> term a -> term a
-    lamAbs   :: a -> name a -> Type tyname a -> term a -> term a
-    apply    :: a -> term a -> term a -> term a
-    constant :: a -> Constant a -> term a
-    builtin  :: a -> Builtin a -> term a
-    tyInst   :: a -> term a -> Type tyname a -> term a
-    unwrap   :: a -> term a -> term a
-    iWrap    :: a -> Type tyname a -> Type tyname a -> term a -> term a
-    error    :: a -> Type tyname a -> term a
-    termLet  :: a -> TermDef term tyname name a -> term a -> term a
-    typeLet  :: a -> TypeDef tyname a -> term a -> term a
+class TermLike term tyname name | term -> tyname, term -> name, term -> where
+    var      :: ann -> name ann -> term ann
+    tyAbs    :: ann -> tyname ann -> Kind ann -> term ann -> term ann
+    lamAbs   :: ann -> name ann -> Type tyname ann -> term ann -> term ann
+    apply    :: ann -> term ann -> term ann -> term ann
+    constant :: ann -> Constant ann -> term ann
+    builtin  :: ann -> Builtin ann -> term ann
+    tyInst   :: ann -> term ann -> Type tyname ann -> term ann
+    unwrap   :: ann -> term ann -> term ann
+    iWrap    :: ann -> Type tyname ann -> Type tyname ann -> term ann -> term ann
+    error    :: ann -> Type tyname ann -> term ann
+    termLet  :: ann -> TermDef term tyname name ann -> term ann -> term ann
+    typeLet  :: ann -> TypeDef tyname ann -> term ann -> term ann
 
 instance TermLike (Term tyname name) tyname name where
     var      = Var
@@ -68,7 +72,7 @@ instance TermLike (Term tyname name) tyname name where
     termLet  = mkImmediateLamAbs
     typeLet  = mkImmediateTyAbs
 
-embed :: TermLike term tyname name => Term tyname name a -> term a
+embed :: TermLike term tyname name => Term tyname name ann -> term ann
 embed = \case
     Var a n           -> var a n
     TyAbs a tn k t    -> tyAbs a tn k (embed t)
@@ -77,40 +81,52 @@ embed = \case
     Constant a c      -> constant a c
     Builtin a bi      -> builtin a bi
     TyInst a t ty     -> tyInst a (embed t) ty
-    Error a ty        -> Language.PlutusCore.MkPlc.error a ty
+    Error a ty        -> error a ty
     Unwrap a t        -> unwrap a (embed t)
     IWrap a ty1 ty2 t -> iWrap a ty1 ty2 (embed t)
 
--- | A "variable declaration", i.e. a name and a type for a variable.
-data VarDecl tyname name a = VarDecl {varDeclAnn::a, varDeclName::name a, varDeclType::Type tyname a}
-    deriving (Functor, Show, Eq, Generic)
+-- | A "variable declaration", i.e. a name annnd a type for a variable.
+data VarDecl tyname name ann = VarDecl
+    { varDeclAnn  :: ann
+    , varDeclName :: name ann
+    , varDeclType :: Type tyname ann
+    } deriving (Functor, Show, Eq, Generic)
 
 -- | Make a 'Var' referencing the given 'VarDecl'.
-mkVar :: TermLike term tyname name => a -> VarDecl tyname name a -> term a
-mkVar x = var x . varDeclName
+mkVar :: TermLike term tyname name => ann -> VarDecl tyname name ann -> term ann
+mkVar ann = var ann . varDeclName
 
--- | A "type variable declaration", i.e. a name and a kind for a type variable.
-data TyVarDecl tyname a = TyVarDecl {tyVarDeclAnn::a, tyVarDeclName::tyname a, tyVarDeclKind::Kind a}
-    deriving (Functor, Show, Eq, Generic)
+-- | A "type variable declaration", i.e. a name annnd a kind for a type variable.
+data TyVarDecl tyname ann = TyVarDecl
+    { tyVarDeclAnn  :: ann
+    , tyVarDeclName :: tyname ann
+    , tyVarDeclKind :: Kind ann
+    } deriving (Functor, Show, Eq, Generic)
 
 -- | Make a 'TyVar' referencing the given 'TyVarDecl'.
-mkTyVar :: a -> TyVarDecl tyname a -> Type tyname a
-mkTyVar x = TyVar x . tyVarDeclName
+mkTyVar :: ann -> TyVarDecl tyname ann -> Type tyname ann
+mkTyVar ann = TyVar ann . tyVarDeclName
 
 -- | A "type declaration", i.e. a kind for a type.
-data TyDecl tyname a = TyDecl {tyDeclAnn::a, tyDeclType::Type tyname a, tyDeclKind::Kind a}
-    deriving (Functor, Show, Eq, Generic)
+data TyDecl tyname ann = TyDecl
+    { tyDeclAnn  :: ann
+    , tyDeclType :: Type tyname ann
+    , tyDeclKind :: Kind ann
+    } deriving (Functor, Show, Eq, Generic)
 
-tyDeclVar :: TyVarDecl tyname a -> TyDecl tyname a
+tyDeclVar :: TyVarDecl tyname ann -> TyDecl tyname ann
 tyDeclVar (TyVarDecl ann name kind) = TyDecl ann (TyVar ann name) kind
 
 -- | A definition. Pretty much just a pair with more descriptive names.
-data Def var val = Def { defVar::var, defVal::val} deriving (Show, Eq, Ord, Generic)
+data Def var val = Def
+    { defVar :: var
+    , defVal :: val
+    } deriving (Show, Eq, Ord, Generic)
 
 -- | A term definition as a variable.
-type TermDef term tyname name a = Def (VarDecl tyname name a) (term a)
+type TermDef term tyname name ann = Def (VarDecl tyname name ann) (term ann)
 -- | A type definition as a type variable.
-type TypeDef tyname a = Def (TyVarDecl tyname a) (Type tyname a)
+type TypeDef tyname ann = Def (TyVarDecl tyname ann) (Type tyname ann)
 
 -- | The type of a PLC function.
 data FunctionType tyname ann = FunctionType
@@ -156,89 +172,95 @@ mkFunctionDef _       _    _                     _    = Nothing
 -- | Make a "let-binding" for a term as an immediately applied lambda abstraction.
 mkImmediateLamAbs
     :: TermLike term tyname name
-    => a
-    -> TermDef term tyname name a
-    -> term a -- ^ The body of the let, possibly referencing the name.
-    -> term a
-mkImmediateLamAbs x1 (Def (VarDecl x2 name ty) bind) body = apply x1 (lamAbs x2 name ty body) bind
+    => ann
+    -> TermDef term tyname name ann
+    -> term ann -- ^ The body of the let, possibly referencing the name.
+    -> term ann
+mkImmediateLamAbs ann1 (Def (VarDecl ann2 name ty) bind) body =
+    apply ann1 (lamAbs ann2 name ty body) bind
 
 -- | Make a "let-binding" for a type as an immediately instantiated type abstraction. Note: the body must be a value.
 mkImmediateTyAbs
     :: TermLike term tyname name
-    => a
-    -> TypeDef tyname a
-    -> term a -- ^ The body of the let, possibly referencing the name.
-    -> term a
-mkImmediateTyAbs x1 (Def (TyVarDecl x2 name k) bind) body = tyInst x1 (tyAbs x2 name k body) bind
+    => ann
+    -> TypeDef tyname ann
+    -> term ann -- ^ The body of the let, possibly referencing the name.
+    -> term ann
+mkImmediateTyAbs ann1 (Def (TyVarDecl ann2 name k) bind) body =
+    tyInst ann1 (tyAbs ann2 name k body) bind
 
 -- | Make an iterated application.
 mkIterApp
     :: TermLike term tyname name
-    => a
-    -> term a -- ^ @f@
-    -> [term a] -- ^@[ x0 ... xn ]@
-    -> term a -- ^ @[f x0 ... xn ]@
-mkIterApp x = foldl' (apply x)
+    => ann
+    -> term ann -- ^ @f@
+    -> [term ann] -- ^@[ x0 ... xn ]@
+    -> term ann -- ^ @[f x0 ... xn ]@
+mkIterApp ann = foldl' (apply ann)
 
 -- | Make an iterated instantiation.
 mkIterInst
     :: TermLike term tyname name
-    => a
-    -> term a -- ^ @a@
-    -> [Type tyname a] -- ^ @ [ x0 ... xn ] @
-    -> term a -- ^ @{ a x0 ... xn }@
-mkIterInst x = foldl' (tyInst x)
+    => ann
+    -> term ann -- ^ @a@
+    -> [Type tyname ann] -- ^ @ [ x0 ... xn ] @
+    -> term ann -- ^ @{ a x0 ... xn }@
+mkIterInst ann = foldl' (tyInst ann)
 
 -- | Lambda abstract a list of names.
 mkIterLamAbs
     :: TermLike term tyname name
-    => [VarDecl tyname name a]
-    -> term a
-    -> term a
-mkIterLamAbs args body = foldr (\(VarDecl x n ty) acc -> lamAbs x n ty acc) body args
+    => [VarDecl tyname name ann]
+    -> term ann
+    -> term ann
+mkIterLamAbs args body =
+    foldr (\(VarDecl ann name ty) acc -> lamAbs ann name ty acc) body args
 
 -- | Type abstract a list of names.
 mkIterTyAbs
     :: TermLike term tyname name
-    => [TyVarDecl tyname a]
-    -> term a
-    -> term a
-mkIterTyAbs args body = foldr (\(TyVarDecl x n k) acc -> tyAbs x n k acc) body args
+    => [TyVarDecl tyname ann]
+    -> term ann
+    -> term ann
+mkIterTyAbs args body =
+    foldr (\(TyVarDecl ann name kind) acc -> tyAbs ann name kind acc) body args
 
 -- | Make an iterated type application.
 mkIterTyApp
-    :: a
-    -> Type tyname a -- ^ @f@
-    -> [Type tyname a] -- ^ @[ x0 ... xn ]@
-    -> Type tyname a -- ^ @[ f x0 ... xn ]@
-mkIterTyApp x = foldl' (TyApp x)
+    :: ann
+    -> Type tyname ann -- ^ @f@
+    -> [Type tyname ann] -- ^ @[ x0 ... xn ]@
+    -> Type tyname ann -- ^ @[ f x0 ... xn ]@
+mkIterTyApp ann = foldl' (TyApp ann)
 
 -- | Make an iterated function type.
 mkIterTyFun
-    :: a
-    -> [Type tyname a]
-    -> Type tyname a
-    -> Type tyname a
-mkIterTyFun x tys target = foldr (\ty acc -> TyFun x ty acc) target tys
+    :: ann
+    -> [Type tyname ann]
+    -> Type tyname ann
+    -> Type tyname ann
+mkIterTyFun ann tys target = foldr (\ty acc -> TyFun ann ty acc) target tys
 
 -- | Universally quantify a list of names.
 mkIterTyForall
-    :: [TyVarDecl tyname a]
-    -> Type tyname a
-    -> Type tyname a
-mkIterTyForall args body = foldr (\(TyVarDecl x n k) acc -> TyForall x n k acc) body args
+    :: [TyVarDecl tyname ann]
+    -> Type tyname ann
+    -> Type tyname ann
+mkIterTyForall args body =
+    foldr (\(TyVarDecl ann name kind) acc -> TyForall ann name kind acc) body args
 
 -- | Lambda abstract a list of names.
 mkIterTyLam
-    :: [TyVarDecl tyname a]
-    -> Type tyname a
-    -> Type tyname a
-mkIterTyLam args body = foldr (\(TyVarDecl x n k) acc -> TyLam x n k acc) body args
+    :: [TyVarDecl tyname ann]
+    -> Type tyname ann
+    -> Type tyname ann
+mkIterTyLam args body =
+    foldr (\(TyVarDecl ann name kind) acc -> TyLam ann name kind acc) body args
 
 -- | Make an iterated function kind.
 mkIterKindArrow
-    :: a
-    -> [Kind a]
-    -> Kind a
-    -> Kind a
-mkIterKindArrow x kinds target = foldr (KindArrow x) target kinds
+    :: ann
+    -> [Kind ann]
+    -> Kind ann
+    -> Kind ann
+mkIterKindArrow ann kinds target = foldr (KindArrow ann) target kinds

--- a/language-plutus-core/src/Language/PlutusCore/Pretty.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty.hs
@@ -92,15 +92,15 @@ While the flexible pretty-printing infrastructure is useful when you want it,
 it's helpful to have an implementation of the default Pretty typeclass that
 does the default thing.
 -}
-instance Pretty (Kind a) where
+instance Pretty (Kind ann) where
     pretty = prettyClassicDef
-instance Pretty (Constant a) where
+instance Pretty (Constant ann) where
     pretty = prettyClassicDef
-instance Pretty (Builtin a) where
+instance Pretty (Builtin ann) where
     pretty = prettyClassicDef
-instance PrettyClassic (Type tyname a) => Pretty (Type tyname a) where
+instance PrettyClassic (Type tyname ann) => Pretty (Type tyname ann) where
     pretty = prettyClassicDef
-instance PrettyClassic (Term tyname name a) => Pretty (Term tyname name a) where
+instance PrettyClassic (Term tyname name ann) => Pretty (Term tyname name ann) where
     pretty = prettyClassicDef
-instance PrettyClassic (Program tyname name a) => Pretty (Program tyname name a) where
+instance PrettyClassic (Program tyname name ann) => Pretty (Program tyname name ann) where
     pretty = prettyClassicDef

--- a/language-plutus-core/src/Language/PlutusCore/Pretty/Plc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty/Plc.hs
@@ -80,15 +80,14 @@ instance DefaultPrettyPlcStrategy a => DefaultPrettyBy PrettyConfigPlcStrategy a
 instance DefaultPrettyPlcStrategy a => DefaultPrettyBy PrettyConfigPlc a where
     defaultPrettyBy = defaultPrettyBy . _pcpStrategy
 
-instance PrettyBy PrettyConfigPlc (Kind a)
-instance PrettyBy PrettyConfigPlc (Constant a)
-instance PrettyBy PrettyConfigPlc (Builtin a)
-instance DefaultPrettyPlcStrategy (Type tyname a) =>
-    PrettyBy PrettyConfigPlc (Type tyname a)
-instance DefaultPrettyPlcStrategy (Term tyname name a) =>
-    PrettyBy PrettyConfigPlc (Term tyname name a)
-instance DefaultPrettyPlcStrategy (Program tyname name a) =>
-    PrettyBy PrettyConfigPlc (Program tyname name a)
+instance PrettyBy PrettyConfigPlc (Kind ann)
+instance PrettyBy PrettyConfigPlc (Builtin ann)
+instance DefaultPrettyPlcStrategy (Type tyname ann) =>
+    PrettyBy PrettyConfigPlc (Type tyname ann)
+instance DefaultPrettyPlcStrategy (Term tyname name ann) =>
+    PrettyBy PrettyConfigPlc (Term tyname name ann)
+instance DefaultPrettyPlcStrategy (Program tyname name ann) =>
+    PrettyBy PrettyConfigPlc (Program tyname name ann)
 
 instance PrettyBy PrettyConfigPlc BuiltinName where
     prettyBy _ = pretty

--- a/language-plutus-core/src/Language/PlutusCore/Size.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Size.hs
@@ -1,14 +1,16 @@
-module Language.PlutusCore.Size ( termSize
-                                , typeSize
-                                , kindSize
-                                , programSize
-                                , serialisedSize
-                                ) where
+module Language.PlutusCore.Size
+    ( termSize
+    , typeSize
+    , kindSize
+    , programSize
+    , serialisedSize
+    ) where
+
+import           Language.PlutusCore.Type
 
 import           Codec.Serialise
 import qualified Data.ByteString.Lazy     as BSL
 import           Data.Functor.Foldable
-import           Language.PlutusCore.Type
 
 -- | Count the number of AST nodes in a kind.
 kindSize :: Kind a -> Integer
@@ -17,7 +19,7 @@ kindSize = cata a where
     a (KindArrowF _ k k') = 1 + k + k'
 
 -- | Count the number of AST nodes in a type.
-typeSize :: Type tyname a -> Integer
+typeSize :: Type tyname ann -> Integer
 typeSize = cata a where
     a TyVarF{}             = 1
     a (TyFunF _ ty ty')    = 1 + ty + ty'
@@ -28,7 +30,7 @@ typeSize = cata a where
     a (TyAppF _ ty ty')    = 1 + ty + ty'
 
 -- | Count the number of AST nodes in a term.
-termSize :: Term tyname name a -> Integer
+termSize :: Term tyname name ann -> Integer
 termSize = cata a where
     a VarF{}              = 1
     a (TyAbsF _ _ k t)    = 1 + kindSize k + t
@@ -42,7 +44,7 @@ termSize = cata a where
     a (ErrorF _ ty)       = 1 + typeSize ty
 
 -- | Count the number of AST nodes in a program.
-programSize :: Program tyname name a -> Integer
+programSize :: Program tyname name ann -> Integer
 programSize (Program _ _ t) = termSize t
 
 -- | Compute the size of the serializabled form of a value.

--- a/language-plutus-core/test/Check/Spec.hs
+++ b/language-plutus-core/test/Check/Spec.hs
@@ -190,5 +190,5 @@ normalTypesCheck = runQuote $ do
         , testCase "builtin" $ isRight (checkNormal (builtinNameAsTerm AddInteger)) @? "Normalization"
       ]
         where
-            checkNormal :: Term TyName Name () -> Either (Normal.NormalizationError TyName Name ()) ()
+            checkNormal :: Term TyName Name () -> Either (Normal.NormCheckError TyName Name ()) ()
             checkNormal = Normal.checkTerm

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -195,11 +195,12 @@ testRebindShadowedVariable =
         typeKind = Type ()
 
         -- (all x (type) (fun (all y (type) y) x))
-        type0 = TyForall () xName typeKind (TyFun () (TyForall () yName typeKind varY) varX)
+        l1 = TyForall () xName typeKind (TyFun () (TyForall () yName typeKind varY) varX)
         -- (all x (type) (fun (all x (type) x) x))
-        type1 = TyForall () xName typeKind (TyFun () (TyForall () xName typeKind varX) varX)
+        r1 = TyForall () xName typeKind (TyFun () (TyForall () xName typeKind varX) varX)
+
     in
-        type0 == type1
+        l1 == r1
 
 testRebindCapturedVariable :: Bool
 testRebindCapturedVariable =

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
@@ -75,8 +75,8 @@ instance (PP.Pretty a) => PP.Pretty (Error a) where
 instance PLC.AsTypeError CompileError () where
     _TypeError = _NoContext . _PLCError . PLC._TypeError
 
-instance PLC.AsNormalizationError CompileError PLC.TyName PLC.Name () where
-    _NormalizationError = _NoContext . _PLCError . PLC._NormalizationError
+instance PLC.AsNormCheckError CompileError PLC.TyName PLC.Name () where
+    _NormCheckError = _NoContext . _PLCError . PLC._NormCheckError
 
 instance PLC.AsValueRestrictionError CompileError PLC.TyName () where
     _ValueRestrictionError = _NoContext . _PLCError . PLC._ValueRestrictionError


### PR DESCRIPTION
This

1. makes export lists always indented by 4 spaces. It's diff-friendly, copy-paste-friendly, module-name-changing-friendly and to me it's also eyes-friendly. Also aligns data type declarations in the same way.
2. renames annotations everywhere to `ann`. They were called `a`, `x`, `l`, `pos` and some other names I think. I believe `ann` is more appropriate. I don't like `a`, because sometimes you have some polymorphic functions that deal with annotated things and I want `a` to be reserved for polymorphism
3. renames `NormalizationError` to `NormCheckError`, because the original name never made any sense
4. removes functions needed for handling sizes in Plutus Core
5. splits too long lines into shorter ones