### PR TITLE
[PLC] [Test] Explicit errors in 'TypeEvalCheck' tests

### DIFF
--- a/language-plutus-core/common/PlcTestUtils.hs
+++ b/language-plutus-core/common/PlcTestUtils.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeApplications      #-}
 module PlcTestUtils (
     GetProgram(..),
+    pureTry,
     catchAll,
     rethrow,
     trivialProgram,
@@ -21,8 +22,8 @@ import           Language.PlutusCore.Pretty
 
 import           Control.Exception
 import           Control.Monad.Except
-
 import qualified Data.Text.Prettyprint.Doc                as PP
+import           System.IO.Unsafe
 
 -- | Class for ad-hoc overloading of things which can be turned into a PLC program. Any errors
 -- from the process should be caught.
@@ -34,6 +35,9 @@ instance GetProgram a => GetProgram (ExceptT SomeException IO  a) where
 
 instance GetProgram (Program TyName Name ()) where
     getProgram = pure
+
+pureTry :: Exception e => a -> Either e a
+pureTry = unsafePerformIO . try . evaluate
 
 catchAll :: a -> ExceptT SomeException IO a
 catchAll value = ExceptT $ try @SomeException (evaluate value)

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/TypeEvalCheck.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE OverloadedStrings      #-}
 {-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE TypeApplications       #-}
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE UndecidableInstances   #-}
 
@@ -15,10 +16,13 @@ module Language.PlutusCore.Generators.Internal.TypeEvalCheck
     , unsafeTypeEvalCheck
     ) where
 
+import           PlcTestUtils
+
 import qualified Language.PlutusCore.Check.Value                         as VR
 import           Language.PlutusCore.Constant
 import           Language.PlutusCore.Error
 import           Language.PlutusCore.Evaluation.CkMachine
+import           Language.PlutusCore.Evaluation.MachineException
 import           Language.PlutusCore.Generators.Internal.TypedBuiltinGen
 import           Language.PlutusCore.Generators.Internal.Utils
 import           Language.PlutusCore.Name
@@ -30,6 +34,7 @@ import           PlutusPrelude
 
 import           Control.Lens.TH
 import           Control.Monad.Except
+import           Data.String
 
 {- Note [Type-eval checking]
 We generate terms along with values they are supposed to evaluate to. Before evaluating a term,
@@ -40,6 +45,7 @@ the actual one. Thus "type-eval checking".
 -- | The type of errors that can occur during type-eval checking.
 data TypeEvalCheckError
     = TypeEvalCheckErrorIllFormed (Error ())
+    | TypeEvalCheckErrorException String
     | TypeEvalCheckErrorIllEvaled EvaluationResultDef EvaluationResultDef
       -- ^ The former is an expected result of evaluation, the latter -- is an actual one.
 makeClassyPrisms ''TypeEvalCheckError
@@ -65,6 +71,8 @@ instance (PrettyBy config (Error ()), PrettyBy config (Value TyName Name ())) =>
         PrettyBy config TypeEvalCheckError where
     prettyBy config (TypeEvalCheckErrorIllFormed err)             =
         "The term is ill-formed:" <+> prettyBy config err
+    prettyBy _      (TypeEvalCheckErrorException err)             =
+        "An exception occurred:" <+> fromString err
     prettyBy config (TypeEvalCheckErrorIllEvaled expected actual) =
         "The expected value:" <+> prettyBy config expected <> hardline <>
         "doesn't match with the actual value:" <+> prettyBy config actual
@@ -75,8 +83,9 @@ type TypeEvalCheckM = Either TypeEvalCheckError
 -- See Note [Type-eval checking].
 -- | Type check and evaluate a term and check that the expected result is equal to the actual one.
 typeEvalCheckBy
-    :: KnownType a
-    => (Term TyName Name () -> EvaluationResultDef)  -- ^ An evaluator.
+    :: (Pretty err, KnownType a)
+    => (Term TyName Name () -> Either (MachineException err) EvaluationResultDef)
+       -- ^ An evaluator.
     -> TermOf a
     -> TypeEvalCheckM (TermOf TypeEvalCheckResult)
 typeEvalCheckBy eval (TermOf term x) = TermOf term <$> do
@@ -85,18 +94,19 @@ typeEvalCheckBy eval (TermOf term x) = TermOf term <$> do
     let valExpected = case makeKnown x of
             Error _ _ -> EvaluationFailure
             t         -> EvaluationSuccess t
-    fmap (TypeEvalCheckResult termTy) $ do
-        let valActual = eval term
-        if valExpected == valActual
-            then return valActual
-            else throwError $ TypeEvalCheckErrorIllEvaled valExpected valActual
+    fmap (TypeEvalCheckResult termTy) $ case eval term of
+        Right valActual
+            | valExpected == valActual -> return valActual
+            | otherwise                ->
+                throwError $ TypeEvalCheckErrorIllEvaled valExpected valActual
+        Left exc -> throwError $ TypeEvalCheckErrorException $ show exc
 
 -- | Type check and evaluate a term and check that the expected result is equal to the actual one.
 -- Throw an error in case something goes wrong.
 unsafeTypeEvalCheck
     :: forall a. KnownType a => TermOf a -> TermOf EvaluationResultDef
 unsafeTypeEvalCheck termOfTbv = do
-    let errOrRes = typeEvalCheckBy evaluateCk termOfTbv
+    let errOrRes = typeEvalCheckBy (pureTry @CkMachineException . evaluateCk) termOfTbv
     case errOrRes of
         Left err         -> error $ concat
             [ prettyPlcErrorString err

--- a/language-plutus-core/test/Evaluation/CkMachine.hs
+++ b/language-plutus-core/test/Evaluation/CkMachine.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
 module Evaluation.CkMachine
     ( test_evaluateCk
     ) where
 
 import           Prelude                                    hiding (even)
+
+import           PlcTestUtils
 
 import           Language.PlutusCore
 import           Language.PlutusCore.Evaluation.CkMachine
@@ -98,7 +102,8 @@ goldenVsPretty name value = goldenVsString name ("test/Evaluation/Golden/" ++ na
 
 test_evaluateCk :: TestTree
 test_evaluateCk = testGroup "evaluateCk"
-    [ testGroup "props" $ fromInterestingTermGens (\name -> testProperty name . propEvaluate evaluateCk)
+    [ testGroup "props" $ fromInterestingTermGens $ \name ->
+        testProperty name . propEvaluate (pureTry @CkMachineException . evaluateCk)
     , goldenVsPretty "even2" . pure . evaluateCk $ Apply () even $ metaIntegerToNat 2
     , goldenVsPretty "even3" . pure . evaluateCk $ Apply () even $ metaIntegerToNat 3
     , goldenVsPretty "evenList" . pure . evaluateCk $

--- a/plutus-core-interpreter/src/Language/PlutusCore/Interpreter/LMachine.hs
+++ b/plutus-core-interpreter/src/Language/PlutusCore/Interpreter/LMachine.hs
@@ -35,6 +35,7 @@
 module Language.PlutusCore.Interpreter.LMachine
     ( EvaluationResult (..)
     , EvaluationResultDef
+    , LMachineError
     , evaluateL
     , runL
     ) where
@@ -76,8 +77,7 @@ instance Pretty LMachineError where
 -- to be parametrized by an LMachineError which is required in order to disambiguate
 -- @throw .* MachineException@.  If you just use @throw@ you get compilation errors
 -- because the type is too general to be Typeable (I think).
-throwLMachineException
-    :: MachineError LMachineError -> Term TyName Name () -> a
+throwLMachineException :: MachineError LMachineError -> Term TyName Name () -> a
 throwLMachineException = throw .* MachineException
 
 -- | A term together with an enviroment mapping free variables to heap locations

--- a/plutus-core-interpreter/test/CekMachine.hs
+++ b/plutus-core-interpreter/test/CekMachine.hs
@@ -16,5 +16,5 @@ test_evaluateCek :: TestTree
 test_evaluateCek =
     testGroup "evaluateCek"
         [ testGroup "props" $ fromInterestingTermGens $ \name ->
-            testProperty name . propEvaluate (unsafeEvaluateCek mempty)
+            testProperty name . propEvaluate (evaluateCek mempty)
         ]

--- a/plutus-core-interpreter/test/LMachine.hs
+++ b/plutus-core-interpreter/test/LMachine.hs
@@ -1,9 +1,13 @@
 -- | The L machine tests.
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
 module LMachine
     ( test_evaluateL
     ) where
+
+import           PlcTestUtils
 
 import           Language.PlutusCore.Generators.Interesting
 import           Language.PlutusCore.Generators.Test
@@ -16,5 +20,5 @@ test_evaluateL :: TestTree
 test_evaluateL =
     testGroup "evaluateL"
         [ testGroup "props" $ fromInterestingTermGens $ \name ->
-            testProperty name . propEvaluate evaluateL
+            testProperty name . propEvaluate @LMachineError (pureTry . evaluateL)
         ]


### PR DESCRIPTION
@reactormonk stumbled upon a UX bug where `hedgehog` won't print an exception that comes from the CEK machine. I spent a couple of hours and was unable to understand why (it seems to print exceptions coming from the CK machine just well), so I just made errors explicit.