### PR TITLE
wallet-api/contract: Pretty print hashes

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract/Effects/AwaitSlot.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/AwaitSlot.hs
@@ -40,7 +40,7 @@ newtype WaitingForSlot = WaitingForSlot { unWaitingForSlot :: Maybe Slot }
   deriving newtype (ToJSON, FromJSON)
   deriving Semigroup via Maybe (Min Slot)
   deriving Monoid via Maybe (Min Slot)
-  deriving Pretty via (PrettyShow WaitingForSlot)
+  deriving Pretty via (Tagged "WaitingForSlot:" (Maybe Slot))
   deriving anyclass (IotsType)
 
 type AwaitSlot = SlotSymbol .== (Slot, WaitingForSlot)

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/ExposeEndpoint.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/ExposeEndpoint.hs
@@ -30,14 +30,14 @@ newtype EndpointDescription = EndpointDescription { getEndpointDescription :: St
     deriving stock (Eq, Ord, Generic, Show)
     deriving newtype (ToJSON, FromJSON)
     deriving anyclass (IotsType)
-    deriving Pretty via (PrettyShow String)
+    deriving Pretty via (Tagged "ExposeEndpoint:" String)
 
 newtype EndpointValue a = EndpointValue { unEndpointValue :: a }
     deriving stock (Eq, Ord, Generic, Show)
     deriving newtype (ToJSON, FromJSON)
     deriving anyclass (IotsType)
 
-deriving via (PrettyShow a) instance (Show a => Pretty (EndpointValue a))
+deriving via (Tagged "EndpointValue:" (PrettyShow a)) instance (Show a => Pretty (EndpointValue a))
 
 type HasEndpoint l a s =
   ( HasType l (EndpointValue a) (Input s)

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/WriteTx.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/WriteTx.hs
@@ -40,7 +40,7 @@ data WriteTxResponse =
 instance Pretty WriteTxResponse where
   pretty = \case
     WriteTxFailed e -> "WriteTxFailed:" <+> pretty e
-    WriteTxSuccess i -> "WriteTxSuccess:" <+> viaShow i
+    WriteTxSuccess i -> "WriteTxSuccess:" <+> pretty i
 
 writeTxResponse :: Iso' WriteTxResponse (Either WalletAPIError TxId)
 writeTxResponse = iso f g where

--- a/plutus-contract/src/Language/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Test.hs
@@ -340,7 +340,7 @@ emulatorLog f nm = PredF $ \(_, r) ->
     else do
         tell $ vsep
             [ "Emulator log:"
-            , nest 2 (vsep (fmap viaShow lg))
+            , nest 2 (vsep (fmap pretty lg))
             , "Fails" <+> squotes (fromString nm)
             ]
         pure False

--- a/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
@@ -17,6 +17,7 @@ import qualified Data.Map                    as Map
 import           Data.Maybe                  (fromMaybe)
 import qualified Data.Set                    as Set
 import           Data.String                 (IsString (fromString))
+import           Data.Text.Prettyprint.Doc   (Pretty (..))
 import           Language.Plutus.Contract.Tx (UnbalancedTx)
 import qualified Language.Plutus.Contract.Tx as T
 import qualified Language.PlutusTx.Prelude   as P
@@ -38,7 +39,7 @@ balanceWallet
     => UnbalancedTx
     -> m Tx
 balanceWallet utx = do
-    WAPI.logMsg $ "Balancing an unbalanced transaction: " <> fromString (show utx)
+    WAPI.logMsg $ "Balancing an unbalanced transaction: " <> fromString (show $ pretty utx)
     pk <- WAPI.ownPubKey
     addr <- WAPI.watchedAddresses
     let utxo = addr ^. at (L.pubKeyAddress pk) . to (fromMaybe mempty)

--- a/plutus-emulator/src/Wallet/Emulator/Types.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Types.hs
@@ -232,6 +232,16 @@ data EmulatorEvent =
 instance FromJSON EmulatorEvent
 instance ToJSON EmulatorEvent
 
+instance Pretty EmulatorEvent where
+    pretty = \case
+        TxnSubmit t -> "TxnSubmit" <+> pretty t
+        TxnValidate t -> "TxnValidate" <+> pretty t
+        TxnValidationFail t e -> "TxnValidationFail" <+> pretty t <> colon <+> pretty e
+        SlotAdd sl -> "SlotAdd" <+> pretty sl
+        WalletError w e -> "WalletError" <+> pretty w <> colon <+> pretty e
+        WalletInfo w t -> "WalletInfo" <+> pretty w <> colon <+> pretty t
+
+
 -- | Delete all 'EventHandler' values that are registered for an
 --   'EventTrigger'.
 deleteHandlers :: MonadState WalletState m => EventTrigger -> m ()

--- a/plutus-emulator/src/Wallet/Emulator/Types.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Types.hs
@@ -234,13 +234,12 @@ instance ToJSON EmulatorEvent
 
 instance Pretty EmulatorEvent where
     pretty = \case
-        TxnSubmit t -> "TxnSubmit" <+> pretty t
-        TxnValidate t -> "TxnValidate" <+> pretty t
-        TxnValidationFail t e -> "TxnValidationFail" <+> pretty t <> colon <+> pretty e
-        SlotAdd sl -> "SlotAdd" <+> pretty sl
+        ChainEvent (NC.TxnSubmit t) -> "TxnSubmit" <+> pretty t
+        ChainEvent (NC.TxnValidate t) -> "TxnValidate" <+> pretty t
+        ChainEvent (NC.TxnValidationFail t e) -> "TxnValidationFail" <+> pretty t <> colon <+> pretty e
+        ChainEvent (NC.SlotAdd sl) -> "SlotAdd" <+> pretty sl
         WalletError w e -> "WalletError" <+> pretty w <> colon <+> pretty e
         WalletInfo w t -> "WalletInfo" <+> pretty w <> colon <+> pretty t
-
 
 -- | Delete all 'EventHandler' values that are registered for an
 --   'EventTrigger'.

--- a/plutus-emulator/src/Wallet/Rollup/Render.hs
+++ b/plutus-emulator/src/Wallet/Rollup/Render.hs
@@ -29,7 +29,7 @@ import           Data.Text.Prettyprint.Doc.Render.Text (renderStrict)
 import qualified Language.PlutusTx                     as PlutusTx
 import qualified Language.PlutusTx.AssocMap            as AssocMap
 import qualified Language.PlutusTx.Builtins            as Builtins
-import           Ledger                                (Address, PubKey, Signature, Tx (Tx), TxId (getTxId),
+import           Ledger                                (Address, PubKey, Signature, Tx (Tx), TxId,
                                                         TxIn (TxIn, txInRef, txInType),
                                                         TxInType (ConsumePublicKeyAddress, ConsumeScriptAddress),
                                                         TxOut (TxOut), TxOutRef (TxOutRef, txOutRefId, txOutRefIdx),
@@ -42,7 +42,6 @@ import           Ledger.Scripts                        (DataScript (getDataScrip
 import           Ledger.Value                          (CurrencySymbol (CurrencySymbol), TokenName (TokenName),
                                                         getValue)
 import qualified Ledger.Value                          as Value
-import           LedgerBytes                           (LedgerBytes (..))
 import           Wallet.Emulator.Types                 (Wallet (Wallet))
 import           Wallet.Rollup                         (doAnnotateBlockchain)
 import           Wallet.Rollup.Types                   (AnnotatedTx (AnnotatedTx),
@@ -189,13 +188,13 @@ instance Render BeneficialOwner where
 instance Render Ada where
     render ada@(Lovelace l)
         | Ada.isZero ada = pure "-"
-        | otherwise = pure $ "Lovelace" <+> pretty l
+        | otherwise = pure (pretty l)
 
 instance Render (Digest SHA256) where
     render = render . abbreviate 40 . JSON.encodeSerialise
 
 instance Render TxId where
-    render = pure . pretty . LedgerBytes . getTxId
+    render = pure . pretty
 
 instance Render PubKey where
     render pubKey =

--- a/plutus-emulator/src/Wallet/Rollup/Render.hs
+++ b/plutus-emulator/src/Wallet/Rollup/Render.hs
@@ -29,12 +29,12 @@ import           Data.Text.Prettyprint.Doc.Render.Text (renderStrict)
 import qualified Language.PlutusTx                     as PlutusTx
 import qualified Language.PlutusTx.AssocMap            as AssocMap
 import qualified Language.PlutusTx.Builtins            as Builtins
-import           Ledger                                (Address, PubKey, Signature, Tx (Tx), TxId,
+import           Ledger                                (Address, PubKey, Signature, Tx (Tx), TxId (getTxId),
                                                         TxIn (TxIn, txInRef, txInType),
                                                         TxInType (ConsumePublicKeyAddress, ConsumeScriptAddress),
                                                         TxOut (TxOut), TxOutRef (TxOutRef, txOutRefId, txOutRefIdx),
-                                                        Value, getPubKey, getTxId, txFee, txForge, txOutValue,
-                                                        txOutputs, txSignatures)
+                                                        Value, getPubKey, txFee, txForge, txOutValue, txOutputs,
+                                                        txSignatures)
 import           Ledger.Ada                            (Ada (Lovelace))
 import qualified Ledger.Ada                            as Ada
 import           Ledger.Scripts                        (DataScript (getDataScript), Script, ValidatorScript,
@@ -42,6 +42,7 @@ import           Ledger.Scripts                        (DataScript (getDataScrip
 import           Ledger.Value                          (CurrencySymbol (CurrencySymbol), TokenName (TokenName),
                                                         getValue)
 import qualified Ledger.Value                          as Value
+import           LedgerBytes                           (LedgerBytes (..))
 import           Wallet.Emulator.Types                 (Wallet (Wallet))
 import           Wallet.Rollup                         (doAnnotateBlockchain)
 import           Wallet.Rollup.Types                   (AnnotatedTx (AnnotatedTx),
@@ -188,13 +189,13 @@ instance Render BeneficialOwner where
 instance Render Ada where
     render ada@(Lovelace l)
         | Ada.isZero ada = pure "-"
-        | otherwise = pure $ "Ada" <+> pretty l
+        | otherwise = pure $ "Lovelace" <+> pretty l
 
 instance Render (Digest SHA256) where
     render = render . abbreviate 40 . JSON.encodeSerialise
 
 instance Render TxId where
-    render t = pure $ viaShow (getTxId t)
+    render = pure . pretty . LedgerBytes . getTxId
 
 instance Render PubKey where
     render pubKey =

--- a/plutus-use-cases/test/Spec/contractError.txt
+++ b/plutus-use-cases/test/Spec/contractError.txt
@@ -3,7 +3,7 @@ Test outputs:
 Events by wallet:
   Events for W1:
     • {schedule collection:
-       ()}
+       EndpointValue: ()}
 Contract result by wallet:
   Wallet: W1
     Error:

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -3,159 +3,159 @@ Test outputs:
 Events by wallet:
   Events for W1:
     • {schedule collection:
-       ()}
+       EndpointValue: ()}
     • {slot:
        Slot: 27}
     • {utxo-at:
-       Utxo at 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff = TxId: 5f5820595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaacebff!1: PayToScript: DataScriptHash: "\198_>\EOT\EM1'\SOH\165\248w\131\153\&4L\226d+D\175E\180S\192\221\156\RSnD\DC4\222\136" Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-         TxId: 5f582075b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498ff!1: PayToScript: DataScriptHash: "\227\212\243\ETB\171]nmncM\154{\137\230\NUL\177\223\180\154t\152-f\233\137\163\GS\181\167-\152" Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-         TxId: 5f582093eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705aff!1: PayToScript: DataScriptHash: "]\156R\131g\227\199ea&u\SI\228\228\161\195\193b(\SUB9f\202\253V\191\DLE,\204\207\US\\" Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}}
+       Utxo at Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b = TxId: 595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaaceb!1: PayToScript: DataScriptHash: c65f3e0419312701a5f8778399344ce2642b44af45b453c0dd9c1e6e4414de88 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+         TxId: 75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498!1: PayToScript: DataScriptHash: e3d4f317ab5d6e6d6e634d9a7b89e600b1dfb49a74982d66e989a31db5a72d98 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+         TxId: 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a!1: PayToScript: DataScriptHash: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}}
     • {tx:
-       WriteTxSuccess: TxId {getTxId = "nU\213K\CAN;y`\157\225.\236\241\206\r\237\181\FS\177\227\183\211\223\135\234\143\ACKw\234\186\v#"}}
+       WriteTxSuccess: TxId: 6e55d54b183b79609de12eecf1ce0dedb51cb1e3b7d3df87ea8f0677eaba0b23}
   Events for W2:
     • {contribute:
-       Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}}
+       EndpointValue: Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}}
     • {own-pubkey:
-       fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025}
+       PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025}
     • {tx:
-       WriteTxSuccess: TxId {getTxId = "YR6\249\STX\135F\ESC\GS\227E\a\223g\RS_O7\228\189\r+\199U\137\185U.6\234\172\235"}}
+       WriteTxSuccess: TxId: 595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaaceb}
     • {address:
-       ( 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
-       , Tx TxId: 5f5820595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaacebff:
+       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx TxId: 595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaaceb:
          {inputs:
-            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!8
-              fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
+            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!8
+              PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,90)]})]}} locked by
-             PayToPubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
+             PayToPubKey: PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} locked by
-             PayToScript: DataScriptHash: "\198_>\EOT\EM1'\SOH\165\248w\131\153\&4L\226d+D\175E\180S\192\221\156\RSnD\DC4\222\136"
+             PayToScript: DataScriptHash: c65f3e0419312701a5f8778399344ce2642b44af45b453c0dd9c1e6e4414de88
          forge: Value {getValue = Map {unMap = []}}
