### PR TITLE
marking `MAlonzo.*` as `autogen-modules`; restoring`metatheory` to `cabal.project`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,7 +17,7 @@ packages: language-plutus-core
           plutus-contract
           deployment-server
           iots-export
-	  metatheory
+          metatheory
 optimization: 2
 constraints: language-plutus-core +development
            , plutus-wallet-api +development

--- a/cabal.project
+++ b/cabal.project
@@ -17,6 +17,7 @@ packages: language-plutus-core
           plutus-contract
           deployment-server
           iots-export
+	  metatheory
 optimization: 2
 constraints: language-plutus-core +development
            , plutus-wallet-api +development

--- a/metatheory/plc-agda.cabal
+++ b/metatheory/plc-agda.cabal
@@ -154,7 +154,7 @@ test-suite test-plc-agda
 	Raw
         Scoped
         Opts
-  other-modules:
+  autogen-modules:
         MAlonzo.Code.Agda.Builtin.Bool
         MAlonzo.Code.Agda.Builtin.Char
         MAlonzo.Code.Agda.Builtin.Equality
@@ -299,7 +299,7 @@ test-suite test2-plc-agda
 	Raw
         Scoped
         Opts
-  other-modules:
+  autogen-modules:
         MAlonzo.Code.Agda.Builtin.Bool
         MAlonzo.Code.Agda.Builtin.Char
         MAlonzo.Code.Agda.Builtin.Equality

--- a/metatheory/plc-agda.cabal
+++ b/metatheory/plc-agda.cabal
@@ -15,8 +15,12 @@ category:            Development
 extra-source-files:  README.md
 
 executable plc-agda
-  main-is:             Main.hs
+  main-is:           Main.hs
   other-modules:
+        Raw
+        Scoped
+        Opts
+  autogen-modules:
         MAlonzo.Code.Main
         MAlonzo.Code.Agda.Builtin.Bool
         MAlonzo.Code.Agda.Builtin.Char
@@ -114,9 +118,6 @@ executable plc-agda
         MAlonzo.Code.Type
         MAlonzo.Code.Utils
         MAlonzo.RTE
-        Raw
-        Scoped
-        Opts
         MAlonzo.Code.Algorithmic
         MAlonzo.Code.Algorithmic.CK
         MAlonzo.Code.Check
@@ -150,150 +151,10 @@ test-suite test-plc-agda
   type:    exitcode-stdio-1.0
   main-is: TestSimple.hs
   other-modules:
-   MAlonzo.Code.Agda.Builtin.Bool
-        MAlonzo.Code.Agda.Builtin.Char
-        MAlonzo.Code.Agda.Builtin.Equality
-        MAlonzo.Code.Agda.Builtin.IO
-        MAlonzo.Code.Agda.Builtin.Int
-        MAlonzo.Code.Agda.Builtin.List
-        MAlonzo.Code.Agda.Builtin.Nat
-        MAlonzo.Code.Agda.Builtin.Sigma
-        MAlonzo.Code.Agda.Builtin.String
-        MAlonzo.Code.Agda.Builtin.Unit
-        MAlonzo.Code.Agda.Primitive
-        MAlonzo.Code.Algebra
-        MAlonzo.Code.Algebra.FunctionProperties.Consequences
-        MAlonzo.Code.Algebra.Morphism
-        MAlonzo.Code.Algebra.Properties.BooleanAlgebra
-        MAlonzo.Code.Algebra.Properties.DistributiveLattice
-        MAlonzo.Code.Algebra.Properties.Lattice
-        MAlonzo.Code.Algebra.Properties.Semilattice
-        MAlonzo.Code.Algebra.Structures
-        MAlonzo.Code.Algorithmic
-        MAlonzo.Code.Algorithmic.CK
-        MAlonzo.Code.Algorithmic.Equality
-        MAlonzo.Code.Algorithmic.Reduction
-        MAlonzo.Code.Algorithmic.RenamingSubstitution
-        MAlonzo.Code.Builtin
-        MAlonzo.Code.Builtin.Constant.Term
-        MAlonzo.Code.Builtin.Constant.Type
-        MAlonzo.Code.Builtin.Signature
-        MAlonzo.Code.Category.Applicative.Indexed
-        MAlonzo.Code.Category.Functor
-        MAlonzo.Code.Category.Monad.Indexed
-        MAlonzo.Code.Check
-        MAlonzo.Code.Data.Bool.Base
-        MAlonzo.Code.Data.Bool.Properties
-        MAlonzo.Code.Data.Char.Properties
-        MAlonzo.Code.Data.Digit
-        MAlonzo.Code.Data.Empty
-        MAlonzo.Code.Data.Empty.Irrelevant
-        MAlonzo.Code.Data.Fin.Base
-        MAlonzo.Code.Data.Integer
-        MAlonzo.Code.Data.Integer.Base
-        MAlonzo.Code.Data.Integer.Properties
-        MAlonzo.Code.Data.List.Base
-        MAlonzo.Code.Data.List.NonEmpty
-        MAlonzo.Code.Data.List.Properties
-        MAlonzo.Code.Data.List.Relation.Binary.Lex.Core
-        MAlonzo.Code.Data.List.Relation.Binary.Lex.Strict
-        MAlonzo.Code.Data.List.Relation.Binary.Pointwise
-        MAlonzo.Code.Data.List.Relation.Unary.All
-        MAlonzo.Code.Data.List.Relation.Unary.Any
-        MAlonzo.Code.Data.Maybe.Base
-        MAlonzo.Code.Data.Nat.Base
-        MAlonzo.Code.Data.Nat.DivMod
-        MAlonzo.Code.Data.Nat.DivMod.Core
-        MAlonzo.Code.Data.Nat.Properties
-        MAlonzo.Code.Data.Nat.Show
-        MAlonzo.Code.Data.Product
-        MAlonzo.Code.Data.Sign
-        MAlonzo.Code.Data.String.Base
-        MAlonzo.Code.Data.String.Properties
-        MAlonzo.Code.Data.Sum.Base
-        MAlonzo.Code.Data.These
-        MAlonzo.Code.Data.Vec
-        MAlonzo.Code.Function.Bijection
-        MAlonzo.Code.Function.Equality
-        MAlonzo.Code.Function.Equivalence
-        MAlonzo.Code.Function.Injection
-        MAlonzo.Code.Function.Inverse
-        MAlonzo.Code.Function.LeftInverse
-        MAlonzo.Code.Function.Surjection
-        MAlonzo.Code.Induction
-        MAlonzo.Code.Induction.WellFounded
-        MAlonzo.Code.Level
-        MAlonzo.Code.Main
-        MAlonzo.Code.Raw
-        MAlonzo.Code.Relation.Binary
-        MAlonzo.Code.Relation.Binary.Consequences
-        MAlonzo.Code.Relation.Binary.Construct.NaturalOrder.Left
-        MAlonzo.Code.Relation.Binary.Construct.NonStrictToStrict
-        MAlonzo.Code.Relation.Binary.Construct.On
-        MAlonzo.Code.Relation.Binary.Core
-        MAlonzo.Code.Relation.Binary.Indexed.Heterogeneous
-        MAlonzo.Code.Relation.Binary.Indexed.Heterogeneous.Construct.Trivial
-        MAlonzo.Code.Relation.Binary.Lattice
-        MAlonzo.Code.Relation.Binary.Properties.Poset
-        MAlonzo.Code.Relation.Binary.Properties.Preorder
-        MAlonzo.Code.Relation.Binary.PropositionalEquality
-        MAlonzo.Code.Relation.Binary.PropositionalEquality.Core
-        MAlonzo.Code.Relation.Binary.Reasoning.Base.Single
-        MAlonzo.Code.Relation.Binary.Reasoning.Base.Triple
-        MAlonzo.Code.Relation.Binary.Reasoning.Setoid
-        MAlonzo.Code.Relation.Nullary
-        MAlonzo.Code.Relation.Nullary.Decidable
-        MAlonzo.Code.Relation.Nullary.Negation
-        MAlonzo.Code.Relation.Nullary.Product
-        MAlonzo.Code.Relation.Nullary.Sum
-        MAlonzo.Code.Relation.Unary.Properties
-        MAlonzo.Code.Scoped
-        MAlonzo.Code.Scoped.CK
-        MAlonzo.Code.Scoped.Extrication
-        MAlonzo.Code.Scoped.Reduction
-        MAlonzo.Code.Scoped.RenamingSubstitution
-        MAlonzo.Code.Type
-        MAlonzo.Code.Type.BetaNBE
-        MAlonzo.Code.Type.BetaNBE.Completeness
-        MAlonzo.Code.Type.BetaNBE.RenamingSubstitution
-        MAlonzo.Code.Type.BetaNBE.Soundness
-        MAlonzo.Code.Type.BetaNBE.Stability
-        MAlonzo.Code.Type.BetaNormal
-        MAlonzo.Code.Type.BetaNormal.Equality
-        MAlonzo.Code.Type.Equality
-        MAlonzo.Code.Type.RenamingSubstitution
-        MAlonzo.Code.Utils
-        MAlonzo.RTE
-        Opts
-        Raw
+	Raw
         Scoped
-  build-depends: base,
-                 process,
-                 bytestring -any,
-                 text -any,
-                 ieee754 -any,
-                 cryptonite -any,
-                 memory -any,
-                 optparse-applicative -any,
-                 language-plutus-core -any
-  build-tool-depends: plutus-exe:plc
-
-
-test-suite test2-plc-agda
-    type: detailed-0.9
-    test-module: TestDetailed
-    build-depends: base -any,
-                   Cabal -any,
-                   process -any,
-                   bytestring -any,
-                   text -any,
-                   ieee754 -any,
-                   cryptonite -any,
-                   memory -any,
-                   optparse-applicative -any,
-                   language-plutus-core -any,
-                   directory -any
-    other-modules:
+        Opts
+  other-modules:
         MAlonzo.Code.Agda.Builtin.Bool
         MAlonzo.Code.Agda.Builtin.Char
         MAlonzo.Code.Agda.Builtin.Equality
