### PR TITLE
Fill in Marlowe holes from dropdown

### DIFF
--- a/marlowe-playground-client/src/Halogen/Blockly.purs
+++ b/marlowe-playground-client/src/Halogen/Blockly.purs
@@ -25,7 +25,7 @@ import Halogen.HTML.Properties (class_, classes, id_, ref)
 import Marlowe.Blockly (buildBlocks, buildGenerator)
 import Marlowe.Parser as Parser
 import Marlowe.Pretty (pretty)
-import Marlowe.Semantics (ContractF(..))
+import Marlowe.Semantics (Contract(..))
 import Prelude (Unit, bind, const, discard, map, pure, show, unit, ($), (<<<), (<>))
 import Text.Parsing.Parser (runParser)
 import Text.Parsing.Parser.Basic (parens)
@@ -93,7 +93,7 @@ handleQuery (Resize next) = do
 handleQuery (SetCode code next) = do
   { blocklyState } <- get
   let
-    contract = case runParser code Parser.contract of
+    contract = case runParser code Parser.contractValue of
       Right c -> c
       Left _ -> Close
   case blocklyState of
@@ -126,7 +126,7 @@ handleAction GetCode = do
       blocklyState <- ExceptT <<< map (note $ unexpected "BlocklyState not set") $ use _blocklyState
       generator <- ExceptT <<< map (note $ unexpected "Generator not set") $ use _generator
       code <- ExceptT <<< pure <<< lmap (const "This workspace cannot be converted to code") $ workspaceToCode blocklyState generator