-         fee: Lovelace {getLovelace = 0}
+         fee: Lovelace: 0
          signatures:
-           fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
+           PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
-       , Tx TxId: 5f582075b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498ff:
+       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx TxId: 75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498:
          {inputs:
-            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!3
-              98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!3
+              PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,90)]})]}} locked by
-             PayToPubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+             PayToPubKey: PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} locked by
-             PayToScript: DataScriptHash: "\227\212\243\ETB\171]nmncM\154{\137\230\NUL\177\223\180\154t\152-f\233\137\163\GS\181\167-\152"
+             PayToScript: DataScriptHash: e3d4f317ab5d6e6d6e634d9a7b89e600b1dfb49a74982d66e989a31db5a72d98
          forge: Value {getValue = Map {unMap = []}}
-         fee: Lovelace {getLovelace = 0}
+         fee: Lovelace: 0
          signatures:
-           98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+           PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
-       , Tx TxId: 5f582093eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705aff:
+       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx TxId: 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a:
          {inputs:
-            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!7
-              f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!7
+              PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,99)]})]}} locked by
-             PayToPubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+             PayToPubKey: PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} locked by
-             PayToScript: DataScriptHash: "]\156R\131g\227\199ea&u\SI\228\228\161\195\193b(\SUB9f\202\253V\191\DLE,\204\207\US\\"
+             PayToScript: DataScriptHash: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c
          forge: Value {getValue = Map {unMap = []}}
