### PR TITLE
Import default.nix rather than ./.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ TAGS
 gh-pages
 .importify/
 marlowe-playground-server/playground.yaml
+.envrc

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ localPackages ? import ./. { rev = "in-nix-shell"; }
+{ localPackages ? import ./default.nix { rev = "in-nix-shell"; }
 }:
 localPackages.dev.withDevTools (localPackages.haskellPackages.shellFor {
     packages = p: (map (x: p.${x}) localPackages.localLib.plutusPkgList);


### PR DESCRIPTION
Apparently this trips up lorri: https://github.com/target/lorri#lorri-reevaluates-more-than-expected

Also ignore `.envrc` - this is going to depend on what people want to do locally.