@@ -408,7 +269,149 @@ test-suite test2-plc-agda
         MAlonzo.Code.Type.RenamingSubstitution
         MAlonzo.Code.Utils
         MAlonzo.RTE
-        Opts
-        Raw
+  build-depends: base,
+                 process,
+                 bytestring -any,
+                 text -any,
+                 ieee754 -any,
+                 cryptonite -any,
+                 memory -any,
+                 optparse-applicative -any,
+                 language-plutus-core -any
+  build-tool-depends: plutus-exe:plc
+
+
+test-suite test2-plc-agda
+    type: detailed-0.9
+    test-module: TestDetailed
+    build-depends: base -any,
+                   Cabal -any,
+                   process -any,
+                   bytestring -any,
+                   text -any,
+                   ieee754 -any,
+                   cryptonite -any,
+                   memory -any,
+                   optparse-applicative -any,
+                   language-plutus-core -any,
+                   directory -any
+  other-modules:
+	Raw
         Scoped
+        Opts
+  other-modules:
+        MAlonzo.Code.Agda.Builtin.Bool
+        MAlonzo.Code.Agda.Builtin.Char
+        MAlonzo.Code.Agda.Builtin.Equality
+        MAlonzo.Code.Agda.Builtin.IO
+        MAlonzo.Code.Agda.Builtin.Int
+        MAlonzo.Code.Agda.Builtin.List
+        MAlonzo.Code.Agda.Builtin.Nat
+        MAlonzo.Code.Agda.Builtin.Sigma
+        MAlonzo.Code.Agda.Builtin.String
+        MAlonzo.Code.Agda.Builtin.Unit
+        MAlonzo.Code.Agda.Primitive
+        MAlonzo.Code.Algebra
+        MAlonzo.Code.Algebra.FunctionProperties.Consequences
+        MAlonzo.Code.Algebra.Morphism
+        MAlonzo.Code.Algebra.Properties.BooleanAlgebra
+        MAlonzo.Code.Algebra.Properties.DistributiveLattice
+        MAlonzo.Code.Algebra.Properties.Lattice
+        MAlonzo.Code.Algebra.Properties.Semilattice
+        MAlonzo.Code.Algebra.Structures
+        MAlonzo.Code.Algorithmic
+        MAlonzo.Code.Algorithmic.CK
+        MAlonzo.Code.Algorithmic.Equality
+        MAlonzo.Code.Algorithmic.Reduction
+        MAlonzo.Code.Algorithmic.RenamingSubstitution
+        MAlonzo.Code.Builtin
+        MAlonzo.Code.Builtin.Constant.Term
+        MAlonzo.Code.Builtin.Constant.Type
+        MAlonzo.Code.Builtin.Signature
+        MAlonzo.Code.Category.Applicative.Indexed
+        MAlonzo.Code.Category.Functor
+        MAlonzo.Code.Category.Monad.Indexed
+        MAlonzo.Code.Check
+        MAlonzo.Code.Data.Bool.Base
+        MAlonzo.Code.Data.Bool.Properties
+        MAlonzo.Code.Data.Char.Properties
+        MAlonzo.Code.Data.Digit
+        MAlonzo.Code.Data.Empty
+        MAlonzo.Code.Data.Empty.Irrelevant
+        MAlonzo.Code.Data.Fin.Base
+        MAlonzo.Code.Data.Integer
+        MAlonzo.Code.Data.Integer.Base
+        MAlonzo.Code.Data.Integer.Properties
+        MAlonzo.Code.Data.List.Base
+        MAlonzo.Code.Data.List.NonEmpty
+        MAlonzo.Code.Data.List.Properties
+        MAlonzo.Code.Data.List.Relation.Binary.Lex.Core
+        MAlonzo.Code.Data.List.Relation.Binary.Lex.Strict
+        MAlonzo.Code.Data.List.Relation.Binary.Pointwise
+        MAlonzo.Code.Data.List.Relation.Unary.All
+        MAlonzo.Code.Data.List.Relation.Unary.Any
+        MAlonzo.Code.Data.Maybe.Base
+        MAlonzo.Code.Data.Nat.Base
+        MAlonzo.Code.Data.Nat.DivMod
+        MAlonzo.Code.Data.Nat.DivMod.Core
+        MAlonzo.Code.Data.Nat.Properties
+        MAlonzo.Code.Data.Nat.Show
+        MAlonzo.Code.Data.Product
+        MAlonzo.Code.Data.Sign
+        MAlonzo.Code.Data.String.Base
+        MAlonzo.Code.Data.String.Properties
+        MAlonzo.Code.Data.Sum.Base
+        MAlonzo.Code.Data.These
+        MAlonzo.Code.Data.Vec
+        MAlonzo.Code.Function.Bijection
+        MAlonzo.Code.Function.Equality
+        MAlonzo.Code.Function.Equivalence
+        MAlonzo.Code.Function.Injection
+        MAlonzo.Code.Function.Inverse
+        MAlonzo.Code.Function.LeftInverse
+        MAlonzo.Code.Function.Surjection
+        MAlonzo.Code.Induction
+        MAlonzo.Code.Induction.WellFounded
+        MAlonzo.Code.Level
+        MAlonzo.Code.Main
+        MAlonzo.Code.Raw
+        MAlonzo.Code.Relation.Binary
+        MAlonzo.Code.Relation.Binary.Consequences
+        MAlonzo.Code.Relation.Binary.Construct.NaturalOrder.Left
+        MAlonzo.Code.Relation.Binary.Construct.NonStrictToStrict
+        MAlonzo.Code.Relation.Binary.Construct.On
+        MAlonzo.Code.Relation.Binary.Core
+        MAlonzo.Code.Relation.Binary.Indexed.Heterogeneous
+        MAlonzo.Code.Relation.Binary.Indexed.Heterogeneous.Construct.Trivial
+        MAlonzo.Code.Relation.Binary.Lattice
+        MAlonzo.Code.Relation.Binary.Properties.Poset
+        MAlonzo.Code.Relation.Binary.Properties.Preorder
+        MAlonzo.Code.Relation.Binary.PropositionalEquality
+        MAlonzo.Code.Relation.Binary.PropositionalEquality.Core
+        MAlonzo.Code.Relation.Binary.Reasoning.Base.Single
+        MAlonzo.Code.Relation.Binary.Reasoning.Base.Triple
+        MAlonzo.Code.Relation.Binary.Reasoning.Setoid
+        MAlonzo.Code.Relation.Nullary
+        MAlonzo.Code.Relation.Nullary.Decidable
+        MAlonzo.Code.Relation.Nullary.Negation
+        MAlonzo.Code.Relation.Nullary.Product
+        MAlonzo.Code.Relation.Nullary.Sum
+        MAlonzo.Code.Relation.Unary.Properties
+        MAlonzo.Code.Scoped
+        MAlonzo.Code.Scoped.CK
+        MAlonzo.Code.Scoped.Extrication
+        MAlonzo.Code.Scoped.Reduction
+        MAlonzo.Code.Scoped.RenamingSubstitution
+        MAlonzo.Code.Type
+        MAlonzo.Code.Type.BetaNBE
+        MAlonzo.Code.Type.BetaNBE.Completeness
+        MAlonzo.Code.Type.BetaNBE.RenamingSubstitution
+        MAlonzo.Code.Type.BetaNBE.Soundness
+        MAlonzo.Code.Type.BetaNBE.Stability
+        MAlonzo.Code.Type.BetaNormal
+        MAlonzo.Code.Type.BetaNormal.Equality
+        MAlonzo.Code.Type.Equality
+        MAlonzo.Code.Type.RenamingSubstitution
+        MAlonzo.Code.Utils
+        MAlonzo.RTE
     build-tool-depends: plutus-exe:plc