-         fee: Lovelace {getLovelace = 0}
+         fee: Lovelace: 0
          signatures:
-           f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+           PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
   Events for W3:
     • {contribute:
-       Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}}
+       EndpointValue: Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}}
     • {own-pubkey:
-       98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63}
+       PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63}
     • {tx:
-       WriteTxSuccess: TxId {getTxId = "u\179\190\&5b%;\162S-\169\FS#>v\DC1\EOT\137e\174\138y\SUBW\182\164\242\213\DEL\135$\152"}}
+       WriteTxSuccess: TxId: 75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498}
     • {address:
-       ( 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
-       , Tx TxId: 5f582075b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498ff:
+       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx TxId: 75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498:
          {inputs:
-            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!3
-              98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!3
+              PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,90)]})]}} locked by
-             PayToPubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+             PayToPubKey: PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} locked by
-             PayToScript: DataScriptHash: "\227\212\243\ETB\171]nmncM\154{\137\230\NUL\177\223\180\154t\152-f\233\137\163\GS\181\167-\152"
+             PayToScript: DataScriptHash: e3d4f317ab5d6e6d6e634d9a7b89e600b1dfb49a74982d66e989a31db5a72d98
          forge: Value {getValue = Map {unMap = []}}
-         fee: Lovelace {getLovelace = 0}
+         fee: Lovelace: 0
          signatures:
-           98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+           PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
-       , Tx TxId: 5f582093eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705aff:
+       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx TxId: 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a:
          {inputs:
-            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!7
-              f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!7
+              PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,99)]})]}} locked by
-             PayToPubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+             PayToPubKey: PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} locked by
-             PayToScript: DataScriptHash: "]\156R\131g\227\199ea&u\SI\228\228\161\195\193b(\SUB9f\202\253V\191\DLE,\204\207\US\\"
+             PayToScript: DataScriptHash: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c
          forge: Value {getValue = Map {unMap = []}}
-         fee: Lovelace {getLovelace = 0}
+         fee: Lovelace: 0
          signatures:
-           f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+           PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
   Events for W4:
     • {contribute:
-       Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}}}
+       EndpointValue: Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}}}
     • {own-pubkey:
-       f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863}
+       PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863}
     • {tx:
-       WriteTxSuccess: TxId {getTxId = "\147\234\200\STX\248\245\\\228\167\226\145\v^\246\188\RS\156\196\CAN\247\215E\164(\135a\RS\222M`pZ"}}
+       WriteTxSuccess: TxId: 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a}
     • {address:
-       ( 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
-       , Tx TxId: 5f582093eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705aff:
+       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx TxId: 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a:
          {inputs:
-            - TxId: 5f5820f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2fff!7
-              f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!7
+              PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,99)]})]}} locked by
-             PayToPubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+             PayToPubKey: PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} locked by
-             PayToScript: DataScriptHash: "]\156R\131g\227\199ea&u\SI\228\228\161\195\193b(\SUB9f\202\253V\191\DLE,\204\207\US\\"
+             PayToScript: DataScriptHash: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c
          forge: Value {getValue = Map {unMap = []}}
-         fee: Lovelace {getLovelace = 0}
+         fee: Lovelace: 0
          signatures:
-           f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+           PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
 Contract result by wallet:
   Wallet: W1
     Done
     Wallet: W2
       Running, waiting for input:
-        {address: [ 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff ]
+        {address: [ Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
-         schedule collection: ["schedule collection"]
-         slot: WaitingForSlot {unWaitingForSlot = Just (Slot {getSlot = 30})}
+         schedule collection: [ExposeEndpoint: schedule collection]
+         slot: WaitingForSlot: Slot: 30
          tx: []
          utxo-at: []}
     Wallet: W3
       Running, waiting for input:
-        {address: [ 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff ]
+        {address: [ Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
-         schedule collection: ["schedule collection"]
-         slot: WaitingForSlot {unWaitingForSlot = Just (Slot {getSlot = 30})}
+         schedule collection: [ExposeEndpoint: schedule collection]
+         slot: WaitingForSlot: Slot: 30
          tx: []
          utxo-at: []}
     Wallet: W4
       Running, waiting for input:
-        {address: [ 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff ]
+        {address: [ Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
-         schedule collection: ["schedule collection"]
-         slot: WaitingForSlot {unWaitingForSlot = Just (Slot {getSlot = 30})}
+         schedule collection: [ExposeEndpoint: schedule collection]
+         slot: WaitingForSlot: Slot: 30
          tx: []
          utxo-at: []}

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -7,134 +7,134 @@ Events by wallet:
     • {slot:
        Slot: 27}
     • {utxo-at:
-       Utxo at Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b = TxId: 595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaaceb!1: PayToScript: DataScriptHash: c65f3e0419312701a5f8778399344ce2642b44af45b453c0dd9c1e6e4414de88 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-         TxId: 75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498!1: PayToScript: DataScriptHash: e3d4f317ab5d6e6d6e634d9a7b89e600b1dfb49a74982d66e989a31db5a72d98 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-         TxId: 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a!1: PayToScript: DataScriptHash: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}}
+       Utxo at 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b = 595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaaceb!1: PayToScript: c65f3e0419312701a5f8778399344ce2642b44af45b453c0dd9c1e6e4414de88 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+         75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498!1: PayToScript: e3d4f317ab5d6e6d6e634d9a7b89e600b1dfb49a74982d66e989a31db5a72d98 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+         93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a!1: PayToScript: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}}
     • {tx:
-       WriteTxSuccess: TxId: 6e55d54b183b79609de12eecf1ce0dedb51cb1e3b7d3df87ea8f0677eaba0b23}
+       WriteTxSuccess: 6e55d54b183b79609de12eecf1ce0dedb51cb1e3b7d3df87ea8f0677eaba0b23}
   Events for W2:
     • {contribute:
        EndpointValue: Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}}
     • {own-pubkey:
-       PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025}
+       fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025}
     • {tx:
-       WriteTxSuccess: TxId: 595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaaceb}
+       WriteTxSuccess: 595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaaceb}
     • {address:
-       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
-       , Tx TxId: 595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaaceb:
+       ( 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx 595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaaceb:
          {inputs:
-            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!8
-              PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
+            - f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!8
+              fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,90)]})]}} locked by
-             PayToPubKey: PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
+             PayToPubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} locked by
-             PayToScript: DataScriptHash: c65f3e0419312701a5f8778399344ce2642b44af45b453c0dd9c1e6e4414de88
+             PayToScript: c65f3e0419312701a5f8778399344ce2642b44af45b453c0dd9c1e6e4414de88
          forge: Value {getValue = Map {unMap = []}}
          fee: Lovelace: 0
          signatures:
-           PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
+           fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
-       , Tx TxId: 75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498:
+       ( 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx 75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498:
          {inputs:
-            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!3
-              PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+            - f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!3
+              98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,90)]})]}} locked by
-             PayToPubKey: PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+             PayToPubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} locked by
-             PayToScript: DataScriptHash: e3d4f317ab5d6e6d6e634d9a7b89e600b1dfb49a74982d66e989a31db5a72d98
+             PayToScript: e3d4f317ab5d6e6d6e634d9a7b89e600b1dfb49a74982d66e989a31db5a72d98
          forge: Value {getValue = Map {unMap = []}}
          fee: Lovelace: 0
          signatures:
-           PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+           98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
-       , Tx TxId: 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a:
+       ( 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a:
          {inputs:
-            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!7
-              PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+            - f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!7
+              f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,99)]})]}} locked by
-             PayToPubKey: PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+             PayToPubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} locked by
-             PayToScript: DataScriptHash: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c
+             PayToScript: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c
          forge: Value {getValue = Map {unMap = []}}
          fee: Lovelace: 0
          signatures:
-           PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+           f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
   Events for W3:
     • {contribute:
        EndpointValue: Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}}
     • {own-pubkey:
-       PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63}
+       98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63}
     • {tx:
-       WriteTxSuccess: TxId: 75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498}
+       WriteTxSuccess: 75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498}
     • {address:
-       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
-       , Tx TxId: 75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498:
+       ( 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx 75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498:
          {inputs:
-            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!3
-              PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+            - f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!3
+              98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,90)]})]}} locked by
-             PayToPubKey: PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+             PayToPubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} locked by
-             PayToScript: DataScriptHash: e3d4f317ab5d6e6d6e634d9a7b89e600b1dfb49a74982d66e989a31db5a72d98
+             PayToScript: e3d4f317ab5d6e6d6e634d9a7b89e600b1dfb49a74982d66e989a31db5a72d98
          forge: Value {getValue = Map {unMap = []}}
          fee: Lovelace: 0
          signatures:
-           PubKey: 98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
+           98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
-       , Tx TxId: 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a:
+       ( 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a:
          {inputs:
-            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!7
-              PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+            - f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!7
+              f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,99)]})]}} locked by
-             PayToPubKey: PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+             PayToPubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} locked by
-             PayToScript: DataScriptHash: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c
+             PayToScript: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c
          forge: Value {getValue = Map {unMap = []}}
          fee: Lovelace: 0
          signatures:
-           PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+           f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
   Events for W4:
     • {contribute:
        EndpointValue: Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}}}
     • {own-pubkey:
-       PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863}
+       f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863}
     • {tx:
-       WriteTxSuccess: TxId: 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a}
+       WriteTxSuccess: 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a}
     • {address:
-       ( Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
-       , Tx TxId: 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a:
+       ( 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+       , Tx 93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a:
          {inputs:
-            - TxId: f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!7
-              PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+            - f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f!7
+              f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,99)]})]}} locked by
-             PayToPubKey: PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+             PayToPubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} locked by
-             PayToScript: DataScriptHash: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c
+             PayToScript: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c
          forge: Value {getValue = Map {unMap = []}}
          fee: Lovelace: 0
          signatures:
-           PubKey: f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
+           f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
 Contract result by wallet:
   Wallet: W1
     Done
     Wallet: W2
       Running, waiting for input:
-        {address: [ Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b ]
+        {address: [ 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]
@@ -143,7 +143,7 @@ Contract result by wallet:
          utxo-at: []}
     Wallet: W3
       Running, waiting for input:
-        {address: [ Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b ]
+        {address: [ 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]
@@ -152,7 +152,7 @@ Contract result by wallet:
          utxo-at: []}
     Wallet: W4
       Running, waiting for input:
-        {address: [ Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b ]
+        {address: [ 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+  Destination:  Script: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  10
 
@@ -170,7 +170,7 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+  Script: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  10
 
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+  Destination:  Script: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  10
 
@@ -244,7 +244,7 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+  Script: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  20
 
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  99
   
   ---- Output 1 ----
-  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+  Destination:  Script: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  1
 
@@ -318,7 +318,7 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+  Script: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  21
 
@@ -330,7 +330,7 @@ Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
               Signature: 5f58209ee9741373ed6d29a14da0d2c4331e5032...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+  Destination:  Script: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  10
   Source:
@@ -339,7 +339,7 @@ Inputs:
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
   
   ---- Input 1 ----
-  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+  Destination:  Script: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  10
   Source:
@@ -348,7 +348,7 @@ Inputs:
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
   
   ---- Input 2 ----
-  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+  Destination:  Script: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  1
   Source:
@@ -405,6 +405,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
+  Script: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -1,5 +1,5 @@
 ==== Slot #0, Tx #0 ====
-TxId:       "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
+TxId:       f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f
 Fee:        -
 Forge:      Ada:      Lovelace:  1000
 Signatures  -
@@ -101,7 +101,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100
 
 ==== Slot #2, Tx #0 ====
-TxId:       "YR6\249\STX\135F\ESC\GS\227E\a\223g\RS_O7\228\189\r+\199U\137\185U.6\234\172\235"
+TxId:       595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaaceb
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
@@ -112,7 +112,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
+    Tx:     f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f
     Output #8
     PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
 
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
+  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  10
 
@@ -170,12 +170,12 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
+  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #3, Tx #0 ====
-TxId:       "u\179\190\&5b%;\162S-\169\FS#>v\DC1\EOT\137e\174\138y\SUBW\182\164\242\213\DEL\135$\152"
+TxId:       75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498
 Fee:        -
 Forge:      -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
@@ -186,7 +186,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
+    Tx:     f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f
     Output #3
     PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
 
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
+  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  10
 
@@ -244,12 +244,12 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
+  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  20
 
 ==== Slot #4, Tx #0 ====
-TxId:       "\147\234\200\STX\248\245\\\228\167\226\145\v^\246\188\RS\156\196\CAN\247\215E\164(\135a\RS\222M`pZ"
+TxId:       93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a
 Fee:        -
 Forge:      -
 Signatures  PubKey: f81fb54a825fced95eb033afcd64314075abfb0a...
@@ -260,7 +260,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
+    Tx:     f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f
     Output #7
     PubKey: f81fb54a825fced95eb033afcd64314075abfb0a...
 
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  99
   
   ---- Output 1 ----
-  Destination:  Script: 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
+  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  1
 
@@ -318,41 +318,41 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
+  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  21
 
 ==== Slot #23, Tx #0 ====
-TxId:       "nU\213K\CAN;y`\157\225.\236\241\206\r\237\181\FS\177\227\183\211\223\135\234\143\ACKw\234\186\v#"
+TxId:       6e55d54b183b79609de12eecf1ce0dedb51cb1e3b7d3df87ea8f0677eaba0b23
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
               Signature: 5f58209ee9741373ed6d29a14da0d2c4331e5032...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
+  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     "YR6\249\STX\135F\ESC\GS\227E\a\223g\RS_O7\228\189\r+\199U\137\185U.6\234\172\235"
+    Tx:     595236f90287461b1de34507df671e5f4f37e4bd0d2bc75589b9552e36eaaceb
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
   
   ---- Input 1 ----
-  Destination:  Script: 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
+  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     "u\179\190\&5b%;\162S-\169\FS#>v\DC1\EOT\137e\174\138y\SUBW\182\164\242\213\DEL\135$\152"
+    Tx:     75b3be3562253ba2532da91c233e7611048965ae8a791a57b6a4f2d57f872498
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
   
   ---- Input 2 ----
-  Destination:  Script: 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
+  Destination:  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  1
   Source:
-    Tx:     "\147\234\200\STX\248\245\\\228\167\226\145\v^\246\188\RS\156\196\CAN\247\215E\164(\135a\RS\222M`pZ"
+    Tx:     93eac802f8f55ce4a7e2910b5ef6bc1e9cc418f7d745a42887611ede4d60705a
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
 
@@ -405,6 +405,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 5f58201cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680bff
+  Script: Address: 1cf3e0ed060618856033237a483e8a88dec790fca845183bab7a8e13c6c0680b
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -1,5 +1,5 @@
 ==== Slot #0, Tx #0 ====
-TxId:       "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
+TxId:       f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f
 Fee:        -
 Forge:      Ada:      Lovelace:  1000
 Signatures  -
@@ -101,7 +101,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100
 
 ==== Slot #1, Tx #0 ====
-TxId:       "\214\229\235\nU\187\FS\167\&6\244\196\216\255\STXn,4\240b\219!\153\EM,X\206~@S\249\181\222"
+TxId:       d6e5eb0a55bb1ca736f4c4d8ff026e2c34f062db2199192c58ce7e4053f9b5de
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
@@ -112,7 +112,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
+    Tx:     f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f
     Output #1
     PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
 
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: 5f5820f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07ff
+  Destination:  Script: Address: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
   Value:
     Ada:      Lovelace:  10
 
@@ -170,23 +170,23 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 5f5820f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07ff
+  Script: Address: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       "\227\146\179\134ZE\FS$\211\DLE\171\135\165\&9\175=?\239>\ETB\225\135M\ETXn\SOH~p\165_\250\b"
+TxId:       e392b3865a451c24d310ab87a539af3d3fef3e17e1874d036e017e70a55ffa08
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
               Signature: 5f582042f2ded0d4814e36e2fc57fbeffe03ce52...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 5f5820f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07ff
+  Destination:  Script: Address: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     "\214\229\235\nU\187\FS\167\&6\244\196\216\255\STXn,4\240b\219!\153\EM,X\206~@S\249\181\222"
+    Tx:     d6e5eb0a55bb1ca736f4c4d8ff026e2c34f062db2199192c58ce7e4053f9b5de
     Output #1
     Script: f6f6010000c3f6c3f6c5f6c1f6f664556e697419...
 
@@ -239,6 +239,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 5f5820f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07ff
+  Script: Address: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  90
   
   ---- Output 1 ----
-  Destination:  Script: Address: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
+  Destination:  Script: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
   Value:
     Ada:      Lovelace:  10
 
@@ -170,7 +170,7 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: Address: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
+  Script: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
   Value:
     Ada:      Lovelace:  10
 
@@ -182,7 +182,7 @@ Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
               Signature: 5f582042f2ded0d4814e36e2fc57fbeffe03ce52...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: Address: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
+  Destination:  Script: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
   Value:
     Ada:      Lovelace:  10
   Source:
@@ -239,6 +239,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: Address: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
+  Script: f9e3c15b0601249c2b31f70e58c1c0358a970012557058ed5bdf5ce22500af07
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -1,5 +1,5 @@
 ==== Slot #0, Tx #0 ====
-TxId:       "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
+TxId:       f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f
 Fee:        -
 Forge:      Ada:      Lovelace:  1000
 Signatures  -
@@ -101,7 +101,7 @@ Balances Carried Forward:
     Ada:      Lovelace:  100
 
 ==== Slot #1, Tx #0 ====
-TxId:       "\t\137\163j\178\203_*o\168Q\212\252\&4\SI\190\ESCV\244'k\191n\EOT\218\ACK`\DC1\RS#l\177"
+TxId:       0989a36ab2cb5f2a6fa851d4fc340fbe1b56f4276bbf6e04da0660111e236cb1
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
@@ -112,7 +112,7 @@ Inputs:
   Value:
     Ada:      Lovelace:  100
   Source:
-    Tx:     "\247\\\FS\193L\DC2\DLE\238\168O\160MO\FS\191\236\197\219\212\242\129[\145WE\238\161\130\234\225\187/"
+    Tx:     f75c1cc14c1210eea84fa04d4f1cbfecc5dbd4f2815b915745eea182eae1bb2f
     Output #8
     PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
 
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  40
   
   ---- Output 1 ----
-  Destination:  Script: 5f5820edbf01817333aec76eafa39794bf6fc49ea3520ba4e5e2126c72a1e4a4775562ff
+  Destination:  Script: edbf01817333aec76eafa39794bf6fc49ea3520ba4e5e2126c72a1e4a4775562
   Value:
     Ada:      Lovelace:  60
 
@@ -170,23 +170,23 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 5f5820edbf01817333aec76eafa39794bf6fc49ea3520ba4e5e2126c72a1e4a4775562ff
+  Script: edbf01817333aec76eafa39794bf6fc49ea3520ba4e5e2126c72a1e4a4775562
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #13, Tx #0 ====
-TxId:       "\247\CAN]C?\247\224VW%\219C\FS\DC4\173\174\131)\228X\208\224\241vmf\248\228\ETB\177\226\144"
+TxId:       f7185d433ff7e0565725db431c14adae8329e458d0e0f1766d66f8e417b1e290
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
               Signature: 5f5820424e7db2175dffaafd5b09f3323274f2c1...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 5f5820edbf01817333aec76eafa39794bf6fc49ea3520ba4e5e2126c72a1e4a4775562ff
+  Destination:  Script: edbf01817333aec76eafa39794bf6fc49ea3520ba4e5e2126c72a1e4a4775562
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     "\t\137\163j\178\203_*o\168Q\212\252\&4\SI\190\ESCV\244'k\191n\EOT\218\ACK`\DC1\RS#l\177"
+    Tx:     0989a36ab2cb5f2a6fa851d4fc340fbe1b56f4276bbf6e04da0660111e236cb1
     Output #1
     Script: f6f6010000c3f6c3f6c3f6c5f6c1f6f664556e69...
 
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  10
   
   ---- Output 1 ----
-  Destination:  Script: 5f5820edbf01817333aec76eafa39794bf6fc49ea3520ba4e5e2126c72a1e4a4775562ff
+  Destination:  Script: edbf01817333aec76eafa39794bf6fc49ea3520ba4e5e2126c72a1e4a4775562
   Value:
     Ada:      Lovelace:  50
 
@@ -244,6 +244,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  100
   
-  Script: 5f5820edbf01817333aec76eafa39794bf6fc49ea3520ba4e5e2126c72a1e4a4775562ff
+  Script: edbf01817333aec76eafa39794bf6fc49ea3520ba4e5e2126c72a1e4a4775562
   Value:
     Ada:      Lovelace:  50

--- a/plutus-wallet-api/ledger/Data/Text/Prettyprint/Doc/Extras.hs
+++ b/plutus-wallet-api/ledger/Data/Text/Prettyprint/Doc/Extras.hs
@@ -1,11 +1,19 @@
-{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DerivingVia      #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Text.Prettyprint.Doc.Extras(
     PrettyShow(..)
+    , Pretty(..)
     , PrettyFoldable(..)
+    , Tagged(Tagged)
     ) where
 
 import           Data.Foldable             (Foldable (toList))
+import           Data.Proxy                (Proxy (..))
+import           Data.String               (IsString (..))
 import           Data.Text.Prettyprint.Doc
+import           GHC.TypeLits              (KnownSymbol, symbolVal)
+import           IOTS                      (Tagged (Tagged))
 
 -- | Newtype wrapper for deriving 'Pretty' via a 'Show' instance
 newtype PrettyShow a = PrettyShow { unPrettyShow :: a }
@@ -19,3 +27,9 @@ newtype PrettyFoldable f a = PrettyFoldable { unPrettyFoldable :: f a }
 
 instance (Foldable f, Pretty a) => Pretty (PrettyFoldable f a) where
   pretty = pretty . toList . unPrettyFoldable
+
+instance (KnownSymbol a, Pretty b) => Pretty (Tagged a b) where
+  pretty = prettyTagged
+
+prettyTagged :: forall a b ann. (KnownSymbol a, Pretty b) => Tagged a b -> Doc ann
+prettyTagged (Tagged b) = fromString (symbolVal (Proxy @a)) <+> pretty b

--- a/plutus-wallet-api/ledger/Ledger/Ada.hs
+++ b/plutus-wallet-api/ledger/Ledger/Ada.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DerivingVia        #-}
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
@@ -62,7 +63,7 @@ newtype Ada = Lovelace { getLovelace :: Integer }
     deriving stock (Haskell.Eq, Haskell.Ord, Show, Generic)
     deriving anyclass (ToSchema, ToJSON, FromJSON, IotsType)
     deriving newtype (Eq, Ord, Haskell.Num, AdditiveSemigroup, AdditiveMonoid, AdditiveGroup, MultiplicativeSemigroup, MultiplicativeMonoid, Integral, Real, Serialise, PlutusTx.IsData)
-    deriving Pretty via (PrettyShow Ada)
+    deriving Pretty via (Tagged "Lovelace:" Integer)
 
 instance Haskell.Semigroup Ada where
     Lovelace a1 <> Lovelace a2 = Lovelace (a1 + a2)

--- a/plutus-wallet-api/ledger/Ledger/Address.hs
+++ b/plutus-wallet-api/ledger/Ledger/Address.hs
@@ -20,7 +20,6 @@ import qualified Data.ByteString.Lazy      as BSL
 import           Data.String               (IsString(..))
 import           Data.Hashable             (Hashable, hashWithSalt)
 import           Data.Text.Prettyprint.Doc
-import           Data.Text.Prettyprint.Doc.Extras
 import           GHC.Generics              (Generic)
 import           IOTS                      (IotsType)
 
@@ -35,7 +34,7 @@ newtype Address = Address { getAddress :: BSL.ByteString }
     deriving anyclass (IotsType)
     deriving newtype (Serialise)
     deriving (ToJSON, FromJSON, ToJSONKey, FromJSONKey, IsString) via LedgerBytes
-    deriving Pretty via (Tagged "Address:" LedgerBytes)
+    deriving Pretty via LedgerBytes
 
 instance Hashable Address where
     hashWithSalt s (Address digest) = hashWithSalt s $ BSL.unpack digest

--- a/plutus-wallet-api/ledger/Ledger/Address.hs
+++ b/plutus-wallet-api/ledger/Ledger/Address.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DataKinds      #-}
 {-# LANGUAGE DerivingVia    #-}
 module Ledger.Address (
     -- Note that the constructor is not exported - generally people shouldn't be able
@@ -14,14 +15,16 @@ import qualified Codec.CBOR.Write          as Write
 import           Codec.Serialise.Class     (Serialise, encode)
 import           Crypto.Hash               (Digest, SHA256, hash)
 import           Data.Aeson                (FromJSON, FromJSONKey (..), ToJSON, ToJSONKey (..))
-import           Data.Aeson.Extras         (encodeSerialise)
 import qualified Data.ByteArray            as BA
 import qualified Data.ByteString.Lazy      as BSL
+import           Data.String               (IsString(..))
 import           Data.Hashable             (Hashable, hashWithSalt)
 import           Data.Text.Prettyprint.Doc
+import           Data.Text.Prettyprint.Doc.Extras
 import           GHC.Generics              (Generic)
 import           IOTS                      (IotsType)
 
+import           LedgerBytes               (LedgerBytes(..))
 import           Ledger.Crypto
 import           Ledger.Orphans            ()
 import           Ledger.Scripts
@@ -29,11 +32,10 @@ import           Ledger.Scripts
 -- | A payment address using a hash as the id.
 newtype Address = Address { getAddress :: BSL.ByteString }
     deriving stock (Eq, Ord, Show, Generic)
-    deriving anyclass (FromJSON, ToJSON, FromJSONKey, ToJSONKey, IotsType)
+    deriving anyclass (IotsType)
     deriving newtype (Serialise)
-
-instance Pretty Address where
-    pretty = pretty . encodeSerialise . getAddress
+    deriving (ToJSON, FromJSON, ToJSONKey, FromJSONKey, IsString) via LedgerBytes
+    deriving Pretty via (Tagged "Address:" LedgerBytes)
 
 instance Hashable Address where
     hashWithSalt s (Address digest) = hashWithSalt s $ BSL.unpack digest

--- a/plutus-wallet-api/ledger/Ledger/Crypto.hs
+++ b/plutus-wallet-api/ledger/Ledger/Crypto.hs
@@ -57,17 +57,15 @@ newtype PubKey = PubKey { getPubKey :: LedgerBytes }
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (ToSchema, ToJSON, FromJSON, Newtype, ToJSONKey, FromJSONKey, IotsType)
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
+    deriving Pretty via (Tagged "PubKey:" LedgerBytes)
 makeLift ''PubKey
-
-deriving via (PrettyShow LedgerBytes) instance Pretty PubKey
 
 -- | A cryptographic private key.
 newtype PrivateKey = PrivateKey { getPrivateKey :: LedgerBytes }
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (ToSchema, ToJSON, FromJSON, Newtype, ToJSONKey, FromJSONKey)
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
-
-deriving via (PrettyShow PrivateKey) instance (Pretty PrivateKey)
+    deriving Pretty via (Tagged "PrivateKey:" LedgerBytes)
 
 makeLift ''PrivateKey
 
@@ -82,6 +80,7 @@ newtype Signature = Signature { getSignature :: Builtins.ByteString }
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (ToSchema, IotsType)
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
+    deriving Pretty via (Tagged "Signature:" LedgerBytes)
 
 instance ToJSON Signature where
   toJSON signature =

--- a/plutus-wallet-api/ledger/Ledger/Crypto.hs
+++ b/plutus-wallet-api/ledger/Ledger/Crypto.hs
@@ -38,7 +38,6 @@ import qualified Data.ByteArray             as BA
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy       as BSL
 import           Data.Text.Prettyprint.Doc
-import           Data.Text.Prettyprint.Doc.Extras
 import           GHC.Generics               (Generic)
 import           IOTS                       (IotsType)
 import qualified Language.PlutusTx          as PlutusTx
@@ -57,7 +56,7 @@ newtype PubKey = PubKey { getPubKey :: LedgerBytes }
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (ToSchema, ToJSON, FromJSON, Newtype, ToJSONKey, FromJSONKey, IotsType)
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
-    deriving Pretty via (Tagged "PubKey:" LedgerBytes)
+    deriving Pretty via LedgerBytes
 makeLift ''PubKey
 
 -- | A cryptographic private key.
@@ -65,7 +64,7 @@ newtype PrivateKey = PrivateKey { getPrivateKey :: LedgerBytes }
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (ToSchema, ToJSON, FromJSON, Newtype, ToJSONKey, FromJSONKey)
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
-    deriving Pretty via (Tagged "PrivateKey:" LedgerBytes)
+    deriving Pretty via LedgerBytes
 
 makeLift ''PrivateKey
 
@@ -80,7 +79,7 @@ newtype Signature = Signature { getSignature :: Builtins.ByteString }
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (ToSchema, IotsType)
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
-    deriving Pretty via (Tagged "Signature:" LedgerBytes)
+    deriving Pretty via LedgerBytes
 
 instance ToJSON Signature where
   toJSON signature =

--- a/plutus-wallet-api/ledger/Ledger/Scripts.hs
+++ b/plutus-wallet-api/ledger/Ledger/Scripts.hs
@@ -64,6 +64,7 @@ import           Data.Functor                             (void)
 import           Data.Hashable                            (Hashable)
 import           Data.String
 import           Data.Text.Prettyprint.Doc
+import           Data.Text.Prettyprint.Doc.Extras
 import           GHC.Generics                             (Generic)
 import           IOTS                                     (IotsType (iotsDefinition))
 import qualified Language.PlutusCore                      as PLC
@@ -200,6 +201,7 @@ newtype ValidatorScript = ValidatorScript { getValidator :: Script }
   deriving stock (Generic)
   deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Serialise)
   deriving anyclass (ToJSON, FromJSON, IotsType)
+  deriving Pretty via (PrettyShow ValidatorScript)
 
 instance Show ValidatorScript where
     show = const "ValidatorScript { <script> }"
@@ -215,9 +217,7 @@ newtype DataScript = DataScript { getDataScript :: Data  }
   deriving stock (Generic, Show)
   deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Serialise, IsData)
   deriving anyclass (ToJSON, FromJSON, IotsType)
-
-instance Pretty DataScript where
-    pretty (DataScript dat) = "DataScript:" <+> pretty dat
+  deriving Pretty via (Tagged "DataScript:" Data)
 
 instance BA.ByteArrayAccess DataScript where
     length =
@@ -244,6 +244,7 @@ instance BA.ByteArrayAccess RedeemerScript where
 newtype ValidatorHash =
     ValidatorHash Builtins.ByteString
     deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON) via LedgerBytes
+    deriving Pretty via (Tagged "ValidatorHash:" LedgerBytes)
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
     deriving anyclass (ToSchema)
@@ -255,11 +256,9 @@ instance IotsType ValidatorHash where
 newtype DataScriptHash =
     DataScriptHash Builtins.ByteString
     deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON) via LedgerBytes
+    deriving Pretty via (Tagged "DataScriptHash:" LedgerBytes)
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
-
-instance Pretty DataScriptHash where
-    pretty (DataScriptHash bs) = "DataScriptHash:" <+> pretty (show bs)
 
 instance IotsType DataScriptHash where
     iotsDefinition = iotsDefinition @LedgerBytes
@@ -268,6 +267,7 @@ instance IotsType DataScriptHash where
 newtype RedeemerHash =
     RedeemerHash Builtins.ByteString
     deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON) via LedgerBytes
+    deriving Pretty via (Tagged "RedeemerHash:" LedgerBytes)
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
 

--- a/plutus-wallet-api/ledger/Ledger/Scripts.hs
+++ b/plutus-wallet-api/ledger/Ledger/Scripts.hs
@@ -217,7 +217,7 @@ newtype DataScript = DataScript { getDataScript :: Data  }
   deriving stock (Generic, Show)
   deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Serialise, IsData)
   deriving anyclass (ToJSON, FromJSON, IotsType)
-  deriving Pretty via (Tagged "DataScript:" Data)
+  deriving Pretty via Data
 
 instance BA.ByteArrayAccess DataScript where
     length =
@@ -243,8 +243,7 @@ instance BA.ByteArrayAccess RedeemerScript where
 -- | Script runtime representation of a @Digest SHA256@.
 newtype ValidatorHash =
     ValidatorHash Builtins.ByteString
-    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON) via LedgerBytes
-    deriving Pretty via (Tagged "ValidatorHash:" LedgerBytes)
+    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
     deriving anyclass (ToSchema)
