### PR TITLE
Playground: Fixing a bug with PayToWallet.

### DIFF
--- a/plutus-playground-lib/src/Playground/Contract.hs
+++ b/plutus-playground-lib/src/Playground/Contract.hs
@@ -1,5 +1,8 @@
 -- | Re-export functions that are needed when creating a Contract for use in the playground
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DerivingStrategies  #-}
 {-# LANGUAGE ExplicitNamespaces  #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE MonoLocalBinds      #-}
@@ -88,7 +91,7 @@ import           Language.Plutus.Contract.Trace                  (TraceError (..
 import           Ledger.Interval                                 (always, interval)
 import           Ledger.Scripts                                  (ValidatorHash (ValidatorHash))
 import           Ledger.Tx                                       (Tx, TxOutRef (TxOutRef), txOutRefId)
-import           Ledger.Value                                    (TokenName (TokenName), Value)
+import           Ledger.Value                                    (TokenName (TokenName))
 import           Playground.Interpreter.Util
 import           Playground.Schema                               (endpointsToSchemas)
 import           Playground.TH                                   (ensureIotsDefinitions, ensureKnownCurrencies,
@@ -96,15 +99,18 @@ import           Playground.TH                                   (ensureIotsDefi
                                                                   mkKnownCurrencies, mkSchemaDefinitions,
                                                                   mkSingleFunction)
 import           Playground.Types                                (Expression, FunctionSchema,
-                                                                  KnownCurrency (KnownCurrency), adaCurrency)
+                                                                  KnownCurrency (KnownCurrency),
+                                                                  PayToWalletParams (PayToWalletParams), adaCurrency,
+                                                                  payTo, value)
 import           Schema                                          (FormSchema, ToSchema)
 import           Wallet.API                                      (WalletAPI, payToPublicKey_)
 import           Wallet.Emulator                                 (addBlocksAndNotify, walletPubKey)
 import qualified Wallet.Emulator                                 as Emulator
 import           Wallet.Emulator.Types                           (MockWallet, Trace, Wallet (..))
 
-payToWallet_ :: (Monad m, WalletAPI m) => Value -> Wallet -> m ()
-payToWallet_ v = payToPublicKey_ always v . walletPubKey
+payToWallet_ :: (Monad m, WalletAPI m) => PayToWalletParams -> m ()
+payToWallet_ PayToWalletParams {value, payTo} =
+    payToPublicKey_ always value $ walletPubKey payTo
 
 runWalletActionAndProcessPending :: [Wallet] -> Wallet -> m a -> Trace m [Tx]
 runWalletActionAndProcessPending wllts wllt a =

--- a/plutus-playground-lib/src/Playground/Types.hs
+++ b/plutus-playground-lib/src/Playground/Types.hs
@@ -29,7 +29,7 @@ import qualified Ledger.Ada                   as Ada
 import           Ledger.Scripts               (ValidatorHash)
 import           Ledger.Value                 (TokenName)
 import qualified Ledger.Value                 as V
-import           Schema                       (FormSchema)
+import           Schema                       (FormSchema,ToSchema)
 import           Wallet.Emulator.Types        (EmulatorEvent, Wallet, walletPubKey)
 import           Wallet.Rollup.Types          (AnnotatedTx)
 
@@ -61,17 +61,20 @@ data Expression (schema :: Row *)
     = AddBlocks
           { blocks :: Int
           }
-    | PayToWallet
-          { source :: Wallet
-          , destination :: Wallet
-          , value :: V.Value
-          }
     | CallEndpoint
           { endpointName :: EndpointName
           , wallet :: Wallet
           , arguments :: JSON.Value
           }
     deriving (Show, Generic, ToJSON, FromJSON)
+
+data PayToWalletParams =
+    PayToWalletParams
+        { payTo :: Wallet
+        , value :: V.Value
+        }
+    deriving (Eq, Show, Generic)
+    deriving anyclass (FromJSON, ToJSON, ToSchema)
 
 type Program schema = [Expression schema]
 

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -77,7 +77,6 @@ vestingTest =
                   compile vesting
               assertEqual
                   ""
-                  result
                   [ FunctionSchema
                         { functionName = EndpointName "retrieve funds"
                         , argumentSchema = [FormSchemaValue]
@@ -94,6 +93,7 @@ vestingTest =
                               ]
                         }
                   ]
+                  result
         , testCase "should run simple evaluation" $
           evaluate simpleEvaluation >>=
           hasFundsDistribution

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -26,11 +26,12 @@ import qualified Playground.Interpreter       as PI
 import           Playground.Types             (CompilationResult (CompilationResult), EndpointName (EndpointName),
                                                Evaluation (Evaluation, program, sourceCode, wallets),
                                                EvaluationResult (EvaluationResult, emulatorLog, fundsDistribution, resultBlockchain, walletKeys),
-                                               Expression (AddBlocks, CallEndpoint, PayToWallet, arguments, destination, endpointName, source, value, wallet),
-                                               FunctionSchema (FunctionSchema), KnownCurrency (KnownCurrency),
-                                               PlaygroundError, SimulatorWallet (SimulatorWallet), adaCurrency,
-                                               argumentSchema, functionName, simulatorWalletBalance,
-                                               simulatorWalletWallet)
+                                               Expression (AddBlocks, CallEndpoint), FunctionSchema (FunctionSchema),
+                                               KnownCurrency (KnownCurrency),
+                                               PayToWalletParams (PayToWalletParams, payTo, value), PlaygroundError,
+                                               SimulatorWallet (SimulatorWallet), adaCurrency, argumentSchema,
+                                               arguments, endpointName, functionName, simulatorWalletBalance,
+                                               simulatorWalletWallet, wallet)
 import           Playground.Usecases          (crowdfunding, errorHandling, game, vesting)
 import           Schema                       (FormSchema (FormSchemaInt, FormSchemaObject, FormSchemaUnit, FormSchemaValue))
 import           Test.Tasty                   (TestTree, testGroup)
@@ -88,8 +89,12 @@ vestingTest =
                   , FunctionSchema
                         { functionName = EndpointName "payToWallet_"
                         , argumentSchema =
-                              [ FormSchemaValue
-                              , FormSchemaObject [("getWallet", FormSchemaInt)]
+                              [ FormSchemaObject
+                                    [ ( "payTo"
+                                      , FormSchemaObject
+                                            [("getWallet", FormSchemaInt)])
+                                    , ("value", FormSchemaValue)
+                                    ]
                               ]
                         }
                   ]
@@ -281,16 +286,20 @@ gameTest =
                   ]
             , program =
                   toJSONString
-                      [ PayToWallet
-                            {source = a, destination = b, value = nineAda}
-                      , PayToWallet
-                            {source = b, destination = c, value = nineAda}
-                      , PayToWallet
-                            {source = c, destination = a, value = nineAda}
+                      [ transfer a b nineAda
+                      , transfer b c nineAda
+                      , transfer c a nineAda
                       ]
             }
     nineAda = Ada.adaValueOf 9
     twoAda = Ada.adaOf 2
+    transfer wallet payTo value =
+        CallEndpoint
+            { endpointName = EndpointName "payToWallet_"
+            , wallet
+            , arguments =
+                  toEndpointParam $ JSON.toJSON $ PayToWalletParams {payTo, value}
+            }
 
 hasFundsDistribution ::
        [SimulatorWallet]


### PR DESCRIPTION
We were getting JSON decoding errors when the frontend sent a
`payToWallet_` call. This fixes it by handling more like a every other
contract schema call. (It still needs a bit of special handling, but not
nearly as much.)