--- a/metatheory/plc-agda.cabal
+++ b/metatheory/plc-agda.cabal
@@ -20,6 +20,120 @@ executable plc-agda
         Raw
         Scoped
         Opts
+        MAlonzo.Code.Main
+        MAlonzo.Code.Agda.Builtin.Bool
+        MAlonzo.Code.Agda.Builtin.Char
+        MAlonzo.Code.Agda.Builtin.Equality
+        MAlonzo.Code.Agda.Builtin.IO
+        MAlonzo.Code.Agda.Builtin.Int
+        MAlonzo.Code.Agda.Builtin.List
+        MAlonzo.Code.Agda.Builtin.Nat
+        MAlonzo.Code.Agda.Builtin.Sigma
+        MAlonzo.Code.Agda.Builtin.String
+        MAlonzo.Code.Agda.Builtin.Unit
+        MAlonzo.Code.Agda.Primitive
+        MAlonzo.Code.Algebra
+        MAlonzo.Code.Algebra.FunctionProperties.Consequences
+        MAlonzo.Code.Algebra.Morphism
+        MAlonzo.Code.Algebra.Properties.BooleanAlgebra
+        MAlonzo.Code.Algebra.Properties.DistributiveLattice
+        MAlonzo.Code.Algebra.Properties.Lattice
+        MAlonzo.Code.Algebra.Properties.Semilattice
+        MAlonzo.Code.Algebra.Structures
+        MAlonzo.Code.Builtin
+        MAlonzo.Code.Builtin.Constant.Term
+        MAlonzo.Code.Builtin.Constant.Type
+        MAlonzo.Code.Builtin.Signature
+        MAlonzo.Code.Category.Applicative.Indexed
+        MAlonzo.Code.Category.Functor
+        MAlonzo.Code.Category.Monad.Indexed
+        MAlonzo.Code.Data.Bool.Base
+        MAlonzo.Code.Data.Bool.Properties
+        MAlonzo.Code.Data.Char.Properties
+        MAlonzo.Code.Data.Digit
+        MAlonzo.Code.Data.Empty
+        MAlonzo.Code.Data.Empty.Irrelevant
+        MAlonzo.Code.Data.Fin.Base
+        MAlonzo.Code.Data.Integer
+        MAlonzo.Code.Data.Integer.Base
+        MAlonzo.Code.Data.Integer.Properties
+        MAlonzo.Code.Data.List.Base
+        MAlonzo.Code.Data.List.NonEmpty
+        MAlonzo.Code.Data.List.Properties
+        MAlonzo.Code.Data.List.Relation.Binary.Lex.Core
+        MAlonzo.Code.Data.List.Relation.Binary.Lex.Strict
+        MAlonzo.Code.Data.List.Relation.Binary.Pointwise
+        MAlonzo.Code.Data.List.Relation.Unary.All
+        MAlonzo.Code.Data.List.Relation.Unary.Any
+        MAlonzo.Code.Data.Maybe.Base
+        MAlonzo.Code.Data.Nat.Base
+        MAlonzo.Code.Data.Nat.DivMod
+        MAlonzo.Code.Data.Nat.DivMod.Core
+        MAlonzo.Code.Data.Nat.Properties
+        MAlonzo.Code.Data.Nat.Show
+        MAlonzo.Code.Data.Product
+        MAlonzo.Code.Data.Sign
+        MAlonzo.Code.Data.String.Base
+        MAlonzo.Code.Data.String.Properties
+        MAlonzo.Code.Data.Sum.Base
+        MAlonzo.Code.Data.These
+        MAlonzo.Code.Data.Vec
+        MAlonzo.Code.Function.Bijection
+        MAlonzo.Code.Function.Equality
+        MAlonzo.Code.Function.Equivalence
+        MAlonzo.Code.Function.Injection
+        MAlonzo.Code.Function.Inverse
+        MAlonzo.Code.Function.LeftInverse
+        MAlonzo.Code.Function.Surjection
+        MAlonzo.Code.Induction
+        MAlonzo.Code.Induction.WellFounded
+        MAlonzo.Code.Level
+        MAlonzo.Code.Raw
+        MAlonzo.Code.Relation.Binary
+        MAlonzo.Code.Relation.Binary.Consequences
+        MAlonzo.Code.Relation.Binary.Construct.NaturalOrder.Left
+        MAlonzo.Code.Relation.Binary.Construct.NonStrictToStrict
+        MAlonzo.Code.Relation.Binary.Construct.On
+        MAlonzo.Code.Relation.Binary.Core
+        MAlonzo.Code.Relation.Binary.Indexed.Heterogeneous
+        MAlonzo.Code.Relation.Binary.Indexed.Heterogeneous.Construct.Trivial
+        MAlonzo.Code.Relation.Binary.Lattice
+        MAlonzo.Code.Relation.Binary.Properties.Poset
+        MAlonzo.Code.Relation.Binary.Properties.Preorder
+        MAlonzo.Code.Relation.Binary.PropositionalEquality
+        MAlonzo.Code.Relation.Binary.PropositionalEquality.Core
+        MAlonzo.Code.Relation.Binary.Reasoning.Base.Single
+        MAlonzo.Code.Relation.Binary.Reasoning.Base.Triple
+        MAlonzo.Code.Relation.Binary.Reasoning.Setoid
+        MAlonzo.Code.Relation.Nullary
+        MAlonzo.Code.Relation.Nullary.Decidable
+        MAlonzo.Code.Relation.Nullary.Negation
+        MAlonzo.Code.Relation.Nullary.Product
+        MAlonzo.Code.Relation.Nullary.Sum
+        MAlonzo.Code.Relation.Unary.Properties
+        MAlonzo.Code.Scoped
+        MAlonzo.Code.Scoped.Reduction
+        MAlonzo.Code.Scoped.RenamingSubstitution
+        MAlonzo.Code.Type
+        MAlonzo.Code.Utils
+        MAlonzo.RTE
+        MAlonzo.Code.Algorithmic
+        MAlonzo.Code.Algorithmic.CK
+        MAlonzo.Code.Check
+        MAlonzo.Code.Scoped.CK
+        MAlonzo.Code.Scoped.Extrication
+        MAlonzo.Code.Type.BetaNBE
+        MAlonzo.Code.Type.BetaNBE.Completeness
+        MAlonzo.Code.Type.BetaNBE.Soundness
+        MAlonzo.Code.Type.BetaNBE.Stability
+        MAlonzo.Code.Type.BetaNBE.RenamingSubstitution
+        MAlonzo.Code.Type.BetaNormal
+        MAlonzo.Code.Type.BetaNormal.Equality
+        MAlonzo.Code.Type.Equality
+        MAlonzo.Code.Type.RenamingSubstitution
+        MAlonzo.Code.Algorithmic.Reduction
+        MAlonzo.Code.Algorithmic.RenamingSubstitution
+        MAlonzo.Code.Algorithmic.Equality
   autogen-modules:
         MAlonzo.Code.Main
         MAlonzo.Code.Agda.Builtin.Bool