@@ -255,8 +254,7 @@ instance IotsType ValidatorHash where
 -- | Script runtime representation of a @Digest SHA256@.
 newtype DataScriptHash =
     DataScriptHash Builtins.ByteString
-    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON) via LedgerBytes
-    deriving Pretty via (Tagged "DataScriptHash:" LedgerBytes)
+    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
 
@@ -266,8 +264,7 @@ instance IotsType DataScriptHash where
 -- | Script runtime representation of a @Digest SHA256@.
 newtype RedeemerHash =
     RedeemerHash Builtins.ByteString
-    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON) via LedgerBytes
-    deriving Pretty via (Tagged "RedeemerHash:" LedgerBytes)
+    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
 

--- a/plutus-wallet-api/ledger/Ledger/TxId.hs
+++ b/plutus-wallet-api/ledger/Ledger/TxId.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -14,7 +13,6 @@ import           Codec.Serialise.Class     (Serialise)
 import           Data.Aeson                (FromJSON, ToJSON)
 import qualified Data.ByteString.Lazy      as BSL
 import           Data.Text.Prettyprint.Doc (Pretty)
-import           Data.Text.Prettyprint.Doc.Extras
 import           GHC.Generics              (Generic)
 import           IOTS                      (IotsType)
 import qualified Language.PlutusTx         as PlutusTx
