### PR TITLE
Changing our stylish-haskell options to be diff-safe(r).

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,24 +1,29 @@
----
+# Stylish-haskell configuration file
+#
+# See `stylish-haskell --defaults` or
+# https://github.com/jaspervdj/stylish-haskell/blob/master/data/stylish-haskell.yaml
+# for usage.
+
 steps:
   - simple_align:
-      cases: true
-      top_level_patterns: true
-      records: true
+      cases: false
+      top_level_patterns: false
+      records: false
   - imports:
-      align: global
-      list_align: after_alias
-      pad_module_names: true
-      long_list_align: inline
+      align: none
+      list_align: with_alias
+      pad_module_names: false
+      long_list_align: new_line_multiline
       empty_list_align: inherit
       list_padding: 4
       separate_lists: true
       space_surround: false
   - language_pragmas:
       style: vertical
-      align: true
-      remove_redundant: false
-
+      align: false
+      remove_redundant: true
   - trailing_whitespace: {}
+
 columns: 120
 newline: native
 language_extensions:

--- a/deployment-server/app/Main.hs
+++ b/deployment-server/app/Main.hs
@@ -1,23 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Main where
 
-import           Control.Concurrent       (forkIO)
-import           Control.Concurrent.Chan  (newChan)
-import           Control.Monad            (void)
-import           Control.Newtype.Generics (unpack)
-import           Data.Aeson               (eitherDecodeFileStrict)
-import qualified Data.ByteString.Char8    as BS
-import qualified Data.Text                as Text
-import           Deploy.Server            (app)
-import           Deploy.Types             (Options (..), Secrets (..))
-import           Deploy.Worker            (runWorker)
-import           Network.Wai.Handler.Warp (run)
-import           Options.Generic          (getRecord)
-import           Servant.GitHub.Webhook   (gitHubKey)
-import           System.Exit              (ExitCode (ExitFailure), exitWith)
-import           System.IO                (BufferMode (LineBuffering), hPutStrLn, hSetBuffering, stderr, stdout)
+import Control.Concurrent (forkIO)
+import Control.Concurrent.Chan (newChan)
+import Control.Monad (void)
+import Control.Newtype.Generics (unpack)
+import Data.Aeson (eitherDecodeFileStrict)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.Text as Text
+import Deploy.Server (app)
+import Deploy.Types (Options (..), Secrets (..))
+import Deploy.Worker (runWorker)
+import Network.Wai.Handler.Warp (run)
+import Options.Generic (getRecord)
+import Servant.GitHub.Webhook (gitHubKey)
+import System.Exit (ExitCode (ExitFailure), exitWith)
+import System.IO (BufferMode (LineBuffering), hPutStrLn, hSetBuffering, stderr, stdout)
 
 main :: IO ()
 main = do

--- a/deployment-server/src/Deploy/Server.hs
+++ b/deployment-server/src/Deploy/Server.hs
@@ -1,24 +1,23 @@
-{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Deploy.Server
     ( app
     ) where
 
-import           Control.Concurrent.Chan      (Chan, writeChan)
-import           Control.Monad.IO.Class       (liftIO)
-import           Control.Newtype.Generics     (unpack)
-import           Data.Maybe                   (isJust)
-import           Data.Proxy                   (Proxy (Proxy))
-import           Deploy.Types                 (Ref)
-import           GitHub.Data.Webhooks.Events  (PullRequestEvent (evPullReqPayload))
-import           GitHub.Data.Webhooks.Payload (HookPullRequest (whPullReqBase, whPullReqMergedAt),
-                                               PullRequestTarget (whPullReqTargetRef))
-import           Network.Wai                  (Application)
-import           Servant                      (Context ((:.), EmptyContext), Handler, serveWithContext)
-import           Servant.API                  ((:<|>) ((:<|>)), (:>), Get, JSON, Post)
-import           Servant.GitHub.Webhook       (GitHubEvent, GitHubKey, GitHubSignedReqBody,
-                                               RepoWebhookEvent (WebhookPullRequestEvent))
+import Control.Concurrent.Chan (Chan, writeChan)
+import Control.Monad.IO.Class (liftIO)
+import Control.Newtype.Generics (unpack)
+import Data.Maybe (isJust)
+import Data.Proxy (Proxy (Proxy))
+import Deploy.Types (Ref)
+import GitHub.Data.Webhooks.Events (PullRequestEvent (evPullReqPayload))
+import GitHub.Data.Webhooks.Payload
+    (HookPullRequest (whPullReqBase, whPullReqMergedAt), PullRequestTarget (whPullReqTargetRef))
+import Network.Wai (Application)
+import Servant (Context ((:.), EmptyContext), Handler, serveWithContext)
+import Servant.API ((:<|>) ((:<|>)), (:>), Get, JSON, Post)
+import Servant.GitHub.Webhook (GitHubEvent, GitHubKey, GitHubSignedReqBody, RepoWebhookEvent (WebhookPullRequestEvent))
 
 type Api
      = "github" :> (GitHubEvent '[ 'WebhookPullRequestEvent] :> GitHubSignedReqBody '[ JSON] PullRequestEvent :> Post '[ JSON] ()

--- a/deployment-server/src/Deploy/Types.hs
+++ b/deployment-server/src/Deploy/Types.hs
@@ -1,16 +1,16 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 module Deploy.Types where
 
-import           Control.Newtype.Generics (Newtype, unpack)
-import           Data.Aeson               (FromJSON, parseJSON, withObject, (.:))
-import           Data.Text                (Text)
-import qualified Data.Text                as Text
-import           GHC.Generics             (Generic)
-import           Options.Generic          (ParseField, ParseFields, ParseRecord)
+import Control.Newtype.Generics (Newtype, unpack)
+import Data.Aeson (FromJSON, parseJSON, withObject, (.:))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Generics (Generic)
+import Options.Generic (ParseField, ParseFields, ParseRecord)
 
 newtype WebhookKey = WebhookKey Text
     deriving (Generic, Newtype)

--- a/deployment-server/src/Deploy/Worker.hs
+++ b/deployment-server/src/Deploy/Worker.hs
@@ -1,32 +1,32 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Deploy.Worker where
 
-import           Control.Concurrent.Chan      (Chan, readChan)
-import           Control.Exception            (SomeException, displayException, handle)
-import           Control.Monad                (forever, void)
-import           Control.Monad.Except         (ExceptT (ExceptT), MonadError, runExceptT, throwError)
-import           Control.Monad.IO.Class       (MonadIO, liftIO)
-import           Control.Newtype.Generics     (unpack)
-import qualified Data.ByteString.Char8        as BS
-import qualified Data.ByteString.Lazy.Char8   as LBS
-import           Data.Char                    (isSpace)
-import           Data.List                    (dropWhileEnd, isSuffixOf)
-import           Data.Text                    (Text)
-import qualified Data.Text                    as Text
-import           Deploy.Types                 (Options (Options, configDir, deploymentName, environment, githubToken, include, stateFile))
+import Control.Concurrent.Chan (Chan, readChan)
+import Control.Exception (SomeException, displayException, handle)
+import Control.Monad (forever, void)
+import Control.Monad.Except (ExceptT (ExceptT), MonadError, runExceptT, throwError)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Newtype.Generics (unpack)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.Char (isSpace)
+import Data.List (dropWhileEnd, isSuffixOf)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Deploy.Types (Options (Options, configDir, deploymentName, environment, githubToken, include, stateFile))
 import qualified GitHub
-import           GitHub.Data.Webhooks.Events  (PullRequestEvent (evPullReqPayload))
-import           GitHub.Data.Webhooks.Payload (HookPullRequest (whPullReqBase), PullRequestTarget (whPullReqTargetRef))
-import           System.Directory             (listDirectory)
-import           System.Exit                  (ExitCode (ExitFailure, ExitSuccess))
-import           System.IO.Temp               (withSystemTempDirectory)
-import           System.Process.Typed         (proc, readProcess, setWorkingDir)
+import GitHub.Data.Webhooks.Events (PullRequestEvent (evPullReqPayload))
+import GitHub.Data.Webhooks.Payload (HookPullRequest (whPullReqBase), PullRequestTarget (whPullReqTargetRef))
+import System.Directory (listDirectory)
+import System.Exit (ExitCode (ExitFailure, ExitSuccess))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process.Typed (proc, readProcess, setWorkingDir)
 
 data DeploymentError
     = CommandError Text

--- a/docs/fomega/app/Main.hs
+++ b/docs/fomega/app/Main.hs
@@ -1,4 +1,4 @@
-import           Examples
+import Examples
 
 main :: IO ()
 main = do

--- a/docs/fomega/cek-cps-experiments/src/CekMachine.cps.hs
+++ b/docs/fomega/cek-cps-experiments/src/CekMachine.cps.hs
@@ -23,19 +23,19 @@ module Language.PlutusCore.Interpreter.CekMachine
     , runCek
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Evaluation.MachineException (MachineError (..), MachineException (..))
-import           Language.PlutusCore.Evaluation.Result           (EvaluationResult (..))
-import           Language.PlutusCore.View
-import           PlutusPrelude
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Evaluation.MachineException (MachineError (..), MachineException (..))
+import Language.PlutusCore.Evaluation.Result (EvaluationResult (..))
+import Language.PlutusCore.View
+import PlutusPrelude
 
-import qualified Data.Text                                       as T
-import qualified Data.Text.IO                                    as T
-import qualified Language.PlutusCore.Pretty                      as PLC
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Language.PlutusCore.Pretty as PLC
 
-import           Data.IntMap                                     (IntMap)
-import qualified Data.IntMap                                     as IntMap
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap
 
 termStr :: Plain Term -> String
 termStr = T.unpack . PLC.prettyPlcDefText

--- a/docs/fomega/cek-cps-experiments/src/CekMachine.original.hs
+++ b/docs/fomega/cek-cps-experiments/src/CekMachine.original.hs
@@ -15,15 +15,15 @@ module Language.PlutusCore.Interpreter.CekMachine
     , runCek
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Evaluation.MachineException (MachineError (..), MachineException (..))
-import           Language.PlutusCore.Evaluation.Result           (EvaluationResult (..))
-import           Language.PlutusCore.View
-import           PlutusPrelude
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Evaluation.MachineException (MachineError (..), MachineException (..))
+import Language.PlutusCore.Evaluation.Result (EvaluationResult (..))
+import Language.PlutusCore.View
+import PlutusPrelude
 
-import           Data.IntMap                                     (IntMap)
-import qualified Data.IntMap                                     as IntMap
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap
 
 type Plain f = f TyName Name ()
 

--- a/docs/fomega/cek-cps-experiments/src/CekMachine.recursive.hs
+++ b/docs/fomega/cek-cps-experiments/src/CekMachine.recursive.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- This file contains a version of the CEK machine in
@@ -26,18 +26,18 @@ module Language.PlutusCore.Interpreter.CekMachine
     , runCek
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Evaluation.MachineException (MachineError (..), MachineException (..))
-import           Language.PlutusCore.Evaluation.Result           (EvaluationResult (..))
-import           Language.PlutusCore.View
-import           PlutusPrelude
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Evaluation.MachineException (MachineError (..), MachineException (..))
+import Language.PlutusCore.Evaluation.Result (EvaluationResult (..))
+import Language.PlutusCore.View
+import PlutusPrelude
 
-import qualified Data.Text                                       as T
-import qualified Language.PlutusCore.Pretty                      as PLC
+import qualified Data.Text as T
+import qualified Language.PlutusCore.Pretty as PLC
 
-import           Data.IntMap                                     (IntMap)
-import qualified Data.IntMap                                     as IntMap
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap
 
 termStr :: Plain Term -> String
 termStr = T.unpack . PLC.prettyPlcDefText

--- a/docs/fomega/cek-cps-experiments/src/LMachine.hs
+++ b/docs/fomega/cek-cps-experiments/src/LMachine.hs
@@ -39,15 +39,15 @@ module Language.PlutusCore.Interpreter.LMachine
     , runL
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Evaluation.MachineException
-import           Language.PlutusCore.View
-import           PlutusPrelude
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Evaluation.MachineException
+import Language.PlutusCore.View
+import PlutusPrelude
 
-import           Control.Monad.Identity
-import           Data.IntMap                                     (IntMap)
-import qualified Data.IntMap                                     as IntMap
+import Control.Monad.Identity
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap
 
 type Plain f = f TyName Name ()
 

--- a/docs/fomega/cek-cps-experiments/src/Make.hs
+++ b/docs/fomega/cek-cps-experiments/src/Make.hs
@@ -13,16 +13,16 @@ module Language.PlutusCore.Constant.Make
     , unsafeMakeBuiltin
     ) where
 
-import           Language.PlutusCore.Constant.Typed
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.StdLib.Data.Bool
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Constant.Typed
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.StdLib.Data.Bool
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Data.Bits                            (bit)
-import qualified Data.ByteString.Lazy                 as BSL
-import           Data.Maybe
+import Data.Bits (bit)
+import qualified Data.ByteString.Lazy as BSL
+import Data.Maybe
 
 -- | Return the @[-2^(8s - 1), 2^(8s - 1))@ bounds for integers of a given 'Size'.
 toBoundsInt :: Size -> (Integer, Integer)

--- a/docs/fomega/scott-encoding-benchmarks/Benchmarks.hs
+++ b/docs/fomega/scott-encoding-benchmarks/Benchmarks.hs
@@ -2,10 +2,10 @@
 
 module Main where
 
-import           Criterion.Main
-import           Criterion.Main.Options
-import           Criterion.Types
-import           Test.QuickCheck
+import Criterion.Main
+import Criterion.Main.Options
+import Criterion.Types
+import Test.QuickCheck
 
 --------------------
 -- Scott Encoding --

--- a/docs/fomega/src/AlgTypes.hs
+++ b/docs/fomega/src/AlgTypes.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE GADTs           #-}
-{-# LANGUAGE QuasiQuotes     #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module AlgTypes where
 
-import qualified Data.Set      as S
-import           Language.LBNF
+import qualified Data.Set as S
+import Language.LBNF
 
 -------------------------------------
 -- Parser for Algebraic Data Types --

--- a/docs/fomega/src/Examples.hs
+++ b/docs/fomega/src/Examples.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE GADTs       #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE QuasiQuotes #-}
 module Examples where
 
-import           AlgTypes
-import           Large
-import           Scott
-import           Solver
+import AlgTypes
+import Large
+import Scott
+import Solver
 
-import           Control.Applicative
-import           Control.Monad
-import           System.IO
-import           System.Random
-import           Test.QuickCheck
+import Control.Applicative
+import Control.Monad
+import System.IO
+import System.Random
+import Test.QuickCheck
 
 -- (use the runExample :: AlgSignature -> IO () from AlgTypes)
 

--- a/docs/fomega/src/Large.hs
+++ b/docs/fomega/src/Large.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE QuasiQuotes     #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Large (alfaSig,bnfcSig,javaSig) where
 
-import           AlgTypes
+import AlgTypes
 
 list = [declExp| list = all a.(1 + (a * (list a))) |]
 

--- a/docs/fomega/src/Scott.hs
+++ b/docs/fomega/src/Scott.hs
@@ -1,8 +1,8 @@
 module Scott where
 
-import           AlgTypes
+import AlgTypes
 import qualified Data.Set as S
-import           SystemF
+import SystemF
 
 -- note that "#R" is not a valid bnfc Ident(ifier), and as such it won't
 -- be the name of any variable output by the parser.

--- a/docs/fomega/src/Solver.hs
+++ b/docs/fomega/src/Solver.hs
@@ -1,6 +1,6 @@
 module Solver where
 
-import           AlgTypes
+import AlgTypes
 import qualified Data.Set as S
 
 -----------------------------------------------------

--- a/docs/fomega/z-combinator-benchmarks/Benchmarks.hs
+++ b/docs/fomega/z-combinator-benchmarks/Benchmarks.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RankNTypes      #-}
+{-# LANGUAGE RankNTypes #-}
 module Main where
 
-import           Criterion.Main
-import           Criterion.Main.Options
-import           Criterion.Types
+import Criterion.Main
+import Criterion.Main.Options
+import Criterion.Types
 
 fix' :: ((a -> b) -> a -> b) -> a -> b
 fix' f x = (f $! fix' f) $! x

--- a/docs/model/UTxO.hsproj/Examples/Keys.hs
+++ b/docs/model/UTxO.hsproj/Examples/Keys.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE PackageImports  #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Examples.Keys
 where
 
-import           "cryptonite" Crypto.PubKey.ECC.ECDSA
-import           Crypto.PubKey.ECC.Generate
-import           Crypto.PubKey.ECC.Types
-import           "cryptonite" Crypto.Random
+import "cryptonite" Crypto.PubKey.ECC.ECDSA
+import Crypto.PubKey.ECC.Generate
+import Crypto.PubKey.ECC.Types
+import "cryptonite" Crypto.Random
 
-import           Data.Map                             (Map)
-import qualified Data.Map                             as Map
-import           Data.Set                             (Set)
-import qualified Data.Set                             as Set
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
 
 
 myKeyPair1 :: KeyPair

--- a/docs/model/UTxO.hsproj/Examples/PubKey.hs
+++ b/docs/model/UTxO.hsproj/Examples/PubKey.hs
@@ -1,25 +1,25 @@
-{-# LANGUAGE PackageImports  #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Examples.PubKey
 where
 
-import           "cryptonite" Crypto.PubKey.ECC.ECDSA
-import           Crypto.PubKey.ECC.Generate
-import           Crypto.PubKey.ECC.Types
-import           "cryptonite" Crypto.Random
+import "cryptonite" Crypto.PubKey.ECC.ECDSA
+import Crypto.PubKey.ECC.Generate
+import Crypto.PubKey.ECC.Types
+import "cryptonite" Crypto.Random
 
-import           Data.Map                             (Map)
-import qualified Data.Map                             as Map
-import           Data.Set                             (Set)
-import qualified Data.Set                             as Set
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
 
 
-import           Examples.Keys
-import           Examples.PubKeyHashes
-import           Ledger
-import           UTxO
-import           Witness
+import Examples.Keys
+import Examples.PubKeyHashes
+import Ledger
+import UTxO
+import Witness
 
 
 pubKeyLedger = [t2, t1]

--- a/docs/model/UTxO.hsproj/Examples/PubKeyHashes.hs
+++ b/docs/model/UTxO.hsproj/Examples/PubKeyHashes.hs
@@ -1,23 +1,23 @@
-{-# LANGUAGE PackageImports  #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Examples.PubKeyHashes
 where
 
-import           "cryptonite" Crypto.PubKey.ECC.ECDSA
-import           Crypto.PubKey.ECC.Generate
-import           Crypto.PubKey.ECC.Types
-import           "cryptonite" Crypto.Random
+import "cryptonite" Crypto.PubKey.ECC.ECDSA
+import Crypto.PubKey.ECC.Generate
+import Crypto.PubKey.ECC.Types
+import "cryptonite" Crypto.Random
 
-import           Data.Map                             (Map)
-import qualified Data.Map                             as Map
-import           Data.Set                             (Set)
-import qualified Data.Set                             as Set
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
 
-import           Examples.Keys
-import           Ledger
-import           UTxO
-import           Witness
+import Examples.Keys
+import Ledger
+import UTxO
+import Witness
 
 
 -- Template Haskell splices can't use local definitions, but only imported ones (stage restriction);

--- a/docs/model/UTxO.hsproj/Ledger.hs
+++ b/docs/model/UTxO.hsproj/Ledger.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE PackageImports  #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Ledger (
@@ -10,14 +10,14 @@ module Ledger (
   hashTx, preHashTx, validValuesTx, state
 ) where
 
-import           "cryptonite" Crypto.Hash
-import qualified Data.ByteArray           as BA
-import qualified Data.ByteString.Char8    as BS
-import           Data.Set                 (Set)
-import qualified Data.Set                 as Set
+import "cryptonite" Crypto.Hash
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString.Char8 as BS
+import Data.Set (Set)
+import qualified Data.Set as Set
 
-import           Types
-import           Witness
+import Types
+import Witness
 
 
 -- Ledger and transaction types

--- a/docs/model/UTxO.hsproj/Types.hs
+++ b/docs/model/UTxO.hsproj/Types.hs
@@ -13,7 +13,7 @@
 module Types
 where
 
-import           "cryptonite" Crypto.Hash
+import "cryptonite" Crypto.Hash
 
 
 -- Basic types

--- a/docs/model/UTxO.hsproj/UTxO.hs
+++ b/docs/model/UTxO.hsproj/UTxO.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE BangPatterns    #-}
-{-# LANGUAGE PackageImports  #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 -- This code models a UTxO-style ledger using the approach from
@@ -22,17 +22,17 @@
 module UTxO
 where
 
-import           "cryptonite" Crypto.Hash
-import           Data.List
-import           Data.Map                 (Map)
-import qualified Data.Map                 as Map
-import           Data.Maybe
-import           Data.Set                 (Set)
-import qualified Data.Set                 as Set
+import "cryptonite" Crypto.Hash
+import Data.List
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe
+import Data.Set (Set)
+import qualified Data.Set as Set
 
-import           Ledger
-import           Types
-import           Witness
+import Ledger
+import Types
+import Witness
 
 
 -- |Determine the transaction that an input refers to.

--- a/example/app/Main.hs
+++ b/example/app/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import           Lib
+import Lib
 
 main :: IO ()
 main = someFunc

--- a/example/src/Lib.hs
+++ b/example/src/Lib.hs
@@ -2,7 +2,7 @@ module Lib
     ( someFunc
     ) where
 
-import           Language.PlutusCore
+import Language.PlutusCore
 
 someFunc :: IO ()
 someFunc = putStrLn "someFunc"

--- a/iots-export/src/IOTS.hs
+++ b/iots-export/src/IOTS.hs
@@ -1,16 +1,16 @@
-{-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DefaultSignatures    #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE RecordWildCards      #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module IOTS
@@ -22,27 +22,43 @@ module IOTS
   , Tagged(Tagged)
   ) where
 
-import           Control.Monad.State          (State, evalState, foldM, gets, modify)
-import           Data.Foldable                (fold, toList)
-import           Data.Kind                    (Type)
-import           Data.Map                     (Map)
-import           Data.Proxy                   (Proxy (Proxy))
-import           Data.Sequence                (Seq, (|>))
-import           Data.Set                     (Set)
-import qualified Data.Set                     as Set
-import           Data.Text                    (Text)
-import qualified Data.Text                    as Text
-import           Data.Tree                    (Forest, Tree (Node), rootLabel)
-import           GHC.Generics                 ((:*:) ((:*:)), (:+:), C1, Constructor, D1, Datatype, Generic, M1 (M1),
-                                               Rec0, Rep, S1, Selector, U1, conIsRecord, conName, selName)
-import qualified GHC.Generics                 as Generics
-import           GHC.TypeLits                 (KnownSymbol, symbolVal)
-import           IOTS.Leijen                  (jsArray, jsObject, jsParams, render, stringDoc, symbol, upperFirst)
-import           IOTS.Tree                    (depthfirstM)
-import           Text.PrettyPrint.Leijen.Text (Doc, angles, braces, comma, dquotes, hsep, linebreak, parens, punctuate,
-                                               semi, squotes, textStrict, vsep, (<+>))
-import           Type.Reflection              (SomeTypeRep (SomeTypeRep), Typeable, someTypeRep)
-import qualified Type.Reflection              as R
+import Control.Monad.State (State, evalState, foldM, gets, modify)
+import Data.Foldable (fold, toList)
+import Data.Kind (Type)
+import Data.Map (Map)
+import Data.Proxy (Proxy (Proxy))
+import Data.Sequence (Seq, (|>))
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Tree (Forest, Tree (Node), rootLabel)
+import GHC.Generics
+    ( (:*:) ((:*:))
+    , (:+:)
+    , C1
+    , Constructor
+    , D1
+    , Datatype
+    , Generic
+    , M1 (M1)
+    , Rec0
+    , Rep
+    , S1
+    , Selector
+    , U1
+    , conIsRecord
+    , conName
+    , selName
+    )
+import qualified GHC.Generics as Generics
+import GHC.TypeLits (KnownSymbol, symbolVal)
+import IOTS.Leijen (jsArray, jsObject, jsParams, render, stringDoc, symbol, upperFirst)
+import IOTS.Tree (depthfirstM)
+import Text.PrettyPrint.Leijen.Text
+    (Doc, angles, braces, comma, dquotes, hsep, linebreak, parens, punctuate, semi, squotes, textStrict, vsep, (<+>))
+import Type.Reflection (SomeTypeRep (SomeTypeRep), Typeable, someTypeRep)
+import qualified Type.Reflection as R
 
 {-# ANN module ("HLint: ignore Avoid restricted function" :: Text)
         #-}

--- a/iots-export/src/IOTS/Leijen.hs
+++ b/iots-export/src/IOTS/Leijen.hs
@@ -1,16 +1,28 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 
 module IOTS.Leijen where
 
-import           Data.Proxy                   (Proxy (Proxy))
-import           Data.Text                    (Text)
-import qualified Data.Text                    as Text
-import           GHC.TypeLits                 (KnownSymbol, symbolVal)
-import           Text.PrettyPrint.Leijen.Text (Doc, braces, brackets, comma, displayTStrict, indent, linebreak, parens,
-                                               punctuate, renderPretty, textStrict, vsep)
+import Data.Proxy (Proxy (Proxy))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.TypeLits (KnownSymbol, symbolVal)
+import Text.PrettyPrint.Leijen.Text
+    ( Doc
+    , braces
+    , brackets
+    , comma
+    , displayTStrict
+    , indent
+    , linebreak
+    , parens
+    , punctuate
+    , renderPretty
+    , textStrict
+    , vsep
+    )
 
 -- | `Doc` to `Text` with reasonable defaults for pretty printing.
 render :: Doc -> Text

--- a/iots-export/src/IOTS/Tree.hs
+++ b/iots-export/src/IOTS/Tree.hs
@@ -1,8 +1,8 @@
 module IOTS.Tree where
 
-import           Control.Monad.Fix (fix)
-import           Data.Foldable     (foldlM)
-import           Data.Tree         (Tree (Node))
+import Control.Monad.Fix (fix)
+import Data.Foldable (foldlM)
+import Data.Tree (Tree (Node))
 
 depthfirstM :: Monad m => (b -> a -> m b) -> b -> Tree a -> m b
 depthfirstM f =

--- a/iots-export/test/IOTSSpec.hs
+++ b/iots-export/test/IOTSSpec.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE DeriveAnyClass   #-}
-{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeApplications #-}
 
 module IOTSSpec where
 
-import           Data.ByteString.Lazy (ByteString, fromStrict)
-import           Data.Map             (Map)
-import           Data.Proxy           (Proxy (Proxy))
-import           Data.Text            (Text)
-import           Data.Text.Encoding   (encodeUtf8)
-import           GHC.Generics         (Generic)
-import           IOTS                 (HList (HCons, HNil), IotsExportable, IotsType, Tagged (Tagged), export)
-import           Test.Tasty           (TestTree, testGroup)
-import           Test.Tasty.Golden    (goldenVsString)
+import Data.ByteString.Lazy (ByteString, fromStrict)
+import Data.Map (Map)
+import Data.Proxy (Proxy (Proxy))
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8)
+import GHC.Generics (Generic)
+import IOTS (HList (HCons, HNil), IotsExportable, IotsType, Tagged (Tagged), export)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Golden (goldenVsString)
 
 tests :: TestTree
 tests =

--- a/iots-export/test/Spec.hs
+++ b/iots-export/test/Spec.hs
@@ -3,7 +3,7 @@ module Main
     ) where
 
 import qualified IOTSSpec
-import           Test.Tasty (defaultMain, testGroup)
+import Test.Tasty (defaultMain, testGroup)
 
 main :: IO ()
 main = defaultMain $ testGroup "all tests" [IOTSSpec.tests]

--- a/language-plutus-core/bench/Bench.hs
+++ b/language-plutus-core/bench/Bench.hs
@@ -2,16 +2,16 @@
 
 module Main (main) where
 
-import           Codec.Serialise
-import           Control.Monad
-import           Criterion.Main
-import           Crypto
-import qualified Data.ByteString.Lazy                     as BSL
-import           Language.PlutusCore
-import qualified Language.PlutusCore.Check.Normal         as Normal
-import           Language.PlutusCore.Constant.Dynamic
-import           Language.PlutusCore.Evaluation.CkMachine (runCk)
-import           Language.PlutusCore.Pretty
+import Codec.Serialise
+import Control.Monad
+import Criterion.Main
+import Crypto
+import qualified Data.ByteString.Lazy as BSL
+import Language.PlutusCore
+import qualified Language.PlutusCore.Check.Normal as Normal
+import Language.PlutusCore.Constant.Dynamic
+import Language.PlutusCore.Evaluation.CkMachine (runCk)
+import Language.PlutusCore.Pretty
 
 
 pubKey, sig, msg :: BSL.ByteString

--- a/language-plutus-core/common/Common.hs
+++ b/language-plutus-core/common/Common.hs
@@ -13,16 +13,16 @@ module Common
     , nestedGoldenVsDocM
     ) where
 
-import           Language.PlutusCore.Pretty
+import Language.PlutusCore.Pretty
 
-import           Control.Monad.Reader       (Reader, runReader)
-import qualified Control.Monad.Reader       as Reader
-import qualified Data.ByteString.Lazy       as BSL
-import           Data.Text                  (Text)
-import           Data.Text.Encoding         (encodeUtf8)
-import           System.FilePath            ((</>))
-import           Test.Tasty
-import           Test.Tasty.Golden
+import Control.Monad.Reader (Reader, runReader)
+import qualified Control.Monad.Reader as Reader
+import qualified Data.ByteString.Lazy as BSL
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8)
+import System.FilePath ((</>))
+import Test.Tasty
+import Test.Tasty.Golden
 
 -- | A 'TestTree' of tests under some name prefix.
 type TestNested = Reader [String] TestTree

--- a/language-plutus-core/common/PlcTestUtils.hs
+++ b/language-plutus-core/common/PlcTestUtils.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeApplications #-}
 module PlcTestUtils (
     GetProgram(..),
     catchAll,
@@ -12,17 +12,17 @@ module PlcTestUtils (
     goldenEval,
     goldenEvalCatch) where
 
-import           Common
+import Common
 
-import           Language.PlutusCore
-import           Language.PlutusCore.DeBruijn
-import           Language.PlutusCore.Evaluation.CkMachine
-import           Language.PlutusCore.Pretty
+import Language.PlutusCore
+import Language.PlutusCore.DeBruijn
+import Language.PlutusCore.Evaluation.CkMachine
+import Language.PlutusCore.Pretty
 
-import           Control.Exception
-import           Control.Monad.Except
+import Control.Exception
+import Control.Monad.Except
 
-import qualified Data.Text.Prettyprint.Doc                as PP
+import qualified Data.Text.Prettyprint.Doc as PP
 
 -- | Class for ad-hoc overloading of things which can be turned into a PLC program. Any errors
 -- from the process should be caught.

--- a/language-plutus-core/examples/Language/PlutusCore/Examples/Data/InterList.hs
+++ b/language-plutus-core/examples/Language/PlutusCore/Examples/Data/InterList.hs
@@ -7,14 +7,14 @@ module Language.PlutusCore.Examples.Data.InterList
     , foldrInterList
     ) where
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
-import           Language.PlutusCore.StdLib.Data.Function
-import           Language.PlutusCore.StdLib.Data.Unit
-import           Language.PlutusCore.StdLib.Type
+import Language.PlutusCore.StdLib.Data.Function
+import Language.PlutusCore.StdLib.Data.Unit
+import Language.PlutusCore.StdLib.Type
 
 {- Note [InterList]
 We encode the following in this module:

--- a/language-plutus-core/examples/Language/PlutusCore/Examples/Data/TreeForest.hs
+++ b/language-plutus-core/examples/Language/PlutusCore/Examples/Data/TreeForest.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Language.PlutusCore.Examples.Data.TreeForest
     ( treeData
@@ -11,13 +11,13 @@ module Language.PlutusCore.Examples.Data.TreeForest
     , forestCons
     ) where
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Normalize
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Normalize
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
-import           Language.PlutusCore.StdLib.Type
+import Language.PlutusCore.StdLib.Type
 
 {- Note [Tree]
 Here we encode the following:

--- a/language-plutus-core/examples/Language/PlutusCore/Examples/Everything.hs
+++ b/language-plutus-core/examples/Language/PlutusCore/Examples/Everything.hs
@@ -10,12 +10,12 @@ module Language.PlutusCore.Examples.Everything
     ( examples
     ) where
 
-import           Language.PlutusCore.FsTree
+import Language.PlutusCore.FsTree
 
-import           Language.PlutusCore.StdLib.Type
+import Language.PlutusCore.StdLib.Type
 
-import           Language.PlutusCore.Examples.Data.InterList
-import           Language.PlutusCore.Examples.Data.TreeForest
+import Language.PlutusCore.Examples.Data.InterList
+import Language.PlutusCore.Examples.Data.TreeForest
 
 -- | All examples exported as a single value.
 examples :: PlcFolderContents

--- a/language-plutus-core/generate-evaluation-test/Main.hs
+++ b/language-plutus-core/generate-evaluation-test/Main.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Generators
-import           Language.PlutusCore.Pretty
+import Language.PlutusCore
+import Language.PlutusCore.Generators
+import Language.PlutusCore.Pretty
 
-import           Data.Foldable
-import           Data.Text                      (Text)
-import qualified Data.Text                      as Text
-import qualified Data.Text.IO                   as Text
-import qualified Hedgehog.Gen                   as Gen
+import Data.Foldable
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import qualified Hedgehog.Gen as Gen
 
 -- | Generate a test sample: a term of arbitrary type and what it computes to.
 -- Uses 'genTermLoose' under the hood.

--- a/language-plutus-core/generators/Language/PlutusCore/Generators.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators.hs
@@ -4,9 +4,9 @@ module Language.PlutusCore.Generators
     ( module Export
     ) where
 
-import           Language.PlutusCore.Generators.Internal.Denotation      as Export
-import           Language.PlutusCore.Generators.Internal.Dependent       as Export
-import           Language.PlutusCore.Generators.Internal.Entity          as Export
-import           Language.PlutusCore.Generators.Internal.TypedBuiltinGen as Export
-import           Language.PlutusCore.Generators.Internal.TypeEvalCheck   as Export
-import           Language.PlutusCore.Generators.Internal.Utils           as Export
+import Language.PlutusCore.Generators.Internal.Denotation as Export
+import Language.PlutusCore.Generators.Internal.Dependent as Export
+import Language.PlutusCore.Generators.Internal.Entity as Export
+import Language.PlutusCore.Generators.Internal.TypedBuiltinGen as Export
+import Language.PlutusCore.Generators.Internal.TypeEvalCheck as Export
+import Language.PlutusCore.Generators.Internal.Utils as Export

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/AST.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/AST.hs
@@ -16,20 +16,20 @@ module Language.PlutusCore.Generators.AST
     , mangleNames
     ) where
 
-import           PlutusPrelude
+import PlutusPrelude
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Subst
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Subst
 
-import           Control.Monad.Morph          (hoist)
-import           Control.Monad.Reader
-import qualified Data.ByteString.Lazy         as BSL
-import           Data.Set                     (Set)
-import qualified Data.Set                     as Set
-import           Hedgehog                     hiding (Size, Var)
-import qualified Hedgehog.Internal.Gen        as Gen
-import qualified Hedgehog.Range               as Range
+import Control.Monad.Morph (hoist)
+import Control.Monad.Reader
+import qualified Data.ByteString.Lazy as BSL
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Hedgehog hiding (Size, Var)
+import qualified Hedgehog.Internal.Gen as Gen
+import qualified Hedgehog.Range as Range
 
 simpleRecursive :: MonadGen m => [m a] -> [m a] -> m a
 simpleRecursive = Gen.recursive Gen.choice

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Interesting.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Interesting.hs
@@ -1,8 +1,8 @@
 -- | Sample generators used for tests.
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes        #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Language.PlutusCore.Generators.Interesting
     ( TermGen
@@ -17,27 +17,27 @@ module Language.PlutusCore.Generators.Interesting
     , fromInterestingTermGens
     ) where
 
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Evaluation.Result
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Evaluation.Result
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
-import           Language.PlutusCore.StdLib.Data.Bool
-import           Language.PlutusCore.StdLib.Data.Function as Function
-import           Language.PlutusCore.StdLib.Data.List     as List
-import           Language.PlutusCore.StdLib.Data.Nat
-import           Language.PlutusCore.StdLib.Data.Unit
-import           Language.PlutusCore.StdLib.Meta
-import           Language.PlutusCore.StdLib.Type
+import Language.PlutusCore.StdLib.Data.Bool
+import Language.PlutusCore.StdLib.Data.Function as Function
+import Language.PlutusCore.StdLib.Data.List as List
+import Language.PlutusCore.StdLib.Data.Nat
+import Language.PlutusCore.StdLib.Data.Unit
+import Language.PlutusCore.StdLib.Meta
+import Language.PlutusCore.StdLib.Type
 
-import           Language.PlutusCore.Generators
+import Language.PlutusCore.Generators
 
-import           Data.List                                (genericIndex)
-import           Hedgehog                                 hiding (Size, Var)
-import qualified Hedgehog.Gen                             as Gen
-import qualified Hedgehog.Range                           as Range
+import Data.List (genericIndex)
+import Hedgehog hiding (Size, Var)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
 -- | The type of terms-and-their-values generators.
 type TermGen a = Gen (TermOf a)

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Denotation.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Denotation.hs
@@ -2,7 +2,7 @@
 -- Haskell values.
 
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE GADTs #-}
 
 module Language.PlutusCore.Generators.Internal.Denotation
     ( Denotation(..)
@@ -15,18 +15,18 @@ module Language.PlutusCore.Generators.Internal.Denotation
     , typedBuiltinNames
     ) where
 
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
 
-import           Language.PlutusCore.Generators.Internal.Dependent
+import Language.PlutusCore.Generators.Internal.Dependent
 
-import qualified Data.ByteString.Lazy                              as BSL
-import qualified Data.ByteString.Lazy.Hash                         as Hash
-import           Data.Dependent.Map                                (DMap)
-import qualified Data.Dependent.Map                                as DMap
-import           Data.Functor.Compose
-import           Data.Proxy
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Lazy.Hash as Hash
+import Data.Dependent.Map (DMap)
+import qualified Data.Dependent.Map as DMap
+import Data.Functor.Compose
+import Data.Proxy
 
 -- | Haskell denotation of a PLC object. An object can be a 'BuiltinName' or a variable for example.
 data Denotation object r = forall a. Denotation

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Dependent.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Dependent.hs
@@ -11,12 +11,12 @@ module Language.PlutusCore.Generators.Internal.Dependent
     , proxyAsKnownType
     ) where
 
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Pretty
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Pretty
 
-import           Control.Monad
-import           Data.GADT.Compare
-import           Unsafe.Coerce
+import Control.Monad
+import Data.GADT.Compare
+import Unsafe.Coerce
 
 liftOrdering :: Ordering -> GOrdering a b
 liftOrdering LT = GLT

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Entity.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Entity.hs
@@ -1,13 +1,13 @@
 -- | Generators of various PLC things: 'Builtin's, 'IterApp's, 'Term's, etc.
 
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE TupleSections         #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Language.PlutusCore.Generators.Internal.Entity
     ( PlcGenT
@@ -21,29 +21,29 @@ module Language.PlutusCore.Generators.Internal.Entity
     , withAnyTermLoose
     ) where
 
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Evaluation.Result
-import           Language.PlutusCore.Generators.Internal.Denotation
-import           Language.PlutusCore.Generators.Internal.Dependent
-import           Language.PlutusCore.Generators.Internal.TypedBuiltinGen
-import           Language.PlutusCore.Generators.Internal.TypeEvalCheck
-import           Language.PlutusCore.Generators.Internal.Utils
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
-import           Language.PlutusCore.View
-import           PlutusPrelude
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Evaluation.Result
+import Language.PlutusCore.Generators.Internal.Denotation
+import Language.PlutusCore.Generators.Internal.Dependent
+import Language.PlutusCore.Generators.Internal.TypedBuiltinGen
+import Language.PlutusCore.Generators.Internal.TypeEvalCheck
+import Language.PlutusCore.Generators.Internal.Utils
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
+import Language.PlutusCore.View
+import PlutusPrelude
 
-import qualified Control.Monad.Morph                                     as Morph
-import           Control.Monad.Reader
-import           Control.Monad.Trans.Class                               (lift)
-import qualified Data.ByteString.Lazy                                    as BSL
-import qualified Data.Dependent.Map                                      as DMap
-import           Data.Functor.Compose
-import           Data.Proxy
-import           Data.Text.Prettyprint.Doc
-import           Hedgehog                                                hiding (Size, Var)
-import qualified Hedgehog.Gen                                            as Gen
+import qualified Control.Monad.Morph as Morph
+import Control.Monad.Reader
+import Control.Monad.Trans.Class (lift)
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Dependent.Map as DMap
+import Data.Functor.Compose
+import Data.Proxy
+import Data.Text.Prettyprint.Doc
+import Hedgehog hiding (Size, Var)
+import qualified Hedgehog.Gen as Gen
 
 -- | Generators of built-ins supplied to computations that run in the 'PlcGenT' monad.
 newtype BuiltinGensT m = BuiltinGensT

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
@@ -1,11 +1,11 @@
 -- | This module defines types and functions related to "type-eval checking".
 
-{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE OverloadedStrings      #-}
-{-# LANGUAGE TemplateHaskell        #-}
-{-# LANGUAGE TypeFamilies           #-}
-{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Language.PlutusCore.Generators.Internal.TypeEvalCheck
     ( TypeEvalCheckError (..)
@@ -15,21 +15,21 @@ module Language.PlutusCore.Generators.Internal.TypeEvalCheck
     , unsafeTypeEvalCheck
     ) where
 
-import qualified Language.PlutusCore.Check.Value                         as VR
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Error
-import           Language.PlutusCore.Evaluation.CkMachine
-import           Language.PlutusCore.Generators.Internal.TypedBuiltinGen
-import           Language.PlutusCore.Generators.Internal.Utils
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
-import           Language.PlutusCore.TypeCheck
-import           PlutusPrelude
+import qualified Language.PlutusCore.Check.Value as VR
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Error
+import Language.PlutusCore.Evaluation.CkMachine
+import Language.PlutusCore.Generators.Internal.TypedBuiltinGen
+import Language.PlutusCore.Generators.Internal.Utils
+import Language.PlutusCore.Name
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
+import Language.PlutusCore.TypeCheck
+import PlutusPrelude
 
-import           Control.Lens.TH
-import           Control.Monad.Except
+import Control.Lens.TH
+import Control.Monad.Except
 
 {- Note [Type-eval checking]
 We generate terms along with values they are supposed to evaluate to. Before evaluating a term,

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypedBuiltinGen.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypedBuiltinGen.hs
@@ -1,12 +1,12 @@
 -- | This module defines the 'TypedBuiltinGen' type and functions of this type.
 
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Language.PlutusCore.Generators.Internal.TypedBuiltinGen
     ( TermOf(..)
@@ -18,19 +18,19 @@ module Language.PlutusCore.Generators.Internal.TypedBuiltinGen
     , genTypedBuiltinDivide
     ) where
 
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Language.PlutusCore.Generators.Internal.Dependent
+import Language.PlutusCore.Generators.Internal.Dependent
 
-import qualified Data.ByteString.Lazy                              as BSL
-import           Data.Functor.Identity
-import           Data.GADT.Compare
-import           Hedgehog                                          hiding (Size, Var)
-import qualified Hedgehog.Gen                                      as Gen
-import qualified Hedgehog.Range                                    as Range
+import qualified Data.ByteString.Lazy as BSL
+import Data.Functor.Identity
+import Data.GADT.Compare
+import Hedgehog hiding (Size, Var)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
 -- | Generate a UTF-8 lazy 'ByteString' containg lower-case letters.
 genLowerBytes :: Monad m => Range Int -> GenT m BSL.ByteString

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Utils.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Utils.hs
@@ -1,6 +1,6 @@
 -- | Utilities used in modules from the @TestSupport@ folder.
 
-{-# LANGUAGE GADTs      #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Language.PlutusCore.Generators.Internal.Utils
@@ -17,14 +17,14 @@ module Language.PlutusCore.Generators.Internal.Utils
     , prettyPlcErrorString
     ) where
 
-import           Language.PlutusCore.Pretty
+import Language.PlutusCore.Pretty
 
-import           Control.Monad.Morph
-import           Control.Monad.Reader
-import           Data.Functor.Identity
-import           Hedgehog                   hiding (Size, Var)
-import qualified Hedgehog.Gen               as Gen
-import           Hedgehog.Internal.Property (forAllWithT)
+import Control.Monad.Morph
+import Control.Monad.Reader
+import Data.Functor.Identity
+import Hedgehog hiding (Size, Var)
+import qualified Hedgehog.Gen as Gen
+import Hedgehog.Internal.Property (forAllWithT)
 
 -- | @hoist lift@
 liftT :: (MFunctor t, MonadTrans s, Monad m) => t m a -> t (s m) a

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Test.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Test.hs
@@ -13,23 +13,23 @@ module Language.PlutusCore.Generators.Test
     , propEvaluate
     ) where
 
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Evaluation.Result
-import           Language.PlutusCore.Generators.Interesting
-import           Language.PlutusCore.Generators.Internal.TypedBuiltinGen
-import           Language.PlutusCore.Generators.Internal.TypeEvalCheck
-import           Language.PlutusCore.Generators.Internal.Utils
-import           Language.PlutusCore.Lexer.Type                          hiding (name)
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Evaluation.Result
+import Language.PlutusCore.Generators.Interesting
+import Language.PlutusCore.Generators.Internal.TypedBuiltinGen
+import Language.PlutusCore.Generators.Internal.TypeEvalCheck
+import Language.PlutusCore.Generators.Internal.Utils
+import Language.PlutusCore.Lexer.Type hiding (name)
+import Language.PlutusCore.Name
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.Type
 
-import           Control.Monad.Except
-import           Data.Functor                                            ((<&>))
-import qualified Data.Text.IO                                            as Text
-import           Hedgehog                                                hiding (Size, Var, eval)
-import qualified Hedgehog.Gen                                            as Gen
-import           System.FilePath                                         ((</>))
+import Control.Monad.Except
+import Data.Functor ((<&>))
+import qualified Data.Text.IO as Text
+import Hedgehog hiding (Size, Var, eval)
+import qualified Hedgehog.Gen as Gen
+import System.FilePath ((</>))
 
 -- | Generate a term using a given generator and check that it's well-typed and evaluates correctly.
 getSampleTermValue :: KnownType a => TermGen a -> IO (TermOf EvaluationResultDef)

--- a/language-plutus-core/prelude/PlutusPrelude.hs
+++ b/language-plutus-core/prelude/PlutusPrelude.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE DefaultSignatures     #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module PlutusPrelude
     ( -- * Reexports from base
@@ -94,38 +94,38 @@ module PlutusPrelude
     , showText
     ) where
 
-import           Control.Applicative                     (Alternative (..))
-import           Control.Arrow                           ((&&&))
-import           Control.Composition                     ((.*))
-import           Control.DeepSeq                         (NFData)
-import           Control.Exception                       (Exception, throw)
-import           Control.Lens
-import           Control.Monad                           (guard, join, (<=<), (>=>))
-import           Data.Bifunctor                          (first, second)
-import           Data.Bool                               (bool)
-import qualified Data.ByteString.Lazy                    as BSL
-import           Data.Coerce                             (Coercible, coerce)
-import           Data.Either                             (fromRight, isRight)
-import           Data.Foldable                           (fold, toList)
-import           Data.Function                           (on)
-import           Data.Functor                            (void, ($>), (<&>))
-import           Data.List                               (foldl')
-import           Data.List.NonEmpty                      (NonEmpty (..))
-import           Data.Maybe                              (fromMaybe, isJust, isNothing)
-import qualified Data.Text                               as T
-import qualified Data.Text.Encoding                      as TE
-import           Data.Text.Prettyprint.Doc
-import           Data.Text.Prettyprint.Doc.Custom        as X
-import           Data.Text.Prettyprint.Doc.Render.String (renderString)
-import           Data.Text.Prettyprint.Doc.Render.Text   (renderStrict)
-import           Data.Traversable                        (for)
-import           Data.Typeable                           (Typeable)
-import           Data.Word                               (Word8)
-import           Debug.Trace
-import           GHC.Generics
-import           GHC.Natural                             (Natural)
+import Control.Applicative (Alternative (..))
+import Control.Arrow ((&&&))
+import Control.Composition ((.*))
+import Control.DeepSeq (NFData)
+import Control.Exception (Exception, throw)
+import Control.Lens
+import Control.Monad (guard, join, (<=<), (>=>))
+import Data.Bifunctor (first, second)
+import Data.Bool (bool)
+import qualified Data.ByteString.Lazy as BSL
+import Data.Coerce (Coercible, coerce)
+import Data.Either (fromRight, isRight)
+import Data.Foldable (fold, toList)
+import Data.Function (on)
+import Data.Functor (void, ($>), (<&>))
+import Data.List (foldl')
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Maybe (fromMaybe, isJust, isNothing)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Custom as X
+import Data.Text.Prettyprint.Doc.Render.String (renderString)
+import Data.Text.Prettyprint.Doc.Render.Text (renderStrict)
+import Data.Traversable (for)
+import Data.Typeable (Typeable)
+import Data.Word (Word8)
+import Debug.Trace
+import GHC.Generics
+import GHC.Natural (Natural)
 
-import           Data.Functor.Compose
+import Data.Functor.Compose
 
 infixr 2 ?
 infixl 4 <<$>>, <<*>>

--- a/language-plutus-core/src/Control/Monad/Trans/Inner.hs
+++ b/language-plutus-core/src/Control/Monad/Trans/Inner.hs
@@ -1,7 +1,7 @@
 -- | Getting monad transformers out of 'Traversable' 'Monad's.
 
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 module Control.Monad.Trans.Inner
@@ -11,8 +11,8 @@ module Control.Monad.Trans.Inner
     , mapInnerT
     ) where
 
-import           Control.Monad
-import           Control.Monad.Except
+import Control.Monad
+import Control.Monad.Except
 
 forBind :: (Monad m, Traversable m, Applicative f) => m a -> (a -> f (m b)) -> f (m b)
 forBind a f = join <$> traverse f a

--- a/language-plutus-core/src/Crypto.hs
+++ b/language-plutus-core/src/Crypto.hs
@@ -1,9 +1,9 @@
 module Crypto (verifySignature) where
 
-import           Control.Applicative
-import           Crypto.ECC.Ed25519Donna
-import           Crypto.Error            (maybeCryptoError)
-import qualified Data.ByteString.Lazy    as BSL
+import Control.Applicative
+import Crypto.ECC.Ed25519Donna
+import Crypto.Error (maybeCryptoError)
+import qualified Data.ByteString.Lazy as BSL
 
 verifySignature
     :: Alternative f

--- a/language-plutus-core/src/Data/ByteString/Lazy/Hash.hs
+++ b/language-plutus-core/src/Data/ByteString/Lazy/Hash.hs
@@ -5,8 +5,8 @@ module Data.ByteString.Lazy.Hash
     , sha3
     ) where
 
-import           Crypto.Hash          (SHA256, SHA3_256, hashlazy)
-import qualified Data.ByteArray       as B
+import Crypto.Hash (SHA256, SHA3_256, hashlazy)
+import qualified Data.ByteArray as B
 import qualified Data.ByteString.Lazy as BSL
 
 -- | Hash a [[BSL.ByteString]] using the SHA-256 hash function.

--- a/language-plutus-core/src/Data/Functor/Foldable/Monadic.hs
+++ b/language-plutus-core/src/Data/Functor/Foldable/Monadic.hs
@@ -1,7 +1,7 @@
 module Data.Functor.Foldable.Monadic (cataM) where
 
-import           Data.Functor.Foldable
-import           PlutusPrelude
+import Data.Functor.Foldable
+import PlutusPrelude
 
 cataM :: (Recursive t, Traversable (Base t), Monad m) => (Base t a -> m a) -> t -> m a
 cataM f = c where c = f <=< (traverse c . project)

--- a/language-plutus-core/src/Data/Text/Prettyprint/Doc/Custom.hs
+++ b/language-plutus-core/src/Data/Text/Prettyprint/Doc/Custom.hs
@@ -8,7 +8,7 @@ module Data.Text.Prettyprint.Doc.Custom ( brackets'
                                         , (<//>)
                                         ) where
 
-import           Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc
 
 infixr 5 </>
 infixr 5 <//>

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -97,29 +97,29 @@ module Language.PlutusCore
     , serialisedSize
     ) where
 
-import           Control.Monad.Except
-import qualified Data.ByteString.Lazy                     as BSL
-import qualified Data.Text                                as T
-import           Data.Text.Prettyprint.Doc
-import           Language.PlutusCore.CBOR                 ()
-import qualified Language.PlutusCore.Check.Normal         as Normal
-import qualified Language.PlutusCore.Check.Uniques        as Uniques
-import qualified Language.PlutusCore.Check.Value          as VR
-import           Language.PlutusCore.Error
-import           Language.PlutusCore.Evaluation.CkMachine
-import           Language.PlutusCore.Lexer
-import           Language.PlutusCore.Lexer.Type
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Normalize
-import           Language.PlutusCore.Parser
-import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Rename
-import           Language.PlutusCore.Size
-import           Language.PlutusCore.Type
-import           Language.PlutusCore.TypeCheck            as TypeCheck
-import           Language.PlutusCore.View
-import           PlutusPrelude
+import Control.Monad.Except
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text as T
+import Data.Text.Prettyprint.Doc
+import Language.PlutusCore.CBOR ()
+import qualified Language.PlutusCore.Check.Normal as Normal
+import qualified Language.PlutusCore.Check.Uniques as Uniques
+import qualified Language.PlutusCore.Check.Value as VR
+import Language.PlutusCore.Error
+import Language.PlutusCore.Evaluation.CkMachine
+import Language.PlutusCore.Lexer
+import Language.PlutusCore.Lexer.Type
+import Language.PlutusCore.Name
+import Language.PlutusCore.Normalize
+import Language.PlutusCore.Parser
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Rename
+import Language.PlutusCore.Size
+import Language.PlutusCore.Type
+import Language.PlutusCore.TypeCheck as TypeCheck
+import Language.PlutusCore.View
+import PlutusPrelude
 
 -- | Given a file at @fibonacci.plc@, @fileType "fibonacci.plc"@ will display
 -- its type or an error message.

--- a/language-plutus-core/src/Language/PlutusCore/Analysis/Definitions.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Analysis/Definitions.hs
@@ -9,19 +9,19 @@ module Language.PlutusCore.Analysis.Definitions
     , runTypeDefs
     ) where
 
-import           Language.PlutusCore.Error
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Error
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
 
-import           Data.Functor.Foldable
+import Data.Functor.Foldable
 
-import           Control.Lens              hiding (use, uses)
-import           Control.Monad.Except
-import           Control.Monad.State
-import           Control.Monad.Writer
+import Control.Lens hiding (use, uses)
+import Control.Monad.Except
+import Control.Monad.State
+import Control.Monad.Writer
 
-import           Data.Foldable
-import qualified Data.Set                  as Set
+import Data.Foldable
+import qualified Data.Set as Set
 
 {- Note [Unique usage errors]
 The definitions analysis can find a number of problems with usage of uniques, however

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -1,27 +1,27 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
 -- | Serialise instances for Plutus Core types. Make sure to read the Note [Stable encoding of PLC]
 -- before touching anything in this file.
 module Language.PlutusCore.CBOR () where
 
-import           Language.PlutusCore.DeBruijn
-import           Language.PlutusCore.Error
-import           Language.PlutusCore.Lexer      (AlexPosn)
-import           Language.PlutusCore.Lexer.Type hiding (name)
-import           Language.PlutusCore.MkPlc      (TyVarDecl (..), VarDecl (..))
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.DeBruijn
+import Language.PlutusCore.Error
+import Language.PlutusCore.Lexer (AlexPosn)
+import Language.PlutusCore.Lexer.Type hiding (name)
+import Language.PlutusCore.MkPlc (TyVarDecl (..), VarDecl (..))
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Codec.CBOR.Decoding
-import           Codec.CBOR.Encoding
-import           Codec.Serialise
-import qualified Data.ByteString.Lazy           as BSL
-import           Data.Functor.Foldable          hiding (fold)
+import Codec.CBOR.Decoding
+import Codec.CBOR.Encoding
+import Codec.Serialise
+import qualified Data.ByteString.Lazy as BSL
+import Data.Functor.Foldable hiding (fold)
 
 {- Note [Stable encoding of PLC]
 READ THIS BEFORE TOUCHING ANYTHING IN THIS FILE

--- a/language-plutus-core/src/Language/PlutusCore/Check/Normal.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Normal.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 
 -- | This module makes sure types are normalized inside programs.
 module Language.PlutusCore.Check.Normal
@@ -10,12 +10,12 @@ module Language.PlutusCore.Check.Normal
     , NormCheckError (..)
     ) where
 
-import           Control.Monad.Except
+import Control.Monad.Except
 
-import           Language.PlutusCore.Error
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Error
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
+import PlutusPrelude
 
 -- | Ensure that all types in the 'Program' are normalized.
 checkProgram

--- a/language-plutus-core/src/Language/PlutusCore/Check/Uniques.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Uniques.hs
@@ -6,15 +6,15 @@ module Language.PlutusCore.Check.Uniques
     , AsUniqueError (..)
     ) where
 
-import           Language.PlutusCore.Analysis.Definitions
-import           Language.PlutusCore.Error
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Analysis.Definitions
+import Language.PlutusCore.Error
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
 
-import           Control.Monad.Error.Lens
-import           Control.Monad.Except
+import Control.Monad.Error.Lens
+import Control.Monad.Except
 
-import           Data.Foldable
+import Data.Foldable
 
 checkProgram
     :: (Ord ann,

--- a/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Language.PlutusCore.Check.Value
     ( checkTerm
@@ -8,14 +8,14 @@ module Language.PlutusCore.Check.Value
     , AsValueRestrictionError (..)
     ) where
 
-import           Language.PlutusCore.Error
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Error
+import Language.PlutusCore.Type
 
-import           Control.Monad.Error.Lens
-import           Control.Monad.Except
-import           Data.Either
-import           Data.Foldable             (traverse_)
-import           Data.Functor.Foldable
+import Control.Monad.Error.Lens
+import Control.Monad.Except
+import Data.Either
+import Data.Foldable (traverse_)
+import Data.Functor.Foldable
 
 -- | Check whether a term satisfies the value restriction.
 checkTerm

--- a/language-plutus-core/src/Language/PlutusCore/Constant.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant.hs
@@ -4,8 +4,8 @@ module Language.PlutusCore.Constant
     ( module Export
     ) where
 
-import           Language.PlutusCore.Constant.Apply    as Export
-import           Language.PlutusCore.Constant.Function as Export
-import           Language.PlutusCore.Constant.Make     as Export
-import           Language.PlutusCore.Constant.Name     as Export
-import           Language.PlutusCore.Constant.Typed    as Export
+import Language.PlutusCore.Constant.Apply as Export
+import Language.PlutusCore.Constant.Function as Export
+import Language.PlutusCore.Constant.Make as Export
+import Language.PlutusCore.Constant.Name as Export
+import Language.PlutusCore.Constant.Typed as Export

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
@@ -1,12 +1,12 @@
 -- | Computing constant application.
 
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Language.PlutusCore.Constant.Apply
     ( ConstAppError (..)
@@ -22,22 +22,22 @@ module Language.PlutusCore.Constant.Apply
     , runApplyBuiltinName
     ) where
 
-import           Language.PlutusCore.Constant.Dynamic.Instances ()
-import           Language.PlutusCore.Constant.Name
-import           Language.PlutusCore.Constant.Typed
-import           Language.PlutusCore.Evaluation.Result
-import           Language.PlutusCore.Lexer.Type                 (BuiltinName (..))
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Constant.Dynamic.Instances ()
+import Language.PlutusCore.Constant.Name
+import Language.PlutusCore.Constant.Typed
+import Language.PlutusCore.Evaluation.Result
+import Language.PlutusCore.Lexer.Type (BuiltinName (..))
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Inner
-import           Crypto
-import qualified Data.ByteString.Lazy                           as BSL
-import qualified Data.ByteString.Lazy.Hash                      as Hash
-import           Data.Proxy
-import           Data.Text                                      (Text)
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Inner
+import Crypto
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Lazy.Hash as Hash
+import Data.Proxy
+import Data.Text (Text)
 
 -- | The type of constant applications errors.
 data ConstAppError

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic.hs
@@ -4,9 +4,9 @@ module Language.PlutusCore.Constant.Dynamic
     ( module Export
     ) where
 
-import           Language.PlutusCore.Constant.Dynamic.BuiltinName as Export
-import           Language.PlutusCore.Constant.Dynamic.Call        as Export
-import           Language.PlutusCore.Constant.Dynamic.Emit        as Export
-import           Language.PlutusCore.Constant.Dynamic.Instances   as Export
-import           Language.PlutusCore.Constant.Dynamic.OffChain    as Export
-import           Language.PlutusCore.Constant.Dynamic.OnChain     as Export
+import Language.PlutusCore.Constant.Dynamic.BuiltinName as Export
+import Language.PlutusCore.Constant.Dynamic.Call as Export
+import Language.PlutusCore.Constant.Dynamic.Emit as Export
+import Language.PlutusCore.Constant.Dynamic.Instances as Export
+import Language.PlutusCore.Constant.Dynamic.OffChain as Export
+import Language.PlutusCore.Constant.Dynamic.OnChain as Export

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/BuiltinName.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/BuiltinName.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Language.PlutusCore.Constant.Dynamic.BuiltinName
     ( dynamicCharToStringName
@@ -15,14 +15,14 @@ module Language.PlutusCore.Constant.Dynamic.BuiltinName
     , dynamicTraceDefinitionMock
     ) where
 
-import           Language.PlutusCore.Constant.Dynamic.Instances ()
-import           Language.PlutusCore.Constant.Make
-import           Language.PlutusCore.Constant.Typed
-import           Language.PlutusCore.Lexer.Type
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant.Dynamic.Instances ()
+import Language.PlutusCore.Constant.Make
+import Language.PlutusCore.Constant.Typed
+import Language.PlutusCore.Lexer.Type
+import Language.PlutusCore.Type
 
-import           Data.Proxy
-import           Debug.Trace                                    (trace)
+import Data.Proxy
+import Debug.Trace (trace)
 
 dynamicCharToStringName :: DynamicBuiltinName
 dynamicCharToStringName = DynamicBuiltinName "charToString"

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Call.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Call.hs
@@ -7,13 +7,13 @@ module Language.PlutusCore.Constant.Dynamic.Call
     , dynamicCall
     ) where
 
-import           Language.PlutusCore.Constant.Make
-import           Language.PlutusCore.Constant.Typed
-import           Language.PlutusCore.Lexer.Type     hiding (name)
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant.Make
+import Language.PlutusCore.Constant.Typed
+import Language.PlutusCore.Lexer.Type hiding (name)
+import Language.PlutusCore.Type
 
-import           Data.Proxy
-import           System.IO.Unsafe
+import Data.Proxy
+import System.IO.Unsafe
 
 dynamicCallTypeScheme :: KnownType a => TypeScheme (a -> ()) ()
 dynamicCallTypeScheme = Proxy `TypeSchemeArrow` TypeSchemeResult Proxy

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Emit.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Emit.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Language.PlutusCore.Constant.Dynamic.Emit
     ( withEmit
@@ -11,17 +11,17 @@ module Language.PlutusCore.Constant.Dynamic.Emit
     , withEmitEvaluateBy
     ) where
 
-import           Language.PlutusCore.Constant.Dynamic.Call
-import           Language.PlutusCore.Constant.Function
-import           Language.PlutusCore.Constant.Typed
-import           Language.PlutusCore.Evaluation.Result
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant.Dynamic.Call
+import Language.PlutusCore.Constant.Function
+import Language.PlutusCore.Constant.Typed
+import Language.PlutusCore.Evaluation.Result
+import Language.PlutusCore.Name
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.Type
 
-import           Control.Exception                         (evaluate)
-import           Data.IORef
-import           System.IO.Unsafe                          (unsafePerformIO)
+import Control.Exception (evaluate)
+import Data.IORef
+import System.IO.Unsafe (unsafePerformIO)
 
 -- This does not stream elements lazily. There is a version that allows to stream elements lazily,
 -- but we do not have it here because it's way too convoluted.

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Instances.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Instances.hs
@@ -4,38 +4,38 @@
 
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Language.PlutusCore.Constant.Dynamic.Instances
     ( PlcList (..)
     ) where
 
-import           Language.PlutusCore.Constant.Make
-import           Language.PlutusCore.Constant.Typed
-import           Language.PlutusCore.Evaluation.Result
-import           Language.PlutusCore.Lexer.Type             (prettyBytes)
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.StdLib.Data.Bool
-import qualified Language.PlutusCore.StdLib.Data.Function   as Plc
-import           Language.PlutusCore.StdLib.Data.List
-import           Language.PlutusCore.StdLib.Data.Sum        as Plc
-import           Language.PlutusCore.StdLib.Data.Unit
-import           Language.PlutusCore.StdLib.Meta
-import           Language.PlutusCore.StdLib.Meta.Data.Tuple
-import           Language.PlutusCore.StdLib.Type
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant.Make
+import Language.PlutusCore.Constant.Typed
+import Language.PlutusCore.Evaluation.Result
+import Language.PlutusCore.Lexer.Type (prettyBytes)
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.Quote
+import Language.PlutusCore.StdLib.Data.Bool
+import qualified Language.PlutusCore.StdLib.Data.Function as Plc
+import Language.PlutusCore.StdLib.Data.List
+import Language.PlutusCore.StdLib.Data.Sum as Plc
+import Language.PlutusCore.StdLib.Data.Unit
+import Language.PlutusCore.StdLib.Meta
+import Language.PlutusCore.StdLib.Meta.Data.Tuple
+import Language.PlutusCore.StdLib.Type
+import Language.PlutusCore.Type
 
-import           Control.Monad.Except
-import           Data.Bifunctor
-import qualified Data.ByteString.Lazy                       as BSL
-import           Data.Char
-import           Data.Proxy
-import qualified Data.Text                                  as Text
-import qualified Data.Text.Prettyprint.Doc                  as Doc
-import           GHC.TypeLits
+import Control.Monad.Except
+import Data.Bifunctor
+import qualified Data.ByteString.Lazy as BSL
+import Data.Char
+import Data.Proxy
+import qualified Data.Text as Text
+import qualified Data.Text.Prettyprint.Doc as Doc
+import GHC.TypeLits
 
 {- Note [Sequencing]
 WARNING: it is not allowed to call 'eval' or @readKnown eval@ over a term that already

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/OffChain.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/OffChain.hs
@@ -1,11 +1,11 @@
 module Language.PlutusCore.Constant.Dynamic.OffChain ( getStringBuiltinTypes ) where
 
-import           Control.Monad.Except
-import           Language.PlutusCore.Constant.Dynamic.BuiltinName
-import           Language.PlutusCore.Constant.Function
-import           Language.PlutusCore.Error
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.TypeCheck
+import Control.Monad.Except
+import Language.PlutusCore.Constant.Dynamic.BuiltinName
+import Language.PlutusCore.Constant.Function
+import Language.PlutusCore.Error
+import Language.PlutusCore.Quote
+import Language.PlutusCore.TypeCheck
 
 getStringBuiltinTypes
     :: (AsTypeError e ann, MonadError e m, MonadQuote m) => ann -> m DynamicBuiltinNameTypes

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/OnChain.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/OnChain.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LiberalTypeSynonyms #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Language.PlutusCore.Constant.Dynamic.OnChain
     ( OnChain (..)
@@ -19,20 +19,20 @@ module Language.PlutusCore.Constant.Dynamic.OnChain
     , evaluateHandlersBy
     ) where
 
-import           Language.PlutusCore.Constant.Dynamic.Call
-import           Language.PlutusCore.Constant.Dynamic.Emit
-import           Language.PlutusCore.Constant.Dynamic.Instances ()
-import           Language.PlutusCore.Constant.Function
-import           Language.PlutusCore.Constant.Make
-import           Language.PlutusCore.Constant.Typed
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant.Dynamic.Call
+import Language.PlutusCore.Constant.Dynamic.Emit
+import Language.PlutusCore.Constant.Dynamic.Instances ()
+import Language.PlutusCore.Constant.Function
+import Language.PlutusCore.Constant.Make
+import Language.PlutusCore.Constant.Typed
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
 
-import           Control.Exception
-import           Data.Coerce
-import           Data.Proxy
-import qualified Data.Text                                      as Text
-import           GHC.TypeLits
+import Control.Exception
+import Data.Coerce
+import Data.Proxy
+import qualified Data.Text as Text
+import GHC.TypeLits
 
 {- Note [Interpretation of names]
 The thing about dynamic built-in names is that they really can denote arbitrary effects.

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Function.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Function.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE GADTs            #-}
-{-# LANGUAGE RankNTypes       #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Language.PlutusCore.Constant.Function
@@ -10,15 +10,15 @@ module Language.PlutusCore.Constant.Function
     , typeOfTypedBuiltinName
     ) where
 
-import           Language.PlutusCore.Constant.Typed
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant.Typed
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
-import qualified Data.Map                           as Map
-import           Data.Proxy
-import qualified Data.Text                          as Text
-import           GHC.TypeLits
+import qualified Data.Map as Map
+import Data.Proxy
+import qualified Data.Text as Text
+import GHC.TypeLits
 
 -- | Convert a 'TypeScheme' to the corresponding 'Type'.
 -- Basically, a map from the PHOAS representation to the FOAS one.

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Make.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Make.hs
@@ -11,10 +11,10 @@ module Language.PlutusCore.Constant.Make
     , makeBuiltinStr
     ) where
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Type
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Type
 
-import qualified Data.ByteString.Lazy      as BSL
+import qualified Data.ByteString.Lazy as BSL
 
 -- | Lift a 'BuiltinName' to 'Term'.
 builtinNameAsTerm :: TermLike term tyname name => BuiltinName -> term ()

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Name.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Name.hs
@@ -25,13 +25,13 @@ module Language.PlutusCore.Constant.Name
     , typedGtByteString
     ) where
 
-import           Language.PlutusCore.Constant.Dynamic.Instances ()
-import           Language.PlutusCore.Constant.Typed
-import           Language.PlutusCore.Evaluation.Result
-import           Language.PlutusCore.Lexer.Type
+import Language.PlutusCore.Constant.Dynamic.Instances ()
+import Language.PlutusCore.Constant.Typed
+import Language.PlutusCore.Evaluation.Result
+import Language.PlutusCore.Lexer.Type
 
-import qualified Data.ByteString.Lazy.Char8                     as BSL
-import           Data.Proxy
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.Proxy
 
 -- | Apply a continuation to the typed version of a 'BuiltinName'.
 withTypedBuiltinName :: BuiltinName -> (forall a r. TypedBuiltinName a r -> c) -> c

--- a/language-plutus-core/src/Language/PlutusCore/DeBruijn.hs
+++ b/language-plutus-core/src/Language/PlutusCore/DeBruijn.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE OverloadedStrings #-}
 -- | Support for using de Bruijn indices for term and type names.
 module Language.PlutusCore.DeBruijn
     ( Index (..)
@@ -17,23 +17,23 @@ module Language.PlutusCore.DeBruijn
     , unDeBruijnProgram
     ) where
 
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Name
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
-import           Control.Exception
-import           Control.Lens               hiding (Index, Level, index, ix)
-import           Control.Monad.Except
-import           Control.Monad.Reader
+import Control.Exception
+import Control.Lens hiding (Index, Level, index, ix)
+import Control.Monad.Except
+import Control.Monad.Reader
 
-import qualified Data.Bimap                 as BM
-import qualified Data.Text                  as T
-import           Data.Typeable
+import qualified Data.Bimap as BM
+import qualified Data.Text as T
+import Data.Typeable
 
-import           Numeric.Natural
+import Numeric.Natural
 
-import           GHC.Generics
+import GHC.Generics
 
 -- | A relative index used for de Bruijn identifiers.
 newtype Index = Index Natural

--- a/language-plutus-core/src/Language/PlutusCore/Error.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Error.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE DeriveAnyClass         #-}
-{-# LANGUAGE DerivingStrategies     #-}
-{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE OverloadedStrings      #-}
-{-# LANGUAGE TemplateHaskell        #-}
-{-# LANGUAGE TypeFamilies           #-}
-{-# LANGUAGE TypeOperators          #-}
-{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- appears in the generated instances
 {-# OPTIONS_GHC -Wno-overlapping-patterns #-}
 
@@ -30,18 +30,18 @@ module Language.PlutusCore.Error
     , throwingEither
     ) where
 
-import           Language.PlutusCore.Lexer.Type     hiding (name)
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Lexer.Type hiding (name)
+import Language.PlutusCore.Name
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Control.Lens                       hiding (use)
-import           Control.Monad.Error.Lens
-import           Control.Monad.Except
+import Control.Lens hiding (use)
+import Control.Monad.Error.Lens
+import Control.Monad.Except
 
-import qualified Data.Text                          as T
-import           Data.Text.Prettyprint.Doc.Internal (Doc (Text))
+import qualified Data.Text as T
+import Data.Text.Prettyprint.Doc.Internal (Doc (Text))
 
 -- | Lifts an 'Either' into an error context where we can embed the 'Left' value into the error.
 throwingEither :: MonadError e m => AReview e t -> Either t a -> m a

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/CkMachine.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/CkMachine.hs
@@ -11,15 +11,15 @@ module Language.PlutusCore.Evaluation.CkMachine
     , runCk
     ) where
 
-import           Language.PlutusCore.Constant.Apply
-import           Language.PlutusCore.Evaluation.MachineException
-import           Language.PlutusCore.Evaluation.Result
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
-import           Language.PlutusCore.View
-import           PlutusPrelude
+import Language.PlutusCore.Constant.Apply
+import Language.PlutusCore.Evaluation.MachineException
+import Language.PlutusCore.Evaluation.Result
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
+import Language.PlutusCore.View
+import PlutusPrelude
 
-import           Data.Functor.Identity
+import Data.Functor.Identity
 
 infix 4 |>, <|
 

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/MachineException.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/MachineException.hs
@@ -1,20 +1,20 @@
 -- | The exceptions that an abstract machine can throw.
 
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Language.PlutusCore.Evaluation.MachineException
     ( MachineError (..)
     , MachineException (..)
     ) where
 
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Pretty.Plc
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Name
+import Language.PlutusCore.Pretty.Plc
+import Language.PlutusCore.Type
+import PlutusPrelude
 
 -- | Errors which can occur during a run of an abstract machine.
 data MachineError err

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/Result.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/Result.hs
@@ -1,10 +1,10 @@
 -- | This module defines a common type various evaluation machine use to return their results.
 
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Language.PlutusCore.Evaluation.Result
     ( EvaluationResult (..)
@@ -13,12 +13,12 @@ module Language.PlutusCore.Evaluation.Result
     , isEvaluationFailure
     ) where
 
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Name
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.Type
 
-import           Control.Applicative
-import           PlutusPrelude
+import Control.Applicative
+import PlutusPrelude
 
 -- | The parameterized type of results various evaluation engines return.
 -- On the PLC side this becomes (via @makeKnown@) either a call to 'error' or

--- a/language-plutus-core/src/Language/PlutusCore/FsTree.hs
+++ b/language-plutus-core/src/Language/PlutusCore/FsTree.hs
@@ -18,8 +18,8 @@ module Language.PlutusCore.FsTree
     , foldPlcFolderContents
     ) where
 
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
 
 -- We use 'String's for names, because 'FilePath's are 'String's.
 -- | An 'FsTree' is either a file or a folder with a list of 'FsTree's inside.

--- a/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Lexer/Type.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Language.PlutusCore.Lexer.Type
     ( TypeBuiltin (..)
@@ -17,14 +17,14 @@ module Language.PlutusCore.Lexer.Type
     , defaultVersion
     ) where
 
-import           Language.PlutusCore.Name
-import           PlutusPrelude
+import Language.PlutusCore.Name
+import PlutusPrelude
 
-import qualified Data.ByteString.Lazy               as BSL
-import qualified Data.Text                          as T
-import           Data.Text.Prettyprint.Doc.Internal (Doc (Text))
-import           Language.Haskell.TH.Syntax         (Lift)
-import           Numeric                            (showHex)
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text as T
+import Data.Text.Prettyprint.Doc.Internal (Doc (Text))
+import Language.Haskell.TH.Syntax (Lift)
+import Numeric (showHex)
 
 -- | A builtin type
 data TypeBuiltin

--- a/language-plutus-core/src/Language/PlutusCore/Name.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Name.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE DeriveAnyClass         #-}
-{-# LANGUAGE DerivingStrategies     #-}
-{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Language.PlutusCore.Name
     ( -- * Types
@@ -37,15 +37,15 @@ module Language.PlutusCore.Name
     , debugPrettyConfigName
     ) where
 
-import           PlutusPrelude
+import PlutusPrelude
 
-import           Control.Lens
-import           Control.Monad.State
-import qualified Data.IntMap                as IM
-import qualified Data.Map                   as M
-import qualified Data.Text                  as T
-import           Instances.TH.Lift          ()
-import           Language.Haskell.TH.Syntax (Lift)
+import Control.Lens
+import Control.Monad.State
+import qualified Data.IntMap as IM
+import qualified Data.Map as M
+import qualified Data.Text as T
+import Instances.TH.Lift ()
+import Language.Haskell.TH.Syntax (Lift)
 
 -- | A 'Name' represents variables/names in Plutus Core.
 data Name ann = Name

--- a/language-plutus-core/src/Language/PlutusCore/Normalize.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Normalize.hs
@@ -10,13 +10,13 @@ module Language.PlutusCore.Normalize
     , normalizeTypesFullInProgram
     ) where
 
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Normalize.Internal
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Rename
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Name
+import Language.PlutusCore.Normalize.Internal
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Rename
+import Language.PlutusCore.Type
 
-import           Control.Monad                          ((>=>))
+import Control.Monad ((>=>))
 
 -- See Note [Normalization].
 -- | Normalize a 'Type'.

--- a/language-plutus-core/src/Language/PlutusCore/Normalize/Internal.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Normalize/Internal.hs
@@ -4,7 +4,7 @@
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Language.PlutusCore.Normalize.Internal
     ( NormalizeTypeT
@@ -17,16 +17,16 @@ module Language.PlutusCore.Normalize.Internal
     , normalizeTypesInM
     ) where
 
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Rename
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Rename
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Control.Lens
-import           Control.Monad.Reader
-import           Control.Monad.State
-import           Control.Monad.Trans.Maybe
+import Control.Lens
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Trans.Maybe
 
 {- Note [Global uniqueness]
 WARNING: everything in this module works under the assumption that the global uniqueness condition

--- a/language-plutus-core/src/Language/PlutusCore/Pretty.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty.hs
@@ -61,14 +61,14 @@ module Language.PlutusCore.Pretty
     , botPrettyConfigReadable
     ) where
 
-import           Language.PlutusCore.Name            as Export
-import           Language.PlutusCore.Pretty.Classic  as Export
-import           Language.PlutusCore.Pretty.Plc      as Export
-import           Language.PlutusCore.Pretty.Readable as Export
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Name as Export
+import Language.PlutusCore.Pretty.Classic as Export
+import Language.PlutusCore.Pretty.Plc as Export
+import Language.PlutusCore.Pretty.Readable as Export
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Data.Text                           (Text)
+import Data.Text (Text)
 
 -- | Pretty-print a value in the default mode using the classic view.
 prettyPlcDef :: PrettyPlc a => a -> Doc ann

--- a/language-plutus-core/src/Language/PlutusCore/Pretty/Classic.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty/Classic.hs
@@ -1,10 +1,10 @@
 -- | A "classic" (i.e. as seen in the specification) way to pretty-print PLC entities.
 
-{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Language.PlutusCore.Pretty.Classic
     ( PrettyConfigClassic (..)
@@ -14,12 +14,12 @@ module Language.PlutusCore.Pretty.Classic
     , prettyClassicDebug
     ) where
 
-import           Language.PlutusCore.Lexer.Type
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Lexer.Type
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Data.Functor.Foldable
+import Data.Functor.Foldable
 
 -- | Configuration for the classic pretty-printing.
 newtype PrettyConfigClassic configName = PrettyConfigClassic

--- a/language-plutus-core/src/Language/PlutusCore/Pretty/Plc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty/Plc.hs
@@ -1,11 +1,11 @@
 -- | The global pretty-printing config used to pretty-print everything in the PLC world.
 -- This module also defines custom pretty-printing functions for PLC types as a convenience.
 
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Language.PlutusCore.Pretty.Plc
     (
@@ -28,12 +28,12 @@ module Language.PlutusCore.Pretty.Plc
     , prettyPlcCondensedErrorBy
     ) where
 
-import           Data.Text.Prettyprint.Doc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Pretty.Classic
-import           Language.PlutusCore.Pretty.Readable
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Data.Text.Prettyprint.Doc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Pretty.Classic
+import Language.PlutusCore.Pretty.Readable
+import Language.PlutusCore.Type
+import PlutusPrelude
 
 -- | Whether to pretty-print PLC errors in full or with some information omitted.
 data CondensedErrors

--- a/language-plutus-core/src/Language/PlutusCore/Pretty/Readable.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Pretty/Readable.hs
@@ -1,13 +1,13 @@
 -- | A "readable" Agda-like way to pretty-print PLC entities.
 
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Language.PlutusCore.Pretty.Readable
     ( RenderContext (..)
@@ -19,12 +19,12 @@ module Language.PlutusCore.Pretty.Readable
     , botPrettyConfigReadable
     ) where
 
-import           Language.PlutusCore.Lexer.Type     hiding (name)
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Lexer.Type hiding (name)
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Data.Text.Prettyprint.Doc.Internal (enclose)
+import Data.Text.Prettyprint.Doc.Internal (enclose)
 
 -- | Associativity of an expression.
 data Associativity

--- a/language-plutus-core/src/Language/PlutusCore/Quote.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Quote.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE DefaultSignatures     #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- just for the type equality constraint
-{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE GADTs #-}
 
 module Language.PlutusCore.Quote
     ( runQuoteT
@@ -26,23 +26,23 @@ module Language.PlutusCore.Quote
     , liftQuote
     ) where
 
-import           Control.Lens              (coerced)
-import           Control.Monad.Except
-import           Control.Monad.Morph       as MM
-import           Control.Monad.Reader
-import           Control.Monad.State
-import           Control.Monad.Trans.Maybe
+import Control.Lens (coerced)
+import Control.Monad.Except
+import Control.Monad.Morph as MM
+import Control.Monad.Reader
+import Control.Monad.State
+import Control.Monad.Trans.Maybe
 
-import           Data.Functor.Foldable
-import           Data.Functor.Identity
-import           Data.Maybe                (fromMaybe)
-import qualified Data.Set                  as Set
-import qualified Data.Text                 as Text
-import           Hedgehog                  (GenT, PropertyT)
+import Data.Functor.Foldable
+import Data.Functor.Identity
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import Hedgehog (GenT, PropertyT)
 
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
+import PlutusPrelude
 
 -- | The state contains the "next" 'Unique' that should be used for a name
 type FreshState = Unique

--- a/language-plutus-core/src/Language/PlutusCore/Rename.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Rename.hs
@@ -1,6 +1,6 @@
 -- | The user-facing API of the renamer.
 
-{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Language.PlutusCore.Rename
@@ -9,13 +9,13 @@ module Language.PlutusCore.Rename
     , liftDupable
     ) where
 
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Rename.Internal
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Rename.Internal
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Data.Functor.Identity
+import Data.Functor.Identity
 
 {- Note [Marking]
 We use functions from the @markNonFresh*@ family in order to ensure that bound variables never get

--- a/language-plutus-core/src/Language/PlutusCore/Rename/Internal.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Rename/Internal.hs
@@ -1,10 +1,10 @@
 -- | The internal module of the renamer that defines the actual algorithms,
 -- but not the user-facing API.
 
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Language.PlutusCore.Rename.Internal
     ( RenameM (..)
@@ -26,14 +26,14 @@ module Language.PlutusCore.Rename.Internal
     , renameProgramM
     ) where
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Control.Lens.TH
-import           Control.Monad.Reader
+import Control.Lens.TH
+import Control.Monad.Reader
 
 -- | The monad the renamer runs in.
 newtype RenameM renaming a = RenameM

--- a/language-plutus-core/src/Language/PlutusCore/Size.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Size.hs
@@ -6,11 +6,11 @@ module Language.PlutusCore.Size
     , serialisedSize
     ) where
 
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Type
 
-import           Codec.Serialise
-import qualified Data.ByteString.Lazy     as BSL
-import           Data.Functor.Foldable
+import Codec.Serialise
+import qualified Data.ByteString.Lazy as BSL
+import Data.Functor.Foldable
 
 -- | Count the number of AST nodes in a kind.
 kindSize :: Kind a -> Integer

--- a/language-plutus-core/src/Language/PlutusCore/Subst.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Subst.hs
@@ -17,13 +17,13 @@ module Language.PlutusCore.Subst
     , tvTy
     ) where
 
-import           PlutusPrelude
+import PlutusPrelude
 
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Type
 
-import           Control.Lens
-import           Data.Functor.Foldable    (cata)
-import           Data.Set                 as Set
+import Control.Lens
+import Data.Functor.Foldable (cata)
+import Data.Set as Set
 
 purely :: ((a -> Identity b) -> c -> Identity d) -> (a -> b) -> c -> d
 purely = coerce

--- a/language-plutus-core/src/Language/PlutusCore/TypeCheck.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeCheck.hs
@@ -25,16 +25,16 @@ module Language.PlutusCore.TypeCheck
     , checkTypeOfProgram
     ) where
 
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Error
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Normalize
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Rename
-import           Language.PlutusCore.Type
-import           Language.PlutusCore.TypeCheck.Internal
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Error
+import Language.PlutusCore.Name
+import Language.PlutusCore.Normalize
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Rename
+import Language.PlutusCore.Type
+import Language.PlutusCore.TypeCheck.Internal
 
-import           Control.Monad.Except
+import Control.Monad.Except
 
 -- | The default amount of gas to run the type checker with.
 defTypeCheckGas :: Gas

--- a/language-plutus-core/src/Language/PlutusCore/TypeCheck/Internal.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeCheck/Internal.hs
@@ -4,10 +4,10 @@
 -- 'makeLenses' produces an unused lens.
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes        #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Language.PlutusCore.TypeCheck.Internal
     ( DynamicBuiltinNameTypes (..)
@@ -27,24 +27,24 @@ module Language.PlutusCore.TypeCheck.Internal
     , checkTypeM
     ) where
 
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Error
-import           Language.PlutusCore.Lexer.Type         hiding (name)
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Normalize
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Error
+import Language.PlutusCore.Lexer.Type hiding (name)
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Normalize
 import qualified Language.PlutusCore.Normalize.Internal as Norm
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Rename
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Rename
+import Language.PlutusCore.Type
+import PlutusPrelude
 
-import           Control.Lens.TH                        (makeLenses)
-import           Control.Monad.Error.Lens
-import           Control.Monad.Except
-import           Control.Monad.Reader
-import           Data.Map                               (Map)
-import qualified Data.Map                               as Map
+import Control.Lens.TH (makeLenses)
+import Control.Monad.Error.Lens
+import Control.Monad.Except
+import Control.Monad.Reader
+import Data.Map (Map)
+import qualified Data.Map as Map
 
 {- Note [Global uniqueness]
 WARNING: type inference/checking works under the assumption that the global uniqueness condition

--- a/language-plutus-core/src/Language/PlutusCore/View.hs
+++ b/language-plutus-core/src/Language/PlutusCore/View.hs
@@ -1,6 +1,6 @@
 -- | Various views of PLC entities.
 
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 module Language.PlutusCore.View
@@ -14,9 +14,9 @@ module Language.PlutusCore.View
     , termAsPrimIterApp
     ) where
 
-import           Language.PlutusCore.Lexer.Type (StagedBuiltinName (..))
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.Lexer.Type (StagedBuiltinName (..))
+import Language.PlutusCore.Type
+import PlutusPrelude
 
 -- | A function (called "head") applied to a list of arguments (called "spine").
 data IterApp head arg = IterApp

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Bool.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Bool.hs
@@ -9,12 +9,12 @@ module Language.PlutusCore.StdLib.Data.Bool
     , ifThenElse
     ) where
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
-import           Language.PlutusCore.StdLib.Data.Unit
+import Language.PlutusCore.StdLib.Data.Unit
 
 -- | 'Bool' as a PLC type.
 --

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/ChurchNat.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/ChurchNat.hs
@@ -8,10 +8,10 @@ module Language.PlutusCore.StdLib.Data.ChurchNat
     , churchSucc
     ) where
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
 -- | Church-encoded @Nat@ as a PLC type.
 --

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Function.hs
@@ -14,19 +14,19 @@ module Language.PlutusCore.StdLib.Data.Function
     , getMutualFixOf
     ) where
 
-import           PlutusPrelude
-import           Prelude                                    hiding (const)
+import PlutusPrelude
+import Prelude hiding (const)
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
-import           Language.PlutusCore.StdLib.Meta.Data.Tuple
-import           Language.PlutusCore.StdLib.Type
+import Language.PlutusCore.StdLib.Meta.Data.Tuple
+import Language.PlutusCore.StdLib.Type
 
-import           Control.Lens.Indexed                       (ifor)
-import           Control.Monad
+import Control.Lens.Indexed (ifor)
+import Control.Monad
 
 -- | 'id' as a PLC term.
 --

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Integer.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Integer.hs
@@ -6,11 +6,11 @@ module Language.PlutusCore.StdLib.Data.Integer
     ( succInteger
     ) where
 
-import           Language.PlutusCore.Constant.Make (makeIntConstant)
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant.Make (makeIntConstant)
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
 -- |  @succ :: Integer -> Integer@ as a PLC term.
 --

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
@@ -1,6 +1,6 @@
 -- | @list@ and related functions.
 
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Language.PlutusCore.StdLib.Data.List
@@ -15,19 +15,19 @@ module Language.PlutusCore.StdLib.Data.List
     , product
     ) where
 
-import           Prelude                                  hiding (enumFromTo, product, reverse, sum)
+import Prelude hiding (enumFromTo, product, reverse, sum)
 
-import           Language.PlutusCore.Constant.Make        (makeIntConstant)
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant.Make (makeIntConstant)
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
-import           Language.PlutusCore.StdLib.Data.Bool
-import           Language.PlutusCore.StdLib.Data.Function
-import           Language.PlutusCore.StdLib.Data.Integer
-import           Language.PlutusCore.StdLib.Data.Unit
-import           Language.PlutusCore.StdLib.Type
+import Language.PlutusCore.StdLib.Data.Bool
+import Language.PlutusCore.StdLib.Data.Function
+import Language.PlutusCore.StdLib.Data.Integer
+import Language.PlutusCore.StdLib.Data.Unit
+import Language.PlutusCore.StdLib.Type
 
 -- | @List@ as a PLC type.
 --

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
@@ -11,16 +11,16 @@ module Language.PlutusCore.StdLib.Data.Nat
     , natToInteger
     ) where
 
-import           Prelude                                  hiding (succ)
+import Prelude hiding (succ)
 
-import           Language.PlutusCore.Constant.Make        (makeIntConstant)
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.Constant.Make (makeIntConstant)
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
-import           Language.PlutusCore.StdLib.Data.Function
-import           Language.PlutusCore.StdLib.Type
+import Language.PlutusCore.StdLib.Data.Function
+import Language.PlutusCore.StdLib.Type
 
 -- | @Nat@ as a PLC type.
 --

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Sum.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Sum.hs
@@ -8,12 +8,12 @@ module Language.PlutusCore.StdLib.Data.Sum
     , right
     ) where
 
-import           Prelude                   hiding (sum)
+import Prelude hiding (sum)
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
 -- | 'Either' as a PLC type.
 --

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Unit.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Unit.hs
@@ -8,10 +8,10 @@ module Language.PlutusCore.StdLib.Data.Unit
     , sequ
     ) where
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
 -- | '()' as a PLC type.
 --

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Everything.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Everything.hs
@@ -10,18 +10,18 @@ module Language.PlutusCore.StdLib.Everything
     ( stdLib
     ) where
 
-import           Language.PlutusCore.FsTree
+import Language.PlutusCore.FsTree
 
-import           Language.PlutusCore.StdLib.Data.Bool
-import           Language.PlutusCore.StdLib.Data.ChurchNat
-import           Language.PlutusCore.StdLib.Data.Function   as Function
-import           Language.PlutusCore.StdLib.Data.Integer
-import           Language.PlutusCore.StdLib.Data.List       as List
-import           Language.PlutusCore.StdLib.Data.Nat        as Nat
-import           Language.PlutusCore.StdLib.Data.Sum        as Sum
-import           Language.PlutusCore.StdLib.Data.Unit
-import           Language.PlutusCore.StdLib.Meta.Data.Tuple
-import           Language.PlutusCore.StdLib.Type
+import Language.PlutusCore.StdLib.Data.Bool
+import Language.PlutusCore.StdLib.Data.ChurchNat
+import Language.PlutusCore.StdLib.Data.Function as Function
+import Language.PlutusCore.StdLib.Data.Integer
+import Language.PlutusCore.StdLib.Data.List as List
+import Language.PlutusCore.StdLib.Data.Nat as Nat
+import Language.PlutusCore.StdLib.Data.Sum as Sum
+import Language.PlutusCore.StdLib.Data.Unit
+import Language.PlutusCore.StdLib.Meta.Data.Tuple
+import Language.PlutusCore.StdLib.Type
 
 -- | The entire stdlib exported as a single value.
 stdLib :: PlcFolderContents

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta.hs
@@ -8,13 +8,13 @@ module Language.PlutusCore.StdLib.Meta
     , metaListToList
     ) where
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Type
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Type
 
-import           Language.PlutusCore.StdLib.Data.List
-import           Language.PlutusCore.StdLib.Data.Nat  as Plc
-import           Language.PlutusCore.StdLib.Data.Sum
+import Language.PlutusCore.StdLib.Data.List
+import Language.PlutusCore.StdLib.Data.Nat as Plc
+import Language.PlutusCore.StdLib.Data.Sum
 
 -- | Convert an 'Integer' to a @nat@. TODO: convert PLC's @integer@ to @nat@ instead.
 metaIntegerToNat :: TermLike term TyName Name => Integer -> term ()

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Function.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Function.hs
@@ -2,10 +2,10 @@
 -- | Meta-functions relating to functions.
 module Language.PlutusCore.StdLib.Meta.Data.Function (constPartial) where
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
 
 -- | 'const' as a PLC term.
 --

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Type.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Type.hs
@@ -1,19 +1,19 @@
 -- | This module defines Haskell data types that simplify construction of PLC types and terms.
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE Rank2Types        #-}
+{-# LANGUAGE Rank2Types #-}
 
 module Language.PlutusCore.StdLib.Type
     ( RecursiveType (..)
     , makeRecursiveType
     ) where
 
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.Quote
-import           Language.PlutusCore.Type
-import           PlutusPrelude
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Name
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.Quote
+import Language.PlutusCore.Type
+import PlutusPrelude
 
 {- Note [Arity of patterns functors]
 The arity of a pattern functor is the number of arguments the pattern functor receives in addition

--- a/language-plutus-core/test/Check/Spec.hs
+++ b/language-plutus-core/test/Check/Spec.hs
@@ -1,20 +1,20 @@
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Check.Spec (tests) where
 
-import           Language.PlutusCore
-import qualified Language.PlutusCore.Check.Normal   as Normal
-import qualified Language.PlutusCore.Check.Uniques  as Uniques
-import qualified Language.PlutusCore.Check.Value    as VR
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Generators.AST
+import Language.PlutusCore
+import qualified Language.PlutusCore.Check.Normal as Normal
+import qualified Language.PlutusCore.Check.Uniques as Uniques
+import qualified Language.PlutusCore.Check.Value as VR
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Generators.AST
 
-import           Control.Monad.Except
-import           Data.Either
-import           Hedgehog                           hiding (Var)
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
-import           Test.Tasty.HUnit
+import Control.Monad.Except
+import Data.Either
+import Hedgehog hiding (Var)
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "checks"

--- a/language-plutus-core/test/Evaluation/CkMachine.hs
+++ b/language-plutus-core/test/Evaluation/CkMachine.hs
@@ -3,29 +3,29 @@ module Evaluation.CkMachine
     ( test_evaluateCk
     ) where
 
-import           Prelude                                    hiding (even)
+import Prelude hiding (even)
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Evaluation.CkMachine
-import           Language.PlutusCore.Generators.Interesting
-import           Language.PlutusCore.Generators.Test
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Pretty
+import Language.PlutusCore
+import Language.PlutusCore.Evaluation.CkMachine
+import Language.PlutusCore.Generators.Interesting
+import Language.PlutusCore.Generators.Test
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Pretty
 
-import           Language.PlutusCore.StdLib.Data.Bool
-import           Language.PlutusCore.StdLib.Data.Function
-import           Language.PlutusCore.StdLib.Data.List
-import           Language.PlutusCore.StdLib.Data.Nat
-import           Language.PlutusCore.StdLib.Meta
-import           Language.PlutusCore.StdLib.Meta.Data.Tuple
-import           Language.PlutusCore.StdLib.Type
+import Language.PlutusCore.StdLib.Data.Bool
+import Language.PlutusCore.StdLib.Data.Function
+import Language.PlutusCore.StdLib.Data.List
+import Language.PlutusCore.StdLib.Data.Nat
+import Language.PlutusCore.StdLib.Meta
+import Language.PlutusCore.StdLib.Meta.Data.Tuple
+import Language.PlutusCore.StdLib.Type
 
-import           Control.Monad.Except
-import qualified Data.ByteString.Lazy                       as BSL
-import           Data.Text.Encoding                         (encodeUtf8)
-import           Test.Tasty
-import           Test.Tasty.Golden
-import           Test.Tasty.Hedgehog
+import Control.Monad.Except
+import qualified Data.ByteString.Lazy as BSL
+import Data.Text.Encoding (encodeUtf8)
+import Test.Tasty
+import Test.Tasty.Golden
+import Test.Tasty.Hedgehog
 
 evenAndOdd :: Tuple (Term TyName Name) ()
 evenAndOdd = runQuote $ do

--- a/language-plutus-core/test/Evaluation/Constant/All.hs
+++ b/language-plutus-core/test/Evaluation/Constant/All.hs
@@ -2,10 +2,10 @@ module Evaluation.Constant.All
     ( test_constant
     ) where
 
-import           Evaluation.Constant.Success
-import           Evaluation.Constant.SuccessFailure
+import Evaluation.Constant.Success
+import Evaluation.Constant.SuccessFailure
 
-import           Test.Tasty
+import Test.Tasty
 
 test_constant :: TestTree
 test_constant =

--- a/language-plutus-core/test/Evaluation/Constant/Apply.hs
+++ b/language-plutus-core/test/Evaluation/Constant/Apply.hs
@@ -2,7 +2,7 @@
 -- See the "Success" and "SuccessFailure" module for actual tests implemented
 -- in terms of functions defined here.
 
-{-# LANGUAGE GADTs      #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 module Evaluation.Constant.Apply
     ( prop_applyBuiltinName
@@ -11,14 +11,14 @@ module Evaluation.Constant.Apply
     , prop_applyBuiltinNameFailure
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Evaluation.CkMachine
-import           Language.PlutusCore.Generators
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Evaluation.CkMachine
+import Language.PlutusCore.Generators
 
-import           Data.Foldable
-import           Data.List
-import           Hedgehog                                 hiding (Var)
+import Data.Foldable
+import Data.List
+import Hedgehog hiding (Var)
 
 -- | This a generic property-based testing procedure for 'applyBuiltinName'.
 -- It generates Haskell values of builtin types (see 'TypedBuiltin' for the list of such types)

--- a/language-plutus-core/test/Evaluation/Constant/Success.hs
+++ b/language-plutus-core/test/Evaluation/Constant/Success.hs
@@ -2,15 +2,15 @@ module Evaluation.Constant.Success
     ( test_constantSuccess
     ) where
 
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Generators
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Generators
 
-import           Evaluation.Constant.Apply
+import Evaluation.Constant.Apply
 
-import qualified Data.ByteString.Lazy           as BSL
-import qualified Data.ByteString.Lazy.Hash      as Hash
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Lazy.Hash as Hash
+import Test.Tasty
+import Test.Tasty.Hedgehog
 
 test_typedAddIntegerSuccess :: TestTree
 test_typedAddIntegerSuccess

--- a/language-plutus-core/test/Evaluation/Constant/SuccessFailure.hs
+++ b/language-plutus-core/test/Evaluation/Constant/SuccessFailure.hs
@@ -2,12 +2,12 @@ module Evaluation.Constant.SuccessFailure
     ( test_applyBuiltinNameSuccessFailure
     ) where
 
-import           Language.PlutusCore.Constant
+import Language.PlutusCore.Constant
 
-import           Evaluation.Constant.Apply
+import Evaluation.Constant.Apply
 
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
+import Test.Tasty
+import Test.Tasty.Hedgehog
 
 test_typedAddIntegerSuccessFailure :: TestTree
 test_typedAddIntegerSuccessFailure

--- a/language-plutus-core/test/Normalization/Check.hs
+++ b/language-plutus-core/test/Normalization/Check.hs
@@ -2,10 +2,10 @@
 
 module Normalization.Check ( test_normalizationCheck ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Check.Normal
-import           Test.Tasty
-import           Test.Tasty.HUnit
+import Language.PlutusCore
+import Language.PlutusCore.Check.Normal
+import Test.Tasty
+import Test.Tasty.HUnit
 
 -- test that [rec (lam dat (fun (type) (type)) [dat a])] is a type value
 test_applyToValue :: IO ()

--- a/language-plutus-core/test/Normalization/Type.hs
+++ b/language-plutus-core/test/Normalization/Type.hs
@@ -4,19 +4,19 @@ module Normalization.Type
     ( test_typeNormalization
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Generators.AST
-import           Language.PlutusCore.MkPlc
-import           Language.PlutusCore.Normalize
+import Language.PlutusCore
+import Language.PlutusCore.Generators.AST
+import Language.PlutusCore.MkPlc
+import Language.PlutusCore.Normalize
 
-import           Control.Monad.Morph                (hoist)
+import Control.Monad.Morph (hoist)
 
-import           Hedgehog
-import qualified Hedgehog.Gen                       as Gen
-import           Hedgehog.Internal.Property         (forAllT)
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
-import           Test.Tasty.HUnit
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import Hedgehog.Internal.Property (forAllT)
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import Test.Tasty.HUnit
 
 test_appAppLamLam :: IO ()
 test_appAppLamLam = do

--- a/language-plutus-core/test/Pretty/Readable.hs
+++ b/language-plutus-core/test/Pretty/Readable.hs
@@ -1,14 +1,14 @@
 module Pretty.Readable (test_Pretty) where
 
-import           Language.PlutusCore.FsTree              (foldPlcFolderContents)
-import           Language.PlutusCore.Pretty
+import Language.PlutusCore.FsTree (foldPlcFolderContents)
+import Language.PlutusCore.Pretty
 
-import           Language.PlutusCore.Examples.Everything (examples)
-import           Language.PlutusCore.StdLib.Everything   (stdLib)
+import Language.PlutusCore.Examples.Everything (examples)
+import Language.PlutusCore.StdLib.Everything (stdLib)
 
-import           Common
+import Common
 
-import           Test.Tasty
+import Test.Tasty
 
 prettyConfigReadable :: PrettyConfigPlc
 prettyConfigReadable

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -4,35 +4,35 @@ module Main
     ( main
     ) where
 
-import           PlutusPrelude
+import PlutusPrelude
 
-import qualified Check.Spec                                 as Check
-import           Evaluation.CkMachine
-import           Evaluation.Constant.All
-import           Normalization.Check
-import           Normalization.Type
-import           Pretty.Readable
-import           TypeSynthesis.Spec                         (test_typecheck)
+import qualified Check.Spec as Check
+import Evaluation.CkMachine
+import Evaluation.Constant.All
+import Normalization.Check
+import Normalization.Type
+import Pretty.Readable
+import TypeSynthesis.Spec (test_typecheck)
 
-import           Language.PlutusCore
-import           Language.PlutusCore.DeBruijn
-import           Language.PlutusCore.Evaluation.CkMachine   (runCk)
-import           Language.PlutusCore.Generators
-import           Language.PlutusCore.Generators.AST         as AST
-import           Language.PlutusCore.Generators.Interesting
-import           Language.PlutusCore.Pretty
+import Language.PlutusCore
+import Language.PlutusCore.DeBruijn
+import Language.PlutusCore.Evaluation.CkMachine (runCk)
+import Language.PlutusCore.Generators
+import Language.PlutusCore.Generators.AST as AST
+import Language.PlutusCore.Generators.Interesting
+import Language.PlutusCore.Pretty
 
-import           Codec.Serialise
-import           Control.Monad.Except
-import qualified Data.ByteString.Lazy                       as BSL
-import qualified Data.Text                                  as T
-import           Data.Text.Encoding                         (encodeUtf8)
-import           Hedgehog                                   hiding (Var)
-import qualified Hedgehog.Gen                               as Gen
-import           Test.Tasty
-import           Test.Tasty.Golden
-import           Test.Tasty.Hedgehog
-import           Test.Tasty.HUnit
+import Codec.Serialise
+import Control.Monad.Except
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text as T
+import Data.Text.Encoding (encodeUtf8)
+import Hedgehog hiding (Var)
+import qualified Hedgehog.Gen as Gen
+import Test.Tasty
+import Test.Tasty.Golden
+import Test.Tasty.Hedgehog
+import Test.Tasty.HUnit
 
 main :: IO ()
 main = do

--- a/language-plutus-core/test/TypeSynthesis/Spec.hs
+++ b/language-plutus-core/test/TypeSynthesis/Spec.hs
@@ -4,20 +4,20 @@ module TypeSynthesis.Spec
     ( test_typecheck
     ) where
 
-import           Language.PlutusCore
-import qualified Language.PlutusCore.Check.Value         as VR
-import           Language.PlutusCore.FsTree              (foldPlcFolderContents)
-import           Language.PlutusCore.Pretty
+import Language.PlutusCore
+import qualified Language.PlutusCore.Check.Value as VR
+import Language.PlutusCore.FsTree (foldPlcFolderContents)
+import Language.PlutusCore.Pretty
 
-import           Language.PlutusCore.Examples.Everything (examples)
-import           Language.PlutusCore.StdLib.Everything   (stdLib)
+import Language.PlutusCore.Examples.Everything (examples)
+import Language.PlutusCore.StdLib.Everything (stdLib)
 
-import           Common
+import Common
 
-import           Control.Monad.Except
-import           System.FilePath                         ((</>))
-import           Test.Tasty
-import           Test.Tasty.HUnit
+import Control.Monad.Except
+import System.FilePath ((</>))
+import Test.Tasty
+import Test.Tasty.HUnit
 
 kindcheck :: MonadError (Error ()) m => Type TyName () -> m (Type TyName ())
 kindcheck ty = do

--- a/marlowe-playground-server/app/Main.hs
+++ b/marlowe-playground-server/app/Main.hs
@@ -1,23 +1,46 @@
-{-# LANGUAGE ApplicativeDo       #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Main
     ( main
     ) where
 
-import           Control.Monad.IO.Class   (MonadIO, liftIO)
-import           Control.Monad.Logger     (MonadLogger, logInfoN, runStderrLoggingT)
-import           Data.Monoid              ((<>))
-import qualified Data.Text                as Text
-import           Data.Yaml                (decodeFileThrow)
-import           Git                      (gitRev)
-import           Network.Wai.Handler.Warp (HostPreference, defaultSettings, setHost, setPort)
-import           Options.Applicative      (CommandFields, Mod, Parser, argument, auto, command, customExecParser,
-                                           disambiguate, fullDesc, help, helper, idm, info, infoOption, long, metavar,
-                                           option, prefs, short, showDefault, showHelpOnEmpty, str, strOption,
-                                           subparser, value)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Logger (MonadLogger, logInfoN, runStderrLoggingT)
+import Data.Monoid ((<>))
+import qualified Data.Text as Text
+import Data.Yaml (decodeFileThrow)
+import Git (gitRev)
+import Network.Wai.Handler.Warp (HostPreference, defaultSettings, setHost, setPort)
+import Options.Applicative
+    ( CommandFields
+    , Mod
+    , Parser
+    , argument
+    , auto
+    , command
+    , customExecParser
+    , disambiguate
+    , fullDesc
+    , help
+    , helper
+    , idm
+    , info
+    , infoOption
+    , long
+    , metavar
+    , option
+    , prefs
+    , short
+    , showDefault
+    , showHelpOnEmpty
+    , str
+    , strOption
+    , subparser
+    , value
+    )
 import qualified PSGenerator
 import qualified Webserver
 

--- a/marlowe-playground-server/app/PSGenerator.hs
+++ b/marlowe-playground-server/app/PSGenerator.hs
@@ -1,59 +1,79 @@
-{-# LANGUAGE AutoDeriveTypeable    #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE AutoDeriveTypeable #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module PSGenerator
     ( generate
     ) where
 
-import           API                                        (RunResult)
+import API (RunResult)
 import qualified API
-import           Auth                                       (AuthRole, AuthStatus)
+import Auth (AuthRole, AuthStatus)
 import qualified Auth
-import           Control.Applicative                        (empty, (<|>))
-import           Control.Lens                               (set, (&))
-import           Control.Monad.Reader                       (MonadReader)
+import Control.Applicative (empty, (<|>))
+import Control.Lens (set, (&))
+import Control.Monad.Reader (MonadReader)
 import qualified CouponBondGuaranteed
-import qualified Data.ByteString                            as BS
-import qualified Data.ByteString.Char8                      as BS8
-import           Data.Monoid                                ()
-import           Data.Proxy                                 (Proxy (Proxy))
-import qualified Data.Set                                   as Set ()
-import qualified Data.Text.Encoding                         as T ()
-import qualified Data.Text.IO                               as T ()
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import Data.Monoid ()
+import Data.Proxy (Proxy (Proxy))
+import qualified Data.Set as Set ()
+import qualified Data.Text.Encoding as T ()
+import qualified Data.Text.IO as T ()
 import qualified Escrow
-import           Gist                                       (Gist, GistFile, GistId, NewGist, NewGistFile, Owner)
-import           Language.Haskell.Interpreter               (CompilationError, InterpreterError, InterpreterResult,
-                                                             SourceCode, Warning)
-import           Language.Marlowe.Pretty                    (pretty)
-import           Language.PureScript.Bridge                 (BridgePart, Language (Haskell), PSType, SumType,
-                                                             TypeInfo (TypeInfo), buildBridge, doCheck, haskType,
-                                                             isTuple, mkSumType, order, psTypeParameters, typeModule,
-                                                             typeName, writePSTypesWith, (^==))
-import           Language.PureScript.Bridge.Builder         (BridgeData)
-import           Language.PureScript.Bridge.CodeGenSwitches (ForeignOptions (ForeignOptions), defaultSwitch, genForeign)
-import           Language.PureScript.Bridge.PSTypes         (psArray, psInt)
-import           Language.PureScript.Bridge.TypeParameters  (A)
-import           Marlowe.Contracts                          (couponBondGuaranteed, escrow, swap, zeroCouponBond)
-import qualified Marlowe.Symbolic.Types.Request             as MSReq
-import qualified Marlowe.Symbolic.Types.Response            as MSRes
-import           Servant                                    ((:<|>))
-import           Servant.PureScript                         (HasBridge, Settings, apiModuleName, defaultBridge,
-                                                             defaultSettings, languageBridge,
-                                                             writeAPIModuleWithSettings, _generateSubscriberAPI)
+import Gist (Gist, GistFile, GistId, NewGist, NewGistFile, Owner)
+import Language.Haskell.Interpreter (CompilationError, InterpreterError, InterpreterResult, SourceCode, Warning)
+import Language.Marlowe.Pretty (pretty)
+import Language.PureScript.Bridge
+    ( BridgePart
+    , Language (Haskell)
+    , PSType
+    , SumType
+    , TypeInfo (TypeInfo)
+    , buildBridge
+    , doCheck
+    , haskType
+    , isTuple
+    , mkSumType
+    , order
+    , psTypeParameters
+    , typeModule
+    , typeName
+    , writePSTypesWith
+    , (^==)
+    )
+import Language.PureScript.Bridge.Builder (BridgeData)
+import Language.PureScript.Bridge.CodeGenSwitches (ForeignOptions (ForeignOptions), defaultSwitch, genForeign)
+import Language.PureScript.Bridge.PSTypes (psArray, psInt)
+import Language.PureScript.Bridge.TypeParameters (A)
+import Marlowe.Contracts (couponBondGuaranteed, escrow, swap, zeroCouponBond)
+import qualified Marlowe.Symbolic.Types.Request as MSReq
+import qualified Marlowe.Symbolic.Types.Response as MSRes
+import Servant ((:<|>))
+import Servant.PureScript
+    ( HasBridge
+    , Settings
+    , apiModuleName
+    , defaultBridge
+    , defaultSettings
+    , languageBridge
+    , writeAPIModuleWithSettings
+    , _generateSubscriberAPI
+    )
 import qualified Swap
-import           System.Directory                           (createDirectoryIfMissing)
-import           System.FilePath                            ((</>))
-import           WebSocket                                  (WebSocketRequestMessage, WebSocketResponseMessage)
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
+import WebSocket (WebSocketRequestMessage, WebSocketResponseMessage)
 import qualified ZeroCouponBond
 
 psNonEmpty :: MonadReader BridgeData m => m PSType

--- a/marlowe-playground-server/app/Types.hs
+++ b/marlowe-playground-server/app/Types.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Types
   ( Config(..)
   ) where
 
 import qualified Auth
-import           Data.Aeson     (FromJSON, parseJSON, withObject, (.:))
+import Data.Aeson (FromJSON, parseJSON, withObject, (.:))
 import qualified Marlowe.Config as MC
 
 data Config = Config

--- a/marlowe-playground-server/app/Webserver.hs
+++ b/marlowe-playground-server/app/Webserver.hs
@@ -1,53 +1,63 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC   -Wno-orphans #-}
 
 module Webserver
   ( run
   ) where
 
-import qualified API                                            as MA
+import qualified API as MA
 import qualified Auth
-import           Control.Concurrent                             (forkIO)
-import           Control.Monad                                  (void)
-import           Control.Monad.Except                           (ExceptT)
-import           Control.Monad.IO.Class                         (MonadIO, liftIO)
-import           Control.Monad.Logger                           (LoggingT, MonadLogger, logInfoN, runStderrLoggingT)
-import           Control.Monad.Reader                           (ReaderT, runReaderT)
-import           Data.Default.Class                             (def)
-import           Data.Proxy                                     (Proxy (Proxy))
-import           Data.Text                                      (Text)
-import qualified Data.Text                                      as Text
-import           Git                                            (gitRev)
-import           Marlowe.Config                                 (_apiKey, _callbackUrl, _symbolicUrl)
-import qualified Marlowe.Symbolic.Types.API                     as MS
-import           Network.HTTP.Client                            (newManager)
-import           Network.HTTP.Client.TLS                        (tlsManagerSettings)
-import           Network.HTTP.Types                             (Method)
-import           Network.Wai                                    (Application)
-import           Network.Wai.Handler.Warp                       (Settings, runSettings)
-import           Network.Wai.Middleware.Cors                    (cors, corsRequestHeaders, simpleCorsResourcePolicy)
-import           Network.Wai.Middleware.Gzip                    (gzip)
-import           Network.Wai.Middleware.RequestLogger           (logStdout)
-import           Servant                                        ((:<|>) ((:<|>)), (:>), Get, Handler (Handler), JSON,
-                                                                 PlainText, Raw, ServantErr, hoistServer, serve,
-                                                                 serveDirectoryFileServer)
-import           Servant.Client                                 (ClientEnv, mkClientEnv, parseBaseUrl)
-import           Servant.Foreign                                (GenerateList, NoContent, Req, generateList)
-import           Servant.Prometheus                             (monitorEndpoints)
-import           Servant.Server                                 (Server)
-import           Server                                         (mkHandlers)
-import           System.Metrics.Prometheus.Concurrent.RegistryT (runRegistryT)
-import           System.Metrics.Prometheus.Http.Scrape          (serveHttpTextMetricsT)
-import           Types                                          (Config (Config, _authConfig, _marloweConfig))
+import Control.Concurrent (forkIO)
+import Control.Monad (void)
+import Control.Monad.Except (ExceptT)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Logger (LoggingT, MonadLogger, logInfoN, runStderrLoggingT)
+import Control.Monad.Reader (ReaderT, runReaderT)
+import Data.Default.Class (def)
+import Data.Proxy (Proxy (Proxy))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Git (gitRev)
+import Marlowe.Config (_apiKey, _callbackUrl, _symbolicUrl)
+import qualified Marlowe.Symbolic.Types.API as MS
+import Network.HTTP.Client (newManager)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types (Method)
+import Network.Wai (Application)
+import Network.Wai.Handler.Warp (Settings, runSettings)
+import Network.Wai.Middleware.Cors (cors, corsRequestHeaders, simpleCorsResourcePolicy)
+import Network.Wai.Middleware.Gzip (gzip)
+import Network.Wai.Middleware.RequestLogger (logStdout)
+import Servant
+    ( (:<|>) ((:<|>))
+    , (:>)
+    , Get
+    , Handler (Handler)
+    , JSON
+    , PlainText
+    , Raw
+    , ServantErr
+    , hoistServer
+    , serve
+    , serveDirectoryFileServer
+    )
+import Servant.Client (ClientEnv, mkClientEnv, parseBaseUrl)
+import Servant.Foreign (GenerateList, NoContent, Req, generateList)
+import Servant.Prometheus (monitorEndpoints)
+import Servant.Server (Server)
+import Server (mkHandlers)
+import System.Metrics.Prometheus.Concurrent.RegistryT (runRegistryT)
+import System.Metrics.Prometheus.Http.Scrape (serveHttpTextMetricsT)
+import Types (Config (Config, _authConfig, _marloweConfig))
 
 instance GenerateList NoContent (Method -> Req NoContent) where
   generateList _ = []

--- a/marlowe-playground-server/contracts/CouponBondGuaranteed.hs
+++ b/marlowe-playground-server/contracts/CouponBondGuaranteed.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module CouponBondGuaranteed where
 
-import           Language.Marlowe
+import Language.Marlowe
 
 main :: IO ()
 main = print . pretty $ contract

--- a/marlowe-playground-server/contracts/Escrow.hs
+++ b/marlowe-playground-server/contracts/Escrow.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Escrow where
 
-import           Language.Marlowe
+import Language.Marlowe
 
 main :: IO ()
 main = print . pretty $ contract

--- a/marlowe-playground-server/contracts/Swap.hs
+++ b/marlowe-playground-server/contracts/Swap.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Swap where
 
-import           Language.Marlowe
+import Language.Marlowe
 
 main :: IO ()
 main = print . pretty $ contract

--- a/marlowe-playground-server/contracts/ZeroCouponBond.hs
+++ b/marlowe-playground-server/contracts/ZeroCouponBond.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module ZeroCouponBond where
 
-import           Language.Marlowe
+import Language.Marlowe
 
 main :: IO ()
 main = print . pretty $ contract

--- a/marlowe-playground-server/src/API.hs
+++ b/marlowe-playground-server/src/API.hs
@@ -1,20 +1,20 @@
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE TypeOperators #-}
 module API where
 
-import           Control.Newtype.Generics        (Newtype)
-import           Data.Aeson                      (FromJSON, ToJSON)
-import           Data.Text                       (Text)
-import           GHC.Generics                    (Generic)
-import           Language.Haskell.Interpreter    (InterpreterError, InterpreterResult, SourceCode)
-import qualified Marlowe.Symbolic.Types.Request  as MSReq
+import Control.Newtype.Generics (Newtype)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Language.Haskell.Interpreter (InterpreterError, InterpreterResult, SourceCode)
+import qualified Marlowe.Symbolic.Types.Request as MSReq
 import qualified Marlowe.Symbolic.Types.Response as MSRes
-import           Servant.API                     ((:<|>), (:>), Get, Header, JSON, NoContent, Post, ReqBody)
-import           Servant.API.WebSocket           (WebSocketPending)
+import Servant.API ((:<|>), (:>), Get, Header, JSON, NoContent, Post, ReqBody)
+import Servant.API.WebSocket (WebSocketPending)
 
 type API
    = "contract" :> "haskell" :> ReqBody '[ JSON] SourceCode :> Post '[ JSON] (Either InterpreterError (InterpreterResult RunResult))

--- a/marlowe-playground-server/src/Interpreter.hs
+++ b/marlowe-playground-server/src/Interpreter.hs
@@ -1,33 +1,39 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Interpreter where
 
-import           API                          (RunResult (RunResult))
-import           Control.Monad                (unless)
-import           Control.Monad.Catch          (MonadCatch, MonadMask, bracket, catch)
-import           Control.Monad.Error.Class    (MonadError, catchError, throwError)
-import           Control.Monad.Except.Extras  (mapError)
-import           Control.Monad.IO.Class       (MonadIO, liftIO)
-import           Control.Monad.Trans.Class    (lift)
-import           Control.Monad.Trans.State    (StateT, evalStateT, get, put)
-import           Control.Newtype.Generics     (Newtype)
-import qualified Control.Newtype.Generics     as Newtype
-import           Data.Aeson                   (FromJSON, ToJSON)
-import           Data.Bifunctor               (second)
-import           Data.Monoid                  ((<>))
-import           Data.Text                    (Text)
-import qualified Data.Text                    as Text
-import qualified Data.Text.Internal.Search    as Text
-import qualified Data.Text.IO                 as Text
-import           Data.Time.Units              (TimeUnit)
-import           Language.Haskell.Interpreter (CompilationError (RawError), InterpreterError (CompilationErrors),
-                                               InterpreterResult (InterpreterResult), SourceCode, avoidUnsafe, runghc)
-import           System.Directory             (removeFile)
-import           System.FilePath              ((</>))
-import           System.IO                    (Handle, IOMode (ReadWriteMode), hFlush)
-import           System.IO.Extras             (withFile)
-import           System.IO.Temp               (getCanonicalTemporaryDirectory, openTempFile, withSystemTempDirectory)
-import           System.Process               (cwd, proc, readProcessWithExitCode)
+import API (RunResult (RunResult))
+import Control.Monad (unless)
+import Control.Monad.Catch (MonadCatch, MonadMask, bracket, catch)
+import Control.Monad.Error.Class (MonadError, catchError, throwError)
+import Control.Monad.Except.Extras (mapError)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State (StateT, evalStateT, get, put)
+import Control.Newtype.Generics (Newtype)
+import qualified Control.Newtype.Generics as Newtype
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Bifunctor (second)
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Internal.Search as Text
+import qualified Data.Text.IO as Text
+import Data.Time.Units (TimeUnit)
+import Language.Haskell.Interpreter
+    ( CompilationError (RawError)
+    , InterpreterError (CompilationErrors)
+    , InterpreterResult (InterpreterResult)
+    , SourceCode
+    , avoidUnsafe
+    , runghc
+    )
+import System.Directory (removeFile)
+import System.FilePath ((</>))
+import System.IO (Handle, IOMode (ReadWriteMode), hFlush)
+import System.IO.Extras (withFile)
+import System.IO.Temp (getCanonicalTemporaryDirectory, openTempFile, withSystemTempDirectory)
+import System.Process (cwd, proc, readProcessWithExitCode)
 
 runscript
     :: (Show t, TimeUnit t, MonadMask m, MonadIO m, MonadError InterpreterError m)

--- a/marlowe-playground-server/src/Marlowe/Config.hs
+++ b/marlowe-playground-server/src/Marlowe/Config.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 module Marlowe.Config where
 
-import           Data.Aeson (FromJSON, parseJSON, withObject, (.:))
-import           Data.Text  (Text)
+import Data.Aeson (FromJSON, parseJSON, withObject, (.:))
+import Data.Text (Text)
 
 data Config = Config
     { _symbolicUrl :: Text

--- a/marlowe-playground-server/src/Marlowe/Contracts.hs
+++ b/marlowe-playground-server/src/Marlowe/Contracts.hs
@@ -2,8 +2,8 @@
 
 module Marlowe.Contracts where
 
-import           Data.ByteString (ByteString)
-import           Data.FileEmbed  (embedFile, makeRelativeToProject)
+import Data.ByteString (ByteString)
+import Data.FileEmbed (embedFile, makeRelativeToProject)
 
 escrow :: ByteString
 escrow = $(makeRelativeToProject "contracts/Escrow.hs" >>= embedFile)

--- a/marlowe-playground-server/src/Server.hs
+++ b/marlowe-playground-server/src/Server.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC   -Wno-orphans     #-}
 
 module Server
@@ -12,44 +12,52 @@ module Server
     )
 where
 
-import           API                             (API, MarloweSymbolicAPI, RunResult, WSAPI)
-import           Control.Concurrent              (forkIO, threadDelay)
-import           Control.Concurrent.STM          (atomically)
-import           Control.Concurrent.STM.TVar     (TVar, modifyTVar, readTVarIO)
-import           Control.Monad                   (forever, void, when)
-import           Control.Monad.Catch             (MonadCatch, MonadMask, bracket, catch)
-import           Control.Monad.Except            (MonadError, runExceptT, throwError)
-import           Control.Monad.IO.Class          (MonadIO, liftIO)
-import           Control.Monad.Logger            (MonadLogger, logInfoN)
-import           Data.Aeson                      (ToJSON, eitherDecode, encode)
-import qualified Data.ByteString.Char8           as BS
-import qualified Data.ByteString.Lazy.Char8      as BSL
-import           Data.Maybe                      (fromMaybe)
-import           Data.Proxy                      (Proxy (Proxy))
-import           Data.Text                       (Text)
-import qualified Data.Text                       as Text
-import           Data.Time.Units                 (Microsecond, fromMicroseconds)
-import qualified Data.UUID                       as UUID
-import           Data.UUID.V4                    (nextRandom)
+import API (API, MarloweSymbolicAPI, RunResult, WSAPI)
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM.TVar (TVar, modifyTVar, readTVarIO)
+import Control.Monad (forever, void, when)
+import Control.Monad.Catch (MonadCatch, MonadMask, bracket, catch)
+import Control.Monad.Except (MonadError, runExceptT, throwError)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Logger (MonadLogger, logInfoN)
+import Data.Aeson (ToJSON, eitherDecode, encode)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.Maybe (fromMaybe)
+import Data.Proxy (Proxy (Proxy))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Units (Microsecond, fromMicroseconds)
+import qualified Data.UUID as UUID
+import Data.UUID.V4 (nextRandom)
 import qualified Interpreter
-import           Language.Haskell.Interpreter    (InterpreterError (CompilationErrors), InterpreterResult,
-                                                  SourceCode (SourceCode))
-import           Marlowe.Contracts               (escrow)
-import qualified Marlowe.Symbolic.Types.API      as MS
-import qualified Marlowe.Symbolic.Types.Request  as MSReq
+import Language.Haskell.Interpreter (InterpreterError (CompilationErrors), InterpreterResult, SourceCode (SourceCode))
+import Marlowe.Contracts (escrow)
+import qualified Marlowe.Symbolic.Types.API as MS
+import qualified Marlowe.Symbolic.Types.Request as MSReq
 import qualified Marlowe.Symbolic.Types.Response as MSRes
-import           Network.HTTP.Types              (hContentType)
-import           Network.WebSockets.Connection   (Connection, PendingConnection, receiveData, sendTextData)
-import           Servant                         (ServantErr, err400, errBody, errHeaders)
-import           Servant.API                     ((:<|>) ((:<|>)), (:>), JSON, NoContent (NoContent), Post, ReqBody)
-import           Servant.Client                  (ClientEnv, ClientM, client, runClientM)
-import           Servant.Server                  (Handler, Server)
-import           System.Timeout                  (timeout)
-import           WebSocket                       (Registry, WebSocketRequestMessage (CheckForWarnings),
-                                                  WebSocketResponseMessage (CheckForWarningsResult, OtherError),
-                                                  deleteFromRegistry, finishWaiting, initializeConnection,
-                                                  insertIntoRegistry, isWaiting, lookupInRegistry, newRegistry,
-                                                  runWithConnection, startWaiting)
+import Network.HTTP.Types (hContentType)
+import Network.WebSockets.Connection (Connection, PendingConnection, receiveData, sendTextData)
+import Servant (ServantErr, err400, errBody, errHeaders)
+import Servant.API ((:<|>) ((:<|>)), (:>), JSON, NoContent (NoContent), Post, ReqBody)
+import Servant.Client (ClientEnv, ClientM, client, runClientM)
+import Servant.Server (Handler, Server)
+import System.Timeout (timeout)
+import WebSocket
+    ( Registry
+    , WebSocketRequestMessage (CheckForWarnings)
+    , WebSocketResponseMessage (CheckForWarningsResult, OtherError)
+    , deleteFromRegistry
+    , finishWaiting
+    , initializeConnection
+    , insertIntoRegistry
+    , isWaiting
+    , lookupInRegistry
+    , newRegistry
+    , runWithConnection
+    , startWaiting
+    )
 
 acceptSourceCode :: SourceCode -> Handler (Either InterpreterError (InterpreterResult RunResult))
 acceptSourceCode sourceCode = do

--- a/marlowe-playground-server/src/WebSocket.hs
+++ b/marlowe-playground-server/src/WebSocket.hs
@@ -1,27 +1,26 @@
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module WebSocket where
 
-import           Control.Concurrent.STM          (STM)
-import           Control.Concurrent.STM.TVar     (TVar, newTVar)
-import           Control.Exception               (SomeException, handle)
-import           Control.Monad                   (forever)
-import           Control.Monad.Except            (MonadError, throwError)
-import           Control.Monad.IO.Class          (MonadIO, liftIO)
-import           Control.Newtype.Generics        (Newtype, over, unpack)
-import           Data.Aeson                      (FromJSON, ToJSON)
-import           Data.Map.Strict                 (Map)
-import qualified Data.Map.Strict                 as Map
-import           Data.Text                       (Text)
-import           Data.UUID                       (UUID)
-import           Data.UUID.V4                    (nextRandom)
-import           GHC.Generics                    (Generic)
+import Control.Concurrent.STM (STM)
+import Control.Concurrent.STM.TVar (TVar, newTVar)
+import Control.Exception (SomeException, handle)
+import Control.Monad (forever)
+import Control.Monad.Except (MonadError, throwError)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Newtype.Generics (Newtype, over, unpack)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import Data.UUID (UUID)
+import Data.UUID.V4 (nextRandom)
+import GHC.Generics (Generic)
 import qualified Marlowe.Symbolic.Types.Response as MSRes
-import           Network.WebSockets              (WebSocketsData)
-import           Network.WebSockets.Connection   (Connection, PendingConnection, acceptRequest, forkPingThread,
-                                                  receiveData)
+import Network.WebSockets (WebSocketsData)
+import Network.WebSockets.Connection (Connection, PendingConnection, acceptRequest, forkPingThread, receiveData)
 
 newtype WebSocketRequestMessage
     = CheckForWarnings String

--- a/marlowe-playground-server/test/Spec.hs
+++ b/marlowe-playground-server/test/Spec.hs
@@ -1,20 +1,19 @@
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE QuasiQuotes         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main (main) where
 
-import           API                          (RunResult (RunResult))
-import           Control.Monad.Except         (runExceptT)
-import           Data.ByteString              (ByteString)
-import qualified Data.ByteString.Char8        as BSC
-import qualified Data.Text                    as Text
-import           Data.Time.Units              (Microsecond, fromMicroseconds)
+import API (RunResult (RunResult))
+import Control.Monad.Except (runExceptT)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.Text as Text
+import Data.Time.Units (Microsecond, fromMicroseconds)
 import qualified Interpreter
-import           Language.Haskell.Interpreter (InterpreterError, InterpreterResult (InterpreterResult),
-                                               SourceCode (SourceCode))
-import           Marlowe.Contracts            (escrow)
-import           Test.Hspec                   (Spec, describe, hspec, it, shouldBe)
-import           Text.RawString.QQ            (r)
+import Language.Haskell.Interpreter (InterpreterError, InterpreterResult (InterpreterResult), SourceCode (SourceCode))
+import Marlowe.Contracts (escrow)
+import Test.Hspec (Spec, describe, hspec, it, shouldBe)
+import Text.RawString.QQ (r)
 
 main :: IO ()
 main = hspec runBasicSpec

--- a/marlowe-symbolic/src/App.hs
+++ b/marlowe-symbolic/src/App.hs
@@ -1,28 +1,30 @@
 {-# LANGUAGE TemplateHaskell #-}
 module App where
 
-import           Aws.Lambda
-import           Control.Concurrent                    (forkOS, killThread, threadDelay)
-import           Control.Concurrent.MVar               (MVar, newEmptyMVar, putMVar, readMVar)
-import           Control.Exception                     (try)
-import           Data.Aeson                            (encode)
-import           Data.ByteString.UTF8                  as BSU
-import           Data.Proxy                            (Proxy (Proxy))
-import           Language.Marlowe                      (Slot (Slot), TransactionInput, TransactionWarning)
-import           Language.Marlowe.Analysis.FSSemantics (warningsTrace)
-import           Language.Marlowe.Pretty
-import           Marlowe.Symbolic.Types.API            (API)
-import           Marlowe.Symbolic.Types.Request        (Request (Request, callbackUrl, contract))
-import qualified Marlowe.Symbolic.Types.Request        as Req
-import           Marlowe.Symbolic.Types.Response       (Response (Response, result), Result (CounterExample, Error, Valid, initialSlot, transactionList, transactionWarning))
-import qualified Marlowe.Symbolic.Types.Response       as Res
-import           Network.HTTP.Client                   (newManager)
-import           Network.HTTP.Client.TLS               (tlsManagerSettings)
-import           Servant.API                           (NoContent)
-import           Servant.Client                        (ClientEnv, ClientM, client, mkClientEnv, parseBaseUrl,
-                                                        runClientM)
-import           System.Process                        (system)
-import           Text.PrettyPrint.Leijen               (displayS, renderCompact)
+import Aws.Lambda
+import Control.Concurrent (forkOS, killThread, threadDelay)
+import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, readMVar)
+import Control.Exception (try)
+import Data.Aeson (encode)
+import Data.ByteString.UTF8 as BSU
+import Data.Proxy (Proxy (Proxy))
+import Language.Marlowe (Slot (Slot), TransactionInput, TransactionWarning)
+import Language.Marlowe.Analysis.FSSemantics (warningsTrace)
+import Language.Marlowe.Pretty
+import Marlowe.Symbolic.Types.API (API)
+import Marlowe.Symbolic.Types.Request (Request (Request, callbackUrl, contract))
+import qualified Marlowe.Symbolic.Types.Request as Req
+import Marlowe.Symbolic.Types.Response
+    ( Response (Response, result)
+    , Result (CounterExample, Error, Valid, initialSlot, transactionList, transactionWarning)
+    )
+import qualified Marlowe.Symbolic.Types.Response as Res
+import Network.HTTP.Client (newManager)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Servant.API (NoContent)
+import Servant.Client (ClientEnv, ClientM, client, mkClientEnv, parseBaseUrl, runClientM)
+import System.Process (system)
+import Text.PrettyPrint.Leijen (displayS, renderCompact)
 
 notifyApi :: Proxy API
 notifyApi = Proxy

--- a/marlowe-symbolic/src/Language/Marlowe/Analysis/FSMap.hs
+++ b/marlowe-symbolic/src/Language/Marlowe/Analysis/FSMap.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE OverloadedLists #-}
 module Language.Marlowe.Analysis.FSMap where
 
-import           Data.SBV
-import           Data.SBV.List  as SL
-import           Data.SBV.Maybe as SM
-import           Data.SBV.Tuple as ST
-import           Prelude        hiding (all, lookup)
+import Data.SBV
+import Data.SBV.List as SL
+import Data.SBV.Maybe as SM
+import Data.SBV.Tuple as ST
+import Prelude hiding (all, lookup)
 
 type NMap a b = [(a, b)]
 type FSMap a b = SList (a, b)

--- a/marlowe-symbolic/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe-symbolic/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -1,26 +1,26 @@
-{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Language.Marlowe.Analysis.FSSemantics where
 
-import           Data.List                              (foldl')
-import           Data.Map.Strict                        (Map)
-import qualified Data.Map.Strict                        as M
-import           Data.SBV
-import qualified Data.SBV.Either                        as SE
-import           Data.SBV.Internals                     (SMTModel (..))
-import qualified Data.SBV.List                          as SL
-import qualified Data.SBV.Maybe                         as SM
-import qualified Data.SBV.Tuple                         as ST
-import           Data.Set                               (Set)
-import qualified Data.Set                               as S
-import           Language.Marlowe.Analysis.IntegerArray (IntegerArray, NIntegerArray)
+import Data.List (foldl')
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Data.SBV
+import qualified Data.SBV.Either as SE
+import Data.SBV.Internals (SMTModel (..))
+import qualified Data.SBV.List as SL
+import qualified Data.SBV.Maybe as SM
+import qualified Data.SBV.Tuple as ST
+import Data.Set (Set)
+import qualified Data.Set as S
+import Language.Marlowe.Analysis.IntegerArray (IntegerArray, NIntegerArray)
 import qualified Language.Marlowe.Analysis.IntegerArray as IntegerArray
-import           Language.Marlowe.Analysis.MkSymb       (mkSymbolicDatatype)
-import           Language.Marlowe.Analysis.Numbering
-import qualified Language.Marlowe.Semantics             as MS
-import           Ledger                                 (Slot (..))
-import qualified Ledger.Ada                             as Ada
+import Language.Marlowe.Analysis.MkSymb (mkSymbolicDatatype)
+import Language.Marlowe.Analysis.Numbering
+import qualified Language.Marlowe.Semantics as MS
+import Ledger (Slot (..))
+import qualified Ledger.Ada as Ada
 
 data Bounds = Bounds { numParties  :: Integer
                      , numChoices  :: Integer

--- a/marlowe-symbolic/src/Language/Marlowe/Analysis/FSSet.hs
+++ b/marlowe-symbolic/src/Language/Marlowe/Analysis/FSSet.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE OverloadedLists #-}
 module Language.Marlowe.Analysis.FSSet where
 
-import           Data.SBV
-import           Data.SBV.List as SL
+import Data.SBV
+import Data.SBV.List as SL
 
 type NSet a = [a]
 type FSSet a = SList a

--- a/marlowe-symbolic/src/Language/Marlowe/Analysis/IntegerArray.hs
+++ b/marlowe-symbolic/src/Language/Marlowe/Analysis/IntegerArray.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE OverloadedLists #-}
 module Language.Marlowe.Analysis.IntegerArray where
 
-import           Data.SBV
-import           Data.SBV.List  as SL
-import           Data.SBV.Maybe as SM
-import           Data.SBV.Tuple as ST
-import           Prelude        hiding (all, lookup)
+import Data.SBV
+import Data.SBV.List as SL
+import Data.SBV.Maybe as SM
+import Data.SBV.Tuple as ST
+import Prelude hiding (all, lookup)
 
 type NIntegerArray = [Maybe Integer]
 type IntegerArray = SList (Maybe Integer)

--- a/marlowe-symbolic/src/Language/Marlowe/Analysis/MkSymb.hs
+++ b/marlowe-symbolic/src/Language/Marlowe/Analysis/MkSymb.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Language.Marlowe.Analysis.MkSymb where
 
-import           Data.Either         (Either (..))
-import           Data.List           (foldl', foldl1')
-import           Data.SBV
-import           Data.SBV.Either     as SE
-import           Data.SBV.Tuple      as ST
-import           Language.Haskell.TH as TH
+import Data.Either (Either (..))
+import Data.List (foldl', foldl1')
+import Data.SBV
+import Data.SBV.Either as SE
+import Data.SBV.Tuple as ST
+import Language.Haskell.TH as TH
 
 nestClauses :: [Con] -> TypeQ
 nestClauses [] = error "No constructors for type"

--- a/marlowe-symbolic/src/Language/Marlowe/Analysis/Numbering.hs
+++ b/marlowe-symbolic/src/Language/Marlowe/Analysis/Numbering.hs
@@ -1,6 +1,6 @@
 module Language.Marlowe.Analysis.Numbering (Numbering, emptyNumbering, getNumbering, getLabel, numberOfLabels) where
 
-import           Data.Map.Strict (Map)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 
 data Numbering a = Numbering { numbering     :: Map a Integer

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Types/API.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Types/API.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 module Marlowe.Symbolic.Types.API where
 
-import           Marlowe.Symbolic.Types.Response (Response)
-import           Servant.API                     ((:<|>), (:>), Get, JSON, NoContent, Post, ReqBody)
+import Marlowe.Symbolic.Types.Response (Response)
+import Servant.API ((:<|>), (:>), Get, JSON, NoContent, Post, ReqBody)
 
 type API = "notify" :> ReqBody '[JSON] Response :> Post '[JSON] NoContent

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Types/Request.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Types/Request.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Marlowe.Symbolic.Types.Request where
 
-import           Data.Aeson
-import           GHC.Generics
+import Data.Aeson
+import GHC.Generics
 
 data Request = Request
   { uuid        :: String

--- a/marlowe-symbolic/src/Marlowe/Symbolic/Types/Response.hs
+++ b/marlowe-symbolic/src/Marlowe/Symbolic/Types/Response.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Marlowe.Symbolic.Types.Response where
 
-import           Data.Aeson   (FromJSON, ToJSON)
-import           GHC.Generics
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics
 
 data Result = Valid
             | CounterExample

--- a/marlowe/src/Language/Marlowe.hs
+++ b/marlowe/src/Language/Marlowe.hs
@@ -7,8 +7,8 @@ module Language.Marlowe
     )
 where
 
-import           Language.Marlowe.Client
-import           Language.Marlowe.Pretty
-import           Language.Marlowe.Semantics
-import           Language.Marlowe.Util
-import           Ledger                     (Slot (..))
+import Language.Marlowe.Client
+import Language.Marlowe.Pretty
+import Language.Marlowe.Semantics
+import Language.Marlowe.Util
+import Ledger (Slot (..))

--- a/marlowe/src/Language/Marlowe/Pretty.hs
+++ b/marlowe/src/Language/Marlowe/Pretty.hs
@@ -1,22 +1,22 @@
-{-# LANGUAGE DefaultSignatures  #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts   #-}
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE TypeOperators      #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -fno-warn-orphans       #-}
 module Language.Marlowe.Pretty where
 
-import qualified Data.ByteString.Lazy    as BSL
-import           Data.String             (fromString)
-import           Data.Text               (Text)
-import qualified Data.Text               as Text
-import           GHC.Generics            ((:*:) ((:*:)), (:+:) (L1, R1), C, Constructor, D, Generic, K1 (K1), M1 (M1),
-                                          Rep, S, U1, conName, from)
-import           Ledger                  (PubKey (..), Slot (..))
-import           Ledger.Ada              (Ada, getLovelace)
-import           LedgerBytes
-import           Text.PrettyPrint.Leijen (Doc, comma, encloseSep, hang, lbracket, line, lparen, parens, rbracket,
-                                          rparen, space, text)
+import qualified Data.ByteString.Lazy as BSL
+import Data.String (fromString)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Generics
+    ((:*:) ((:*:)), (:+:) (L1, R1), C, Constructor, D, Generic, K1 (K1), M1 (M1), Rep, S, U1, conName, from)
+import Ledger (PubKey (..), Slot (..))
+import Ledger.Ada (Ada, getLovelace)
+import LedgerBytes
+import Text.PrettyPrint.Leijen
+    (Doc, comma, encloseSep, hang, lbracket, line, lparen, parens, rbracket, rparen, space, text)
 
 -- | This function will pretty print an a but will not wrap the whole
 -- expression in parentheses or add an initial newline, where as for

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE NamedFieldPuns     #-}
-{-# LANGUAGE NoImplicitPrelude  #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE RecordWildCards    #-}
-{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 -- Big hammer, but helps
 {-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
@@ -35,22 +35,22 @@ and actions (i.e. /Choices/) are passed as
 
 module Language.Marlowe.Semantics where
 
-import           GHC.Generics               (Generic)
-import           Language.Marlowe.Pretty    (Pretty (..))
-import           Language.PlutusTx          (makeIsData)
-import qualified Language.PlutusTx          as PlutusTx
-import           Language.PlutusTx.AssocMap (Map)
+import GHC.Generics (Generic)
+import Language.Marlowe.Pretty (Pretty (..))
+import Language.PlutusTx (makeIsData)
+import qualified Language.PlutusTx as PlutusTx
+import Language.PlutusTx.AssocMap (Map)
 import qualified Language.PlutusTx.AssocMap as Map
-import           Language.PlutusTx.Lift     (makeLift)
-import           Language.PlutusTx.Prelude  hiding ((<>))
-import           Ledger                     (PubKey (..), Slot (..))
-import           Ledger.Ada                 (Ada)
-import qualified Ledger.Ada                 as Ada
-import           Ledger.Interval            (Extended (..), Interval (..), LowerBound (..), UpperBound (..))
-import           Ledger.Scripts             (DataScript (..))
-import           Ledger.Validation
-import qualified Prelude                    as P
-import           Text.PrettyPrint.Leijen    (comma, hang, lbrace, line, rbrace, space, text, (<>))
+import Language.PlutusTx.Lift (makeLift)
+import Language.PlutusTx.Prelude hiding ((<>))
+import Ledger (PubKey (..), Slot (..))
+import Ledger.Ada (Ada)
+import qualified Ledger.Ada as Ada
+import Ledger.Interval (Extended (..), Interval (..), LowerBound (..), UpperBound (..))
+import Ledger.Scripts (DataScript (..))
+import Ledger.Validation
+import qualified Prelude as P
+import Text.PrettyPrint.Leijen (comma, hang, lbrace, line, rbrace, space, text, (<>))
 
 {-# ANN module ("HLint: ignore Avoid restricted function" :: String) #-}
 

--- a/marlowe/src/Language/Marlowe/Util.hs
+++ b/marlowe/src/Language/Marlowe/Util.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Language.Marlowe.Util where
-import           Data.List                  (foldl')
-import           Data.Map.Strict            (Map)
-import qualified Data.Map.Strict            as Map
-import           Data.String
+import Data.List (foldl')
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.String
 
-import           Language.Marlowe.Pretty
-import           Language.Marlowe.Semantics
-import           Ledger                     (PubKey (..))
-import qualified Ledger.Ada                 as Ada
+import Language.Marlowe.Pretty
+import Language.Marlowe.Semantics
+import Ledger (PubKey (..))
+import qualified Ledger.Ada as Ada
 
 instance IsString PubKey where
     fromString = pubKeyFromString

--- a/marlowe/test/Spec.hs
+++ b/marlowe/test/Spec.hs
@@ -4,8 +4,8 @@ module Main(main) where
 -- import qualified Spec.Actus
 import qualified Spec.Marlowe.Marlowe
 
-import           Test.Tasty
-import           Test.Tasty.Hedgehog  (HedgehogTestLimit (..))
+import Test.Tasty
+import Test.Tasty.Hedgehog (HedgehogTestLimit (..))
 
 main :: IO ()
 main = defaultMain tests

--- a/marlowe/test/Spec/Marlowe/Common.hs
+++ b/marlowe/test/Spec/Marlowe/Common.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns -fno-warn-name-shadowing -fno-warn-unused-do-bind #-}
 module Spec.Marlowe.Common where
 
-import           Data.Map.Strict            (Map)
+import Data.Map.Strict (Map)
 
-import           Hedgehog                   (Gen, Size (..))
-import           Hedgehog.Gen               (choice, element, integral, sized)
-import qualified Hedgehog.Range             as Range
+import Hedgehog (Gen, Size (..))
+import Hedgehog.Gen (choice, element, integral, sized)
+import qualified Hedgehog.Range as Range
 
-import           Language.Marlowe.Semantics
+import Language.Marlowe.Semantics
 import qualified Ledger
-import           Wallet                     (PubKey (..))
+import Wallet (PubKey (..))
 
 newtype MarloweScenario = MarloweScenario { mlInitialBalances :: Map PubKey Ledger.Value }
 

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE NumericUnderscores  #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns
 -fno-warn-name-shadowing
@@ -12,32 +12,32 @@ module Spec.Marlowe.Marlowe
     )
 where
 
-import           Control.Monad              (void)
-import qualified Data.ByteString            as BS
-import           Data.Either                (isRight)
-import qualified Data.Map.Strict            as Map
-import           Data.String
+import Control.Monad (void)
+import qualified Data.ByteString as BS
+import Data.Either (isRight)
+import qualified Data.Map.Strict as Map
+import Data.String
 
-import qualified Codec.CBOR.Write           as Write
-import qualified Codec.Serialise            as Serialise
-import           Hedgehog                   (Gen, Property, forAll, property)
+import qualified Codec.CBOR.Write as Write
+import qualified Codec.Serialise as Serialise
+import Hedgehog (Gen, Property, forAll, property)
 import qualified Hedgehog
-import           Hedgehog.Gen               (integral)
-import qualified Hedgehog.Range             as Range
-import           Language.Marlowe
+import Hedgehog.Gen (integral)
+import qualified Hedgehog.Range as Range
+import Language.Marlowe
 import qualified Language.PlutusTx.AssocMap as AssocMap
-import qualified Language.PlutusTx.Prelude  as P
-import           Ledger                     hiding (Value)
-import qualified Ledger.Ada                 as Ada
-import           Spec.Marlowe.Common
-import           Test.Tasty
-import           Test.Tasty.Hedgehog        (HedgehogTestLimit (..), testProperty)
-import           Test.Tasty.HUnit
-import           Wallet                     (PubKey (..))
-import           Wallet.Emulator
+import qualified Language.PlutusTx.Prelude as P
+import Ledger hiding (Value)
+import qualified Ledger.Ada as Ada
+import Spec.Marlowe.Common
+import Test.Tasty
+import Test.Tasty.Hedgehog (HedgehogTestLimit (..), testProperty)
+import Test.Tasty.HUnit
+import Wallet (PubKey (..))
+import Wallet.Emulator
 import qualified Wallet.Emulator.Generators as Gen
-import           Wallet.Emulator.NodeClient
-import qualified Wallet.Generators          as Gen
+import Wallet.Emulator.NodeClient
+import qualified Wallet.Generators as Gen
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: String) #-}
 {-# ANN module ("HLint: ignore Redundant if" :: String) #-}

--- a/metatheory/Opts.hs
+++ b/metatheory/Opts.hs
@@ -1,9 +1,9 @@
 module Opts where
 
-import           Data.Semigroup      ((<>))
-import qualified Data.Text           as T
-import qualified Data.Text.IO        as T
-import           Options.Applicative
+import Data.Semigroup ((<>))
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import Options.Applicative
 
 data Input = FileInput T.Text | StdInput deriving (Show, Read)
 

--- a/metatheory/Raw.hs
+++ b/metatheory/Raw.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 module Raw where
 
-import           GHC.Natural
+import GHC.Natural
 
-import           Data.ByteString.Lazy       as BSL
-import qualified Data.Text                  as T
-import           Language.PlutusCore
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.Parser
-import           Language.PlutusCore.Pretty
+import Data.ByteString.Lazy as BSL
+import qualified Data.Text as T
+import Language.PlutusCore
+import Language.PlutusCore.Name
+import Language.PlutusCore.Parser
+import Language.PlutusCore.Pretty
 
-import           Data.Either
+import Data.Either
 
 data RKind = RKiStar
            | RKiFun RKind RKind

--- a/metatheory/Scoped.hs
+++ b/metatheory/Scoped.hs
@@ -1,6 +1,6 @@
 module Scoped where
 
-import           Language.PlutusCore
+import Language.PlutusCore
 
 data ScKind = ScKiStar
             | ScKiFun ScKind ScKind

--- a/metatheory/TestDetailed.hs
+++ b/metatheory/TestDetailed.hs
@@ -1,15 +1,15 @@
 module TestDetailed where
-import           Control.Exception
-import           GHC.IO.Handle
-import           System.Directory
-import           System.Environment
-import           System.Exit
-import           System.IO
-import           System.Process
+import Control.Exception
+import GHC.IO.Handle
+import System.Directory
+import System.Environment
+import System.Exit
+import System.IO
+import System.Process
 
-import           Distribution.TestSuite
+import Distribution.TestSuite
 
-import qualified MAlonzo.Code.Main      as M
+import qualified MAlonzo.Code.Main as M
 
 -- this function is based on this stackoverflow answer:
 -- https://stackoverflow.com/a/9664017

--- a/metatheory/TestSimple.hs
+++ b/metatheory/TestSimple.hs
@@ -2,12 +2,12 @@
 
 module Main where
 
-import           Control.Exception
-import           System.Environment
-import           System.Exit
-import           System.Process
+import Control.Exception
+import System.Environment
+import System.Exit
+import System.Process
 
-import qualified MAlonzo.Code.Main  as M
+import qualified MAlonzo.Code.Main as M
 
 succeedingEvalTests = ["succInteger"
         ,"unitval"

--- a/playground-common/src/Auth.hs
+++ b/playground-common/src/Auth.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Auth
     ( API
@@ -34,48 +34,80 @@ module Auth
     , githubEndpointsCallbackUri
     ) where
 
-import           Auth.Types                  (OAuthClientId, OAuthClientSecret, OAuthCode, OAuthToken, Token (Token),
-                                              TokenProvider (Github), addUserAgent, oAuthTokenAccessToken)
-import           Control.Lens                (makeLenses, view, _1, _2)
-import           Control.Monad               (guard)
-import           Control.Monad.Except        (MonadError)
-import           Control.Monad.IO.Class      (MonadIO, liftIO)
-import           Control.Monad.Logger        (MonadLogger, logDebugN, logErrorN)
-import           Control.Monad.Now           (MonadNow, getCurrentTime, getPOSIXTime)
-import           Control.Monad.Reader        (MonadReader)
-import           Control.Monad.Trace         (attempt, runTrace, withTrace)
-import           Control.Monad.Web           (MonadWeb, doRequest, makeManager)
-import           Control.Newtype.Generics    (Newtype, O, unpack)
-import           Data.Aeson                  (FromJSON, ToJSON, Value (String), eitherDecode, parseJSON, withObject,
-                                              (.:))
-import           Data.Bifunctor              (first)
-import           Data.ByteString             (ByteString)
-import qualified Data.ByteString.Lazy        as LBS
-import qualified Data.Map                    as Map
-import           Data.Text                   (Text)
-import qualified Data.Text                   as Text
-import           Data.Text.Encoding          (decodeUtf8, encodeUtf8)
-import           Data.Time                   (NominalDiffTime, UTCTime, addUTCTime)
-import           Data.Time.Clock.POSIX       (POSIXTime, utcTimeToPOSIXSeconds)
-import           GHC.Generics                (Generic)
-import           Gist                        (Gist, GistId, NewGist)
+import Auth.Types
+    ( OAuthClientId
+    , OAuthClientSecret
+    , OAuthCode
+    , OAuthToken
+    , Token (Token)
+    , TokenProvider (Github)
+    , addUserAgent
+    , oAuthTokenAccessToken
+    )
+import Control.Lens (makeLenses, view, _1, _2)
+import Control.Monad (guard)
+import Control.Monad.Except (MonadError)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Logger (MonadLogger, logDebugN, logErrorN)
+import Control.Monad.Now (MonadNow, getCurrentTime, getPOSIXTime)
+import Control.Monad.Reader (MonadReader)
+import Control.Monad.Trace (attempt, runTrace, withTrace)
+import Control.Monad.Web (MonadWeb, doRequest, makeManager)
+import Control.Newtype.Generics (Newtype, O, unpack)
+import Data.Aeson (FromJSON, ToJSON, Value (String), eitherDecode, parseJSON, withObject, (.:))
+import Data.Bifunctor (first)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import Data.Time (NominalDiffTime, UTCTime, addUTCTime)
+import Data.Time.Clock.POSIX (POSIXTime, utcTimeToPOSIXSeconds)
+import GHC.Generics (Generic)
+import Gist (Gist, GistId, NewGist)
 import qualified Gist
-import           Network.HTTP.Client         (managerModifyRequest)
-import           Network.HTTP.Client.Conduit (getUri)
-import           Network.HTTP.Client.TLS     (tlsManagerSettings)
-import           Network.HTTP.Conduit        (Request, newManager, parseRequest, responseBody, responseStatus,
-                                              setQueryString)
-import           Network.HTTP.Simple         (addRequestHeader)
-import           Network.HTTP.Types          (hAccept, statusIsSuccessful)
-import           Servant                     ((:<|>) ((:<|>)), (:>), Get, Header, Headers, JSON, NoContent (NoContent),
-                                              QueryParam, ServantErr, ServerT, StdMethod (GET), ToHttpApiData, Verb,
-                                              addHeader, err401, err500, errBody, throwError)
-import           Servant.API.BrowserHeader   (BrowserHeader)
-import           Servant.Client              (BaseUrl, ClientM, mkClientEnv, parseBaseUrl, runClientM)
-import           Web.Cookie                  (SetCookie, defaultSetCookie, parseCookies, setCookieExpires,
-                                              setCookieHttpOnly, setCookieMaxAge, setCookieName, setCookiePath,
-                                              setCookieSecure, setCookieValue)
-import qualified Web.JWT                     as JWT
+import Network.HTTP.Client (managerModifyRequest)
+import Network.HTTP.Client.Conduit (getUri)
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Conduit (Request, newManager, parseRequest, responseBody, responseStatus, setQueryString)
+import Network.HTTP.Simple (addRequestHeader)
+import Network.HTTP.Types (hAccept, statusIsSuccessful)
+import Servant
+    ( (:<|>) ((:<|>))
+    , (:>)
+    , Get
+    , Header
+    , Headers
+    , JSON
+    , NoContent (NoContent)
+    , QueryParam
+    , ServantErr
+    , ServerT
+    , StdMethod (GET)
+    , ToHttpApiData
+    , Verb
+    , addHeader
+    , err401
+    , err500
+    , errBody
+    , throwError
+    )
+import Servant.API.BrowserHeader (BrowserHeader)
+import Servant.Client (BaseUrl, ClientM, mkClientEnv, parseBaseUrl, runClientM)
+import Web.Cookie
+    ( SetCookie
+    , defaultSetCookie
+    , parseCookies
+    , setCookieExpires
+    , setCookieHttpOnly
+    , setCookieMaxAge
+    , setCookieName
+    , setCookiePath
+    , setCookieSecure
+    , setCookieValue
+    )
+import qualified Web.JWT as JWT
 
 -- | https://gist.github.com/alpmestan/757094ecf9401f85c5ba367ca20b8900
 type GetRedirect headers = Verb 'GET 302 '[ JSON] (headers NoContent)

--- a/playground-common/src/Auth/Types.hs
+++ b/playground-common/src/Auth/Types.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Auth.Types
   ( addUserAgent
@@ -20,15 +20,15 @@ module Auth.Types
   , OAuthClientSecret(..)
   ) where
 
-import           Control.Newtype.Generics (Newtype)
-import           Data.Aeson               (FromJSON, ToJSON, genericParseJSON, parseJSON)
-import           Data.Aeson.Casing        (aesonDrop, snakeCase)
-import           Data.Text                (Text)
-import           GHC.Generics             (Generic)
-import           Network.HTTP.Conduit     (Request)
-import           Network.HTTP.Simple      (addRequestHeader)
-import           Network.HTTP.Types       (hUserAgent)
-import           Servant                  (FromHttpApiData, ToHttpApiData, parseQueryParam, toUrlPiece)
+import Control.Newtype.Generics (Newtype)
+import Data.Aeson (FromJSON, ToJSON, genericParseJSON, parseJSON)
+import Data.Aeson.Casing (aesonDrop, snakeCase)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Network.HTTP.Conduit (Request)
+import Network.HTTP.Simple (addRequestHeader)
+import Network.HTTP.Types (hUserAgent)
+import Servant (FromHttpApiData, ToHttpApiData, parseQueryParam, toUrlPiece)
 
 ------------------------------------------------------------
 newtype OAuthCode =

--- a/playground-common/src/Control/Monad/Except/Extras.hs
+++ b/playground-common/src/Control/Monad/Except/Extras.hs
@@ -1,7 +1,7 @@
 module Control.Monad.Except.Extras where
 
-import           Control.Monad.Error.Class (MonadError, throwError)
-import           Control.Monad.Except      (ExceptT, runExceptT)
+import Control.Monad.Error.Class (MonadError, throwError)
+import Control.Monad.Except (ExceptT, runExceptT)
 
 mapError :: (MonadError f m) => (e -> f) -> ExceptT e m a -> m a
 mapError f action = do

--- a/playground-common/src/Control/Monad/Now.hs
+++ b/playground-common/src/Control/Monad/Now.hs
@@ -6,14 +6,14 @@ module Control.Monad.Now
   , getPOSIXTime
   ) where
 
-import           Control.Monad.Except      (ExceptT)
-import           Control.Monad.Logger      (LoggingT)
-import           Control.Monad.Reader      (ReaderT)
-import           Control.Monad.Trans.Class (lift)
-import           Data.Time                 (UTCTime)
-import qualified Data.Time                 as Time
-import           Data.Time.Clock.POSIX     (POSIXTime)
-import qualified Data.Time.Clock.POSIX     as Time
+import Control.Monad.Except (ExceptT)
+import Control.Monad.Logger (LoggingT)
+import Control.Monad.Reader (ReaderT)
+import Control.Monad.Trans.Class (lift)
+import Data.Time (UTCTime)
+import qualified Data.Time as Time
+import Data.Time.Clock.POSIX (POSIXTime)
+import qualified Data.Time.Clock.POSIX as Time
 
 class Monad m =>
       MonadNow m

--- a/playground-common/src/Control/Monad/Trace.hs
+++ b/playground-common/src/Control/Monad/Trace.hs
@@ -1,10 +1,10 @@
 module Control.Monad.Trace where
 
-import           Control.Monad.Trans               (lift)
-import           Control.Monad.Trans.Maybe         (MaybeT (MaybeT), runMaybeT)
-import           Control.Monad.Trans.Writer.Strict (Writer, runWriter)
-import           Control.Monad.Writer.Class        (tell)
-import           Data.Monoid                       (Last (Last))
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT), runMaybeT)
+import Control.Monad.Trans.Writer.Strict (Writer, runWriter)
+import Control.Monad.Writer.Class (tell)
+import Data.Monoid (Last (Last))
 
 ------------------------------------------------------------
 -- | `Trace` is a neat way to run a `Maybe` monad, but leave a trail behind

--- a/playground-common/src/Control/Monad/Web.hs
+++ b/playground-common/src/Control/Monad/Web.hs
@@ -4,14 +4,14 @@ module Control.Monad.Web
   , makeManager
   ) where
 
-import           Control.Monad.Except        (ExceptT)
-import           Control.Monad.Logger        (LoggingT)
-import           Control.Monad.Reader        (ReaderT)
-import           Control.Monad.Trans.Class   (lift)
-import qualified Data.ByteString.Lazy        as LBS
-import           Data.Text                   (Text)
-import           Network.HTTP.Client.Conduit (defaultManagerSettings)
-import           Network.HTTP.Conduit        (Manager, Request, Response, httpLbs, newManager)
+import Control.Monad.Except (ExceptT)
+import Control.Monad.Logger (LoggingT)
+import Control.Monad.Reader (ReaderT)
+import Control.Monad.Trans.Class (lift)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import Network.HTTP.Client.Conduit (defaultManagerSettings)
+import Network.HTTP.Conduit (Manager, Request, Response, httpLbs, newManager)
 
 class Monad m =>
       MonadWeb m

--- a/playground-common/src/Gist.hs
+++ b/playground-common/src/Gist.hs
@@ -1,16 +1,16 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedLists       #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 module Gist
     ( API
     , GistAPI
@@ -26,23 +26,47 @@ module Gist
     , NewGistFile(..)
     ) where
 
-import           Auth.Types        (Token, TokenProvider (Github))
-import           Data.Aeson        (FromJSON, GFromJSON, ToJSON, Value, Zero, genericParseJSON, object, parseJSON,
-                                    toJSON, withObject, (.:), (.:?), (.=))
-import           Data.Aeson.Casing (aesonPrefix, snakeCase)
-import           Data.Aeson.Types  (Parser)
-import           Data.Bifunctor    (bimap)
-import           Data.Map          (Map)
-import qualified Data.Map          as Map
-import           Data.Proxy        (Proxy (Proxy))
-import           Data.Text         (Text)
-import qualified Data.Text         as T
-import           GHC.Generics      (Generic, Rep)
-import           Servant.API       ((:<|>), (:>), Capture, FromHttpApiData (parseQueryParam), Get, Header, JSON, Patch,
-                                    Post, ReqBody, ToHttpApiData (toQueryParam))
-import           Servant.Client    (ClientM, client)
+import Auth.Types (Token, TokenProvider (Github))
+import Data.Aeson
+    ( FromJSON
+    , GFromJSON
+    , ToJSON
+    , Value
+    , Zero
+    , genericParseJSON
+    , object
+    , parseJSON
+    , toJSON
+    , withObject
+    , (.:)
+    , (.:?)
+    , (.=)
+    )
+import Data.Aeson.Casing (aesonPrefix, snakeCase)
+import Data.Aeson.Types (Parser)
+import Data.Bifunctor (bimap)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Proxy (Proxy (Proxy))
+import Data.Text (Text)
+import qualified Data.Text as T
+import GHC.Generics (Generic, Rep)
+import Servant.API
+    ( (:<|>)
+    , (:>)
+    , Capture
+    , FromHttpApiData (parseQueryParam)
+    , Get
+    , Header
+    , JSON
+    , Patch
+    , Post
+    , ReqBody
+    , ToHttpApiData (toQueryParam)
+    )
+import Servant.Client (ClientM, client)
 import qualified Servant.Extra
-import           Text.Read         (readEither)
+import Text.Read (readEither)
 
 type API = Header "Authorization" (Token 'Github) :> "gists" :> GistAPI
 

--- a/playground-common/src/Git.hs
+++ b/playground-common/src/Git.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Git where
 
-import           Data.FileEmbed     (dummySpaceWith)
-import           Data.String        (fromString)
-import           Data.Text          (Text)
-import qualified Data.Text          as T
-import           Data.Text.Encoding (decodeUtf8)
-import           Git.TH             (gitRevFromGit)
+import Data.FileEmbed (dummySpaceWith)
+import Data.String (fromString)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8)
+import Git.TH (gitRevFromGit)
 
 -- | Try to get the git revision from the possibly injected gitRevEmbed
 --   If it hasn't been embeded then try to get from the current compilation

--- a/playground-common/src/Git/TH.hs
+++ b/playground-common/src/Git/TH.hs
@@ -1,10 +1,10 @@
 module Git.TH where
 
-import           Control.Exception.Safe (handleJust)
-import qualified Language.Haskell.TH    as TH
-import           System.Exit            (ExitCode (ExitSuccess))
-import           System.IO.Error        (ioeGetErrorType, isDoesNotExistErrorType)
-import           System.Process         (readProcessWithExitCode)
+import Control.Exception.Safe (handleJust)
+import qualified Language.Haskell.TH as TH
+import System.Exit (ExitCode (ExitSuccess))
+import System.IO.Error (ioeGetErrorType, isDoesNotExistErrorType)
+import System.Process (readProcessWithExitCode)
 
 -- | Git revision found by running git rev-parse. If git could not be
 -- executed, then this will be an empty string.

--- a/playground-common/src/Language/Haskell/Interpreter.hs
+++ b/playground-common/src/Language/Haskell/Interpreter.hs
@@ -1,37 +1,37 @@
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveFunctor              #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Language.Haskell.Interpreter (runghc, CompilationError(..), InterpreterError(..), SourceCode(..), avoidUnsafe, Warning(..), InterpreterResult(..)) where
 
-import           Control.Monad             (unless)
-import           Control.Monad.Catch       (MonadCatch, MonadMask)
-import           Control.Monad.Error.Class (MonadError, throwError)
-import           Control.Monad.IO.Class    (MonadIO, liftIO)
-import           Control.Monad.Trans.Class (lift)
-import           Control.Monad.Trans.State (StateT, evalStateT, get, put)
-import           Control.Newtype.Generics  (Newtype)
-import qualified Control.Newtype.Generics  as Newtype
-import           Control.Timeout           (timeout)
-import           Data.Aeson                (FromJSON, ToJSON)
-import           Data.Bifunctor            (second)
-import           Data.Maybe                (fromMaybe)
-import           Data.Monoid               ((<>))
-import           Data.Text                 (Text)
-import qualified Data.Text                 as Text
+import Control.Monad (unless)
+import Control.Monad.Catch (MonadCatch, MonadMask)
+import Control.Monad.Error.Class (MonadError, throwError)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State (StateT, evalStateT, get, put)
+import Control.Newtype.Generics (Newtype)
+import qualified Control.Newtype.Generics as Newtype
+import Control.Timeout (timeout)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Bifunctor (second)
+import Data.Maybe (fromMaybe)
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import qualified Data.Text as Text
 import qualified Data.Text.Internal.Search as Text
-import           Data.Time.Units           (TimeUnit)
-import           GHC.Generics              (Generic)
-import           System.Environment        (lookupEnv)
-import           System.Exit               (ExitCode (ExitSuccess))
-import           System.IO.Error           (tryIOError)
-import           System.Process            (readProcessWithExitCode)
-import           Text.Read                 (readMaybe)
+import Data.Time.Units (TimeUnit)
+import GHC.Generics (Generic)
+import System.Environment (lookupEnv)
+import System.Exit (ExitCode (ExitSuccess))
+import System.IO.Error (tryIOError)
+import System.Process (readProcessWithExitCode)
+import Text.Read (readMaybe)
 
 data CompilationError
     = RawError Text

--- a/playground-common/src/Schema.hs
+++ b/playground-common/src/Schema.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DefaultSignatures   #-}
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Schema
     ( ToSchema
@@ -17,12 +17,28 @@ module Schema
     , FormSchema(..)
     ) where
 
-import           Data.Aeson   (FromJSON, ToJSON)
-import           Data.Monoid  ((<>))
-import           Data.Proxy   (Proxy)
-import           Data.Text    (Text)
-import           GHC.Generics ((:*:) ((:*:)), (:+:), C1, Constructor, D1, Generic, M1 (M1), Rec0, Rep, S1, Selector, U1,
-                               conIsRecord, conName, from, selName)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Monoid ((<>))
+import Data.Proxy (Proxy)
+import Data.Text (Text)
+import GHC.Generics
+    ( (:*:) ((:*:))
+    , (:+:)
+    , C1
+    , Constructor
+    , D1
+    , Generic
+    , M1 (M1)
+    , Rec0
+    , Rep
+    , S1
+    , Selector
+    , U1
+    , conIsRecord
+    , conName
+    , from
+    , selName
+    )
 
 {-# ANN module ("HLint: ignore Avoid restricted function" :: Text)
         #-}

--- a/playground-common/src/Servant/Extra.hs
+++ b/playground-common/src/Servant/Extra.hs
@@ -2,7 +2,7 @@
 
 module Servant.Extra where
 
-import           Servant ((:<|>) ((:<|>)))
+import Servant ((:<|>) ((:<|>)))
 
 left ::
        (a

--- a/playground-common/src/Servant/Prometheus.hs
+++ b/playground-common/src/Servant/Prometheus.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE PolyKinds           #-}
-{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Servant.Prometheus (
@@ -17,38 +17,56 @@ module Servant.Prometheus (
     monitorEndpoints
 ) where
 
-import           Control.Exception                              (bracket, bracket_)
-import           Control.Monad                                  (mplus)
-import           Control.Monad.IO.Class                         (MonadIO)
-import           Control.Monad.Logger                           (MonadLogger, MonadLoggerIO)
-import           Data.Hashable                                  (Hashable)
-import qualified Data.HashMap.Strict                            as H
-import           Data.Proxy                                     (Proxy (Proxy))
-import           Data.Text                                      (Text)
-import qualified Data.Text                                      as T
-import qualified Data.Text.Encoding                             as T
-import           Data.Time.Clock                                (diffUTCTime, getCurrentTime)
-import           GHC.Generics                                   (Generic)
-import           GHC.TypeLits                                   (KnownSymbol, Symbol, symbolVal)
-import           Network.HTTP.Types                             (Method, Status (Status, statusCode))
-import           Network.Wai                                    (Middleware, Request, pathInfo, requestMethod,
-                                                                 responseStatus)
-import           Servant.API                                    ((:<|>), (:>), BasicAuth, Capture', CaptureAll,
-                                                                 Description, EmptyAPI, Header', HttpVersion, IsSecure,
-                                                                 QueryFlag, QueryParam', QueryParams, Raw,
-                                                                 ReflectMethod, RemoteHost, ReqBody', Stream, Summary,
-                                                                 Vault, Verb, WithNamedContext, reflectMethod)
+import Control.Exception (bracket, bracket_)
+import Control.Monad (mplus)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Logger (MonadLogger, MonadLoggerIO)
+import Data.Hashable (Hashable)
+import qualified Data.HashMap.Strict as H
+import Data.Proxy (Proxy (Proxy))
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import GHC.Generics (Generic)
+import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
+import Network.HTTP.Types (Method, Status (Status, statusCode))
+import Network.Wai (Middleware, Request, pathInfo, requestMethod, responseStatus)
+import Servant.API
+    ( (:<|>)
+    , (:>)
+    , BasicAuth
+    , Capture'
+    , CaptureAll
+    , Description
+    , EmptyAPI
+    , Header'
+    , HttpVersion
+    , IsSecure
+    , QueryFlag
+    , QueryParam'
+    , QueryParams
+    , Raw
+    , ReflectMethod
+    , RemoteHost
+    , ReqBody'
+    , Stream
+    , Summary
+    , Vault
+    , Verb
+    , WithNamedContext
+    , reflectMethod
+    )
 #if MIN_VERSION_servant(0,15,0)
-import           Servant.API                                    (StreamBody')
+import Servant.API (StreamBody')
 #endif
-import           Servant.API.BrowserHeader                      (BrowserHeader)
-import           Servant.API.WebSocket                          (WebSocket, WebSocketPending)
-import           System.Metrics.Prometheus.Concurrent.RegistryT (RegistryT, registerCounter, registerGauge,
-                                                                 registerHistogram)
-import qualified System.Metrics.Prometheus.Metric.Counter       as Counter
-import qualified System.Metrics.Prometheus.Metric.Gauge         as Gauge
-import qualified System.Metrics.Prometheus.Metric.Histogram     as Histogram
-import qualified System.Metrics.Prometheus.MetricId             as MetricId
+import Servant.API.BrowserHeader (BrowserHeader)
+import Servant.API.WebSocket (WebSocket, WebSocketPending)
+import System.Metrics.Prometheus.Concurrent.RegistryT (RegistryT, registerCounter, registerGauge, registerHistogram)
+import qualified System.Metrics.Prometheus.Metric.Counter as Counter
+import qualified System.Metrics.Prometheus.Metric.Gauge as Gauge
+import qualified System.Metrics.Prometheus.Metric.Histogram as Histogram
+import qualified System.Metrics.Prometheus.MetricId as MetricId
 
 instance MonadLogger m => MonadLogger (RegistryT m)
 instance MonadLoggerIO m => MonadLoggerIO (RegistryT m)

--- a/playground-common/src/System/IO/Extras.hs
+++ b/playground-common/src/System/IO/Extras.hs
@@ -1,8 +1,8 @@
 module System.IO.Extras where
 
-import           Control.Monad.Catch    (MonadMask, bracket)
-import           Control.Monad.IO.Class (MonadIO, liftIO)
-import           System.IO              (Handle, IOMode, hClose, openFile)
+import Control.Monad.Catch (MonadMask, bracket)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import System.IO (Handle, IOMode, hClose, openFile)
 
 -- withFile is a clone of System.IO.withFile however it is generalized over the monad
 -- This might be done using unliftio I think however it looked to be more pain that

--- a/playground-common/test/Auth/TypesSpec.hs
+++ b/playground-common/test/Auth/TypesSpec.hs
@@ -1,18 +1,24 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Auth.TypesSpec
     ( tests
     ) where
 
-import           Auth.Types              (OAuthToken (OAuthToken), Token (Token), TokenProvider (Github),
-                                          oAuthTokenAccessToken, oAuthTokenScope, oAuthTokenTokenType)
-import           Data.Aeson              (eitherDecode)
-import qualified Data.ByteString.Lazy    as LBS
-import           Paths_playground_common (getDataFileName)
-import           Test.Tasty              (TestTree, testGroup)
-import           Test.Tasty.HUnit        (assertEqual, testCase)
+import Auth.Types
+    ( OAuthToken (OAuthToken)
+    , Token (Token)
+    , TokenProvider (Github)
+    , oAuthTokenAccessToken
+    , oAuthTokenScope
+    , oAuthTokenTokenType
+    )
+import Data.Aeson (eitherDecode)
+import qualified Data.ByteString.Lazy as LBS
+import Paths_playground_common (getDataFileName)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
 
 tests :: TestTree
 tests = testGroup "Auth.TypesSpec" [oAuthTokenJsonHandlingSpec]

--- a/playground-common/test/SchemaSpec.hs
+++ b/playground-common/test/SchemaSpec.hs
@@ -1,20 +1,22 @@
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 
 module SchemaSpec
     ( tests
     ) where
 
-import           Data.Text        (Text)
-import           GHC.Generics     (Generic)
-import           Schema           (FormSchema (FormSchemaArray, FormSchemaBool, FormSchemaInt, FormSchemaMaybe, FormSchemaObject, FormSchemaString, FormSchemaTuple),
-                                   ToSchema (toSchema))
-import           Test.Tasty       (TestTree, testGroup)
-import           Test.Tasty.HUnit (assertEqual, testCase)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Schema
+    ( FormSchema (FormSchemaArray, FormSchemaBool, FormSchemaInt, FormSchemaMaybe, FormSchemaObject, FormSchemaString, FormSchemaTuple)
+    , ToSchema (toSchema)
+    )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
 
 tests :: TestTree
 tests = testGroup "Schema" [toSchemaTests]

--- a/playground-common/test/Spec.hs
+++ b/playground-common/test/Spec.hs
@@ -4,7 +4,7 @@ module Main
 
 import qualified Auth.TypesSpec
 import qualified SchemaSpec
-import           Test.Tasty     (defaultMain, testGroup)
+import Test.Tasty (defaultMain, testGroup)
 
 main :: IO ()
 main =

--- a/plutus-book/test/Auction/EnglishSpec.hs
+++ b/plutus-book/test/Auction/EnglishSpec.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Auction.EnglishSpec (spec) where
 
-import           Utils
+import Utils
 
-import           Auction.English
+import Auction.English
 
-import           Ledger
-import qualified Ledger.Ada                 as A
-import qualified Ledger.Value               as V
-import           Wallet.Emulator
+import Ledger
+import qualified Ledger.Ada as A
+import qualified Ledger.Value as V
+import Wallet.Emulator
 
-import           Control.Monad              (replicateM_, void)
+import Control.Monad (replicateM_, void)
 import qualified Data.ByteString.Lazy.Char8 as C
-import           Data.Either                (isRight)
-import           Data.Text                  (Text)
-import           Test.Hspec
+import Data.Either (isRight)
+import Data.Text (Text)
+import Test.Hspec
 
 {-# ANN spec ("HLint: ignore" :: Text) #-}
 

--- a/plutus-book/test/Game/GuessSpec.hs
+++ b/plutus-book/test/Game/GuessSpec.hs
@@ -1,18 +1,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Game.GuessSpec (spec) where
 
-import           Utils
+import Utils
 
-import           Game.Guess
+import Game.Guess
 
-import           Ledger
-import           Ledger.Ada
-import           Wallet.Emulator
+import Ledger
+import Ledger.Ada
+import Wallet.Emulator
 
-import           Control.Monad   (void)
-import           Data.Either     (isRight)
-import           Data.Text       (Text)
-import           Test.Hspec
+import Control.Monad (void)
+import Data.Either (isRight)
+import Data.Text (Text)
+import Test.Hspec
 
 {-# ANN spec ("HLint: ignore Reduce duplication" :: Text) #-}
 spec :: Spec

--- a/plutus-book/test/Marlowe/Spec/Common.hs
+++ b/plutus-book/test/Marlowe/Spec/Common.hs
@@ -1,31 +1,31 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns
 -fno-warn-name-shadowing
 -fno-warn-unused-do-bind #-}
 module Marlowe.Spec.Common where
 
-import           Control.Monad                   (void)
-import           Data.Either                     (isRight)
-import           Data.Map.Strict                 (Map)
-import qualified Data.Map.Strict                 as Map
-import           Data.Set                        (Set)
-import qualified Data.Set                        as Set
+import Control.Monad (void)
+import Data.Either (isRight)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
 
-import           Hedgehog                        (Gen, Property, Size (..), forAll, property)
+import Hedgehog (Gen, Property, Size (..), forAll, property)
 import qualified Hedgehog
-import           Hedgehog.Gen                    (choice, element, integral, sized)
-import qualified Hedgehog.Range                  as Range
+import Hedgehog.Gen (choice, element, integral, sized)
+import qualified Hedgehog.Range as Range
 
-import           Ledger                          hiding (Value)
+import Ledger hiding (Value)
 import qualified Ledger
-import           Marlowe.Language.Marlowe        hiding (discountFromPairList, insertCommit, mergeChoices)
-import           Marlowe.Language.Marlowe.Client (createContract, marloweValidator, spendDeposit)
-import           Wallet                          (PubKey (..))
-import           Wallet.Emulator
-import qualified Wallet.Emulator.Generators      as Gen
-import qualified Wallet.Generators               as Gen
+import Marlowe.Language.Marlowe hiding (discountFromPairList, insertCommit, mergeChoices)
+import Marlowe.Language.Marlowe.Client (createContract, marloweValidator, spendDeposit)
+import Wallet (PubKey (..))
+import Wallet.Emulator
+import qualified Wallet.Emulator.Generators as Gen
+import qualified Wallet.Generators as Gen
 
 newtype MarloweScenario = MarloweScenario { mlInitialBalances :: Map.Map PubKey Ledger.Value }
 data Bounds = Bounds {

--- a/plutus-book/test/Marlowe/Spec/Marlowe.hs
+++ b/plutus-book/test/Marlowe/Spec/Marlowe.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE NoImplicitPrelude   #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns
 -fno-warn-name-shadowing
@@ -11,33 +11,32 @@ module Marlowe.Spec.Marlowe
     )
 where
 
-import           Language.PlutusTx.Prelude
-import qualified Prelude                         as Haskell
+import Language.PlutusTx.Prelude
+import qualified Prelude as Haskell
 
-import           Control.Monad                   (void, when)
-import qualified Data.List                       as List
-import qualified Data.Map.Strict                 as Map
-import qualified Data.Set                        as Set
+import Control.Monad (void, when)
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
-import           Hedgehog                        (Property, forAll, property)
+import Hedgehog (Property, forAll, property)
 import qualified Hedgehog
-import           Hedgehog.Gen                    (list)
-import qualified Hedgehog.Range                  as Range
-import           Test.Tasty
-import           Test.Tasty.Hedgehog             (HedgehogTestLimit (..), testProperty)
-import           Test.Tasty.HUnit
+import Hedgehog.Gen (list)
+import qualified Hedgehog.Range as Range
+import Test.Tasty
+import Test.Tasty.Hedgehog (HedgehogTestLimit (..), testProperty)
+import Test.Tasty.HUnit
 
-import           Language.Marlowe
-import           Ledger                          hiding (Value)
-import qualified Ledger.Ada                      as Ada
-import           Ledger.Validation               (OracleValue (..))
-import           Wallet                          (PubKey (..), startWatching)
-import           Wallet.Emulator
+import Language.Marlowe
+import Ledger hiding (Value)
+import qualified Ledger.Ada as Ada
+import Ledger.Validation (OracleValue (..))
+import Wallet (PubKey (..), startWatching)
+import Wallet.Emulator
 
-import           Marlowe.Language.Marlowe.Client (commit, commit', interpretObs, marloweValidator, receivePayment,
-                                                  redeem)
-import           Marlowe.Language.Marlowe.Escrow as Escrow
-import           Marlowe.Spec.Common
+import Marlowe.Language.Marlowe.Client (commit, commit', interpretObs, marloweValidator, receivePayment, redeem)
+import Marlowe.Language.Marlowe.Escrow as Escrow
+import Marlowe.Spec.Common
 
 {-# ANN module ("HLint: ignore"::String) #-}
 

--- a/plutus-book/test/Multi/VestingSpec.hs
+++ b/plutus-book/test/Multi/VestingSpec.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Multi.VestingSpec (spec) where
 
-import           Utils
+import Utils
 
-import           Multi.Vesting
+import Multi.Vesting
 
 import qualified Language.PlutusTx.Numeric as P
-import           Ledger
-import           Ledger.Ada
-import           Wallet.Emulator
+import Ledger
+import Ledger.Ada
+import Wallet.Emulator
 
-import           Control.Monad             (replicateM_, void)
-import           Data.Either               (isRight)
-import           Data.Text                 (Text)
-import           Test.Hspec
+import Control.Monad (replicateM_, void)
+import Data.Either (isRight)
+import Data.Text (Text)
+import Test.Hspec
 
 {-# ANN spec ("HLint: ignore Reduce duplication" :: Text) #-}
 spec :: Spec

--- a/plutus-book/test/NonFungible/NonFungible1Spec.hs
+++ b/plutus-book/test/NonFungible/NonFungible1Spec.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module NonFungible.NonFungible1Spec (spec) where
 
-import           Utils
+import Utils
 
-import           NonFungible.NonFungible1
+import NonFungible.NonFungible1
 
-import           Ledger
-import qualified Ledger.Ada                 as A
-import qualified Ledger.Value               as V
-import           Wallet.Emulator
+import Ledger
+import qualified Ledger.Ada as A
+import qualified Ledger.Value as V
+import Wallet.Emulator
 
-import           Control.Monad              (void)
+import Control.Monad (void)
 import qualified Data.ByteString.Lazy.Char8 as C
-import           Data.Either                (isRight)
-import           Test.Hspec
+import Data.Either (isRight)
+import Test.Hspec
 
 spec :: Spec
 spec =

--- a/plutus-book/test/NonFungible/NonFungible2Spec.hs
+++ b/plutus-book/test/NonFungible/NonFungible2Spec.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module NonFungible.NonFungible2Spec (spec) where
 
-import           Utils
+import Utils
 
-import           NonFungible.NonFungible2
+import NonFungible.NonFungible2
 
-import           Ledger
-import qualified Ledger.Ada                 as A
-import qualified Ledger.Value               as V
-import           Wallet.Emulator
+import Ledger
+import qualified Ledger.Ada as A
+import qualified Ledger.Value as V
+import Wallet.Emulator
 
-import           Control.Monad              (void)
+import Control.Monad (void)
 import qualified Data.ByteString.Lazy.Char8 as C
-import           Data.Either                (isRight)
-import           Test.Hspec
+import Data.Either (isRight)
+import Test.Hspec
 
 spec :: Spec
 spec =

--- a/plutus-book/test/NonFungible/NonFungible3Spec.hs
+++ b/plutus-book/test/NonFungible/NonFungible3Spec.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module NonFungible.NonFungible3Spec (spec) where
 
-import           Utils
+import Utils
 
-import           NonFungible.NonFungible3
+import NonFungible.NonFungible3
 
-import           Ledger
-import qualified Ledger.Ada                 as A
-import qualified Ledger.Value               as V
-import           Wallet.Emulator
+import Ledger
+import qualified Ledger.Ada as A
+import qualified Ledger.Value as V
+import Wallet.Emulator
 
-import           Control.Monad              (void)
+import Control.Monad (void)
 import qualified Data.ByteString.Lazy.Char8 as C
-import           Data.Either                (isRight)
-import           Test.Hspec
+import Data.Either (isRight)
+import Test.Hspec
 
 spec :: Spec
 spec =

--- a/plutus-book/test/NonFungible/NonFungible4Spec.hs
+++ b/plutus-book/test/NonFungible/NonFungible4Spec.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module NonFungible.NonFungible4Spec (spec) where
 
-import           Utils
+import Utils
 
-import           NonFungible.NonFungible4
+import NonFungible.NonFungible4
 
-import           Ledger
-import qualified Ledger.Ada                 as A
-import qualified Ledger.Value               as V
-import           Wallet.Emulator
+import Ledger
+import qualified Ledger.Ada as A
+import qualified Ledger.Value as V
+import Wallet.Emulator
 
-import           Control.Monad              (void)
+import Control.Monad (void)
 import qualified Data.ByteString.Lazy.Char8 as C
-import           Data.Either                (isRight)
-import           Test.Hspec
+import Data.Either (isRight)
+import Test.Hspec
 
 spec :: Spec
 spec =

--- a/plutus-book/test/NonFungible/NonFungible5Spec.hs
+++ b/plutus-book/test/NonFungible/NonFungible5Spec.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module NonFungible.NonFungible5Spec (spec) where
 
-import           Utils
+import Utils
 
-import           NonFungible.NonFungible5
+import NonFungible.NonFungible5
 
-import           Ledger
-import qualified Ledger.Ada                 as A
-import qualified Ledger.Value               as V
-import           Wallet.Emulator
+import Ledger
+import qualified Ledger.Ada as A
+import qualified Ledger.Value as V
+import Wallet.Emulator
 
-import           Control.Monad              (void)
+import Control.Monad (void)
 import qualified Data.ByteString.Lazy.Char8 as C
-import           Data.Either                (isRight)
-import           Test.Hspec
+import Data.Either (isRight)
+import Test.Hspec
 
 spec :: Spec
 spec =

--- a/plutus-book/test/NonFungible/NonFungible6Spec.hs
+++ b/plutus-book/test/NonFungible/NonFungible6Spec.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
 module NonFungible.NonFungible6Spec (spec) where
 
-import           Utils
+import Utils
 
-import           NonFungible.NonFungible6
+import NonFungible.NonFungible6
 
-import           Ledger
-import qualified Ledger.Ada                 as A
-import qualified Ledger.Value               as V
-import           Wallet.Emulator
+import Ledger
+import qualified Ledger.Ada as A
+import qualified Ledger.Value as V
+import Wallet.Emulator
 
-import           Control.Monad              (void)
+import Control.Monad (void)
 import qualified Data.ByteString.Lazy.Char8 as C
-import           Data.Either                (isRight)
-import           Data.Text                  (Text)
-import           Test.Hspec
+import Data.Either (isRight)
+import Data.Text (Text)
+import Test.Hspec
 
 {-# ANN spec ("HLint: ignore Reduce duplication" :: Text) #-}
 spec :: Spec

--- a/plutus-book/test/NonFungible/NonFungible7Spec.hs
+++ b/plutus-book/test/NonFungible/NonFungible7Spec.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
 module NonFungible.NonFungible7Spec (spec) where
 
-import           Utils
+import Utils
 
-import           NonFungible.NonFungible7
+import NonFungible.NonFungible7
 
-import           Ledger
-import qualified Ledger.Ada                 as A
-import qualified Ledger.Value               as V
-import           Wallet.Emulator
+import Ledger
+import qualified Ledger.Ada as A
+import qualified Ledger.Value as V
+import Wallet.Emulator
 
-import           Control.Monad              (void)
+import Control.Monad (void)
 import qualified Data.ByteString.Lazy.Char8 as C
-import           Data.Either                (isRight)
-import           Data.Text                  (Text)
-import           Test.Hspec
+import Data.Either (isRight)
+import Data.Text (Text)
+import Test.Hspec
 
 {-# ANN spec ("HLint: ignore Reduce duplication" :: Text) #-}
 spec :: Spec

--- a/plutus-book/test/NonFungible/NonFungible8Spec.hs
+++ b/plutus-book/test/NonFungible/NonFungible8Spec.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
 module NonFungible.NonFungible8Spec (spec) where
 
-import           Utils
+import Utils
 
-import           NonFungible.NonFungible8
+import NonFungible.NonFungible8
 
-import           Ledger
-import qualified Ledger.Ada                 as A
-import qualified Ledger.Value               as V
-import           Wallet.Emulator
+import Ledger
+import qualified Ledger.Ada as A
+import qualified Ledger.Value as V
+import Wallet.Emulator
 
-import           Control.Monad              (replicateM_, void)
+import Control.Monad (replicateM_, void)
 import qualified Data.ByteString.Lazy.Char8 as C
-import           Data.Either                (isRight)
-import           Data.Text                  (Text)
-import           Test.Hspec
+import Data.Either (isRight)
+import Data.Text (Text)
+import Test.Hspec
 
 {-# ANN spec ("HLint: ignore" :: Text) #-}
 

--- a/plutus-book/test/OffChain/HelloSpec.hs
+++ b/plutus-book/test/OffChain/HelloSpec.hs
@@ -2,15 +2,15 @@
 
 module OffChain.HelloSpec (spec) where
 
-import           Utils
+import Utils
 
-import           OffChain.Hello  (hello)
+import OffChain.Hello (hello)
 
-import           Wallet.Emulator
+import Wallet.Emulator
 
-import           Control.Monad   (void)
-import           Data.Either     (isRight)
-import           Test.Hspec
+import Control.Monad (void)
+import Data.Either (isRight)
+import Test.Hspec
 
 spec :: Spec
 spec = describe "hello" $

--- a/plutus-book/test/OffChain/PayToWalletSpec.hs
+++ b/plutus-book/test/OffChain/PayToWalletSpec.hs
@@ -1,18 +1,18 @@
 module OffChain.PayToWalletSpec (spec) where
 
-import           Utils
+import Utils
 
-import qualified OffChain.PayToWallet       as P1
+import qualified OffChain.PayToWallet as P1
 import qualified OffChain.PayToWalletSimple as P2
 
-import qualified Language.PlutusTx.Numeric  as P
-import           Ledger
-import           Ledger.Ada
-import           Wallet.Emulator
+import qualified Language.PlutusTx.Numeric as P
+import Ledger
+import Ledger.Ada
+import Wallet.Emulator
 
-import           Control.Monad              (void)
-import           Data.Either                (isRight)
-import           Test.Hspec
+import Control.Monad (void)
+import Data.Either (isRight)
+import Test.Hspec
 
 spec :: Spec
 spec = do

--- a/plutus-book/test/OffChain/TriggerSpec.hs
+++ b/plutus-book/test/OffChain/TriggerSpec.hs
@@ -1,18 +1,18 @@
 module OffChain.TriggerSpec (spec) where
 
-import           Utils
+import Utils
 
-import qualified OffChain.Trigger          as T1
-import qualified OffChain.TriggerSimple    as T2
+import qualified OffChain.Trigger as T1
+import qualified OffChain.TriggerSimple as T2
 
 import qualified Language.PlutusTx.Numeric as P
-import           Ledger
-import           Ledger.Ada
-import           Wallet.Emulator
+import Ledger
+import Ledger.Ada
+import Wallet.Emulator
 
-import           Control.Monad             (void)
-import           Data.Either               (isRight)
-import           Test.Hspec
+import Control.Monad (void)
+import Data.Either (isRight)
+import Test.Hspec
 
 spec :: Spec
 spec = do

--- a/plutus-book/test/Parameters/CrowdSpec.hs
+++ b/plutus-book/test/Parameters/CrowdSpec.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Parameters.CrowdSpec (spec) where
 
-import           Utils
+import Utils
 
-import           Parameters.Crowd
+import Parameters.Crowd
 
 import qualified Language.PlutusTx.Numeric as P
-import           Ledger
-import           Ledger.Ada
-import           Wallet.Emulator
+import Ledger
+import Ledger.Ada
+import Wallet.Emulator
 
-import           Control.Monad             (replicateM_, void)
-import           Data.Either               (isRight)
-import           Data.Text                 (Text)
-import           Test.Hspec
+import Control.Monad (replicateM_, void)
+import Data.Either (isRight)
+import Data.Text (Text)
+import Test.Hspec
 
 {-# ANN spec ("HLint: ignore Reduce duplication" :: Text) #-}
 spec :: Spec

--- a/plutus-book/test/Token/FungibleSpec.hs
+++ b/plutus-book/test/Token/FungibleSpec.hs
@@ -1,21 +1,21 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Token.FungibleSpec (spec) where
 
-import           Utils
+import Utils
 
-import           Token.Fungible
+import Token.Fungible
 
-import qualified Language.PlutusTx.Numeric  as P
-import           Ledger
-import qualified Ledger.Ada                 as A
-import qualified Ledger.Value               as V
-import           Wallet.Emulator
+import qualified Language.PlutusTx.Numeric as P
+import Ledger
+import qualified Ledger.Ada as A
+import qualified Ledger.Value as V
+import Wallet.Emulator
 
-import           Control.Monad              (replicateM_, void)
+import Control.Monad (replicateM_, void)
 import qualified Data.ByteString.Lazy.Char8 as C
-import           Data.Either                (isRight)
-import           Data.Text                  (Text)
-import           Test.Hspec
+import Data.Either (isRight)
+import Data.Text (Text)
+import Test.Hspec
 
 {-# ANN spec ("HLint: ignore Reduce duplication" :: Text) #-}
 spec :: Spec

--- a/plutus-book/test/Utils.hs
+++ b/plutus-book/test/Utils.hs
@@ -16,16 +16,16 @@ module Utils
     , assertFunds3
     ) where
 
-import           Ledger
-import           Ledger.Ada
-import           Wallet.Emulator
-import           Wallet.Emulator.Generators
-import           Wallet.Generators
+import Ledger
+import Ledger.Ada
+import Wallet.Emulator
+import Wallet.Emulator.Generators
+import Wallet.Generators
 
-import           Control.Arrow              (first)
-import           Control.Monad              (forM_, void)
-import qualified Data.Map.Strict            as Map
-import           Debug.Trace                (traceM)
+import Control.Arrow (first)
+import Control.Monad (forM_, void)
+import qualified Data.Map.Strict as Map
+import Debug.Trace (traceM)
 
 w1, w2, w3, w4 :: Wallet
 w1 = Wallet 1

--- a/plutus-contract/doctest/Main.hs
+++ b/plutus-contract/doctest/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import           ContractAPI
+import ContractAPI
 
 main :: IO ()
 main = pure ()

--- a/plutus-contract/src/Data/Row/Extras.hs
+++ b/plutus-contract/src/Data/Row/Extras.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- | Instances for 'Data.Row.Records.Rec' and 'Data.Row.Variants.Var' types
 module Data.Row.Extras(
@@ -9,18 +9,18 @@ module Data.Row.Extras(
     , MonoidRec(..)
     ) where
 
-import           Data.Aeson            (FromJSON, ToJSON, (.:), (.=))
-import qualified Data.Aeson            as Aeson
-import qualified Data.Aeson.Types      as Aeson
-import           Data.Functor.Identity
-import           Data.Functor.Product
-import           Data.Proxy            (Proxy (..))
-import           Data.Row
-import           Data.Row.Internal
-import qualified Data.Row.Records      as Records
-import qualified Data.Row.Variants     as Variants
-import           Data.Text             (Text)
-import qualified Data.Text             as Text
+import Data.Aeson (FromJSON, ToJSON, (.:), (.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import Data.Functor.Identity
+import Data.Functor.Product
+import Data.Proxy (Proxy (..))
+import Data.Row
+import Data.Row.Internal
+import qualified Data.Row.Records as Records
+import qualified Data.Row.Variants as Variants
+import Data.Text (Text)
+import qualified Data.Text as Text
 
 newtype JsonVar s = JsonVar { unJsonVar :: Var s }
 

--- a/plutus-contract/src/Language/Plutus/Contract.hs
+++ b/plutus-contract/src/Language/Plutus/Contract.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE MonoLocalBinds   #-}
-{-# LANGUAGE TypeOperators    #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE TypeOperators #-}
 module Language.Plutus.Contract(
       Contract(..)
     , ContractError(..)
@@ -59,26 +59,25 @@ module Language.Plutus.Contract(
     , waitingForBlockchainActions
     ) where
 
-import           Control.Applicative                             (Alternative (..))
-import           Data.Row
+import Control.Applicative (Alternative (..))
+import Data.Row
 
-import           Language.Plutus.Contract.Effects.AwaitSlot
-import           Language.Plutus.Contract.Effects.ExposeEndpoint
-import           Language.Plutus.Contract.Effects.OwnPubKey      as OwnPubKey
-import           Language.Plutus.Contract.Effects.UtxoAt         as UtxoAt
-import           Language.Plutus.Contract.Effects.WatchAddress   as WatchAddress
-import           Language.Plutus.Contract.Effects.WriteTx
-import           Language.Plutus.Contract.Util                   (both, selectEither)
+import Language.Plutus.Contract.Effects.AwaitSlot
+import Language.Plutus.Contract.Effects.ExposeEndpoint
+import Language.Plutus.Contract.Effects.OwnPubKey as OwnPubKey
+import Language.Plutus.Contract.Effects.UtxoAt as UtxoAt
+import Language.Plutus.Contract.Effects.WatchAddress as WatchAddress
+import Language.Plutus.Contract.Effects.WriteTx
+import Language.Plutus.Contract.Util (both, selectEither)
 
-import           Language.Plutus.Contract.Request                (AsContractError (..), Contract (..),
-                                                                  ContractError (..), ContractRow, checkpoint, select,
-                                                                  withContractError)
-import           Language.Plutus.Contract.Schema                 (Handlers)
+import Language.Plutus.Contract.Request
+    (AsContractError (..), Contract (..), ContractError (..), ContractRow, checkpoint, select, withContractError)
+import Language.Plutus.Contract.Schema (Handlers)
 
-import           Language.Plutus.Contract.Tx                     as Tx
+import Language.Plutus.Contract.Tx as Tx
 
-import           Prelude                                         hiding (until)
-import           Wallet.API                                      (WalletAPIError)
+import Prelude hiding (until)
+import Wallet.API (WalletAPIError)
 
 -- | Schema for contracts that can interact with the blockchain (via a node
 --   client & signing process)

--- a/plutus-contract/src/Language/Plutus/Contract/App.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/App.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 -- | Run a Plutus contract as a servant application.
 module Language.Plutus.Contract.App(
       run
@@ -11,24 +11,24 @@ module Language.Plutus.Contract.App(
     , Wallet(..)
     ) where
 
-import           Control.Monad                    (foldM_)
-import           Data.Aeson                       (FromJSON, ToJSON)
-import qualified Data.Aeson                       as Aeson
-import qualified Data.ByteString.Lazy.Char8       as BSL
-import           Data.Foldable                    (traverse_)
-import qualified Data.Map                         as Map
-import           Data.Row
-import           Data.Row.Internal                (Unconstrained1)
-import qualified Data.Text.IO                     as Text
-import           Language.Plutus.Contract
-import           Language.Plutus.Contract.Schema  (Input, Output)
-import           Language.Plutus.Contract.Servant (Request (..), Response (..), contractApp, initialResponse, runUpdate)
-import           Language.Plutus.Contract.Trace   (ContractTrace, EmulatorAction, TraceError, execTrace)
-import qualified Network.Wai.Handler.Warp         as Warp
-import           System.Environment               (getArgs)
-import           Wallet.Emulator                  (Wallet (..))
+import Control.Monad (foldM_)
+import Data.Aeson (FromJSON, ToJSON)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.Foldable (traverse_)
+import qualified Data.Map as Map
+import Data.Row
+import Data.Row.Internal (Unconstrained1)
+import qualified Data.Text.IO as Text
+import Language.Plutus.Contract
+import Language.Plutus.Contract.Schema (Input, Output)
+import Language.Plutus.Contract.Servant (Request (..), Response (..), contractApp, initialResponse, runUpdate)
+import Language.Plutus.Contract.Trace (ContractTrace, EmulatorAction, TraceError, execTrace)
+import qualified Network.Wai.Handler.Warp as Warp
+import System.Environment (getArgs)
+import Wallet.Emulator (Wallet (..))
 
-import           Language.Plutus.Contract.IOTS    (IotsRow, IotsType, rowSchema)
+import Language.Plutus.Contract.IOTS (IotsRow, IotsType, rowSchema)
 
 -- | A number of constraints to ensure that 's' is the schema
 --   of a contract whose inputs and outputs can be serialised to

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/UtxoAt.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/UtxoAt.hs
@@ -1,35 +1,35 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE MonoLocalBinds      #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE OverloadedLabels    #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 module Language.Plutus.Contract.Effects.UtxoAt where
 
-import           Data.Aeson                                    (FromJSON, ToJSON)
-import           Data.Map                                      (Map)
-import qualified Data.Map                                      as Map
-import           Data.Row
-import           Data.Set                                      (Set)
-import qualified Data.Set                                      as Set
-import           Data.Text.Prettyprint.Doc
-import           GHC.Generics                                  (Generic)
-import           Ledger                                        (Address, TxOut (..), TxOutTx (..))
-import           Ledger.AddressMap                             (AddressMap)
-import qualified Ledger.AddressMap                             as AM
-import           Ledger.Tx                                     (TxOutRef)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Row
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text.Prettyprint.Doc
+import GHC.Generics (Generic)
+import Ledger (Address, TxOut (..), TxOutTx (..))
+import Ledger.AddressMap (AddressMap)
+import qualified Ledger.AddressMap as AM
+import Ledger.Tx (TxOutRef)
 
-import           IOTS                                          (IotsType)
-import           Language.Plutus.Contract.Effects.WatchAddress (AddressSet (..))
-import           Language.Plutus.Contract.Request              (Contract, ContractRow, requestMaybe)
-import           Language.Plutus.Contract.Schema               (Event (..), Handlers (..), Input, Output)
+import IOTS (IotsType)
+import Language.Plutus.Contract.Effects.WatchAddress (AddressSet (..))
+import Language.Plutus.Contract.Request (Contract, ContractRow, requestMaybe)
+import Language.Plutus.Contract.Schema (Event (..), Handlers (..), Input, Output)
 
 type UtxoAtSym = "utxo-at"
 

--- a/plutus-contract/src/Language/Plutus/Contract/IOTS.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/IOTS.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE ConstraintKinds      #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DerivingVia          #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE IncoherentInstances  #-}
-{-# LANGUAGE OverloadedLabels     #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE IncoherentInstances #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
 module Language.Plutus.Contract.IOTS(
@@ -20,13 +20,13 @@ module Language.Plutus.Contract.IOTS(
   , rowSchema
   ) where
 
-import           Data.Kind         (Type)
-import           Data.Row
-import           Data.Row.Internal
-import           Data.Text         (Text)
-import           Type.Reflection   (Typeable)
+import Data.Kind (Type)
+import Data.Row
+import Data.Row.Internal
+import Data.Text (Text)
+import Type.Reflection (Typeable)
 
-import           IOTS
+import IOTS
 
 class IotsExportable (HList (IotsRowTypes s)) => IotsRow (s :: Row *) where
 

--- a/plutus-contract/src/Language/Plutus/Contract/Record.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Record.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE LambdaCase         #-}
-{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Language.Plutus.Contract.Record where
 
-import           Control.Lens
-import           Data.Bifunctor            (Bifunctor (..))
-import           Data.Text.Prettyprint.Doc
-import           GHC.Generics              (Generic)
+import Control.Lens
+import Data.Bifunctor (Bifunctor (..))
+import Data.Text.Prettyprint.Doc
+import GHC.Generics (Generic)
 
-import           Data.Aeson                (Value)
-import qualified Data.Aeson                as Aeson
-import qualified Data.Aeson.Text           as Aeson
+import Data.Aeson (Value)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Text as Aeson
 
 -- | The serialisable state of a contract instance, containing a mix of raw
 --   input events and serialised checkpoints.

--- a/plutus-contract/src/Language/Plutus/Contract/Request.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Request.hs
@@ -1,37 +1,37 @@
-{-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE ConstraintKinds      #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DerivingVia          #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE OverloadedLabels     #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Language.Plutus.Contract.Request where
 
-import           Control.Applicative
-import           Control.Lens
-import           Control.Monad                      (MonadPlus)
-import           Control.Monad.Except               (MonadError)
-import qualified Data.Aeson                         as Aeson
-import           Data.Row
-import qualified Data.Text                          as T
+import Control.Applicative
+import Control.Lens
+import Control.Monad (MonadPlus)
+import Control.Monad.Except (MonadError)
+import qualified Data.Aeson as Aeson
+import Data.Row
+import qualified Data.Text as T
 
-import           Language.Plutus.Contract.Resumable
-import           Language.Plutus.Contract.Schema    (Event (..), Handlers (..), Input, Output)
-import qualified Language.Plutus.Contract.Schema    as Events
+import Language.Plutus.Contract.Resumable
+import Language.Plutus.Contract.Schema (Event (..), Handlers (..), Input, Output)
+import qualified Language.Plutus.Contract.Schema as Events
 
-import qualified Language.PlutusTx.Applicative      as PlutusTx
-import qualified Language.PlutusTx.Functor          as PlutusTx
-import           Prelude                            as Haskell
-import           Wallet.API                         (WalletAPIError)
-import           Wallet.Emulator.Types              (AsAssertionError (..), AssertionError)
+import qualified Language.PlutusTx.Applicative as PlutusTx
+import qualified Language.PlutusTx.Functor as PlutusTx
+import Prelude as Haskell
+import Wallet.API (WalletAPIError)
+import Wallet.Emulator.Types (AsAssertionError (..), AssertionError)
 
 -- | @Contract s a@ is a contract with schema 's', producing a value of
 --  type 'a' or a 'ContractError'. See note [Contract Schema].

--- a/plutus-contract/src/Language/Plutus/Contract/Servant.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Servant.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DerivingVia          #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Language.Plutus.Contract.Servant(
       contractServer
@@ -17,24 +17,24 @@ module Language.Plutus.Contract.Servant(
     , Response(..)
     ) where
 
-import           Control.Lens                       (from, view)
-import           Control.Monad.Except               (MonadError (..), runExcept)
-import           Control.Monad.Writer               (runWriterT)
-import           Data.Aeson                         (FromJSON, ToJSON)
-import           Data.Bifunctor
-import           Data.Proxy                         (Proxy (..))
-import           Data.Row
-import           Data.String                        (IsString (fromString))
-import           GHC.Generics                       (Generic)
-import           Servant                            ((:<|>) ((:<|>)), (:>), Get, JSON, Post, ReqBody, err500, errBody)
-import           Servant.Server                     (Application, ServantErr, Server, serve)
+import Control.Lens (from, view)
+import Control.Monad.Except (MonadError (..), runExcept)
+import Control.Monad.Writer (runWriterT)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Bifunctor
+import Data.Proxy (Proxy (..))
+import Data.Row
+import Data.String (IsString (fromString))
+import GHC.Generics (Generic)
+import Servant ((:<|>) ((:<|>)), (:>), Get, JSON, Post, ReqBody, err500, errBody)
+import Servant.Server (Application, ServantErr, Server, serve)
 
-import           Language.Plutus.Contract.Record    (Record)
-import qualified Language.Plutus.Contract.Record    as Rec
-import           Language.Plutus.Contract.Request   (Contract (..))
-import           Language.Plutus.Contract.Resumable (ResumableError)
+import Language.Plutus.Contract.Record (Record)
+import qualified Language.Plutus.Contract.Record as Rec
+import Language.Plutus.Contract.Request (Contract (..))
+import Language.Plutus.Contract.Resumable (ResumableError)
 import qualified Language.Plutus.Contract.Resumable as Resumable
-import           Language.Plutus.Contract.Schema    (Event, Handlers, Input, Output)
+import Language.Plutus.Contract.Schema (Event, Handlers, Input, Output)
 
 newtype State e = State { record :: Record e }
     deriving stock (Generic, Eq)

--- a/plutus-contract/src/Language/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Trace.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE AllowAmbiguousTypes    #-}
-{-# LANGUAGE DataKinds              #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE KindSignatures         #-}
-{-# LANGUAGE MonoLocalBinds         #-}
-{-# LANGUAGE NamedFieldPuns         #-}
-{-# LANGUAGE RankNTypes             #-}
-{-# LANGUAGE TemplateHaskell        #-}
-{-# LANGUAGE TupleSections          #-}
-{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 -- | A trace is a sequence of actions by simulated wallets that can be run
 --   on the mockchain. This module contains the functions needed to build
 --   traces.
@@ -52,49 +52,48 @@ module Language.Plutus.Contract.Trace
     , allWallets
     ) where
 
-import           Control.Lens                                    (at, from, makeClassyPrisms, makeLenses, use, view,
-                                                                  (%=))
-import           Control.Monad                                   (void, (>=>))
-import           Control.Monad.Reader                            ()
-import           Control.Monad.State                             (MonadState, StateT, gets, runStateT)
-import           Control.Monad.Trans.Class                       (lift)
-import           Data.Foldable                                   (toList, traverse_)
-import           Data.Map                                        (Map)
-import qualified Data.Map                                        as Map
-import           Data.Maybe                                      (fromMaybe)
-import           Data.Row                                        (AllUniqueLabels, Forall, HasType)
-import           Data.Sequence                                   (Seq, (|>))
-import qualified Data.Set                                        as Set
+import Control.Lens (at, from, makeClassyPrisms, makeLenses, use, view, (%=))
+import Control.Monad (void, (>=>))
+import Control.Monad.Reader ()
+import Control.Monad.State (MonadState, StateT, gets, runStateT)
+import Control.Monad.Trans.Class (lift)
+import Data.Foldable (toList, traverse_)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Row (AllUniqueLabels, Forall, HasType)
+import Data.Sequence (Seq, (|>))
+import qualified Data.Set as Set
 
-import           Language.Plutus.Contract                        (Contract (..), HasUtxoAt, HasWatchAddress, HasWriteTx,
-                                                                  waitingForBlockchainActions, withContractError)
-import qualified Language.Plutus.Contract.Resumable              as State
-import           Language.Plutus.Contract.Schema                 (Event, Handlers, Input, Output)
-import           Language.Plutus.Contract.Tx                     (UnbalancedTx)
-import qualified Language.Plutus.Contract.Wallet                 as Wallet
+import Language.Plutus.Contract
+    (Contract (..), HasUtxoAt, HasWatchAddress, HasWriteTx, waitingForBlockchainActions, withContractError)
+import qualified Language.Plutus.Contract.Resumable as State
+import Language.Plutus.Contract.Schema (Event, Handlers, Input, Output)
+import Language.Plutus.Contract.Tx (UnbalancedTx)
+import qualified Language.Plutus.Contract.Wallet as Wallet
 
-import           Language.Plutus.Contract.Effects.AwaitSlot      (SlotSymbol)
-import qualified Language.Plutus.Contract.Effects.AwaitSlot      as AwaitSlot
-import           Language.Plutus.Contract.Effects.ExposeEndpoint (HasEndpoint)
+import Language.Plutus.Contract.Effects.AwaitSlot (SlotSymbol)
+import qualified Language.Plutus.Contract.Effects.AwaitSlot as AwaitSlot
+import Language.Plutus.Contract.Effects.ExposeEndpoint (HasEndpoint)
 import qualified Language.Plutus.Contract.Effects.ExposeEndpoint as Endpoint
-import           Language.Plutus.Contract.Effects.OwnPubKey      (HasOwnPubKey, OwnPubKeyRequest (..))
-import qualified Language.Plutus.Contract.Effects.OwnPubKey      as OwnPubKey
-import           Language.Plutus.Contract.Effects.UtxoAt         (UtxoAtAddress (..))
-import qualified Language.Plutus.Contract.Effects.UtxoAt         as UtxoAt
-import qualified Language.Plutus.Contract.Effects.WatchAddress   as WatchAddress
-import           Language.Plutus.Contract.Effects.WriteTx        (TxSymbol, WriteTxResponse)
-import qualified Language.Plutus.Contract.Effects.WriteTx        as WriteTx
+import Language.Plutus.Contract.Effects.OwnPubKey (HasOwnPubKey, OwnPubKeyRequest (..))
+import qualified Language.Plutus.Contract.Effects.OwnPubKey as OwnPubKey
+import Language.Plutus.Contract.Effects.UtxoAt (UtxoAtAddress (..))
+import qualified Language.Plutus.Contract.Effects.UtxoAt as UtxoAt
+import qualified Language.Plutus.Contract.Effects.WatchAddress as WatchAddress
+import Language.Plutus.Contract.Effects.WriteTx (TxSymbol, WriteTxResponse)
+import qualified Language.Plutus.Contract.Effects.WriteTx as WriteTx
 
-import qualified Ledger.Ada                                      as Ada
-import           Ledger.Address                                  (Address)
-import qualified Ledger.AddressMap                               as AM
-import           Ledger.Slot                                     (Slot)
-import           Ledger.Tx                                       (Tx, txId)
-import           Ledger.Value                                    (Value)
+import qualified Ledger.Ada as Ada
+import Ledger.Address (Address)
+import qualified Ledger.AddressMap as AM
+import Ledger.Slot (Slot)
+import Ledger.Tx (Tx, txId)
+import Ledger.Value (Value)
 
-import           Wallet.API                                      (WalletAPIError, defaultSlotRange, payToPublicKey_)
-import           Wallet.Emulator                                 (EmulatorAction, EmulatorState, MonadEmulator, Wallet)
-import qualified Wallet.Emulator                                 as EM
+import Wallet.API (WalletAPIError, defaultSlotRange, payToPublicKey_)
+import Wallet.Emulator (EmulatorAction, EmulatorState, MonadEmulator, Wallet)
+import qualified Wallet.Emulator as EM
 
 -- | Error produced while running a trace. Either a contract-specific
 --   error (of type 'e'), or an 'EM.AssertionError' from the emulator.

--- a/plutus-contract/src/Language/Plutus/Contract/Tx.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Tx.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE DataKinds              #-}
-{-# LANGUAGE DeriveAnyClass         #-}
-{-# LANGUAGE DeriveGeneric          #-}
-{-# LANGUAGE DerivingStrategies     #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE NamedFieldPuns         #-}
-{-# LANGUAGE OverloadedStrings      #-}
-{-# LANGUAGE TemplateHaskell        #-}
-{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 module Language.Plutus.Contract.Tx(
       UnbalancedTx
     , inputs
@@ -32,30 +32,29 @@ module Language.Plutus.Contract.Tx(
     , Tx.scriptTxOut'
     ) where
 
-import           Control.Lens              ((&), (<>~))
-import qualified Control.Lens.TH           as Lens.TH
-import qualified Data.Aeson                as Aeson
-import           Data.Foldable             (toList)
-import qualified Data.Map                  as Map
-import           Data.Set                  (Set)
-import qualified Data.Set                  as Set
-import           Data.Text.Prettyprint.Doc
-import           GHC.Generics              (Generic)
+import Control.Lens ((&), (<>~))
+import qualified Control.Lens.TH as Lens.TH
+import qualified Data.Aeson as Aeson
+import Data.Foldable (toList)
+import qualified Data.Map as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text.Prettyprint.Doc
+import GHC.Generics (Generic)
 
-import           Language.PlutusTx.Lattice
+import Language.PlutusTx.Lattice
 
-import           IOTS                      (IotsType)
-import           Ledger                    (Address, DataScript, PubKey, RedeemerScript, TxOutRef, TxOutTx,
-                                            ValidatorScript)
-import qualified Ledger                    as L
-import           Ledger.AddressMap         (AddressMap)
-import           Ledger.Index              (minFee)
-import qualified Ledger.Interval           as I
-import           Ledger.Slot               (SlotRange)
-import qualified Ledger.Tx                 as Tx
-import           Ledger.Value              as V
+import IOTS (IotsType)
+import Ledger (Address, DataScript, PubKey, RedeemerScript, TxOutRef, TxOutTx, ValidatorScript)
+import qualified Ledger as L
+import Ledger.AddressMap (AddressMap)
+import Ledger.Index (minFee)
+import qualified Ledger.Interval as I
+import Ledger.Slot (SlotRange)
+import qualified Ledger.Tx as Tx
+import Ledger.Value as V
 
-import qualified Wallet.API                as WAPI
+import qualified Wallet.API as WAPI
 
 -- | An unsigned and potentially unbalanced transaction, as produced by
 --   a contract endpoint. See note [Unbalanced transactions].

--- a/plutus-contract/src/Language/Plutus/Contract/Typed/Tx.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Typed/Tx.hs
@@ -1,20 +1,20 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 -- | Functions for working with the contract interface using typed transactions.
 module Language.Plutus.Contract.Typed.Tx where
 
 import qualified Language.Plutus.Contract.Tx as Contract
-import qualified Language.PlutusTx           as PlutusTx
-import           Ledger                      (TxOutRef, TxOutTx)
-import qualified Ledger                      as L
-import           Ledger.AddressMap           (AddressMap)
-import qualified Ledger.Typed.Scripts        as Scripts
-import qualified Ledger.Typed.Tx             as Typed
+import qualified Language.PlutusTx as PlutusTx
+import Ledger (TxOutRef, TxOutTx)
+import qualified Ledger as L
+import Ledger.AddressMap (AddressMap)
+import qualified Ledger.Typed.Scripts as Scripts
+import qualified Ledger.Typed.Tx as Typed
 
-import qualified Wallet.Typed.API            as Typed
+import qualified Wallet.Typed.API as Typed
 
 -- | Given the pay to script address of the 'ValidatorScript', collect from it
 --   all the outputs that match a predicate, using the 'RedeemerScript'.

--- a/plutus-contract/src/Language/Plutus/Contract/Util.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Util.hs
@@ -1,6 +1,6 @@
 module Language.Plutus.Contract.Util where
 
-import           Control.Applicative (Alternative (..), liftA2)
+import Control.Applicative (Alternative (..), liftA2)
 
 -- | A monadic version of 'loop', where the predicate returns 'Left' as a seed
 --   for the next loop or 'Right' to abort the loop.

--- a/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | Balance  `UnbalancedTx` values using the
 --   wallet API.
@@ -9,28 +9,28 @@ module Language.Plutus.Contract.Wallet(
     , WAPI.startWatching
     ) where
 
-import           Control.Lens
-import           Control.Monad.Except
-import           Data.Bifunctor              (second)
-import           Data.Map                    (Map)
-import qualified Data.Map                    as Map
-import           Data.Maybe                  (fromMaybe)
-import qualified Data.Set                    as Set
-import           Data.String                 (IsString (fromString))
-import           Data.Text.Prettyprint.Doc   (Pretty (..))
-import           Language.Plutus.Contract.Tx (UnbalancedTx)
+import Control.Lens
+import Control.Monad.Except
+import Data.Bifunctor (second)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import Data.String (IsString (fromString))
+import Data.Text.Prettyprint.Doc (Pretty (..))
+import Language.Plutus.Contract.Tx (UnbalancedTx)
 import qualified Language.Plutus.Contract.Tx as T
-import qualified Language.PlutusTx.Prelude   as P
-import qualified Ledger                      as L
-import qualified Ledger.Ada                  as Ada
-import qualified Ledger.AddressMap           as AM
-import           Ledger.Tx                   (Tx, TxOut, TxOutRef)
-import qualified Ledger.Tx                   as Tx
-import           Ledger.Value                (Value)
-import qualified Ledger.Value                as Value
-import           Wallet.API                  (MonadWallet, PubKey, WalletAPIError)
-import qualified Wallet.API                  as WAPI
-import qualified Wallet.Emulator             as E
+import qualified Language.PlutusTx.Prelude as P
+import qualified Ledger as L
+import qualified Ledger.Ada as Ada
+import qualified Ledger.AddressMap as AM
+import Ledger.Tx (Tx, TxOut, TxOutRef)
+import qualified Ledger.Tx as Tx
+import Ledger.Value (Value)
+import qualified Ledger.Value as Value
+import Wallet.API (MonadWallet, PubKey, WalletAPIError)
+import qualified Wallet.API as WAPI
+import qualified Wallet.Emulator as E
 
 -- | Balance an unbalanced transaction in a 'MonadWallet' context. See note
 --   [Unbalanced transactions].

--- a/plutus-contract/test/Spec.hs
+++ b/plutus-contract/test/Spec.hs
@@ -4,7 +4,7 @@ module Main(main) where
 import qualified Spec.Contract
 import qualified Spec.Rows
 import qualified Spec.State
-import           Test.Tasty
+import Test.Tasty
 
 main :: IO ()
 main = defaultMain tests

--- a/plutus-contract/test/Spec/Rows.hs
+++ b/plutus-contract/test/Spec/Rows.hs
@@ -1,16 +1,16 @@
-{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 module Spec.Rows(tests) where
 
-import qualified Data.Aeson                                      as Aeson
-import           Test.Tasty
-import qualified Test.Tasty.HUnit                                as HUnit
-import           Test.Tasty.Providers                            (TestTree)
+import qualified Data.Aeson as Aeson
+import Test.Tasty
+import qualified Test.Tasty.HUnit as HUnit
+import Test.Tasty.Providers (TestTree)
 
-import           Language.Plutus.Contract
-import           Language.Plutus.Contract.Effects.ExposeEndpoint as Endpoint
+import Language.Plutus.Contract
+import Language.Plutus.Contract.Effects.ExposeEndpoint as Endpoint
 
 type TheSchema = Endpoint "endpoint1" Int .\/ Endpoint "endpoint2" String
 

--- a/plutus-contract/test/Spec/State.hs
+++ b/plutus-contract/test/Spec/State.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators    #-}
+{-# LANGUAGE TypeOperators #-}
 module Spec.State where
 
-import           Control.Applicative                             (Alternative (..))
-import           Control.Lens                                    (from, view)
-import           Control.Monad                                   (foldM)
-import           Control.Monad.Except                            (runExcept)
-import           Control.Monad.Writer                            (runWriterT)
-import           Data.Either                                     (fromRight, isRight)
-import           Language.Plutus.Contract                        as Con
-import           Language.Plutus.Contract.Record                 (Record (ClosedRec), jsonLeaf, record)
-import           Test.Tasty
-import qualified Test.Tasty.HUnit                                as HUnit
+import Control.Applicative (Alternative (..))
+import Control.Lens (from, view)
+import Control.Monad (foldM)
+import Control.Monad.Except (runExcept)
+import Control.Monad.Writer (runWriterT)
+import Data.Either (fromRight, isRight)
+import Language.Plutus.Contract as Con
+import Language.Plutus.Contract.Record (Record (ClosedRec), jsonLeaf, record)
+import Test.Tasty
+import qualified Test.Tasty.HUnit as HUnit
 
 import qualified Language.Plutus.Contract.Effects.ExposeEndpoint as Endpoint
-import qualified Language.Plutus.Contract.Resumable              as S
+import qualified Language.Plutus.Contract.Resumable as S
 
 type Schema =
     BlockchainActions

--- a/plutus-core-interpreter/bench/Bench.hs
+++ b/plutus-core-interpreter/bench/Bench.hs
@@ -1,10 +1,10 @@
 module Main (main) where
 
-import           Control.Monad                              (void)
-import           Criterion.Main
-import qualified Data.ByteString.Lazy                       as BSL
-import           Language.PlutusCore
-import           Language.PlutusCore.Interpreter.CekMachine (unsafeRunCek)
+import Control.Monad (void)
+import Criterion.Main
+import qualified Data.ByteString.Lazy as BSL
+import Language.PlutusCore
+import Language.PlutusCore.Interpreter.CekMachine (unsafeRunCek)
 
 main :: IO ()
 main =

--- a/plutus-core-interpreter/src/Language/PlutusCore/Interpreter/CekMachine.hs
+++ b/plutus-core-interpreter/src/Language/PlutusCore/Interpreter/CekMachine.hs
@@ -24,17 +24,17 @@ module Language.PlutusCore.Interpreter.CekMachine
     , unsafeRunCek
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Evaluation.MachineException
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.View
-import           PlutusPrelude
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Evaluation.MachineException
+import Language.PlutusCore.Name
+import Language.PlutusCore.View
+import PlutusPrelude
 
-import           Control.Lens.TH                                 (makeLenses)
-import           Control.Monad.Except
-import           Control.Monad.Reader
-import qualified Data.Map                                        as Map
+import Control.Lens.TH (makeLenses)
+import Control.Monad.Except
+import Control.Monad.Reader
+import qualified Data.Map as Map
 
 type Plain f = f TyName Name ()
 

--- a/plutus-core-interpreter/src/Language/PlutusCore/Interpreter/LMachine.hs
+++ b/plutus-core-interpreter/src/Language/PlutusCore/Interpreter/LMachine.hs
@@ -39,16 +39,16 @@ module Language.PlutusCore.Interpreter.LMachine
     , runL
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Evaluation.MachineException
-import           Language.PlutusCore.Name
-import           Language.PlutusCore.View
-import           PlutusPrelude
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Evaluation.MachineException
+import Language.PlutusCore.Name
+import Language.PlutusCore.View
+import PlutusPrelude
 
-import           Control.Monad.Identity
-import           Data.IntMap                                     (IntMap)
-import qualified Data.IntMap                                     as IntMap
+import Control.Monad.Identity
+import Data.IntMap (IntMap)
+import qualified Data.IntMap as IntMap
 
 type Plain f = f TyName Name ()
 

--- a/plutus-core-interpreter/test/CekMachine.hs
+++ b/plutus-core-interpreter/test/CekMachine.hs
@@ -5,12 +5,12 @@ module CekMachine
     ( test_evaluateCek
     ) where
 
-import           Language.PlutusCore.Generators.Interesting
-import           Language.PlutusCore.Generators.Test
-import           Language.PlutusCore.Interpreter.CekMachine
+import Language.PlutusCore.Generators.Interesting
+import Language.PlutusCore.Generators.Test
+import Language.PlutusCore.Interpreter.CekMachine
 
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
+import Test.Tasty
+import Test.Tasty.Hedgehog
 
 test_evaluateCek :: TestTree
 test_evaluateCek =

--- a/plutus-core-interpreter/test/DynamicBuiltins/Common.hs
+++ b/plutus-core-interpreter/test/DynamicBuiltins/Common.hs
@@ -5,12 +5,12 @@ module DynamicBuiltins.Common
     , typecheckReadKnownCek
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
+import Language.PlutusCore
+import Language.PlutusCore.Constant
 
-import           Language.PlutusCore.Interpreter.CekMachine
+import Language.PlutusCore.Interpreter.CekMachine
 
-import           Control.Monad.Except
+import Control.Monad.Except
 
 -- | Type check and evaluate a term that can contain dynamic built-ins.
 typecheckAnd

--- a/plutus-core-interpreter/test/DynamicBuiltins/Definition.hs
+++ b/plutus-core-interpreter/test/DynamicBuiltins/Definition.hs
@@ -1,34 +1,34 @@
 -- | A dynamic built-in name test.
 
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 
 module DynamicBuiltins.Definition
     ( test_definition
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Constant.Dynamic
-import           Language.PlutusCore.Generators.Interesting
-import           Language.PlutusCore.MkPlc
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Constant.Dynamic
+import Language.PlutusCore.Generators.Interesting
+import Language.PlutusCore.MkPlc
 
-import           Language.PlutusCore.StdLib.Data.Bool
-import qualified Language.PlutusCore.StdLib.Data.Function   as Plc
-import qualified Language.PlutusCore.StdLib.Data.List       as Plc
+import Language.PlutusCore.StdLib.Data.Bool
+import qualified Language.PlutusCore.StdLib.Data.Function as Plc
+import qualified Language.PlutusCore.StdLib.Data.List as Plc
 
-import           DynamicBuiltins.Common
+import DynamicBuiltins.Common
 
-import           Data.Either                                (isRight)
-import           Data.Proxy
-import           Hedgehog                                   hiding (Size, Var)
-import qualified Hedgehog.Gen                               as Gen
-import qualified Hedgehog.Range                             as Range
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
-import           Test.Tasty.HUnit
+import Data.Either (isRight)
+import Data.Proxy
+import Hedgehog hiding (Size, Var)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import Test.Tasty.HUnit
 
 dynamicFactorialName :: DynamicBuiltinName
 dynamicFactorialName = DynamicBuiltinName "factorial"

--- a/plutus-core-interpreter/test/DynamicBuiltins/Logging.hs
+++ b/plutus-core-interpreter/test/DynamicBuiltins/Logging.hs
@@ -1,27 +1,27 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeApplications #-}
 
 module DynamicBuiltins.Logging
     ( test_logging
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Constant.Dynamic
-import           Language.PlutusCore.MkPlc
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Constant.Dynamic
+import Language.PlutusCore.MkPlc
 
-import           Language.PlutusCore.StdLib.Data.List as Plc
-import           Language.PlutusCore.StdLib.Data.Unit
+import Language.PlutusCore.StdLib.Data.List as Plc
+import Language.PlutusCore.StdLib.Data.Unit
 
-import           DynamicBuiltins.Common
+import DynamicBuiltins.Common
 
-import           Control.Monad.Except
-import           Data.Either                          (isRight)
-import           Data.Proxy
-import           Test.Tasty
-import           Test.Tasty.HUnit
+import Control.Monad.Except
+import Data.Either (isRight)
+import Data.Proxy
+import Test.Tasty
+import Test.Tasty.HUnit
 
 dynamicIntToStringName :: DynamicBuiltinName
 dynamicIntToStringName = DynamicBuiltinName "intToString"

--- a/plutus-core-interpreter/test/DynamicBuiltins/MakeRead.hs
+++ b/plutus-core-interpreter/test/DynamicBuiltins/MakeRead.hs
@@ -1,29 +1,29 @@
 -- | Tests of dynamic strings and characters.
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeApplications #-}
 
 module DynamicBuiltins.MakeRead
     ( test_dynamicMakeRead
     ) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Constant.Dynamic
-import           Language.PlutusCore.Evaluation.Result
-import           Language.PlutusCore.MkPlc             hiding (error)
-import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.StdLib.Data.Unit
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Constant.Dynamic
+import Language.PlutusCore.Evaluation.Result
+import Language.PlutusCore.MkPlc hiding (error)
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.StdLib.Data.Unit
 
-import           DynamicBuiltins.Common
+import DynamicBuiltins.Common
 
-import           Control.Monad.IO.Class                (liftIO)
-import           Hedgehog                              hiding (Size, Var)
-import qualified Hedgehog.Gen                          as Gen
-import qualified Hedgehog.Range                        as Range
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
-import           Test.Tasty.HUnit
+import Control.Monad.IO.Class (liftIO)
+import Hedgehog hiding (Size, Var)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import Test.Tasty.HUnit
 
 -- | Convert a Haskell value to a PLC term and then convert back to a Haskell value
 -- of a different type.

--- a/plutus-core-interpreter/test/DynamicBuiltins/Spec.hs
+++ b/plutus-core-interpreter/test/DynamicBuiltins/Spec.hs
@@ -1,9 +1,9 @@
 module DynamicBuiltins.Spec (test_dynamicBuiltins) where
 
-import           DynamicBuiltins.Definition (test_definition)
-import           DynamicBuiltins.Logging    (test_logging)
-import           DynamicBuiltins.MakeRead   (test_dynamicMakeRead)
-import           Test.Tasty
+import DynamicBuiltins.Definition (test_definition)
+import DynamicBuiltins.Logging (test_logging)
+import DynamicBuiltins.MakeRead (test_dynamicMakeRead)
+import Test.Tasty
 
 test_dynamicBuiltins :: TestTree
 test_dynamicBuiltins =

--- a/plutus-core-interpreter/test/LMachine.hs
+++ b/plutus-core-interpreter/test/LMachine.hs
@@ -5,12 +5,12 @@ module LMachine
     ( test_evaluateL
     ) where
 
-import           Language.PlutusCore.Generators.Interesting
-import           Language.PlutusCore.Generators.Test
-import           Language.PlutusCore.Interpreter.LMachine
+import Language.PlutusCore.Generators.Interesting
+import Language.PlutusCore.Generators.Test
+import Language.PlutusCore.Interpreter.LMachine
 
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
+import Test.Tasty
+import Test.Tasty.Hedgehog
 
 test_evaluateL :: TestTree
 test_evaluateL =

--- a/plutus-core-interpreter/test/Main.hs
+++ b/plutus-core-interpreter/test/Main.hs
@@ -1,10 +1,10 @@
 module Main (main) where
 
-import           CekMachine           (test_evaluateCek)
-import           DynamicBuiltins.Spec (test_dynamicBuiltins)
-import           LMachine             (test_evaluateL)
+import CekMachine (test_evaluateCek)
+import DynamicBuiltins.Spec (test_dynamicBuiltins)
+import LMachine (test_evaluateL)
 
-import           Test.Tasty
+import Test.Tasty
 
 test_machines :: TestTree
 test_machines =

--- a/plutus-core-interpreter/weigh/Bench.hs
+++ b/plutus-core-interpreter/weigh/Bench.hs
@@ -1,10 +1,10 @@
 module Main (main) where
 
-import           Control.Monad                              (void)
-import qualified Data.ByteString.Lazy                       as BSL
-import           Language.PlutusCore
-import           Language.PlutusCore.Interpreter.CekMachine (unsafeRunCek)
-import           Weigh
+import Control.Monad (void)
+import qualified Data.ByteString.Lazy as BSL
+import Language.PlutusCore
+import Language.PlutusCore.Interpreter.CekMachine (unsafeRunCek)
+import Weigh
 
 main :: IO ()
 main = do

--- a/plutus-emulator/src/Wallet/Emulator.hs
+++ b/plutus-emulator/src/Wallet/Emulator.hs
@@ -2,4 +2,4 @@ module Wallet.Emulator(
     module Types
     ) where
 
-import           Wallet.Emulator.Types as Types
+import Wallet.Emulator.Types as Types

--- a/plutus-emulator/src/Wallet/Emulator/Generators.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Generators.hs
@@ -3,10 +3,10 @@ module Wallet.Emulator.Generators(
     , runTraceOn
     ) where
 
-import           Hedgehog
+import Hedgehog
 
-import           Wallet.Emulator   as Emulator
-import           Wallet.Generators (GeneratorModel, Mockchain (Mockchain), genMockchain')
+import Wallet.Emulator as Emulator
+import Wallet.Generators (GeneratorModel, Mockchain (Mockchain), genMockchain')
 
 
 -- | Run an emulator trace on a mockchain.

--- a/plutus-emulator/src/Wallet/Emulator/NodeClient.hs
+++ b/plutus-emulator/src/Wallet/Emulator/NodeClient.hs
@@ -1,28 +1,28 @@
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TupleSections         #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 module Wallet.Emulator.NodeClient where
 
-import           Control.Lens        hiding (index)
-import           Control.Monad.State
-import           Data.Aeson          (FromJSON, ToJSON)
-import           Data.List           (partition)
-import           Data.Maybe          (isNothing)
-import           Data.Traversable    (for)
-import           GHC.Generics        (Generic)
+import Control.Lens hiding (index)
+import Control.Monad.State
+import Data.Aeson (FromJSON, ToJSON)
+import Data.List (partition)
+import Data.Maybe (isNothing)
+import Data.Traversable (for)
+import GHC.Generics (Generic)
 
-import           Ledger              (Blockchain, Slot (..), Tx (..), TxId, lastSlot, txId)
-import qualified Ledger.Index        as Index
-import qualified Ledger.Interval     as Interval
+import Ledger (Blockchain, Slot (..), Tx (..), TxId, lastSlot, txId)
+import qualified Ledger.Index as Index
+import qualified Ledger.Interval as Interval
 
 
 -- | Events produced by the blockchain emulator.

--- a/plutus-emulator/src/Wallet/Emulator/Types.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Types.hs
@@ -1,16 +1,16 @@
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TupleSections         #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-overlapping-patterns #-}
 module Wallet.Emulator.Types(
     -- * Wallets
@@ -85,46 +85,73 @@ module Wallet.Emulator.Types(
     selectCoin
     ) where
 
-import           Control.Lens               hiding (index)
-import           Control.Monad.Error.Lens
-import           Control.Monad.Except
-import           Control.Monad.Operational  as Op hiding (view)
-import           Control.Monad.State
-import           Control.Monad.Writer
-import           Control.Newtype.Generics   (Newtype)
-import           Data.Aeson                 (FromJSON, ToJSON, ToJSONKey)
-import           Data.Bifunctor             (Bifunctor (..))
-import qualified Data.ByteString.Lazy       as BSL
-import           Data.Foldable              (traverse_)
-import           Data.Hashable              (Hashable)
-import           Data.HashMap.Strict        (HashMap)
-import qualified Data.HashMap.Strict        as HashMap
-import           Data.Map                   (Map)
-import qualified Data.Map                   as Map
-import           Data.Maybe
-import qualified Data.Set                   as Set
-import           Data.String                (fromString)
-import qualified Data.Text                  as T
-import           Data.Text.Prettyprint.Doc  hiding (annotate)
-import           GHC.Generics               (Generic)
-import           IOTS                       (IotsType (iotsDefinition))
-import qualified Ledger.Crypto              as Crypto
-import           Prelude                    as P
-import           Schema                     (ToSchema)
-import           Servant.API                (FromHttpApiData (..), ToHttpApiData (..))
+import Control.Lens hiding (index)
+import Control.Monad.Error.Lens
+import Control.Monad.Except
+import Control.Monad.Operational as Op hiding (view)
+import Control.Monad.State
+import Control.Monad.Writer
+import Control.Newtype.Generics (Newtype)
+import Data.Aeson (FromJSON, ToJSON, ToJSONKey)
+import Data.Bifunctor (Bifunctor (..))
+import qualified Data.ByteString.Lazy as BSL
+import Data.Foldable (traverse_)
+import Data.Hashable (Hashable)
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe
+import qualified Data.Set as Set
+import Data.String (fromString)
+import qualified Data.Text as T
+import Data.Text.Prettyprint.Doc hiding (annotate)
+import GHC.Generics (Generic)
+import IOTS (IotsType (iotsDefinition))
+import qualified Ledger.Crypto as Crypto
+import Prelude as P
+import Schema (ToSchema)
+import Servant.API (FromHttpApiData (..), ToHttpApiData (..))
 
-import qualified Language.PlutusTx.Prelude  as PlutusTx
+import qualified Language.PlutusTx.Prelude as PlutusTx
 
-import           Ledger                     (Address, Block, Blockchain, PrivateKey (..), PubKey (..), Slot, Tx (..),
-                                             TxIn (..), TxOut (..), TxOutRef, TxOutTx (..), Value, addSignature,
-                                             pubKeyAddress, pubKeyTxIn, pubKeyTxOut, toPublicKey, txId, txOutAddress)
-import qualified Ledger.Ada                 as Ada
-import qualified Ledger.AddressMap          as AM
-import qualified Ledger.Index               as Index
-import qualified Ledger.Value               as Value
-import           Wallet.API                 (EventHandler (..), EventTrigger, WalletAPI (..), WalletAPIError (..),
-                                             WalletDiagnostics (..), WalletLog (..), addresses, annTruthValue, getAnnot)
-import qualified Wallet.API                 as WAPI
+import Ledger
+    ( Address
+    , Block
+    , Blockchain
+    , PrivateKey (..)
+    , PubKey (..)
+    , Slot
+    , Tx (..)
+    , TxIn (..)
+    , TxOut (..)
+    , TxOutRef
+    , TxOutTx (..)
+    , Value
+    , addSignature
+    , pubKeyAddress
+    , pubKeyTxIn
+    , pubKeyTxOut
+    , toPublicKey
+    , txId
+    , txOutAddress
+    )
+import qualified Ledger.Ada as Ada
+import qualified Ledger.AddressMap as AM
+import qualified Ledger.Index as Index
+import qualified Ledger.Value as Value
+import Wallet.API
+    ( EventHandler (..)
+    , EventTrigger
+    , WalletAPI (..)
+    , WalletAPIError (..)
+    , WalletDiagnostics (..)
+    , WalletLog (..)
+    , addresses
+    , annTruthValue
+    , getAnnot
+    )
+import qualified Wallet.API as WAPI
 import qualified Wallet.Emulator.NodeClient as NC
 
 -- | A wallet in the emulator model.

--- a/plutus-emulator/src/Wallet/Rollup.hs
+++ b/plutus-emulator/src/Wallet/Rollup.hs
@@ -1,32 +1,55 @@
-{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns   #-}
-{-# LANGUAGE RecordWildCards  #-}
-{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Wallet.Rollup
     ( doAnnotateBlockchain
     ) where
 
-import           Control.Lens             (assign, ifoldr, makeLenses, over, use)
-import           Control.Lens.Combinators (itraverse)
-import           Control.Monad.Except     (MonadError, throwError)
-import           Control.Monad.State      (StateT, evalStateT)
-import qualified Data.ByteString.Lazy     as BSL
-import           Data.Map                 (Map)
-import qualified Data.Map                 as Map
-import qualified Data.Set                 as Set
-import           Data.Text                (Text)
-import qualified Data.Text                as Text
-import           GHC.Generics             (Generic)
-import           Language.PlutusTx.Monoid (inv)
-import           Ledger                   (Tx (Tx), TxId (TxId), TxIn (TxIn), TxOut (TxOut), Value, getTxId, outValue,
-                                           txInRef, txInputs, txOutRefId, txOutRefIdx, txOutValue, txOutputs)
-import qualified Ledger.Tx                as Tx
-import           Wallet.Rollup.Types      (AnnotatedTx (AnnotatedTx), BeneficialOwner,
-                                           DereferencedInput (DereferencedInput, refersTo), SequenceId (SequenceId),
-                                           balances, dereferencedInputs, sequenceId, slotIndex, toBeneficialOwner, tx,
-                                           txId, txIndex)
+import Control.Lens (assign, ifoldr, makeLenses, over, use)
+import Control.Lens.Combinators (itraverse)
+import Control.Monad.Except (MonadError, throwError)
+import Control.Monad.State (StateT, evalStateT)
+import qualified Data.ByteString.Lazy as BSL
+import Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Generics (Generic)
+import Language.PlutusTx.Monoid (inv)
+import Ledger
+    ( Tx (Tx)
+    , TxId (TxId)
+    , TxIn (TxIn)
+    , TxOut (TxOut)
+    , Value
+    , getTxId
+    , outValue
+    , txInRef
+    , txInputs
+    , txOutRefId
+    , txOutRefIdx
+    , txOutValue
+    , txOutputs
+    )
+import qualified Ledger.Tx as Tx
+import Wallet.Rollup.Types
+    ( AnnotatedTx (AnnotatedTx)
+    , BeneficialOwner
+    , DereferencedInput (DereferencedInput, refersTo)
+    , SequenceId (SequenceId)
+    , balances
+    , dereferencedInputs
+    , sequenceId
+    , slotIndex
+    , toBeneficialOwner
+    , tx
+    , txId
+    , txIndex
+    )
 
 data TxKey =
     TxKey

--- a/plutus-emulator/src/Wallet/Rollup/Types.hs
+++ b/plutus-emulator/src/Wallet/Rollup/Types.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveFunctor              #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DeriveLift                 #-}
-{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Wallet.Rollup.Types where
 
-import           Control.Lens (makeLenses)
-import           Data.Aeson   (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
-import           Data.Map     (Map)
-import           GHC.Generics
-import           Ledger
+import Control.Lens (makeLenses)
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import Data.Map (Map)
+import GHC.Generics
+import Ledger
 
 data SequenceId =
     SequenceId

--- a/plutus-exe/src/Main.hs
+++ b/plutus-exe/src/Main.hs
@@ -1,36 +1,36 @@
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main (main) where
 
-import qualified Language.PlutusCore                        as PLC
-import qualified Language.PlutusCore.Evaluation.CkMachine   as PLC
-import qualified Language.PlutusCore.Generators             as PLC
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore.Evaluation.CkMachine as PLC
+import qualified Language.PlutusCore.Generators as PLC
 import qualified Language.PlutusCore.Generators.Interesting as PLC
-import qualified Language.PlutusCore.Generators.Test        as PLC
+import qualified Language.PlutusCore.Generators.Test as PLC
 import qualified Language.PlutusCore.Interpreter.CekMachine as PLC
-import qualified Language.PlutusCore.Interpreter.LMachine   as PLC
-import qualified Language.PlutusCore.Pretty                 as PLC
-import qualified Language.PlutusCore.StdLib.Data.Bool       as PLC
-import qualified Language.PlutusCore.StdLib.Data.ChurchNat  as PLC
-import qualified Language.PlutusCore.StdLib.Data.Integer    as PLC
-import qualified Language.PlutusCore.StdLib.Data.Unit       as PLC
+import qualified Language.PlutusCore.Interpreter.LMachine as PLC
+import qualified Language.PlutusCore.Pretty as PLC
+import qualified Language.PlutusCore.StdLib.Data.Bool as PLC
+import qualified Language.PlutusCore.StdLib.Data.ChurchNat as PLC
+import qualified Language.PlutusCore.StdLib.Data.Integer as PLC
+import qualified Language.PlutusCore.StdLib.Data.Unit as PLC
 
-import           Control.Lens
-import           Control.Monad
-import           Control.Monad.Trans.Except                 (runExceptT)
-import           Data.Bifunctor                             (second)
-import           Data.Foldable                              (traverse_)
+import Control.Lens
+import Control.Monad
+import Control.Monad.Trans.Except (runExceptT)
+import Data.Bifunctor (second)
+import Data.Foldable (traverse_)
 
-import qualified Data.ByteString.Lazy                       as BSL
-import qualified Data.Text                                  as T
-import           Data.Text.Encoding                         (encodeUtf8)
-import qualified Data.Text.IO                               as T
-import           Data.Text.Prettyprint.Doc
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text as T
+import Data.Text.Encoding (encodeUtf8)
+import qualified Data.Text.IO as T
+import Data.Text.Prettyprint.Doc
 
-import           System.Exit
+import System.Exit
 
-import           Options.Applicative
+import Options.Applicative
 
 data Input = FileInput FilePath | StdInput
 

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans       #-}
 module Language.PlutusIR (
     TyName (..),
@@ -29,21 +29,21 @@ module Language.PlutusIR (
     Program (..)
     ) where
 
-import           PlutusPrelude
+import PlutusPrelude
 
-import           Language.PlutusCore        (Kind, Name, TyName, Type (..), typeSubtypes)
-import qualified Language.PlutusCore        as PLC
-import           Language.PlutusCore.CBOR   ()
-import           Language.PlutusCore.MkPlc  (Def (..), TermLike (..), TyVarDecl (..), VarDecl (..))
+import Language.PlutusCore (Kind, Name, TyName, Type (..), typeSubtypes)
+import qualified Language.PlutusCore as PLC
+import Language.PlutusCore.CBOR ()
+import Language.PlutusCore.MkPlc (Def (..), TermLike (..), TyVarDecl (..), VarDecl (..))
 import qualified Language.PlutusCore.Pretty as PLC
 
-import           Control.Lens               hiding (Strict)
+import Control.Lens hiding (Strict)
 
-import           Codec.Serialise            (Serialise)
+import Codec.Serialise (Serialise)
 
-import qualified Data.Text                  as T
+import qualified Data.Text as T
 
-import           GHC.Generics               (Generic)
+import GHC.Generics (Generic)
 
 -- Datatypes
 

--- a/plutus-ir/src/Language/PlutusIR/Analysis/Dependencies.hs
+++ b/plutus-ir/src/Language/PlutusIR/Analysis/Dependencies.hs
@@ -1,22 +1,22 @@
-{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs            #-}
-{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 -- | Functions for computing the dependency graph of variables within a term or type. A "dependency" between
 -- two nodes "A depends on B" means that B cannot be removed from the program without also removing A.
 module Language.PlutusIR.Analysis.Dependencies (Node (..), DepGraph, runTermDeps, runTypeDeps) where
 
-import qualified Language.PlutusCore               as PLC
-import qualified Language.PlutusCore.Name          as PLC
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore.Name as PLC
 
-import           Language.PlutusIR
+import Language.PlutusIR
 import qualified Language.PlutusIR.Analysis.Usages as Usages
 
-import           Control.Lens
-import           Control.Monad.Reader
+import Control.Lens
+import Control.Monad.Reader
 
-import qualified Algebra.Graph.Class               as G
-import qualified Data.Set                          as Set
+import qualified Algebra.Graph.Class as G
+import qualified Data.Set as Set
 
 -- | A node in a dependency graph. Either a specific 'PLC.Unique', or a specific
 -- node indicating the root of the graph. We need the root node because when computing the

--- a/plutus-ir/src/Language/PlutusIR/Analysis/Usages.hs
+++ b/plutus-ir/src/Language/PlutusIR/Analysis/Usages.hs
@@ -2,18 +2,18 @@
 -- | Functions for computing variable usage inside terms and types.
 module Language.PlutusIR.Analysis.Usages (runTermUsages, runTypeUsages, Usages, isUsed, allUsed) where
 
-import           Language.PlutusIR
+import Language.PlutusIR
 
-import qualified Language.PlutusCore      as PLC
+import qualified Language.PlutusCore as PLC
 import qualified Language.PlutusCore.Name as PLC
 
-import           Control.Lens
-import           Control.Monad.State
+import Control.Lens
+import Control.Monad.State
 
-import           Data.Coerce
-import           Data.Foldable
-import qualified Data.Map                 as Map
-import qualified Data.Set                 as Set
+import Data.Coerce
+import Data.Foldable
+import qualified Data.Map as Map
+import qualified Data.Set as Set
 
 -- | Variable uses, as a map from the 'PLC.Unique' to its usage count. Unused variables may be missing
 -- or have usage count 0.

--- a/plutus-ir/src/Language/PlutusIR/Compiler.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler.hs
@@ -15,22 +15,22 @@ module Language.PlutusIR.Compiler (
     ccEnclosing,
     defaultCompilationCtx) where
 
-import           Language.PlutusIR
+import Language.PlutusIR
 
-import           Language.PlutusIR.Compiler.Error
-import qualified Language.PlutusIR.Compiler.Let              as Let
-import           Language.PlutusIR.Compiler.Lower
-import           Language.PlutusIR.Compiler.Provenance
-import           Language.PlutusIR.Compiler.Types
-import qualified Language.PlutusIR.Optimizer.DeadCode        as DeadCode
-import qualified Language.PlutusIR.Transform.NonStrict       as NonStrict
-import           Language.PlutusIR.Transform.Rename          ()
+import Language.PlutusIR.Compiler.Error
+import qualified Language.PlutusIR.Compiler.Let as Let
+import Language.PlutusIR.Compiler.Lower
+import Language.PlutusIR.Compiler.Provenance
+import Language.PlutusIR.Compiler.Types
+import qualified Language.PlutusIR.Optimizer.DeadCode as DeadCode
+import qualified Language.PlutusIR.Transform.NonStrict as NonStrict
+import Language.PlutusIR.Transform.Rename ()
 import qualified Language.PlutusIR.Transform.ThunkRecursions as ThunkRec
 
-import qualified Language.PlutusCore                         as PLC
+import qualified Language.PlutusCore as PLC
 
-import           Control.Monad
-import           Control.Monad.Reader
+import Control.Monad
+import Control.Monad.Reader
 
 -- | Perform some simplification of a 'Term'.
 simplifyTerm :: MonadReader (CompilationCtx a) m => Term TyName Name b -> m (Term TyName Name b)

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
@@ -1,27 +1,27 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeApplications #-}
 -- | Functions for compiling let-bound PIR datatypes into PLC.
 module Language.PlutusIR.Compiler.Datatype (compileDatatype, compileRecDatatypes) where
 
-import           PlutusPrelude                          (showText)
+import PlutusPrelude (showText)
 
-import           Language.PlutusIR
-import           Language.PlutusIR.Compiler.Error
-import           Language.PlutusIR.Compiler.Names
-import           Language.PlutusIR.Compiler.Provenance
-import           Language.PlutusIR.Compiler.Types
-import qualified Language.PlutusIR.MkPir                as PIR
-import           Language.PlutusIR.Transform.Substitute
+import Language.PlutusIR
+import Language.PlutusIR.Compiler.Error
+import Language.PlutusIR.Compiler.Names
+import Language.PlutusIR.Compiler.Provenance
+import Language.PlutusIR.Compiler.Types
+import qualified Language.PlutusIR.MkPir as PIR
+import Language.PlutusIR.Transform.Substitute
 
-import qualified Language.PlutusCore.MkPlc              as PLC
-import           Language.PlutusCore.Quote
-import qualified Language.PlutusCore.StdLib.Type        as Types
+import qualified Language.PlutusCore.MkPlc as PLC
+import Language.PlutusCore.Quote
+import qualified Language.PlutusCore.StdLib.Type as Types
 
-import           Control.Monad.Error.Lens
+import Control.Monad.Error.Lens
 
-import qualified Data.Text                              as T
-import           Data.Traversable
+import qualified Data.Text as T
+import Data.Traversable
 
 -- Utilities
 

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Definitions.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Definitions.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE AllowAmbiguousTypes    #-}
-{-# LANGUAGE DefaultSignatures      #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE LambdaCase             #-}
-{-# LANGUAGE OverloadedStrings      #-}
-{-# LANGUAGE RankNTypes             #-}
-{-# LANGUAGE TemplateHaskell        #-}
-{-# LANGUAGE TypeApplications       #-}
-{-# LANGUAGE UndecidableInstances   #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- | Support for generating PIR with global definitions with dependencies between them.
 module Language.PlutusIR.Compiler.Definitions (DefT
                                               , MonadDefs (..)
@@ -24,27 +24,27 @@ module Language.PlutusIR.Compiler.Definitions (DefT
                                               , lookupConstructors
                                               , lookupDestructor) where
 
-import           Language.PlutusIR
-import           Language.PlutusIR.MkPir              hiding (error)
+import Language.PlutusIR
+import Language.PlutusIR.MkPir hiding (error)
 
-import qualified Language.PlutusCore.MkPlc            as PLC
-import           Language.PlutusCore.Quote
+import qualified Language.PlutusCore.MkPlc as PLC
+import Language.PlutusCore.Quote
 
-import           Control.Lens
-import           Control.Monad.Except
-import qualified Control.Monad.Morph                  as MM
-import           Control.Monad.Reader
-import           Control.Monad.State
+import Control.Lens
+import Control.Monad.Except
+import qualified Control.Monad.Morph as MM
+import Control.Monad.Reader
+import Control.Monad.State
 
-import qualified Algebra.Graph.AdjacencyMap           as AM
+import qualified Algebra.Graph.AdjacencyMap as AM
 import qualified Algebra.Graph.AdjacencyMap.Algorithm as AM
-import qualified Algebra.Graph.NonEmpty.AdjacencyMap  as NAM
-import qualified Algebra.Graph.ToGraph                as Graph
+import qualified Algebra.Graph.NonEmpty.AdjacencyMap as NAM
+import qualified Algebra.Graph.ToGraph as Graph
 
-import           Data.Foldable
-import qualified Data.Map                             as Map
-import           Data.Maybe
-import qualified Data.Set                             as Set
+import Data.Foldable
+import qualified Data.Map as Map
+import Data.Maybe
+import qualified Data.Set as Set
 
 -- | A map from keys to pairs of bindings and their dependencies (as a list of keys).
 type DefMap key def = Map.Map key (def, Set.Set key)

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Error.hs
@@ -1,20 +1,20 @@
-{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE LambdaCase             #-}
-{-# LANGUAGE OverloadedStrings      #-}
-{-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Language.PlutusIR.Compiler.Error (Error (..), AsError (..)) where
 
-import qualified Language.PlutusCore        as PLC
+import qualified Language.PlutusCore as PLC
 import qualified Language.PlutusCore.Pretty as PLC
 
-import           Control.Exception
-import           Control.Lens
+import Control.Exception
+import Control.Lens
 
-import qualified Data.Text                  as T
-import           Data.Text.Prettyprint.Doc  ((<+>), (<>))
-import qualified Data.Text.Prettyprint.Doc  as PP
-import           Data.Typeable
+import qualified Data.Text as T
+import Data.Text.Prettyprint.Doc ((<+>), (<>))
+import qualified Data.Text.Prettyprint.Doc as PP
+import Data.Typeable
 
 data Error a = CompilationError a T.Text -- ^ A generic compilation error.
                | UnsupportedError a T.Text -- ^ An error relating specifically to an unsupported feature.

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
@@ -1,23 +1,23 @@
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | Functions for compiling PIR let terms.
 module Language.PlutusIR.Compiler.Let (compileLets, LetKind(..)) where
 
-import           Language.PlutusIR
-import           Language.PlutusIR.Compiler.Datatype
-import           Language.PlutusIR.Compiler.Error
-import           Language.PlutusIR.Compiler.Provenance
-import           Language.PlutusIR.Compiler.Recursion
-import           Language.PlutusIR.Compiler.Types
-import qualified Language.PlutusIR.MkPir               as PIR
+import Language.PlutusIR
+import Language.PlutusIR.Compiler.Datatype
+import Language.PlutusIR.Compiler.Error
+import Language.PlutusIR.Compiler.Provenance
+import Language.PlutusIR.Compiler.Recursion
+import Language.PlutusIR.Compiler.Types
+import qualified Language.PlutusIR.MkPir as PIR
 
-import           Control.Monad
-import           Control.Monad.Error.Lens
+import Control.Monad
+import Control.Monad.Error.Lens
 
-import           Control.Lens                          hiding (Strict)
+import Control.Lens hiding (Strict)
 
-import           Data.List
+import Data.List
 
 data LetKind = RecTerms | NonRecTerms | Types
 

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Lower.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Lower.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Language.PlutusIR.Compiler.Lower where
 
-import           Language.PlutusIR
-import           Language.PlutusIR.Compiler.Error
-import           Language.PlutusIR.Compiler.Types
+import Language.PlutusIR
+import Language.PlutusIR.Compiler.Error
+import Language.PlutusIR.Compiler.Types
 
-import qualified Language.PlutusCore              as PLC
+import qualified Language.PlutusCore as PLC
 
-import           Control.Monad.Error.Lens
+import Control.Monad.Error.Lens
 
 -- | Turns a PIR 'Term' with no remaining PIR-specific features into a PLC 'PLC.Term' by simply
 -- translating the constructors across.

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Names.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Names.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Language.PlutusIR.Compiler.Names (safeFreshName, safeFreshTyName) where
 
-import qualified Language.PlutusCore       as PLC
-import           Language.PlutusCore.Quote
+import qualified Language.PlutusCore as PLC
+import Language.PlutusCore.Quote
 
-import           Data.Char
-import           Data.List
-import qualified Data.Text                 as T
+import Data.Char
+import Data.List
+import qualified Data.Text as T
 
 {- Note [PLC names]
 We convert names from other kinds of names quite frequently, but PLC admits a much

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Provenance.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Provenance.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE OverloadedStrings #-}
 -- | Module handling provenances of terms.
 module Language.PlutusIR.Compiler.Provenance where
 
-import           Language.PlutusIR
+import Language.PlutusIR
 
 import qualified Language.PlutusCore.Pretty as PLC
 
-import           Data.Text.Prettyprint.Doc  ((<+>), (<>))
-import qualified Data.Text.Prettyprint.Doc  as PP
+import Data.Text.Prettyprint.Doc ((<+>), (<>))
+import qualified Data.Text.Prettyprint.Doc as PP
 
 -- | Indicates where a value comes from.
 --

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Recursion.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Recursion.hs
@@ -1,20 +1,20 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | Functions for compiling PIR recursive let-bound functions into PLC.
 module Language.PlutusIR.Compiler.Recursion where
 
-import           Language.PlutusIR
-import           Language.PlutusIR.Compiler.Error
-import           Language.PlutusIR.Compiler.Provenance
-import           Language.PlutusIR.Compiler.Types
-import qualified Language.PlutusIR.MkPir                    as PIR
+import Language.PlutusIR
+import Language.PlutusIR.Compiler.Error
+import Language.PlutusIR.Compiler.Provenance
+import Language.PlutusIR.Compiler.Types
+import qualified Language.PlutusIR.MkPir as PIR
 
-import           Control.Monad
-import           Control.Monad.Error.Lens
+import Control.Monad
+import Control.Monad.Error.Lens
 
-import qualified Language.PlutusCore                        as PLC
-import           Language.PlutusCore.Quote
-import qualified Language.PlutusCore.StdLib.Data.Function   as Function
+import qualified Language.PlutusCore as PLC
+import Language.PlutusCore.Quote
+import qualified Language.PlutusCore.StdLib.Data.Function as Function
 import qualified Language.PlutusCore.StdLib.Meta.Data.Tuple as Tuple
 
 {- Note [Recursive lets]

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Language.PlutusIR.Compiler.Types where
 
-import qualified Language.PlutusIR                     as PIR
-import           Language.PlutusIR.Compiler.Error
-import           Language.PlutusIR.Compiler.Provenance
+import qualified Language.PlutusIR as PIR
+import Language.PlutusIR.Compiler.Error
+import Language.PlutusIR.Compiler.Provenance
 
-import           Control.Monad.Except
-import           Control.Monad.Reader
+import Control.Monad.Except
+import Control.Monad.Reader
 
-import           Control.Lens
+import Control.Lens
 
-import qualified Language.PlutusCore                   as PLC
-import qualified Language.PlutusCore.MkPlc             as PLC
-import           Language.PlutusCore.Quote
-import qualified Language.PlutusCore.StdLib.Type       as Types
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore.MkPlc as PLC
+import Language.PlutusCore.Quote
+import qualified Language.PlutusCore.StdLib.Type as Types
 
 newtype CompilationOpts = CompilationOpts {
     _coOptimize :: Bool

--- a/plutus-ir/src/Language/PlutusIR/Generators/AST.hs
+++ b/plutus-ir/src/Language/PlutusIR/Generators/AST.hs
@@ -13,15 +13,15 @@ module Language.PlutusIR.Generators.AST
     , genRecursivity
     ) where
 
-import           Language.PlutusIR
+import Language.PlutusIR
 
-import           Language.PlutusCore.Generators.AST as Export (AstGen, genBuiltin, genBuiltinName, genConstant, genKind,
-                                                               genVersion, runAstGen, simpleRecursive)
+import Language.PlutusCore.Generators.AST as Export
+    (AstGen, genBuiltin, genBuiltinName, genConstant, genKind, genVersion, runAstGen, simpleRecursive)
 import qualified Language.PlutusCore.Generators.AST as PLC
 
-import           Hedgehog                           hiding (Var)
-import qualified Hedgehog.Gen                       as Gen
-import qualified Hedgehog.Range                     as Range
+import Hedgehog hiding (Var)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
 genName :: PLC.AstGen (Name ())
 genName = Gen.filter (not . isPirKw . nameString) PLC.genName where

--- a/plutus-ir/src/Language/PlutusIR/MkPir.hs
+++ b/plutus-ir/src/Language/PlutusIR/MkPir.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -7,9 +7,9 @@ module Language.PlutusIR.MkPir ( module MkPlc
                                , mkLet
                                ) where
 
-import           Language.PlutusIR
+import Language.PlutusIR
 
-import           Language.PlutusCore.MkPlc as MkPlc
+import Language.PlutusCore.MkPlc as MkPlc
 
 -- | A datatype definition as a type variable.
 type DatatypeDef tyname name a = Def (TyVarDecl tyname a) (Datatype tyname name a)

--- a/plutus-ir/src/Language/PlutusIR/Optimizer/DeadCode.hs
+++ b/plutus-ir/src/Language/PlutusIR/Optimizer/DeadCode.hs
@@ -1,25 +1,25 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE LambdaCase #-}
 -- | Optimization passes for removing dead code, mainly dead let bindings.
 module Language.PlutusIR.Optimizer.DeadCode (removeDeadBindings) where
 
-import           Language.PlutusIR
+import Language.PlutusIR
 import qualified Language.PlutusIR.Analysis.Dependencies as Deps
-import           Language.PlutusIR.MkPir
-import           Language.PlutusIR.Transform.Rename      ()
+import Language.PlutusIR.MkPir
+import Language.PlutusIR.Transform.Rename ()
 
-import qualified Language.PlutusCore                     as PLC
-import qualified Language.PlutusCore.Name                as PLC
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore.Name as PLC
 
-import           Control.Lens
-import           Control.Monad
-import           Control.Monad.Reader
+import Control.Lens
+import Control.Monad
+import Control.Monad.Reader
 
-import           Data.Coerce
-import qualified Data.Set                                as Set
+import Data.Coerce
+import qualified Data.Set as Set
 
-import qualified Algebra.Graph                           as G
-import qualified Algebra.Graph.ToGraph                   as T
+import qualified Algebra.Graph as G
+import qualified Algebra.Graph.ToGraph as T
 
 -- | Remove all the dead let bindings in a term.
 removeDeadBindings

--- a/plutus-ir/src/Language/PlutusIR/Parser.hs
+++ b/plutus-ir/src/Language/PlutusIR/Parser.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE RankNTypes #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Language.PlutusIR.Parser
@@ -17,30 +17,30 @@ module Language.PlutusIR.Parser
     , SourcePos
     ) where
 
-import           Prelude                      hiding (fail)
+import Prelude hiding (fail)
 
-import           Control.Applicative          hiding (many, some)
-import           Control.Monad.State          hiding (fail)
+import Control.Applicative hiding (many, some)
+import Control.Monad.State hiding (fail)
 
-import qualified Language.PlutusCore          as PLC
+import qualified Language.PlutusCore as PLC
 import qualified Language.PlutusCore.Constant as PLC
-import           Language.PlutusIR            as PIR
-import qualified Language.PlutusIR.MkPir      as PIR
-import           PlutusPrelude                (prettyText)
-import           Text.Megaparsec              hiding (ParseError, State, parse)
-import qualified Text.Megaparsec              as Parsec
+import Language.PlutusIR as PIR
+import qualified Language.PlutusIR.MkPir as PIR
+import PlutusPrelude (prettyText)
+import Text.Megaparsec hiding (ParseError, State, parse)
+import qualified Text.Megaparsec as Parsec
 
-import           Data.ByteString.Internal     (c2w)
-import qualified Data.ByteString.Lazy         as BSL
-import           Data.Char
-import           Data.Foldable
-import qualified Data.Map                     as M
-import qualified Data.Text                    as T
-import           Data.Word
-import           GHC.Natural
+import Data.ByteString.Internal (c2w)
+import qualified Data.ByteString.Lazy as BSL
+import Data.Char
+import Data.Foldable
+import qualified Data.Map as M
+import qualified Data.Text as T
+import Data.Word
+import GHC.Natural
 
-import           Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer   as Lex
+import Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as Lex
 
 newtype ParserState = ParserState { identifiers :: M.Map T.Text PLC.Unique }
     deriving (Show)

--- a/plutus-ir/src/Language/PlutusIR/Transform/NonStrict.hs
+++ b/plutus-ir/src/Language/PlutusIR/Transform/NonStrict.hs
@@ -1,20 +1,20 @@
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | Compile non-strict bindings into strict bindings.
 module Language.PlutusIR.Transform.NonStrict (compileNonStrictBindings) where
 
-import           Language.PlutusIR
-import           Language.PlutusIR.Transform.Rename     ()
-import           Language.PlutusIR.Transform.Substitute
+import Language.PlutusIR
+import Language.PlutusIR.Transform.Rename ()
+import Language.PlutusIR.Transform.Substitute
 
-import           Language.PlutusCore.Quote
-import qualified Language.PlutusCore.StdLib.Data.Unit   as Unit
+import Language.PlutusCore.Quote
+import qualified Language.PlutusCore.StdLib.Data.Unit as Unit
 
-import           Control.Lens                           hiding (Strict)
-import           Control.Monad.State
+import Control.Lens hiding (Strict)
+import Control.Monad.State
 
-import qualified Data.Map                               as Map
+import qualified Data.Map as Map
 
 {- Note [Compiling non-strict bindings]
 Given `let x : ty = rhs in body`, we

--- a/plutus-ir/src/Language/PlutusIR/Transform/Rename.hs
+++ b/plutus-ir/src/Language/PlutusIR/Transform/Rename.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE LambdaCase #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- | Renaming of PIR terms. Import this module to bring the @PLC.Rename (Term tyname name ann)@
 -- instance in scope.
 module Language.PlutusIR.Transform.Rename () where
 
-import           Language.PlutusIR
+import Language.PlutusIR
 
-import qualified Language.PlutusCore                 as PLC
-import qualified Language.PlutusCore.Name            as PLC
-import qualified Language.PlutusCore.Rename          as PLC
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore.Name as PLC
+import qualified Language.PlutusCore.Rename as PLC
 import qualified Language.PlutusCore.Rename.Internal as PLC
 
-import           Control.Monad.Reader
-import           Control.Monad.Trans.Class           (lift)
-import           Control.Monad.Trans.Cont            (ContT (..))
+import Control.Monad.Reader
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Cont (ContT (..))
 
 {- Note [Renaming of mutually recursive bindings]
 The 'RenameM' monad is a newtype wrapper around @ReaderT renaming Quote@, so in order to bring

--- a/plutus-ir/src/Language/PlutusIR/Transform/Substitute.hs
+++ b/plutus-ir/src/Language/PlutusIR/Transform/Substitute.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ViewPatterns     #-}
+{-# LANGUAGE ViewPatterns #-}
 -- | Implements naive substitution functions for replacing type and term variables.
 module Language.PlutusIR.Transform.Substitute (
       substVar
@@ -11,11 +11,11 @@ module Language.PlutusIR.Transform.Substitute (
     , bindingSubstTyNames
     ) where
 
-import           Language.PlutusIR
+import Language.PlutusIR
 
-import           Language.PlutusCore.Subst (substTyVar, typeSubstTyNames)
+import Language.PlutusCore.Subst (substTyVar, typeSubstTyNames)
 
-import           Control.Lens
+import Control.Lens
 
 -- Needs to be different from the PLC version since we have different Terms
 -- | Replace a variable using the given function.

--- a/plutus-ir/src/Language/PlutusIR/Transform/ThunkRecursions.hs
+++ b/plutus-ir/src/Language/PlutusIR/Transform/ThunkRecursions.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE LambdaCase #-}
 -- | Implements a PIR-to-PIR transformation that makes all recursive term definitions
 -- compilable to PLC. See Note [Thunking recursions] for details.
 module Language.PlutusIR.Transform.ThunkRecursions (thunkRecursions) where
 
-import           PlutusPrelude
+import PlutusPrelude
 
-import           Language.PlutusIR
+import Language.PlutusIR
 
 {- Note [Thunking recursions]
 Our fixpoint combinators in Plutus Core know how to handle mutually recursive values

--- a/plutus-ir/src/Language/PlutusIR/Value.hs
+++ b/plutus-ir/src/Language/PlutusIR/Value.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 module Language.PlutusIR.Value (isTermValue) where
 
-import           Language.PlutusIR
+import Language.PlutusIR
 
 -- | Whether the given PIR term is (will compile to) a PLC term value. Very similar to
 -- the PLC definition.

--- a/plutus-ir/test/OptimizerSpec.hs
+++ b/plutus-ir/test/OptimizerSpec.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 module OptimizerSpec where
 
-import           Common
-import           TestLib
+import Common
+import TestLib
 
-import           Language.PlutusIR.Optimizer.DeadCode
-import           Language.PlutusIR.Parser
-import           Language.PlutusIR.Transform.Rename   ()
+import Language.PlutusIR.Optimizer.DeadCode
+import Language.PlutusIR.Parser
+import Language.PlutusIR.Transform.Rename ()
 
 optimizer :: TestNested
 optimizer = testNested "optimizer" [

--- a/plutus-ir/test/ParserSpec.hs
+++ b/plutus-ir/test/ParserSpec.hs
@@ -1,23 +1,23 @@
 {-# LANGUAGE FlexibleContexts #-}
 module ParserSpec (parsing) where
 
-import           PlutusPrelude
+import PlutusPrelude
 
-import           Common
+import Common
 
-import           Data.Char
-import qualified Data.Text                        as T
+import Data.Char
+import qualified Data.Text as T
 
-import           Language.PlutusIR
-import           Language.PlutusIR.Generators.AST
-import           Language.PlutusIR.Parser
+import Language.PlutusIR
+import Language.PlutusIR.Generators.AST
+import Language.PlutusIR.Parser
 
-import           Hedgehog                         hiding (Var)
-import qualified Hedgehog.Gen                     as Gen
-import qualified Hedgehog.Range                   as Range
+import Hedgehog hiding (Var)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
-import           Test.Tasty
-import           Test.Tasty.Hedgehog
+import Test.Tasty
+import Test.Tasty.Hedgehog
 
 newtype PrettyProg = PrettyProg { prog :: Program TyName Name SourcePos }
 instance Show PrettyProg where

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -1,37 +1,37 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Main (main) where
 
-import           Common
-import           PlcTestUtils
-import           PlutusPrelude              hiding (hoist)
-import           TestLib
+import Common
+import PlcTestUtils
+import PlutusPrelude hiding (hoist)
+import TestLib
 
-import           OptimizerSpec
-import           ParserSpec
-import           TransformSpec
+import OptimizerSpec
+import ParserSpec
+import TransformSpec
 
-import           Language.PlutusCore.Quote
+import Language.PlutusCore.Quote
 
-import           Language.PlutusIR
-import           Language.PlutusIR.Compiler
-import           Language.PlutusIR.Parser   hiding (Error)
+import Language.PlutusIR
+import Language.PlutusIR.Compiler
+import Language.PlutusIR.Parser hiding (Error)
 
-import qualified Language.PlutusCore        as PLC
+import qualified Language.PlutusCore as PLC
 
-import           Test.Tasty
+import Test.Tasty
 
-import           Codec.Serialise
-import           Control.Exception
-import           Control.Monad
-import           Control.Monad.Except
-import           Control.Monad.Morph
-import           Control.Monad.Reader
+import Codec.Serialise
+import Control.Exception
+import Control.Monad
+import Control.Monad.Except
+import Control.Monad.Morph
+import Control.Monad.Reader
 
-import           Data.Functor.Identity
-import           Text.Megaparsec.Pos
+import Data.Functor.Identity
+import Text.Megaparsec.Pos
 
 main :: IO ()
 main = defaultMain $ runTestNestedIn ["test"] tests

--- a/plutus-ir/test/TestLib.hs
+++ b/plutus-ir/test/TestLib.hs
@@ -1,27 +1,27 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 module TestLib where
 
-import           Common
-import           PlcTestUtils
-import           PlutusPrelude                hiding ((</>))
+import Common
+import PlcTestUtils
+import PlutusPrelude hiding ((</>))
 
-import           Control.Exception
-import           Control.Monad.Except
-import           Control.Monad.Reader         as Reader
+import Control.Exception
+import Control.Monad.Except
+import Control.Monad.Reader as Reader
 
 import qualified Language.PlutusCore.DeBruijn as PLC
-import           Language.PlutusCore.Pretty
-import           Language.PlutusCore.Quote
-import           Language.PlutusIR
-import           Language.PlutusIR.Parser     as Parser
+import Language.PlutusCore.Pretty
+import Language.PlutusCore.Quote
+import Language.PlutusIR
+import Language.PlutusIR.Parser as Parser
 
-import           System.FilePath              (joinPath, (</>))
+import System.FilePath (joinPath, (</>))
 
-import           Text.Megaparsec.Error        as Megaparsec
+import Text.Megaparsec.Error as Megaparsec
 
-import qualified Data.Text                    as T
-import qualified Data.Text.IO                 as T
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
 
 withGoldenFileM :: String -> (T.Text -> IO T.Text) -> TestNested
 withGoldenFileM name op = do

--- a/plutus-ir/test/TransformSpec.hs
+++ b/plutus-ir/test/TransformSpec.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 module TransformSpec where
 
-import           Common
-import           TestLib
+import Common
+import TestLib
 
-import           Language.PlutusCore.Quote
+import Language.PlutusCore.Quote
 
-import           Language.PlutusIR.Parser
-import qualified Language.PlutusIR.Transform.NonStrict       as NonStrict
+import Language.PlutusIR.Parser
+import qualified Language.PlutusIR.Transform.NonStrict as NonStrict
 import qualified Language.PlutusIR.Transform.ThunkRecursions as ThunkRec
 
 transform :: TestNested

--- a/plutus-playground-lib/src/Playground/API.hs
+++ b/plutus-playground-lib/src/Playground/API.hs
@@ -1,25 +1,25 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Playground.API where
 
-import           Control.Monad.Trans.Class    (lift)
-import           Control.Monad.Trans.State    (StateT, evalStateT, get, put)
-import           Data.Bifunctor               (second)
-import           Data.Maybe                   (fromMaybe)
-import           Data.Text                    (Text)
-import qualified Data.Text                    as Text
-import           Language.Haskell.Interpreter (CompilationError (CompilationError, RawError), InterpreterResult,
-                                               SourceCode, column, filename, row, text)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State (StateT, evalStateT, get, put)
+import Data.Bifunctor (second)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Language.Haskell.Interpreter
+    (CompilationError (CompilationError, RawError), InterpreterResult, SourceCode, column, filename, row, text)
 import qualified Language.Haskell.Interpreter as HI
-import           Playground.Types             (CompilationResult, Evaluation, EvaluationResult, PlaygroundError)
-import           Servant.API                  ((:<|>), (:>), Get, JSON, Post, ReqBody)
-import           Text.Read                    (readMaybe)
+import Playground.Types (CompilationResult, Evaluation, EvaluationResult, PlaygroundError)
+import Servant.API ((:<|>), (:>), Get, JSON, Post, ReqBody)
+import Text.Read (readMaybe)
 
 type API
      = "contract" :> ReqBody '[ JSON] SourceCode :> Post '[ JSON] (Either HI.InterpreterError (InterpreterResult CompilationResult))

--- a/plutus-playground-lib/src/Playground/Contract.hs
+++ b/plutus-playground-lib/src/Playground/Contract.hs
@@ -1,16 +1,16 @@
 -- | Re-export functions that are needed when creating a Contract for use in the playground
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE ExplicitNamespaces  #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE MonoLocalBinds      #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 {-# OPTIONS_GHC -fno-warn-missing-import-lists #-}
@@ -70,43 +70,65 @@ module Playground.Contract
     , Expression
     ) where
 
-import           Data.Aeson                                      (FromJSON, ToJSON)
-import qualified Data.Aeson                                      as JSON
-import           Data.ByteArray                                  (ByteArrayAccess)
-import qualified Data.ByteArray                                  as BA
-import           Data.ByteString.Lazy                            (ByteString)
-import qualified Data.ByteString.Lazy                            as BSL
-import qualified Data.ByteString.Lazy.Char8                      as LBC8
-import           Data.List.NonEmpty                              (NonEmpty ((:|)))
-import           Data.Text                                       (Text)
-import           GHC.Generics                                    (Generic)
-import           IOTS                                            (IotsType (iotsDefinition))
-import           Language.Plutus.Contract                        (type (.\/), AsContractError, BlockchainActions,
-                                                                  Contract, Endpoint, awaitSlot, inputs,
-                                                                  nextTransactionAt, utxoAt, validityRange,
-                                                                  watchAddressUntil, writeTx, writeTxSuccess)
-import           Language.Plutus.Contract.Effects.ExposeEndpoint (endpoint)
-import           Language.Plutus.Contract.Effects.OwnPubKey      (ownPubKey)
-import           Language.Plutus.Contract.Trace                  (TraceError (..), runTraceWithDistribution)
-import           Ledger.Interval                                 (always, interval)
-import           Ledger.Scripts                                  (ValidatorHash (ValidatorHash))
-import           Ledger.Tx                                       (Tx, TxOutRef (TxOutRef), txOutRefId)
-import           Ledger.Value                                    (TokenName (TokenName))
-import           Playground.Interpreter.Util
-import           Playground.Schema                               (endpointsToSchemas)
-import           Playground.TH                                   (ensureIotsDefinitions, ensureKnownCurrencies,
-                                                                  mkFunction, mkFunctions, mkIotsDefinitions,
-                                                                  mkKnownCurrencies, mkSchemaDefinitions,
-                                                                  mkSingleFunction)
-import           Playground.Types                                (Expression, FunctionSchema,
-                                                                  KnownCurrency (KnownCurrency),
-                                                                  PayToWalletParams (PayToWalletParams), adaCurrency,
-                                                                  payTo, value)
-import           Schema                                          (FormSchema, ToSchema)
-import           Wallet.API                                      (WalletAPI, payToPublicKey_)
-import           Wallet.Emulator                                 (addBlocksAndNotify, walletPubKey)
-import qualified Wallet.Emulator                                 as Emulator
-import           Wallet.Emulator.Types                           (MockWallet, Trace, Wallet (..))
+import Data.Aeson (FromJSON, ToJSON)
+import qualified Data.Aeson as JSON
+import Data.ByteArray (ByteArrayAccess)
+import qualified Data.ByteArray as BA
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Lazy.Char8 as LBC8
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import IOTS (IotsType (iotsDefinition))
+import Language.Plutus.Contract
+    ( type (.\/)
+    , AsContractError
+    , BlockchainActions
+    , Contract
+    , Endpoint
+    , awaitSlot
+    , inputs
+    , nextTransactionAt
+    , utxoAt
+    , validityRange
+    , watchAddressUntil
+    , writeTx
+    , writeTxSuccess
+    )
+import Language.Plutus.Contract.Effects.ExposeEndpoint (endpoint)
+import Language.Plutus.Contract.Effects.OwnPubKey (ownPubKey)
+import Language.Plutus.Contract.Trace (TraceError (..), runTraceWithDistribution)
+import Ledger.Interval (always, interval)
+import Ledger.Scripts (ValidatorHash (ValidatorHash))
+import Ledger.Tx (Tx, TxOutRef (TxOutRef), txOutRefId)
+import Ledger.Value (TokenName (TokenName))
+import Playground.Interpreter.Util
+import Playground.Schema (endpointsToSchemas)
+import Playground.TH
+    ( ensureIotsDefinitions
+    , ensureKnownCurrencies
+    , mkFunction
+    , mkFunctions
+    , mkIotsDefinitions
+    , mkKnownCurrencies
+    , mkSchemaDefinitions
+    , mkSingleFunction
+    )
+import Playground.Types
+    ( Expression
+    , FunctionSchema
+    , KnownCurrency (KnownCurrency)
+    , PayToWalletParams (PayToWalletParams)
+    , adaCurrency
+    , payTo
+    , value
+    )
+import Schema (FormSchema, ToSchema)
+import Wallet.API (WalletAPI, payToPublicKey_)
+import Wallet.Emulator (addBlocksAndNotify, walletPubKey)
+import qualified Wallet.Emulator as Emulator
+import Wallet.Emulator.Types (MockWallet, Trace, Wallet (..))
 
 payToWallet_ :: (Monad m, WalletAPI m) => PayToWalletParams -> m ()
 payToWallet_ PayToWalletParams {value, payTo} =

--- a/plutus-playground-lib/src/Playground/Schema.hs
+++ b/plutus-playground-lib/src/Playground/Schema.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE AllowAmbiguousTypes   #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
 
 {-| This module handles exposing a Contract API to the Plutus Playground frontend.
@@ -24,13 +24,13 @@ module Playground.Schema
     , EndpointToSchema
     ) where
 
-import           Data.Row                                        (Empty, KnownSymbol, Label (Label))
-import           Data.Row.Internal                               (LT ((:->)), Row (R))
-import qualified Data.Text                                       as Text
-import           Language.Plutus.Contract.Effects.ExposeEndpoint (ActiveEndpoints, EndpointValue)
-import           Language.Plutus.Contract.Schema                 ()
-import           Playground.Types                                (EndpointName (EndpointName), FunctionSchema (FunctionSchema, argumentSchema, functionName))
-import           Schema                                          (FormSchema, ToSchema, toSchema)
+import Data.Row (Empty, KnownSymbol, Label (Label))
+import Data.Row.Internal (LT ((:->)), Row (R))
+import qualified Data.Text as Text
+import Language.Plutus.Contract.Effects.ExposeEndpoint (ActiveEndpoints, EndpointValue)
+import Language.Plutus.Contract.Schema ()
+import Playground.Types (EndpointName (EndpointName), FunctionSchema (FunctionSchema, argumentSchema, functionName))
+import Schema (FormSchema, ToSchema, toSchema)
 
 class EndpointToSchema (s :: Row *) where
     endpointsToSchemas :: [FunctionSchema FormSchema]

--- a/plutus-playground-lib/src/Playground/TH.hs
+++ b/plutus-playground-lib/src/Playground/TH.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE DeriveAnyClass   #-}
-{-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE KindSignatures   #-}
-{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators    #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Playground.TH
     ( mkFunction
@@ -17,20 +17,42 @@ module Playground.TH
     , mkKnownCurrencies
     ) where
 
-import           Data.Row                 (type (.\\))
-import           Data.Text                (pack)
-import           IOTS                     (HList (HCons, HNil), Tagged (Tagged))
+import Data.Row (type (.\\))
+import Data.Text (pack)
+import IOTS (HList (HCons, HNil), Tagged (Tagged))
 import qualified IOTS
-import           Language.Haskell.TH      (Body (NormalB), Clause (Clause), Dec (FunD, SigD, TySynD, ValD),
-                                           Exp (ListE, LitE, VarE), ExpQ, Info (TyConI, VarI), Lit (StringL), Name,
-                                           Pat (VarP), Q, Type (AppT, ArrowT, ConT, ForallT, ListT, TupleT, VarT),
-                                           appTypeE, conE, conT, litT, lookupValueName, mkName, nameBase, normalB,
-                                           reify, sigD, strTyLit, valD, varE, varP)
-import           Language.Plutus.Contract (BlockchainActions)
-import           Playground.Schema        (endpointsToSchemas)
-import           Playground.Types         (EndpointName (EndpointName), FunctionSchema (FunctionSchema), adaCurrency)
-import           Schema                   (FormSchema, toSchema)
-import           Wallet.Emulator.Types    (MockWallet)
+import Language.Haskell.TH
+    ( Body (NormalB)
+    , Clause (Clause)
+    , Dec (FunD, SigD, TySynD, ValD)
+    , Exp (ListE, LitE, VarE)
+    , ExpQ
+    , Info (TyConI, VarI)
+    , Lit (StringL)
+    , Name
+    , Pat (VarP)
+    , Q
+    , Type (AppT, ArrowT, ConT, ForallT, ListT, TupleT, VarT)
+    , appTypeE
+    , conE
+    , conT
+    , litT
+    , lookupValueName
+    , mkName
+    , nameBase
+    , normalB
+    , reify
+    , sigD
+    , strTyLit
+    , valD
+    , varE
+    , varP
+    )
+import Language.Plutus.Contract (BlockchainActions)
+import Playground.Schema (endpointsToSchemas)
+import Playground.Types (EndpointName (EndpointName), FunctionSchema (FunctionSchema), adaCurrency)
+import Schema (FormSchema, toSchema)
+import Wallet.Emulator.Types (MockWallet)
 
 mkFunctions :: [Name] -> Q [Dec]
 mkFunctions names = do

--- a/plutus-playground-lib/test/Playground/APISpec.hs
+++ b/plutus-playground-lib/test/Playground/APISpec.hs
@@ -4,12 +4,11 @@ module Playground.APISpec
     ( spec
     ) where
 
-import           Data.Aeson                   (encode, object, toJSON)
-import           Language.Haskell.Interpreter (CompilationError (CompilationError, RawError), column, filename, row,
-                                               text)
-import           Playground.API               (parseErrorText)
-import           Playground.Types             (adaCurrency)
-import           Test.Hspec                   (Spec, describe, it, shouldBe)
+import Data.Aeson (encode, object, toJSON)
+import Language.Haskell.Interpreter (CompilationError (CompilationError, RawError), column, filename, row, text)
+import Playground.API (parseErrorText)
+import Playground.Types (adaCurrency)
+import Test.Hspec (Spec, describe, it, shouldBe)
 
 spec :: Spec
 spec = do

--- a/plutus-playground-lib/test/Playground/THSpec.hs
+++ b/plutus-playground-lib/test/Playground/THSpec.hs
@@ -1,20 +1,20 @@
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Playground.THSpec where
 
-import           Data.Text        (Text)
-import           Ledger.Value     (Value)
-import           Playground.TH    (mkFunctions, mkSingleFunction)
-import           Playground.Types (EndpointName (EndpointName), FunctionSchema (FunctionSchema))
-import           Schema           (FormSchema (FormSchemaArray, FormSchemaInt, FormSchemaString, FormSchemaTuple, FormSchemaValue))
-import           Test.Hspec       (Spec, describe, it, shouldBe)
-import           Wallet           (MonadWallet)
+import Data.Text (Text)
+import Ledger.Value (Value)
+import Playground.TH (mkFunctions, mkSingleFunction)
+import Playground.Types (EndpointName (EndpointName), FunctionSchema (FunctionSchema))
+import Schema (FormSchema (FormSchemaArray, FormSchemaInt, FormSchemaString, FormSchemaTuple, FormSchemaValue))
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Wallet (MonadWallet)
 
 -- f1..fn are functions that we should be able to generate schemas
 -- for, using `mkFunction`. The schemas will be called f1Schema etc.

--- a/plutus-playground-server/app/Main.hs
+++ b/plutus-playground-server/app/Main.hs
@@ -1,23 +1,46 @@
-{-# LANGUAGE ApplicativeDo       #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Main
     ( main
     ) where
 
-import           Control.Monad.IO.Class   (MonadIO, liftIO)
-import           Control.Monad.Logger     (MonadLogger, logInfoN, runStderrLoggingT)
-import           Data.Monoid              ((<>))
-import qualified Data.Text                as Text
-import           Data.Yaml                (decodeFileThrow)
-import           Git                      (gitRev)
-import           Network.Wai.Handler.Warp (HostPreference, defaultSettings, setHost, setPort)
-import           Options.Applicative      (CommandFields, Mod, Parser, argument, auto, command, customExecParser,
-                                           disambiguate, fullDesc, help, helper, idm, info, infoOption, long, metavar,
-                                           option, prefs, short, showDefault, showHelpOnEmpty, str, strOption,
-                                           subparser, value)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Logger (MonadLogger, logInfoN, runStderrLoggingT)
+import Data.Monoid ((<>))
+import qualified Data.Text as Text
+import Data.Yaml (decodeFileThrow)
+import Git (gitRev)
+import Network.Wai.Handler.Warp (HostPreference, defaultSettings, setHost, setPort)
+import Options.Applicative
+    ( CommandFields
+    , Mod
+    , Parser
+    , argument
+    , auto
+    , command
+    , customExecParser
+    , disambiguate
+    , fullDesc
+    , help
+    , helper
+    , idm
+    , info
+    , infoOption
+    , long
+    , metavar
+    , option
+    , prefs
+    , short
+    , showDefault
+    , showHelpOnEmpty
+    , str
+    , strOption
+    , subparser
+    , value
+    )
 import qualified PSGenerator
 import qualified Webserver
 

--- a/plutus-playground-server/app/Types.hs
+++ b/plutus-playground-server/app/Types.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Types
   ( Config(..)
   ) where
 
 import qualified Auth
-import           Data.Aeson (FromJSON, parseJSON, withObject, (.:))
+import Data.Aeson (FromJSON, parseJSON, withObject, (.:))
 
 newtype Config = Config
   { _authConfig :: Auth.Config

--- a/plutus-playground-server/app/Webserver.hs
+++ b/plutus-playground-server/app/Webserver.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC   -Wno-orphans #-}
 
 module Webserver
@@ -15,33 +15,43 @@ module Webserver
     ) where
 
 import qualified Auth
-import           Control.Concurrent                             (forkIO)
-import           Control.Monad                                  (void)
-import           Control.Monad.Except                           (ExceptT)
-import           Control.Monad.IO.Class                         (MonadIO, liftIO)
-import           Control.Monad.Logger                           (LoggingT, MonadLogger, logInfoN, runStderrLoggingT)
-import           Control.Monad.Reader                           (ReaderT, runReaderT)
-import           Data.Default.Class                             (def)
-import           Data.Proxy                                     (Proxy (Proxy))
-import           Data.Text                                      (Text)
-import           Git                                            (gitRev)
-import           Network.HTTP.Types                             (Method)
-import           Network.Wai                                    (Application)
-import           Network.Wai.Handler.Warp                       (Settings, runSettings)
-import           Network.Wai.Middleware.Cors                    (cors, corsRequestHeaders, simpleCorsResourcePolicy)
-import           Network.Wai.Middleware.Gzip                    (gzip)
-import           Network.Wai.Middleware.RequestLogger           (logStdout)
-import qualified Playground.API                                 as PA
-import qualified Playground.Server                              as PS
-import           Servant                                        ((:<|>) ((:<|>)), (:>), Get, Handler (Handler), JSON,
-                                                                 PlainText, Raw, ServantErr, hoistServer, serve,
-                                                                 serveDirectoryFileServer)
-import           Servant.Foreign                                (GenerateList, NoContent, Req, generateList)
-import           Servant.Prometheus                             (monitorEndpoints)
-import           Servant.Server                                 (Server)
-import           System.Metrics.Prometheus.Concurrent.RegistryT (runRegistryT)
-import           System.Metrics.Prometheus.Http.Scrape          (serveHttpTextMetricsT)
-import           Types                                          (Config (Config, _authConfig))
+import Control.Concurrent (forkIO)
+import Control.Monad (void)
+import Control.Monad.Except (ExceptT)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Logger (LoggingT, MonadLogger, logInfoN, runStderrLoggingT)
+import Control.Monad.Reader (ReaderT, runReaderT)
+import Data.Default.Class (def)
+import Data.Proxy (Proxy (Proxy))
+import Data.Text (Text)
+import Git (gitRev)
+import Network.HTTP.Types (Method)
+import Network.Wai (Application)
+import Network.Wai.Handler.Warp (Settings, runSettings)
+import Network.Wai.Middleware.Cors (cors, corsRequestHeaders, simpleCorsResourcePolicy)
+import Network.Wai.Middleware.Gzip (gzip)
+import Network.Wai.Middleware.RequestLogger (logStdout)
+import qualified Playground.API as PA
+import qualified Playground.Server as PS
+import Servant
+    ( (:<|>) ((:<|>))
+    , (:>)
+    , Get
+    , Handler (Handler)
+    , JSON
+    , PlainText
+    , Raw
+    , ServantErr
+    , hoistServer
+    , serve
+    , serveDirectoryFileServer
+    )
+import Servant.Foreign (GenerateList, NoContent, Req, generateList)
+import Servant.Prometheus (monitorEndpoints)
+import Servant.Server (Server)
+import System.Metrics.Prometheus.Concurrent.RegistryT (runRegistryT)
+import System.Metrics.Prometheus.Http.Scrape (serveHttpTextMetricsT)
+import Types (Config (Config, _authConfig))
 
 instance GenerateList NoContent (Method -> Req NoContent) where
     generateList _ = []

--- a/plutus-playground-server/src/Playground/Interpreter.hs
+++ b/plutus-playground-server/src/Playground/Interpreter.hs
@@ -1,39 +1,47 @@
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Playground.Interpreter where
 
-import           Control.Exception            (IOException, try)
-import           Control.Monad.Catch          (MonadMask)
-import           Control.Monad.Error.Class    (MonadError, liftEither, throwError)
-import           Control.Monad.Except.Extras  (mapError)
-import           Control.Monad.IO.Class       (MonadIO, liftIO)
-import qualified Control.Newtype.Generics     as Newtype
-import qualified Data.Aeson                   as JSON
-import           Data.Bifunctor               (first)
-import qualified Data.ByteString.Char8        as BS8
-import qualified Data.ByteString.Lazy.Char8   as BSL
-import           Data.Text                    (Text)
-import qualified Data.Text                    as Text
-import qualified Data.Text.IO                 as Text
-import           Data.Time.Units              (TimeUnit)
-import           Language.Haskell.Interpreter (CompilationError (CompilationError, RawError),
-                                               InterpreterError (CompilationErrors),
-                                               InterpreterResult (InterpreterResult), SourceCode (SourceCode),
-                                               Warning (Warning), avoidUnsafe, runghc)
-import           Language.Haskell.TH          (Ppr, Q, pprint, runQ)
-import           Language.Haskell.TH.Syntax   (liftString)
-import           Playground.Types             (CompilationResult (CompilationResult),
-                                               Evaluation (program, sourceCode, wallets), EvaluationResult,
-                                               PlaygroundError (InterpreterError, JsonDecodingError, OtherError, decodingError, expected, input))
-import           System.FilePath              ((</>))
-import           System.IO                    (Handle, IOMode (ReadWriteMode), hFlush)
-import           System.IO.Extras             (withFile)
-import           System.IO.Temp               (withSystemTempDirectory)
-import qualified Text.Regex                   as Regex
+import Control.Exception (IOException, try)
+import Control.Monad.Catch (MonadMask)
+import Control.Monad.Error.Class (MonadError, liftEither, throwError)
+import Control.Monad.Except.Extras (mapError)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import qualified Control.Newtype.Generics as Newtype
+import qualified Data.Aeson as JSON
+import Data.Bifunctor (first)
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import Data.Time.Units (TimeUnit)
+import Language.Haskell.Interpreter
+    ( CompilationError (CompilationError, RawError)
+    , InterpreterError (CompilationErrors)
+    , InterpreterResult (InterpreterResult)
+    , SourceCode (SourceCode)
+    , Warning (Warning)
+    , avoidUnsafe
+    , runghc
+    )
+import Language.Haskell.TH (Ppr, Q, pprint, runQ)
+import Language.Haskell.TH.Syntax (liftString)
+import Playground.Types
+    ( CompilationResult (CompilationResult)
+    , Evaluation (program, sourceCode, wallets)
+    , EvaluationResult
+    , PlaygroundError (InterpreterError, JsonDecodingError, OtherError, decodingError, expected, input)
+    )
+import System.FilePath ((</>))
+import System.IO (Handle, IOMode (ReadWriteMode), hFlush)
+import System.IO.Extras (withFile)
+import System.IO.Temp (withSystemTempDirectory)
+import qualified Text.Regex as Regex
 
 replaceModuleName :: Text -> Text
 replaceModuleName script =

--- a/plutus-playground-server/src/Playground/Server.hs
+++ b/plutus-playground-server/src/Playground/Server.hs
@@ -1,31 +1,30 @@
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Playground.Server
     ( mkHandlers
     , doAnnotateBlockchain
     ) where
 
-import           Control.Monad.Except         (runExceptT, throwError)
-import           Control.Monad.IO.Class       (liftIO)
-import           Control.Monad.Logger         (MonadLogger, logInfoN)
-import qualified Data.ByteString.Lazy.Char8   as BSL
-import           Data.Time.Units              (Microsecond, fromMicroseconds)
-import           Language.Haskell.Interpreter (InterpreterError (CompilationErrors), InterpreterResult,
-                                               SourceCode (SourceCode))
+import Control.Monad.Except (runExceptT, throwError)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Logger (MonadLogger, logInfoN)
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.Time.Units (Microsecond, fromMicroseconds)
+import Language.Haskell.Interpreter (InterpreterError (CompilationErrors), InterpreterResult, SourceCode (SourceCode))
 import qualified Language.Haskell.Interpreter as Interpreter
-import           Playground.API               (API)
-import qualified Playground.Interpreter       as PI
-import           Playground.Types             (CompilationResult, Evaluation, EvaluationResult, PlaygroundError)
-import           Playground.Usecases          (vesting)
-import           Servant                      (err400, errBody)
-import           Servant.API                  ((:<|>) ((:<|>)))
-import           Servant.Server               (Handler, Server)
-import           Wallet.Rollup                (doAnnotateBlockchain)
+import Playground.API (API)
+import qualified Playground.Interpreter as PI
+import Playground.Types (CompilationResult, Evaluation, EvaluationResult, PlaygroundError)
+import Playground.Usecases (vesting)
+import Servant (err400, errBody)
+import Servant.API ((:<|>) ((:<|>)))
+import Servant.Server (Handler, Server)
+import Wallet.Rollup (doAnnotateBlockchain)
 
 acceptSourceCode ::
        SourceCode

--- a/plutus-playground-server/src/Playground/Usecases.hs
+++ b/plutus-playground-server/src/Playground/Usecases.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Playground.Usecases where
 
-import           Data.FileEmbed     (embedFile, makeRelativeToProject)
-import qualified Data.Text          as T
+import Data.FileEmbed (embedFile, makeRelativeToProject)
+import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
 marker :: T.Text

--- a/plutus-playground-server/test/GistSpec.hs
+++ b/plutus-playground-server/test/GistSpec.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module GistSpec
     ( tests
     ) where
 
-import           Data.Aeson                     (eitherDecode)
-import qualified Data.ByteString.Lazy           as LBS
-import           Data.Text                      ()
-import           Gist                           (Gist)
-import           Paths_plutus_playground_server (getDataFileName)
-import           Test.Tasty                     (TestTree, testGroup)
-import           Test.Tasty.HUnit               (assertEqual, testCase)
+import Data.Aeson (eitherDecode)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text ()
+import Gist (Gist)
+import Paths_plutus_playground_server (getDataFileName)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
 
 tests :: TestTree
 tests = testGroup "Schema" [gistJsonHandlingTests]

--- a/plutus-playground-server/test/Playground/InterpreterSpec.hs
+++ b/plutus-playground-server/test/Playground/InterpreterSpec.hs
@@ -1,26 +1,29 @@
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Playground.InterpreterSpec
     ( tests
     ) where
 
-import           Control.Monad.Except         (runExceptT)
-import qualified Data.Aeson                   as JSON
-import qualified Data.Aeson.Text              as JSON
-import           Data.Text                    (Text)
-import qualified Data.Text                    as Text
-import qualified Data.Text.Lazy               as TL
-import           Language.Haskell.Interpreter (SourceCode (SourceCode))
-import qualified Ledger.Ada                   as Ada
-import           Playground.Interpreter       (mkExpr, mkRunScript)
-import           Playground.Types             (Evaluation (Evaluation, program, sourceCode, wallets),
-                                               Expression (AddBlocks), PlaygroundError,
-                                               SimulatorWallet (SimulatorWallet))
-import           Test.Tasty                   (TestTree, testGroup)
-import           Test.Tasty.HUnit             (assertEqual, testCase)
-import           Wallet.Emulator.Types        (Wallet (Wallet))
+import Control.Monad.Except (runExceptT)
+import qualified Data.Aeson as JSON
+import qualified Data.Aeson.Text as JSON
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as TL
+import Language.Haskell.Interpreter (SourceCode (SourceCode))
+import qualified Ledger.Ada as Ada
+import Playground.Interpreter (mkExpr, mkRunScript)
+import Playground.Types
+    ( Evaluation (Evaluation, program, sourceCode, wallets)
+    , Expression (AddBlocks)
+    , PlaygroundError
+    , SimulatorWallet (SimulatorWallet)
+    )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+import Wallet.Emulator.Types (Wallet (Wallet))
 
 tests :: TestTree
 tests = testGroup "Playground.Interpreter" [mkRunScriptTest]

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -1,43 +1,54 @@
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Playground.UsecasesSpec
     ( tests
     ) where
 
-import           Control.Monad                (unless)
-import           Control.Monad.Except         (runExceptT)
-import qualified Data.Aeson                   as JSON
-import qualified Data.Aeson.Text              as JSON
-import           Data.Foldable                (traverse_)
-import           Data.List.NonEmpty           (NonEmpty ((:|)))
-import           Data.Text                    (Text)
-import qualified Data.Text                    as Text
-import qualified Data.Text.IO                 as Text
-import qualified Data.Text.Lazy               as TL
-import           Data.Time.Units              (Microsecond, fromMicroseconds)
-import           Language.Haskell.Interpreter (InterpreterError, InterpreterResult (InterpreterResult, result),
-                                               SourceCode (SourceCode))
-import qualified Ledger.Ada                   as Ada
-import           Ledger.Scripts               (ValidatorHash (ValidatorHash))
-import           Ledger.Value                 (TokenName (TokenName), Value)
-import qualified Playground.Interpreter       as PI
-import           Playground.Types             (CompilationResult (CompilationResult), EndpointName (EndpointName),
-                                               Evaluation (Evaluation, program, sourceCode, wallets),
-                                               EvaluationResult (EvaluationResult, emulatorLog, fundsDistribution, resultBlockchain, walletKeys),
-                                               Expression (AddBlocks, CallEndpoint), FunctionSchema (FunctionSchema),
-                                               KnownCurrency (KnownCurrency),
-                                               PayToWalletParams (PayToWalletParams, payTo, value), PlaygroundError,
-                                               SimulatorWallet (SimulatorWallet), adaCurrency, argumentSchema,
-                                               arguments, endpointName, functionName, simulatorWalletBalance,
-                                               simulatorWalletWallet, wallet)
-import           Playground.Usecases          (crowdfunding, errorHandling, game, vesting)
-import           Schema                       (FormSchema (FormSchemaInt, FormSchemaObject, FormSchemaUnit, FormSchemaValue))
-import           Test.Tasty                   (TestTree, testGroup)
-import           Test.Tasty.HUnit             (Assertion, assertEqual, assertFailure, testCase)
-import           Wallet.Emulator.Types        (Wallet (Wallet), walletPubKey)
-import           Wallet.Rollup.Render         (showBlockchain)
+import Control.Monad (unless)
+import Control.Monad.Except (runExceptT)
+import qualified Data.Aeson as JSON
+import qualified Data.Aeson.Text as JSON
+import Data.Foldable (traverse_)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import qualified Data.Text.Lazy as TL
+import Data.Time.Units (Microsecond, fromMicroseconds)
+import Language.Haskell.Interpreter
+    (InterpreterError, InterpreterResult (InterpreterResult, result), SourceCode (SourceCode))
+import qualified Ledger.Ada as Ada
+import Ledger.Scripts (ValidatorHash (ValidatorHash))
+import Ledger.Value (TokenName (TokenName), Value)
+import qualified Playground.Interpreter as PI
+import Playground.Types
+    ( CompilationResult (CompilationResult)
+    , EndpointName (EndpointName)
+    , Evaluation (Evaluation, program, sourceCode, wallets)
+    , EvaluationResult (EvaluationResult, emulatorLog, fundsDistribution, resultBlockchain, walletKeys)
+    , Expression (AddBlocks, CallEndpoint)
+    , FunctionSchema (FunctionSchema)
+    , KnownCurrency (KnownCurrency)
+    , PayToWalletParams (PayToWalletParams, payTo, value)
+    , PlaygroundError
+    , SimulatorWallet (SimulatorWallet)
+    , adaCurrency
+    , argumentSchema
+    , arguments
+    , endpointName
+    , functionName
+    , simulatorWalletBalance
+    , simulatorWalletWallet
+    , wallet
+    )
+import Playground.Usecases (crowdfunding, errorHandling, game, vesting)
+import Schema (FormSchema (FormSchemaInt, FormSchemaObject, FormSchemaUnit, FormSchemaValue))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertEqual, assertFailure, testCase)
+import Wallet.Emulator.Types (Wallet (Wallet), walletPubKey)
+import Wallet.Rollup.Render (showBlockchain)
 
 tests :: TestTree
 tests =

--- a/plutus-playground-server/test/Spec.hs
+++ b/plutus-playground-server/test/Spec.hs
@@ -5,7 +5,7 @@ module Main
 import qualified GistSpec
 import qualified Playground.InterpreterSpec
 import qualified Playground.UsecasesSpec
-import           Test.Tasty                 (defaultMain, testGroup)
+import Test.Tasty (defaultMain, testGroup)
 
 main :: IO ()
 main =

--- a/plutus-playground-server/usecases/ErrorHandling.hs
+++ b/plutus-playground-server/usecases/ErrorHandling.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE MonoLocalBinds    #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 
 module ErrorHandling where
 
@@ -16,16 +16,25 @@ module ErrorHandling where
 -- then use 'MyError' in our contracts with the combinators from
 -- 'Control.Monad.Error.Lens'. The unit tests in 'Spec.ErrorHandling' show how
 -- to write tests for error conditions.
-import           Control.Lens             (makeClassyPrisms)
-import           Control.Monad            (void)
-import           Control.Monad.Error.Lens (catching, throwing, throwing_)
-import           Data.Text                (Text)
+import Control.Lens (makeClassyPrisms)
+import Control.Monad (void)
+import Control.Monad.Error.Lens (catching, throwing, throwing_)
+import Data.Text (Text)
 
-import           Control.Applicative      ((<|>))
-import           Language.Plutus.Contract (type (.\/), AsContractError (_ContractError), BlockchainActions, Contract,
-                                           ContractError, Endpoint, HasWriteTx, endpoint, writeTxSuccess)
-import           Playground.Contract
-import           Prelude                  (Show, mempty, pure, ($), (>>))
+import Control.Applicative ((<|>))
+import Language.Plutus.Contract
+    ( type (.\/)
+    , AsContractError (_ContractError)
+    , BlockchainActions
+    , Contract
+    , ContractError
+    , Endpoint
+    , HasWriteTx
+    , endpoint
+    , writeTxSuccess
+    )
+import Playground.Contract
+import Prelude (Show, mempty, pure, ($), (>>))
 
 type Schema =
     BlockchainActions

--- a/plutus-tutorial/doctest/Main.hs
+++ b/plutus-tutorial/doctest/Main.hs
@@ -1,8 +1,8 @@
 module Main where
 
-import           Tutorial.PlutusTx         ()
-import           Tutorial.ValidatorScripts ()
-import           Tutorial.WalletAPI        ()
+import Tutorial.PlutusTx ()
+import Tutorial.ValidatorScripts ()
+import Tutorial.WalletAPI ()
 
 main :: IO ()
 main = pure ()

--- a/plutus-tx/compiler/Language/PlutusTx/Builtins.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Builtins.hs
@@ -43,13 +43,13 @@ module Language.PlutusTx.Builtins (
                                 ) where
 
 import qualified Crypto
-import           Data.ByteString.Lazy      as BSL
+import Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Hash as Hash
-import           Data.Maybe                (fromMaybe)
-import           Prelude                   hiding (String, error)
+import Data.Maybe (fromMaybe)
+import Prelude hiding (String, error)
 
-import           Language.PlutusTx.Data
-import           Language.PlutusTx.Utils   (mustBeReplaced)
+import Language.PlutusTx.Data
+import Language.PlutusTx.Utils (mustBeReplaced)
 
 {- Note [Builtin name definitions]
 The builtins here have definitions so they can be used in off-chain code too.

--- a/plutus-tx/compiler/Language/PlutusTx/Code.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Code.hs
@@ -1,22 +1,22 @@
-{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE ViewPatterns       #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
 module Language.PlutusTx.Code where
 
-import qualified Language.PlutusTx.Lift.Class     as Lift
-import           Language.PlutusTx.Lift.Instances ()
+import qualified Language.PlutusTx.Lift.Class as Lift
+import Language.PlutusTx.Lift.Instances ()
 
-import qualified Language.PlutusIR                as PIR
-import qualified Language.PlutusIR.MkPir          as PIR
+import qualified Language.PlutusIR as PIR
+import qualified Language.PlutusIR.MkPir as PIR
 
-import qualified Language.PlutusCore              as PLC
+import qualified Language.PlutusCore as PLC
 
-import           Codec.Serialise                  (DeserialiseFailure, deserialiseOrFail)
-import           Control.Exception
+import Codec.Serialise (DeserialiseFailure, deserialiseOrFail)
+import Control.Exception
 
-import qualified Data.ByteString                  as BS
-import qualified Data.ByteString.Lazy             as BSL
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
 
 -- NOTE: any changes to this type must be paralleled by changes
 -- in the plugin code that generates values of this type. That is

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Binders.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Binders.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 -- | Convenient functions for compiling binders.
 module Language.PlutusTx.Compiler.Binders where
 
-import           Language.PlutusTx.Compiler.Names
-import           Language.PlutusTx.Compiler.Types
-import           Language.PlutusTx.Compiler.ValueRestriction
-import           Language.PlutusTx.PIRTypes
+import Language.PlutusTx.Compiler.Names
+import Language.PlutusTx.Compiler.Types
+import Language.PlutusTx.Compiler.ValueRestriction
+import Language.PlutusTx.PIRTypes
 
-import qualified GhcPlugins                                  as GHC
+import qualified GhcPlugins as GHC
 
-import qualified Language.PlutusIR                           as PIR
+import qualified Language.PlutusIR as PIR
 
-import           Control.Monad.Reader
+import Control.Monad.Reader
 
-import           Data.Traversable
+import Data.Traversable
 
 -- Binder helpers
 

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Builtins.hs
@@ -1,11 +1,10 @@
-{-# LANGUAGE ConstraintKinds   #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Functions for compiling Plutus Core builtins.
 module Language.PlutusTx.Compiler.Builtins (
@@ -17,40 +16,40 @@ module Language.PlutusTx.Compiler.Builtins (
     , errorTy
     , errorFunc) where
 
-import qualified Language.PlutusTx.Builtins                  as Builtins
-import           Language.PlutusTx.Compiler.Error
+import qualified Language.PlutusTx.Builtins as Builtins
+import Language.PlutusTx.Compiler.Error
 import {-# SOURCE #-} Language.PlutusTx.Compiler.Expr
-import           Language.PlutusTx.Compiler.Names
+import Language.PlutusTx.Compiler.Names
 import {-# SOURCE #-} Language.PlutusTx.Compiler.Type
-import           Language.PlutusTx.Compiler.Types
-import           Language.PlutusTx.Compiler.Utils
-import           Language.PlutusTx.Compiler.ValueRestriction
-import           Language.PlutusTx.PIRTypes
-import           Language.PlutusTx.Utils
+import Language.PlutusTx.Compiler.Types
+import Language.PlutusTx.Compiler.Utils
+import Language.PlutusTx.Compiler.ValueRestriction
+import Language.PlutusTx.PIRTypes
+import Language.PlutusTx.Utils
 
-import qualified Language.PlutusIR                           as PIR
-import qualified Language.PlutusIR.Compiler.Definitions      as PIR
-import           Language.PlutusIR.Compiler.Names
-import qualified Language.PlutusIR.MkPir                     as PIR
+import qualified Language.PlutusIR as PIR
+import qualified Language.PlutusIR.Compiler.Definitions as PIR
+import Language.PlutusIR.Compiler.Names
+import qualified Language.PlutusIR.MkPir as PIR
 
-import qualified Language.PlutusCore                         as PLC
-import qualified Language.PlutusCore.Constant                as PLC
-import qualified Language.PlutusCore.Constant.Dynamic        as PLC
-import           Language.PlutusCore.Quote
-import qualified Language.PlutusCore.StdLib.Data.Bool        as Bool
-import qualified Language.PlutusCore.StdLib.Data.Unit        as Unit
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore.Constant as PLC
+import qualified Language.PlutusCore.Constant.Dynamic as PLC
+import Language.PlutusCore.Quote
+import qualified Language.PlutusCore.StdLib.Data.Bool as Bool
+import qualified Language.PlutusCore.StdLib.Data.Unit as Unit
 
-import qualified GhcPlugins                                  as GHC
+import qualified GhcPlugins as GHC
 
-import qualified Language.Haskell.TH.Syntax                  as TH
+import qualified Language.Haskell.TH.Syntax as TH
 
-import           Control.Monad
-import           Control.Monad.Reader
+import Control.Monad
+import Control.Monad.Reader
 
-import qualified Data.ByteString.Lazy                        as BSL
-import qualified Data.Map                                    as Map
-import           Data.Proxy
-import qualified Data.Set                                    as Set
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Map as Map
+import Data.Proxy
+import qualified Data.Set as Set
 
 {- Note [Mapping builtins]
 We want the user to be able to call the Plutus builtins as normal Haskell functions.

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Error.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE LambdaCase             #-}
-{-# LANGUAGE OverloadedStrings      #-}
-{-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Language.PlutusTx.Compiler.Error (
     CompileError
     , Error (..)
@@ -13,19 +13,19 @@ module Language.PlutusTx.Compiler.Error (
     , throwPlain
     , pruneContext) where
 
-import qualified Language.PlutusIR.Compiler        as PIR
+import qualified Language.PlutusIR.Compiler as PIR
 
-import qualified Language.PlutusCore               as PLC
+import qualified Language.PlutusCore as PLC
 import qualified Language.PlutusCore.Check.Uniques as PLC
-import qualified Language.PlutusCore.Check.Value   as PLC
-import qualified Language.PlutusCore.Pretty        as PLC
+import qualified Language.PlutusCore.Check.Value as PLC
+import qualified Language.PlutusCore.Pretty as PLC
 
-import           Control.Lens
-import           Control.Monad.Except
+import Control.Lens
+import Control.Monad.Except
 
-import qualified Data.Text                         as T
-import qualified Data.Text.Prettyprint.Doc         as PP
-import           Data.Typeable
+import qualified Data.Text as T
+import qualified Data.Text.Prettyprint.Doc as PP
+import Data.Typeable
 
 -- | An error with some (nested) context. The integer argument to 'WithContextC' represents
 -- the priority of the context when displaying it. Lower numbers are more prioritised.

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Expr.hs
@@ -1,48 +1,48 @@
-{-# LANGUAGE ConstraintKinds   #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Functions for compiling GHC Core expressions into Plutus Core terms.
 module Language.PlutusTx.Compiler.Expr (compileExpr, compileExprWithDefs, compileDataConRef) where
 
-import           PlutusPrelude                          (bsToStr)
+import PlutusPrelude (bsToStr)
 
-import           Language.PlutusTx.Compiler.Binders
-import           Language.PlutusTx.Compiler.Builtins
-import           Language.PlutusTx.Compiler.Error
-import           Language.PlutusTx.Compiler.Laziness
-import           Language.PlutusTx.Compiler.Names
-import           Language.PlutusTx.Compiler.Primitives
-import           Language.PlutusTx.Compiler.Type
-import           Language.PlutusTx.Compiler.Types
-import           Language.PlutusTx.Compiler.Utils
-import           Language.PlutusTx.PIRTypes
+import Language.PlutusTx.Compiler.Binders
+import Language.PlutusTx.Compiler.Builtins
+import Language.PlutusTx.Compiler.Error
+import Language.PlutusTx.Compiler.Laziness
+import Language.PlutusTx.Compiler.Names
+import Language.PlutusTx.Compiler.Primitives
+import Language.PlutusTx.Compiler.Type
+import Language.PlutusTx.Compiler.Types
+import Language.PlutusTx.Compiler.Utils
+import Language.PlutusTx.PIRTypes
 
-import qualified Class                                  as GHC
-import qualified FV                                     as GHC
-import qualified GhcPlugins                             as GHC
-import qualified MkId                                   as GHC
-import qualified PrelNames                              as GHC
+import qualified Class as GHC
+import qualified FV as GHC
+import qualified GhcPlugins as GHC
+import qualified MkId as GHC
+import qualified PrelNames as GHC
 
-import qualified Language.PlutusIR                      as PIR
+import qualified Language.PlutusIR as PIR
 import qualified Language.PlutusIR.Compiler.Definitions as PIR
-import           Language.PlutusIR.Compiler.Names
-import qualified Language.PlutusIR.MkPir                as PIR
-import qualified Language.PlutusIR.Value                as PIR
+import Language.PlutusIR.Compiler.Names
+import qualified Language.PlutusIR.MkPir as PIR
+import qualified Language.PlutusIR.Value as PIR
 
-import qualified Language.PlutusCore                    as PLC
-import qualified Language.PlutusCore.Constant           as PLC
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore.Constant as PLC
 
-import           Control.Monad.Reader
+import Control.Monad.Reader
 
-import qualified Data.ByteString.Lazy                   as BSL
-import           Data.List                              (elem, elemIndex)
-import qualified Data.List.NonEmpty                     as NE
-import qualified Data.Set                               as Set
-import qualified Data.Text                              as T
-import           Data.Traversable
+import qualified Data.ByteString.Lazy as BSL
+import Data.List (elem, elemIndex)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import Data.Traversable
 
 {- Note [System FC and System FW]
 Haskell uses system FC, which includes type equalities and coercions.

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Kind.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Kind.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Functions for compiling GHC kinds into PlutusCore kinds.
 module Language.PlutusTx.Compiler.Kind (compileKind) where
 
-import           Language.PlutusTx.Compiler.Error
-import           Language.PlutusTx.Compiler.Types
-import           Language.PlutusTx.Compiler.Utils
+import Language.PlutusTx.Compiler.Error
+import Language.PlutusTx.Compiler.Types
+import Language.PlutusTx.Compiler.Utils
 
-import qualified GhcPlugins                       as GHC
-import qualified Kind                             as GHC
+import qualified GhcPlugins as GHC
+import qualified Kind as GHC
 
-import qualified Language.PlutusCore              as PLC
+import qualified Language.PlutusCore as PLC
 
 compileKind :: Compiling m => GHC.Kind -> m (PLC.Kind ())
 compileKind k = withContextM 2 (sdToTxt $ "Compiling kind:" GHC.<+> GHC.ppr k) $ case k of

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Laziness.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Laziness.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | Simulating laziness.
 module Language.PlutusTx.Compiler.Laziness where
 
 import {-# SOURCE #-} Language.PlutusTx.Compiler.Expr
 import {-# SOURCE #-} Language.PlutusTx.Compiler.Type
-import           Language.PlutusTx.Compiler.Types
-import           Language.PlutusTx.PIRTypes
+import Language.PlutusTx.Compiler.Types
+import Language.PlutusTx.PIRTypes
 
-import qualified Language.PlutusIR                as PIR
+import qualified Language.PlutusIR as PIR
 
-import           Language.PlutusCore.Quote
+import Language.PlutusCore.Quote
 
-import qualified GhcPlugins                       as GHC
+import qualified GhcPlugins as GHC
 
 {- Note [Object- vs meta-language combinators]
 Many of the things we define as *meta*-langugage combinators (i.e. operations on terms) could be defined

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Names.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Names.hs
@@ -1,28 +1,28 @@
-{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 -- | Functions for compiling GHC names into Plutus Core names.
 module Language.PlutusTx.Compiler.Names where
 
 
-import           Language.PlutusTx.Compiler.Kind
+import Language.PlutusTx.Compiler.Kind
 import {-# SOURCE #-} Language.PlutusTx.Compiler.Type
-import           Language.PlutusTx.Compiler.Types
-import           Language.PlutusTx.PLCTypes
+import Language.PlutusTx.Compiler.Types
+import Language.PlutusTx.PLCTypes
 
-import qualified GhcPlugins                       as GHC
+import qualified GhcPlugins as GHC
 
-import qualified Language.PlutusCore              as PLC
-import qualified Language.PlutusCore.MkPlc        as PLC
-import           Language.PlutusCore.Quote
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore.MkPlc as PLC
+import Language.PlutusCore.Quote
 
-import           Language.PlutusIR.Compiler.Names
+import Language.PlutusIR.Compiler.Names
 
-import           Data.Char
-import           Data.List
-import qualified Data.List.NonEmpty               as NE
-import qualified Data.Map                         as Map
-import qualified Data.Text                        as T
+import Data.Char
+import Data.List
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as Map
+import qualified Data.Text as T
 
 lookupName :: Scope -> GHC.Name -> Maybe PLCVar
 lookupName (Scope ns _) n = Map.lookup n ns

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Primitives.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Primitives.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE ConstraintKinds   #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- | Functions for compiling GHC primitives into Plutus Core primitives.
 module Language.PlutusTx.Compiler.Primitives where
 
-import qualified Language.PlutusTx.Builtins          as Builtins
-import           Language.PlutusTx.Compiler.Builtins
-import           Language.PlutusTx.Compiler.Error
-import           Language.PlutusTx.Compiler.Types
-import           Language.PlutusTx.Compiler.Utils
-import           Language.PlutusTx.PIRTypes
+import qualified Language.PlutusTx.Builtins as Builtins
+import Language.PlutusTx.Compiler.Builtins
+import Language.PlutusTx.Compiler.Error
+import Language.PlutusTx.Compiler.Types
+import Language.PlutusTx.Compiler.Utils
+import Language.PlutusTx.PIRTypes
 
-import qualified GhcPlugins                          as GHC
-import qualified PrimOp                              as GHC
+import qualified GhcPlugins as GHC
+import qualified PrimOp as GHC
 
 -- These never seem to come up, rather we get the typeclass operations. Not sure if we need them.
 compilePrimitiveOp :: Compiling m => GHC.PrimOp -> m PIRTerm

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Type.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE ConstraintKinds   #-}
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | Functions for compiling GHC types into PlutusCore types, as well as compiling constructors,
 -- matchers, and pattern match alternatives.
@@ -16,32 +16,32 @@ module Language.PlutusTx.Compiler.Type (
     getMatch,
     getMatchInstantiated) where
 
-import           Language.PlutusTx.Compiler.Binders
-import           Language.PlutusTx.Compiler.Builtins
-import           Language.PlutusTx.Compiler.Error
-import           Language.PlutusTx.Compiler.Kind
-import           Language.PlutusTx.Compiler.Names
-import           Language.PlutusTx.Compiler.Types
-import           Language.PlutusTx.Compiler.Utils
-import           Language.PlutusTx.PIRTypes
+import Language.PlutusTx.Compiler.Binders
+import Language.PlutusTx.Compiler.Builtins
+import Language.PlutusTx.Compiler.Error
+import Language.PlutusTx.Compiler.Kind
+import Language.PlutusTx.Compiler.Names
+import Language.PlutusTx.Compiler.Types
+import Language.PlutusTx.Compiler.Utils
+import Language.PlutusTx.PIRTypes
 
-import qualified FamInstEnv                             as GHC
-import qualified GhcPlugins                             as GHC
-import qualified TysPrim                                as GHC
+import qualified FamInstEnv as GHC
+import qualified GhcPlugins as GHC
+import qualified TysPrim as GHC
 
-import qualified Language.PlutusIR                      as PIR
+import qualified Language.PlutusIR as PIR
 import qualified Language.PlutusIR.Compiler.Definitions as PIR
-import qualified Language.PlutusIR.MkPir                as PIR
+import qualified Language.PlutusIR.MkPir as PIR
 
-import qualified Language.PlutusCore.Name               as PLC
+import qualified Language.PlutusCore.Name as PLC
 
-import           Control.Monad.Extra
-import           Control.Monad.Reader
+import Control.Monad.Extra
+import Control.Monad.Reader
 
-import           Data.List                              (reverse, sortBy)
-import qualified Data.List.NonEmpty                     as NE
-import qualified Data.Set                               as Set
-import           Data.Traversable
+import Data.List (reverse, sortBy)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Set as Set
+import Data.Traversable
 
 -- Types
 

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Types.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Types.hs
@@ -1,29 +1,29 @@
-{-# LANGUAGE ConstraintKinds   #-}
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE Rank2Types        #-}
+{-# LANGUAGE Rank2Types #-}
 
 module Language.PlutusTx.Compiler.Types where
 
-import           Language.PlutusTx.Compiler.Error
-import           Language.PlutusTx.PLCTypes
+import Language.PlutusTx.Compiler.Error
+import Language.PlutusTx.PLCTypes
 
-import           Language.PlutusIR.Compiler.Definitions
+import Language.PlutusIR.Compiler.Definitions
 
-import           Language.PlutusCore.Quote
+import Language.PlutusCore.Quote
 
-import qualified FamInstEnv                             as GHC
-import qualified GhcPlugins                             as GHC
+import qualified FamInstEnv as GHC
+import qualified GhcPlugins as GHC
 
-import           Control.Monad.Except
-import           Control.Monad.Reader
-import           Control.Monad.State
+import Control.Monad.Except
+import Control.Monad.Reader
+import Control.Monad.State
 
-import qualified Data.List.NonEmpty                     as NE
-import qualified Data.Map                               as Map
-import qualified Data.Set                               as Set
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as Map
+import qualified Data.Set as Set
 
-import qualified Language.Haskell.TH.Syntax             as TH
+import qualified Language.Haskell.TH.Syntax as TH
 
 type BuiltinNameInfo = Map.Map TH.Name GHC.TyThing
 

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/Utils.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/Utils.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Language.PlutusTx.Compiler.Utils where
 
-import           Language.PlutusTx.Compiler.Error
-import           Language.PlutusTx.Compiler.Types
+import Language.PlutusTx.Compiler.Error
+import Language.PlutusTx.Compiler.Types
 
-import qualified CoreSyn                          as GHC
-import qualified GhcPlugins                       as GHC
+import qualified CoreSyn as GHC
+import qualified GhcPlugins as GHC
 
-import           Control.Monad.Except
-import           Control.Monad.Reader
+import Control.Monad.Except
+import Control.Monad.Reader
 
-import qualified Data.Text                        as T
+import qualified Data.Text as T
 
 sdToTxt :: MonadReader CompileContext m => GHC.SDoc -> m T.Text
 sdToTxt sd = do

--- a/plutus-tx/compiler/Language/PlutusTx/Compiler/ValueRestriction.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Compiler/ValueRestriction.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE LambdaCase #-}
 
 -- | Functions for dealing with the Plutus Core value restriction.
 module Language.PlutusTx.Compiler.ValueRestriction where
 
-import           Language.PlutusTx.Compiler.Error
-import           Language.PlutusTx.Compiler.Laziness
-import           Language.PlutusTx.Compiler.Types
-import           Language.PlutusTx.PIRTypes
+import Language.PlutusTx.Compiler.Error
+import Language.PlutusTx.Compiler.Laziness
+import Language.PlutusTx.Compiler.Types
+import Language.PlutusTx.PIRTypes
 
-import qualified Language.PlutusIR                   as PIR
-import qualified Language.PlutusIR.Value             as PIR
+import qualified Language.PlutusIR as PIR
+import qualified Language.PlutusIR.Value as PIR
 
-import           Control.Monad.Reader
+import Control.Monad.Reader
 
 -- Value restriction
 

--- a/plutus-tx/compiler/Language/PlutusTx/Data.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Data.hs
@@ -1,23 +1,23 @@
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE LambdaCase         #-}
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE ViewPatterns       #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
 module Language.PlutusTx.Data (Data (..), fromTerm, toTerm) where
 
-import           Prelude                   hiding (fail)
+import Prelude hiding (fail)
 
-import           Data.Bifunctor            (bimap)
-import           Data.Bitraversable        (bitraverse)
-import           Data.ByteString.Lazy      as BSL
+import Data.Bifunctor (bimap)
+import Data.Bitraversable (bitraverse)
+import Data.ByteString.Lazy as BSL
 
-import           Control.Monad.Fail
+import Control.Monad.Fail
 
-import qualified Codec.CBOR.Term           as CBOR
-import qualified Codec.Serialise           as Serialise
+import qualified Codec.CBOR.Term as CBOR
+import qualified Codec.Serialise as Serialise
 
-import           Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc
 
-import           GHC.Generics
+import GHC.Generics
 
 -- | A generic "data" type.
 --

--- a/plutus-tx/compiler/Language/PlutusTx/Lift.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Lift.hs
@@ -12,28 +12,28 @@ module Language.PlutusTx.Lift (
     typeCheckAgainst,
     typeCode) where
 
-import           Language.PlutusTx.Code
-import           Language.PlutusTx.Lift.Class                  (makeLift)
-import qualified Language.PlutusTx.Lift.Class                  as Lift
-import           Language.PlutusTx.Lift.Instances              ()
+import Language.PlutusTx.Code
+import Language.PlutusTx.Lift.Class (makeLift)
+import qualified Language.PlutusTx.Lift.Class as Lift
+import Language.PlutusTx.Lift.Instances ()
 
-import           Language.PlutusIR
-import           Language.PlutusIR.Compiler
-import           Language.PlutusIR.Compiler.Definitions
-import qualified Language.PlutusIR.MkPir                       as PIR
+import Language.PlutusIR
+import Language.PlutusIR.Compiler
+import Language.PlutusIR.Compiler.Definitions
+import qualified Language.PlutusIR.MkPir as PIR
 
-import qualified Language.PlutusCore                           as PLC
-import qualified Language.PlutusCore.Constant.Dynamic          as PLC
-import           Language.PlutusCore.Quote
-import qualified Language.PlutusCore.StdLib.Data.Function      as PLC
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore.Constant.Dynamic as PLC
+import Language.PlutusCore.Quote
+import qualified Language.PlutusCore.StdLib.Data.Function as PLC
 import qualified Language.PlutusCore.StdLib.Meta.Data.Function as PLC
 
-import           Control.Exception
-import           Control.Monad.Except                          hiding (lift)
-import           Control.Monad.Reader                          hiding (lift)
+import Control.Exception
+import Control.Monad.Except hiding (lift)
+import Control.Monad.Reader hiding (lift)
 
-import           Data.Functor                                  (void)
-import           Data.Proxy
+import Data.Functor (void)
+import Data.Proxy
 
 -- | Get a Plutus Core term corresponding to the given value.
 safeLift :: (Lift.Lift a, AsError e (Provenance ()), MonadError e m, MonadQuote m) => a -> m (PLC.Term TyName Name ())

--- a/plutus-tx/compiler/Language/PlutusTx/Lift/Instances.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Lift/Instances.hs
@@ -1,22 +1,22 @@
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PolyKinds         #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Language.PlutusTx.Lift.Instances () where
 
-import qualified Language.PlutusCore          as PLC
+import qualified Language.PlutusCore as PLC
 
-import           Language.PlutusTx.Builtins
-import           Language.PlutusTx.Lift.Class
+import Language.PlutusTx.Builtins
+import Language.PlutusTx.Lift.Class
 
-import           Language.PlutusIR
-import           Language.PlutusIR.MkPir
+import Language.PlutusIR
+import Language.PlutusIR.MkPir
 
-import           Data.Proxy
+import Data.Proxy
 
 -- Derived instances
 

--- a/plutus-tx/compiler/Language/PlutusTx/Lift/THUtils.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Lift/THUtils.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Language.PlutusTx.Lift.THUtils where
 
-import           Language.PlutusIR
-import           Language.PlutusIR.Compiler.Names
+import Language.PlutusIR
+import Language.PlutusIR.Compiler.Names
 
-import           Language.PlutusCore.Quote
+import Language.PlutusCore.Quote
 
-import           Control.Monad
+import Control.Monad
 
-import qualified Data.Text                        as T
+import qualified Data.Text as T
 
-import qualified Language.Haskell.TH              as TH
-import qualified Language.Haskell.TH.Datatype     as TH
-import qualified Language.Haskell.TH.Syntax       as TH
+import qualified Language.Haskell.TH as TH
+import qualified Language.Haskell.TH.Datatype as TH
+import qualified Language.Haskell.TH.Syntax as TH
 
 -- | Very nearly the same as 'TH.showName', but doesn't print uniques, since we don't need to
 -- incorporate them into our names.

--- a/plutus-tx/compiler/Language/PlutusTx/PLCTypes.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/PLCTypes.hs
@@ -1,6 +1,6 @@
 module Language.PlutusTx.PLCTypes where
 
-import qualified Language.PlutusCore       as PLC
+import qualified Language.PlutusCore as PLC
 import qualified Language.PlutusCore.MkPlc as PLC
 
 type PLCKind = PLC.Kind ()

--- a/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Plugin.hs
@@ -1,56 +1,56 @@
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TupleSections              #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-unused-foralls #-}
 module Language.PlutusTx.Plugin (plugin, plc) where
 
-import           Language.PlutusTx.Code
-import           Language.PlutusTx.Compiler.Builtins
-import           Language.PlutusTx.Compiler.Error
-import           Language.PlutusTx.Compiler.Expr
-import           Language.PlutusTx.Compiler.Types
-import           Language.PlutusTx.Compiler.Utils
-import           Language.PlutusTx.PIRTypes
-import           Language.PlutusTx.PLCTypes
-import           Language.PlutusTx.Utils
+import Language.PlutusTx.Code
+import Language.PlutusTx.Compiler.Builtins
+import Language.PlutusTx.Compiler.Error
+import Language.PlutusTx.Compiler.Expr
+import Language.PlutusTx.Compiler.Types
+import Language.PlutusTx.Compiler.Utils
+import Language.PlutusTx.PIRTypes
+import Language.PlutusTx.PLCTypes
+import Language.PlutusTx.Utils
 
-import qualified FamInstEnv                             as GHC
-import qualified GhcPlugins                             as GHC
-import qualified Panic                                  as GHC
+import qualified FamInstEnv as GHC
+import qualified GhcPlugins as GHC
+import qualified Panic as GHC
 
-import qualified Language.PlutusCore                    as PLC
-import qualified Language.PlutusCore.Constant.Dynamic   as PLC
-import           Language.PlutusCore.Quote
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore.Constant.Dynamic as PLC
+import Language.PlutusCore.Quote
 
-import qualified Language.PlutusIR                      as PIR
-import qualified Language.PlutusIR.Compiler             as PIR
+import qualified Language.PlutusIR as PIR
+import qualified Language.PlutusIR.Compiler as PIR
 import qualified Language.PlutusIR.Compiler.Definitions as PIR
 
-import           Language.Haskell.TH.Syntax             as TH
+import Language.Haskell.TH.Syntax as TH
 
-import           Codec.Serialise                        (serialise)
-import           Control.Lens
-import           Control.Monad
-import           Control.Monad.Except
-import           Control.Monad.Reader
-import           Control.Monad.State
+import Codec.Serialise (serialise)
+import Control.Lens
+import Control.Monad
+import Control.Monad.Except
+import Control.Monad.Reader
+import Control.Monad.State
 
-import qualified Data.ByteString                        as BS
-import qualified Data.ByteString.Lazy                   as BSL
-import qualified Data.ByteString.Unsafe                 as BSUnsafe
-import qualified Data.Map                               as Map
-import qualified Data.Text.Prettyprint.Doc              as PP
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Unsafe as BSUnsafe
+import qualified Data.Map as Map
+import qualified Data.Text.Prettyprint.Doc as PP
 
-import           GHC.TypeLits
-import           System.IO.Unsafe                       (unsafePerformIO)
+import GHC.TypeLits
+import System.IO.Unsafe (unsafePerformIO)
 
 -- if we inline this then we won't be able to find it later!
 {-# NOINLINE plc #-}

--- a/plutus-tx/compiler/Language/PlutusTx/Utils.hs
+++ b/plutus-tx/compiler/Language/PlutusTx/Utils.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE ConstraintKinds  #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 
 module Language.PlutusTx.Utils where
 
 import qualified Language.PlutusCore as PLC
-import qualified Language.PlutusIR   as PIR
+import qualified Language.PlutusIR as PIR
 
 mkBuiltin :: PLC.BuiltinName -> PIR.Term tyname name ()
 mkBuiltin n = PIR.Builtin () $ PLC.BuiltinName () n

--- a/plutus-tx/src/Language/PlutusTx.hs
+++ b/plutus-tx/src/Language/PlutusTx.hs
@@ -15,9 +15,9 @@ module Language.PlutusTx (
     liftCode,
     constCode) where
 
-import           Language.PlutusTx.Code       (CompiledCode, applyCode, getPir, getPlc)
-import           Language.PlutusTx.Data       (Data (..))
-import           Language.PlutusTx.IsData     (IsData (..), makeIsData, makeIsDataIndexed)
-import           Language.PlutusTx.Lift       (constCode, liftCode, makeLift, safeLiftCode)
-import           Language.PlutusTx.Lift.Class (Lift, Typeable)
-import           Language.PlutusTx.TH         as Export
+import Language.PlutusTx.Code (CompiledCode, applyCode, getPir, getPlc)
+import Language.PlutusTx.Data (Data (..))
+import Language.PlutusTx.IsData (IsData (..), makeIsData, makeIsDataIndexed)
+import Language.PlutusTx.Lift (constCode, liftCode, makeLift, safeLiftCode)
+import Language.PlutusTx.Lift.Class (Lift, Typeable)
+import Language.PlutusTx.TH as Export

--- a/plutus-tx/src/Language/PlutusTx/Applicative.hs
+++ b/plutus-tx/src/Language/PlutusTx/Applicative.hs
@@ -2,8 +2,8 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Language.PlutusTx.Applicative where
 
-import           Language.PlutusTx.Functor
-import           Prelude                   (Maybe (..))
+import Language.PlutusTx.Functor
+import Prelude (Maybe (..))
 
 {-# ANN module "HLint: ignore" #-}
 

--- a/plutus-tx/src/Language/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/Language/PlutusTx/AssocMap.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE MonoLocalBinds       #-}
-{-# LANGUAGE NoImplicitPrelude    #-}
-{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 -- Prevent unboxing, which the plugin can't deal with
@@ -29,12 +29,12 @@ module Language.PlutusTx.AssocMap (
     , mapThese
     ) where
 
-import           GHC.Generics              (Generic)
-import           Language.PlutusTx.IsData
-import           Language.PlutusTx.Lift    (makeLift)
-import           Language.PlutusTx.Prelude hiding (all, lookup)
+import GHC.Generics (Generic)
+import Language.PlutusTx.IsData
+import Language.PlutusTx.Lift (makeLift)
+import Language.PlutusTx.Prelude hiding (all, lookup)
 import qualified Language.PlutusTx.Prelude as P
-import           Language.PlutusTx.These
+import Language.PlutusTx.These
 
 {-# ANN module ("HLint: ignore Use newtype instead of data"::String) #-}
 

--- a/plutus-tx/src/Language/PlutusTx/Bool.hs
+++ b/plutus-tx/src/Language/PlutusTx/Bool.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Language.PlutusTx.Bool ((&&), (||), not) where
 
-import           Prelude hiding (not, (&&), (||))
+import Prelude hiding (not, (&&), (||))
 
 {-# ANN module ("HLint: ignore"::String) #-}
 

--- a/plutus-tx/src/Language/PlutusTx/Eq.hs
+++ b/plutus-tx/src/Language/PlutusTx/Eq.hs
@@ -1,10 +1,10 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Language.PlutusTx.Eq (Eq(..), (/=)) where
 
-import           Language.PlutusTx.Bool
+import Language.PlutusTx.Bool
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Data
-import           Prelude                    hiding (Eq (..), not, (&&))
+import Language.PlutusTx.Data
+import Prelude hiding (Eq (..), not, (&&))
 
 {-# ANN module ("HLint: ignore"::String) #-}
 

--- a/plutus-tx/src/Language/PlutusTx/Evaluation.hs
+++ b/plutus-tx/src/Language/PlutusTx/Evaluation.hs
@@ -1,13 +1,13 @@
 module Language.PlutusTx.Evaluation (evaluateCek, unsafeEvaluateCek, evaluateCekTrace, CekMachineException) where
 
-import           Language.PlutusCore
-import           Language.PlutusCore.Constant
-import           Language.PlutusCore.Constant.Dynamic
-import           Language.PlutusCore.Interpreter.CekMachine hiding (evaluateCek, unsafeEvaluateCek)
+import Language.PlutusCore
+import Language.PlutusCore.Constant
+import Language.PlutusCore.Constant.Dynamic
+import Language.PlutusCore.Interpreter.CekMachine hiding (evaluateCek, unsafeEvaluateCek)
 
-import           Control.Exception
+import Control.Exception
 
-import           System.IO.Unsafe
+import System.IO.Unsafe
 
 stringBuiltins :: DynamicBuiltinNameMeanings
 stringBuiltins =

--- a/plutus-tx/src/Language/PlutusTx/Functor.hs
+++ b/plutus-tx/src/Language/PlutusTx/Functor.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Language.PlutusTx.Functor (Functor(..), (<$>), (<$), const, id) where
 
-import           Prelude hiding (Functor (..), const, id, (<$), (<$>))
+import Prelude hiding (Functor (..), const, id, (<$), (<$>))
 
 {-# ANN module ("HLint: ignore"::String) #-}
 

--- a/plutus-tx/src/Language/PlutusTx/IsData.hs
+++ b/plutus-tx/src/Language/PlutusTx/IsData.hs
@@ -1,5 +1,5 @@
 module Language.PlutusTx.IsData (module Export) where
 
-import           Language.PlutusTx.IsData.Class     as Export
-import           Language.PlutusTx.IsData.Instances ()
-import           Language.PlutusTx.IsData.TH        as Export
+import Language.PlutusTx.IsData.Class as Export
+import Language.PlutusTx.IsData.Instances ()
+import Language.PlutusTx.IsData.TH as Export

--- a/plutus-tx/src/Language/PlutusTx/IsData/Class.hs
+++ b/plutus-tx/src/Language/PlutusTx/IsData/Class.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-strictness #-}
 {-# OPTIONS_GHC -fno-specialise #-}
 module Language.PlutusTx.IsData.Class where
 
-import           Data.ByteString.Lazy          as BSL
+import Data.ByteString.Lazy as BSL
 
-import           Prelude                       (Integer, Maybe (..))
+import Prelude (Integer, Maybe (..))
 
-import           Language.PlutusTx.Data
+import Language.PlutusTx.Data
 
-import           Language.PlutusTx.Applicative
-import           Language.PlutusTx.Functor
+import Language.PlutusTx.Applicative
+import Language.PlutusTx.Functor
 
-import           Data.Kind
+import Data.Kind
 
 {-# ANN module "HLint: ignore" #-}
 

--- a/plutus-tx/src/Language/PlutusTx/IsData/Instances.hs
+++ b/plutus-tx/src/Language/PlutusTx/IsData/Instances.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-strictness #-}
 {-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Language.PlutusTx.IsData.Instances where
 
-import           Prelude                     (Bool (..), Either (..), Maybe (..))
+import Prelude (Bool (..), Either (..), Maybe (..))
 
-import           Language.PlutusTx.IsData.TH
+import Language.PlutusTx.IsData.TH
 
 -- While these types should be stable, we really don't want them changing, so index
 -- them explicitly to be sure.

--- a/plutus-tx/src/Language/PlutusTx/IsData/TH.hs
+++ b/plutus-tx/src/Language/PlutusTx/IsData/TH.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Language.PlutusTx.IsData.TH (makeIsData, makeIsDataIndexed) where
 
-import           Data.Foldable
-import           Data.Traversable
+import Data.Foldable
+import Data.Traversable
 
-import qualified Language.Haskell.TH            as TH
-import qualified Language.Haskell.TH.Datatype   as TH
+import qualified Language.Haskell.TH as TH
+import qualified Language.Haskell.TH.Datatype as TH
 
-import qualified Language.PlutusTx.Applicative  as PlutusTx
-import           Language.PlutusTx.Data
-import qualified Language.PlutusTx.Eq           as PlutusTx
+import qualified Language.PlutusTx.Applicative as PlutusTx
+import Language.PlutusTx.Data
+import qualified Language.PlutusTx.Eq as PlutusTx
 
-import           Language.PlutusTx.IsData.Class
+import Language.PlutusTx.IsData.Class
 
 toDataClause :: (TH.ConstructorInfo, Int) -> TH.Q TH.Clause
 toDataClause (TH.ConstructorInfo{TH.constructorName=name, TH.constructorFields=argTys}, index) = do

--- a/plutus-tx/src/Language/PlutusTx/Lattice.hs
+++ b/plutus-tx/src/Language/PlutusTx/Lattice.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE ConstraintKinds #-}
 module Language.PlutusTx.Lattice where
 
-import           Language.PlutusTx.Bool
-import           Prelude                hiding (not, (&&), (||))
+import Language.PlutusTx.Bool
+import Prelude hiding (not, (&&), (||))
 
 -- | A join semi-lattice, i.e. a partially ordered set equipped with a
 -- binary operation '(\/)'.

--- a/plutus-tx/src/Language/PlutusTx/List.hs
+++ b/plutus-tx/src/Language/PlutusTx/List.hs
@@ -1,11 +1,11 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Language.PlutusTx.List (null, map, foldr, foldl, length, all, any, elem, filter, listToMaybe, uniqueElement, findIndices, findIndex, find, reverse, zip, (++), (!!)) where
 
-import           Language.PlutusTx.Bool
+import Language.PlutusTx.Bool
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Eq
-import           Prelude                    hiding (Eq (..), all, any, elem, filter, foldl, foldr, length, map, null,
-                                             reverse, zip, (!!), (&&), (++), (||))
+import Language.PlutusTx.Eq
+import Prelude hiding
+    (Eq (..), all, any, elem, filter, foldl, foldr, length, map, null, reverse, zip, (!!), (&&), (++), (||))
 
 {-# ANN module ("HLint: ignore"::String) #-}
 

--- a/plutus-tx/src/Language/PlutusTx/Maybe.hs
+++ b/plutus-tx/src/Language/PlutusTx/Maybe.hs
@@ -1,8 +1,8 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Language.PlutusTx.Maybe (isJust, isNothing, maybe, mapMaybe) where
 
-import           Language.PlutusTx.List
-import           Prelude                hiding (foldr, maybe)
+import Language.PlutusTx.List
+import Prelude hiding (foldr, maybe)
 
 {-# ANN module ("HLint: ignore"::String) #-}
 

--- a/plutus-tx/src/Language/PlutusTx/Monoid.hs
+++ b/plutus-tx/src/Language/PlutusTx/Monoid.hs
@@ -1,9 +1,9 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Language.PlutusTx.Monoid (Monoid (..), mappend, mconcat, Group (..), gsub) where
 
-import qualified Language.PlutusTx.Builtins  as Builtins
-import           Language.PlutusTx.Semigroup
-import           Prelude                     hiding (Monoid (..), Semigroup (..), mconcat)
+import qualified Language.PlutusTx.Builtins as Builtins
+import Language.PlutusTx.Semigroup
+import Prelude hiding (Monoid (..), Semigroup (..), mconcat)
 
 {-# ANN module ("HLint: ignore"::String) #-}
 

--- a/plutus-tx/src/Language/PlutusTx/Numeric.hs
+++ b/plutus-tx/src/Language/PlutusTx/Numeric.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE ConstraintKinds        #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Language.PlutusTx.Numeric (AdditiveSemigroup (..), AdditiveMonoid (..), AdditiveGroup (..), negate, Additive (..), MultiplicativeSemigroup (..), MultiplicativeMonoid (..), Multiplicative (..), Semiring, Ring, Module (..)) where
 
-import           Language.PlutusTx.Builtins
-import           Language.PlutusTx.Monoid
-import           Language.PlutusTx.Semigroup
-import           Prelude                     hiding (Functor (..), Monoid (..), Num (..), Semigroup (..))
+import Language.PlutusTx.Builtins
+import Language.PlutusTx.Monoid
+import Language.PlutusTx.Semigroup
+import Prelude hiding (Functor (..), Monoid (..), Num (..), Semigroup (..))
 
 -- | A 'Semigroup' that it is sensible to describe using addition.
 class AdditiveSemigroup a where

--- a/plutus-tx/src/Language/PlutusTx/Ord.hs
+++ b/plutus-tx/src/Language/PlutusTx/Ord.hs
@@ -1,11 +1,11 @@
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Language.PlutusTx.Ord (Ord(..), Max (..), Min (..)) where
 
-import qualified Language.PlutusTx.Builtins  as Builtins
-import           Language.PlutusTx.Data
-import           Language.PlutusTx.Eq
-import           Language.PlutusTx.Semigroup
-import           Prelude                     hiding (Eq (..), Ord (..), Semigroup (..))
+import qualified Language.PlutusTx.Builtins as Builtins
+import Language.PlutusTx.Data
+import Language.PlutusTx.Eq
+import Language.PlutusTx.Semigroup
+import Prelude hiding (Eq (..), Ord (..), Semigroup (..))
 
 {-# ANN module ("HLint: ignore"::String) #-}
 

--- a/plutus-tx/src/Language/PlutusTx/Prelude.hs
+++ b/plutus-tx/src/Language/PlutusTx/Prelude.hs
@@ -56,28 +56,72 @@ module Language.PlutusTx.Prelude (
     module Prelude
     ) where
 
-import           Language.PlutusTx.Applicative as Applicative
-import           Language.PlutusTx.Bool        as Bool
-import           Language.PlutusTx.Builtins    (ByteString, concatenate, dropByteString, emptyByteString,
-                                                equalsByteString, greaterThanByteString, lessThanByteString, sha2_256,
-                                                sha3_256, takeByteString, verifySignature)
-import qualified Language.PlutusTx.Builtins    as Builtins
-import           Language.PlutusTx.Eq          as Eq
-import           Language.PlutusTx.Functor     as Functor
-import           Language.PlutusTx.Lattice     as Lattice
-import           Language.PlutusTx.List        as List
-import           Language.PlutusTx.Maybe       as Maybe
-import           Language.PlutusTx.Monoid      as Monoid
-import           Language.PlutusTx.Numeric     as Numeric
-import           Language.PlutusTx.Ord         as Ord
-import           Language.PlutusTx.Ratio       as Ratio
-import           Language.PlutusTx.Semigroup   as Semigroup
-import           Prelude                       as Prelude hiding (Applicative (..), Eq (..), Functor (..), Monoid (..),
-                                                           Num (..), Ord (..), Rational, Semigroup (..), all, any,
-                                                           const, elem, error, filter, foldMap, foldl, foldr, fst, id,
-                                                           length, map, max, maybe, min, not, null, reverse, round,
-                                                           sequence, snd, traverse, zip, (!!), ($), (&&), (++), (<$>),
-                                                           (||))
+import Language.PlutusTx.Applicative as Applicative
+import Language.PlutusTx.Bool as Bool
+import Language.PlutusTx.Builtins
+    ( ByteString
+    , concatenate
+    , dropByteString
+    , emptyByteString
+    , equalsByteString
+    , greaterThanByteString
+    , lessThanByteString
+    , sha2_256
+    , sha3_256
+    , takeByteString
+    , verifySignature
+    )
+import qualified Language.PlutusTx.Builtins as Builtins
+import Language.PlutusTx.Eq as Eq
+import Language.PlutusTx.Functor as Functor
+import Language.PlutusTx.Lattice as Lattice
+import Language.PlutusTx.List as List
+import Language.PlutusTx.Maybe as Maybe
+import Language.PlutusTx.Monoid as Monoid
+import Language.PlutusTx.Numeric as Numeric
+import Language.PlutusTx.Ord as Ord
+import Language.PlutusTx.Ratio as Ratio
+import Language.PlutusTx.Semigroup as Semigroup
+import Prelude as Prelude hiding
+    ( Applicative (..)
+    , Eq (..)
+    , Functor (..)
+    , Monoid (..)
+    , Num (..)
+    , Ord (..)
+    , Rational
+    , Semigroup (..)
+    , all
+    , any
+    , const
+    , elem
+    , error
+    , filter
+    , foldMap
+    , foldl
+    , foldr
+    , fst
+    , id
+    , length
+    , map
+    , max
+    , maybe
+    , min
+    , not
+    , null
+    , reverse
+    , round
+    , sequence
+    , snd
+    , traverse
+    , zip
+    , (!!)
+    , ($)
+    , (&&)
+    , (++)
+    , (<$>)
+    , (||)
+    )
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}

--- a/plutus-tx/src/Language/PlutusTx/Ratio.hs
+++ b/plutus-tx/src/Language/PlutusTx/Ratio.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fplugin-opt Language.PlutusTx.Plugin:debug-context #-}
 {-# OPTIONS_GHC -fno-strictness #-}
@@ -25,17 +25,17 @@ module Language.PlutusTx.Ratio(
     , reduce
     ) where
 
-import qualified Language.PlutusTx.Bool     as P
-import qualified Language.PlutusTx.Eq       as P
-import qualified Language.PlutusTx.IsData   as P
-import qualified Language.PlutusTx.Lift     as P
-import qualified Language.PlutusTx.Numeric  as P
-import qualified Language.PlutusTx.Ord      as P
+import qualified Language.PlutusTx.Bool as P
+import qualified Language.PlutusTx.Eq as P
+import qualified Language.PlutusTx.IsData as P
+import qualified Language.PlutusTx.Lift as P
+import qualified Language.PlutusTx.Numeric as P
+import qualified Language.PlutusTx.Ord as P
 
 import qualified Language.PlutusTx.Builtins as Builtins
 
-import qualified GHC.Real                   as Ratio
-import           Prelude                    (Bool (True), Integer)
+import qualified GHC.Real as Ratio
+import Prelude (Bool (True), Integer)
 
 data Ratio a = a :% a
 

--- a/plutus-tx/src/Language/PlutusTx/Semigroup.hs
+++ b/plutus-tx/src/Language/PlutusTx/Semigroup.hs
@@ -2,8 +2,8 @@
 module Language.PlutusTx.Semigroup (Semigroup (..)) where
 
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.List
-import           Prelude                    hiding (Functor (..), Semigroup (..), (++))
+import Language.PlutusTx.List
+import Prelude hiding (Functor (..), Semigroup (..), (++))
 
 {-# ANN module ("HLint: ignore"::String) #-}
 

--- a/plutus-tx/src/Language/PlutusTx/TH.hs
+++ b/plutus-tx/src/Language/PlutusTx/TH.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 module Language.PlutusTx.TH (
     compile,
     compileUntyped) where
 
-import           Language.PlutusTx.Code
-import           Language.PlutusTx.Plugin
+import Language.PlutusTx.Code
+import Language.PlutusTx.Plugin
 
-import qualified Language.Haskell.TH        as TH
+import qualified Language.Haskell.TH as TH
 import qualified Language.Haskell.TH.Syntax as TH
 
 -- | Compile a quoted Haskell expression into a corresponding Plutus Core program.

--- a/plutus-tx/test/Lift/Spec.hs
+++ b/plutus-tx/test/Lift/Spec.hs
@@ -1,20 +1,20 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC   -Wno-orphans #-}
 module Lift.Spec where
 
-import           Plugin.Data.Spec
-import           Plugin.Primitives.Spec
+import Plugin.Data.Spec
+import Plugin.Primitives.Spec
 
-import           Common
-import           PlcTestUtils
+import Common
+import PlcTestUtils
 
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Code
-import qualified Language.PlutusTx.Lift     as Lift
+import Language.PlutusTx.Code
+import qualified Language.PlutusTx.Lift as Lift
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}

--- a/plutus-tx/test/Plugin/Basic/Spec.hs
+++ b/plutus-tx/test/Plugin/Basic/Spec.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:no-context #-}
 
 module Plugin.Basic.Spec where
 
-import           Common
-import           PlcTestUtils
-import           Plugin.Lib
+import Common
+import PlcTestUtils
+import Plugin.Lib
 
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Code
-import           Language.PlutusTx.Plugin
+import Language.PlutusTx.Code
+import Language.PlutusTx.Plugin
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}

--- a/plutus-tx/test/Plugin/Errors/Spec.hs
+++ b/plutus-tx/test/Plugin/Errors/Spec.hs
@@ -1,25 +1,25 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:no-context #-}
 
 module Plugin.Errors.Spec where
 
-import           Common
-import           PlcTestUtils
-import           Plugin.Lib
+import Common
+import PlcTestUtils
+import Plugin.Lib
 
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Code
-import           Language.PlutusTx.Plugin
+import Language.PlutusTx.Code
+import Language.PlutusTx.Plugin
 
-import           Language.PlutusTx.Plugin
+import Language.PlutusTx.Plugin
 
 -- Normally GHC will irritatingly case integers for us in some circumstances, but we want to do it
 -- explicitly here, so we need to see the constructors.
-import           GHC.Integer.GMP.Internals
+import GHC.Integer.GMP.Internals
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}

--- a/plutus-tx/test/Plugin/Functions/Spec.hs
+++ b/plutus-tx/test/Plugin/Functions/Spec.hs
@@ -1,20 +1,20 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:no-context #-}
 
 module Plugin.Functions.Spec where
 
-import           Common
-import           PlcTestUtils
-import           Plugin.Lib
+import Common
+import PlcTestUtils
+import Plugin.Lib
 
-import           Plugin.Data.Spec
+import Plugin.Data.Spec
 
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Code
-import           Language.PlutusTx.Plugin
+import Language.PlutusTx.Code
+import Language.PlutusTx.Plugin
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}

--- a/plutus-tx/test/Plugin/Laziness/Spec.hs
+++ b/plutus-tx/test/Plugin/Laziness/Spec.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:no-context #-}
 
 module Plugin.Laziness.Spec where
 
-import           Common
-import           PlcTestUtils
-import           Plugin.Lib
+import Common
+import PlcTestUtils
+import Plugin.Lib
 
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Code
-import           Language.PlutusTx.Plugin
+import Language.PlutusTx.Code
+import Language.PlutusTx.Plugin
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}

--- a/plutus-tx/test/Plugin/Lib.hs
+++ b/plutus-tx/test/Plugin/Lib.hs
@@ -1,21 +1,21 @@
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Plugin.Lib where
 
-import           Common
-import           PlcTestUtils
+import Common
+import PlcTestUtils
 
-import           Language.Haskell.TH
-import           Language.PlutusTx.Prelude
+import Language.Haskell.TH
+import Language.PlutusTx.Prelude
 
-import qualified Language.PlutusTx.Builtins   as Builtins
-import           Language.PlutusTx.Code
-import           Language.PlutusTx.Evaluation
-import           Language.PlutusTx.Prelude
-import           Language.PlutusTx.TH
+import qualified Language.PlutusTx.Builtins as Builtins
+import Language.PlutusTx.Code
+import Language.PlutusTx.Evaluation
+import Language.PlutusTx.Prelude
+import Language.PlutusTx.TH
 
-import           Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc
 
 {-# ANN module "HLint: ignore" #-}
 

--- a/plutus-tx/test/Plugin/Primitives/Spec.hs
+++ b/plutus-tx/test/Plugin/Primitives/Spec.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:no-context #-}
 
 module Plugin.Primitives.Spec where
 
-import           Common
-import           PlcTestUtils
-import           Plugin.Lib
+import Common
+import PlcTestUtils
+import Plugin.Lib
 
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Code
-import           Language.PlutusTx.Lift
-import           Language.PlutusTx.Plugin
+import Language.PlutusTx.Code
+import Language.PlutusTx.Lift
+import Language.PlutusTx.Plugin
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}

--- a/plutus-tx/test/Plugin/ReadValue/Spec.hs
+++ b/plutus-tx/test/Plugin/ReadValue/Spec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:strip-context #-}
 
@@ -6,16 +6,16 @@ module Plugin.ReadValue.Spec
     ( readDyns
     ) where
 
-import           Language.PlutusTx.Code
-import           Language.PlutusTx.Plugin
+import Language.PlutusTx.Code
+import Language.PlutusTx.Plugin
 
-import qualified Language.PlutusCore                        as PLC
-import qualified Language.PlutusCore.Constant               as PLC
-import qualified Language.PlutusCore.Constant.Dynamic       as PLC
+import qualified Language.PlutusCore as PLC
+import qualified Language.PlutusCore.Constant as PLC
+import qualified Language.PlutusCore.Constant.Dynamic as PLC
 import qualified Language.PlutusCore.Interpreter.CekMachine as PLC
 
-import           Test.Tasty
-import           Test.Tasty.HUnit
+import Test.Tasty
+import Test.Tasty.HUnit
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}

--- a/plutus-tx/test/Plugin/Spec.hs
+++ b/plutus-tx/test/Plugin/Spec.hs
@@ -1,17 +1,17 @@
 module Plugin.Spec where
 
-import           Common
-import           PlcTestUtils
-import           Plugin.Lib
+import Common
+import PlcTestUtils
+import Plugin.Lib
 
-import           Plugin.Basic.Spec
-import           Plugin.Data.Spec
-import           Plugin.Errors.Spec
-import           Plugin.Functions.Spec
-import           Plugin.Laziness.Spec
-import           Plugin.Primitives.Spec
-import           Plugin.ReadValue.Spec
-import           Plugin.Typeclasses.Spec
+import Plugin.Basic.Spec
+import Plugin.Data.Spec
+import Plugin.Errors.Spec
+import Plugin.Functions.Spec
+import Plugin.Laziness.Spec
+import Plugin.Primitives.Spec
+import Plugin.ReadValue.Spec
+import Plugin.Typeclasses.Spec
 
 tests :: TestNested
 tests = testNested "Plugin" [

--- a/plutus-tx/test/Plugin/Typeclasses/Spec.hs
+++ b/plutus-tx/test/Plugin/Typeclasses/Spec.hs
@@ -1,24 +1,24 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 {-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:no-context #-}
 
 module Plugin.Typeclasses.Spec where
 
-import           Common
-import           PlcTestUtils
-import           Plugin.Lib
+import Common
+import PlcTestUtils
+import Plugin.Lib
 
-import           Plugin.Data.Spec
+import Plugin.Data.Spec
 
 import qualified Language.PlutusTx.Builtins as Builtins
-import           Language.PlutusTx.Code
-import           Language.PlutusTx.Plugin
-import qualified Language.PlutusTx.Prelude  as P
+import Language.PlutusTx.Code
+import Language.PlutusTx.Plugin
+import qualified Language.PlutusTx.Prelude as P
 
-import           Plugin.Typeclasses.Lib
+import Plugin.Typeclasses.Lib
 
 -- this module does lots of weird stuff deliberately
 {-# ANN module ("HLint: ignore"::String) #-}

--- a/plutus-tx/test/Spec.hs
+++ b/plutus-tx/test/Spec.hs
@@ -1,13 +1,13 @@
 module Main (main) where
 
-import qualified Lift.Spec   as Lift
+import qualified Lift.Spec as Lift
 import qualified Plugin.Spec as Plugin
 import qualified StdLib.Spec as Lib
-import qualified TH.Spec     as TH
+import qualified TH.Spec as TH
 
-import           Common
+import Common
 
-import           Test.Tasty
+import Test.Tasty
 
 main :: IO ()
 main = defaultMain $ runTestNestedIn ["test"] tests

--- a/plutus-tx/test/StdLib/Spec.hs
+++ b/plutus-tx/test/StdLib/Spec.hs
@@ -1,31 +1,31 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS -fplugin Language.PlutusTx.Plugin -fplugin-opt Language.PlutusTx.Plugin:defer-errors -fplugin-opt Language.PlutusTx.Plugin:no-context #-}
 module StdLib.Spec where
 
-import           Common
-import qualified Data.ByteString.Lazy     as BSL
-import           Data.Ratio               ((%))
-import           GHC.Real                 (reduce)
-import           Hedgehog                 (Gen, MonadGen, Property)
+import Common
+import qualified Data.ByteString.Lazy as BSL
+import Data.Ratio ((%))
+import GHC.Real (reduce)
+import Hedgehog (Gen, MonadGen, Property)
 import qualified Hedgehog
-import qualified Hedgehog.Gen             as Gen
-import qualified Hedgehog.Range           as Range
-import           PlcTestUtils
-import           Test.Tasty               (TestName)
-import           Test.Tasty.Hedgehog      (testProperty)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import PlcTestUtils
+import Test.Tasty (TestName)
+import Test.Tasty.Hedgehog (testProperty)
 
-import           Language.PlutusTx.Data   (Data (..))
-import qualified Language.PlutusTx.Data   as Data
-import qualified Language.PlutusTx.Eq     as PlutusTx
-import qualified Language.PlutusTx.Ord    as PlutusTx
-import qualified Language.PlutusTx.Ratio  as Ratio
+import Language.PlutusTx.Data (Data (..))
+import qualified Language.PlutusTx.Data as Data
+import qualified Language.PlutusTx.Eq as PlutusTx
+import qualified Language.PlutusTx.Ord as PlutusTx
+import qualified Language.PlutusTx.Ratio as Ratio
 
-import           Language.PlutusTx.Code
-import qualified Language.PlutusTx.Lift   as Lift
-import           Language.PlutusTx.Plugin
+import Language.PlutusTx.Code
+import qualified Language.PlutusTx.Lift as Lift
+import Language.PlutusTx.Plugin
 
 {-# ANN module ("HLint: ignore"::String) #-}
 

--- a/plutus-use-cases/bench/Opt.hs
+++ b/plutus-use-cases/bench/Opt.hs
@@ -6,7 +6,7 @@
 {-# OPTIONS_GHC -fno-strictness #-}
 module Opt where
 
-import           Prelude                   hiding (tail)
+import Prelude hiding (tail)
 
 import qualified Language.PlutusTx.Prelude as P
 

--- a/plutus-use-cases/bench/Recursion.hs
+++ b/plutus-use-cases/bench/Recursion.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE TypeOperators #-}
 module Recursion where
 
-import           Data.Functor.Identity
+import Data.Functor.Identity
 
-import           IFix
+import IFix
 
 newtype SelfF f a = SelfF (f a -> a)
 -- | Values that can be applied to themselves.

--- a/plutus-use-cases/bench/Scott.hs
+++ b/plutus-use-cases/bench/Scott.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Scott where
 
-import           Prelude hiding (replicate, tail)
+import Prelude hiding (replicate, tail)
 
-import           IFix
+import IFix
 
 {-# ANN module "HLint: ignore" #-}
 

--- a/plutus-use-cases/exe/crowdfunding/Main.hs
+++ b/plutus-use-cases/exe/crowdfunding/Main.hs
@@ -2,9 +2,9 @@
 -- | Contract interface for the crowdfunding contract
 module Main where
 
-import           Language.Plutus.Contract                              (ContractError)
-import qualified Language.Plutus.Contract.App                          as App
-import           Language.PlutusTx.Coordination.Contracts.CrowdFunding (crowdfunding, successfulCampaign, theCampaign)
+import Language.Plutus.Contract (ContractError)
+import qualified Language.Plutus.Contract.App as App
+import Language.PlutusTx.Coordination.Contracts.CrowdFunding (crowdfunding, successfulCampaign, theCampaign)
 
 main :: IO ()
 main = App.runWithTraces (crowdfunding @ContractError theCampaign)

--- a/plutus-use-cases/exe/game/Main.hs
+++ b/plutus-use-cases/exe/game/Main.hs
@@ -2,9 +2,9 @@
 -- | Contract interface for the guessing game
 module Main where
 
-import           Language.Plutus.Contract                      (ContractError)
-import qualified Language.Plutus.Contract.App                  as App
-import           Language.PlutusTx.Coordination.Contracts.Game (game, guessTrace, lockTrace)
+import Language.Plutus.Contract (ContractError)
+import qualified Language.Plutus.Contract.App as App
+import Language.PlutusTx.Coordination.Contracts.Game (game, guessTrace, lockTrace)
 
 main :: IO ()
 main = App.runWithTraces (game @ContractError)

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/ErrorHandling.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/ErrorHandling.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE MonoLocalBinds    #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 module Language.PlutusTx.Coordination.Contracts.ErrorHandling(
     Schema
     , MyError(..)
@@ -12,12 +12,12 @@ module Language.PlutusTx.Coordination.Contracts.ErrorHandling(
     , contract
     ) where
 
-import           Control.Lens
-import           Control.Monad            (void)
-import           Control.Monad.Error.Lens
-import           Data.Text                (Text)
+import Control.Lens
+import Control.Monad (void)
+import Control.Monad.Error.Lens
+import Data.Text (Text)
 
-import           Language.Plutus.Contract
+import Language.Plutus.Contract
 
 -- $errorHandling
 -- Demonstrates how to deal with errors in Plutus contracts. We define a custom

--- a/plutus-use-cases/test/Spec.hs
+++ b/plutus-use-cases/test/Spec.hs
@@ -14,8 +14,8 @@ import qualified Spec.PubKey
 import qualified Spec.Rollup
 import qualified Spec.TokenAccount
 import qualified Spec.Vesting
-import           Test.Tasty
-import           Test.Tasty.Hedgehog       (HedgehogTestLimit (..))
+import Test.Tasty
+import Test.Tasty.Hedgehog (HedgehogTestLimit (..))
 
 main :: IO ()
 main = defaultMain tests

--- a/plutus-use-cases/test/Spec/Currency.hs
+++ b/plutus-use-cases/test/Spec/Currency.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Spec.Currency(tests) where
 
-import           Language.Plutus.Contract
-import           Language.Plutus.Contract.Test
+import Language.Plutus.Contract
+import Language.Plutus.Contract.Test
 import qualified Ledger
 
-import           Wallet.Emulator                                   (walletPubKey)
+import Wallet.Emulator (walletPubKey)
 
-import           Language.PlutusTx.Coordination.Contracts.Currency (Currency)
+import Language.PlutusTx.Coordination.Contracts.Currency (Currency)
 import qualified Language.PlutusTx.Coordination.Contracts.Currency as Cur
 
 
-import           Test.Tasty
+import Test.Tasty
 
 tests :: TestTree
 tests = testGroup "currency"

--- a/plutus-use-cases/test/Spec/ErrorHandling.hs
+++ b/plutus-use-cases/test/Spec/ErrorHandling.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 module Spec.ErrorHandling(tests) where
 
-import           Language.Plutus.Contract.Test
+import Language.Plutus.Contract.Test
 
-import           Language.PlutusTx.Coordination.Contracts.ErrorHandling
+import Language.PlutusTx.Coordination.Contracts.ErrorHandling
 
-import           Test.Tasty
+import Test.Tasty
 
 tests :: TestTree
 tests = testGroup "error handling"

--- a/plutus-use-cases/test/Spec/Escrow.hs
+++ b/plutus-use-cases/test/Spec/Escrow.hs
@@ -1,22 +1,22 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 module Spec.Escrow where
 
-import           Control.Monad                                   (void)
+import Control.Monad (void)
 
-import           Language.Plutus.Contract
-import           Language.Plutus.Contract.Test
-import qualified Ledger.Ada                                      as Ada
-import qualified Spec.Lib                                        as Lib
+import Language.Plutus.Contract
+import Language.Plutus.Contract.Test
+import qualified Ledger.Ada as Ada
+import qualified Spec.Lib as Lib
 
-import           Wallet.Emulator                                 (walletPubKey)
+import Wallet.Emulator (walletPubKey)
 
-import           Language.PlutusTx.Coordination.Contracts.Escrow
-import           Language.PlutusTx.Lattice
+import Language.PlutusTx.Coordination.Contracts.Escrow
+import Language.PlutusTx.Lattice
 
-import           Test.Tasty
-import qualified Test.Tasty.HUnit                                as HUnit
+import Test.Tasty
+import qualified Test.Tasty.HUnit as HUnit
 
 tests :: TestTree
 tests = testGroup "escrow"

--- a/plutus-use-cases/test/Spec/Lib.hs
+++ b/plutus-use-cases/test/Spec/Lib.hs
@@ -6,21 +6,21 @@ module Spec.Lib
     , timesFeeAdjustV
     ) where
 
-import           Control.Monad.IO.Class    (MonadIO (liftIO))
-import           Test.Tasty
-import           Test.Tasty.Golden
-import           Test.Tasty.HUnit
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Test.Tasty
+import Test.Tasty.Golden
+import Test.Tasty.HUnit
 
-import           Data.Maybe
-import           Data.String
-import           Data.Text.Prettyprint.Doc
+import Data.Maybe
+import Data.String
+import Data.Text.Prettyprint.Doc
 
-import           Language.PlutusTx
+import Language.PlutusTx
 import qualified Language.PlutusTx.Prelude as P
-import           Ledger                    (ValidatorScript)
+import Ledger (ValidatorScript)
 import qualified Ledger
-import qualified Ledger.Ada                as Ada
-import           Ledger.Value              (Value)
+import qualified Ledger.Ada as Ada
+import Ledger.Value (Value)
 
 -- | Assert that the size of a 'ValidatorScript' is below
 --   the maximum.

--- a/plutus-use-cases/test/Spec/PubKey.hs
+++ b/plutus-use-cases/test/Spec/PubKey.hs
@@ -1,18 +1,18 @@
 module Spec.PubKey(tests) where
 
-import           Control.Lens
-import           Control.Monad                                   (void)
-import qualified Data.Set                                        as Set
+import Control.Lens
+import Control.Monad (void)
+import qualified Data.Set as Set
 
-import           Language.Plutus.Contract
-import           Language.Plutus.Contract.Test
-import           Language.PlutusTx.Lattice
-import qualified Ledger.Ada                                      as Ada
-import           Wallet.Emulator                                 (walletPubKey)
+import Language.Plutus.Contract
+import Language.Plutus.Contract.Test
+import Language.PlutusTx.Lattice
+import qualified Ledger.Ada as Ada
+import Wallet.Emulator (walletPubKey)
 
-import           Language.PlutusTx.Coordination.Contracts.PubKey (pubKeyContract)
+import Language.PlutusTx.Coordination.Contracts.PubKey (pubKeyContract)
 
-import           Test.Tasty
+import Test.Tasty
 
 w1 :: Wallet
 w1 = Wallet 1

--- a/plutus-use-cases/test/Spec/Rollup.hs
+++ b/plutus-use-cases/test/Spec/Rollup.hs
@@ -2,28 +2,28 @@
 module Spec.Rollup where
 
 
-import           Data.ByteString.Lazy                                  (ByteString)
-import qualified Data.ByteString.Lazy                                  as LBS
-import qualified Data.Map                                              as Map
-import qualified Data.Text                                             as T
-import           Data.Text.Encoding                                    (encodeUtf8)
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Data.Text.Encoding (encodeUtf8)
 
-import           Language.Plutus.Contract
-import           Language.Plutus.Contract.Trace
-import           Ledger
+import Language.Plutus.Contract
+import Language.Plutus.Contract.Trace
+import Ledger
 
-import           Language.Plutus.Contract.Request                      (ContractRow)
-import           Language.PlutusTx.Coordination.Contracts.CrowdFunding
-import           Language.PlutusTx.Coordination.Contracts.Game
-import           Language.PlutusTx.Coordination.Contracts.Vesting
+import Language.Plutus.Contract.Request (ContractRow)
+import Language.PlutusTx.Coordination.Contracts.CrowdFunding
+import Language.PlutusTx.Coordination.Contracts.Game
+import Language.PlutusTx.Coordination.Contracts.Vesting
 import qualified Spec.Vesting
 
-import           Test.Tasty                                            (TestTree, testGroup)
-import           Test.Tasty.Golden                                     (goldenVsString)
-import           Test.Tasty.HUnit                                      (assertFailure)
-import qualified Wallet.Emulator.NodeClient                            as NC
-import           Wallet.Emulator.Types
-import           Wallet.Rollup.Render                                  (showBlockchain)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Golden (goldenVsString)
+import Test.Tasty.HUnit (assertFailure)
+import qualified Wallet.Emulator.NodeClient as NC
+import Wallet.Emulator.Types
+import Wallet.Rollup.Render (showBlockchain)
 
 tests :: TestTree
 tests = testGroup "showBlockchain"

--- a/plutus-use-cases/test/Spec/TokenAccount.hs
+++ b/plutus-use-cases/test/Spec/TokenAccount.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeApplications #-}
 module Spec.TokenAccount(tests) where
 
-import           Test.Tasty
+import Test.Tasty
 
-import           Language.Plutus.Contract
-import           Language.Plutus.Contract.Test
-import           Language.PlutusTx.Lattice
-import qualified Ledger.Ada                                            as Ada
-import           Ledger.Value                                          (TokenName, Value)
+import Language.Plutus.Contract
+import Language.Plutus.Contract.Test
+import Language.PlutusTx.Lattice
+import qualified Ledger.Ada as Ada
+import Ledger.Value (TokenName, Value)
 
-import           Language.PlutusTx.Coordination.Contracts.TokenAccount (AccountOwner (..), TokenAccountSchema,
-                                                                        tokenAccountContract)
+import Language.PlutusTx.Coordination.Contracts.TokenAccount
+    (AccountOwner (..), TokenAccountSchema, tokenAccountContract)
 import qualified Language.PlutusTx.Coordination.Contracts.TokenAccount as Accounts
 
 tests :: TestTree

--- a/plutus-wallet-api/ledger/Data/Aeson/Extras.hs
+++ b/plutus-wallet-api/ledger/Data/Aeson/Extras.hs
@@ -8,18 +8,18 @@ module Data.Aeson.Extras(
     , tryDecode
     ) where
 
-import qualified Codec.CBOR.Write       as Write
-import           Codec.Serialise        (deserialiseOrFail)
-import           Codec.Serialise.Class  (Serialise, encode)
-import           Control.Monad          ((>=>))
-import qualified Data.Aeson             as Aeson
-import qualified Data.Aeson.Types       as Aeson
-import           Data.Bifunctor         (first)
-import qualified Data.ByteString        as BSS
+import qualified Codec.CBOR.Write as Write
+import Codec.Serialise (deserialiseOrFail)
+import Codec.Serialise.Class (Serialise, encode)
+import Control.Monad ((>=>))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import Data.Bifunctor (first)
+import qualified Data.ByteString as BSS
 import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Lazy   as BSL
-import qualified Data.Text              as Text
-import qualified Data.Text.Encoding     as TE
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TE
 
 encodeByteString :: BSS.ByteString -> Text.Text
 encodeByteString = TE.decodeUtf8 . Base16.encode

--- a/plutus-wallet-api/ledger/Data/Text/Prettyprint/Doc/Extras.hs
+++ b/plutus-wallet-api/ledger/Data/Text/Prettyprint/Doc/Extras.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DerivingVia      #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Text.Prettyprint.Doc.Extras(
@@ -8,12 +8,12 @@ module Data.Text.Prettyprint.Doc.Extras(
     , Tagged(Tagged)
     ) where
 
-import           Data.Foldable             (Foldable (toList))
-import           Data.Proxy                (Proxy (..))
-import           Data.String               (IsString (..))
-import           Data.Text.Prettyprint.Doc
-import           GHC.TypeLits              (KnownSymbol, symbolVal)
-import           IOTS                      (Tagged (Tagged))
+import Data.Foldable (Foldable (toList))
+import Data.Proxy (Proxy (..))
+import Data.String (IsString (..))
+import Data.Text.Prettyprint.Doc
+import GHC.TypeLits (KnownSymbol, symbolVal)
+import IOTS (Tagged (Tagged))
 
 -- | Newtype wrapper for deriving 'Pretty' via a 'Show' instance
 newtype PrettyShow a = PrettyShow { unPrettyShow :: a }

--- a/plutus-wallet-api/ledger/Ledger.hs
+++ b/plutus-wallet-api/ledger/Ledger.hs
@@ -5,15 +5,15 @@ module Ledger (
     Ada
     ) where
 
-import           Ledger.Ada        (Ada)
-import           Ledger.Address    as Export
-import           Ledger.Blockchain as Export
-import           Ledger.Crypto     as Export
-import           Ledger.Index      as Export
-import           Ledger.Interval   as Export
-import           Ledger.Scripts    as Export
-import           Ledger.Slot       as Export
-import           Ledger.Tx         as Export
-import           Ledger.TxId       as Export
-import           Ledger.Validation as Export
-import           Ledger.Value      (CurrencySymbol, Value)
+import Ledger.Ada (Ada)
+import Ledger.Address as Export
+import Ledger.Blockchain as Export
+import Ledger.Crypto as Export
+import Ledger.Index as Export
+import Ledger.Interval as Export
+import Ledger.Scripts as Export
+import Ledger.Slot as Export
+import Ledger.Tx as Export
+import Ledger.TxId as Export
+import Ledger.Validation as Export
+import Ledger.Value (CurrencySymbol, Value)

--- a/plutus-wallet-api/ledger/Ledger/AddressMap.hs
+++ b/plutus-wallet-api/ledger/Ledger/AddressMap.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE TemplateHaskell    #-}
-{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 -- | 'AddressMap's and functions for working on them.
 --
 -- 'AddressMap's are used to represent the limited knowledge about the state of the ledger that
@@ -23,24 +23,23 @@ module Ledger.AddressMap(
     fromChain
     ) where
 
-import           Codec.Serialise.Class (Serialise)
-import           Control.Lens          (At (..), Index, IxValue, Ixed (..), lens, (&), (.~), (^.))
-import           Control.Monad         (join)
-import           Data.Aeson            (FromJSON (..), ToJSON (..))
-import qualified Data.Aeson            as JSON
-import qualified Data.Aeson.Extras     as JSON
-import           Data.Foldable         (fold)
-import           Data.Map              (Map)
-import qualified Data.Map              as Map
-import           Data.Maybe            (mapMaybe)
-import           Data.Monoid           (Monoid (..))
-import           Data.Semigroup        (Semigroup (..))
-import qualified Data.Set              as Set
-import           GHC.Generics          (Generic)
+import Codec.Serialise.Class (Serialise)
+import Control.Lens (At (..), Index, IxValue, Ixed (..), lens, (&), (.~), (^.))
+import Control.Monad (join)
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import qualified Data.Aeson as JSON
+import qualified Data.Aeson.Extras as JSON
+import Data.Foldable (fold)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (mapMaybe)
+import Data.Monoid (Monoid (..))
+import Data.Semigroup (Semigroup (..))
+import qualified Data.Set as Set
+import GHC.Generics (Generic)
 
-import           Ledger                (Address, Tx (..), TxIn (..), TxOut (..), TxOutRef (..), TxOutTx (..), Value,
-                                        txId)
-import           Ledger.Blockchain
+import Ledger (Address, Tx (..), TxIn (..), TxOut (..), TxOutRef (..), TxOutTx (..), Value, txId)
+import Ledger.Blockchain
 
 -- | A map of 'Address'es and their unspent outputs.
 newtype AddressMap = AddressMap { getAddressMap :: Map Address (Map TxOutRef TxOutTx) }

--- a/plutus-wallet-api/ledger/Ledger/Blockchain.hs
+++ b/plutus-wallet-api/ledger/Ledger/Blockchain.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts   #-}
-{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Ledger.Blockchain (
     Block,
     Blockchain,
@@ -19,17 +19,17 @@ module Ledger.Blockchain (
     validValuesTx
     ) where
 
-import           Control.Monad  (join)
-import           Data.Map       (Map)
-import qualified Data.Map       as Map
-import           Data.Maybe     (listToMaybe)
+import Control.Monad (join)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (listToMaybe)
 
-import           Ledger.Crypto
-import           Ledger.Scripts
-import           Ledger.Slot    (Slot (..))
-import           Ledger.Tx
-import           Ledger.TxId
-import           Ledger.Value   (Value)
+import Ledger.Crypto
+import Ledger.Scripts
+import Ledger.Slot (Slot (..))
+import Ledger.Tx
+import Ledger.TxId
+import Ledger.Value (Value)
 
 -- | A block on the blockchain. This is just a list of transactions which
 -- successfully validate following on from the chain so far.

--- a/plutus-wallet-api/ledger/Ledger/Interval.hs
+++ b/plutus-wallet-api/ledger/Ledger/Interval.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE MonoLocalBinds       #-}
-{-# LANGUAGE NoImplicitPrelude    #-}
-{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
@@ -33,16 +33,16 @@ module Ledger.Interval(
     , strictUpperBound
     ) where
 
-import           Codec.Serialise.Class     (Serialise)
-import           Data.Aeson                (FromJSON, ToJSON)
-import           Data.Hashable             (Hashable)
-import           GHC.Generics              (Generic)
-import           IOTS                      (IotsType)
-import qualified Prelude                   as Haskell
+import Codec.Serialise.Class (Serialise)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Hashable (Hashable)
+import GHC.Generics (Generic)
+import IOTS (IotsType)
+import qualified Prelude as Haskell
 
-import qualified Language.PlutusTx         as PlutusTx
-import           Language.PlutusTx.Lift    (makeLift)
-import           Language.PlutusTx.Prelude
+import qualified Language.PlutusTx as PlutusTx
+import Language.PlutusTx.Lift (makeLift)
+import Language.PlutusTx.Prelude
 
 -- | An interval of @a@s.
 --

--- a/plutus-wallet-api/ledger/Ledger/Orphans.hs
+++ b/plutus-wallet-api/ledger/Ledger/Orphans.hs
@@ -1,23 +1,23 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Ledger.Orphans where
 
-import           Codec.Serialise.Class      (Serialise, decode, encode)
-import           Crypto.Hash                (Digest, SHA256, digestFromByteString)
-import           Data.Aeson                 (FromJSON (parseJSON), ToJSON (toJSON))
-import qualified Data.Aeson                 as JSON
-import qualified Data.Aeson.Extras          as JSON
-import qualified Data.ByteArray             as BA
-import qualified Data.ByteString            as BSS
-import qualified Data.ByteString.Lazy       as BSL
-import           IOTS                       (IotsType (iotsDefinition))
-import           Language.PlutusTx          (Data)
+import Codec.Serialise.Class (Serialise, decode, encode)
+import Crypto.Hash (Digest, SHA256, digestFromByteString)
+import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON))
+import qualified Data.Aeson as JSON
+import qualified Data.Aeson.Extras as JSON
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BSS
+import qualified Data.ByteString.Lazy as BSL
+import IOTS (IotsType (iotsDefinition))
+import Language.PlutusTx (Data)
 import qualified Language.PlutusTx.AssocMap as Map
-import qualified Language.PlutusTx.Prelude  as P
-import           Schema                     (FormSchema (FormSchemaHex), ToSchema (toSchema))
-import           Type.Reflection            (Typeable)
+import qualified Language.PlutusTx.Prelude as P
+import Schema (FormSchema (FormSchemaHex), ToSchema (toSchema))
+import Type.Reflection (Typeable)
 
 instance Serialise (Digest SHA256) where
     encode = encode . BA.unpack

--- a/plutus-wallet-api/ledger/Ledger/Slot.hs
+++ b/plutus-wallet-api/ledger/Ledger/Slot.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DerivingStrategies   #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE MonoLocalBinds       #-}
-{-# LANGUAGE NoImplicitPrelude    #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- Otherwise we get a complaint about the 'fromIntegral' call in the generated instance of 'Integral' for 'Ada'
 {-# OPTIONS_GHC -Wno-identities #-}
@@ -19,21 +19,21 @@ module Ledger.Slot(
     , width
     ) where
 
-import           Codec.Serialise.Class     (Serialise)
-import           Data.Aeson                (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
-import           Data.Hashable             (Hashable)
-import           Data.Text.Prettyprint.Doc (Pretty (pretty), (<+>))
-import           GHC.Generics              (Generic)
-import           IOTS                      (IotsType)
-import qualified Prelude                   as Haskell
-import           Schema                    (FormSchema (FormSchemaSlotRange), ToSchema (toSchema))
+import Codec.Serialise.Class (Serialise)
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import Data.Hashable (Hashable)
+import Data.Text.Prettyprint.Doc (Pretty (pretty), (<+>))
+import GHC.Generics (Generic)
+import IOTS (IotsType)
+import qualified Prelude as Haskell
+import Schema (FormSchema (FormSchemaSlotRange), ToSchema (toSchema))
 
 
-import qualified Language.PlutusTx         as PlutusTx
-import           Language.PlutusTx.Lift    (makeLift)
-import           Language.PlutusTx.Prelude
+import qualified Language.PlutusTx as PlutusTx
+import Language.PlutusTx.Lift (makeLift)
+import Language.PlutusTx.Prelude
 
-import           Ledger.Interval
+import Ledger.Interval
 
 {-# ANN module ("HLint: ignore Redundant if" :: String) #-}
 

--- a/plutus-wallet-api/ledger/Ledger/Tx.hs
+++ b/plutus-wallet-api/ledger/Ledger/Tx.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE DerivingVia       #-}
-{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Ledger.Tx(
     -- * Transactions
@@ -56,33 +56,33 @@ module Ledger.Tx(
     scriptTxIn
     ) where
 
-import qualified Codec.CBOR.Write          as Write
-import           Codec.Serialise.Class     (Serialise, encode)
-import           Control.Lens
-import           Crypto.Hash               (Digest, SHA256, hash)
-import           Data.Aeson                (FromJSON, FromJSONKey (..), ToJSON, ToJSONKey (..))
-import qualified Data.ByteArray            as BA
-import qualified Data.ByteString.Lazy      as BSL
-import           Data.Map                  (Map)
-import qualified Data.Map                  as Map
-import           Data.Maybe                (isJust)
-import qualified Data.Set                  as Set
-import           Data.Text.Prettyprint.Doc
-import           GHC.Generics              (Generic)
-import           IOTS                      (IotsType)
-import           Schema                    (ToSchema)
+import qualified Codec.CBOR.Write as Write
+import Codec.Serialise.Class (Serialise, encode)
+import Control.Lens
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.Aeson (FromJSON, FromJSONKey (..), ToJSON, ToJSONKey (..))
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString.Lazy as BSL
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (isJust)
+import qualified Data.Set as Set
+import Data.Text.Prettyprint.Doc
+import GHC.Generics (Generic)
+import IOTS (IotsType)
+import Schema (ToSchema)
 
-import           Language.PlutusTx.Lattice
+import Language.PlutusTx.Lattice
 
-import           Ledger.Ada
-import           Ledger.Address
-import           Ledger.Crypto
-import           Ledger.Orphans            ()
-import           Ledger.Scripts
-import           Ledger.Slot
-import           Ledger.TxId
-import           Ledger.Value
-import qualified Ledger.Value              as V
+import Ledger.Ada
+import Ledger.Address
+import Ledger.Crypto
+import Ledger.Orphans ()
+import Ledger.Scripts
+import Ledger.Slot
+import Ledger.TxId
+import Ledger.Value
+import qualified Ledger.Value as V
 
 {- Note [Serialisation and hashing]
 

--- a/plutus-wallet-api/ledger/Ledger/Typed/Scripts.hs
+++ b/plutus-wallet-api/ledger/Ledger/Typed/Scripts.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE ViewPatterns        #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-specialise #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 module Ledger.Typed.Scripts where
 
-import           Language.PlutusTx
+import Language.PlutusTx
 
-import           Language.PlutusTx.Prelude (check)
-import qualified Ledger.Address            as Addr
-import           Ledger.Scripts
-import qualified Ledger.Validation         as Validation
+import Language.PlutusTx.Prelude (check)
+import qualified Ledger.Address as Addr
+import Ledger.Scripts
+import qualified Ledger.Validation as Validation
 
-import           Data.Kind
+import Data.Kind
 
 -- | A class that associates a type standing for a connection type with two types, the type of the redeemer
 -- and the data script for that connection type.

--- a/plutus-wallet-api/ledger/Ledger/Typed/Tx.hs
+++ b/plutus-wallet-api/ledger/Ledger/Typed/Tx.hs
@@ -1,53 +1,53 @@
-{-# LANGUAGE ConstraintKinds           #-}
-{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE GADTs                     #-}
-{-# LANGUAGE MultiParamTypeClasses     #-}
-{-# LANGUAGE NamedFieldPuns            #-}
-{-# LANGUAGE PolyKinds                 #-}
-{-# LANGUAGE Rank2Types                #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TypeApplications          #-}
-{-# LANGUAGE TypeFamilies              #-}
-{-# LANGUAGE TypeOperators             #-}
-{-# LANGUAGE UndecidableInstances      #-}
-{-# LANGUAGE ViewPatterns              #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 -- | Typed transactions. This module defines typed versions of various ledger types. The ultimate
 -- goal is to make sure that the script types attached to inputs and outputs line up, to avoid
 -- type errors at validation time.
 module Ledger.Typed.Tx where
 
-import           Ledger.Address             hiding (scriptAddress)
-import           Ledger.Crypto
-import qualified Ledger.Interval            as Interval
-import           Ledger.Scripts
-import           Ledger.Slot
-import           Ledger.Tx
-import           Ledger.TxId
-import           Ledger.Typed.Scripts
-import qualified Ledger.Value               as Value
+import Ledger.Address hiding (scriptAddress)
+import Ledger.Crypto
+import qualified Ledger.Interval as Interval
+import Ledger.Scripts
+import Ledger.Slot
+import Ledger.Tx
+import Ledger.TxId
+import Ledger.Typed.Scripts
+import qualified Ledger.Value as Value
 
-import           Ledger.Typed.TypeUtils
+import Ledger.Typed.TypeUtils
 
-import qualified Language.PlutusCore        as PLC
+import qualified Language.PlutusCore as PLC
 import qualified Language.PlutusCore.Pretty as PLC
 
-import           Language.PlutusTx
-import           Language.PlutusTx.Lift     as Lift
-import           Language.PlutusTx.Numeric
+import Language.PlutusTx
+import Language.PlutusTx.Lift as Lift
+import Language.PlutusTx.Numeric
 
 import qualified Language.PlutusIR.Compiler as PIR
 
-import           Data.Coerce
-import           Data.Kind
-import           Data.List                  (foldl')
-import qualified Data.Map                   as Map
-import           Data.Proxy
-import qualified Data.Set                   as Set
+import Data.Coerce
+import Data.Kind
+import Data.List (foldl')
+import qualified Data.Map as Map
+import Data.Proxy
+import qualified Data.Set as Set
 
-import           Control.Monad.Except
+import Control.Monad.Except
 
 -- | A 'TxIn' tagged by two phantom types: a list of the types of the data scripts in the transaction; and the connection type of the input.
 data TypedScriptTxIn a = TypedScriptTxIn { tyTxInTxIn :: TxIn, tyTxInOutRef :: TypedScriptTxOutRef a }

--- a/plutus-wallet-api/ledger/Ledger/Typed/TypeUtils.hs
+++ b/plutus-wallet-api/ledger/Ledger/Typed/TypeUtils.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE Rank2Types            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 module Ledger.Typed.TypeUtils where
 
-import           Data.Kind
+import Data.Kind
 
 -- | A heterogeneous list where every element is wrapped with the given functor.
 data HListF (f :: Type -> Type) (l :: [Type]) where

--- a/plutus-wallet-api/ledger/Ledger/Validation.hs
+++ b/plutus-wallet-api/ledger/Ledger/Validation.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DeriveFunctor        #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DerivingVia          #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE NoImplicitPrelude    #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
 {-# OPTIONS_GHC -fno-strictness #-}
@@ -52,21 +52,21 @@ module Ledger.Validation
     , fromSymbol
     ) where
 
-import           GHC.Generics              (Generic)
-import           Language.PlutusTx
-import           Language.PlutusTx.Lift    (makeLift)
-import           Language.PlutusTx.Prelude
-import qualified Prelude                   as Haskell
+import GHC.Generics (Generic)
+import Language.PlutusTx
+import Language.PlutusTx.Lift (makeLift)
+import Language.PlutusTx.Prelude
+import qualified Prelude as Haskell
 
-import           Ledger.Ada                (Ada)
-import qualified Ledger.Ada                as Ada
-import           Ledger.Crypto             (PubKey (..), Signature (..))
-import           Ledger.Scripts
-import           Ledger.Slot               (Slot, SlotRange)
-import           Ledger.TxId
-import           Ledger.Value              (CurrencySymbol (..), Value)
-import qualified Ledger.Value              as Value
-import           LedgerBytes               (LedgerBytes (..))
+import Ledger.Ada (Ada)
+import qualified Ledger.Ada as Ada
+import Ledger.Crypto (PubKey (..), Signature (..))
+import Ledger.Scripts
+import Ledger.Slot (Slot, SlotRange)
+import Ledger.TxId
+import Ledger.Value (CurrencySymbol (..), Value)
+import qualified Ledger.Value as Value
+import LedgerBytes (LedgerBytes (..))
 
 {- Note [Script types in pending transactions]
 To validate a transaction, we have to evaluate the validation script of each of

--- a/plutus-wallet-api/src/Wallet.hs
+++ b/plutus-wallet-api/src/Wallet.hs
@@ -2,4 +2,4 @@ module Wallet (
     module API
     ) where
 
-import           Wallet.API as API
+import Wallet.API as API

--- a/plutus-wallet-api/src/Wallet/API.hs
+++ b/plutus-wallet-api/src/Wallet/API.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TupleSections       #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
@@ -86,35 +86,35 @@ module Wallet.API(
     WalletLog(..)
     ) where
 
-import           Control.Lens              hiding (contains)
-import           Control.Monad             (void, when)
-import           Control.Monad.Error.Class (MonadError (..))
-import           Data.Aeson                (FromJSON, FromJSON1, ToJSON, ToJSON1)
-import qualified Data.ByteString.Lazy      as BSL
-import           Data.Eq.Deriving          (deriveEq1)
-import           Data.Foldable             (fold)
-import           Data.Functor.Compose      (Compose (..))
-import           Data.Functor.Foldable     (Corecursive (..), Fix (..), Recursive (..), unfix)
-import           Data.Hashable             (Hashable, hashWithSalt)
-import           Data.Hashable.Lifted      (Hashable1, hashWithSalt1)
-import qualified Data.Map                  as Map
-import           Data.Maybe                (fromMaybe, mapMaybe, maybeToList)
-import qualified Data.Set                  as Set
-import           Data.Text                 (Text)
-import           IOTS                      (IotsType)
+import Control.Lens hiding (contains)
+import Control.Monad (void, when)
+import Control.Monad.Error.Class (MonadError (..))
+import Data.Aeson (FromJSON, FromJSON1, ToJSON, ToJSON1)
+import qualified Data.ByteString.Lazy as BSL
+import Data.Eq.Deriving (deriveEq1)
+import Data.Foldable (fold)
+import Data.Functor.Compose (Compose (..))
+import Data.Functor.Foldable (Corecursive (..), Fix (..), Recursive (..), unfix)
+import Data.Hashable (Hashable, hashWithSalt)
+import Data.Hashable.Lifted (Hashable1, hashWithSalt1)
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import IOTS (IotsType)
 
-import qualified Data.Text                 as Text
-import           Data.Text.Prettyprint.Doc hiding (width)
-import           GHC.Generics              (Generic, Generic1)
-import           Ledger                    hiding (inputs, out, sign, to, value)
-import           Ledger.AddressMap         (AddressMap)
-import           Ledger.Index              (minFee)
-import           Ledger.Interval           (Interval (..), after, always, before, contains, interval, isEmpty, member)
-import qualified Ledger.Interval           as Interval
-import qualified Ledger.Value              as Value
-import           Text.Show.Deriving        (deriveShow1)
+import qualified Data.Text as Text
+import Data.Text.Prettyprint.Doc hiding (width)
+import GHC.Generics (Generic, Generic1)
+import Ledger hiding (inputs, out, sign, to, value)
+import Ledger.AddressMap (AddressMap)
+import Ledger.Index (minFee)
+import Ledger.Interval (Interval (..), after, always, before, contains, interval, isEmpty, member)
+import qualified Ledger.Interval as Interval
+import qualified Ledger.Value as Value
+import Text.Show.Deriving (deriveShow1)
 
-import           Prelude                   hiding (Ordering (..))
+import Prelude hiding (Ordering (..))
 
 data EventTriggerF f =
     TAnd f f

--- a/plutus-wallet-api/src/Wallet/Generators.hs
+++ b/plutus-wallet-api/src/Wallet/Generators.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeApplications #-}
 -- | Generators for constructing blockchains and transactions for use in property-based testing.
 module Wallet.Generators(
     -- * Mockchain
@@ -31,26 +31,26 @@ module Wallet.Generators(
     signAll
     ) where
 
-import           Data.Bifunctor            (Bifunctor (..))
-import qualified Data.ByteString.Lazy      as BSL
-import           Data.Foldable             (fold, foldl')
-import           Data.Map                  (Map)
-import qualified Data.Map                  as Map
-import           Data.Maybe                (catMaybes, isNothing)
-import           Data.Set                  (Set)
-import qualified Data.Set                  as Set
-import           GHC.Stack                 (HasCallStack)
-import           Hedgehog
-import qualified Hedgehog.Gen              as Gen
-import qualified Hedgehog.Range            as Range
+import Data.Bifunctor (Bifunctor (..))
+import qualified Data.ByteString.Lazy as BSL
+import Data.Foldable (fold, foldl')
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (catMaybes, isNothing)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import GHC.Stack (HasCallStack)
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 import qualified Language.PlutusTx.Prelude as P
-import qualified Ledger.Ada                as Ada
-import qualified Ledger.Index              as Index
-import qualified Ledger.Interval           as Interval
-import qualified Ledger.Value              as Value
+import qualified Ledger.Ada as Ada
+import qualified Ledger.Index as Index
+import qualified Ledger.Interval as Interval
+import qualified Ledger.Value as Value
 
-import           Ledger
-import qualified Wallet.API                as W
+import Ledger
+import qualified Wallet.API as W
 
 -- | Attach signatures of all known private keys to a transaction.
 signAll :: Tx -> Tx

--- a/plutus-wallet-api/src/Wallet/Graph.hs
+++ b/plutus-wallet-api/src/Wallet/Graph.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 
 -- | Support for visualisation of a blockchain as a graph.
@@ -15,19 +15,19 @@ module Wallet.Graph
   , UtxoLocation
   ) where
 
-import           Data.Aeson.Types  (ToJSON, toJSON)
-import           Data.List         (nub)
-import qualified Data.Map          as Map
-import           Data.Maybe        (catMaybes)
-import qualified Data.Set          as Set
-import qualified Data.Text         as Text
-import           GHC.Generics      (Generic)
+import Data.Aeson.Types (ToJSON, toJSON)
+import Data.List (nub)
+import qualified Data.Map as Map
+import Data.Maybe (catMaybes)
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import GHC.Generics (Generic)
 
-import qualified Ledger.Ada        as Ada
-import           Ledger.Blockchain
-import           Ledger.Crypto
-import           Ledger.Tx
-import           Ledger.TxId
+import qualified Ledger.Ada as Ada
+import Ledger.Blockchain
+import Ledger.Crypto
+import Ledger.Tx
+import Ledger.TxId
 
 -- | The owner of an unspent transaction output.
 data UtxOwner

--- a/plutus-wallet-api/src/Wallet/Typed/API.hs
+++ b/plutus-wallet-api/src/Wallet/Typed/API.hs
@@ -1,33 +1,33 @@
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Wallet.Typed.API where
 
-import qualified Language.PlutusTx    as PlutusTx
-import           Ledger.AddressMap
-import           Ledger.Tx
+import qualified Language.PlutusTx as PlutusTx
+import Ledger.AddressMap
+import Ledger.Tx
 import qualified Ledger.Typed.Scripts as Scripts
-import qualified Ledger.Typed.Tx      as Typed
-import           Ledger.Value
-import           Wallet.API           (SlotRange, WalletAPI, WalletAPIError)
-import qualified Wallet.API           as WAPI
+import qualified Ledger.Typed.Tx as Typed
+import Ledger.Value
+import Wallet.API (SlotRange, WalletAPI, WalletAPIError)
+import qualified Wallet.API as WAPI
 
-import           Control.Lens
-import           Control.Monad.Except
+import Control.Lens
+import Control.Monad.Except
 
-import           Data.Either
-import qualified Data.Map             as Map
-import           Data.Maybe
-import qualified Data.Set             as Set
-import qualified Data.Text            as T
+import Data.Either
+import qualified Data.Map as Map
+import Data.Maybe
+import qualified Data.Set as Set
+import qualified Data.Text as T
 
 signTxAndSubmit
     :: forall ins outs m .

--- a/plutus-wallet-api/src/Wallet/Typed/StateMachine.hs
+++ b/plutus-wallet-api/src/Wallet/Typed/StateMachine.hs
@@ -1,20 +1,20 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 module Wallet.Typed.StateMachine where
 
-import           Control.Monad
-import qualified Data.Text                      as T
+import Control.Monad
+import qualified Data.Text as T
 
-import qualified Language.PlutusTx              as PlutusTx
+import qualified Language.PlutusTx as PlutusTx
 import qualified Language.PlutusTx.StateMachine as SM
-import qualified Ledger.Typed.Scripts           as Scripts
-import qualified Ledger.Typed.Tx                as Typed
-import           Ledger.Value
-import qualified Wallet.API                     as WAPI
-import qualified Wallet.Typed.API               as WAPITyped
+import qualified Ledger.Typed.Scripts as Scripts
+import qualified Ledger.Typed.Tx as Typed
+import Ledger.Value
+import qualified Wallet.API as WAPI
+import qualified Wallet.Typed.API as WAPITyped
 
 mkInitialise
     :: forall s i m

--- a/plutus-wallet-api/test/Spec.hs
+++ b/plutus-wallet-api/test/Spec.hs
@@ -1,44 +1,44 @@
-{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 module Main(main) where
 
-import           Control.Lens
-import           Control.Monad              (void)
-import           Control.Monad.Trans.Except (runExcept)
-import qualified Data.Aeson                 as JSON
-import qualified Data.Aeson.Extras          as JSON
-import qualified Data.Aeson.Internal        as Aeson
-import qualified Data.ByteString            as BSS
-import qualified Data.ByteString.Lazy       as BSL
-import           Data.Either                (isLeft, isRight)
-import           Data.Foldable              (fold, foldl', traverse_)
-import           Data.List                  (sort)
-import qualified Data.Map                   as Map
-import           Data.Monoid                (Sum (..))
-import qualified Data.Set                   as Set
-import           Data.String                (IsString (fromString))
-import           Hedgehog                   (Property, forAll, property)
+import Control.Lens
+import Control.Monad (void)
+import Control.Monad.Trans.Except (runExcept)
+import qualified Data.Aeson as JSON
+import qualified Data.Aeson.Extras as JSON
+import qualified Data.Aeson.Internal as Aeson
+import qualified Data.ByteString as BSS
+import qualified Data.ByteString.Lazy as BSL
+import Data.Either (isLeft, isRight)
+import Data.Foldable (fold, foldl', traverse_)
+import Data.List (sort)
+import qualified Data.Map as Map
+import Data.Monoid (Sum (..))
+import qualified Data.Set as Set
+import Data.String (IsString (fromString))
+import Hedgehog (Property, forAll, property)
 import qualified Hedgehog
-import qualified Hedgehog.Gen               as Gen
-import qualified Hedgehog.Range             as Range
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 import qualified Language.PlutusTx.AssocMap as AssocMap
 import qualified Language.PlutusTx.Builtins as Builtins
-import qualified Language.PlutusTx.Prelude  as PlutusTx
-import           Ledger
-import qualified Ledger.Ada                 as Ada
-import qualified Ledger.Index               as Index
-import           Ledger.Value               (CurrencySymbol, Value (Value))
-import qualified Ledger.Value               as Value
-import           LedgerBytes
-import           Test.Tasty
-import           Test.Tasty.Hedgehog        (testProperty)
-import           Test.Tasty.HUnit           (testCase)
-import qualified Test.Tasty.HUnit           as HUnit
-import           Wallet
-import qualified Wallet.API                 as W
-import qualified Wallet.Generators          as Gen
+import qualified Language.PlutusTx.Prelude as PlutusTx
+import Ledger
+import qualified Ledger.Ada as Ada
+import qualified Ledger.Index as Index
+import Ledger.Value (CurrencySymbol, Value (Value))
+import qualified Ledger.Value as Value
+import LedgerBytes
+import Test.Tasty
+import Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty.HUnit (testCase)
+import qualified Test.Tasty.HUnit as HUnit
+import Wallet
+import qualified Wallet.API as W
+import qualified Wallet.Generators as Gen
 import qualified Wallet.Graph
 
 main :: IO ()

--- a/scripts/set-git-rev/set-git-rev.hs
+++ b/scripts/set-git-rev/set-git-rev.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main where
 
-import           Control.DeepSeq        (force)
-import           Control.Exception      (ErrorCall (..), handle)
-import           Control.Exception.Base (evaluate)
-import           Control.Monad.IO.Class (liftIO)
-import           Data.ByteString        (ByteString)
-import qualified Data.ByteString.Char8  as B8
-import           Data.FileEmbed         (injectWith)
-import           Data.List              (isInfixOf)
-import           System.Environment     (getArgs)
-import           System.Exit            (die, exitFailure, exitSuccess)
+import Control.DeepSeq (force)
+import Control.Exception (ErrorCall (..), handle)
+import Control.Exception.Base (evaluate)
+import Control.Monad.IO.Class (liftIO)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as B8
+import Data.FileEmbed (injectWith)
+import Data.List (isInfixOf)
+import System.Environment (getArgs)
+import System.Exit (die, exitFailure, exitSuccess)
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Our previous settings can create really pointless merge headaches if two
people have been working on the same file.
    
This does create a longer files, but who cares? Whitespace is cheap,
time spent resolving needless merge conflicts is not.
    
(The purpose of a code formatter should be to reduce formatting
problems, not create them. :-D)