### PR TITLE
Fix UselessTransaction check

### DIFF
--- a/marlowe-playground-client/src/Marlowe/Semantics.purs
+++ b/marlowe-playground-client/src/Marlowe/Semantics.purs
@@ -876,7 +876,7 @@ computeTransaction tx state contract =
     case fixInterval (unwrap tx).interval state of
       IntervalTrimmed env fixState -> case applyAllInputs env fixState contract inputs of
         ApplyAllSuccess warnings payments newState cont ->
-          if contract == cont then
+          if (contract == cont) && ((contract /= Close) || (Map.isEmpty $ (unwrap state).accounts)) then
             Error TEUselessTransaction
           else
             TransactionOutput

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -677,7 +677,7 @@ computeTransaction tx state contract = let
     in case fixInterval (txInterval tx) state of
         IntervalTrimmed env fixState -> case applyAllInputs env fixState contract inputs of
             ApplyAllSuccess warnings payments newState cont -> let
-                in  if contract == cont
+                in  if (contract == cont) && ((contract /= Close) || (Map.null $ accounts state))
                     then Error TEUselessTransaction
                     else TransactionOutput { txOutWarnings = warnings
                                            , txOutPayments = payments

--- a/plutus-emulator/test/Spec.hs
+++ b/plutus-emulator/test/Spec.hs
@@ -200,7 +200,7 @@ invalidTrace = property $ do
         (result, st) = Gen.runTrace m $ simpleTrace invalidTxn
     Hedgehog.assert (isLeft result)
     Hedgehog.assert ([] == st ^. chainState . txPool)
-    Hedgehog.assert (not (null $ _emulatorLog st))
+    Hedgehog.assert (not (PlutusTx.null $ _emulatorLog st))
     Hedgehog.annotateShow (_emulatorLog st)
     Hedgehog.assert (case reverse $ _emulatorLog st of
         ChainEvent (Chain.SlotAdd _) : ChainEvent (Chain.TxnValidationFail _ _) : _ -> True
@@ -236,7 +236,7 @@ invalidScript = property $ do
 
     Hedgehog.assert (isRight result)
     Hedgehog.assert ([] == st ^. chainState . txPool)
-    Hedgehog.assert (not (null $ _emulatorLog st))
+    Hedgehog.assert (not (PlutusTx.null $ _emulatorLog st))
     Hedgehog.annotateShow (_emulatorLog st)
     Hedgehog.assert $ case reverse $ _emulatorLog st of
         ChainEvent (Chain.SlotAdd{}) : ChainEvent (Chain.TxnValidationFail _ (ScriptFailure (EvaluationError ["I always fail everything"]))) : _

--- a/plutus-tx/src/Language/PlutusTx/AssocMap.hs
+++ b/plutus-tx/src/Language/PlutusTx/AssocMap.hs
@@ -17,6 +17,7 @@ module Language.PlutusTx.AssocMap (
     Map
     , singleton
     , empty
+    , null
     , fromList
     , toList
     , keys
@@ -32,7 +33,7 @@ module Language.PlutusTx.AssocMap (
 import           GHC.Generics              (Generic)
 import           Language.PlutusTx.IsData
 import           Language.PlutusTx.Lift    (makeLift)
-import           Language.PlutusTx.Prelude hiding (all, lookup)
+import           Language.PlutusTx.Prelude hiding (all, lookup, null)
 import qualified Language.PlutusTx.Prelude as P
 import           Language.PlutusTx.These
 
@@ -169,5 +170,10 @@ singleton c i = Map [(c, i)]
 -- | An empty 'Map'.
 empty :: () -> Map k v
 empty _ = Map ([] :: [(k, v)])
+
+{-# INLINABLE null #-}
+-- | Is the map empty?
+null :: Map k v -> Bool
+null = P.null . unMap
 
 makeLift ''Map


### PR DESCRIPTION
Currently, Marlowe semantics is only checking whether a contract has been modified to decide whether a transaction is useless. This adds the condition that accounts have to be empty too, in case for some reason a contract consists only of `Close` but has accounts with money on them (this should not happen in practice, but it is more consistent this way).