-      contract <- ExceptT <<< pure <<< lmap (unexpected <<< show) $ runParser code (parens Parser.contract <|> Parser.contract)
+      contract <- ExceptT <<< pure <<< lmap (unexpected <<< show) $ runParser code (parens Parser.contractValue <|> Parser.contractValue)
       lift <<< raise <<< CurrentCode <<< show <<< pretty $ contract
   case res of
     Left e -> assign _errorMessage $ Just e

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -1,0 +1,564 @@
+module Marlowe.Holes where
+
+import Prelude
+import Data.Array (foldMap, foldl, mapWithIndex, (:))
+import Data.BigInteger (BigInteger)
+import Data.Foldable (intercalate)
+import Data.FoldableWithIndex (foldlWithIndex)
+import Data.Function (on)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Eq (genericEq)
+import Data.Generic.Rep.Show (genericShow)
+import Data.Map (Map)
+import Data.Map as Map
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.String (length)
+import Data.Traversable (traverse)
+import Data.Tuple (Tuple(..))
+import Data.Tuple.Nested ((/\))
+import Marlowe.Pretty (class Pretty, genericPretty, prettyFragment)
+import Marlowe.Semantics (ChosenNum, Money, Party, PubKey, Slot, Timeout)
+import Marlowe.Semantics as S
+import Text.Parsing.Parser.Basic (replaceInPosition)
+import Text.Parsing.Parser.Pos (Position(..))
+import Text.PrettyPrint.Leijen (appendWithSoftbreak)
+import Text.PrettyPrint.Leijen as Leijen
+import Type.Proxy (Proxy)
+
+data MarloweType
+  = StringType
+  | BigIntegerType
+  | SlotType
+  | AccountIdType
+  | ChoiceIdType
+  | ValueIdType
+  | ActionType
+  | PayeeType
+  | CaseType
+  | ValueType
+  | InputType
+  | ObservationType
+  | ContractType
+  | BoundType
+
+derive instance eqMarloweType :: Eq MarloweType
+
+data Argument
+  = ArrayArg String
+  | DataArg String
+  | NewtypeArg
+
+getMarloweConstructors :: MarloweType -> Map String (Array Argument)
+getMarloweConstructors StringType = Map.singleton "String" [ NewtypeArg ]
+
+getMarloweConstructors BigIntegerType = Map.singleton "Integer" [ NewtypeArg ]
+
+getMarloweConstructors SlotType = Map.singleton "Integer" [ NewtypeArg ]
+
+getMarloweConstructors AccountIdType = Map.singleton "AccountId" [ DataArg "accNumber", DataArg "accHolder" ]
+
+getMarloweConstructors ChoiceIdType = Map.singleton "ChoiceId" [ DataArg "choiceNumber", DataArg "choiceOwner" ]
+
+getMarloweConstructors ValueIdType = Map.singleton "ValueId" [ NewtypeArg ]
+
+getMarloweConstructors ActionType =
+  Map.fromFoldable
+    [ (Tuple "Deposit" [ DataArg "accountId", DataArg "party", DataArg "value" ])
+    , (Tuple "Choice" [ DataArg "choiceId", ArrayArg "bounds" ])
+    , (Tuple "Notify" [ DataArg "observation" ])
+    ]
+
+getMarloweConstructors PayeeType =
+  Map.fromFoldable
+    [ (Tuple "Account" [ DataArg "accountId" ])
+    , (Tuple "Party" [ DataArg "party" ])
+    ]
+
+getMarloweConstructors CaseType = Map.singleton "Case" [ DataArg "action", DataArg "contract" ]
+
+getMarloweConstructors ValueType =
+  Map.fromFoldable
+    [ (Tuple "AvailableMoney" [ DataArg "accountId" ])
+    , (Tuple "Constant" [ DataArg "amount" ])
+    , (Tuple "NegValue" [ DataArg "value" ])
+    , (Tuple "AddValue" [ DataArg "value", DataArg "value" ])
+    , (Tuple "SubValue" [ DataArg "value", DataArg "value" ])
+    , (Tuple "ChoiceValue" [ DataArg "choiceId", DataArg "value" ])
+    , (Tuple "SlotIntervalStart" [])
+    , (Tuple "SlotIntervalEnd" [])
+    , (Tuple "UseValue" [ DataArg "valueId" ])
+    ]
+
+getMarloweConstructors InputType =
+  Map.fromFoldable
+    [ (Tuple "IDeposit" [ DataArg "accountId", DataArg "party", DataArg "money" ])
+    , (Tuple "IChoice" [ DataArg "choiceId", DataArg "choiceNum" ])
+    , (Tuple "INotify" [])
+    ]
+
+getMarloweConstructors ObservationType =
+  Map.fromFoldable
+    [ (Tuple "AndObs" [ DataArg "observation", DataArg "observation" ])
+    , (Tuple "OrObs" [ DataArg "observation", DataArg "observation" ])
+    , (Tuple "NotObs" [ DataArg "observation" ])
+    , (Tuple "ChoseSomething" [ DataArg "choiceId" ])
+    , (Tuple "ValueGE" [ DataArg "value", DataArg "value" ])
+    , (Tuple "ValueGT" [ DataArg "value", DataArg "value" ])
+    , (Tuple "ValueLE" [ DataArg "value", DataArg "value" ])
+    , (Tuple "ValueLT" [ DataArg "value", DataArg "value" ])
+    , (Tuple "ValueEQ" [ DataArg "value", DataArg "value" ])
+    , (Tuple "TrueObs" [])
+    , (Tuple "FalseObs" [])
+    ]
+
+getMarloweConstructors ContractType =
+  Map.fromFoldable
+    [ (Tuple "Close" [])
+    , (Tuple "Pay" [ DataArg "accountId", DataArg "payee", DataArg "value", DataArg "contract" ])
+    , (Tuple "If" [ DataArg "observation", DataArg "contract", DataArg "contract" ])
+    , (Tuple "When" [ ArrayArg "case", DataArg "timeout", DataArg "contract" ])
+    , (Tuple "Let" [ DataArg "valueId", DataArg "value", DataArg "contract" ])
+    ]
+
+getMarloweConstructors BoundType = Map.singleton "Bound" [ DataArg "from", DataArg "to" ]
+
+constructMarloweType :: String -> MarloweHole -> Map String (Array Argument) -> String
+constructMarloweType constructorName (MarloweHole { name, marloweType, start }) m = case Map.lookup constructorName m of
+  Nothing -> ""
+  Just [] -> constructorName
+  Just vs ->
+    let
+      Position { line, column } = start
+    in
+      "(" <> constructorName <> " " <> intercalate " " (mapWithIndex (showArgument line column) vs) <> ")"
+  where
+  showArgument line column i (ArrayArg arg) = "[ ?" <> arg <> "_" <> show line <> "_" <> show (column + i) <> " ]"
+
+  showArgument line column i (DataArg arg) = "?" <> arg <> "_" <> show line <> "_" <> show (column + i)
+
+  showArgument _ _ _ NewtypeArg = ""
+
+derive instance genericMarloweType :: Generic MarloweType _
+
+instance showMarloweType :: Show MarloweType where
+  show = genericShow
+
+data Term a
+  = Term a
+  | Hole String (Proxy a) Position Position
+
+derive instance genericTerm :: Generic (Term a) _
+
+instance eqTerm :: Eq a => Eq (Term a) where
+  eq a b = genericEq a b
+
+instance showTerm :: Show a => Show (Term a) where
+  show (Term a) = show a
+  show (Hole name _ _ _) = "?" <> name
+
+instance prettyTerm :: Pretty a => Pretty (Term a) where
+  prettyFragment (Term a) = prettyFragment a
+  prettyFragment (Hole name _ _ _) = Leijen.text $ "?" <> name
+
+-- a concrete type for holes only
+data MarloweHole
+  = MarloweHole
+    { name :: String
+    , marloweType :: MarloweType
+    , start :: Position
+    , end :: Position
+    }
+
+derive instance eqMarloweHole :: Eq MarloweHole
+
+instance ordMarloweHole :: Ord MarloweHole where
+  compare (MarloweHole { start: (Position a) }) (MarloweHole { start: (Position b) }) = (compare `on` _.line <> compare `on` _.column) a b
+
+class IsMarloweType a where
+  marloweType :: Proxy a -> MarloweType
+
+instance stringIsMarloweType :: IsMarloweType String where
+  marloweType _ = StringType
+
+instance bigIntegerIsMarloweType :: IsMarloweType BigInteger where
+  marloweType _ = BigIntegerType
+
+-- a Monoid for collecting Holes
+data Holes
+  = Holes (Map String (Array MarloweHole))
+
+instance semigroupHoles :: Semigroup Holes where
+  append (Holes a) (Holes b) = Holes (Map.unionWith append a b)
+
+instance monoidHoles :: Monoid Holes where
+  mempty = Holes mempty
+
+{- | Find holes with the same name
+  We collect all the `Holes` using `getHoles` and then we fold through the result
+  to find occurances that have the same name as well as changing the values to be
+  single MarloweHoles rather than an array of MarloweHoles
+-}
+validateHoles :: Holes -> Tuple (Array MarloweHole) (Map String MarloweHole)
+validateHoles (Holes m) = foldlWithIndex f (Tuple [] mempty) m
+  where
+  f k (Tuple duplicates uniquesMap) [ v ] = Tuple duplicates (Map.insert k v uniquesMap)
+
+  f k (Tuple duplicates uniquesMap) vs = Tuple (duplicates <> vs) uniquesMap
+
+insertHole :: forall a. IsMarloweType a => Holes -> Term a -> Holes
+insertHole m (Term _) = m
+
+insertHole (Holes m) (Hole name proxy start end) = Holes $ Map.alter f name m
+  where
+  marloweHole = MarloweHole { name, marloweType: (marloweType proxy), start, end }
+
+  f v = Just (marloweHole : fromMaybe [] v)
+
+class HasMarloweHoles a where
+  getHoles :: Holes -> a -> Holes
+
+instance termHasMarloweHoles :: (IsMarloweType a, HasMarloweHoles a) => HasMarloweHoles (Term a) where
+  getHoles m (Term a) = getHoles m a
+  getHoles m h = insertHole m h
+
+instance arrayHasMarloweHoles :: HasMarloweHoles a => HasMarloweHoles (Array a) where
+  getHoles m as = foldMap (getHoles m) as
+
+-- Parsable versions of the Marlowe types
+data Bound
+  = Bound (Term BigInteger) (Term BigInteger)
+
+derive instance genericBound :: Generic Bound _
+
+instance showBound :: Show Bound where
+  show v = genericShow v
+
+instance prettyBound :: Pretty Bound where
+  prettyFragment a = Leijen.text $ show a
+
+instance boundFromTerm :: FromTerm Bound S.Bound where
+  fromTerm (Bound a b) = S.Bound <$> termToValue a <*> termToValue b
+
+instance boundIsMarloweType :: IsMarloweType Bound where
+  marloweType _ = BoundType
+
+instance boundHasMarloweHoles :: HasMarloweHoles Bound where
+  getHoles m (Bound a b) = insertHole m a <> insertHole m b
+
+data AccountId
+  = AccountId (Term BigInteger) (Term PubKey)
+
+derive instance genericAccountId :: Generic AccountId _
+
+instance showAccountId :: Show AccountId where
+  show v = genericShow v
+
+instance prettyAccountId :: Pretty AccountId where
+  prettyFragment a = Leijen.text (show a)
+
+instance accountIdFromTerm :: FromTerm AccountId S.AccountId where
+  fromTerm (AccountId (Term b) (Term c)) = pure $ S.AccountId b c
+  fromTerm _ = Nothing
+
+instance accountIdIsMarloweType :: IsMarloweType AccountId where
+  marloweType _ = AccountIdType
+
+instance accountIdHasMarloweHoles :: HasMarloweHoles AccountId where
+  getHoles m (AccountId a b) = insertHole m a <> insertHole m b
+
+data ChoiceId
+  = ChoiceId (Term String) (Term PubKey)
+
+derive instance genericChoiceId :: Generic ChoiceId _
+
+instance showChoiceId :: Show ChoiceId where
+  show v = genericShow v
+
+instance prettyChoiceId :: Pretty ChoiceId where
+  prettyFragment a = Leijen.text (show a)
+
+instance choiceIdFromTerm :: FromTerm ChoiceId S.ChoiceId where
+  fromTerm (ChoiceId (Term a) (Term b)) = pure $ S.ChoiceId a b
+  fromTerm _ = Nothing
+
+instance choiceIdIsMarloweType :: IsMarloweType ChoiceId where
+  marloweType _ = ChoiceIdType
+
+instance choiceIdHasMarloweHoles :: HasMarloweHoles ChoiceId where
+  getHoles m (ChoiceId a b) = insertHole m a <> insertHole m b
+
+data Action
+  = Deposit (Term AccountId) (Term Party) (Term Value)
+  | Choice (Term ChoiceId) (Array (Term Bound))
+  | Notify (Term Observation)
+
+derive instance genericAction :: Generic Action _
+
+instance showAction :: Show Action where
+  show v = genericShow v
+
+instance prettyAction :: Pretty Action where
+  prettyFragment a = Leijen.text (show a)
+
+instance actionFromTerm :: FromTerm Action S.Action where
+  fromTerm (Deposit a b c) = S.Deposit <$> fromTerm a <*> termToValue b <*> fromTerm c
+  fromTerm (Choice a b) = S.Choice <$> fromTerm a <*> (traverse fromTerm b)
+  fromTerm (Notify a) = S.Notify <$> fromTerm a
+
+instance actionMarloweType :: IsMarloweType Action where
+  marloweType _ = ActionType
+
+instance actionHasMarloweHoles :: HasMarloweHoles Action where
+  getHoles m (Deposit a b c) = getHoles m a <> insertHole m b <> getHoles m c
+  getHoles m (Choice a bs) = getHoles m a <> getHoles m bs
+  getHoles m (Notify a) = getHoles m a
+
+data Payee
+  = Account (Term AccountId)
+  | Party (Term Party)
+
+derive instance genericPayee :: Generic Payee _
+
+instance showPayee :: Show Payee where
+  show v = genericShow v
+
+instance prettyPayee :: Pretty Payee where
+  prettyFragment a = genericPretty a
+
+instance payeeFromTerm :: FromTerm Payee S.Payee where
+  fromTerm (Account a) = S.Account <$> fromTerm a
+  fromTerm (Party (Term a)) = pure $ S.Party a
+  fromTerm _ = Nothing
+
+instance payeeMarloweType :: IsMarloweType Payee where
+  marloweType _ = PayeeType
+
+instance payeeHasMarloweHoles :: HasMarloweHoles Payee where
+  getHoles m (Account a) = getHoles m a
+  getHoles m (Party a) = insertHole m a
+
+data Case
+  = Case (Term Action) (Term Contract)
+
+derive instance genericCase :: Generic Case _
+
+instance showCase :: Show Case where
+  show v = genericShow v
+
+-- FIXME: pretty printing is a disaster and slooooowwwww
+instance prettyCase :: Pretty Case where
+  prettyFragment (Case action' contract') = appendWithSoftbreak (Leijen.text "Case " <> prettyFragment action' <> Leijen.text " ") (prettyFragment contract')
+
+instance caseFromTerm :: FromTerm Case S.Case where
+  fromTerm (Case a b) = S.Case <$> fromTerm a <*> fromTerm b
+
+instance caseMarloweType :: IsMarloweType Case where
+  marloweType _ = CaseType
+
+instance caseHasMarloweHoles :: HasMarloweHoles Case where
+  getHoles m (Case a b) = getHoles m a <> getHoles m b
+
+data Value
+  = AvailableMoney (Term AccountId)
+  | Constant (Term BigInteger)
+  | NegValue (Term Value)
+  | AddValue (Term Value) (Term Value)
+  | SubValue (Term Value) (Term Value)
+  | ChoiceValue (Term ChoiceId) (Term Value)
+  | SlotIntervalStart
+  | SlotIntervalEnd
+  | UseValue (Term ValueId)
+
+derive instance genericValue :: Generic Value _
+
+instance showValue :: Show Value where
+  show v = genericShow v
+
+instance prettyValue :: Pretty Value where
+  prettyFragment a = genericPretty a
+
+instance valueFromTerm :: FromTerm Value S.Value where
+  fromTerm (AvailableMoney a) = S.AvailableMoney <$> fromTerm a
+  fromTerm (Constant a) = S.Constant <$> termToValue a
+  fromTerm (NegValue a) = S.NegValue <$> fromTerm a
+  fromTerm (AddValue a b) = S.AddValue <$> fromTerm a <*> fromTerm b
+  fromTerm (SubValue a b) = S.SubValue <$> fromTerm a <*> fromTerm b
+  fromTerm (ChoiceValue a b) = S.ChoiceValue <$> fromTerm a <*> fromTerm b
+  fromTerm SlotIntervalStart = pure S.SlotIntervalStart
+  fromTerm SlotIntervalEnd = pure S.SlotIntervalEnd
+  fromTerm (UseValue a) = S.UseValue <$> fromTerm a
+
+instance valueIsMarloweType :: IsMarloweType Value where
+  marloweType _ = ValueType
+
+instance valueHasMarloweHoles :: HasMarloweHoles Value where
+  getHoles m (AvailableMoney a) = getHoles m a
+  getHoles m (Constant a) = insertHole m a
+  getHoles m (NegValue a) = getHoles m a
+  getHoles m (AddValue a b) = getHoles m a <> getHoles m b
+  getHoles m (SubValue a b) = getHoles m a <> getHoles m b
+  getHoles m (ChoiceValue a b) = getHoles m a <> getHoles m b
+  getHoles m SlotIntervalStart = mempty
+  getHoles m SlotIntervalEnd = mempty
+  getHoles m (UseValue a) = getHoles m a
+
+data Input
+  = IDeposit (Term AccountId) (Term Party) (Term Money)
+  | IChoice (Term ChoiceId) (Term ChosenNum)
+  | INotify
+
+data Observation
+  = AndObs (Term Observation) (Term Observation)
+  | OrObs (Term Observation) (Term Observation)
+  | NotObs (Term Observation)
+  | ChoseSomething (Term ChoiceId)
+  | ValueGE (Term Value) (Term Value)
+  | ValueGT (Term Value) (Term Value)
+  | ValueLT (Term Value) (Term Value)
+  | ValueLE (Term Value) (Term Value)
+  | ValueEQ (Term Value) (Term Value)
+  | TrueObs
+  | FalseObs
+
+derive instance genericObservation :: Generic Observation _
+
+instance showObservation :: Show Observation where
+  show v = genericShow v
+
+instance prettyObservation :: Pretty Observation where
+  prettyFragment a = genericPretty a
+
+instance fromTermTerm :: FromTerm a b => FromTerm (Term a) b where
+  fromTerm (Term a) = fromTerm a
+  fromTerm _ = Nothing
+
+instance observationFromTerm :: FromTerm Observation S.Observation where
+  fromTerm (AndObs a b) = S.AndObs <$> fromTerm a <*> fromTerm b
+  fromTerm (OrObs a b) = S.OrObs <$> fromTerm a <*> fromTerm b
+  fromTerm (NotObs a) = S.NotObs <$> fromTerm a
+  fromTerm (ChoseSomething a) = S.ChoseSomething <$> fromTerm a
+  fromTerm (ValueGE a b) = S.ValueGE <$> fromTerm a <*> fromTerm b
+  fromTerm (ValueGT a b) = S.ValueGT <$> fromTerm a <*> fromTerm b
+  fromTerm (ValueLT a b) = S.ValueLT <$> fromTerm a <*> fromTerm b
+  fromTerm (ValueLE a b) = S.ValueLE <$> fromTerm a <*> fromTerm b
+  fromTerm (ValueEQ a b) = S.ValueEQ <$> fromTerm a <*> fromTerm b
+  fromTerm TrueObs = pure S.TrueObs
+  fromTerm FalseObs = pure S.FalseObs
+
+instance observationIsMarloweType :: IsMarloweType Observation where
+  marloweType _ = ObservationType
+
+instance observationHasMarloweHoles :: HasMarloweHoles Observation where
+  getHoles m (AndObs a b) = getHoles m a <> getHoles m b
+  getHoles m (OrObs a b) = getHoles m a <> getHoles m b
+  getHoles m (NotObs a) = getHoles m a
+  getHoles m (ChoseSomething a) = getHoles m a
+  getHoles m (ValueGE a b) = getHoles m a <> getHoles m b
+  getHoles m (ValueGT a b) = getHoles m a <> getHoles m b
+  getHoles m (ValueLT a b) = getHoles m a <> getHoles m b
+  getHoles m (ValueLE a b) = getHoles m a <> getHoles m b
+  getHoles m (ValueEQ a b) = getHoles m a <> getHoles m b
+  getHoles m TrueObs = mempty
+  getHoles m FalseObs = mempty
+
+data Contract
+  = Close
+  | Pay (Term AccountId) (Term Payee) (Term Value) (Term Contract)
+  | If (Term Observation) (Term Contract) (Term Contract)
+  | When (Array (Term Case)) (Term Timeout) (Term Contract)
+  | Let (Term ValueId) (Term Value) (Term Contract)
+
+derive instance genericContract :: Generic Contract _
+
+instance showContract :: Show Contract where
+  show v = genericShow v
+
+instance prettyContract :: Pretty Contract where
+  prettyFragment a = genericPretty a
+
+instance contractFromTerm :: FromTerm Contract S.Contract where
+  fromTerm Close = pure S.Close
+  fromTerm (Pay a b c d) = S.Pay <$> fromTerm a <*> fromTerm b <*> fromTerm c <*> fromTerm d
+  fromTerm (If a b c) = S.If <$> fromTerm a <*> fromTerm b <*> fromTerm c
+  fromTerm (When as b c) = S.When <$> (traverse fromTerm as) <*> termToValue b <*> fromTerm c
+  fromTerm (Let a b c) = S.Let <$> fromTerm a <*> fromTerm b <*> fromTerm c
+
+instance contractIsMarloweType :: IsMarloweType Contract where
+  marloweType _ = ContractType
+
+instance contractHasMarloweHoles :: HasMarloweHoles Contract where
+  getHoles m Close = mempty
+  getHoles m (Pay a b c d) = getHoles m a <> getHoles m b <> getHoles m c <> getHoles m d
+  getHoles m (If a b c) = getHoles m a <> getHoles m b <> getHoles m c
+  getHoles m (When as b c) = getHoles m as <> insertHole m b <> getHoles m c
+  getHoles m (Let a b c) = getHoles m a <> getHoles m b <> getHoles m c
+
+newtype ValueId
+  = ValueId String
+
+derive instance genericValueId :: Generic ValueId _
+
+instance showValueId :: Show ValueId where
+  show (ValueId valueId') = show valueId'
+
+instance prettyValueId :: Pretty ValueId where
+  prettyFragment a = Leijen.text (show a)
+
+instance valueIdFromTerm :: FromTerm ValueId S.ValueId where
+  fromTerm (ValueId a) = pure $ S.ValueId a
+
+instance valueIdIsMarloweType :: IsMarloweType ValueId where
+  marloweType _ = ValueIdType
+
+instance valueIdHasMarloweHoles :: HasMarloweHoles ValueId where
+  getHoles m _ = m
+
+termToValue :: forall a. Term a -> Maybe a
+termToValue (Term a) = Just a
+
+termToValue _ = Nothing
+
+class FromTerm a b where
+  fromTerm :: a -> Maybe b
+
+instance slotMarloweType :: IsMarloweType Slot where
+  marloweType _ = SlotType
+
+-- Replace all holes of a certain name with the value
+replaceInPositions :: String -> MarloweHole -> Array MarloweHole -> String -> String
+replaceInPositions constructor firstHole@(MarloweHole { marloweType }) holes currentContract =
+  let
+    offset (Position { line, column }) x = Position { line, column: column + x }
+
+    lengthOfReplacement value (Position { column: start }) (Position { column: end }) = (length value) - (end - start)
+
+    getLine (Position { line }) = line
+
+    m = getMarloweConstructors marloweType
+
+    holeString = constructMarloweType constructor firstHole m
+
+    (_ /\ _ /\ final) =
+      ( foldl
+          ( \(currLength /\ currLineNumber /\ currString) hole@(MarloweHole { name, marloweType, start, end }) ->
+              let
+                thisLine = getLine start
+
+                thisLength = currLength + (lengthOfReplacement holeString start end)
+              in
+                if currLineNumber == thisLine then
+                  ( thisLength
+                      /\ thisLine
+                      /\ (replaceInPosition (offset start thisLength) (offset end thisLength) holeString currString)
+                  )
+                else
+                  ( 0
+                      /\ thisLine
+                      /\ (replaceInPosition start end holeString currString)
+                  )
+          )
+          (0 /\ 0 /\ currentContract)
+          holes
+      )
+  in
+    final

--- a/marlowe-playground-client/src/Marlowe/Parser.purs
+++ b/marlowe-playground-client/src/Marlowe/Parser.purs
@@ -3,337 +3,57 @@ module Marlowe.Parser where
 import Control.Alternative ((<|>))
 import Control.Lazy (fix)
 import Control.Monad.State as MonadState
-import Data.Array (foldMap, fromFoldable, many, (:))
+import Data.Array (fromFoldable, many)
 import Data.Array as Array
 import Data.Bifunctor (lmap)
 import Data.BigInteger (BigInteger)
 import Data.BigInteger as BigInteger
 import Data.Either (Either)
-import Data.FoldableWithIndex (foldlWithIndex)
-import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Eq (genericEq)
-import Data.Generic.Rep.Show (genericShow)
-import Data.Identity (Identity)
 import Data.List (List, some)
-import Data.Map (Map)
-import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.String.CodeUnits (fromCharArray)
-import Data.Traversable (traverse)
-import Data.Tuple (Tuple(..))
-import Marlowe.Pretty (class Pretty, prettyFragment)
-import Marlowe.Semantics (AccountIdF(..), ActionF(..), Ada(..), BoundF(..), CaseF(..), ChoiceIdF(..), ContractF(..), IdentityF(..), InputF(..), ObservationF(..), Party, PayeeF(..), PubKey, Slot(..), SlotInterval(..), Timeout, TransactionInput, TransactionInputF(..), TransactionWarning(..), ValueF(..), ValueIdF(..))
-import Marlowe.Semantics as Semantics
-import Prelude (class Eq, class Monoid, class Semigroup, class Show, append, bind, const, discard, flip, mempty, pure, show, void, ($), (*>), (<$>), (<*), (<*>), (<<<), (<>))
-import Text.Parsing.Parser (ParseState(..), Parser, ParserT, fail, runParser)
+import Marlowe.Holes (class FromTerm, AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Payee(..), Term(..), Value(..), ValueId(..), fromTerm)
+import Marlowe.Semantics (Ada(..), Party, PubKey, Slot(..), SlotInterval(..), Timeout, TransactionInput(..), TransactionWarning(..))
+import Marlowe.Semantics as S
+import Prelude (bind, const, discard, flip, pure, show, void, ($), (*>), (<$>), (<*), (<*>), (<<<))
+import Text.Parsing.Parser (ParseState(..), Parser, fail, runParser)
 import Text.Parsing.Parser.Basic (integral, parens)
 import Text.Parsing.Parser.Combinators (between, choice, sepBy)
-import Text.Parsing.Parser.Pos (Position)
 import Text.Parsing.Parser.String (char, string)
 import Text.Parsing.Parser.Token (alphaNum, space)
-import Text.PrettyPrint.Leijen as Leijen
 import Type.Proxy (Proxy(..))
 
 parse :: forall a. Parser String a -> String -> Either String a
 parse p = lmap show <<< flip runParser (parens p <|> p)
 
-data MarloweType
-  = StringType
-  | BigIntegerType
-  | SlotType
-  | AccountIdType
-  | ChoiceIdType
-  | ValueIdType
-  | ActionType
-  | PayeeType
-  | CaseType
-  | ValueType
-  | InputType
-  | ObservationType
-  | ContractType
-
-derive instance genericMarloweType :: Generic MarloweType _
-
-instance showMarloweType :: Show MarloweType where
-  show = genericShow
-
-data Term a
-  = Term a
-  | Hole String (Proxy a) Position Position
-
-derive instance genericTerm :: Generic (Term a) _
-
-instance eqTerm :: Eq a => Eq (Term a) where
-  eq a b = genericEq a b
-
-instance showTerm :: Show a => Show (Term a) where
-  show (Term a) = show a
-  show (Hole name _ _ _) = "?" <> name
-
-instance prettyTerm :: Pretty a => Pretty (Term a) where
-  prettyFragment (Term a) = prettyFragment a
-  prettyFragment (Hole name _ _ _) = Leijen.text $ "?" <> name
-
--- a concrete type for holes only
-data MarloweHole
-  = MarloweHole
-    { name :: String
-    , marloweType :: MarloweType
-    , start :: Position
-    , end :: Position
-    }
-
-class IsMarloweType a where
-  marloweType :: Proxy a -> MarloweType
-
-instance stringIsMarloweType :: IsMarloweType String where
-  marloweType _ = StringType
-
-instance bigIntegerIsMarloweType :: IsMarloweType BigInteger where
-  marloweType _ = BigIntegerType
-
--- a Monoid for collecting Holes
-data Holes
-  = Holes (Map String (Array MarloweHole))
-
-instance semigroupHoles :: Semigroup Holes where
-  append (Holes a) (Holes b) = Holes (Map.unionWith append a b)
-
-instance monoidHoles :: Monoid Holes where
-  mempty = Holes mempty
-
-{- | Find holes with the same name
-  We collect all the `Holes` using `getHoles` and then we fold through the result
-  to find occurances that have the same name as well as changing the values to be
-  single MarloweHoles rather than an array of MarloweHoles
--}
-validateHoles :: Holes -> Tuple (Array MarloweHole) (Map String MarloweHole)
-validateHoles (Holes m) = foldlWithIndex f (Tuple [] mempty) m
-  where
-  f k (Tuple duplicates uniquesMap) [ v ] = Tuple duplicates (Map.insert k v uniquesMap)
-
-  f k (Tuple duplicates uniquesMap) vs = Tuple (duplicates <> vs) uniquesMap
-
-insertHole :: forall a. IsMarloweType a => Holes -> Term a -> Holes
-insertHole m (Term _) = m
-
-insertHole (Holes m) (Hole name proxy start end) = Holes $ Map.alter f name m
-  where
-  marloweHole = MarloweHole { name, marloweType: (marloweType proxy), start, end }
-
-  f (Just v) = Just (marloweHole : v)
-
-  f Nothing = Just [ marloweHole ]
-
-class HasMarloweHoles a where
-  getHoles :: Holes -> a -> Holes
-
-instance arrayHasMarloweHoles :: HasMarloweHoles a => HasMarloweHoles (Array a) where
-  getHoles m as = foldMap (getHoles m) as
-
--- Parsable versions of the Marlowe types
-type Bound
-  = BoundF Term
-
-type AccountId
-  = AccountIdF Term
-
-type ChoiceId
-  = ChoiceIdF Term
-
-type ValueId
-  = ValueIdF Term
-
-type Action
-  = ActionF Term
-
-type Payee
-  = PayeeF Term
-
-type Case
-  = CaseF Term
-
-type Value
-  = ValueF Term
-
-type Input
-  = InputF Term
-
-type Observation
-  = ObservationF Term
-
-type Contract
-  = ContractF Term
-
-termToValue :: forall a. Term a -> Maybe (IdentityF a)
-termToValue (Term a) = Just (Identity a)
-
-termToValue _ = Nothing
-
-class FromTerm f where
-  fromTerm :: f Term -> Maybe (f IdentityF)
-
-instance boundHasMarloweHoles :: HasMarloweHoles (BoundF Term) where
-  getHoles m (Bound a b) = insertHole m a <> insertHole m b
-
-instance boundFromTerm :: FromTerm BoundF where
-  fromTerm (Bound a b) = Bound <$> termToValue a <*> termToValue b
-
-instance slotMarloweType :: IsMarloweType Slot where
-  marloweType _ = SlotType
-
-instance payeeFromTerm :: FromTerm PayeeF where
-  fromTerm (Account a) = Account <$> fromTerm a
-  fromTerm (Party (Term a)) = pure $ Party $ Identity a
-  fromTerm _ = Nothing
-
-instance payeeMarloweType :: IsMarloweType (PayeeF f) where
-  marloweType _ = PayeeType
-
-instance payeeHasMarloweHoles :: HasMarloweHoles (PayeeF Term) where
-  getHoles m (Account a) = getHoles m a
-  getHoles m (Party a) = insertHole m a
-
-instance actionFromTerm :: FromTerm ActionF where
-  fromTerm (Deposit a b c) = Deposit <$> fromTerm a <*> termToValue b <*> fromTerm c
-  fromTerm (Choice a b) = Choice <$> fromTerm a <*> (traverse fromTerm b)
-  fromTerm (Notify a) = Notify <$> fromTerm a
-
-instance actionMarloweType :: IsMarloweType (ActionF f) where
-  marloweType _ = ActionType
-
-instance actionHasMarloweHoles :: HasMarloweHoles (ActionF Term) where
-  getHoles m (Deposit a b c) = getHoles m a <> insertHole m b <> getHoles m c
-  getHoles m (Choice a b) = getHoles m a <> getHoles m b
-  getHoles m (Notify a) = getHoles m a
-
-instance caseFromTerm :: FromTerm CaseF where
-  fromTerm (Case a b) = Case <$> fromTerm a <*> fromTerm b
-
-instance caseMarloweType :: IsMarloweType (CaseF f) where
-  marloweType _ = CaseType
-
-instance caseHasMarloweHoles :: HasMarloweHoles (CaseF Term) where
-  getHoles m (Case a b) = getHoles m a <> getHoles m b
-
-instance accountIdFromTerm :: FromTerm AccountIdF where
-  fromTerm (AccountId (Term b) (Term c)) = pure $ AccountId (Identity b) (Identity c)
-  fromTerm _ = Nothing
-
-instance accountIdIsMarloweType :: IsMarloweType (AccountIdF Term) where
-  marloweType _ = AccountIdType
-
-instance accountIdHasMarloweHoles :: HasMarloweHoles (AccountIdF Term) where
-  getHoles m (AccountId a b) = insertHole m a <> insertHole m b
-
-instance choiceIdFromTerm :: FromTerm ChoiceIdF where
-  fromTerm (ChoiceId (Term a) (Term b)) = pure $ ChoiceId (Identity a) (Identity b)
-  fromTerm _ = Nothing
-
-instance choiceIdIsMarloweType :: IsMarloweType (ChoiceIdF Term) where
-  marloweType _ = ChoiceIdType
-
-instance choiceIdHasMarloweHoles :: HasMarloweHoles (ChoiceIdF Term) where
-  getHoles m (ChoiceId a b) = insertHole m a <> insertHole m b
-
-instance valueIdFromTerm :: FromTerm ValueIdF where
-  fromTerm (ValueId (Term a)) = pure $ ValueId (Identity a)
-  fromTerm _ = Nothing
-
-instance valueIdIsMarloweType :: IsMarloweType (ValueIdF Term) where
-  marloweType _ = ValueIdType
-
-instance valueIdHasMarloweHoles :: HasMarloweHoles (ValueIdF Term) where
-  getHoles m (ValueId a) = insertHole m a
-
-instance valueFromTerm :: FromTerm ValueF where
-  fromTerm (AvailableMoney accountIdF) = AvailableMoney <$> fromTerm accountIdF
-  fromTerm (Constant a) = Constant <$> termToValue a
-  fromTerm (NegValue a) = NegValue <$> fromTerm a
-  fromTerm (AddValue a b) = AddValue <$> fromTerm a <*> fromTerm b
-  fromTerm (SubValue a b) = SubValue <$> fromTerm a <*> fromTerm b
-  fromTerm (ChoiceValue a b) = ChoiceValue <$> fromTerm a <*> fromTerm b
-  fromTerm SlotIntervalStart = pure SlotIntervalStart
-  fromTerm SlotIntervalEnd = pure SlotIntervalEnd
-  fromTerm (UseValue a) = UseValue <$> fromTerm a
-
-instance valueIsMarloweType :: IsMarloweType (ValueF Term) where
-  marloweType _ = ValueType
-
-instance valueHasMarloweHoles :: HasMarloweHoles (ValueF Term) where
-  getHoles m (AvailableMoney a) = getHoles m a
-  getHoles m (Constant a) = insertHole m a
-  getHoles m (NegValue a) = getHoles m a
-  getHoles m (AddValue a b) = getHoles m a <> getHoles m b
-  getHoles m (SubValue a b) = getHoles m a <> getHoles m b
-  getHoles m (ChoiceValue a b) = getHoles m a <> getHoles m b
-  getHoles m SlotIntervalStart = mempty
-  getHoles m SlotIntervalEnd = mempty
-  getHoles m (UseValue a) = getHoles m a
-
-instance observationFromTerm :: FromTerm ObservationF where
-  fromTerm (AndObs a b) = AndObs <$> fromTerm a <*> fromTerm b
-  fromTerm (OrObs a b) = OrObs <$> fromTerm a <*> fromTerm b
-  fromTerm (NotObs a) = NotObs <$> fromTerm a
-  fromTerm (ChoseSomething a) = ChoseSomething <$> fromTerm a
-  fromTerm (ValueGE a b) = ValueGE <$> fromTerm a <*> fromTerm b
-  fromTerm (ValueGT a b) = ValueGT <$> fromTerm a <*> fromTerm b
-  fromTerm (ValueLT a b) = ValueLT <$> fromTerm a <*> fromTerm b
-  fromTerm (ValueLE a b) = ValueLE <$> fromTerm a <*> fromTerm b
-  fromTerm (ValueEQ a b) = ValueEQ <$> fromTerm a <*> fromTerm b
-  fromTerm TrueObs = pure TrueObs
-  fromTerm FalseObs = pure FalseObs
-
-instance observationIsMarloweType :: IsMarloweType (ObservationF Term) where
-  marloweType _ = ObservationType
-
-instance observationHasMarloweHoles :: HasMarloweHoles (ObservationF Term) where
-  getHoles m (AndObs a b) = getHoles m a <> getHoles m b
-  getHoles m (OrObs a b) = getHoles m a <> getHoles m b
-  getHoles m (NotObs a) = getHoles m a
-  getHoles m (ChoseSomething a) = getHoles m a
-  getHoles m (ValueGE a b) = getHoles m a <> getHoles m b
-  getHoles m (ValueGT a b) = getHoles m a <> getHoles m b
-  getHoles m (ValueLT a b) = getHoles m a <> getHoles m b
-  getHoles m (ValueLE a b) = getHoles m a <> getHoles m b
-  getHoles m (ValueEQ a b) = getHoles m a <> getHoles m b
-  getHoles m TrueObs = mempty
-  getHoles m FalseObs = mempty
-
-instance contractFromTerm :: FromTerm ContractF where
-  fromTerm Close = pure Semantics.Close
-  fromTerm (Pay a b c d) = Pay <$> fromTerm a <*> fromTerm b <*> fromTerm c <*> fromTerm d
-  fromTerm (If a b c) = If <$> fromTerm a <*> fromTerm b <*> fromTerm c
-  fromTerm (When as b c) = When <$> (traverse fromTerm as) <*> termToValue b <*> fromTerm c
-  fromTerm (Let a b c) = Let <$> fromTerm a <*> fromTerm b <*> fromTerm c
-
-instance contractIsMarloweType :: IsMarloweType (ContractF Term) where
-  marloweType _ = ContractType
-
-instance contractHasMarloweHoles :: HasMarloweHoles (ContractF Term) where
-  getHoles m Close = mempty
-  getHoles m (Pay a b c d) = getHoles m a <> getHoles m b <> getHoles m c <> getHoles m d
-  getHoles m (If a b c) = getHoles m a <> getHoles m b <> getHoles m c
-  getHoles m (When a b c) = getHoles m a <> insertHole m b <> getHoles m c
-  getHoles m (Let a b c) = getHoles m a <> getHoles m b <> getHoles m c
+parseToValue :: forall a b. FromTerm a b => Parser String a -> Parser String b
+parseToValue p = do
+  v <- p
+  let
+    mV = fromTerm v
+  case mV of
+    (Just a) -> pure a
+    _ -> fail "Found a hole but was expecting terms only"
 
 hole :: forall a. Parser String (Term a)
 hole = do
   (ParseState _ start _) <- MonadState.get
-  name <- fromCharArray <$> (char '?' *> many alphaNum)
+  name <- fromCharArray <$> (char '?' *> many nameChars)
   (ParseState _ end _) <- MonadState.get
   pure $ Hole name Proxy start end
+  where
+  nameChars = alphaNum <|> char '_'
 
 parseTerm :: forall a. Parser String a -> Parser String (Term a)
 parseTerm p = hole <|> (Term <$> p)
 
--- All arguments are space separated so we add **> to reduce boilerplate
 maybeSpaces :: Parser String (Array Char)
 maybeSpaces = many space
 
 spaces :: Parser String (List Char)
 spaces = some space
 
+-- All arguments are space separated so we add **> to reduce boilerplate
 appRSpaces :: forall a b. Parser String a -> Parser String b -> Parser String b
 appRSpaces p q = p *> spaces *> q
 
@@ -347,16 +67,18 @@ infixl 4 appSpaces as <**>
 text :: Parser String String
 text = between (char '"') (char '"') $ fromCharArray <<< fromFoldable <$> many (choice [ alphaNum, space ])
 
+squareParens :: forall a. Parser String a -> Parser String a
+squareParens = between (string "[") (string "]")
+
 haskellList :: forall a. Parser String a -> Parser String (List a)
-haskellList p =
-  squareParens
-    $ do
-        void maybeSpaces
-        v <- p `sepBy` (maybeSpaces *> string "," *> maybeSpaces)
-        void maybeSpaces
-        pure v
-  where
-  squareParens = between (string "[") (string "]")
+haskellList p = squareParens (trim p `sepBy` string ",")
+
+trim :: forall a. Parser String a -> Parser String a
+trim p = do
+  void maybeSpaces
+  v <- p
+  void maybeSpaces
+  pure v
 
 maybeParens :: forall a. Parser String a -> Parser String a
 maybeParens p = parens p <|> p
@@ -376,7 +98,7 @@ bigIntegerTerm :: Parser String (Term BigInteger)
 bigIntegerTerm = parseTerm bigInteger
 
 valueId :: Parser String ValueId
-valueId = ValueId <$> parseTerm text
+valueId = ValueId <$> text
 
 slot :: Parser String Slot
 slot = Slot <$> maybeParens bigInteger
@@ -418,16 +140,15 @@ atomValue =
 
 recValue :: Parser String Value
 recValue =
-  (AvailableMoney <$> (string "AvailableMoney" **> accountId))
+  (AvailableMoney <$> (string "AvailableMoney" **> parseTerm accountId))
     <|> (Constant <$> (string "Constant" **> bigIntegerTerm))
     <|> (NegValue <$> (string "NegValue" **> value'))
     <|> (AddValue <$> (string "AddValue" **> value') <**> value')
     <|> (SubValue <$> (string "SubValue" **> value') <**> value')
-    <|> (ChoiceValue <$> (string "ChoiceValue" **> choiceId) <**> value')
-    <|> (UseValue <$> (string "UseValue" **> valueId))
+    <|> (ChoiceValue <$> (string "ChoiceValue" **> parseTerm choiceId) <**> value')
+    <|> (UseValue <$> (string "UseValue" **> parseTerm valueId))
   where
-  value' :: Parser String Value
-  value' = atomValue <|> fix (\p -> parens recValue)
+  value' = parseTerm $ atomValue <|> fix (\p -> parens recValue)
 
 value :: Parser String Value
 value = atomValue <|> recValue
@@ -442,23 +163,23 @@ recObservation =
   (AndObs <$> (string "AndObs" **> observation') <**> observation')
     <|> (OrObs <$> (string "OrObs" **> observation') <**> observation')
     <|> (NotObs <$> (string "NotObs" **> observation'))
-    <|> (ChoseSomething <$> (string "ChoseSomething" **> choiceId))
+    <|> (ChoseSomething <$> (string "ChoseSomething" **> parseTerm choiceId))
     <|> (ValueGE <$> (string "ValueGE" **> value') <**> value')
     <|> (ValueGT <$> (string "ValueGT" **> value') <**> value')
     <|> (ValueLT <$> (string "ValueLT" **> value') <**> value')
     <|> (ValueLE <$> (string "ValueLE" **> value') <**> value')
     <|> (ValueEQ <$> (string "ValueEQ" **> value') <**> value')
   where
-  observation' = atomObservation <|> fix \p -> parens recObservation
+  observation' = parseTerm $ atomObservation <|> fix \p -> parens recObservation
 
-  value' = atomValue <|> fix (\p -> parens value)
+  value' = parseTerm $ atomValue <|> fix (\p -> parens value)
 
 observation :: Parser String Observation
 observation = atomObservation <|> recObservation
 
 payee :: Parser String Payee
 payee =
-  (Account <$> (string "Account" **> accountId))
+  (Account <$> (string "Account" **> parseTerm accountId))
     <|> (Party <$> (string "Party" **> parseTerm text))
 
 pubkey :: Parser String PubKey
@@ -468,35 +189,34 @@ party :: Parser String Party
 party = pubkey
 
 bound :: Parser String Bound
-bound =
-  parens do
-    void maybeSpaces
-    void $ string "Bound"
-    void spaces
-    first <- parseTerm $ maybeParens bigInteger
-    void spaces
-    second <- parseTerm $ maybeParens bigInteger
-    void maybeSpaces
-    pure (Bound first second)
+bound = do
+  void maybeSpaces
+  void $ string "Bound"
+  void spaces
+  first <- parseTerm $ maybeParens bigInteger
+  void spaces
+  second <- parseTerm $ maybeParens bigInteger
+  void maybeSpaces
+  pure (Bound first second)
 
 action :: Parser String Action
 action =
-  (Deposit <$> (string "Deposit" **> accountId) <**> parseTerm party <**> value')
-    <|> (Choice <$> (string "Choice" **> choiceId) <**> array bound)
+  (Deposit <$> (string "Deposit" **> parseTerm accountId) <**> parseTerm party <**> value')
+    <|> (Choice <$> (string "Choice" **> parseTerm choiceId) <**> array (maybeParens (parseTerm bound)))
     <|> (Notify <$> (string "Notify" **> observation'))
   where
-  observation' = atomObservation <|> fix \p -> parens recObservation
+  observation' = parseTerm $ atomObservation <|> fix \p -> parens recObservation
 
-  value' = atomValue <|> fix (\p -> parens recValue)
+  value' = parseTerm $ atomValue <|> fix (\p -> parens recValue)
 
 case' :: Parser String Case
 case' = do
   void maybeSpaces
   void $ string "Case"
   void spaces
-  first <- parens action
+  first <- parseTerm $ parens action
   void spaces
-  second <- contract'
+  second <- parseTerm contract'
   void maybeSpaces
   pure $ Case first second
   where
@@ -510,35 +230,31 @@ atomContract = pure Close <* string "Close"
 
 recContract :: Parser String Contract
 recContract =
-  ( Pay <$> (string "Pay" **> accountId)
-      <**> parens payee
+  ( Pay <$> (string "Pay" **> parseTerm accountId)
+      <**> parseTerm (parens payee)
       <**> value'
       <**> contract'
   )
     <|> (If <$> (string "If" **> observation') <**> contract' <**> contract')
-    <|> (When <$> (string "When" **> (array (maybeParens case'))) <**> parseTerm timeout <**> contract')
-    <|> (Let <$> (string "Let" **> valueId) <**> value' <**> contract')
+    <|> (When <$> (string "When" **> (array (maybeParens (parseTerm case')))) <**> parseTerm timeout <**> contract')
+    <|> (Let <$> (string "Let" **> parseTerm valueId) <**> value' <**> contract')
     <|> (fail "not a valid Contract")
   where
-  contract' = atomContract <|> fix \p -> parens recContract
+  contract' = parseTerm $ atomContract <|> fix \p -> parens recContract
 
-  observation' = atomObservation <|> fix \p -> parens observation
+  observation' = parseTerm $ atomObservation <|> fix \p -> parens observation
 
-  value' = atomValue <|> fix (\p -> parens value)
+  value' = parseTerm $ atomValue <|> fix (\p -> parens value)
 
-contractTerm :: Parser String Contract
-contractTerm = do
+contract :: Parser String Contract
+contract = do
   void maybeSpaces
   c <- (atomContract <|> recContract)
   void maybeSpaces
   pure c
 
-contract :: Parser String Semantics.Contract
-contract = do
-  c <- contractTerm
-  case fromTerm c of
-    Just contract' -> pure contract'
-    Nothing -> fail "Contract has holes"
+contractValue :: Parser String S.Contract
+contractValue = parseToValue contract
 
 testString :: String
 testString =
@@ -662,43 +378,26 @@ testString =
 
 -- These parsers are not used by the front end at this time and so they are `Parser String (Identity a)`
 -- rather than `Parser String (Term a)`
-input :: Parser String (InputF IdentityF)
+input :: Parser String S.Input
 input =
   maybeParens
-    (IDeposit <$> (string "IDeposit" **> accountIdValue) <**> party <**> (Lovelace <$> (maybeParens bigInteger)))
-    <|> (IChoice <$> (string "IChoice" **> choiceIdValue) <**> (maybeParens bigInteger))
-    <|> ((const INotify) <$> (string "INotify"))
+    (S.IDeposit <$> (string "IDeposit" **> accountIdValue) <**> party <**> (Lovelace <$> (maybeParens bigInteger)))
+    <|> (S.IChoice <$> (string "IChoice" **> choiceIdValue) <**> (maybeParens bigInteger))
+    <|> ((const S.INotify) <$> (string "INotify"))
 
-accountIdValue :: ParserT String Identity (AccountIdF IdentityF)
-accountIdValue = do
-  accountId' <- accountId
-  case accountId' of
-    (AccountId (Term a) (Term b)) -> pure $ AccountId (Identity a) (Identity b)
-    _ -> fail "Found a hole when parsing an AccountIf"
+accountIdValue :: Parser String S.AccountId
+accountIdValue = parseToValue accountId
 
-choiceIdValue :: ParserT String Identity (ChoiceIdF IdentityF)
-choiceIdValue = do
-  choiceId' <- choiceId
-  case choiceId' of
-    (ChoiceId (Term a) (Term b)) -> pure $ ChoiceId (Identity a) (Identity b)
-    _ -> fail "Found a hole when parsing an ChoiceId"
+choiceIdValue :: Parser String S.ChoiceId
+choiceIdValue = parseToValue choiceId
 
-valueIdValue :: ParserT String Identity (ValueIdF IdentityF)
-valueIdValue = do
-  valueId' <- valueId
-  case valueId' of
-    (ValueId (Term a)) -> pure $ ValueId (Identity a)
-    _ -> fail "Found a hole when parsing an ValueId"
+valueIdValue :: Parser String S.ValueId
+valueIdValue = parseToValue valueId
 
-payeeValue :: ParserT String Identity (PayeeF IdentityF)
-payeeValue = do
-  payee' <- payee
-  case payee' of
-    (Account (AccountId (Term a) (Term b))) -> pure $ Account (AccountId (Identity a) (Identity b))
-    (Party (Term p)) -> pure $ Party (Identity p)
-    _ -> fail "Found a hole when parsing an Payee"
+payeeValue :: Parser String S.Payee
+payeeValue = parseToValue payee
 
-inputList :: Parser String (List (InputF IdentityF))
+inputList :: Parser String (List S.Input)
 inputList = haskellList input
 
 slotInterval :: Parser String SlotInterval

--- a/marlowe-playground-client/src/Text/Parsing/Parser/Basic.purs
+++ b/marlowe-playground-client/src/Text/Parsing/Parser/Basic.purs
@@ -2,10 +2,14 @@ module Text.Parsing.Parser.Basic where
 
 import Prelude hiding (between)
 import Control.Alternative ((<|>))
-import Data.Array ((:), many)
-import Data.String.CodeUnits (fromCharArray)
+import Data.Array (foldl, many, mapWithIndex, (:))
+import Data.Array as Array
+import Data.Maybe (Maybe(..))
+import Data.String.CodeUnits (drop, fromCharArray, take)
+import Data.String.CodeUnits as String
 import Text.Parsing.Parser (ParserT)
 import Text.Parsing.Parser.Combinators (between)
+import Text.Parsing.Parser.Pos (Position(..))
 import Text.Parsing.Parser.String (char)
 import Text.Parsing.Parser.Token (digit)
 
@@ -17,3 +21,43 @@ integral = do
 
 parens :: forall m a. Monad m => ParserT String m a -> ParserT String m a
 parens = between (char '(') (char ')')
+
+unlines :: Array String -> String
+unlines = foldl f ""
+  where
+  f :: String -> String -> String
+  f acc a = acc <> a <> "\n"
+
+lines :: String -> Array String
+lines = map String.fromCharArray <<< go <<< String.toCharArray
+  where
+  go :: Array Char -> Array (Array Char)
+  go s = case Array.uncons s of
+    Nothing -> []
+    Just _ ->
+      let
+        withBreaks = break ((==) '\n') s
+      in
+        withBreaks.init `Array.cons` go (stripNewLine withBreaks.rest)
+
+  stripNewLine :: Array Char -> Array Char
+  stripNewLine s = case Array.uncons s of
+    Nothing -> []
+    Just { head: '\n', tail: tail } -> tail
+    Just { head: head, tail: tail } -> head `Array.cons` tail
+
+  -- | `break p as` is `span (not <<< p) as`.
+  break :: forall a. (a -> Boolean) -> Array a -> { init :: (Array a), rest :: (Array a) }
+  break p = Array.span (not <<< p)
+
+replaceInPosition :: Position -> Position -> String -> String -> String
+replaceInPosition (Position start) (Position end) value initial =
+  unlines
+    $ mapWithIndex
+        ( \i line ->
+            if i == (start.line - 1) then
+              (take (start.column - 1) line) <> value <> (drop (end.column - 1) line)
+            else
+              line
+        )
+    $ lines initial

--- a/marlowe-playground-client/static/main.scss
+++ b/marlowe-playground-client/static/main.scss
@@ -126,3 +126,9 @@
     margin-bottom: 0px;
     margin-right: 15px;
 }
+
+.button-box {
+    border-radius: 0;
+    background: $card-bg;
+    border: none;
+}

--- a/marlowe-playground-client/test/Marlowe/BlocklyTests.purs
+++ b/marlowe-playground-client/test/Marlowe/BlocklyTests.purs
@@ -4,7 +4,6 @@ import Prelude
 import Blockly (getBlockById)
 import Blockly as Blockly
 import Blockly.Generator (Generator, getInputWithName, inputList, workspaceToCode)
-import Marlowe.GenWithHoles (GenWithHoles, unGenWithHoles)
 import Blockly.Headless as Headless
 import Blockly.Types (BlocklyState)
 import Control.Alt ((<|>))
@@ -21,6 +20,8 @@ import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Unsafe (unsafePerformEffect)
 import Marlowe.Blockly (blockDefinitions, buildGenerator, toBlockly)
 import Marlowe.Gen (genContract)
+import Marlowe.GenWithHoles (GenWithHoles, unGenWithHoles)
+import Marlowe.Holes as Holes
 import Marlowe.Parser as Parser
 import Marlowe.Semantics (Contract)
 import Test.QuickCheck (class Testable, Result(..), (===))
@@ -55,7 +56,7 @@ mkTestState = do
 c2b2c :: GenWithHoles Result
 c2b2c = do
   termContract <- genContract
-  case Parser.fromTerm termContract of
+  case Holes.fromTerm termContract of
     -- Unfortunately quickcheck runs the concrete Gen monad and it would need to be re-written to use MonadGen
     -- https://github.com/purescript/purescript-quickcheck/blob/v5.0.0/src/Test/QuickCheck.purs#L97
     -- I made the executive decision that it's not worth my time to do it in this specific case
@@ -71,7 +72,7 @@ runContract contract = do
     eCode = workspaceToCode state.blocklyState state.generator
   pure
     $ case eCode of
-        Right code -> lmap show $ runParser code (parens Parser.contract <|> Parser.contract)
+        Right code -> lmap show $ runParser code (parens Parser.contractValue <|> Parser.contractValue)
         Left err -> Left err
 
 buildBlocks :: forall r. BlocklyState -> Contract -> ST r Unit

--- a/marlowe-playground-client/test/Marlowe/ContractTests.purs
+++ b/marlowe-playground-client/test/Marlowe/ContractTests.purs
@@ -12,7 +12,7 @@ import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Tuple (Tuple(..))
 import Examples.Marlowe.Contracts as Contracts
-import Marlowe.Semantics (AccountIdF(..), Ada(..), ChoiceIdF(..), ContractF(..), InputF(..))
+import Marlowe.Semantics (AccountId(..), Ada(..), ChoiceId(..), Contract(..), Input(..))
 import MonadApp (class MonadApp, applyTransactions, extendWith, marloweEditorSetAnnotations, updateContractInState, updateContractInStateP, updateMarloweState, updatePossibleActions, updateStateP)
 import Network.RemoteData (RemoteData(..))
 import Test.Unit (TestSuite, suite, test)
@@ -46,6 +46,7 @@ instance monadAppState :: MonadApp MockApp where
   marloweEditorSetValue _ _ = pure unit
   marloweEditorGetValue = pure (Just Contracts.escrow)
   marloweEditorSetAnnotations _ = pure unit
+  marloweEditorMoveCursorToPosition _ = pure unit
   preventDefault _ = pure unit
   readFileFromDragEvent _ = pure ""
   updateContractInState contract = do
@@ -86,6 +87,7 @@ initialState =
     , gistUrl: Nothing
     , blocklyState: Nothing
     , analysisState: NotAsked
+    , selectedHole: Nothing
     }
 
 runTests :: forall a. MockApp a -> Tuple a FrontendState
@@ -101,13 +103,13 @@ all =
 
         bob = "bob"
 
-        deposit = IDeposit (AccountId (wrap (fromIntegral 0)) (wrap alice)) alice (Lovelace (fromIntegral 450))
+        deposit = IDeposit (AccountId (fromIntegral 0) alice) alice (Lovelace (fromIntegral 450))
 
-        choice = ChoiceId (wrap "choice")
+        choice = ChoiceId "choice"
 
-        choice1 = IChoice (choice (wrap alice)) (fromIntegral 0)
+        choice1 = IChoice (choice alice) (fromIntegral 0)
 
-        choice2 = IChoice (choice (wrap bob)) (fromIntegral 0)
+        choice2 = IChoice (choice bob) (fromIntegral 0)
 
         (Tuple _ finalState) =
           runTests

--- a/marlowe-playground-client/test/Marlowe/ParserTests.purs
+++ b/marlowe-playground-client/test/Marlowe/ParserTests.purs
@@ -6,7 +6,8 @@ import Control.Monad.Reader (runReaderT)
 import Data.Either (Either(..))
 import Marlowe.Gen (genAction, genContract, genObservation, genValue)
 import Marlowe.GenWithHoles (GenWithHoles, unGenWithHoles)
-import Marlowe.Parser (Action, Contract, Observation, Value, action, contractTerm, observation, value)
+import Marlowe.Holes (Action, Contract, Observation, Value)
+import Marlowe.Parser (action, contract, observation, value)
 import Marlowe.Pretty (pretty)
 import Test.QuickCheck (class Testable, Result, (===))
 import Test.Unit (TestSuite, Test, suite, test)
@@ -28,7 +29,7 @@ all =
     test "Pretty Contract Parser" $ quickCheckGen prettyContractParser
 
 quickCheckGen :: forall prop. Testable prop => GenWithHoles prop -> Test
-quickCheckGen g = quickCheck $ runReaderT (unGenWithHoles g) true
+quickCheckGen g = quickCheck $ runReaderT (unGenWithHoles g) false
 
 -- NOTE: If a generated value has a hole in it, the start and end positions in that
 --       hole will not be the same as when they have been parsed so we `show` the
@@ -91,7 +92,7 @@ contractParser :: GenWithHoles Result
 contractParser = do
   v <- genContract
   let
-    result = runParser (show v) (parens contractTerm <|> contractTerm)
+    result = runParser (show v) (parens contract <|> contract)
 
     (expected :: Either String Contract) = Right v
   pure (show result === show expected)
@@ -100,7 +101,7 @@ prettyContractParser :: GenWithHoles Result
 prettyContractParser = do
   v <- genContract
   let
-    result = runParser (show $ pretty v) (parens contractTerm <|> contractTerm)
+    result = runParser (show $ pretty v) (parens contract <|> contract)
 
     (expected :: Either String Contract) = Right v
   pure (show result === show expected)

--- a/web-common/src/Bootstrap.purs
+++ b/web-common/src/Bootstrap.purs
@@ -259,6 +259,9 @@ btnExtraSmall = ClassName "btn-xs"
 btnLink :: ClassName
 btnLink = ClassName "btn-link"
 
+dropdownToggle :: ClassName
+dropdownToggle = ClassName "dropdown-toggle"
+
 pullLeft :: ClassName
 pullLeft = ClassName "pull-left"
 

--- a/web-common/src/Bootstrap/Extra.purs
+++ b/web-common/src/Bootstrap/Extra.purs
@@ -1,6 +1,19 @@
 module Bootstrap.Extra where
 
-import Halogen.HTML (ClassName(..))
+import Halogen.HTML (ClassName(..), IProp, prop, PropName(..))
+import Prelude (show)
 
 clickable :: ClassName
 clickable = ClassName "clickable"
+
+dataToggle :: forall r i. String -> IProp r i
+dataToggle = prop (PropName "data-toggle")
+
+ariaHasPopup :: forall r i. Boolean -> IProp r i
+ariaHasPopup hasPopup = prop (PropName "data-toggle") (show hasPopup)
+
+ariaExpanded :: forall r i. Boolean -> IProp r i
+ariaExpanded expanded = prop (PropName "data-toggle") (show expanded)
+
+ariaLabelledBy :: forall r i. String -> IProp r i
+ariaLabelledBy label = prop (PropName "data-toggle") label


### PR DESCRIPTION
Deployed to https://david.marlowe.iohkdev.io/ go to the Simulation tab and enter `?contract` in the editor. You can play from there.

Styling and UX suggestions welcome.

As part of this I had to remove parametrized marlowe types. In the end it was possibly impossible to do what I wanted and even if it was possible the complexity cost had started to outweigh the cost of having duplicate types.