### PR TITLE
Frontend: Removing the circular dependencies from web-common.

### DIFF
--- a/marlowe-playground-client/spago.dhall
+++ b/marlowe-playground-client/spago.dhall
@@ -34,6 +34,6 @@ You can edit this file as you like.
     [ "src/**/*.purs"
     , "test/**/*.purs"
     , "generated/**/*.purs"
-    , "../web-common/**/*.purs"
+    , "../web-common/src/**/*.purs"
     ]
 }

--- a/marlowe-playground-client/src/MonadApp.purs
+++ b/marlowe-playground-client/src/MonadApp.purs
@@ -47,7 +47,7 @@ import Servant.PureScript.Settings (SPSettings_)
 import StaticData (bufferLocalStorageKey, marloweBufferLocalStorageKey)
 import Text.Parsing.Parser (ParseError(..), runParser)
 import Text.Parsing.Parser.Pos (Position(..))
-import Types (ActionInput(..), ActionInputId, ChildSlots, FrontendState, HAction, MarloweState, WebData, WebsocketMessage(..), _Head, _blocklySlot, _contract, _currentMarloweState, _editorErrors, _editorSlot, _holes, _marloweEditorSlot, _marloweState, _moneyInContract, _oldContract, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError, actionToActionInput, emptyMarloweState)
+import Types (ActionInput(..), ActionInputId, ChildSlots, FrontendState, HAction, MarloweState, WebData, WebsocketMessage(..), _Head, _blocklySlot, _contract, _currentMarloweState, _editorErrors, _haskellEditorSlot, _holes, _marloweEditorSlot, _marloweState, _moneyInContract, _oldContract, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError, actionToActionInput, emptyMarloweState)
 import Web.HTML.Event.DragEvent (DragEvent)
 import WebSocket (WebSocketRequestMessage(CheckForWarnings))
 
@@ -213,7 +213,7 @@ withHaskellEditor ::
   MonadEffect m =>
   (Editor -> Effect a) ->
   HalogenApp m (Maybe a)
-withHaskellEditor = HalogenApp <<< Editor.withEditor _editorSlot unit
+withHaskellEditor = HalogenApp <<< Editor.withEditor _haskellEditorSlot unit
 
 withMarloweEditor ::
   forall m a.

--- a/marlowe-playground-client/src/Types.purs
+++ b/marlowe-playground-client/src/Types.purs
@@ -23,7 +23,9 @@ import Data.Newtype (class Newtype)
 import Data.NonEmpty (foldl1, (:|))
 import Data.Symbol (SProxy(..))
 import Data.Tuple (Tuple(..))
+import Editor (EditorAction)
 import Gist (Gist)
+import Gists (GistAction)
 import Halogen as H
 import Halogen.Blockly (BlocklyQuery, BlocklyMessage)
 import Language.Haskell.Interpreter (InterpreterError, InterpreterResult)
@@ -45,24 +47,17 @@ data HQuery a
 
 data HAction
   -- Haskell Editor
-  = HandleEditorMessage AceMessage
-  | HandleDragEvent DragEvent
-  | HandleDropEvent DragEvent
-  | MarloweHandleEditorMessage AceMessage
+  = MarloweHandleEditorMessage AceMessage
   | MarloweHandleDragEvent DragEvent
   | MarloweHandleDropEvent DragEvent
   | MarloweMoveToPosition Ace.Position
+  | HaskellEditorAction EditorAction
   -- Gist support.
   | CheckAuthStatus
-  | PublishGist
-  | SetGistUrl String
-  | LoadGist
+  | GistAction GistAction
   -- haskell actions
   | ChangeView View
-  | LoadScript String
-  | CompileProgram
   | SendResult
-  | ScrollTo { row :: Int, column :: Int }
   | LoadMarloweScript String
   -- marlowe actions
   | ApplyTransaction
@@ -85,13 +80,13 @@ data WebsocketMessage
 
 ------------------------------------------------------------
 type ChildSlots