@@ -25,11 +23,10 @@ import           Schema                    (ToSchema)
 
 -- | A transaction ID, using a SHA256 hash as the transaction id.
 newtype TxId = TxId { getTxId :: BSL.ByteString }
-    deriving (Eq, Ord, Generic)
+    deriving (Eq, Ord, Generic, Show)
     deriving anyclass (ToSchema, IotsType)
     deriving newtype (PlutusTx.Eq, PlutusTx.Ord, Serialise)
-    deriving (ToJSON, FromJSON, Show) via LedgerBytes
-    deriving Pretty via (Tagged "TxId:" LedgerBytes)
+    deriving (ToJSON, FromJSON, Pretty) via LedgerBytes
 
 PlutusTx.makeLift ''TxId
 PlutusTx.makeIsData ''TxId

--- a/plutus-wallet-api/ledger/Ledger/TxId.hs
+++ b/plutus-wallet-api/ledger/Ledger/TxId.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -11,24 +12,24 @@ module Ledger.TxId(
 
 import           Codec.Serialise.Class     (Serialise)
 import           Data.Aeson                (FromJSON, ToJSON)
-import qualified Data.Aeson.Extras         as JSON
 import qualified Data.ByteString.Lazy      as BSL
-import           Data.Text.Prettyprint.Doc (Pretty (pretty), (<+>))
+import           Data.Text.Prettyprint.Doc (Pretty)
+import           Data.Text.Prettyprint.Doc.Extras
 import           GHC.Generics              (Generic)
 import           IOTS                      (IotsType)
 import qualified Language.PlutusTx         as PlutusTx
 import qualified Language.PlutusTx.Prelude as PlutusTx
+import           LedgerBytes               (LedgerBytes(..))
 import           Ledger.Orphans            ()
 import           Schema                    (ToSchema)
 
 -- | A transaction ID, using a SHA256 hash as the transaction id.
 newtype TxId = TxId { getTxId :: BSL.ByteString }
-    deriving (Eq, Ord, Show, Generic)
-    deriving anyclass (ToJSON, FromJSON, ToSchema, IotsType)
+    deriving (Eq, Ord, Generic)
+    deriving anyclass (ToSchema, IotsType)
     deriving newtype (PlutusTx.Eq, PlutusTx.Ord, Serialise)
-
-instance Pretty TxId where
-    pretty t = "TxId:" <+> pretty (JSON.encodeSerialise $ getTxId t)
+    deriving (ToJSON, FromJSON, Show) via LedgerBytes
+    deriving Pretty via (Tagged "TxId:" LedgerBytes)
 
 PlutusTx.makeLift ''TxId
 PlutusTx.makeIsData ''TxId

--- a/plutus-wallet-api/ledger/Ledger/Value.hs
+++ b/plutus-wallet-api/ledger/Ledger/Value.hs
@@ -67,7 +67,7 @@ import           IOTS                         (IotsType)
 import           Ledger.Orphans               ()
 
 newtype CurrencySymbol = CurrencySymbol { unCurrencySymbol :: Builtins.ByteString }
-    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise) via LedgerBytes
+    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, PlutusTx.IsData)
     deriving anyclass (Hashable, ToSchema, IotsType)