@@ -151,9 +265,123 @@ test-suite test-plc-agda
   type:    exitcode-stdio-1.0
   main-is: TestSimple.hs
   other-modules:
-	Raw
+        Raw
         Scoped
         Opts
+        MAlonzo.Code.Main
+        MAlonzo.Code.Agda.Builtin.Bool
+        MAlonzo.Code.Agda.Builtin.Char
+        MAlonzo.Code.Agda.Builtin.Equality
+        MAlonzo.Code.Agda.Builtin.IO
+        MAlonzo.Code.Agda.Builtin.Int
+        MAlonzo.Code.Agda.Builtin.List
+        MAlonzo.Code.Agda.Builtin.Nat
+        MAlonzo.Code.Agda.Builtin.Sigma
+        MAlonzo.Code.Agda.Builtin.String
+        MAlonzo.Code.Agda.Builtin.Unit
+        MAlonzo.Code.Agda.Primitive
+        MAlonzo.Code.Algebra
+        MAlonzo.Code.Algebra.FunctionProperties.Consequences
+        MAlonzo.Code.Algebra.Morphism
+        MAlonzo.Code.Algebra.Properties.BooleanAlgebra
+        MAlonzo.Code.Algebra.Properties.DistributiveLattice
+        MAlonzo.Code.Algebra.Properties.Lattice
+        MAlonzo.Code.Algebra.Properties.Semilattice
+        MAlonzo.Code.Algebra.Structures
+        MAlonzo.Code.Builtin
+        MAlonzo.Code.Builtin.Constant.Term
+        MAlonzo.Code.Builtin.Constant.Type
+        MAlonzo.Code.Builtin.Signature
+        MAlonzo.Code.Category.Applicative.Indexed
+        MAlonzo.Code.Category.Functor
+        MAlonzo.Code.Category.Monad.Indexed
+        MAlonzo.Code.Data.Bool.Base
+        MAlonzo.Code.Data.Bool.Properties
+        MAlonzo.Code.Data.Char.Properties
+        MAlonzo.Code.Data.Digit
+        MAlonzo.Code.Data.Empty
+        MAlonzo.Code.Data.Empty.Irrelevant
+        MAlonzo.Code.Data.Fin.Base
+        MAlonzo.Code.Data.Integer
+        MAlonzo.Code.Data.Integer.Base
+        MAlonzo.Code.Data.Integer.Properties
+        MAlonzo.Code.Data.List.Base
+        MAlonzo.Code.Data.List.NonEmpty
+        MAlonzo.Code.Data.List.Properties
+        MAlonzo.Code.Data.List.Relation.Binary.Lex.Core
+        MAlonzo.Code.Data.List.Relation.Binary.Lex.Strict
+        MAlonzo.Code.Data.List.Relation.Binary.Pointwise
+        MAlonzo.Code.Data.List.Relation.Unary.All
+        MAlonzo.Code.Data.List.Relation.Unary.Any
+        MAlonzo.Code.Data.Maybe.Base
+        MAlonzo.Code.Data.Nat.Base
+        MAlonzo.Code.Data.Nat.DivMod
+        MAlonzo.Code.Data.Nat.DivMod.Core
+        MAlonzo.Code.Data.Nat.Properties
+        MAlonzo.Code.Data.Nat.Show
+        MAlonzo.Code.Data.Product
+        MAlonzo.Code.Data.Sign
+        MAlonzo.Code.Data.String.Base
+        MAlonzo.Code.Data.String.Properties
+        MAlonzo.Code.Data.Sum.Base
+        MAlonzo.Code.Data.These
+        MAlonzo.Code.Data.Vec
+        MAlonzo.Code.Function.Bijection
+        MAlonzo.Code.Function.Equality
+        MAlonzo.Code.Function.Equivalence
+        MAlonzo.Code.Function.Injection
+        MAlonzo.Code.Function.Inverse
+        MAlonzo.Code.Function.LeftInverse
+        MAlonzo.Code.Function.Surjection
+        MAlonzo.Code.Induction
+        MAlonzo.Code.Induction.WellFounded
+        MAlonzo.Code.Level
+        MAlonzo.Code.Raw
+        MAlonzo.Code.Relation.Binary
+        MAlonzo.Code.Relation.Binary.Consequences
+        MAlonzo.Code.Relation.Binary.Construct.NaturalOrder.Left
+        MAlonzo.Code.Relation.Binary.Construct.NonStrictToStrict
+        MAlonzo.Code.Relation.Binary.Construct.On
+        MAlonzo.Code.Relation.Binary.Core
+        MAlonzo.Code.Relation.Binary.Indexed.Heterogeneous
+        MAlonzo.Code.Relation.Binary.Indexed.Heterogeneous.Construct.Trivial
+        MAlonzo.Code.Relation.Binary.Lattice
+        MAlonzo.Code.Relation.Binary.Properties.Poset
+        MAlonzo.Code.Relation.Binary.Properties.Preorder
+        MAlonzo.Code.Relation.Binary.PropositionalEquality
+        MAlonzo.Code.Relation.Binary.PropositionalEquality.Core
+        MAlonzo.Code.Relation.Binary.Reasoning.Base.Single
+        MAlonzo.Code.Relation.Binary.Reasoning.Base.Triple
+        MAlonzo.Code.Relation.Binary.Reasoning.Setoid
+        MAlonzo.Code.Relation.Nullary
+        MAlonzo.Code.Relation.Nullary.Decidable
+        MAlonzo.Code.Relation.Nullary.Negation
+        MAlonzo.Code.Relation.Nullary.Product
+        MAlonzo.Code.Relation.Nullary.Sum
+        MAlonzo.Code.Relation.Unary.Properties
+        MAlonzo.Code.Scoped
+        MAlonzo.Code.Scoped.Reduction
+        MAlonzo.Code.Scoped.RenamingSubstitution
+        MAlonzo.Code.Type
+        MAlonzo.Code.Utils
+        MAlonzo.RTE
+        MAlonzo.Code.Algorithmic
+        MAlonzo.Code.Algorithmic.CK
+        MAlonzo.Code.Check
+        MAlonzo.Code.Scoped.CK
+        MAlonzo.Code.Scoped.Extrication
+        MAlonzo.Code.Type.BetaNBE
+        MAlonzo.Code.Type.BetaNBE.Completeness
+        MAlonzo.Code.Type.BetaNBE.Soundness
+        MAlonzo.Code.Type.BetaNBE.Stability
+        MAlonzo.Code.Type.BetaNBE.RenamingSubstitution
+        MAlonzo.Code.Type.BetaNormal
+        MAlonzo.Code.Type.BetaNormal.Equality
+        MAlonzo.Code.Type.Equality
+        MAlonzo.Code.Type.RenamingSubstitution
+        MAlonzo.Code.Algorithmic.Reduction
+        MAlonzo.Code.Algorithmic.RenamingSubstitution
+        MAlonzo.Code.Algorithmic.Equality
   autogen-modules:
         MAlonzo.Code.Agda.Builtin.Bool
         MAlonzo.Code.Agda.Builtin.Char
