### PR TITLE
Making our code-formatting tools available from devTools.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -473,15 +473,19 @@ let
         '';
       };
 
-      withDevTools = env: env.overrideAttrs (attrs: { nativeBuildInputs = attrs.nativeBuildInputs ++ 
-                                                                        [ packages.cabal-install 
-                                                                          pkgs.git 
-                                                                          pkgs.cacert 
-                                                                          pkgs.yarn
-                                                                          easyPS.purs
-                                                                          easyPS.spago
-                                                                          easyPS.purty
-                                                                          ]; });
+      withDevTools = env: env.overrideAttrs (attrs:
+        { nativeBuildInputs = attrs.nativeBuildInputs ++
+                              [ packages.cabal-install
+                                pkgs.git
+                                pkgs.cacert
+                                pkgs.haskellPackages.hlint
+                                pkgs.haskellPackages.stylish-haskell
+                                pkgs.yarn
+                                easyPS.purs
+                                easyPS.spago
+                                easyPS.purty
+                              ];
+        });
     };
   });
 


### PR DESCRIPTION
This makes it easy to ensure we're using the same version as the
project.