-  = ( editorSlot :: H.Slot AceQuery AceMessage Unit
+  = ( haskellEditorSlot :: H.Slot AceQuery AceMessage Unit
     , marloweEditorSlot :: H.Slot AceQuery AceMessage Unit
     , blocklySlot :: H.Slot BlocklyQuery BlocklyMessage Unit
     )
 
-_editorSlot :: SProxy "editorSlot"
-_editorSlot = SProxy
+_haskellEditorSlot :: SProxy "haskellEditorSlot"
+_haskellEditorSlot = SProxy
 
 _marloweEditorSlot :: SProxy "marloweEditorSlot"
 _marloweEditorSlot = SProxy
@@ -226,9 +221,6 @@ _holes = prop (SProxy :: SProxy "holes")
 --- Language.Haskell.Interpreter ---
 _result :: forall s a. Lens' { result :: a | s } a
 _result = prop (SProxy :: SProxy "result")
-
-_warnings :: forall s a. Lens' { warnings :: a | s } a
-_warnings = prop (SProxy :: SProxy "warnings")
 
 _payments :: forall s a. Lens' { payments :: a | s } a
 _payments = prop (SProxy :: SProxy "payments")

--- a/plutus-playground-client/spago.dhall
+++ b/plutus-playground-client/spago.dhall
@@ -32,6 +32,6 @@ You can edit this file as you like.
     [ "src/**/*.purs"
     , "test/**/*.purs"
     , "generated/**/*.purs"
-    , "../web-common/**/*.purs"
+    , "../web-common/src/**/*.purs"
     ]
 }

--- a/plutus-playground-client/src/Types.purs
+++ b/plutus-playground-client/src/Types.purs
@@ -28,12 +28,14 @@ import Data.Symbol (SProxy(..))
 import Data.Traversable (sequence, traverse)
 import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\))
+import Editor (EditorAction)
 import Foreign (Foreign)
 import Foreign.Class (class Decode, class Encode, encode)
 import Foreign.Generic (defaultOptions, encodeJSON, genericDecode, genericEncode)
 import Foreign.Generic.Class (Options, aesonSumEncoding)
 import Foreign.Object as FO
 import Gist (Gist)
+import Gists (GistAction)
 import Halogen as H
 import Halogen.Chartist as Chartist
 import Language.Haskell.Interpreter (InterpreterError, InterpreterResult, SourceCode, _InterpreterResult)
@@ -183,22 +185,15 @@ data Query a
 data HAction
   = Mounted
   -- SubEvents.
-  | HandleEditorMessage AceMessage
-  | HandleDragEvent DragEvent
   | ActionDragAndDrop Int DragAndDropEventType DragEvent
-  | HandleDropEvent DragEvent
   | HandleBalancesChartMessage Chartist.Message
   -- Gist support.
   | CheckAuthStatus
-  | PublishGist
-  | SetGistUrl String
-  | LoadGist
+  | GistAction GistAction
   -- Tabs.
   | ChangeView View
   -- Editor.
-  | LoadScript String
-  | CompileProgram
-  | ScrollTo { row :: Int, column :: Int }
+  | EditorAction EditorAction
   -- Simulations
   | AddSimulationSlot
   | SetSimulationSlot Int

--- a/plutus-playground-client/src/View.purs
+++ b/plutus-playground-client/src/View.purs
@@ -20,6 +20,7 @@ import Effect.Aff.Class (class MonadAff)
 import Gists (gistControls)
 import Halogen.HTML (ClassName(ClassName), HTML, ComponentHTML, a, div, div_, h1, strong_, text)
 import Halogen.HTML.Events (onClick)
+import Halogen.HTML.Extra (mapComponent)
 import Halogen.HTML.Properties (class_, classes, href, id_)
 import Icons (Icon(..), icon)
 import Network.RemoteData (RemoteData(..))
@@ -39,12 +40,14 @@ render state@(State { currentView, blockchainVisualisationState }) =
             [ mainHeader
             , div [ classes [ row, noGutters, justifyContentBetween ] ]
                 [ div [ classes [ colXs12, colSm6 ] ] [ mainTabBar currentView ]
-                , div [ classes [ colXs12, colSm5 ] ] [ gistControls (unwrap state) ]
+                , div
+                    [ classes [ colXs12, colSm5 ] ]
+                    [ GistAction <$> gistControls (unwrap state) ]
                 ]
             ]
         , viewContainer currentView Editor
