### PR TITLE
contracts: State machine client code

### DIFF
--- a/plutus-contract/plutus-contract.cabal
+++ b/plutus-contract/plutus-contract.cabal
@@ -53,6 +53,7 @@ library
         Language.Plutus.Contract.IOTS
         Language.Plutus.Contract.Servant
         Language.Plutus.Contract.Resumable
+        Language.Plutus.Contract.StateMachine
         Language.Plutus.Contract.Tx
         Language.Plutus.Contract.Util
         Language.Plutus.Contract.Wallet

--- a/plutus-contract/src/Language/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/StateMachine.hs
@@ -1,0 +1,206 @@
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MonoLocalBinds         #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE NamedFieldPuns         #-}
+{-# LANGUAGE TemplateHaskell        #-}
+{-# LANGUAGE TypeApplications       #-}
+module Language.Plutus.Contract.StateMachine(
+    -- $statemachine
+    StateMachineClient(..)
+    , ValueAllocation(..)
+    , SMContractError(..)
+    , AsSMContractError(..)
+    , SM.StateMachine(..)
+    , SM.StateMachineInstance(..)
+    -- * Constructing the machine instance
+    , SM.mkValidator
+    -- * Constructing the state machine client
+    , mkStateMachineClient
+    , defaultChooser
+    -- * Running the state machine
+    , runStep
+    , runInitialise
+    ) where
+
+import           Control.Lens
+import           Control.Monad                     (unless)
+import           Control.Monad.Error.Lens
+import           Data.Text                         (Text)
+import qualified Data.Text                         as Text
+
+import           Language.Plutus.Contract
+import qualified Language.Plutus.Contract.Tx       as Tx
+import qualified Language.Plutus.Contract.Typed.Tx as Tx
+import qualified Language.PlutusTx                 as PlutusTx
+import           Language.PlutusTx.StateMachine    (StateMachine (..), StateMachineInstance (..))
+import qualified Language.PlutusTx.StateMachine    as SM
+import           Ledger                            (Value)
+import           Ledger.Typed.Tx                   (TypedScriptTxOut (..))
+import qualified Ledger.Typed.Tx                   as Typed
+import qualified Ledger.Value                      as Value
+
+import qualified Wallet.Typed.StateMachine         as SM
+
+-- $statemachine
+-- To write your contract as a state machine you need
+-- * Two types @state@ and @input@ for the state and inputs of the machine
+-- * A 'SM.StateMachineInstance state input' describing the transitions and
+--   checks of the state machine (this is the on-chain code)
+-- * A 'StateMachineClient state input' with the state machine instance and
+--   an allocation function
+--
+-- You can then use 'runInitialise' and 'runStep' to initialise and transition
+-- the state machine. 'runStep' gets the current state from the utxo set and
+-- makes the transition to the next state using the given input and taking care
+-- of all payments.
+
+data SMContractError s i =
+    SMError (SM.SMError s i)
+    | InvalidTransition
+    | NonZeroValueAllocatedInFinalState
+    | ChooserError Text
+    deriving (Show)
+
+makeClassyPrisms ''SMContractError
+
+-- | Allocation of funds to outputs of the state machine transition transaction.
+data ValueAllocation =
+    ValueAllocation
+        { vaOwnAddress    :: Value
+        -- ^ How much should stay locked in the contract
+        , vaOtherPayments :: UnbalancedTx
+        -- ^ Any other payments
+        }
+
+instance Semigroup ValueAllocation where
+    l <> r =
+        ValueAllocation
+            { vaOwnAddress = vaOwnAddress l <> vaOwnAddress r
+            , vaOtherPayments = vaOtherPayments l <> vaOtherPayments r
+            }
+
+instance Monoid ValueAllocation where
+    mappend = (<>)
+    mempty  = ValueAllocation mempty mempty
+
+-- | Client-side definition of a state machine.
+data StateMachineClient s i = StateMachineClient
+    { scInstance :: SM.StateMachineInstance s i
+    -- ^ The instance of the state machine, defining the machine's transitions,
+    --   its final state and its check function.
+    , scPayments :: s -> i -> Value -> ValueAllocation
+    -- ^ A function that determines the 'ValueAllocation' of each transition,
+    --   given the value currently locked by the contract.
+    , scChooser  :: [SM.OnChainState s i] -> Either (SMContractError s i) (SM.OnChainState s i)
+    -- ^ A function that chooses the relevant on-chain state, given a list of
+    --   all potential on-chain states found at the contract address.
+    }
+
+-- | A state chooser function that fails if confronted with anything other
+--   than exactly one output
+defaultChooser ::
+    forall state input
+    . [SM.OnChainState state input]
+    -> Either (SMContractError state input) (SM.OnChainState state input)
+defaultChooser [x] = Right x
+defaultChooser xs  =
+    let msg = "Found " <> show (length xs) <> " outputs, expected 1"
+    in Left (ChooserError (Text.pack msg))
+
+-- | A state machine client with the 'defaultChooser' function
+mkStateMachineClient ::
+    forall state input
+    . SM.StateMachineInstance state input
+    -> (state -> input -> Value -> ValueAllocation)
+    -> StateMachineClient state input
+mkStateMachineClient inst payments =
+    StateMachineClient
+        { scInstance = inst
+        , scPayments = payments
+        , scChooser  = defaultChooser
+        }
+
+getOnChainState :: (AsSMContractError e state i, PlutusTx.IsData state, HasUtxoAt schema) => StateMachineClient state i -> Contract schema e (SM.OnChainState state i)
+getOnChainState StateMachineClient{scInstance, scChooser} = do
+    utxo <- utxoAt (SM.machineAddress scInstance)
+    let states = SM.getStates scInstance utxo
+    either (throwing _SMContractError) pure $ scChooser states
+
+-- | Run one step of a state machine, returning the new state.
+runStep ::
+    forall e state schema input.
+    ( AsSMContractError e state input
+    , AsContractError e
+    , PlutusTx.IsData state
+    , PlutusTx.IsData input
+    , HasUtxoAt schema
+    , HasWriteTx schema
+    , HasTxConfirmation schema
+    )
+    => StateMachineClient state input
+    -- ^ The state machine
+    -> input
+    -- ^ The input to apply to the state machine
+    -> Contract schema e state
+runStep smc input = do
+    (typedTx, newState, ValueAllocation{vaOtherPayments}) <- mkStep smc input
+    let tx = case typedTx of
+            (Typed.TypedTxSomeOuts tx') -> Tx.fromLedgerTx (Typed.toUntypedTx tx')
+    submitTxConfirmed (tx <> vaOtherPayments)
+    pure newState
+
+-- | Initialise a state machine
+runInitialise ::
+    forall e state schema input.
+    ( PlutusTx.IsData state
+    , AsContractError e
+    , HasTxConfirmation schema
+    , HasWriteTx schema
+    )
+    => StateMachineClient state input
+    -- ^ The state machine
+    -> state
+    -- ^ The initial state
+    -> Value
+    -- ^ The value locked by the contract at the beginning
+    -> Contract schema e state
+runInitialise StateMachineClient{scInstance} initialState initialValue = do
+    let StateMachineInstance{validatorInstance} = scInstance
+        tx = Tx.makeScriptPayment validatorInstance initialValue initialState
+    submitTxConfirmed tx
+    pure initialState
+
+mkStep ::
+    forall e state schema input.
+    ( AsSMContractError e state input
+    , HasUtxoAt schema
+    , PlutusTx.IsData state
+    , PlutusTx.IsData input
+    )
+    => StateMachineClient state input
+    -> input
+    -> Contract schema e (Typed.TypedTxSomeOuts '[SM.StateMachine state input], state, ValueAllocation)
+mkStep client@StateMachineClient{scInstance, scPayments} input = do
+    let StateMachineInstance{stateMachine=StateMachine{smTransition, smFinal}, validatorInstance} = scInstance
+    (TypedScriptTxOut{tyTxOutData=currentState}, txOutRef) <- getOnChainState client
+    newState <- case smTransition currentState input of
+        Just s  -> pure s
+        Nothing -> throwing_ _InvalidTransition
+
+    let typedTxIn = Typed.makeTypedScriptTxIn @(SM.StateMachine state input) validatorInstance input txOutRef
+        valueAllocation = scPayments currentState input (Typed.txInValue typedTxIn)
+        tx = Typed.TypedTxSomeOuts (Typed.addTypedTxIn typedTxIn Typed.baseTx)
+
+    finalTx <- if smFinal newState
+               then do
+                    unless (Value.isZero (vaOwnAddress valueAllocation)) (throwing_ _NonZeroValueAllocatedInFinalState)
+                    pure tx
+               else do
+                    let output = Typed.makeTypedScriptTxOut validatorInstance newState (vaOwnAddress valueAllocation)
+                        fullTx = Typed.addSomeTypedTxOut output tx
+                    pure fullTx
+
+    pure (finalTx, newState, valueAllocation)

--- a/plutus-contract/src/Language/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/StateMachine.hs
@@ -90,7 +90,7 @@ instance Monoid ValueAllocation where
 data StateMachineClient s i = StateMachineClient
     { scInstance :: SM.StateMachineInstance s i
     -- ^ The instance of the state machine, defining the machine's transitions,
-    --   its final state and its check function.
+    --   its final states and its check function.
     , scPayments :: s -> i -> Value -> ValueAllocation
     -- ^ A function that determines the 'ValueAllocation' of each transition,
     --   given the value currently locked by the contract.

--- a/plutus-contract/src/Language/Plutus/Contract/Tx.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Tx.hs
@@ -71,6 +71,12 @@ data UnbalancedTx = UnbalancedTx
         , _dataValues         :: [DataScript]
         , _validityRange      :: SlotRange
         , _valueMoved         :: Value
+        -- ^ The minimum size of the transaction's left and right side. The
+        --   purpose of this field is to enable proof of ownership for tokens
+        --   (a transaction proves ownership of a token if the value consumed
+        --   and spent by it includes the token. The value in the '_valueMoved'
+        --   field will be paid from the wallet's own funds back to an address
+        --   owned by the wallet)
         }
         deriving stock (Eq, Show, Generic)
         deriving anyclass (Aeson.FromJSON, Aeson.ToJSON, IotsType)

--- a/plutus-contract/src/Language/Plutus/Contract/Tx.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Tx.hs
@@ -16,6 +16,7 @@ module Language.Plutus.Contract.Tx(
     , forge
     , requiredSignatures
     , validityRange
+    , valueMoved
     , toLedgerTx
     , fromLedgerTx
     -- * Constructing transactions
@@ -24,6 +25,7 @@ module Language.Plutus.Contract.Tx(
     , collectFromScript
     , collectFromScriptFilter
     , forgeValue
+    , moveValue
     -- * Constructing inputs
     , Tx.pubKeyTxIn
     , Tx.scriptTxIn
@@ -68,6 +70,7 @@ data UnbalancedTx = UnbalancedTx
         , _requiredSignatures :: [PubKey]
         , _dataValues         :: [DataScript]
         , _validityRange      :: SlotRange
+        , _valueMoved         :: Value
         }
         deriving stock (Eq, Show, Generic)
         deriving anyclass (Aeson.FromJSON, Aeson.ToJSON, IotsType)
@@ -75,7 +78,7 @@ data UnbalancedTx = UnbalancedTx
 Lens.TH.makeLenses ''UnbalancedTx
 
 instance Pretty UnbalancedTx where
-    pretty UnbalancedTx{_inputs, _outputs, _forge, _requiredSignatures, _dataValues, _validityRange} =
+    pretty UnbalancedTx{_inputs, _outputs, _forge, _requiredSignatures, _dataValues, _validityRange, _valueMoved} =
         let renderOutput Tx.TxOut{Tx.txOutType, Tx.txOutValue} =
                 hang 2 $ vsep ["-" <+> pretty txOutValue <+> "locked by", pretty txOutType]
             renderInput Tx.TxIn{Tx.txInRef,Tx.txInType} =
@@ -93,6 +96,7 @@ instance Pretty UnbalancedTx where
                 , hang 2 (vsep ("required signatures:": fmap pretty _requiredSignatures))
                 , hang 2 (vsep ("data values:" : fmap pretty _dataValues))
                 , "validity range:" <+> viaShow _validityRange
+                , "value moved:" <+> pretty _valueMoved
                 ]
         in braces $ nest 2 $ vsep lines'
 
@@ -105,6 +109,7 @@ fromLedgerTx tx = UnbalancedTx
             , _requiredSignatures = Map.keys $ L.txSignatures tx
             , _dataValues = toList $ L.txData tx
             , _validityRange = L.txValidRange tx
+            , _valueMoved = mempty
             }
 
 instance Semigroup UnbalancedTx where
@@ -114,11 +119,12 @@ instance Semigroup UnbalancedTx where
         _forge = _forge tx1 <> _forge tx2,
         _requiredSignatures = _requiredSignatures tx1 <> _requiredSignatures tx2,
         _dataValues = _dataValues tx1 <> _dataValues tx2,
-        _validityRange = _validityRange tx1 /\ _validityRange tx2
+        _validityRange = _validityRange tx1 /\ _validityRange tx2,
+        _valueMoved = _valueMoved tx1 <> _valueMoved tx2
         }
 
 instance Monoid UnbalancedTx where
-    mempty = UnbalancedTx mempty mempty mempty mempty mempty top
+    mempty = UnbalancedTx mempty mempty mempty mempty mempty top mempty
 
 -- | The ledger transaction of the 'UnbalancedTx'. Note that the result
 --   does not have any signatures, and is potentially unbalanced (ie. invalid).
@@ -140,7 +146,7 @@ toLedgerTx utx =
 --   will be ignored.
 --   Note: this doesn't populate the data scripts, so is not exported. Prefer using 'payToScript' etc.
 unbalancedTx :: [L.TxIn] -> [L.TxOut] -> UnbalancedTx
-unbalancedTx ins outs = UnbalancedTx (Set.fromList ins) outs mempty mempty mempty I.always
+unbalancedTx ins outs = UnbalancedTx (Set.fromList ins) outs mempty mempty mempty I.always mempty
 
 -- | Create an `UnbalancedTx` that pays money to a script address.
 payToScript :: Value -> Address -> DataScript -> UnbalancedTx
@@ -178,6 +184,10 @@ collectFromScriptFilter flt am vls red =
 -- | An 'UnbalancedTx' that forges the specified value.
 forgeValue :: Value -> UnbalancedTx
 forgeValue vl = mempty { _forge = vl }
+
+-- | An 'UnbalancedTx' that moves the specified value
+moveValue :: Value -> UnbalancedTx
+moveValue vl = mempty { _valueMoved = vl }
 
 {- Note [Unbalanced transactions]
 

--- a/plutus-use-cases/test/Spec/GameStateMachine.hs
+++ b/plutus-use-cases/test/Spec/GameStateMachine.hs
@@ -38,7 +38,7 @@ tests =
         /\ walletFundsChange w1 (Ada.lovelaceValueOf (-4) <> G.gameTokenVal))
         ( successTrace
         >> payToWallet w2 w1 G.gameTokenVal 
-        >> callEndpoint @"guess" w1 GuessArgs{guessArgsOldSecret="new secret", guessArgsNewSecret="hello", guessArgsValueLocked=Ada.lovelaceValueOf 1}
+        >> callEndpoint @"guess" w1 GuessArgs{guessArgsOldSecret="new secret", guessArgsNewSecret="hello", guessArgsValueTakenOut=Ada.lovelaceValueOf 4}
         >> handleBlockchainEvents w1
         )
 
@@ -50,7 +50,7 @@ tests =
         ( callEndpoint @"lock" w1 LockArgs{lockArgsSecret="hello", lockArgsValue= Ada.lovelaceValueOf 8}
         >> handleBlockchainEvents w1
         >> payToWallet w1 w2 G.gameTokenVal
-        >> callEndpoint @"guess" w2 GuessArgs{guessArgsOldSecret="hola", guessArgsNewSecret="new secret", guessArgsValueLocked=Ada.lovelaceValueOf 5}
+        >> callEndpoint @"guess" w2 GuessArgs{guessArgsOldSecret="hola", guessArgsNewSecret="new secret", guessArgsValueTakenOut=Ada.lovelaceValueOf 3}
         >> handleBlockchainEvents w2)
 
 
@@ -78,5 +78,5 @@ successTrace = do
     callEndpoint @"lock" w1 LockArgs{lockArgsSecret="hello", lockArgsValue= Ada.lovelaceValueOf 8}
     handleBlockchainEvents w1
     payToWallet w1 w2 G.gameTokenVal
-    callEndpoint @"guess" w2 GuessArgs{guessArgsOldSecret="hello", guessArgsNewSecret="new secret", guessArgsValueLocked=Ada.lovelaceValueOf 5}
+    callEndpoint @"guess" w2 GuessArgs{guessArgsOldSecret="hello", guessArgsNewSecret="new secret", guessArgsValueTakenOut=Ada.lovelaceValueOf 3}
     handleBlockchainEvents w2

--- a/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
+++ b/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
@@ -54,12 +54,12 @@ tests =
         /\ walletFundsChange w2 (Ada.lovelaceValueOf 10))
         (lockProposeSignPay 3 2)
 
