### PR TITLE
plutus-tx: try and give better errors for uses of == arising from literal patterns

### DIFF
--- a/plutus-tx/test/Plugin/Errors/literalCaseBs.plc.golden
+++ b/plutus-tx/test/Plugin/Errors/literalCaseBs.plc.golden
@@ -1,0 +1,1 @@
+Error: Unsupported feature: Use of Haskell ByteString equality, possibly via the Haskell Eq typeclass

--- a/plutus-tx/test/Plugin/Errors/literalCaseInt.plc.golden
+++ b/plutus-tx/test/Plugin/Errors/literalCaseInt.plc.golden
@@ -1,0 +1,1 @@
+Error: Unsupported feature: Use of Haskell Integer equality, possibly via the Haskell Eq typeclass

--- a/plutus-tx/test/Plugin/Errors/literalCaseOther.plc.golden
+++ b/plutus-tx/test/Plugin/Errors/literalCaseOther.plc.golden
@@ -1,0 +1,384 @@
+(program 1.0.0
+  [
+    [
+      {
+        (abs
+          Unit_i0
+          (type)
+          (lam
+            Unit_i0
+            Unit_i2
+            (lam
+              Unit_match_i0
+              (fun Unit_i3 (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1)))
+              [
+                [
+                  {
+                    (abs
+                      AType_i0
+                      (type)
+                      (lam
+                        AType_i0
+                        AType_i2
+                        (lam
+                          AType_match_i0
+                          (fun AType_i3 (all out_AType_i0 (type) (fun out_AType_i1 out_AType_i1)))
+                          [
+                            [
+                              [
+                                {
+                                  (abs
+                                    Bool_i0
+                                    (type)
+                                    (lam
+                                      True_i0
+                                      Bool_i2
+                                      (lam
+                                        False_i0
+                                        Bool_i3
+                                        (lam
+                                          Bool_match_i0
+                                          (fun Bool_i4 (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                          [
+                                            (lam
+                                              c_i0
+                                              (fun AType_i8 (fun AType_i8 Bool_i5))
+                                              [
+                                                [
+                                                  [
+                                                    {
+                                                      (abs
+                                                        List_i0
+                                                        (fun (type) (type))
+                                                        (lam
+                                                          Nil_i0
+                                                          (all a_i0 (type) [List_i3 a_i1])
+                                                          (lam
+                                                            Cons_i0
+                                                            (all a_i0 (type) (fun a_i1 (fun [List_i4 a_i1] [List_i4 a_i1])))
+                                                            (lam
+                                                              Nil_match_i0
+                                                              (all a_i0 (type) (fun [List_i5 a_i1] (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i6 a_i2] out_List_i1)) out_List_i1)))))
+                                                              [
+                                                                (lam
+                                                                  cfromString_i0
+                                                                  (fun [List_i5 (con integer)] AType_i13)
+                                                                  [
+                                                                    (lam
+                                                                      fIsStringAType_i0
+                                                                      (fun (all a_i0 (type) (fun a_i1 a_i1)) [(lam a_i0 (type) (fun [List_i7 (con integer)] a_i1)) AType_i14])
+                                                                      [
+                                                                        (lam
+                                                                          fromString_i0
+                                                                          (all a_i0 (type) (fun [(lam a_i0 (type) (fun [List_i9 (con integer)] a_i1)) a_i1] (fun [List_i8 (con integer)] a_i1)))
+                                                                          (lam
+                                                                            x_i0
+                                                                            AType_i16
+                                                                            [
+                                                                              [
+                                                                                [
+                                                                                  {
+                                                                                    [
+                                                                                      Bool_match_i10
+                                                                                      [
+                                                                                        [
+                                                                                          c_i9
+                                                                                          x_i1
+                                                                                        ]
+                                                                                        [
+                                                                                          [
+                                                                                            {
+                                                                                              fromString_i2
+                                                                                              AType_i16
+                                                                                            }
+                                                                                            [
+                                                                                              fIsStringAType_i3
+                                                                                              (abs
+                                                                                                a_i0
+                                                                                                (type)
+                                                                                                (lam
+                                                                                                  x_i0
+                                                                                                  a_i2
+                                                                                                  x_i1
+                                                                                                )
+                                                                                              )
+                                                                                            ]
+                                                                                          ]
+                                                                                          [
+                                                                                            [
+                                                                                              {
+                                                                                                Cons_i6
+                                                                                                (con integer)
+                                                                                              }
+                                                                                              (con
+                                                                                                97
+                                                                                              )
+                                                                                            ]
+                                                                                            [
+                                                                                              [
+                                                                                                {
+                                                                                                  Cons_i6
+                                                                                                  (con integer)
+                                                                                                }
+                                                                                                (con
+                                                                                                  98
+                                                                                                )
+                                                                                              ]
+                                                                                              [
+                                                                                                [
+                                                                                                  {
+                                                                                                    Cons_i6
+                                                                                                    (con integer)
+                                                                                                  }
+                                                                                                  (con
+                                                                                                    99
+                                                                                                  )
+                                                                                                ]
+                                                                                                {
+                                                                                                  Nil_i7
+                                                                                                  (con integer)
+                                                                                                }
+                                                                                              ]
+                                                                                            ]
+                                                                                          ]
+                                                                                        ]
+                                                                                      ]
+                                                                                    ]
+                                                                                    (fun Unit_i19 AType_i16)
+                                                                                  }
+                                                                                  (lam
+                                                                                    thunk_i0
+                                                                                    Unit_i20
+                                                                                    [
+                                                                                      [
+                                                                                        {
+                                                                                          fromString_i3
+                                                                                          AType_i17
+                                                                                        }
+                                                                                        [
+                                                                                          fIsStringAType_i4
+                                                                                          (abs
+                                                                                            a_i0
+                                                                                            (type)
+                                                                                            (lam
+                                                                                              x_i0
+                                                                                              a_i2
+                                                                                              x_i1
+                                                                                            )
+                                                                                          )
+                                                                                        ]
+                                                                                      ]
+                                                                                      {
+                                                                                        Nil_i8
+                                                                                        (con integer)
+                                                                                      }
+                                                                                    ]
+                                                                                  )
+                                                                                ]
+                                                                                (lam
+                                                                                  thunk_i0
+                                                                                  Unit_i20
+                                                                                  x_i2
+                                                                                )
+                                                                              ]
+                                                                              Unit_i18
+                                                                            ]
+                                                                          )
+                                                                        )
+                                                                        (abs
+                                                                          a_i0
+                                                                          (type)
+                                                                          (lam
+                                                                            v_i0
+                                                                            [(lam a_i0 (type) (fun [List_i9 (con integer)] a_i1)) a_i2]
+                                                                            v_i1
+                                                                          )
+                                                                        )
+                                                                      ]
+                                                                    )
+                                                                    (lam
+                                                                      arg_i0
+                                                                      (all a_i0 (type) (fun a_i1 a_i1))
+                                                                      cfromString_i2
+                                                                    )
+                                                                  ]
+                                                                )
+                                                                (lam
+                                                                  ds_i0
+                                                                  [List_i5 (con integer)]
+                                                                  AType_i12
+                                                                )
+                                                              ]
+                                                            )
+                                                          )
+                                                        )
+                                                      )
+                                                      (lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1))
+                                                    }
+                                                    (abs
+                                                      a_i0
+                                                      (type)
+                                                      (iwrap
+                                                        (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1)))))
+                                                        a_i1
+                                                        (abs
+                                                          out_List_i0
+                                                          (type)
+                                                          (lam
+                                                            case_Nil_i0
+                                                            out_List_i2
+                                                            (lam
+                                                              case_Cons_i0
+                                                              (fun a_i4 (fun [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i4] out_List_i3))
+                                                              case_Nil_i2
+                                                            )
+                                                          )
+                                                        )
+                                                      )
+                                                    )
+                                                  ]
+                                                  (abs
+                                                    a_i0
+                                                    (type)
+                                                    (lam
+                                                      arg_0_i0
+                                                      a_i2
+                                                      (lam
+                                                        arg_1_i0
+                                                        [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i3]
+                                                        (iwrap
+                                                          (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1)))))
+                                                          a_i3
+                                                          (abs
+                                                            out_List_i0
+                                                            (type)
+                                                            (lam
+                                                              case_Nil_i0
+                                                              out_List_i2
+                                                              (lam
+                                                                case_Cons_i0
+                                                                (fun a_i6 (fun [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i6] out_List_i3))
+                                                                [
+                                                                  [
+                                                                    case_Cons_i1
+                                                                    arg_0_i5
+                                                                  ]
+                                                                  arg_1_i4
+                                                                ]
+                                                              )
+                                                            )
+                                                          )
+                                                        )
+                                                      )
+                                                    )
+                                                  )
+                                                ]
+                                                (abs
+                                                  a_i0
+                                                  (type)
+                                                  (lam
+                                                    x_i0
+                                                    [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i2]
+                                                    (unwrap x_i1)
+                                                  )
+                                                )
+                                              ]
+                                            )
+                                            (lam
+                                              ds_i0
+                                              AType_i8
+                                              (lam
+                                                ds_i0
+                                                AType_i9
+                                                [
+                                                  [
+                                                    {
+                                                      [ AType_match_i7 ds_i2 ]
+                                                      (fun Unit_i12 Bool_i6)
+                                                    }
+                                                    (lam
+                                                      thunk_i0
+                                                      Unit_i13
+                                                      [
+                                                        [
+                                                          {
+                                                            [
+                                                              AType_match_i8
+                                                              ds_i2
+                                                            ]
+                                                            (fun Unit_i13 Bool_i7)
+                                                          }
+                                                          (lam
+                                                            thunk_i0
+                                                            Unit_i14
+                                                            True_i7
+                                                          )
+                                                        ]
+                                                        Unit_i12
+                                                      ]
+                                                    )
+                                                  ]
+                                                  Unit_i11
+                                                ]
+                                              )
+                                            )
+                                          ]
+                                        )
+                                      )
+                                    )
+                                  )
+                                  (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
+                                }
+                                (abs
+                                  out_Bool_i0
+                                  (type)
+                                  (lam
+                                    case_True_i0
+                                    out_Bool_i2
+                                    (lam case_False_i0 out_Bool_i3 case_True_i2)
+                                  )
+                                )
+                              ]
+                              (abs
+                                out_Bool_i0
+                                (type)
+                                (lam
+                                  case_True_i0
+                                  out_Bool_i2
+                                  (lam case_False_i0 out_Bool_i3 case_False_i1)
+                                )
+                              )
+                            ]
+                            (lam
+                              x_i0
+                              (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
+                              x_i1
+                            )
+                          ]
+                        )
+                      )
+                    )
+                    (all out_AType_i0 (type) (fun out_AType_i1 out_AType_i1))
+                  }
+                  (abs
+                    out_AType_i0
+                    (type)
+                    (lam case_AType_i0 out_AType_i2 case_AType_i1)
+                  )
+                ]
+                (lam
+                  x_i0
+                  (all out_AType_i0 (type) (fun out_AType_i1 out_AType_i1))
+                  x_i1
+                )
+              ]
+            )
+          )
+        )
+        (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1))
+      }
+      (abs out_Unit_i0 (type) (lam case_Unit_i0 out_Unit_i2 case_Unit_i1))
+    ]
+    (lam x_i0 (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1)) x_i1)
+  ]
+)


### PR DESCRIPTION
Fixes #1737 (more-or-less).

This is annoying, for the reasons described in the issue. Nonetheless,
we can still give better errors for the special cases of Integer and
ByteString, since we can recognize the inlined versions.