### PR TITLE
Frontend: Scrolling to a particular line should also take focus.

### DIFF
--- a/web-common/src/Editor.purs
+++ b/web-common/src/Editor.purs
@@ -66,7 +66,10 @@ handleAction _ (SetPreferences preferencesAction) editor = setPreferences prefer
 
 handleAction _ (HandleDragEvent event) _ = liftEffect $ preventDefault event
 
-handleAction _ (ScrollTo { row, column }) editor = liftEffect $ AceEditor.gotoLine row (Just column) (Just true) editor
+handleAction _ (ScrollTo { row, column }) editor =
+  liftEffect do
+    AceEditor.gotoLine row (Just column) (Just true) editor
+    AceEditor.focus editor
 
 handleAction bufferLocalStorageKey (HandleDropEvent event) editor =
   liftAff do


### PR DESCRIPTION
It's annoying to click on an error, jump there, and not be able to
edit straight away. This fixes this by making a jump to a cursor
position also grab the focus.