-        , checkPredicate @MultiSigSchema @MultiSigError "lock, propose, sign 3x, pay x3 - FAILURE"
-            (MS.contract params)
-            (assertContractError w1 (\case { ContractError MS.MSContractStateNotFound -> True; _ -> False}) "contract should fail"
-            /\ walletFundsChange w1 (Ada.lovelaceValueOf (-10))
-            /\ walletFundsChange w2 (Ada.lovelaceValueOf 10))
-            (lockProposeSignPay 3 3)
+    , checkPredicate @MultiSigSchema @MultiSigError "lock, propose, sign 3x, pay x3 - FAILURE"
+        (MS.contract params)
+        (assertContractError w1 (\case { ContractError MS.MSStateMachineError{} -> True; _ -> False}) "contract should fail"
+        /\ walletFundsChange w1 (Ada.lovelaceValueOf (-10))
+        /\ walletFundsChange w2 (Ada.lovelaceValueOf 10))
+        (lockProposeSignPay 3 3)
 
     , Lib.goldenPir "test/Spec/multisigStateMachine.pir" $$(PlutusTx.compile [|| MS.mkValidator ||])
     , HUnit.testCase "script size is reasonable" (Lib.reasonable (Scripts.validatorScript $ MS.scriptInstance params) 50000)