@@ -96,7 +96,7 @@ currencySymbol :: ByteString -> CurrencySymbol
 currencySymbol = CurrencySymbol
 
 newtype TokenName = TokenName { unTokenName :: Builtins.ByteString }
-    deriving (Serialise) via LedgerBytes
+    deriving (Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, PlutusTx.IsData)
     deriving anyclass (Hashable, ToSchema, IotsType)

--- a/plutus-wallet-api/ledger/LedgerBytes.hs
+++ b/plutus-wallet-api/ledger/LedgerBytes.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# OPTIONS_GHC -Wno-orphans            #-}
 
 module LedgerBytes ( LedgerBytes (..)
@@ -24,6 +25,7 @@ import           Data.Bifunctor             (bimap)
 import qualified Data.ByteString.Lazy       as BSL
 import           Data.String                (IsString (..))
 import qualified Data.Text                  as Text
+import           Data.Text.Prettyprint.Doc.Extras (Pretty, PrettyShow(..))
 import           Data.Word                  (Word8)
 import           GHC.Generics               (Generic)
 import           IOTS                       (IotsType (iotsDefinition))
@@ -66,6 +68,7 @@ newtype LedgerBytes = LedgerBytes { getLedgerBytes :: Builtins.ByteString } -- T
     deriving stock (Eq, Ord, Generic)
     deriving newtype (Serialise, P.Eq, P.Ord, PlutusTx.IsData)
     deriving anyclass (JSON.ToJSONKey, JSON.FromJSONKey)
+    deriving Pretty via (PrettyShow LedgerBytes)
 
 bytes :: LedgerBytes -> BSL.ByteString
 bytes = getLedgerBytes


### PR DESCRIPTION
* Adds an `instance Pretty (Tagged a b)` and uses it to derive `Pretty` instances for the various hashes that we have
* One effect of this PR is that the prefix `5f582` disappears from a number of hashes in the pretty-printed .txt files. Presumably this is an artefact of the serialisation and not of the hash itself. 

Also, there seem to be two different approaches to pretty-printing things that are wrapped in newtypes (say `newtype A = A b`)

1. Include the name of the newtype in the Pretty instance of `A`
2. Derive `Pretty A` via `b` and include the name of `A` only in `Pretty` instances of types that contain an `A`. The main use for this is in `Wallet.Rollup.Render` where the names of the newtypes and their values are aligned vertically

I decided to go with (2) in all the `Pretty` instances of `ByteString` wrappers, and with (1) in the contract endpoints