### PR TITLE
contracts: Better interface for UnbalancedTx

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
@@ -88,7 +88,7 @@ balanceTx
     -> m Tx
 balanceTx utxo pk utx = do
     let tx0 = T.toLedgerTx utx
-        tx = addMissingValueMoved pk (view T.valueMoved utx) tx0
+        tx = addMissingValueMoved pk (T.valueMoved utx) tx0
     (neg, pos) <- Value.split <$> computeBalance tx
 
     tx' <- if Value.isZero pos
@@ -145,7 +145,7 @@ addMissingValueMoved pk vl tx =
 --   it to the chain in the context of a wallet.
 handleTx :: MonadWallet m => SigningProcess -> UnbalancedTx -> m Tx
 handleTx p utx =
-    balanceWallet utx >>= addSignatures p (view T.requiredSignatures utx) >>= WAPI.signTxAndSubmit
+    balanceWallet utx >>= addSignatures p (T.requiredSignatures utx) >>= WAPI.signTxAndSubmit
 
 -- | The signing process gets a finished transaction and a list of public keys,
 --   and signs the transaction with the corresponding private keys.

--- a/plutus-contract/test/Spec/Contract.hs
+++ b/plutus-contract/test/Spec/Contract.hs
@@ -8,7 +8,6 @@
 {-# OPTIONS_GHC -Wno-partial-type-signatures #-}
 module Spec.Contract(tests) where
 
-import           Control.Lens                          ((&), (.~))
 import           Control.Monad                         (void)
 import           Control.Monad.Error.Lens
 import           Test.Tasty
@@ -105,7 +104,7 @@ tests =
             (waitingForSlot w1 20 /\ interestingAddress w1 someAddress)
             (handleBlockchainEvents w1 >> addBlocks 1)
 
-        , let smallTx = mempty & Tx.outputs .~ [Tx.pubKeyTxOut (Ada.lovelaceValueOf 10) (walletPubKey (Wallet 2))]
+        , let smallTx = mustProduceOutput (Tx.pubKeyTxOut (Ada.lovelaceValueOf 10) (walletPubKey (Wallet 2)))
           in cp "handle several blockchain events"
                 (submitTx smallTx >> submitTx smallTx)
                 (assertDone w1 (const True) "all blockchain events should be processed"

--- a/plutus-playground-lib/src/Playground/Contract.hs
+++ b/plutus-playground-lib/src/Playground/Contract.hs
@@ -56,7 +56,7 @@ module Playground.Contract
     , ownPubKey
     , BlockchainActions
     , awaitSlot
-    , inputs
+    , modifiesUtxoSet
     , nextTransactionAt
     , utxoAt
     , validityRange
@@ -79,7 +79,7 @@ import           Data.Text                                       (Text)
 import           GHC.Generics                                    (Generic)
 import           IOTS                                            (IotsType (iotsDefinition))
 import           Language.Plutus.Contract                        (type (.\/), AsContractError, BlockchainActions,
-                                                                  Contract, Endpoint, awaitSlot, inputs,
+                                                                  Contract, Endpoint, awaitSlot, modifiesUtxoSet,
                                                                   nextTransactionAt, submitTx, utxoAt, validityRange,
                                                                   watchAddressUntil)
 import           Language.Plutus.Contract.Effects.ExposeEndpoint (endpoint)

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -39,14 +39,14 @@ module Language.PlutusTx.Coordination.Contracts.Future(
     , scriptInstance
     ) where
 
-import           Control.Lens                   ((&), (.~), prism', review, makeClassyPrisms)
+import           Control.Lens                   (prism', review, makeClassyPrisms)
 import           Control.Monad                  (void)
 import           Control.Monad.Error.Lens       (throwing)
 import           GHC.Generics                   (Generic)
 import           Language.Plutus.Contract
 import           Language.Plutus.Contract.Util  (loopM)
 import qualified Language.PlutusTx              as PlutusTx
-import           Language.PlutusTx.Prelude
+import           Language.PlutusTx.Prelude      hiding (Semigroup(..))
 import qualified Language.PlutusTx.StateMachine as SM
 import           Ledger                         (PubKey, Slot (..), Validator, Value, Address, DataValue, ValidatorHash)
 import qualified Ledger
@@ -66,6 +66,7 @@ import           Language.Plutus.Contract.StateMachine (ValueAllocation(..), AsS
 import qualified Language.Plutus.Contract.StateMachine as SM
 
 import qualified Prelude as Haskell
+import           Prelude (Semigroup(..))
 
 -- $future
 -- A futures contract in Plutus. This example illustrates a number of concepts.
@@ -341,7 +342,7 @@ payoutsTx
     Payouts{payoutsShort, payoutsLong}
     FutureAccounts{ftoShort, ftoLong} =
         TokenAccount.payTx (TokenAccount.scriptInstance ftoShort) payoutsShort
-        Haskell.<> TokenAccount.payTx (TokenAccount.scriptInstance ftoLong) payoutsLong
+        <> TokenAccount.payTx (TokenAccount.scriptInstance ftoLong) payoutsLong
 
 {-# INLINABLE payouts #-}
 -- | Compute the payouts for each role given the future data,
@@ -415,7 +416,7 @@ allocate future ftos (Running accounts) (Settle ov) vl = do
         { vaOwnAddress = mempty
         , vaOtherPayments =
             payoutsTx payments ftos
-                & validityRange .~ Interval.from (succ $ ftDeliveryDate future)
+                <> mustBeValidIn (Interval.from (succ $ ftDeliveryDate future))
         }
 allocate _ _ _ _ vl = Nothing
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/MultiSig.hs
@@ -20,15 +20,16 @@ module Language.PlutusTx.Coordination.Contracts.MultiSig
     , validate
     ) where
 
-import           Control.Lens                 ((&), (.~))
 import           Control.Monad                (void)
 import           Language.Plutus.Contract
 import qualified Language.Plutus.Contract.Tx  as Tx
-import           Language.PlutusTx.Prelude    hiding (foldMap)
+import           Language.PlutusTx.Prelude    hiding (Semigroup(..), foldMap)
 import qualified Language.PlutusTx            as PlutusTx
 import           Ledger
 import qualified Ledger.Typed.Scripts         as Scripts
 import           Ledger.Validation            as V
+
+import           Prelude                      (Semigroup(..), foldMap)
 
 type MultiSigSchema =
     BlockchainActions
@@ -76,5 +77,5 @@ unlock = do
     let val = validator ms
     utx <- utxoAt (Ledger.scriptAddress val)
     let tx = collectFromScript utx val unitRedeemer
-                & Tx.requiredSignatures .~ pks
+                <> foldMap Tx.mustBeSignedBy pks
     void $ submitTx tx

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/TokenAccount.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/TokenAccount.hs
@@ -147,12 +147,14 @@ redeemTx
     -> Contract s e UnbalancedTx
 redeemTx account pk = do
     let inst = scriptInstance account
-    utxos <- utxoAt (Scripts.scriptAddress inst)
-    let tx = TypedTx.collectFromScript utxos inst ()
+    utxos <- utxoAt (address account)
+    let pkOut = pubKeyTxOut (accountToken account) pk
+        tx = TypedTx.collectFromScript utxos inst ()
+                <> mustProduceOutput pkOut
     -- TODO. Replace 'PubKey' with a more general 'Address' type of output?
     --       Or perhaps add a field 'requiredTokens' to 'UnbalancedTx' and let the
     --       balancing mechanism take care of providing the token.
-    pure $ tx & outputs .~ [pubKeyTxOut (accountToken account) pk]
+    pure tx
 
 -- | Empty the account by spending all outputs belonging to the 'Account'.
 redeem

--- a/plutus-use-cases/test/Spec/PubKey.hs
+++ b/plutus-use-cases/test/Spec/PubKey.hs
@@ -1,8 +1,6 @@
 module Spec.PubKey(tests) where
 
-import           Control.Lens
 import           Control.Monad                                   (void)
-import qualified Data.Set                                        as Set
 
 import           Language.Plutus.Contract
 import           Language.Plutus.Contract.Test
@@ -20,7 +18,7 @@ w1 = Wallet 1
 theContract :: Contract BlockchainActions ContractError ()
 theContract = do
   txin <- pubKeyContract (walletPubKey w1) (Ada.lovelaceValueOf 10)
-  void $ submitTx $ mempty & inputs .~ Set.singleton txin
+  void $ submitTx $ mustSpendInput txin
 
 tests :: TestTree
 tests = testGroup "pubkey"


### PR DESCRIPTION
This is what I did initially when working on #1753 before I realised I was going in the wrong direction. (we can't actually use `UnbalancedTx` in on-chain code because it includes validator, redeemer & data values in full, not just hashed). So this PR just makes the syntax a bit nicer by removing the need for `lens`. 

It does add new instances of our prelude's semigroup and monoid classes, which goes against the principle of using those classes in on-chain code only. So, feel free to reject this if you feel strongly about it.