### PR TITLE
contracts: Update MultiSigStateMachine

### DIFF
--- a/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
+++ b/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
@@ -1,56 +1,69 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE TypeApplications         #-}
-{-# LANGUAGE ScopedTypeVariables         #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -fno-strictness #-}
+{-# LANGUAGE MonoLocalBinds      #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# OPTIONS_GHC -fno-strictness  #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 {-# OPTIONS -fplugin-opt Language.PlutusTx.Plugin:debug-context #-}
 module Spec.MultiSigStateMachine(tests) where
 
-import           Control.Monad                                                 (foldM, foldM_, void, (>=>))
-import           Data.Either                                                   (isLeft, isRight)
-import           Data.Foldable                                                 (traverse_)
-import qualified Data.Map                                                      as Map
-import           Test.Tasty                                                    (TestTree, testGroup)
-import qualified Test.Tasty.HUnit                                              as HUnit
+import           Data.Foldable                                   (traverse_)
+import           Test.Tasty                                      (TestTree, testGroup)
+import qualified Test.Tasty.HUnit                                as HUnit
 
-import           Spec.Lib                                                      as Lib
+import           Spec.Lib                                        as Lib
 
-import qualified Ledger.Ada                                                    as Ada
-import qualified Ledger.Typed.Scripts                                          as Scripts
-import           Ledger.Value                                                  (Value, scale)
-import           Wallet.API                                                    (WalletAPI,
-                                                                                WalletDiagnostics)
-import qualified Wallet.Emulator                                               as EM
+import           Language.PlutusTx.Lattice
+import qualified Ledger.Ada                                      as Ada
+import           Ledger.Index                                    (ValidationError(ScriptFailure))
+import           Ledger.Scripts                                  (ScriptError(EvaluationError))
+import           Ledger.TxId                                     (TxId)
+import qualified Ledger.Typed.Scripts                            as Scripts
+import qualified Wallet.Emulator                                 as EM
 
 import qualified Language.PlutusTx as PlutusTx
+import           Language.Plutus.Contract.Test
 
-import           Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine (Payment, State)
+import           Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine (MultiSigSchema, MultiSigError)
 import qualified Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine as MS
 
 tests :: TestTree
-tests = testGroup "multi sig state machine tests" [
-    HUnit.testCaseSteps "lock, propose, sign 3x, pay - SUCCESS" (runTrace (lockProposeSignPay 3 1) isRight),
-    HUnit.testCaseSteps "lock, propose, sign 2x, pay - FAILURE" (runTrace (lockProposeSignPay 2 1) isLeft),
-    HUnit.testCaseSteps "lock, propose, sign 3x, pay x2 - SUCCESS" (runTrace (lockProposeSignPay 3 2) isRight),
-    HUnit.testCaseSteps "lock, propose, sign 3x, pay x3 - FAILURE" (runTrace (lockProposeSignPay 3 3) isLeft),
-    Lib.goldenPir "test/Spec/multisigStateMachine.pir" $$(PlutusTx.compile [|| MS.mkValidator ||]),
-    HUnit.testCase "script size is reasonable" (Lib.reasonable (Scripts.validatorScript $ MS.scriptInstance params) 50000)
+tests = 
+    testGroup "multi sig state machine tests"
+    [ checkPredicate @MultiSigSchema @MultiSigError "lock, propose, sign 3x, pay - SUCCESS"
+        (MS.contract params)
+        (assertNoFailedTransactions
+        /\ walletFundsChange w1 (Ada.lovelaceValueOf (-10))
+        /\ walletFundsChange w2 (Ada.lovelaceValueOf 5))
+        (lockProposeSignPay 3 1)
+
+    , checkPredicate @MultiSigSchema @MultiSigError "lock, propose, sign 2x, pay - FAILURE"
+        (MS.contract params)
+        (assertFailedTransaction checkScriptError
+        /\ walletFundsChange w1 (Ada.lovelaceValueOf (-10))
+        /\ walletFundsChange w2 (Ada.lovelaceValueOf 0))
+        (lockProposeSignPay 2 1)
+
+    , checkPredicate @MultiSigSchema @MultiSigError "lock, propose, sign 3x, pay x2 - SUCCESS"
+        (MS.contract params)
+        (assertNoFailedTransactions
+        /\ walletFundsChange w1 (Ada.lovelaceValueOf (-10))
+        /\ walletFundsChange w2 (Ada.lovelaceValueOf 10))
+        (lockProposeSignPay 3 2)
+
+        , checkPredicate @MultiSigSchema @MultiSigError "lock, propose, sign 3x, pay x3 - FAILURE"
+            (MS.contract params)
+            (assertContractError w1 (\case { ContractError MS.MSContractStateNotFound -> True; _ -> False}) "contract should fail"
+            /\ walletFundsChange w1 (Ada.lovelaceValueOf (-10))
+            /\ walletFundsChange w2 (Ada.lovelaceValueOf 10))
+            (lockProposeSignPay 3 3)
+
+    , Lib.goldenPir "test/Spec/multisigStateMachine.pir" $$(PlutusTx.compile [|| MS.mkValidator ||])
+    , HUnit.testCase "script size is reasonable" (Lib.reasonable (Scripts.validatorScript $ MS.scriptInstance params) 50000)
     ]
-
-runTrace :: EM.EmulatorAction EM.AssertionError a -> (Either EM.AssertionError a -> Bool) -> (String -> IO ()) -> IO ()
-runTrace t f step = do
-    let initialState = EM.emulatorStateInitialDist (Map.singleton (EM.walletPubKey (EM.Wallet 1)) (Ada.adaValueOf 10))
-        (result, st) = EM.runEmulator initialState t
-    if f result
-    then pure ()
-    else do
-        step (show $ EM.emLog st)
-        HUnit.assertFailure "transaction failed to validate"
-
-processAndNotify :: EM.Trace m ()
-processAndNotify = void (EM.addBlocksAndNotify [w1, w2, w3] 1)
 
 w1, w2, w3 :: EM.Wallet
 w1 = EM.Wallet 1
@@ -62,64 +75,41 @@ params :: MS.Params
 params = MS.Params keys 3 where
     keys = EM.walletPubKey . EM.Wallet <$> [1..5]
 
+checkScriptError :: TxId -> ValidationError -> Bool
+checkScriptError _ = \case
+    ScriptFailure (EvaluationError ["State transition invalid - checks failed"]) -> True
+    _ -> False
+
 -- | A payment of 5 Ada to the public key address of wallet 2
 payment :: MS.Payment
 payment =
     MS.Payment
-        { MS.paymentAmount    = Ada.adaValueOf 5
+        { MS.paymentAmount    = Ada.lovelaceValueOf 5
         , MS.paymentRecipient = EM.walletPubKey w2
         , MS.paymentDeadline  = 20
         }
 
-initialise' :: WalletAPI m => m ()
-initialise' = MS.initialise params
+-- | Lock some funds in the contract, then propose the payment
+--   'payment', then call @"add-signature"@ a number of times and
+--   finally call @"pay"@ a number of times.
+lockProposeSignPay 
+    :: MonadEmulator (TraceError MultiSigError) m
+    => Integer
+    -> Integer
+    -> ContractTrace MultiSigSchema MultiSigError m a ()
+lockProposeSignPay signatures rounds = do
+    callEndpoint @"lock" w1 (Ada.lovelaceValueOf 10)
+    handleBlockchainEvents w1
 
--- State machine transitions partially applied to the 'payment' multisig contract
+    let proposeSignPay = do
+            callEndpoint @"propose-payment" w2 payment
+            handleBlockchainEvents w2
 
-lock' :: (WalletAPI m, WalletDiagnostics m) => Value -> m State
-lock' = MS.lock params
+            -- Call @"add-signature"@ @signatures@ times
+            traverse_ (\wllt -> callEndpoint @"add-signature" wllt () >> handleBlockchainEvents wllt) (EM.Wallet <$> [1..signatures])
 
-proposePayment' :: (WalletAPI m, WalletDiagnostics m) => State -> Payment -> m State
-proposePayment' = MS.proposePayment params
+            -- Call @"pay"@ on wallet 1
+            callEndpoint @"pay" w1 ()
+            handleBlockchainEvents w1
 
-addSignature' :: (WalletAPI m, WalletDiagnostics m) => State -> m State
-addSignature' = MS.addSignature params
-
-makePayment' :: (WalletAPI m, WalletDiagnostics m) => State -> m State
-makePayment' = MS.makePayment params
-
-initialise'' :: WalletAPI m => EM.Trace m ()
-initialise'' =
-    -- instruct all three wallets to start watching the contract address
-    traverse_ (\w -> EM.walletAction w initialise') [w1, w2, w3]
-
-lock'' :: (WalletAPI m, WalletDiagnostics m) => Value -> EM.Trace m State
--- wallet 1 locks the funds
-lock'' value = processAndNotify >> fst <$> EM.walletAction w1 (lock' value)
-
-proposePayment'' :: (WalletAPI m, WalletDiagnostics m) => State -> EM.Trace m State
-proposePayment'' st = processAndNotify >> fst <$> EM.walletAction w2 (proposePayment' st payment)
-
-addSignature'' :: (WalletAPI m, WalletDiagnostics m) => Integer -> State -> EM.Trace m State
--- i wallets add their signatures
-addSignature'' i inSt = foldM (\st w -> (processAndNotify >> fst <$> EM.walletAction w (addSignature' st))) inSt (take (fromIntegral i) [w1, w2, w3])
-
-makePayment'' :: (WalletAPI m, WalletDiagnostics m) => State -> EM.Trace m State
-makePayment'' st = processAndNotify >> fst <$> EM.walletAction w3 (makePayment' st)
-
-proposeSignPay :: (WalletAPI m, WalletDiagnostics m) => Integer -> State -> EM.Trace m State
-proposeSignPay i = proposePayment'' >=> addSignature'' i >=> makePayment''
-
-lockProposeSignPay :: forall e m . (EM.MonadEmulator e m) => Integer -> Integer -> m ()
-lockProposeSignPay i j = EM.processEmulated $ do
-
-    -- stX contain the state of the contract. See note [Current state of the
-    -- contract] in
-    -- Language.PlutusTx.Coordination.Contracts.MultiSigStateMachine
-    initialise''
-    st1 <- lock'' (Ada.adaValueOf 10)
-
-    foldM_ (\st _ -> proposeSignPay i st) st1 [1..j]
-
-    processAndNotify
-    EM.assertOwnFundsEq w2 (scale j (Ada.adaValueOf 5))
+    traverse_ (\_ -> proposeSignPay) [1..rounds]


### PR DESCRIPTION
* Use the new contracts API in `MultiSigStateMachine`
* It now gets the current state of the contract from the chain (an improvement over the old version), but doing this is still a bit awkward
* Tests and error handling are also better now
* I tried to use the state machine & typed transaction libs where possible but I think what we really need is a `TypedUnbalancedTx`