--- a/plutus-use-cases/test/Spec/gameStateMachine.pir
+++ b/plutus-use-cases/test/Spec/gameStateMachine.pir
@@ -8185,7 +8185,7 @@
                                                                                                 )
                                                                                                 (vardecl
                                                                                                   Guess
-                                                                                                  (fun (con bytestring) (fun (con bytestring) GameInput))
+                                                                                                  (fun (con bytestring) (fun (con bytestring) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] GameInput)))
                                                                                                 )
                                                                                               )
                                                                                             )
@@ -9169,7 +9169,11 @@
                                                                                                                                 (lam
                                                                                                                                   ipv
                                                                                                                                   (con bytestring)
-                                                                                                                                  False
+                                                                                                                                  (lam
+                                                                                                                                    ipv
+                                                                                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                    False
+                                                                                                                                  )
                                                                                                                                 )
                                                                                                                               )
                                                                                                                             ]
@@ -9202,106 +9206,110 @@
                                                                                                                                 (lam
                                                                                                                                   ds
                                                                                                                                   (con bytestring)
-                                                                                                                                  [
+                                                                                                                                  (lam
+                                                                                                                                    ds
+                                                                                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                                                                                     [
                                                                                                                                       [
-                                                                                                                                        {
-                                                                                                                                          [
-                                                                                                                                            Bool_match
+                                                                                                                                        [
+                                                                                                                                          {
                                                                                                                                             [
+                                                                                                                                              Bool_match
                                                                                                                                               [
-                                                                                                                                                equalsByteString
-                                                                                                                                                currentSecret
-                                                                                                                                              ]
-                                                                                                                                              [
-                                                                                                                                                sha2_
-                                                                                                                                                theGuess
+                                                                                                                                                [
+                                                                                                                                                  equalsByteString
+                                                                                                                                                  currentSecret
+                                                                                                                                                ]
+                                                                                                                                                [
+                                                                                                                                                  sha2_
+                                                                                                                                                  theGuess
+                                                                                                                                                ]
                                                                                                                                               ]
                                                                                                                                             ]
-                                                                                                                                          ]
-                                                                                                                                          (fun Unit Bool)
-                                                                                                                                        }
-                                                                                                                                        (lam
-                                                                                                                                          thunk
-                                                                                                                                          Unit
-                                                                                                                                          [
+                                                                                                                                            (fun Unit Bool)
+                                                                                                                                          }
+                                                                                                                                          (lam
+                                                                                                                                            thunk
+                                                                                                                                            Unit
                                                                                                                                             [
                                                                                                                                               [
-                                                                                                                                                {
-                                                                                                                                                  [
-                                                                                                                                                    Bool_match
+                                                                                                                                                [
+                                                                                                                                                  {
+                                                                                                                                                    [
+                                                                                                                                                      Bool_match
+                                                                                                                                                      [
+                                                                                                                                                        [
+                                                                                                                                                          [
+                                                                                                                                                            checkBinRel
+                                                                                                                                                            greaterThanEqInteger
+                                                                                                                                                          ]
+                                                                                                                                                          [
+                                                                                                                                                            valueSpent
+                                                                                                                                                            ptx
+                                                                                                                                                          ]
+                                                                                                                                                        ]
+                                                                                                                                                        [
+                                                                                                                                                          tokenVal
+                                                                                                                                                          tn
+                                                                                                                                                        ]
+                                                                                                                                                      ]
+                                                                                                                                                    ]
+                                                                                                                                                    (fun Unit Bool)
+                                                                                                                                                  }
+                                                                                                                                                  (lam
+                                                                                                                                                    thunk
+                                                                                                                                                    Unit
                                                                                                                                                     [
                                                                                                                                                       [
                                                                                                                                                         [
                                                                                                                                                           checkBinRel
-                                                                                                                                                          greaterThanEqInteger
+                                                                                                                                                          equalsInteger
                                                                                                                                                         ]
-                                                                                                                                                        [
-                                                                                                                                                          valueSpent
-                                                                                                                                                          ptx
-                                                                                                                                                        ]
+                                                                                                                                                        {
+                                                                                                                                                          Nil
+                                                                                                                                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                        }
                                                                                                                                                       ]
                                                                                                                                                       [
-                                                                                                                                                        tokenVal
-                                                                                                                                                        tn
-                                                                                                                                                      ]
-                                                                                                                                                    ]
-                                                                                                                                                  ]
-                                                                                                                                                  (fun Unit Bool)
-                                                                                                                                                }
-                                                                                                                                                (lam
-                                                                                                                                                  thunk
-                                                                                                                                                  Unit
-                                                                                                                                                  [
-                                                                                                                                                    [
-                                                                                                                                                      [
-                                                                                                                                                        checkBinRel
-                                                                                                                                                        equalsInteger
-                                                                                                                                                      ]
-                                                                                                                                                      {
-                                                                                                                                                        Nil
-                                                                                                                                                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                      }
-                                                                                                                                                    ]
-                                                                                                                                                    [
-                                                                                                                                                      {
-                                                                                                                                                        [
-                                                                                                                                                          {
-                                                                                                                                                            PendingTx_match
-                                                                                                                                                            [PendingTxIn [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
-                                                                                                                                                          }
-                                                                                                                                                          ptx
-                                                                                                                                                        ]
-                                                                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                                                      }
-                                                                                                                                                      (lam
-                                                                                                                                                        ds
-                                                                                                                                                        [List [PendingTxIn [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]]]
+                                                                                                                                                        {
+                                                                                                                                                          [
+                                                                                                                                                            {
+                                                                                                                                                              PendingTx_match
+                                                                                                                                                              [PendingTxIn [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
+                                                                                                                                                            }
+                                                                                                                                                            ptx
+                                                                                                                                                          ]
+                                                                                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                        }
                                                                                                                                                         (lam
                                                                                                                                                           ds
-                                                                                                                                                          [List PendingTxOut]
+                                                                                                                                                          [List [PendingTxIn [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]]]
                                                                                                                                                           (lam
                                                                                                                                                             ds
-                                                                                                                                                            (con integer)
+                                                                                                                                                            [List PendingTxOut]
                                                                                                                                                             (lam
                                                                                                                                                               ds
-                                                                                                                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                                              (con integer)
                                                                                                                                                               (lam
                                                                                                                                                                 ds
-                                                                                                                                                                [PendingTxIn [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
+                                                                                                                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                                                                                                                 (lam
                                                                                                                                                                   ds
-                                                                                                                                                                  [Interval (con integer)]
+                                                                                                                                                                  [PendingTxIn [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
                                                                                                                                                                   (lam
                                                                                                                                                                     ds
-                                                                                                                                                                    [List [[Tuple2 (con bytestring)] (con bytestring)]]
+                                                                                                                                                                    [Interval (con integer)]
                                                                                                                                                                     (lam
                                                                                                                                                                       ds
-                                                                                                                                                                      [List [[Tuple2 (con bytestring)] Data]]
+                                                                                                                                                                      [List [[Tuple2 (con bytestring)] (con bytestring)]]
                                                                                                                                                                       (lam
                                                                                                                                                                         ds
-                                                                                                                                                                        (con bytestring)
-                                                                                                                                                                        ds
+                                                                                                                                                                        [List [[Tuple2 (con bytestring)] Data]]
+                                                                                                                                                                        (lam
+                                                                                                                                                                          ds
+                                                                                                                                                                          (con bytestring)
+                                                                                                                                                                          ds
+                                                                                                                                                                        )
                                                                                                                                                                       )
                                                                                                                                                                     )
                                                                                                                                                                   )
@@ -9310,29 +9318,29 @@
                                                                                                                                                             )
                                                                                                                                                           )
                                                                                                                                                         )
-                                                                                                                                                      )
+                                                                                                                                                      ]
                                                                                                                                                     ]
-                                                                                                                                                  ]
+                                                                                                                                                  )
+                                                                                                                                                ]
+                                                                                                                                                (lam
+                                                                                                                                                  thunk
+                                                                                                                                                  Unit
+                                                                                                                                                  False
                                                                                                                                                 )
                                                                                                                                               ]
-                                                                                                                                              (lam
-                                                                                                                                                thunk
-                                                                                                                                                Unit
-                                                                                                                                                False
-                                                                                                                                              )
+                                                                                                                                              Unit
                                                                                                                                             ]
-                                                                                                                                            Unit
-                                                                                                                                          ]
+                                                                                                                                          )
+                                                                                                                                        ]
+                                                                                                                                        (lam
+                                                                                                                                          thunk
+                                                                                                                                          Unit
+                                                                                                                                          False
                                                                                                                                         )
                                                                                                                                       ]
-                                                                                                                                      (lam
-                                                                                                                                        thunk
-                                                                                                                                        Unit
-                                                                                                                                        False
-                                                                                                                                      )
+                                                                                                                                      Unit
                                                                                                                                     ]
-                                                                                                                                    Unit
-                                                                                                                                  ]
+                                                                                                                                  )
                                                                                                                                 )
                                                                                                                               )
                                                                                                                             ]
@@ -9506,10 +9514,14 @@
                                                                                                                                 (lam
                                                                                                                                   ipv
                                                                                                                                   (con bytestring)
-                                                                                                                                  {
-                                                                                                                                    Nothing
-                                                                                                                                    GameState
-                                                                                                                                  }
+                                                                                                                                  (lam
+                                                                                                                                    ipv
+                                                                                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                                    {
+                                                                                                                                      Nothing
+                                                                                                                                      GameState
+                                                                                                                                    }
+                                                                                                                                  )
                                                                                                                                 )
                                                                                                                               )
                                                                                                                             ]
@@ -9545,19 +9557,23 @@
                                                                                                                                 (lam
                                                                                                                                   nextSecret
                                                                                                                                   (con bytestring)
-                                                                                                                                  [
-                                                                                                                                    {
-                                                                                                                                      Just
-                                                                                                                                      GameState
-                                                                                                                                    }
+                                                                                                                                  (lam
+                                                                                                                                    ds
+                                                                                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                                                                                     [
+                                                                                                                                      {
+                                                                                                                                        Just
+                                                                                                                                        GameState
+                                                                                                                                      }
                                                                                                                                       [
-                                                                                                                                        Locked
-                                                                                                                                        tn
+                                                                                                                                        [
+                                                                                                                                          Locked
+                                                                                                                                          tn
+                                                                                                                                        ]
+                                                                                                                                        nextSecret
                                                                                                                                       ]
-                                                                                                                                      nextSecret
                                                                                                                                     ]
-                                                                                                                                  ]
+                                                                                                                                  )
                                                                                                                                 )
                                                                                                                               )
                                                                                                                             ]

--- a/plutus-wallet-api/ledger/Ledger/Typed/Tx.hs
+++ b/plutus-wallet-api/ledger/Ledger/Typed/Tx.hs
@@ -77,6 +77,7 @@ makePubKeyTxIn ref pubkey = PubKeyTxIn $ TxIn ref $ ConsumePublicKeyAddress pubk
 
 -- | A 'TxOut' tagged by a phantom type: and the connection type of the output.
 data TypedScriptTxOut a = IsData (DataType a) => TypedScriptTxOut { tyTxOutTxOut :: TxOut, tyTxOutData :: DataType a }
+
 -- | Create a 'TypedScriptTxOut' from a correctly-typed data script, an address, and a value.
 makeTypedScriptTxOut
     :: forall out
@@ -187,6 +188,18 @@ addManyTypedTxIns
     -> TypedTx ins outs
     -> TypedTxSomeIns outs
 addManyTypedTxIns ins tx = foldl' (\someTx inn -> addSomeTypedTxIn inn someTx) (TypedTxSomeIns tx) ins
+
+-- | A wrapper around a 'TypedTx' that hides the output list type as an existential parameter.
+data TypedTxSomeOuts (ins :: [Type]) = forall outs . TypedTxSomeOuts (TypedTx ins outs)
+
+-- | Add a 'TypedScriptTxOut' to a 'TypedTxSomeOuts'. Note that we do not have to track
+-- the output connection types explicitly.
+addSomeTypedTxOut
+    :: forall (ins :: [Type]) (newOut :: *)
+    . TypedScriptTxOut newOut
+    -> TypedTxSomeOuts ins
+    -> TypedTxSomeOuts ins
+addSomeTypedTxOut out (TypedTxSomeOuts tx) = TypedTxSomeOuts $ addTypedTxOut out tx
 
 -- | Convert a 'TypedTx' to a 'Tx'.
 toUntypedTx

--- a/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
+++ b/plutus-wallet-api/src/Language/PlutusTx/StateMachine.hs
@@ -12,12 +12,14 @@
 module Language.PlutusTx.StateMachine(
       StateMachine(..)
     , StateMachineInstance (..)
+    , machineAddress
     , mkValidator
     ) where
 
 import           Language.PlutusTx.Prelude hiding (check)
 import qualified Language.PlutusTx as PlutusTx
 
+import           Ledger                    (Address)
 import           Ledger.Typed.Scripts
 import           Ledger.Scripts (DataScript (..))
 import           Ledger.Validation         (PendingTx, PendingTxOut (..), PendingTxOutType (..), getContinuingOutputs, findData)
@@ -44,6 +46,9 @@ data StateMachineInstance s i = StateMachineInstance {
     -- | The validator code for this state machine.
     validatorInstance :: ScriptInstance (StateMachine s i)
     }
+
+machineAddress :: StateMachineInstance s i -> Address
+machineAddress = scriptAddress . validatorInstance
 
 {-# INLINABLE mkValidator #-}
 -- | Turn a transition function 's -> i -> s' into a validator script.

--- a/plutus-wallet-api/src/Wallet/Typed/StateMachine.hs
+++ b/plutus-wallet-api/src/Wallet/Typed/StateMachine.hs
@@ -1,20 +1,52 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE NamedFieldPuns         #-}
+{-# LANGUAGE OverloadedStrings      #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TemplateHaskell        #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+-- needed for makeClassyPrisms
+{-# OPTIONS_GHC -fno-warn-overlapping-patterns #-}
 module Wallet.Typed.StateMachine where
 
+import           Control.Lens
 import           Control.Monad
+import qualified Data.Map                       as Map
+import           Data.Maybe                     (fromMaybe, mapMaybe)
 import qualified Data.Text                      as T
 
 import qualified Language.PlutusTx              as PlutusTx
 import qualified Language.PlutusTx.StateMachine as SM
+import           Ledger.AddressMap              (AddressMap)
 import qualified Ledger.Typed.Scripts           as Scripts
 import qualified Ledger.Typed.Tx                as Typed
 import           Ledger.Value
 import qualified Wallet.API                     as WAPI
 import qualified Wallet.Typed.API               as WAPITyped
+
+data SMError s i = InvalidTransition s i
+    deriving Show
+makeClassyPrisms ''SMError
+
+type OnChainState s i = (Typed.TypedScriptTxOut (SM.StateMachine s i), Typed.TypedScriptTxOutRef (SM.StateMachine s i))
+type SteppingTx s i = Typed.TypedTx '[SM.StateMachine s i] '[SM.StateMachine s i]
+type HaltingTx s i = Typed.TypedTx '[SM.StateMachine s i] '[]
+
+getStates
+    :: forall s i
+    . (PlutusTx.IsData s)
+    => SM.StateMachineInstance s i
+    -> AddressMap
+    -> [OnChainState s i]
+getStates (SM.StateMachineInstance _ si) am =
+    let refMap = fromMaybe Map.empty $ am ^. at (Scripts.scriptAddress si)
+    in flip mapMaybe (Map.toList refMap) $ \(ref, out) -> do
+        tref <- either (const Nothing) pure $ Typed.typeScriptTxOutRef (\r -> Map.lookup r refMap) si ref
+        tout <- either (const Nothing) pure $ Typed.typeScriptTxOut si out
+        pure (tout, tref)
 
 mkInitialise
     :: forall s i m


### PR DESCRIPTION
* Adds the `Language.Plutus.Contract.StateMachine` module, implementing
  the client-side bits of the typed state machine in the new contract API
* Based on
  https://github.com/michaelpj/plutus/commit/045e20770be415f3ebe86ce0df912782273371d8
* I was able to merge mkStep/runStep and mkHalt/runHalt
  - There is a slight annoyance, namely that the we have to check
    the value allocation and throw an error if a non-zero value is
    allocated to the contract in the final state
* This also adds a `valueMoved` field to the `UnbalancedTx` type
  - One more step towards the constraints approach