### PR TITLE
Correcting some of our JSON instances to work correctly with purescript-bridge.

### DIFF
--- a/plutus-wallet-api/ledger/Ledger/Address.hs
+++ b/plutus-wallet-api/ledger/Ledger/Address.hs
@@ -31,9 +31,9 @@ import           Ledger.Scripts
 -- | A payment address using a hash as the id.
 newtype Address = Address { getAddress :: BSL.ByteString }
     deriving stock (Eq, Ord, Show, Generic)
-    deriving anyclass (IotsType)
+    deriving anyclass (ToJSON, FromJSON, ToJSONKey, FromJSONKey, IotsType)
     deriving newtype (Serialise)
-    deriving (ToJSON, FromJSON, ToJSONKey, FromJSONKey, IsString) via LedgerBytes
+    deriving (IsString) via LedgerBytes
     deriving Pretty via LedgerBytes
 
 instance Hashable Address where

--- a/plutus-wallet-api/ledger/Ledger/Scripts.hs
+++ b/plutus-wallet-api/ledger/Ledger/Scripts.hs
@@ -243,10 +243,10 @@ instance BA.ByteArrayAccess RedeemerScript where
 -- | Script runtime representation of a @Digest SHA256@.
 newtype ValidatorHash =
     ValidatorHash Builtins.ByteString
-    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON, Pretty) via LedgerBytes
+    deriving (IsString, Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
-    deriving anyclass (ToSchema)
+    deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey, ToSchema)
 
 instance IotsType ValidatorHash where
     iotsDefinition = iotsDefinition @LedgerBytes
@@ -254,9 +254,10 @@ instance IotsType ValidatorHash where
 -- | Script runtime representation of a @Digest SHA256@.
 newtype DataScriptHash =
     DataScriptHash Builtins.ByteString
-    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON, Pretty) via LedgerBytes
+    deriving (IsString, Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
+    deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey, ToSchema)
 
 instance IotsType DataScriptHash where
     iotsDefinition = iotsDefinition @LedgerBytes
@@ -264,9 +265,10 @@ instance IotsType DataScriptHash where
 -- | Script runtime representation of a @Digest SHA256@.
 newtype RedeemerHash =
     RedeemerHash Builtins.ByteString
-    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, FromJSON, ToJSON, Pretty) via LedgerBytes
+    deriving (IsString, Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, Hashable, IsData)
+    deriving anyclass (FromJSON, ToJSON, ToJSONKey, FromJSONKey, ToSchema)
 
 instance IotsType RedeemerHash where
     iotsDefinition = iotsDefinition @LedgerBytes

--- a/plutus-wallet-api/ledger/Ledger/TxId.hs
+++ b/plutus-wallet-api/ledger/Ledger/TxId.hs
@@ -24,9 +24,9 @@ import           Schema                    (ToSchema)
 -- | A transaction ID, using a SHA256 hash as the transaction id.
 newtype TxId = TxId { getTxId :: BSL.ByteString }
     deriving (Eq, Ord, Generic, Show)
-    deriving anyclass (ToSchema, IotsType)
+    deriving anyclass (ToJSON, FromJSON, ToSchema, IotsType)
     deriving newtype (PlutusTx.Eq, PlutusTx.Ord, Serialise)
-    deriving (ToJSON, FromJSON, Pretty) via LedgerBytes
+    deriving (Pretty) via LedgerBytes
 
 PlutusTx.makeLift ''TxId
 PlutusTx.makeIsData ''TxId

--- a/plutus-wallet-api/ledger/Ledger/Value.hs
+++ b/plutus-wallet-api/ledger/Ledger/Value.hs
@@ -67,10 +67,10 @@ import           IOTS                         (IotsType)
 import           Ledger.Orphans               ()
 
 newtype CurrencySymbol = CurrencySymbol { unCurrencySymbol :: Builtins.ByteString }
-    deriving (IsString, Show, ToJSONKey, FromJSONKey, Serialise, Pretty) via LedgerBytes
+    deriving (IsString, Show, Serialise, Pretty) via LedgerBytes
     deriving stock (Generic)
     deriving newtype (Haskell.Eq, Haskell.Ord, Eq, Ord, PlutusTx.IsData)
-    deriving anyclass (Hashable, ToSchema, IotsType)
+    deriving anyclass (Hashable, ToJSONKey, FromJSONKey, ToSchema, IotsType)
 
 instance ToJSON CurrencySymbol where
   toJSON currencySymbol =


### PR DESCRIPTION
psbridge assumes that all JSON instances for newtypes will be derived
from `anyclass`, so if they go to the frontend, they must be.

(This isn't really psbridge's fault. It's weird that Aeson has
different representations for different deriving strategies. I guess
psbridge has to pick one.)