@@ -282,23 +510,137 @@ test-suite test-plc-agda
 
 
 test-suite test2-plc-agda
-    type: detailed-0.9
-    test-module: TestDetailed
-    build-depends: base -any,
-                   Cabal -any,
-                   process -any,
-                   bytestring -any,
-                   text -any,
-                   ieee754 -any,
-                   cryptonite -any,
-                   memory -any,
-                   optparse-applicative -any,
-                   language-plutus-core -any,
-                   directory -any
+  type: detailed-0.9
+  test-module: TestDetailed
+  build-depends: base -any,
+                 Cabal -any,
+                 process -any,
+                 bytestring -any,
+                 text -any,
+                 ieee754 -any,
+                 cryptonite -any,
+                 memory -any,
+                 optparse-applicative -any,
+                 language-plutus-core -any,
+                 directory -any
   other-modules:
-	Raw
+        Raw
         Scoped
         Opts
+        MAlonzo.Code.Main
+        MAlonzo.Code.Agda.Builtin.Bool
+        MAlonzo.Code.Agda.Builtin.Char
+        MAlonzo.Code.Agda.Builtin.Equality
+        MAlonzo.Code.Agda.Builtin.IO
+        MAlonzo.Code.Agda.Builtin.Int
+        MAlonzo.Code.Agda.Builtin.List
+        MAlonzo.Code.Agda.Builtin.Nat
+        MAlonzo.Code.Agda.Builtin.Sigma
+        MAlonzo.Code.Agda.Builtin.String
+        MAlonzo.Code.Agda.Builtin.Unit
+        MAlonzo.Code.Agda.Primitive
+        MAlonzo.Code.Algebra
+        MAlonzo.Code.Algebra.FunctionProperties.Consequences
+        MAlonzo.Code.Algebra.Morphism
+        MAlonzo.Code.Algebra.Properties.BooleanAlgebra
+        MAlonzo.Code.Algebra.Properties.DistributiveLattice
+        MAlonzo.Code.Algebra.Properties.Lattice
+        MAlonzo.Code.Algebra.Properties.Semilattice
+        MAlonzo.Code.Algebra.Structures
+        MAlonzo.Code.Builtin
+        MAlonzo.Code.Builtin.Constant.Term
+        MAlonzo.Code.Builtin.Constant.Type
+        MAlonzo.Code.Builtin.Signature
+        MAlonzo.Code.Category.Applicative.Indexed
+        MAlonzo.Code.Category.Functor
+        MAlonzo.Code.Category.Monad.Indexed
+        MAlonzo.Code.Data.Bool.Base
+        MAlonzo.Code.Data.Bool.Properties
+        MAlonzo.Code.Data.Char.Properties
+        MAlonzo.Code.Data.Digit
+        MAlonzo.Code.Data.Empty
+        MAlonzo.Code.Data.Empty.Irrelevant
+        MAlonzo.Code.Data.Fin.Base
+        MAlonzo.Code.Data.Integer
+        MAlonzo.Code.Data.Integer.Base
+        MAlonzo.Code.Data.Integer.Properties
+        MAlonzo.Code.Data.List.Base
+        MAlonzo.Code.Data.List.NonEmpty
+        MAlonzo.Code.Data.List.Properties
+        MAlonzo.Code.Data.List.Relation.Binary.Lex.Core
+        MAlonzo.Code.Data.List.Relation.Binary.Lex.Strict
+        MAlonzo.Code.Data.List.Relation.Binary.Pointwise
+        MAlonzo.Code.Data.List.Relation.Unary.All
+        MAlonzo.Code.Data.List.Relation.Unary.Any
+        MAlonzo.Code.Data.Maybe.Base
+        MAlonzo.Code.Data.Nat.Base
+        MAlonzo.Code.Data.Nat.DivMod
+        MAlonzo.Code.Data.Nat.DivMod.Core
+        MAlonzo.Code.Data.Nat.Properties
+        MAlonzo.Code.Data.Nat.Show
+        MAlonzo.Code.Data.Product
+        MAlonzo.Code.Data.Sign
+        MAlonzo.Code.Data.String.Base
+        MAlonzo.Code.Data.String.Properties
+        MAlonzo.Code.Data.Sum.Base
+        MAlonzo.Code.Data.These
+        MAlonzo.Code.Data.Vec
+        MAlonzo.Code.Function.Bijection
+        MAlonzo.Code.Function.Equality
+        MAlonzo.Code.Function.Equivalence
+        MAlonzo.Code.Function.Injection
+        MAlonzo.Code.Function.Inverse
+        MAlonzo.Code.Function.LeftInverse
+        MAlonzo.Code.Function.Surjection
+        MAlonzo.Code.Induction
+        MAlonzo.Code.Induction.WellFounded
+        MAlonzo.Code.Level
+        MAlonzo.Code.Raw
+        MAlonzo.Code.Relation.Binary
+        MAlonzo.Code.Relation.Binary.Consequences
+        MAlonzo.Code.Relation.Binary.Construct.NaturalOrder.Left
+        MAlonzo.Code.Relation.Binary.Construct.NonStrictToStrict
+        MAlonzo.Code.Relation.Binary.Construct.On
+        MAlonzo.Code.Relation.Binary.Core
+        MAlonzo.Code.Relation.Binary.Indexed.Heterogeneous
+        MAlonzo.Code.Relation.Binary.Indexed.Heterogeneous.Construct.Trivial
+        MAlonzo.Code.Relation.Binary.Lattice
+        MAlonzo.Code.Relation.Binary.Properties.Poset
+        MAlonzo.Code.Relation.Binary.Properties.Preorder
+        MAlonzo.Code.Relation.Binary.PropositionalEquality
+        MAlonzo.Code.Relation.Binary.PropositionalEquality.Core
+        MAlonzo.Code.Relation.Binary.Reasoning.Base.Single
+        MAlonzo.Code.Relation.Binary.Reasoning.Base.Triple
+        MAlonzo.Code.Relation.Binary.Reasoning.Setoid
+        MAlonzo.Code.Relation.Nullary
+        MAlonzo.Code.Relation.Nullary.Decidable
+        MAlonzo.Code.Relation.Nullary.Negation
+        MAlonzo.Code.Relation.Nullary.Product
+        MAlonzo.Code.Relation.Nullary.Sum
+        MAlonzo.Code.Relation.Unary.Properties
+        MAlonzo.Code.Scoped
+        MAlonzo.Code.Scoped.Reduction
+        MAlonzo.Code.Scoped.RenamingSubstitution
+        MAlonzo.Code.Type
+        MAlonzo.Code.Utils
+        MAlonzo.RTE
+        MAlonzo.Code.Algorithmic
+        MAlonzo.Code.Algorithmic.CK
+        MAlonzo.Code.Check
+        MAlonzo.Code.Scoped.CK
+        MAlonzo.Code.Scoped.Extrication
+        MAlonzo.Code.Type.BetaNBE
+        MAlonzo.Code.Type.BetaNBE.Completeness
+        MAlonzo.Code.Type.BetaNBE.Soundness
+        MAlonzo.Code.Type.BetaNBE.Stability
+        MAlonzo.Code.Type.BetaNBE.RenamingSubstitution
+        MAlonzo.Code.Type.BetaNormal
+        MAlonzo.Code.Type.BetaNormal.Equality
+        MAlonzo.Code.Type.Equality
+        MAlonzo.Code.Type.RenamingSubstitution
+        MAlonzo.Code.Algorithmic.Reduction
+        MAlonzo.Code.Algorithmic.RenamingSubstitution
+        MAlonzo.Code.Algorithmic.Equality
   autogen-modules:
         MAlonzo.Code.Agda.Builtin.Bool
         MAlonzo.Code.Agda.Builtin.Char
@@ -414,4 +756,5 @@ test-suite test2-plc-agda
         MAlonzo.Code.Type.RenamingSubstitution
         MAlonzo.Code.Utils
         MAlonzo.RTE
-    build-tool-depends: plutus-exe:plc
+  build-tool-depends: plutus-exe:plc
+  


### PR DESCRIPTION
With `metatheory` listed as a package in `cabal.project`
```
$ cabal v2-install language-plutus-core
```
gives this error message:
```
...
cabal: Error: Could not find module: MAlonzo.Code.Main with any suffix:
["gc","chs","hsc","x","y","ly","cpphs","hs","lhs","hsig","lhsig"]. If the
module is autogenerated it should be added to 'autogen-modules'.
```

The modules `MAlonzo.*` are autogenerated. I tried moving them from `other-modules` to `autogen-modules` in `metatheory/plc-agda.cabal` as suggested by the error message. It seems to work for me. 