### PR TITLE
wallet-api: delete event handlers

### DIFF
--- a/plutus-tutorial/doctest/Main.hs
+++ b/plutus-tutorial/doctest/Main.hs
@@ -2,8 +2,7 @@ module Main where
 
 import           Tutorial.PlutusTx         ()
 import           Tutorial.ValidatorScripts ()
-import           Tutorial.WalletAPI        ()
+--import           Tutorial.WalletAPI        ()
 
 main :: IO ()
 main = pure ()
-

--- a/plutus-tutorial/plutus-tutorial.cabal
+++ b/plutus-tutorial/plutus-tutorial.cabal
@@ -42,7 +42,7 @@ common lang
                  -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
 
     if flag(defer-plugin-errors)
-        ghc-options: -fplugin-opt Language.PlutusTx.Plugin:defer-errors
+
 
 executable tutorial-doctests
     import: lang
@@ -52,7 +52,9 @@ executable tutorial-doctests
     build-tool-depends: unlit:unlit -any, doctest:doctest -any
     other-modules:
       Tutorial.PlutusTx
-      Tutorial.WalletAPI
+      -- This module relies on triggers, which are removed, and generally needs to be rewritten for the
+      -- new API
+      --Tutorial.WalletAPI
       Tutorial.ValidatorScripts
       Tutorial.Vesting
     build-depends:


### PR DESCRIPTION
They're unused, and a pain to support.

I've just turned off the tutorial module that uses them - it needs to be rewritten with the new API anyway.