-            [ demoScriptsPane
-            , editorPane defaultContents (unwrap <$> view _compilationResult state)
+            [ EditorAction <$> demoScriptsPane
+            , mapComponent EditorAction $ editorPane defaultContents _editorSlot (unwrap <$> view _compilationResult state)
             , case view _compilationResult state of
                 Failure error -> ajaxErrorPane error
                 _ -> empty

--- a/web-common/.gitignore
+++ b/web-common/.gitignore
@@ -1,0 +1,10 @@
+/bower_components/
+/node_modules/
+/.pulp-cache/
+/output/
+/generated-docs/
+/.psc-package/
+/.psc*
+/.purs*
+/.psa*
+/.spago

--- a/web-common/packages.dhall
+++ b/web-common/packages.dhall
@@ -1,0 +1,228 @@
+{-
+Welcome to your new Dhall package-set!
+
+Below are instructions for how to edit this file for most use
+cases, so that you don't need to know Dhall to use it.
+
+## Warning: Don't Move This Top-Level Comment!
+
+Due to how `dhall format` currently works, this comment's
+instructions cannot appear near corresponding sections below
+because `dhall format` will delete the comment. However,
+it will not delete a top-level comment like this one.
+
+## Use Cases
+
+Most will want to do one or both of these options:
+1. Override/Patch a package's dependency
+2. Add a package not already in the default package set
+
+This file will continue to work whether you use one or both options.
+Instructions for each option are explained below.
+
+### Overriding/Patching a package
+
+Purpose:
+- Change a package's dependency to a newer/older release than the
+	default package set's release
+- Use your own modified version of some dependency that may
+	include new API, changed API, removed API by
+	using your custom git repo of the library rather than
+	the package set's repo
+
+Syntax:
+Replace the overrides' "{=}" (an empty record) with the following idea
+The "//" or "⫽" means "merge these two records and
+  when they have the same value, use the one on the right:"
+-------------------------------
+let override =
+  { packageName =
+	  upstream.packageName // { updateEntity1 = "new value", updateEntity2 = "new value" }
+  , packageName =
+	  upstream.packageName // { version = "v4.0.0" }
+  , packageName =
+	  upstream.packageName // { repo = "https://www.example.com/path/to/new/repo.git" }
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let overrides =
+  { halogen =
+	  upstream.halogen // { version = "master" }
+  , halogen-vdom =
+	  upstream.halogen-vdom // { version = "v4.0.0" }
+  }
+-------------------------------
+
+### Additions
+
+Purpose:
+- Add packages that aren't already included in the default package set
+
+Syntax:
+Replace the additions' "{=}" (an empty record) with the following idea:
+-------------------------------
+let additions =
+  { package-name =
+	   { dependencies =
+		   [ "dependency1"
+		   , "dependency2"
+		   ]
+	   , repo =
+		   "https://example.com/path/to/git/repo.git"
+	   , version =
+		   "tag ('v4.0.0') or branch ('master')"
+	   }
+  , package-name =
+	   { dependencies =
+		   [ "dependency1"
+		   , "dependency2"
+		   ]
+	   , repo =
+		   "https://example.com/path/to/git/repo.git"
+	   , version =
+		   "tag ('v4.0.0') or branch ('master')"
+	   }
+  , etc.
+  }
+-------------------------------
+
+Example:
+-------------------------------
+let additions =
+  { benchotron =
+	  { dependencies =
+		  [ "arrays"
+		  , "exists"
+		  , "profunctor"
+		  , "strings"
+		  , "quickcheck"
+		  , "lcg"
+		  , "transformers"
+		  , "foldable-traversable"
+		  , "exceptions"
+		  , "node-fs"
+		  , "node-buffer"
+		  , "node-readline"
+		  , "datetime"
+		  , "now"
+		  ]
+	  , repo =
+		  "https://github.com/hdgarrood/purescript-benchotron.git"
+	  , version =
+		  "v7.0.0"
+	  }
+  }
+-------------------------------
+-}
+
+
+let upstream =
+	  https://github.com/purescript/package-sets/releases/download/psc-0.13.3-20190920/packages.dhall sha256:53873cf2fc4a343a41f335ee47c1706ecf755ac7c5a336e8eb03ad23165dfd28
+
+let overrides = {=}
+
+let additions =
+	  { servant-support =
+		  { dependencies =
+			  [ "console"
+			  , "prelude"
+			  , "either"
+			  , "foldable-traversable"
+			  , "generics-rep"
+			  , "effect"
+			  , "aff"
+			  , "affjax"
+			  , "exceptions"
+			  , "web-xhr"
+			  , "foreign-generic"
+			  ]
+		  , repo =
+			  "https://github.com/shmish111/purescript-servant-support"
+		  , version =
+			  "purs-0.13"
+		  }
+	  , foreign-generic =
+			upstream.foreign-generic
+          //  { repo =
+                  "https://github.com/shmish111/purescript-foreign-generic"
+              , version =
+                  "purs-0.13"
+              }
+      , affjax =
+          { dependencies =
+              [ "aff"
+              , "argonaut-core"
+              , "arraybuffer-types"
+              , "web-xhr"
+              , "foreign"
+              , "form-urlencoded"
+              , "http-methods"
+              , "integers"
+              , "math"
+              , "media-types"
+              , "nullable"
+              , "refs"
+              , "unsafe-coerce"
+              ]
+          , repo =
+              "https://github.com/krisajenkins/purescript-affjax"
+          , version =
+              "purs-0.13"
+          }
+      , ace-halogen =
+          { dependencies =
+              [ "ace"
+              , "halogen"
+              , "now"
+              , "random"
+              , "refs"
+              , "aff"
+              , "foreign-object"
+              , "prelude"
+              ]
+          , repo =
+              "https://github.com/shmish111/purescript-ace-halogen"
+          , version =
+              "purs-0.13"
+          }
+      , ace =
+          { dependencies =
+              [ "effect"
+              , "web-html"
+              , "web-uievents"
+              , "arrays"
+              , "foreign"
+              , "nullable"
+              , "prelude"
+              ]
+          , repo =
+              "https://github.com/slamdata/purescript-ace.git"
+          , version =
+              "v7.0.0"
+          }
+      , matryoshka =
+          { dependencies =
+              [ "prelude"
+              , "fixed-points"
+              , "free"
+              , "transformers"
+              , "profunctor"
+              ]
+          , repo =
+              "https://github.com/slamdata/purescript-matryoshka.git"
+          , version =
+              "v0.4.0"
+          }
+      , numerics =
+          { dependencies =
+              [ "prelude", "integers", "rationals", "uint", "bigints" ]
+          , repo =
+              "https://github.com/Proclivis/purescript-numerics"
+          , version =
+              "v0.1.2"
+          }
+	  }
+
+in  upstream // overrides // additions

--- a/web-common/spago.dhall
+++ b/web-common/spago.dhall
@@ -1,0 +1,27 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+-}
+{ name =
+	"web-common"
+, dependencies =
+	[ "ace-halogen"
+	, "console"
+	, "effect"
+	, "either"
+	, "foreign-generic"
+	, "halogen"
+	, "maybe"
+	, "prelude"
+	, "profunctor-lenses"
+	, "psci-support"
+	, "remotedata"
+	, "servant-support"
+	, "transformers"
+	, "undefinable"
+	]
+, packages =
+	./packages.dhall
+, sources =
+	[ "src/**/*.purs", "test/**/*.purs" ]
+}

--- a/web-common/src/Gists.purs
+++ b/web-common/src/Gists.purs
@@ -1,5 +1,6 @@
 module Gists
-  ( gistControls
+  ( GistAction(..)
+  , gistControls
   , parseGistUrl
   , firstMatch
   ) where
@@ -22,13 +23,17 @@ import Icons (Icon(..), icon)
 import Network.RemoteData (RemoteData(NotAsked, Loading, Failure, Success))
 import Prelude (bind, const, ($), (<$>), (<<<), (<>), (=<<), (==))
 import Servant.PureScript.Ajax (AjaxError)
-import Types (HAction(SetGistUrl, LoadGist, PublishGist))
 
 idPublishGist :: forall r i. IProp ( id :: String | r ) i
 idPublishGist = id_ "publish-gist"
 
 idLoadGist :: forall r i. IProp ( id :: String | r ) i
 idLoadGist = id_ "load-gist"
+
+data GistAction
+  = PublishGist
+  | SetGistUrl String
+  | LoadGist
 
 gistControls ::
   forall a p.
@@ -37,7 +42,7 @@ gistControls ::
   , gistUrl :: Maybe String
   | a
   } ->
-  HTML p HAction
+  HTML p GistAction
 gistControls { authStatus, createGistResult, gistUrl } =
   div [ classes [ ClassName "gist-controls" ] ]
     [ authButton

--- a/web-common/src/Halogen/HTML/Extra.purs
+++ b/web-common/src/Halogen/HTML/Extra.purs
@@ -1,0 +1,8 @@
+module Halogen.HTML.Extra (mapComponent) where
+
+import Data.Bifunctor (bimap)
+import Data.Functor (map)
+import Halogen.HTML (ComponentHTML)
+
+mapComponent :: forall m a b slots. (a -> b) -> ComponentHTML a slots m -> ComponentHTML b slots m
+mapComponent f = bimap (map f) f


### PR DESCRIPTION
Both frontend projects depend on web-common, which in turn depends on
some code from that project. If that sounds confusing or bad, it's
because it is, and this commit removes most of that complexity.

This address most - but not all - of #1077.