### PR TITLE
plutus-ir: share fixpoint combinator

### DIFF
--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Everything.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Everything.hs
@@ -46,7 +46,7 @@ stdLib =
                   , plcTypeFile "Self"   $ _recursiveType selfData
                   , plcTermFile "Unroll" unroll
                   , plcTermFile "Fix"    fix
-                  , plcTermFile "Fix2"   $ fixN 2
+                  , plcTermFile "Fix2"   $ (fst $ fixN 2)
                   ]
               , treeFolderContents "Integer"
                   [ plcTermFile "SuccInteger" succInteger

--- a/language-plutus-core/test/Evaluation/Golden.hs
+++ b/language-plutus-core/test/Evaluation/Golden.hs
@@ -42,7 +42,7 @@ evenAndOdd = runQuote $ do
     evenF <- FunctionDef () evenn (FunctionType () nat bool) <$> eoFunc true oddd
     oddF  <- FunctionDef () oddd  (FunctionType () nat bool) <$> eoFunc false evenn
 
-    getMutualFixOf () [evenF, oddF]
+    getMutualFixOf () (fst $ fixN 2) [evenF, oddF]
 
 even :: Term TyName Name ()
 even = runQuote $ tupleTermAt () 0 evenAndOdd
@@ -82,7 +82,7 @@ evenAndOddList = runQuote $ do
             LamAbs () t listNat $
             Apply () (Var () evenn) (Var () t)
 
-    getMutualFixOf () [evenF, oddF]
+    getMutualFixOf () (fst $ fixN 2) [evenF, oddF]
 
 evenList :: Term TyName Name ()
 evenList = runQuote $ tupleTermAt () 0 evenAndOddList

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
@@ -6,47 +6,72 @@ module Language.PlutusIR.Compiler.Let (compileLets, LetKind(..)) where
 
 import           Language.PlutusIR
 import           Language.PlutusIR.Compiler.Datatype
+import           Language.PlutusIR.Compiler.Definitions
 import           Language.PlutusIR.Compiler.Error
 import           Language.PlutusIR.Compiler.Provenance
 import           Language.PlutusIR.Compiler.Recursion
 import           Language.PlutusIR.Compiler.Types
-import qualified Language.PlutusIR.MkPir               as PIR
+import qualified Language.PlutusIR.MkPir                as PIR
 
 import           Control.Monad
 import           Control.Monad.Error.Lens
+import           Control.Monad.Trans
 
-import           Control.Lens                          hiding (Strict)
+import           Control.Lens                           hiding (Strict)
 
 import           Data.List
+
+{- Note [Extra definitions while compiling let-bindings]
+The let-compiling passes can generate some additional definitions, so we use the
+support from 'Definitions' to ease this.
+
+Specifically, only the recursive term pass should do this (it helps to share fixpoint combinators).
+So putting in the definitions should mostly be a no-op, and we'll get errors if it's not.
+It would be more elegant to somehow indicate that only one of the let-compiling passes needs
+this, but this does the job.
+Also we should pull out more stuff (e.g. see 'NonStrict' which uses unit).
+-}
 
 data LetKind = RecTerms | NonRecTerms | Types
 
 -- | Compile the let terms out of a 'Term'. Note: the result does *not* have globally unique names.
 compileLets :: Compiling m e a => LetKind -> PIRTerm a -> m (PIRTerm a)
-compileLets kind = transformMOf termSubterms (compileLet kind)
+compileLets kind t = getEnclosing >>= \p ->
+    -- See Note [Extra definitions while compiling let-bindings]
+    runDefT p $ transformMOf termSubterms (compileLet kind) t
 
-compileLet :: Compiling m e a => LetKind -> PIRTerm a -> m (PIRTerm a)
+compileLet :: Compiling m e a => LetKind -> PIRTerm a -> DefT SharedName (Provenance a) m (PIRTerm a)
 compileLet kind = \case
     Let p r bs body -> withEnclosing (const $ LetBinding r p) $ case r of
-            NonRec -> foldM (compileNonRecBinding kind) body bs
+            NonRec -> lift $ foldM (compileNonRecBinding kind) body bs
             Rec    -> compileRecBindings kind body bs
     x -> pure x
 
-compileRecBindings :: Compiling m e a => LetKind -> PIRTerm a -> [Binding TyName Name (Provenance a)] -> m (PIRTerm a)
+compileRecBindings
+    :: Compiling m e a
+    => LetKind
+    -> PIRTerm a
+    -> [Binding TyName Name (Provenance a)]
+    -> DefT SharedName (Provenance a) m (PIRTerm a)
 compileRecBindings kind body bs
     | null typeBinds = compileRecTermBindings kind body termBinds
-    | null termBinds = compileRecTypeBindings kind body typeBinds
-    | otherwise      = getEnclosing >>= \p -> throwing _Error $ CompilationError p "Mixed term and type bindings in recursive let"
+    | null termBinds = lift $ compileRecTypeBindings kind body typeBinds
+    | otherwise      = lift $ getEnclosing >>= \p -> throwing _Error $ CompilationError p "Mixed term and type bindings in recursive let"
     where
         (termBinds, typeBinds) = partition (\case { TermBind {} -> True ; _ -> False; }) bs
 
-compileRecTermBindings :: Compiling m e a => LetKind -> PIRTerm a -> [Binding TyName Name (Provenance a)] -> m (PIRTerm a)
+compileRecTermBindings
+    :: Compiling m e a
+    => LetKind
+    -> PIRTerm a
+    -> [Binding TyName Name (Provenance a)]
+    -> DefT SharedName (Provenance a) m (PIRTerm a)
 compileRecTermBindings RecTerms body bs = do
     binds <- forM bs $ \case
         TermBind _ Strict vd rhs -> pure $ PIR.Def vd rhs
-        _ -> getEnclosing >>= \p -> throwing _Error $ CompilationError p "Internal error: type binding in term binding group"
+        _ -> lift $ getEnclosing >>= \p -> throwing _Error $ CompilationError p "Internal error: type binding in term binding group"
     compileRecTerms body binds
-compileRecTermBindings _ body bs = getEnclosing >>= \p -> pure $ Let p Rec bs body
+compileRecTermBindings _ body bs = lift $ getEnclosing >>= \p -> pure $ Let p Rec bs body
 
 compileRecTypeBindings :: Compiling m e a => LetKind -> PIRTerm a -> [Binding TyName Name (Provenance a)] -> m (PIRTerm a)
 compileRecTypeBindings Types body bs = do

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE ConstraintKinds  #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE ConstraintKinds   #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 module Language.PlutusIR.Compiler.Types where
 
 import qualified Language.PlutusIR                     as PIR
@@ -16,6 +17,8 @@ import qualified Language.PlutusCore                   as PLC
 import qualified Language.PlutusCore.MkPlc             as PLC
 import           Language.PlutusCore.Quote
 import qualified Language.PlutusCore.StdLib.Type       as Types
+
+import qualified Data.Text                             as T
 
 newtype CompilationOpts = CompilationOpts {
     _coOptimize :: Bool
@@ -77,3 +80,10 @@ type PIRType a = PIR.Type PIR.TyName (Provenance a)
 type Compiling m e a = (Monad m, MonadReader (CompilationCtx a) m, AsError e (Provenance a), MonadError e m, MonadQuote m)
 
 type TermDef tyname name a = PLC.Def (PLC.VarDecl tyname name a) (PIR.Term tyname name a)
+
+-- | We generate some shared definitions compilation, this datatype
+-- defines the "keys" for those definitions.
+data SharedName = FixpointCombinator Integer deriving (Show, Eq, Ord)
+
+toProgramName :: SharedName -> Quote (PLC.Name ())
+toProgramName (FixpointCombinator n) = freshName () ("fix" <> T.pack (show n))

--- a/plutus-ir/test/recursion/even3.golden
+++ b/plutus-ir/test/recursion/even3.golden
@@ -1,449 +1,417 @@
 (program 1.0.0
   [
-    [
+    (lam
+      fix2_i0
+      (all a_i0 (type) (all b_i0 (type) (all a_i0 (type) (all b_i0 (type) (fun (all Q_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)) (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)))) (all R_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) R_i1)) R_i1)))))))
       [
-        {
-          (abs
-            Nat_i0
-            (type)
-            (lam
-              Zero_i0
-              Nat_i2
-              (lam
-                Suc_i0
-                (fun Nat_i3 Nat_i3)
+        [
+          [
+            {
+              (abs
+                Nat_i0
+                (type)
                 (lam
-                  match_Nat_i0
-                  (fun Nat_i4 (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i5 out_Nat_i1) out_Nat_i1))))
-                  [
+                  Zero_i0
+                  Nat_i2
+                  (lam
+                    Suc_i0
+                    (fun Nat_i3 Nat_i3)
                     (lam
-                      three_i0
-                      Nat_i5
+                      match_Nat_i0
+                      (fun Nat_i4 (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i5 out_Nat_i1) out_Nat_i1))))
                       [
-                        [
+                        (lam
+                          three_i0
+                          Nat_i5
                           [
-                            {
-                              (abs
-                                Bool_i0
-                                (type)
-                                (lam
-                                  True_i0
-                                  Bool_i2
-                                  (lam
-                                    False_i0
-                                    Bool_i3
+                            [
+                              [
+                                {
+                                  (abs
+                                    Bool_i0
+                                    (type)
                                     (lam
-                                      match_Bool_i0
-                                      (fun Bool_i4 (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
-                                      [
+                                      True_i0
+                                      Bool_i2
+                                      (lam
+                                        False_i0
+                                        Bool_i3
                                         (lam
-                                          tup_i0
-                                          (all r_i0 (type) (fun (fun (fun Nat_i11 Bool_i6) (fun (fun Nat_i11 Bool_i6) r_i1)) r_i1))
+                                          match_Bool_i0
+                                          (fun Bool_i4 (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
                                           [
                                             (lam
-                                              even_i0
-                                              (fun Nat_i11 Bool_i6)
-                                              [ even_i1 three_i7 ]
+                                              tup_i0
+                                              (all r_i0 (type) (fun (fun (fun Nat_i11 Bool_i6) (fun (fun Nat_i11 Bool_i6) r_i1)) r_i1))
+                                              [
+                                                (lam
+                                                  even_i0
+                                                  (fun Nat_i11 Bool_i6)
+                                                  [ even_i1 three_i7 ]
+                                                )
+                                                [
+                                                  {
+                                                    tup_i1 (fun Nat_i10 Bool_i5)
+                                                  }
+                                                  (lam
+                                                    arg_0_i0
+                                                    (fun Nat_i11 Bool_i6)
+                                                    (lam
+                                                      arg_1_i0
+                                                      (fun Nat_i12 Bool_i7)
+                                                      arg_0_i2
+                                                    )
+                                                  )
+                                                ]
+                                              ]
                                             )
                                             [
-                                              { tup_i1 (fun Nat_i10 Bool_i5) }
-                                              (lam
-                                                arg_0_i0
-                                                (fun Nat_i11 Bool_i6)
+                                              {
+                                                {
+                                                  {
+                                                    { fix2_i10 Nat_i9 } Bool_i4
+                                                  }
+                                                  Nat_i9
+                                                }
+                                                Bool_i4
+                                              }
+                                              (abs
+                                                Q_i0
+                                                (type)
                                                 (lam
-                                                  arg_1_i0
-                                                  (fun Nat_i12 Bool_i7)
-                                                  arg_0_i2
+                                                  choose_i0
+                                                  (fun (fun Nat_i11 Bool_i6) (fun (fun Nat_i11 Bool_i6) Q_i2))
+                                                  (lam
+                                                    even_i0
+                                                    (fun Nat_i12 Bool_i7)
+                                                    (lam
+                                                      odd_i0
+                                                      (fun Nat_i13 Bool_i8)
+                                                      [
+                                                        [
+                                                          choose_i3
+                                                          (lam
+                                                            n_i0
+                                                            Nat_i14
+                                                            [
+                                                              [
+                                                                {
+                                                                  [
+                                                                    match_Nat_i11
+                                                                    n_i1
+                                                                  ]
+                                                                  Bool_i9
+                                                                }
+                                                                True_i8
+                                                              ]
+                                                              (lam
+                                                                pred_i0
+                                                                Nat_i15
+                                                                [
+                                                                  odd_i3 pred_i1
+                                                                ]
+                                                              )
+                                                            ]
+                                                          )
+                                                        ]
+                                                        (lam
+                                                          n_i0
+                                                          Nat_i14
+                                                          [
+                                                            [
+                                                              {
+                                                                [
+                                                                  match_Nat_i11
+                                                                  n_i1
+                                                                ]
+                                                                Bool_i9
+                                                              }
+                                                              False_i7
+                                                            ]
+                                                            (lam
+                                                              pred_i0
+                                                              Nat_i15
+                                                              [
+                                                                even_i4 pred_i1
+                                                              ]
+                                                            )
+                                                          ]
+                                                        )
+                                                      ]
+                                                    )
+                                                  )
                                                 )
                                               )
                                             ]
                                           ]
                                         )
-                                        [
-                                          {
-                                            {
-                                              {
-                                                {
-                                                  (abs
-                                                    a_i0
-                                                    (type)
-                                                    (abs
-                                                      b_i0
-                                                      (type)
-                                                      (abs
-                                                        a_i0
-                                                        (type)
-                                                        (abs
-                                                          b_i0
-                                                          (type)
-                                                          (lam
-                                                            f_i0
-                                                            (all Q_i0 (type) (fun (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1)) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1))))
-                                                            [
-                                                              [
-                                                                {
-                                                                  (abs
-                                                                    F_i0
-                                                                    (fun (type) (type))
-                                                                    (lam
-                                                                      by_i0
-                                                                      (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
-                                                                      [
-                                                                        {
-                                                                          {
-                                                                            (abs
-                                                                              a_i0
-                                                                              (type)
-                                                                              (abs
-                                                                                b_i0
-                                                                                (type)
-                                                                                (lam
-                                                                                  f_i0
-                                                                                  (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
-                                                                                  [
-                                                                                    {
-                                                                                      (abs
-                                                                                        a_i0
-                                                                                        (type)
-                                                                                        (lam
-                                                                                          s_i0
-                                                                                          [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                                                                          [
-                                                                                            (unwrap
-                                                                                              s_i1
-                                                                                            )
-                                                                                            s_i1
-                                                                                          ]
-                                                                                        )
-                                                                                      )
-                                                                                      (fun a_i3 b_i2)
-                                                                                    }
-                                                                                    (iwrap
-                                                                                      (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
-                                                                                      (fun a_i3 b_i2)
-                                                                                      (lam
-                                                                                        s_i0
-                                                                                        [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
-                                                                                        (lam
-                                                                                          x_i0
-                                                                                          a_i5
-                                                                                          [
-                                                                                            [
-                                                                                              f_i3
-                                                                                              [
-                                                                                                {
-                                                                                                  (abs
-                                                                                                    a_i0
-                                                                                                    (type)
-                                                                                                    (lam
-                                                                                                      s_i0
-                                                                                                      [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                                                                                      [
-                                                                                                        (unwrap
-                                                                                                          s_i1
-                                                                                                        )
-                                                                                                        s_i1
-                                                                                                      ]
-                                                                                                    )
-                                                                                                  )
-                                                                                                  (fun a_i5 b_i4)
-                                                                                                }
-                                                                                                s_i2
-                                                                                              ]
-                                                                                            ]
-                                                                                            x_i1
-                                                                                          ]
-                                                                                        )
-                                                                                      )
-                                                                                    )
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            )
-                                                                            (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
-                                                                          }
-                                                                          (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
-                                                                        }
-                                                                        (lam
-                                                                          rec_i0
-                                                                          (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
-                                                                          (lam
-                                                                            h_i0
-                                                                            (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
-                                                                            (abs
-                                                                              R_i0
-                                                                              (type)
-                                                                              (lam
-                                                                                fr_i0
-                                                                                [F_i6 R_i2]
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      by_i5
-                                                                                      (abs
-                                                                                        Q_i0
-                                                                                        (type)
-                                                                                        (lam
-                                                                                          fq_i0
-                                                                                          [F_i8 Q_i2]
-                                                                                          [
-                                                                                            {
-                                                                                              [
-                                                                                                rec_i6
-                                                                                                h_i5
-                                                                                              ]
-                                                                                              Q_i2
-                                                                                            }
-                                                                                            [
-                                                                                              {
-                                                                                                h_i5
-                                                                                                Q_i2
-                                                                                              }
-                                                                                              fq_i1
-                                                                                            ]
-                                                                                          ]
-                                                                                        )
-                                                                                      )
-                                                                                    ]
-                                                                                    R_i2
-                                                                                  }
-                                                                                  fr_i1
-                                                                                ]
-                                                                              )
-                                                                            )
-                                                                          )
-                                                                        )
-                                                                      ]
-                                                                    )
-                                                                  )
-                                                                  (lam X_i0 (type) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) X_i1)))
-                                                                }
-                                                                (lam
-                                                                  k_i0
-                                                                  (all Q_i0 (type) (fun (fun (fun a_i7 b_i6) (fun (fun a_i5 b_i4) Q_i1)) Q_i1))
-                                                                  (abs
-                                                                    S_i0
-                                                                    (type)
-                                                                    (lam
-                                                                      h_i0
-                                                                      (fun (fun a_i8 b_i7) (fun (fun a_i6 b_i5) S_i2))
-                                                                      [
-                                                                        [
-                                                                          h_i1
-                                                                          (lam
-                                                                            x_i0
-                                                                            a_i9
-                                                                            [
-                                                                              {
-                                                                                k_i4
-                                                                                b_i8
-                                                                              }
-                                                                              (lam
-                                                                                f_0_i0
-                                                                                (fun a_i10 b_i9)
-                                                                                (lam
-                                                                                  f_1_i0
-                                                                                  (fun a_i9 b_i8)
-                                                                                  [
-                                                                                    f_0_i2
-                                                                                    x_i3
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            ]
-                                                                          )
-                                                                        ]
-                                                                        (lam
-                                                                          x_i0
-                                                                          a_i7
-                                                                          [
-                                                                            {
-                                                                              k_i4
-                                                                              b_i6
-                                                                            }
-                                                                            (lam
-                                                                              f_0_i0
-                                                                              (fun a_i10 b_i9)
-                                                                              (lam
-                                                                                f_1_i0
-                                                                                (fun a_i9 b_i8)
-                                                                                [
-                                                                                  f_1_i1
-                                                                                  x_i3
-                                                                                ]
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                        )
-                                                                      ]
-                                                                    )
-                                                                  )
-                                                                )
-                                                              ]
-                                                              f_i1
-                                                            ]
-                                                          )
-                                                        )
-                                                      )
-                                                    )
-                                                  )
-                                                  Nat_i9
-                                                }
-                                                Bool_i4
-                                              }
-                                              Nat_i9
-                                            }
-                                            Bool_i4
-                                          }
-                                          (abs
-                                            Q_i0
-                                            (type)
-                                            (lam
-                                              choose_i0
-                                              (fun (fun Nat_i11 Bool_i6) (fun (fun Nat_i11 Bool_i6) Q_i2))
-                                              (lam
-                                                even_i0
-                                                (fun Nat_i12 Bool_i7)
-                                                (lam
-                                                  odd_i0
-                                                  (fun Nat_i13 Bool_i8)
-                                                  [
-                                                    [
-                                                      choose_i3
-                                                      (lam
-                                                        n_i0
-                                                        Nat_i14
-                                                        [
-                                                          [
-                                                            {
-                                                              [
-                                                                match_Nat_i11
-                                                                n_i1
-                                                              ]
-                                                              Bool_i9
-                                                            }
-                                                            True_i8
-                                                          ]
-                                                          (lam
-                                                            pred_i0
-                                                            Nat_i15
-                                                            [ odd_i3 pred_i1 ]
-                                                          )
-                                                        ]
-                                                      )
-                                                    ]
-                                                    (lam
-                                                      n_i0
-                                                      Nat_i14
-                                                      [
-                                                        [
-                                                          {
-                                                            [
-                                                              match_Nat_i11 n_i1
-                                                            ]
-                                                            Bool_i9
-                                                          }
-                                                          False_i7
-                                                        ]
-                                                        (lam
-                                                          pred_i0
-                                                          Nat_i15
-                                                          [ even_i4 pred_i1 ]
-                                                        )
-                                                      ]
-                                                    )
-                                                  ]
-                                                )
-                                              )
-                                            )
-                                          )
-                                        ]
-                                      ]
+                                      )
                                     )
                                   )
+                                  (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
+                                }
+                                (abs
+                                  out_Bool_i0
+                                  (type)
+                                  (lam
+                                    case_True_i0
+                                    out_Bool_i2
+                                    (lam case_False_i0 out_Bool_i3 case_True_i2)
+                                  )
+                                )
+                              ]
+                              (abs
+                                out_Bool_i0
+                                (type)
+                                (lam
+                                  case_True_i0
+                                  out_Bool_i2
+                                  (lam case_False_i0 out_Bool_i3 case_False_i1)
                                 )
                               )
+                            ]
+                            (lam
+                              x_i0
                               (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
-                            }
-                            (abs
-                              out_Bool_i0
-                              (type)
-                              (lam
-                                case_True_i0
-                                out_Bool_i2
-                                (lam case_False_i0 out_Bool_i3 case_True_i2)
-                              )
+                              x_i1
                             )
                           ]
-                          (abs
-                            out_Bool_i0
-                            (type)
-                            (lam
-                              case_True_i0
-                              out_Bool_i2
-                              (lam case_False_i0 out_Bool_i3 case_False_i1)
-                            )
-                          )
-                        ]
-                        (lam
-                          x_i0
-                          (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
-                          x_i1
                         )
+                        [ Suc_i2 [ Suc_i2 [ Suc_i2 Zero_i3 ] ] ]
                       ]
                     )
-                    [ Suc_i2 [ Suc_i2 [ Suc_i2 Zero_i3 ] ] ]
-                  ]
+                  )
+                )
+              )
+              (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+            }
+            (iwrap
+              (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
+              (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))
+              (abs
+                out_Nat_i0
+                (type)
+                (lam
+                  case_Zero_i0
+                  out_Nat_i2
+                  (lam
+                    case_Suc_i0
+                    (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i3)
+                    case_Zero_i2
+                  )
+                )
+              )
+            )
+          ]
+          (lam
+            arg_0_i0
+            (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+            (iwrap
+              (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
+              (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))
+              (abs
+                out_Nat_i0
+                (type)
+                (lam
+                  case_Zero_i0
+                  out_Nat_i2
+                  (lam
+                    case_Suc_i0
+                    (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i3)
+                    [ case_Suc_i1 arg_0_i4 ]
+                  )
                 )
               )
             )
           )
+        ]
+        (lam
+          x_i0
           (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-        }
-        (iwrap
-          (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
-          (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))
-          (abs
-            out_Nat_i0
-            (type)
-            (lam
-              case_Zero_i0
-              out_Nat_i2
-              (lam
-                case_Suc_i0
-                (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i3)
-                case_Zero_i2
-              )
-            )
-          )
+          (unwrap x_i1)
         )
       ]
-      (lam
-        arg_0_i0
-        (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-        (iwrap
-          (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
-          (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))
+    )
+    (abs
+      a_i0
+      (type)
+      (abs
+        b_i0
+        (type)
+        (abs
+          a_i0
+          (type)
           (abs
-            out_Nat_i0
+            b_i0
             (type)
             (lam
-              case_Zero_i0
-              out_Nat_i2
-              (lam
-                case_Suc_i0
-                (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i3)
-                [ case_Suc_i1 arg_0_i4 ]
-              )
+              f_i0
+              (all Q_i0 (type) (fun (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1)) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1))))
+              [
+                [
+                  {
+                    (abs
+                      F_i0
+                      (fun (type) (type))
+                      (lam
+                        by_i0
+                        (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
+                        [
+                          {
+                            {
+                              (abs
+                                a_i0
+                                (type)
+                                (abs
+                                  b_i0
+                                  (type)
+                                  (lam
+                                    f_i0
+                                    (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
+                                    [
+                                      {
+                                        (abs
+                                          a_i0
+                                          (type)
+                                          (lam
+                                            s_i0
+                                            [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                                            [ (unwrap s_i1) s_i1 ]
+                                          )
+                                        )
+                                        (fun a_i3 b_i2)
+                                      }
+                                      (iwrap
+                                        (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
+                                        (fun a_i3 b_i2)
+                                        (lam
+                                          s_i0
+                                          [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
+                                          (lam
+                                            x_i0
+                                            a_i5
+                                            [
+                                              [
+                                                f_i3
+                                                [
+                                                  {
+                                                    (abs
+                                                      a_i0
+                                                      (type)
+                                                      (lam
+                                                        s_i0
+                                                        [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                                                        [ (unwrap s_i1) s_i1 ]
+                                                      )
+                                                    )
+                                                    (fun a_i5 b_i4)
+                                                  }
+                                                  s_i2
+                                                ]
+                                              ]
+                                              x_i1
+                                            ]
+                                          )
+                                        )
+                                      )
+                                    ]
+                                  )
+                                )
+                              )
+                              (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
+                            }
+                            (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
+                          }
+                          (lam
+                            rec_i0
+                            (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
+                            (lam
+                              h_i0
+                              (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
+                              (abs
+                                R_i0
+                                (type)
+                                (lam
+                                  fr_i0
+                                  [F_i6 R_i2]
+                                  [
+                                    {
+                                      [
+                                        by_i5
+                                        (abs
+                                          Q_i0
+                                          (type)
+                                          (lam
+                                            fq_i0
+                                            [F_i8 Q_i2]
+                                            [
+                                              { [ rec_i6 h_i5 ] Q_i2 }
+                                              [ { h_i5 Q_i2 } fq_i1 ]
+                                            ]
+                                          )
+                                        )
+                                      ]
+                                      R_i2
+                                    }
+                                    fr_i1
+                                  ]
+                                )
+                              )
+                            )
+                          )
+                        ]
+                      )
+                    )
+                    (lam X_i0 (type) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) X_i1)))
+                  }
+                  (lam
+                    k_i0
+                    (all Q_i0 (type) (fun (fun (fun a_i7 b_i6) (fun (fun a_i5 b_i4) Q_i1)) Q_i1))
+                    (abs
+                      S_i0
+                      (type)
+                      (lam
+                        h_i0
+                        (fun (fun a_i8 b_i7) (fun (fun a_i6 b_i5) S_i2))
+                        [
+                          [
+                            h_i1
+                            (lam
+                              x_i0
+                              a_i9
+                              [
+                                { k_i4 b_i8 }
+                                (lam
+                                  f_0_i0
+                                  (fun a_i10 b_i9)
+                                  (lam f_1_i0 (fun a_i9 b_i8) [ f_0_i2 x_i3 ])
+                                )
+                              ]
+                            )
+                          ]
+                          (lam
+                            x_i0
+                            a_i7
+                            [
+                              { k_i4 b_i6 }
+                              (lam
+                                f_0_i0
+                                (fun a_i10 b_i9)
+                                (lam f_1_i0 (fun a_i9 b_i8) [ f_1_i1 x_i3 ])
+                              )
+                            ]
+                          )
+                        ]
+                      )
+                    )
+                  )
+                ]
+                f_i1
+              ]
             )
           )
         )
       )
-    ]
-    (lam
-      x_i0
-      (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-      (unwrap x_i1)
     )
   ]
 )

--- a/plutus-ir/test/recursion/even3Eval.golden
+++ b/plutus-ir/test/recursion/even3Eval.golden
@@ -1,5 +1,5 @@
 (abs
-  out_Bool_83
+  out_Bool_90
   (type)
-  (lam case_True_84 out_Bool_83 (lam case_False_85 out_Bool_83 case_False_85))
+  (lam case_True_91 out_Bool_90 (lam case_False_92 out_Bool_90 case_False_92))
 )

--- a/plutus-ir/test/recursion/mutuallyRecursiveValues.golden
+++ b/plutus-ir/test/recursion/mutuallyRecursiveValues.golden
@@ -1,268 +1,260 @@
 (program 1.0.0
   [
     (lam
-      tup_i0
-      (all r_i0 (type) (fun (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) r_i1)) r_i1))
+      fix2_i0
+      (all a_i0 (type) (all b_i0 (type) (all a_i0 (type) (all b_i0 (type) (fun (all Q_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)) (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)))) (all R_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) R_i1)) R_i1)))))))
       [
         (lam
-          x_i0
-          (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-          [ x_i1 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
+          tup_i0
+          (all r_i0 (type) (fun (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) r_i1)) r_i1))
+          [
+            (lam
+              x_i0
+              (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+              [ x_i1 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
+            )
+            [
+              {
+                tup_i1
+                (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+              }
+              (lam
+                arg_0_i0
+                (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                (lam
+                  arg_1_i0
+                  (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                  arg_0_i2
+                )
+              )
+            ]
+          ]
         )
         [
           {
-            tup_i1
-            (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+            {
+              {
+                { fix2_i1 (all a_i0 (type) (fun a_i1 a_i1)) }
+                (all a_i0 (type) (fun a_i1 a_i1))
+              }
+              (all a_i0 (type) (fun a_i1 a_i1))
+            }
+            (all a_i0 (type) (fun a_i1 a_i1))
           }
-          (lam
-            arg_0_i0
-            (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+          (abs
+            Q_i0
+            (type)
             (lam
-              arg_1_i0
-              (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-              arg_0_i2
+              choose_i0
+              (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) Q_i2))
+              (lam
+                x_i0
+                (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                (lam
+                  y_i0
+                  (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                  [
+                    [
+                      choose_i3
+                      (lam
+                        arg_i0
+                        (all a_i0 (type) (fun a_i1 a_i1))
+                        [ y_i2 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
+                      )
+                    ]
+                    (lam
+                      arg_i0
+                      (all a_i0 (type) (fun a_i1 a_i1))
+                      (abs a_i0 (type) (lam x_i0 a_i2 x_i1))
+                    )
+                  ]
+                )
+              )
             )
           )
         ]
       ]
     )
-    [
-      {
-        {
-          {
-            {
-              (abs
-                a_i0
-                (type)
-                (abs
-                  b_i0
-                  (type)
-                  (abs
-                    a_i0
-                    (type)
+    (abs
+      a_i0
+      (type)
+      (abs
+        b_i0
+        (type)
+        (abs
+          a_i0
+          (type)
+          (abs
+            b_i0
+            (type)
+            (lam
+              f_i0
+              (all Q_i0 (type) (fun (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1)) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1))))
+              [
+                [
+                  {
                     (abs
-                      b_i0
-                      (type)
+                      F_i0
+                      (fun (type) (type))
                       (lam
-                        f_i0
-                        (all Q_i0 (type) (fun (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1)) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1))))
+                        by_i0
+                        (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
                         [
-                          [
+                          {
                             {
                               (abs
-                                F_i0
-                                (fun (type) (type))
-                                (lam
-                                  by_i0
-                                  (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
-                                  [
-                                    {
+                                a_i0
+                                (type)
+                                (abs
+                                  b_i0
+                                  (type)
+                                  (lam
+                                    f_i0
+                                    (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
+                                    [
                                       {
                                         (abs
                                           a_i0
                                           (type)
-                                          (abs
-                                            b_i0
-                                            (type)
-                                            (lam
-                                              f_i0
-                                              (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
-                                              [
-                                                {
-                                                  (abs
-                                                    a_i0
-                                                    (type)
-                                                    (lam
-                                                      s_i0
-                                                      [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                                      [ (unwrap s_i1) s_i1 ]
-                                                    )
-                                                  )
-                                                  (fun a_i3 b_i2)
-                                                }
-                                                (iwrap
-                                                  (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
-                                                  (fun a_i3 b_i2)
-                                                  (lam
-                                                    s_i0
-                                                    [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
-                                                    (lam
-                                                      x_i0
-                                                      a_i5
-                                                      [
-                                                        [
-                                                          f_i3
-                                                          [
-                                                            {
-                                                              (abs
-                                                                a_i0
-                                                                (type)
-                                                                (lam
-                                                                  s_i0
-                                                                  [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                                                  [
-                                                                    (unwrap s_i1
-                                                                    )
-                                                                    s_i1
-                                                                  ]
-                                                                )
-                                                              )
-                                                              (fun a_i5 b_i4)
-                                                            }
-                                                            s_i2
-                                                          ]
-                                                        ]
-                                                        x_i1
-                                                      ]
-                                                    )
-                                                  )
-                                                )
-                                              ]
-                                            )
+                                          (lam
+                                            s_i0
+                                            [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                                            [ (unwrap s_i1) s_i1 ]
                                           )
                                         )
-                                        (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
+                                        (fun a_i3 b_i2)
                                       }
-                                      (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
-                                    }
-                                    (lam
-                                      rec_i0
-                                      (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
-                                      (lam
-                                        h_i0
-                                        (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
-                                        (abs
-                                          R_i0
-                                          (type)
+                                      (iwrap
+                                        (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
+                                        (fun a_i3 b_i2)
+                                        (lam
+                                          s_i0
+                                          [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
                                           (lam
-                                            fr_i0
-                                            [F_i6 R_i2]
+                                            x_i0
+                                            a_i5
                                             [
-                                              {
+                                              [
+                                                f_i3
                                                 [
-                                                  by_i5
-                                                  (abs
-                                                    Q_i0
-                                                    (type)
-                                                    (lam
-                                                      fq_i0
-                                                      [F_i8 Q_i2]
-                                                      [
-                                                        { [ rec_i6 h_i5 ] Q_i2 }
-                                                        [ { h_i5 Q_i2 } fq_i1 ]
-                                                      ]
+                                                  {
+                                                    (abs
+                                                      a_i0
+                                                      (type)
+                                                      (lam
+                                                        s_i0
+                                                        [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                                                        [ (unwrap s_i1) s_i1 ]
+                                                      )
                                                     )
-                                                  )
+                                                    (fun a_i5 b_i4)
+                                                  }
+                                                  s_i2
                                                 ]
-                                                R_i2
-                                              }
-                                              fr_i1
+                                              ]
+                                              x_i1
                                             ]
                                           )
                                         )
                                       )
-                                    )
-                                  ]
+                                    ]
+                                  )
                                 )
                               )
-                              (lam X_i0 (type) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) X_i1)))
+                              (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
                             }
+                            (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
+                          }
+                          (lam
+                            rec_i0
+                            (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
                             (lam
-                              k_i0
-                              (all Q_i0 (type) (fun (fun (fun a_i7 b_i6) (fun (fun a_i5 b_i4) Q_i1)) Q_i1))
+                              h_i0
+                              (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
                               (abs
-                                S_i0
+                                R_i0
                                 (type)
                                 (lam
-                                  h_i0
-                                  (fun (fun a_i8 b_i7) (fun (fun a_i6 b_i5) S_i2))
+                                  fr_i0
+                                  [F_i6 R_i2]
                                   [
-                                    [
-                                      h_i1
-                                      (lam
-                                        x_i0
-                                        a_i9
-                                        [
-                                          { k_i4 b_i8 }
-                                          (lam
-                                            f_0_i0
-                                            (fun a_i10 b_i9)
-                                            (lam
-                                              f_1_i0
-                                              (fun a_i9 b_i8)
-                                              [ f_0_i2 x_i3 ]
-                                            )
-                                          )
-                                        ]
-                                      )
-                                    ]
-                                    (lam
-                                      x_i0
-                                      a_i7
+                                    {
                                       [
-                                        { k_i4 b_i6 }
-                                        (lam
-                                          f_0_i0
-                                          (fun a_i10 b_i9)
+                                        by_i5
+                                        (abs
+                                          Q_i0
+                                          (type)
                                           (lam
-                                            f_1_i0
-                                            (fun a_i9 b_i8)
-                                            [ f_1_i1 x_i3 ]
+                                            fq_i0
+                                            [F_i8 Q_i2]
+                                            [
+                                              { [ rec_i6 h_i5 ] Q_i2 }
+                                              [ { h_i5 Q_i2 } fq_i1 ]
+                                            ]
                                           )
                                         )
                                       ]
-                                    )
+                                      R_i2
+                                    }
+                                    fr_i1
                                   ]
                                 )
                               )
                             )
+                          )
+                        ]
+                      )
+                    )
+                    (lam X_i0 (type) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) X_i1)))
+                  }
+                  (lam
+                    k_i0
+                    (all Q_i0 (type) (fun (fun (fun a_i7 b_i6) (fun (fun a_i5 b_i4) Q_i1)) Q_i1))
+                    (abs
+                      S_i0
+                      (type)
+                      (lam
+                        h_i0
+                        (fun (fun a_i8 b_i7) (fun (fun a_i6 b_i5) S_i2))
+                        [
+                          [
+                            h_i1
+                            (lam
+                              x_i0
+                              a_i9
+                              [
+                                { k_i4 b_i8 }
+                                (lam
+                                  f_0_i0
+                                  (fun a_i10 b_i9)
+                                  (lam f_1_i0 (fun a_i9 b_i8) [ f_0_i2 x_i3 ])
+                                )
+                              ]
+                            )
                           ]
-                          f_i1
+                          (lam
+                            x_i0
+                            a_i7
+                            [
+                              { k_i4 b_i6 }
+                              (lam
+                                f_0_i0
+                                (fun a_i10 b_i9)
+                                (lam f_1_i0 (fun a_i9 b_i8) [ f_1_i1 x_i3 ])
+                              )
+                            ]
+                          )
                         ]
                       )
                     )
                   )
-                )
-              )
-              (all a_i0 (type) (fun a_i1 a_i1))
-            }
-            (all a_i0 (type) (fun a_i1 a_i1))
-          }
-          (all a_i0 (type) (fun a_i1 a_i1))
-        }
-        (all a_i0 (type) (fun a_i1 a_i1))
-      }
-      (abs
-        Q_i0
-        (type)
-        (lam
-          choose_i0
-          (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) Q_i2))
-          (lam
-            x_i0
-            (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-            (lam
-              y_i0
-              (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-              [
-                [
-                  choose_i3
-                  (lam
-                    arg_i0
-                    (all a_i0 (type) (fun a_i1 a_i1))
-                    [ y_i2 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
-                  )
                 ]
-                (lam
-                  arg_i0
-                  (all a_i0 (type) (fun a_i1 a_i1))
-                  (abs a_i0 (type) (lam x_i0 a_i2 x_i1))
-                )
+                f_i1
               ]
             )
           )
         )
       )
-    ]
+    )
   ]
 )

--- a/plutus-tx/test/Plugin/Data/recursive/sameEmptyRose.plc.golden
+++ b/plutus-tx/test/Plugin/Data/recursive/sameEmptyRose.plc.golden
@@ -1,706 +1,495 @@
 (program 1.0.0
   [
-    [
-      {
-        (abs
-          Unit_i0
-          (type)
-          (lam
-            Unit_i0
-            Unit_i2
-            (lam
-              Unit_match_i0
-              (fun Unit_i3 (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1)))
-              [
-                [
+    (lam
+      fix1_i0
+      (all a_i0 (type) (all b_i0 (type) (fun (all Q_i0 (type) (fun (fun (fun a_i3 b_i2) Q_i1) (fun (fun a_i3 b_i2) Q_i1))) (all R_i0 (type) (fun (fun (fun a_i3 b_i2) R_i1) R_i1)))))
+      [
+        [
+          {
+            (abs
+              Unit_i0
+              (type)
+              (lam
+                Unit_i0
+                Unit_i2
+                (lam
+                  Unit_match_i0
+                  (fun Unit_i3 (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1)))
                   [
-                    {
-                      (abs
-                        List_i0
-                        (fun (type) (type))
-                        (lam
-                          Nil_i0
-                          (all a_i0 (type) [List_i3 a_i1])
-                          (lam
-                            Cons_i0
-                            (all a_i0 (type) (fun a_i1 (fun [List_i4 a_i1] [List_i4 a_i1])))
+                    [
+                      [
+                        {
+                          (abs
+                            List_i0
+                            (fun (type) (type))
                             (lam
-                              Nil_match_i0
-                              (all a_i0 (type) (fun [List_i5 a_i1] (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i6 a_i2] out_List_i1)) out_List_i1)))))
-                              [
-                                [
-                                  {
-                                    (abs
-                                      EmptyRose_i0
-                                      (type)
-                                      (lam
-                                        EmptyRose_i0
-                                        (fun [List_i6 EmptyRose_i2] EmptyRose_i2)
-                                        (lam
-                                          EmptyRose_match_i0
-                                          (fun EmptyRose_i3 (all out_EmptyRose_i0 (type) (fun (fun [List_i8 EmptyRose_i4] out_EmptyRose_i1) out_EmptyRose_i1)))
-                                          [
+                              Nil_i0
+                              (all a_i0 (type) [List_i3 a_i1])
+                              (lam
+                                Cons_i0
+                                (all a_i0 (type) (fun a_i1 (fun [List_i4 a_i1] [List_i4 a_i1])))
+                                (lam
+                                  Nil_match_i0
+                                  (all a_i0 (type) (fun [List_i5 a_i1] (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i6 a_i2] out_List_i1)) out_List_i1)))))
+                                  [
+                                    [
+                                      {
+                                        (abs
+                                          EmptyRose_i0
+                                          (type)
+                                          (lam
+                                            EmptyRose_i0
+                                            (fun [List_i6 EmptyRose_i2] EmptyRose_i2)
                                             (lam
-                                              tup_i0
-                                              (all r_i0 (type) (fun (fun (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5])) r_i1) r_i1))
+                                              EmptyRose_match_i0
+                                              (fun EmptyRose_i3 (all out_EmptyRose_i0 (type) (fun (fun [List_i8 EmptyRose_i4] out_EmptyRose_i1) out_EmptyRose_i1)))
                                               [
                                                 (lam
-                                                  map_i0
-                                                  (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5]))
+                                                  tup_i0
+                                                  (all r_i0 (type) (fun (fun (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5])) r_i1) r_i1))
                                                   [
                                                     (lam
-                                                      tup_i0
-                                                      (all r_i0 (type) (fun (fun (fun EmptyRose_i7 EmptyRose_i7) r_i1) r_i1))
+                                                      map_i0
+                                                      (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5]))
                                                       [
                                                         (lam
-                                                          go_i0
-                                                          (fun EmptyRose_i7 EmptyRose_i7)
-                                                          go_i1
+                                                          tup_i0
+                                                          (all r_i0 (type) (fun (fun (fun EmptyRose_i7 EmptyRose_i7) r_i1) r_i1))
+                                                          [
+                                                            (lam
+                                                              go_i0
+                                                              (fun EmptyRose_i7 EmptyRose_i7)
+                                                              go_i1
+                                                            )
+                                                            [
+                                                              {
+                                                                tup_i1
+                                                                (fun EmptyRose_i6 EmptyRose_i6)
+                                                              }
+                                                              (lam
+                                                                arg_0_i0
+                                                                (fun EmptyRose_i7 EmptyRose_i7)
+                                                                arg_0_i1
+                                                              )
+                                                            ]
+                                                          ]
                                                         )
                                                         [
                                                           {
-                                                            tup_i1
-                                                            (fun EmptyRose_i6 EmptyRose_i6)
+                                                            {
+                                                              fix1_i13
+                                                              EmptyRose_i5
+                                                            }
+                                                            EmptyRose_i5
                                                           }
-                                                          (lam
-                                                            arg_0_i0
-                                                            (fun EmptyRose_i7 EmptyRose_i7)
-                                                            arg_0_i1
+                                                          (abs
+                                                            Q_i0
+                                                            (type)
+                                                            (lam
+                                                              choose_i0
+                                                              (fun (fun EmptyRose_i7 EmptyRose_i7) Q_i2)
+                                                              (lam
+                                                                go_i0
+                                                                (fun EmptyRose_i8 EmptyRose_i8)
+                                                                [
+                                                                  choose_i2
+                                                                  (lam
+                                                                    x_i0
+                                                                    EmptyRose_i9
+                                                                    [
+                                                                      EmptyRose_i8
+                                                                      [
+                                                                        [
+                                                                          map_i5
+                                                                          go_i2
+                                                                        ]
+                                                                        [
+                                                                          {
+                                                                            [
+                                                                              EmptyRose_match_i7
+                                                                              x_i1
+                                                                            ]
+                                                                            [List_i13 EmptyRose_i9]
+                                                                          }
+                                                                          (lam
+                                                                            x_i0
+                                                                            [List_i14 EmptyRose_i10]
+                                                                            x_i1
+                                                                          )
+                                                                        ]
+                                                                      ]
+                                                                    ]
+                                                                  )
+                                                                ]
+                                                              )
+                                                            )
                                                           )
                                                         ]
                                                       ]
                                                     )
                                                     [
                                                       {
-                                                        {
-                                                          (abs
-                                                            a_i0
-                                                            (type)
-                                                            (abs
-                                                              b_i0
-                                                              (type)
-                                                              (lam
-                                                                f_i0
-                                                                (all Q_i0 (type) (fun (fun (fun a_i4 b_i3) Q_i1) (fun (fun a_i4 b_i3) Q_i1)))
-                                                                [
-                                                                  [
-                                                                    {
-                                                                      (abs
-                                                                        F_i0
-                                                                        (fun (type) (type))
-                                                                        (lam
-                                                                          by_i0
-                                                                          (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
-                                                                          [
-                                                                            {
-                                                                              {
-                                                                                (abs
-                                                                                  a_i0
-                                                                                  (type)
-                                                                                  (abs
-                                                                                    b_i0
-                                                                                    (type)
-                                                                                    (lam
-                                                                                      f_i0
-                                                                                      (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
-                                                                                      [
-                                                                                        {
-                                                                                          (abs
-                                                                                            a_i0
-                                                                                            (type)
-                                                                                            (lam
-                                                                                              s_i0
-                                                                                              [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                                                                              [
-                                                                                                (unwrap
-                                                                                                  s_i1
-                                                                                                )
-                                                                                                s_i1
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                          (fun a_i3 b_i2)
-                                                                                        }
-                                                                                        (iwrap
-                                                                                          (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
-                                                                                          (fun a_i3 b_i2)
-                                                                                          (lam
-                                                                                            s_i0
-                                                                                            [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
-                                                                                            (lam
-                                                                                              x_i0
-                                                                                              a_i5
-                                                                                              [
-                                                                                                [
-                                                                                                  f_i3
-                                                                                                  [
-                                                                                                    {
-                                                                                                      (abs
-                                                                                                        a_i0
-                                                                                                        (type)
-                                                                                                        (lam
-                                                                                                          s_i0
-                                                                                                          [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                                                                                          [
-                                                                                                            (unwrap
-                                                                                                              s_i1
-                                                                                                            )
-                                                                                                            s_i1
-                                                                                                          ]
-                                                                                                        )
-                                                                                                      )
-                                                                                                      (fun a_i5 b_i4)
-                                                                                                    }
-                                                                                                    s_i2
-                                                                                                  ]
-                                                                                                ]
-                                                                                                x_i1
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                )
-                                                                                (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
-                                                                              }
-                                                                              (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
-                                                                            }
-                                                                            (lam
-                                                                              rec_i0
-                                                                              (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
-                                                                              (lam
-                                                                                h_i0
-                                                                                (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
-                                                                                (abs
-                                                                                  R_i0
-                                                                                  (type)
-                                                                                  (lam
-                                                                                    fr_i0
-                                                                                    [F_i6 R_i2]
-                                                                                    [
-                                                                                      {
-                                                                                        [
-                                                                                          by_i5
-                                                                                          (abs
-                                                                                            Q_i0
-                                                                                            (type)
-                                                                                            (lam
-                                                                                              fq_i0
-                                                                                              [F_i8 Q_i2]
-                                                                                              [
-                                                                                                {
-                                                                                                  [
-                                                                                                    rec_i6
-                                                                                                    h_i5
-                                                                                                  ]
-                                                                                                  Q_i2
-                                                                                                }
-                                                                                                [
-                                                                                                  {
-                                                                                                    h_i5
-                                                                                                    Q_i2
-                                                                                                  }
-                                                                                                  fq_i1
-                                                                                                ]
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                        R_i2
-                                                                                      }
-                                                                                      fr_i1
-                                                                                    ]
-                                                                                  )
-                                                                                )
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                        )
-                                                                      )
-                                                                      (lam X_i0 (type) (fun (fun a_i4 b_i3) X_i1))
-                                                                    }
-                                                                    (lam
-                                                                      k_i0
-                                                                      (all Q_i0 (type) (fun (fun (fun a_i5 b_i4) Q_i1) Q_i1))
-                                                                      (abs
-                                                                        S_i0
-                                                                        (type)
-                                                                        (lam
-                                                                          h_i0
-                                                                          (fun (fun a_i6 b_i5) S_i2)
-                                                                          [
-                                                                            h_i1
-                                                                            (lam
-                                                                              x_i0
-                                                                              a_i7
-                                                                              [
-                                                                                {
-                                                                                  k_i4
-                                                                                  b_i6
-                                                                                }
-                                                                                (lam
-                                                                                  f_0_i0
-                                                                                  (fun a_i8 b_i7)
-                                                                                  [
-                                                                                    f_0_i1
-                                                                                    x_i2
-                                                                                  ]
-                                                                                )
-                                                                              ]
-                                                                            )
-                                                                          ]
-                                                                        )
-                                                                      )
-                                                                    )
-                                                                  ]
-                                                                  f_i1
-                                                                ]
-                                                              )
-                                                            )
-                                                          )
-                                                          EmptyRose_i5
-                                                        }
-                                                        EmptyRose_i5
+                                                        tup_i1
+                                                        (fun (fun EmptyRose_i4 EmptyRose_i4) (fun [List_i8 EmptyRose_i4] [List_i8 EmptyRose_i4]))
                                                       }
-                                                      (abs
-                                                        Q_i0
-                                                        (type)
-                                                        (lam
-                                                          choose_i0
-                                                          (fun (fun EmptyRose_i7 EmptyRose_i7) Q_i2)
-                                                          (lam
-                                                            go_i0
-                                                            (fun EmptyRose_i8 EmptyRose_i8)
-                                                            [
-                                                              choose_i2
-                                                              (lam
-                                                                x_i0
-                                                                EmptyRose_i9
-                                                                [
-                                                                  EmptyRose_i8
-                                                                  [
-                                                                    [
-                                                                      map_i5
-                                                                      go_i2
-                                                                    ]
-                                                                    [
-                                                                      {
-                                                                        [
-                                                                          EmptyRose_match_i7
-                                                                          x_i1
-                                                                        ]
-                                                                        [List_i13 EmptyRose_i9]
-                                                                      }
-                                                                      (lam
-                                                                        x_i0
-                                                                        [List_i14 EmptyRose_i10]
-                                                                        x_i1
-                                                                      )
-                                                                    ]
-                                                                  ]
-                                                                ]
-                                                              )
-                                                            ]
-                                                          )
-                                                        )
+                                                      (lam
+                                                        arg_0_i0
+                                                        (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5]))
+                                                        arg_0_i1
                                                       )
                                                     ]
                                                   ]
                                                 )
                                                 [
                                                   {
-                                                    tup_i1
-                                                    (fun (fun EmptyRose_i4 EmptyRose_i4) (fun [List_i8 EmptyRose_i4] [List_i8 EmptyRose_i4]))
+                                                    {
+                                                      fix1_i11
+                                                      (fun EmptyRose_i3 EmptyRose_i3)
+                                                    }
+                                                    (fun [List_i7 EmptyRose_i3] [List_i7 EmptyRose_i3])
                                                   }
-                                                  (lam
-                                                    arg_0_i0
-                                                    (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5]))
-                                                    arg_0_i1
-                                                  )
-                                                ]
-                                              ]
-                                            )
-                                            [
-                                              {
-                                                {
                                                   (abs
-                                                    a_i0
+                                                    Q_i0
                                                     (type)
-                                                    (abs
-                                                      b_i0
-                                                      (type)
+                                                    (lam
+                                                      choose_i0
+                                                      (fun (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5])) Q_i2)
                                                       (lam
-                                                        f_i0
-                                                        (all Q_i0 (type) (fun (fun (fun a_i4 b_i3) Q_i1) (fun (fun a_i4 b_i3) Q_i1)))
+                                                        map_i0
+                                                        (fun (fun EmptyRose_i6 EmptyRose_i6) (fun [List_i10 EmptyRose_i6] [List_i10 EmptyRose_i6]))
                                                         [
-                                                          [
-                                                            {
-                                                              (abs
-                                                                F_i0
-                                                                (fun (type) (type))
-                                                                (lam
-                                                                  by_i0
-                                                                  (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
+                                                          choose_i2
+                                                          (lam
+                                                            ds_i0
+                                                            (fun EmptyRose_i7 EmptyRose_i7)
+                                                            (lam
+                                                              ds_i0
+                                                              [List_i12 EmptyRose_i8]
+                                                              [
+                                                                [
                                                                   [
                                                                     {
-                                                                      {
-                                                                        (abs
-                                                                          a_i0
-                                                                          (type)
-                                                                          (abs
-                                                                            b_i0
-                                                                            (type)
-                                                                            (lam
-                                                                              f_i0
-                                                                              (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
-                                                                              [
-                                                                                {
-                                                                                  (abs
-                                                                                    a_i0
-                                                                                    (type)
-                                                                                    (lam
-                                                                                      s_i0
-                                                                                      [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                                                                      [
-                                                                                        (unwrap
-                                                                                          s_i1
-                                                                                        )
-                                                                                        s_i1
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                  (fun a_i3 b_i2)
-                                                                                }
-                                                                                (iwrap
-                                                                                  (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
-                                                                                  (fun a_i3 b_i2)
-                                                                                  (lam
-                                                                                    s_i0
-                                                                                    [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
-                                                                                    (lam
-                                                                                      x_i0
-                                                                                      a_i5
-                                                                                      [
-                                                                                        [
-                                                                                          f_i3
-                                                                                          [
-                                                                                            {
-                                                                                              (abs
-                                                                                                a_i0
-                                                                                                (type)
-                                                                                                (lam
-                                                                                                  s_i0
-                                                                                                  [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                                                                                  [
-                                                                                                    (unwrap
-                                                                                                      s_i1
-                                                                                                    )
-                                                                                                    s_i1
-                                                                                                  ]
-                                                                                                )
-                                                                                              )
-                                                                                              (fun a_i5 b_i4)
-                                                                                            }
-                                                                                            s_i2
-                                                                                          ]
-                                                                                        ]
-                                                                                        x_i1
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                )
-                                                                              ]
-                                                                            )
-                                                                          )
-                                                                        )
-                                                                        (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
-                                                                      }
-                                                                      (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
-                                                                    }
-                                                                    (lam
-                                                                      rec_i0
-                                                                      (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
-                                                                      (lam
-                                                                        h_i0
-                                                                        (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
-                                                                        (abs
-                                                                          R_i0
-                                                                          (type)
-                                                                          (lam
-                                                                            fr_i0
-                                                                            [F_i6 R_i2]
-                                                                            [
-                                                                              {
-                                                                                [
-                                                                                  by_i5
-                                                                                  (abs
-                                                                                    Q_i0
-                                                                                    (type)
-                                                                                    (lam
-                                                                                      fq_i0
-                                                                                      [F_i8 Q_i2]
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            rec_i6
-                                                                                            h_i5
-                                                                                          ]
-                                                                                          Q_i2
-                                                                                        }
-                                                                                        [
-                                                                                          {
-                                                                                            h_i5
-                                                                                            Q_i2
-                                                                                          }
-                                                                                          fq_i1
-                                                                                        ]
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                ]
-                                                                                R_i2
-                                                                              }
-                                                                              fr_i1
-                                                                            ]
-                                                                          )
-                                                                        )
-                                                                      )
-                                                                    )
-                                                                  ]
-                                                                )
-                                                              )
-                                                              (lam X_i0 (type) (fun (fun a_i4 b_i3) X_i1))
-                                                            }
-                                                            (lam
-                                                              k_i0
-                                                              (all Q_i0 (type) (fun (fun (fun a_i5 b_i4) Q_i1) Q_i1))
-                                                              (abs
-                                                                S_i0
-                                                                (type)
-                                                                (lam
-                                                                  h_i0
-                                                                  (fun (fun a_i6 b_i5) S_i2)
-                                                                  [
-                                                                    h_i1
-                                                                    (lam
-                                                                      x_i0
-                                                                      a_i7
                                                                       [
                                                                         {
-                                                                          k_i4
-                                                                          b_i6
+                                                                          Nil_match_i9
+                                                                          EmptyRose_i8
                                                                         }
-                                                                        (lam
-                                                                          f_0_i0
-                                                                          (fun a_i8 b_i7)
-                                                                          [
-                                                                            f_0_i1
-                                                                            x_i2
-                                                                          ]
-                                                                        )
+                                                                        ds_i1
                                                                       ]
+                                                                      (fun Unit_i15 [List_i12 EmptyRose_i8])
+                                                                    }
+                                                                    (lam
+                                                                      thunk_i0
+                                                                      Unit_i16
+                                                                      {
+                                                                        Nil_i12
+                                                                        EmptyRose_i9
+                                                                      }
                                                                     )
                                                                   ]
-                                                                )
-                                                              )
+                                                                  (lam
+                                                                    x_i0
+                                                                    EmptyRose_i9
+                                                                    (lam
+                                                                      xs_i0
+                                                                      [List_i14 EmptyRose_i10]
+                                                                      (lam
+                                                                        thunk_i0
+                                                                        Unit_i18
+                                                                        [
+                                                                          [
+                                                                            {
+                                                                              Cons_i13
+                                                                              EmptyRose_i11
+                                                                            }
+                                                                            [
+                                                                              ds_i5
+                                                                              x_i3
+                                                                            ]
+                                                                          ]
+                                                                          [
+                                                                            [
+                                                                              map_i6
+                                                                              ds_i5
+                                                                            ]
+                                                                            xs_i2
+                                                                          ]
+                                                                        ]
+                                                                      )
+                                                                    )
+                                                                  )
+                                                                ]
+                                                                Unit_i14
+                                                              ]
                                                             )
-                                                          ]
-                                                          f_i1
+                                                          )
                                                         ]
                                                       )
                                                     )
                                                   )
-                                                  (fun EmptyRose_i3 EmptyRose_i3)
-                                                }
-                                                (fun [List_i7 EmptyRose_i3] [List_i7 EmptyRose_i3])
-                                              }
-                                              (abs
-                                                Q_i0
-                                                (type)
-                                                (lam
-                                                  choose_i0
-                                                  (fun (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5])) Q_i2)
-                                                  (lam
-                                                    map_i0
-                                                    (fun (fun EmptyRose_i6 EmptyRose_i6) (fun [List_i10 EmptyRose_i6] [List_i10 EmptyRose_i6]))
-                                                    [
-                                                      choose_i2
-                                                      (lam
-                                                        ds_i0
-                                                        (fun EmptyRose_i7 EmptyRose_i7)
-                                                        (lam
-                                                          ds_i0
-                                                          [List_i12 EmptyRose_i8]
-                                                          [
-                                                            [
-                                                              [
-                                                                {
-                                                                  [
-                                                                    {
-                                                                      Nil_match_i9
-                                                                      EmptyRose_i8
-                                                                    }
-                                                                    ds_i1
-                                                                  ]
-                                                                  (fun Unit_i15 [List_i12 EmptyRose_i8])
-                                                                }
-                                                                (lam
-                                                                  thunk_i0
-                                                                  Unit_i16
-                                                                  {
-                                                                    Nil_i12
-                                                                    EmptyRose_i9
-                                                                  }
-                                                                )
-                                                              ]
-                                                              (lam
-                                                                x_i0
-                                                                EmptyRose_i9
-                                                                (lam
-                                                                  xs_i0
-                                                                  [List_i14 EmptyRose_i10]
-                                                                  (lam
-                                                                    thunk_i0
-                                                                    Unit_i18
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          Cons_i13
-                                                                          EmptyRose_i11
-                                                                        }
-                                                                        [
-                                                                          ds_i5
-                                                                          x_i3
-                                                                        ]
-                                                                      ]
-                                                                      [
-                                                                        [
-                                                                          map_i6
-                                                                          ds_i5
-                                                                        ]
-                                                                        xs_i2
-                                                                      ]
-                                                                    ]
-                                                                  )
-                                                                )
-                                                              )
-                                                            ]
-                                                            Unit_i14
-                                                          ]
-                                                        )
-                                                      )
-                                                    ]
-                                                  )
-                                                )
-                                              )
-                                            ]
-                                          ]
+                                                ]
+                                              ]
+                                            )
+                                          )
+                                        )
+                                        (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i6 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))))
+                                      }
+                                      (lam
+                                        arg_0_i0
+                                        [List_i5 (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i7 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))))]
+                                        (iwrap
+                                          (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
+                                          (lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i7 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1)))
+                                          (abs
+                                            out_EmptyRose_i0
+                                            (type)
+                                            (lam
+                                              case_EmptyRose_i0
+                                              (fun [List_i7 (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i9 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))))] out_EmptyRose_i2)
+                                              [ case_EmptyRose_i1 arg_0_i3 ]
+                                            )
+                                          )
                                         )
                                       )
+                                    ]
+                                    (lam
+                                      x_i0
+                                      (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i7 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))))
+                                      (unwrap x_i1)
                                     )
-                                    (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i6 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))))
-                                  }
-                                  (lam
-                                    arg_0_i0
-                                    [List_i5 (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i7 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))))]
-                                    (iwrap
-                                      (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
-                                      (lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i7 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1)))
-                                      (abs
-                                        out_EmptyRose_i0
-                                        (type)
-                                        (lam
-                                          case_EmptyRose_i0
-                                          (fun [List_i7 (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i9 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))))] out_EmptyRose_i2)
-                                          [ case_EmptyRose_i1 arg_0_i3 ]
-                                        )
-                                      )
-                                    )
-                                  )
-                                ]
-                                (lam
-                                  x_i0
-                                  (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam EmptyRose_i0 (type) (all out_EmptyRose_i0 (type) (fun (fun [List_i7 EmptyRose_i2] out_EmptyRose_i1) out_EmptyRose_i1))))
-                                  (unwrap x_i1)
+                                  ]
                                 )
-                              ]
+                              )
                             )
                           )
-                        )
-                      )
-                      (lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1))
-                    }
-                    (abs
-                      a_i0
-                      (type)
-                      (iwrap
-                        (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1)))))
-                        a_i1
+                          (lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1))
+                        }
                         (abs
-                          out_List_i0
+                          a_i0
                           (type)
-                          (lam
-                            case_Nil_i0
-                            out_List_i2
-                            (lam
-                              case_Cons_i0
-                              (fun a_i4 (fun [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i4] out_List_i3))
-                              case_Nil_i2
+                          (iwrap
+                            (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1)))))
+                            a_i1
+                            (abs
+                              out_List_i0
+                              (type)
+                              (lam
+                                case_Nil_i0
+                                out_List_i2
+                                (lam
+                                  case_Cons_i0
+                                  (fun a_i4 (fun [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i4] out_List_i3))
+                                  case_Nil_i2
+                                )
+                              )
                             )
                           )
                         )
-                      )
-                    )
-                  ]
-                  (abs
-                    a_i0
-                    (type)
-                    (lam
-                      arg_0_i0
-                      a_i2
-                      (lam
-                        arg_1_i0
-                        [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i3]
-                        (iwrap
-                          (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1)))))
-                          a_i3
-                          (abs
-                            out_List_i0
-                            (type)
-                            (lam
-                              case_Nil_i0
-                              out_List_i2
-                              (lam
-                                case_Cons_i0
-                                (fun a_i6 (fun [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i6] out_List_i3))
-                                [ [ case_Cons_i1 arg_0_i5 ] arg_1_i4 ]
+                      ]
+                      (abs
+                        a_i0
+                        (type)
+                        (lam
+                          arg_0_i0
+                          a_i2
+                          (lam
+                            arg_1_i0
+                            [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i3]
+                            (iwrap
+                              (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1)))))
+                              a_i3
+                              (abs
+                                out_List_i0
+                                (type)
+                                (lam
+                                  case_Nil_i0
+                                  out_List_i2
+                                  (lam
+                                    case_Cons_i0
+                                    (fun a_i6 (fun [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i6] out_List_i3))
+                                    [ [ case_Cons_i1 arg_0_i5 ] arg_1_i4 ]
+                                  )
+                                )
                               )
                             )
                           )
                         )
                       )
+                    ]
+                    (abs
+                      a_i0
+                      (type)
+                      (lam
+                        x_i0
+                        [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i2]
+                        (unwrap x_i1)
+                      )
                     )
-                  )
-                ]
+                  ]
+                )
+              )
+            )
+            (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1))
+          }
+          (abs out_Unit_i0 (type) (lam case_Unit_i0 out_Unit_i2 case_Unit_i1))
+        ]
+        (lam x_i0 (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1)) x_i1)
+      ]
+    )
+    (abs
+      a_i0
+      (type)
+      (abs
+        b_i0
+        (type)
+        (lam
+          f_i0
+          (all Q_i0 (type) (fun (fun (fun a_i4 b_i3) Q_i1) (fun (fun a_i4 b_i3) Q_i1)))
+          [
+            [
+              {
                 (abs
-                  a_i0
-                  (type)
+                  F_i0
+                  (fun (type) (type))
                   (lam
-                    x_i0
-                    [(lam a_i0 (type) (ifix (lam List_i0 (fun (type) (type)) (lam a_i0 (type) (all out_List_i0 (type) (fun out_List_i1 (fun (fun a_i2 (fun [List_i3 a_i2] out_List_i1)) out_List_i1))))) a_i1)) a_i2]
-                    (unwrap x_i1)
+                    by_i0
+                    (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
+                    [
+                      {
+                        {
+                          (abs
+                            a_i0
+                            (type)
+                            (abs
+                              b_i0
+                              (type)
+                              (lam
+                                f_i0
+                                (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
+                                [
+                                  {
+                                    (abs
+                                      a_i0
+                                      (type)
+                                      (lam
+                                        s_i0
+                                        [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                                        [ (unwrap s_i1) s_i1 ]
+                                      )
+                                    )
+                                    (fun a_i3 b_i2)
+                                  }
+                                  (iwrap
+                                    (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
+                                    (fun a_i3 b_i2)
+                                    (lam
+                                      s_i0
+                                      [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
+                                      (lam
+                                        x_i0
+                                        a_i5
+                                        [
+                                          [
+                                            f_i3
+                                            [
+                                              {
+                                                (abs
+                                                  a_i0
+                                                  (type)
+                                                  (lam
+                                                    s_i0
+                                                    [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                                                    [ (unwrap s_i1) s_i1 ]
+                                                  )
+                                                )
+                                                (fun a_i5 b_i4)
+                                              }
+                                              s_i2
+                                            ]
+                                          ]
+                                          x_i1
+                                        ]
+                                      )
+                                    )
+                                  )
+                                ]
+                              )
+                            )
+                          )
+                          (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
+                        }
+                        (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
+                      }
+                      (lam
+                        rec_i0
+                        (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
+                        (lam
+                          h_i0
+                          (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
+                          (abs
+                            R_i0
+                            (type)
+                            (lam
+                              fr_i0
+                              [F_i6 R_i2]
+                              [
+                                {
+                                  [
+                                    by_i5
+                                    (abs
+                                      Q_i0
+                                      (type)
+                                      (lam
+                                        fq_i0
+                                        [F_i8 Q_i2]
+                                        [
+                                          { [ rec_i6 h_i5 ] Q_i2 }
+                                          [ { h_i5 Q_i2 } fq_i1 ]
+                                        ]
+                                      )
+                                    )
+                                  ]
+                                  R_i2
+                                }
+                                fr_i1
+                              ]
+                            )
+                          )
+                        )
+                      )
+                    ]
                   )
                 )
-              ]
-            )
-          )
+                (lam X_i0 (type) (fun (fun a_i4 b_i3) X_i1))
+              }
+              (lam
+                k_i0
+                (all Q_i0 (type) (fun (fun (fun a_i5 b_i4) Q_i1) Q_i1))
+                (abs
+                  S_i0
+                  (type)
+                  (lam
+                    h_i0
+                    (fun (fun a_i6 b_i5) S_i2)
+                    [
+                      h_i1
+                      (lam
+                        x_i0
+                        a_i7
+                        [
+                          { k_i4 b_i6 }
+                          (lam f_0_i0 (fun a_i8 b_i7) [ f_0_i1 x_i2 ])
+                        ]
+                      )
+                    ]
+                  )
+                )
+              )
+            ]
+            f_i1
+          ]
         )
-        (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1))
-      }
-      (abs out_Unit_i0 (type) (lam case_Unit_i0 out_Unit_i2 case_Unit_i1))
-    ]
-    (lam x_i0 (all out_Unit_i0 (type) (fun out_Unit_i1 out_Unit_i1)) x_i1)
+      )
+    )
   ]
 )

--- a/plutus-tx/test/Plugin/Data/recursive/sameEmptyRoseEval.plc.golden
+++ b/plutus-tx/test/Plugin/Data/recursive/sameEmptyRoseEval.plc.golden
@@ -1,53 +1,53 @@
 (iwrap
-  (lam rec_139 (fun (fun (type) (type)) (type)) (lam f_140 (fun (type) (type)) [f_140 [rec_139 f_140]]))
-  (lam EmptyRose_141 (type) (all out_EmptyRose_142 (type) (fun (fun [List_4 EmptyRose_141] out_EmptyRose_142) out_EmptyRose_142)))
+  (lam rec_98 (fun (fun (type) (type)) (type)) (lam f_99 (fun (type) (type)) [f_99 [rec_98 f_99]]))
+  (lam EmptyRose_100 (type) (all out_EmptyRose_101 (type) (fun (fun [List_55 EmptyRose_100] out_EmptyRose_101) out_EmptyRose_101)))
   (abs
-    out_EmptyRose_143
+    out_EmptyRose_102
     (type)
     (lam
-      case_EmptyRose_144
-      (fun [List_4 (ifix (lam rec_145 (fun (fun (type) (type)) (type)) (lam f_146 (fun (type) (type)) [f_146 [rec_145 f_146]])) (lam EmptyRose_147 (type) (all out_EmptyRose_148 (type) (fun (fun [List_4 EmptyRose_147] out_EmptyRose_148) out_EmptyRose_148))))] out_EmptyRose_143)
+      case_EmptyRose_103
+      (fun [List_55 (ifix (lam rec_104 (fun (fun (type) (type)) (type)) (lam f_105 (fun (type) (type)) [f_105 [rec_104 f_105]])) (lam EmptyRose_106 (type) (all out_EmptyRose_107 (type) (fun (fun [List_55 EmptyRose_106] out_EmptyRose_107) out_EmptyRose_107))))] out_EmptyRose_102)
       [
-        case_EmptyRose_144
+        case_EmptyRose_103
         (iwrap
-          (lam List_176 (fun (type) (type)) (lam a_177 (type) (all out_List_178 (type) (fun out_List_178 (fun (fun a_177 (fun [List_176 a_177] out_List_178)) out_List_178)))))
-          a_169
+          (lam List_135 (fun (type) (type)) (lam a_136 (type) (all out_List_137 (type) (fun out_List_137 (fun (fun a_136 (fun [List_135 a_136] out_List_137)) out_List_137)))))
+          a_128
           (abs
-            out_List_179
+            out_List_138
             (type)
             (lam
-              case_Nil_180
-              out_List_179
+              case_Nil_139
+              out_List_138
               (lam
-                case_Cons_181
-                (fun a_169 (fun [(lam a_182 (type) (ifix (lam List_183 (fun (type) (type)) (lam a_184 (type) (all out_List_185 (type) (fun out_List_185 (fun (fun a_184 (fun [List_183 a_184] out_List_185)) out_List_185))))) a_182)) a_169] out_List_179))
+                case_Cons_140
+                (fun a_128 (fun [(lam a_141 (type) (ifix (lam List_142 (fun (type) (type)) (lam a_143 (type) (all out_List_144 (type) (fun out_List_144 (fun (fun a_143 (fun [List_142 a_143] out_List_144)) out_List_144))))) a_141)) a_128] out_List_138))
                 [
                   [
-                    case_Cons_181
+                    case_Cons_140
                     (iwrap
-                      (lam rec_139 (fun (fun (type) (type)) (type)) (lam f_140 (fun (type) (type)) [f_140 [rec_139 f_140]]))
-                      (lam EmptyRose_141 (type) (all out_EmptyRose_142 (type) (fun (fun [List_4 EmptyRose_141] out_EmptyRose_142) out_EmptyRose_142)))
+                      (lam rec_98 (fun (fun (type) (type)) (type)) (lam f_99 (fun (type) (type)) [f_99 [rec_98 f_99]]))
+                      (lam EmptyRose_100 (type) (all out_EmptyRose_101 (type) (fun (fun [List_55 EmptyRose_100] out_EmptyRose_101) out_EmptyRose_101)))
                       (abs
-                        out_EmptyRose_143
+                        out_EmptyRose_102
                         (type)
                         (lam
-                          case_EmptyRose_144
-                          (fun [List_4 (ifix (lam rec_145 (fun (fun (type) (type)) (type)) (lam f_146 (fun (type) (type)) [f_146 [rec_145 f_146]])) (lam EmptyRose_147 (type) (all out_EmptyRose_148 (type) (fun (fun [List_4 EmptyRose_147] out_EmptyRose_148) out_EmptyRose_148))))] out_EmptyRose_143)
+                          case_EmptyRose_103
+                          (fun [List_55 (ifix (lam rec_104 (fun (fun (type) (type)) (type)) (lam f_105 (fun (type) (type)) [f_105 [rec_104 f_105]])) (lam EmptyRose_106 (type) (all out_EmptyRose_107 (type) (fun (fun [List_55 EmptyRose_106] out_EmptyRose_107) out_EmptyRose_107))))] out_EmptyRose_102)
                           [
-                            case_EmptyRose_144
+                            case_EmptyRose_103
                             (iwrap
-                              (lam List_159 (fun (type) (type)) (lam a_160 (type) (all out_List_161 (type) (fun out_List_161 (fun (fun a_160 (fun [List_159 a_160] out_List_161)) out_List_161)))))
-                              a_158
+                              (lam List_118 (fun (type) (type)) (lam a_119 (type) (all out_List_120 (type) (fun out_List_120 (fun (fun a_119 (fun [List_118 a_119] out_List_120)) out_List_120)))))
+                              a_117
                               (abs
-                                out_List_162
+                                out_List_121
                                 (type)
                                 (lam
-                                  case_Nil_163
-                                  out_List_162
+                                  case_Nil_122
+                                  out_List_121
                                   (lam
-                                    case_Cons_164
-                                    (fun a_158 (fun [(lam a_165 (type) (ifix (lam List_166 (fun (type) (type)) (lam a_167 (type) (all out_List_168 (type) (fun out_List_168 (fun (fun a_167 (fun [List_166 a_167] out_List_168)) out_List_168))))) a_165)) a_158] out_List_162))
-                                    case_Nil_163
+                                    case_Cons_123
+                                    (fun a_117 (fun [(lam a_124 (type) (ifix (lam List_125 (fun (type) (type)) (lam a_126 (type) (all out_List_127 (type) (fun out_List_127 (fun (fun a_126 (fun [List_125 a_126] out_List_127)) out_List_127))))) a_124)) a_117] out_List_121))
+                                    case_Nil_122
                                   )
                                 )
                               )
@@ -58,44 +58,44 @@
                     )
                   ]
                   (iwrap
-                    (lam List_176 (fun (type) (type)) (lam a_177 (type) (all out_List_178 (type) (fun out_List_178 (fun (fun a_177 (fun [List_176 a_177] out_List_178)) out_List_178)))))
-                    a_169
+                    (lam List_135 (fun (type) (type)) (lam a_136 (type) (all out_List_137 (type) (fun out_List_137 (fun (fun a_136 (fun [List_135 a_136] out_List_137)) out_List_137)))))
+                    a_128
                     (abs
-                      out_List_179
+                      out_List_138
                       (type)
                       (lam
-                        case_Nil_180
-                        out_List_179
+                        case_Nil_139
+                        out_List_138
                         (lam
-                          case_Cons_181
-                          (fun a_169 (fun [(lam a_182 (type) (ifix (lam List_183 (fun (type) (type)) (lam a_184 (type) (all out_List_185 (type) (fun out_List_185 (fun (fun a_184 (fun [List_183 a_184] out_List_185)) out_List_185))))) a_182)) a_169] out_List_179))
+                          case_Cons_140
+                          (fun a_128 (fun [(lam a_141 (type) (ifix (lam List_142 (fun (type) (type)) (lam a_143 (type) (all out_List_144 (type) (fun out_List_144 (fun (fun a_143 (fun [List_142 a_143] out_List_144)) out_List_144))))) a_141)) a_128] out_List_138))
                           [
                             [
-                              case_Cons_181
+                              case_Cons_140
                               (iwrap
-                                (lam rec_139 (fun (fun (type) (type)) (type)) (lam f_140 (fun (type) (type)) [f_140 [rec_139 f_140]]))
-                                (lam EmptyRose_141 (type) (all out_EmptyRose_142 (type) (fun (fun [List_4 EmptyRose_141] out_EmptyRose_142) out_EmptyRose_142)))
+                                (lam rec_98 (fun (fun (type) (type)) (type)) (lam f_99 (fun (type) (type)) [f_99 [rec_98 f_99]]))
+                                (lam EmptyRose_100 (type) (all out_EmptyRose_101 (type) (fun (fun [List_55 EmptyRose_100] out_EmptyRose_101) out_EmptyRose_101)))
                                 (abs
-                                  out_EmptyRose_143
+                                  out_EmptyRose_102
                                   (type)
                                   (lam
-                                    case_EmptyRose_144
-                                    (fun [List_4 (ifix (lam rec_145 (fun (fun (type) (type)) (type)) (lam f_146 (fun (type) (type)) [f_146 [rec_145 f_146]])) (lam EmptyRose_147 (type) (all out_EmptyRose_148 (type) (fun (fun [List_4 EmptyRose_147] out_EmptyRose_148) out_EmptyRose_148))))] out_EmptyRose_143)
+                                    case_EmptyRose_103
+                                    (fun [List_55 (ifix (lam rec_104 (fun (fun (type) (type)) (type)) (lam f_105 (fun (type) (type)) [f_105 [rec_104 f_105]])) (lam EmptyRose_106 (type) (all out_EmptyRose_107 (type) (fun (fun [List_55 EmptyRose_106] out_EmptyRose_107) out_EmptyRose_107))))] out_EmptyRose_102)
                                     [
-                                      case_EmptyRose_144
+                                      case_EmptyRose_103
                                       (iwrap
-                                        (lam List_159 (fun (type) (type)) (lam a_160 (type) (all out_List_161 (type) (fun out_List_161 (fun (fun a_160 (fun [List_159 a_160] out_List_161)) out_List_161)))))
-                                        a_158
+                                        (lam List_118 (fun (type) (type)) (lam a_119 (type) (all out_List_120 (type) (fun out_List_120 (fun (fun a_119 (fun [List_118 a_119] out_List_120)) out_List_120)))))
+                                        a_117
                                         (abs
-                                          out_List_162
+                                          out_List_121
                                           (type)
                                           (lam
-                                            case_Nil_163
-                                            out_List_162
+                                            case_Nil_122
+                                            out_List_121
                                             (lam
-                                              case_Cons_164
-                                              (fun a_158 (fun [(lam a_165 (type) (ifix (lam List_166 (fun (type) (type)) (lam a_167 (type) (all out_List_168 (type) (fun out_List_168 (fun (fun a_167 (fun [List_166 a_167] out_List_168)) out_List_168))))) a_165)) a_158] out_List_162))
-                                              case_Nil_163
+                                              case_Cons_123
+                                              (fun a_117 (fun [(lam a_124 (type) (ifix (lam List_125 (fun (type) (type)) (lam a_126 (type) (all out_List_127 (type) (fun out_List_127 (fun (fun a_126 (fun [List_125 a_126] out_List_127)) out_List_127))))) a_124)) a_117] out_List_121))
+                                              case_Nil_122
                                             )
                                           )
                                         )
@@ -106,18 +106,18 @@
                               )
                             ]
                             (iwrap
-                              (lam List_159 (fun (type) (type)) (lam a_160 (type) (all out_List_161 (type) (fun out_List_161 (fun (fun a_160 (fun [List_159 a_160] out_List_161)) out_List_161)))))
-                              a_158
+                              (lam List_118 (fun (type) (type)) (lam a_119 (type) (all out_List_120 (type) (fun out_List_120 (fun (fun a_119 (fun [List_118 a_119] out_List_120)) out_List_120)))))
+                              a_117
                               (abs
-                                out_List_162
+                                out_List_121
                                 (type)
                                 (lam
-                                  case_Nil_163
-                                  out_List_162
+                                  case_Nil_122
+                                  out_List_121
                                   (lam
-                                    case_Cons_164
-                                    (fun a_158 (fun [(lam a_165 (type) (ifix (lam List_166 (fun (type) (type)) (lam a_167 (type) (all out_List_168 (type) (fun out_List_168 (fun (fun a_167 (fun [List_166 a_167] out_List_168)) out_List_168))))) a_165)) a_158] out_List_162))
-                                    case_Nil_163
+                                    case_Cons_123
+                                    (fun a_117 (fun [(lam a_124 (type) (ifix (lam List_125 (fun (type) (type)) (lam a_126 (type) (all out_List_127 (type) (fun out_List_127 (fun (fun a_126 (fun [List_125 a_126] out_List_127)) out_List_127))))) a_124)) a_117] out_List_121))
+                                    case_Nil_122
                                   )
                                 )
                               )

--- a/plutus-tx/test/Plugin/Functions/recursive/even3.plc.golden
+++ b/plutus-tx/test/Plugin/Functions/recursive/even3.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  out_Bool_85
+  out_Bool_90
   (type)
-  (lam case_True_86 out_Bool_85 (lam case_False_87 out_Bool_85 case_False_87))
+  (lam case_True_91 out_Bool_90 (lam case_False_92 out_Bool_90 case_False_92))
 )

--- a/plutus-tx/test/Plugin/Functions/recursive/even4.plc.golden
+++ b/plutus-tx/test/Plugin/Functions/recursive/even4.plc.golden
@@ -1,5 +1,5 @@
 (abs
-  out_Bool_82
+  out_Bool_87
   (type)
-  (lam case_True_83 out_Bool_82 (lam case_False_84 out_Bool_82 case_True_83))
+  (lam case_True_88 out_Bool_87 (lam case_False_89 out_Bool_87 case_True_88))
 )

--- a/plutus-tx/test/TH/all.plc.golden
+++ b/plutus-tx/test/TH/all.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_168
+  out_Bool_173
   (type)
   (lam
-    case_True_169 out_Bool_168 (lam case_False_170 out_Bool_168 case_True_169)
+    case_True_174 out_Bool_173 (lam case_False_175 out_Bool_173 case_True_174)
   )
 )

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -103,7 +103,7 @@ theFuture = Future {
 
 -- | This is the address of contract 'theFuture', initialised by wallet 1
 tokenCurrency :: CurrencySymbol
-tokenCurrency = "ae91bd641d7cff3dbaed8092663175574b01d76ea0ce1fca8086f5af50833123"
+tokenCurrency = "16e2b431d9907e229c7a27387a15ba667363e230084132292ff9e646e45f1d51"
 
 -- | After this trace, the initial margin of wallet 1, and the two tokens,
 --   are locked by the contract.

--- a/plutus-use-cases/test/Spec/TokenAccount.hs
+++ b/plutus-use-cases/test/Spec/TokenAccount.hs
@@ -64,7 +64,7 @@ tokenName = "test token"
 
 account :: Account
 account =
-    let currencySymbol = "dcfb842bf9fa02b6232214131b24e27c02ee21a32cf354baa264053f91d74503"
+    let currencySymbol = "b66fb1a5ce1f188099d40edfc5bc4bacb79e478fc1d3a8c204efd524eaa21e5f"
     in Account (currencySymbol, tokenName)
 
 theToken :: Value

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -7,21 +7,21 @@ Events by wallet:
     • {slot:
        Slot: 27}
     • {utxo-at:
-       Utxo at 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba = 0549951e74ddeb44a2189126cfdd43007e2b6530617d0d9aa9c74c313354da54!1: PayToScript: c65f3e0419312701a5f8778399344ce2642b44af45b453c0dd9c1e6e4414de88 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-         bc91fc821f1bf698600f219b6df8cc4945608a2fa124a2e3dc2ceec52cfc2f8b!1: PayToScript: e3d4f317ab5d6e6d6e634d9a7b89e600b1dfb49a74982d66e989a31db5a72d98 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-         d67326ef593379a5234d1c33d210cf210aab0d2e4fde9695a2fcb000852e84ff!1: PayToScript: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}}
+       Utxo at 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78 = 05de9f510bf3bc891ab6827933f71cf1211e0a19c32ca1bbcef610fe97cb4448!1: PayToScript: 5d9c528367e3c7656126750fe4e4a1c3c162281a3966cafd56bf102ccccf1f5c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}
+         e32acb156d0efeddcefd4f0e40691d92f40f36a02fdf6e692baeb8e70e99f654!1: PayToScript: e3d4f317ab5d6e6d6e634d9a7b89e600b1dfb49a74982d66e989a31db5a72d98 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+         f6c961aff58d40ba1ff91270830ad8cadca8eea7a5ac03e497fa9f9c11d72a98!1: PayToScript: c65f3e0419312701a5f8778399344ce2642b44af45b453c0dd9c1e6e4414de88 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}
     • {tx:
-       WriteTxSuccess: 675ec6348e6eb3c8ada03fc095e2f88f9f44f2113e1aa00a0a63a8e02bc30ba4}
+       WriteTxSuccess: b8f22198d432174fff35d423c645d7bde7cce14b4cb87ed566bf7537618de5c8}
   Events for W2:
     • {contribute:
        EndpointValue: Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}}
     • {own-pubkey:
        fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025}
     • {tx:
-       WriteTxSuccess: 0549951e74ddeb44a2189126cfdd43007e2b6530617d0d9aa9c74c313354da54}
+       WriteTxSuccess: f6c961aff58d40ba1ff91270830ad8cadca8eea7a5ac03e497fa9f9c11d72a98}
     • {address:
-       ( 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
-       , Tx 0549951e74ddeb44a2189126cfdd43007e2b6530617d0d9aa9c74c313354da54:
+       ( 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
+       , Tx f6c961aff58d40ba1ff91270830ad8cadca8eea7a5ac03e497fa9f9c11d72a98:
          {inputs:
             - 7296eb0a70a1b64b155fb5a8f2ab987eec948d5d978b7cba9403f6d3483786f0!8
               fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
@@ -36,8 +36,8 @@ Events by wallet:
            fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
-       , Tx bc91fc821f1bf698600f219b6df8cc4945608a2fa124a2e3dc2ceec52cfc2f8b:
+       ( 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
+       , Tx e32acb156d0efeddcefd4f0e40691d92f40f36a02fdf6e692baeb8e70e99f654:
          {inputs:
             - 7296eb0a70a1b64b155fb5a8f2ab987eec948d5d978b7cba9403f6d3483786f0!3
               98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
@@ -52,8 +52,8 @@ Events by wallet:
            98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
-       , Tx d67326ef593379a5234d1c33d210cf210aab0d2e4fde9695a2fcb000852e84ff:
+       ( 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
+       , Tx 05de9f510bf3bc891ab6827933f71cf1211e0a19c32ca1bbcef610fe97cb4448:
          {inputs:
             - 7296eb0a70a1b64b155fb5a8f2ab987eec948d5d978b7cba9403f6d3483786f0!7
               f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
@@ -73,10 +73,10 @@ Events by wallet:
     • {own-pubkey:
        98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63}
     • {tx:
-       WriteTxSuccess: bc91fc821f1bf698600f219b6df8cc4945608a2fa124a2e3dc2ceec52cfc2f8b}
+       WriteTxSuccess: e32acb156d0efeddcefd4f0e40691d92f40f36a02fdf6e692baeb8e70e99f654}
     • {address:
-       ( 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
-       , Tx bc91fc821f1bf698600f219b6df8cc4945608a2fa124a2e3dc2ceec52cfc2f8b:
+       ( 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
+       , Tx e32acb156d0efeddcefd4f0e40691d92f40f36a02fdf6e692baeb8e70e99f654:
          {inputs:
             - 7296eb0a70a1b64b155fb5a8f2ab987eec948d5d978b7cba9403f6d3483786f0!3
               98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
@@ -91,8 +91,8 @@ Events by wallet:
            98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     • {address:
-       ( 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
-       , Tx d67326ef593379a5234d1c33d210cf210aab0d2e4fde9695a2fcb000852e84ff:
+       ( 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
+       , Tx 05de9f510bf3bc891ab6827933f71cf1211e0a19c32ca1bbcef610fe97cb4448:
          {inputs:
             - 7296eb0a70a1b64b155fb5a8f2ab987eec948d5d978b7cba9403f6d3483786f0!7
               f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
@@ -112,10 +112,10 @@ Events by wallet:
     • {own-pubkey:
        f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863}
     • {tx:
-       WriteTxSuccess: d67326ef593379a5234d1c33d210cf210aab0d2e4fde9695a2fcb000852e84ff}
+       WriteTxSuccess: 05de9f510bf3bc891ab6827933f71cf1211e0a19c32ca1bbcef610fe97cb4448}
     • {address:
-       ( 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
-       , Tx d67326ef593379a5234d1c33d210cf210aab0d2e4fde9695a2fcb000852e84ff:
+       ( 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
+       , Tx 05de9f510bf3bc891ab6827933f71cf1211e0a19c32ca1bbcef610fe97cb4448:
          {inputs:
             - 7296eb0a70a1b64b155fb5a8f2ab987eec948d5d978b7cba9403f6d3483786f0!7
               f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863
@@ -134,7 +134,7 @@ Contract result by wallet:
     Done
     Wallet: W2
       Running, waiting for input:
-        {address: [ 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba ]
+        {address: [ 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78 ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]
@@ -144,7 +144,7 @@ Contract result by wallet:
          utxo-at: []}
     Wallet: W3
       Running, waiting for input:
-        {address: [ 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba ]
+        {address: [ 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78 ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]
@@ -154,7 +154,7 @@ Contract result by wallet:
          utxo-at: []}
     Wallet: W4
       Running, waiting for input:
-        {address: [ 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba ]
+        {address: [ 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78 ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #2, Tx #0 ====
-TxId:       0549951e74ddeb44a2189126cfdd43007e2b6530617d0d9aa9c74c313354da54
+TxId:       f6c961aff58d40ba1ff91270830ad8cadca8eea7a5ac03e497fa9f9c11d72a98
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f5820d5d717ca5ce24fd31dd2252a5dd58b9ba7...
+              Signature: 5f58204c8a95f6bbeaaae4d05896d319e1a5f54c...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
+  Destination:  Script: 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
   Value:
     Ada:      Lovelace:  10
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
+  Script: 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #3, Tx #0 ====
-TxId:       bc91fc821f1bf698600f219b6df8cc4945608a2fa124a2e3dc2ceec52cfc2f8b
+TxId:       e32acb156d0efeddcefd4f0e40691d92f40f36a02fdf6e692baeb8e70e99f654
 Fee:        -
 Forge:      -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 5f5820f42ecd459686503bceca552fdc285a9272...
+              Signature: 5f582042e0206dc7117f53a68e470f97c14a692e...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
+  Destination:  Script: 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
   Value:
     Ada:      Lovelace:  10
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
+  Script: 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
   Value:
     Ada:      Lovelace:  20
 
 ==== Slot #4, Tx #0 ====
-TxId:       d67326ef593379a5234d1c33d210cf210aab0d2e4fde9695a2fcb000852e84ff
+TxId:       05de9f510bf3bc891ab6827933f71cf1211e0a19c32ca1bbcef610fe97cb4448
 Fee:        -
 Forge:      -
 Signatures  PubKey: f81fb54a825fced95eb033afcd64314075abfb0a...
-              Signature: 5f58200c6d455e2b90cb21814f395c44f26ff4fb...
+              Signature: 5f58208330e17a6682822105bcc75ab980b39284...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKey: f81fb54a825fced95eb033afcd64314075abfb0a... (Wallet 4)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  9999
   
   ---- Output 1 ----
-  Destination:  Script: 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
+  Destination:  Script: 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
   Value:
     Ada:      Lovelace:  1
 
@@ -318,43 +318,43 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
+  Script: 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
   Value:
     Ada:      Lovelace:  21
 
 ==== Slot #23, Tx #0 ====
-TxId:       675ec6348e6eb3c8ada03fc095e2f88f9f44f2113e1aa00a0a63a8e02bc30ba4
+TxId:       b8f22198d432174fff35d423c645d7bde7cce14b4cb87ed566bf7537618de5c8
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f5820f3203bd2c6d09c7c367566e10ffae96609...
+              Signature: 5f5820aa0de774583ad1d56d26f032a315014609...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
-  Value:
-    Ada:      Lovelace:  10
-  Source:
-    Tx:     0549951e74ddeb44a2189126cfdd43007e2b6530617d0d9aa9c74c313354da54
-    Output #1
-    Script: f6f601000003f603f603f605f601f6f664556e69...
-  
-  ---- Input 1 ----
-  Destination:  Script: 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
-  Value:
-    Ada:      Lovelace:  10
-  Source:
-    Tx:     bc91fc821f1bf698600f219b6df8cc4945608a2fa124a2e3dc2ceec52cfc2f8b
-    Output #1
-    Script: f6f601000003f603f603f605f601f6f664556e69...
-  
-  ---- Input 2 ----
-  Destination:  Script: 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
+  Destination:  Script: 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
   Value:
     Ada:      Lovelace:  1
   Source:
-    Tx:     d67326ef593379a5234d1c33d210cf210aab0d2e4fde9695a2fcb000852e84ff
+    Tx:     05de9f510bf3bc891ab6827933f71cf1211e0a19c32ca1bbcef610fe97cb4448
     Output #1
-    Script: f6f601000003f603f603f605f601f6f664556e69...
+    Script: f6f601000003f603f602f6f664666978311907d5...
+  
+  ---- Input 1 ----
+  Destination:  Script: 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
+  Value:
+    Ada:      Lovelace:  10
+  Source:
+    Tx:     e32acb156d0efeddcefd4f0e40691d92f40f36a02fdf6e692baeb8e70e99f654
+    Output #1
+    Script: f6f601000003f603f602f6f664666978311907d5...
+  
+  ---- Input 2 ----
+  Destination:  Script: 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
+  Value:
+    Ada:      Lovelace:  10
+  Source:
+    Tx:     f6c961aff58d40ba1ff91270830ad8cadca8eea7a5ac03e497fa9f9c11d72a98
+    Output #1
+    Script: f6f601000003f603f602f6f664666978311907d5...
 
 
 Outputs:
@@ -405,6 +405,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 1a48a11748a35db74b9867449aac53ff8496f9da4be0a09e46f397b0e85fceba
+  Script: 3db9dbec42ff555a4b5aecb0fa0ce1353d582b1a6e68b2df625313823df3de78
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       37baa94bdd03b24d5fd30e515dc041b9f22f627b4aabf6fc6ce6fafcd01fa48d
+TxId:       acc2f1e6db518634a53e514e9498ef85c6a29fc1b85eb500a4f29b10518b212f
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f58201ca44a38f1d109ae09910f1a13087ef630...
+              Signature: 5f58209de9ecb4bb70d372b4a27d2b2b40d915b0...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf... (Wallet 1)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 775d9fd3d9cab57986852f8a9c0df2e409b4c6c378be3eb1f4d5799742713533
+  Destination:  Script: 4ac18d7dc7610bf372c25f0a75c2b6a1e53993715067e586d5cf7bbba9049a75
   Value:
     Ada:      Lovelace:  10
 
@@ -170,25 +170,25 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 775d9fd3d9cab57986852f8a9c0df2e409b4c6c378be3eb1f4d5799742713533
+  Script: 4ac18d7dc7610bf372c25f0a75c2b6a1e53993715067e586d5cf7bbba9049a75
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       6a8b5aa1382d7d49549dd7b29823b82471ccf3c7ff16ba06502cbdf5e3775982
+TxId:       dc51d257a11896e3a87cc76ee4c71be13d6739554a81b4dc7ad458306a9845b1
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f5820706d871b0cce145b5325cc7c8a35dd9a39...
+              Signature: 5f5820bd46335cefca8c5f7c992b25a8a4f77371...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 775d9fd3d9cab57986852f8a9c0df2e409b4c6c378be3eb1f4d5799742713533
+  Destination:  Script: 4ac18d7dc7610bf372c25f0a75c2b6a1e53993715067e586d5cf7bbba9049a75
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     37baa94bdd03b24d5fd30e515dc041b9f22f627b4aabf6fc6ce6fafcd01fa48d
+    Tx:     acc2f1e6db518634a53e514e9498ef85c6a29fc1b85eb500a4f29b10518b212f
     Output #1
-    Script: f6f601000003f603f605f601f6f664556e697419...
+    Script: f6f601000003f602f6f664666978311907c903f6...
 
 
 Outputs:
@@ -239,6 +239,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 775d9fd3d9cab57986852f8a9c0df2e409b4c6c378be3eb1f4d5799742713533
+  Script: 4ac18d7dc7610bf372c25f0a75c2b6a1e53993715067e586d5cf7bbba9049a75
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       962c99aa4f09c8450a16a611898c128880046b89b93e8fc15d6028c3913038f8
+TxId:       874f5346f1cd2bd7945a1a46e39a3f1e474ff1e395c3a1b63dbb32b079a871c7
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f58206e31dd158ea0a7ca339aa2dd6334c54ccc...
+              Signature: 5f58205e3401e36d35a5e018d0eb2c28cbcb3782...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9940
   
   ---- Output 1 ----
-  Destination:  Script: e30e5773a52d77434e0bafb760260e1e04418d2725d87d48a121f80cf577f5a6
+  Destination:  Script: 066a184229d64e9919469715951874bb0015df4f0bee061af88b535fed348931
   Value:
     Ada:      Lovelace:  60
 
@@ -170,25 +170,25 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: e30e5773a52d77434e0bafb760260e1e04418d2725d87d48a121f80cf577f5a6
+  Script: 066a184229d64e9919469715951874bb0015df4f0bee061af88b535fed348931
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #13, Tx #0 ====
-TxId:       1a40221c4d046540e58b5cc3e76ef2283fcf34ab82135871747f3cff0670aa62
+TxId:       67ec335b3ce695bdbfd39421d75dfbfa5fb1ea5cbf869763c7e3cd1212e62be7
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f5820dcf45713f14ba5e2a2e29ee4bc210cc409...
+              Signature: 5f58205d72899d9011801fd4fd9f31cc2a5b1bce...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: e30e5773a52d77434e0bafb760260e1e04418d2725d87d48a121f80cf577f5a6
+  Destination:  Script: 066a184229d64e9919469715951874bb0015df4f0bee061af88b535fed348931
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     962c99aa4f09c8450a16a611898c128880046b89b93e8fc15d6028c3913038f8
+    Tx:     874f5346f1cd2bd7945a1a46e39a3f1e474ff1e395c3a1b63dbb32b079a871c7
     Output #1
-    Script: f6f601000003f603f603f605f601f6f664556e69...
+    Script: f6f601000003f603f602f6f66466697831190837...
 
 
 Outputs:
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  10
   
   ---- Output 1 ----
-  Destination:  Script: e30e5773a52d77434e0bafb760260e1e04418d2725d87d48a121f80cf577f5a6
+  Destination:  Script: 066a184229d64e9919469715951874bb0015df4f0bee061af88b535fed348931
   Value:
     Ada:      Lovelace:  50
 
@@ -244,6 +244,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: e30e5773a52d77434e0bafb760260e1e04418d2725d87d48a121f80cf577f5a6
+  Script: 066a184229d64e9919469715951874bb0015df4f0bee061af88b535fed348931
   Value:
     Ada:      Lovelace:  50


### PR DESCRIPTION
Fixes #1657.

These can be quite big, and otherwise we were making one per recursive
function. We still have one per arity of recursive function, but it
seems to save us ~10% on program size, which is nice.

The `language-plutus-core` changes are pretty minimal: `getMutualFixOf`
lets us provide the fixpoint function ourselves (or - a variable
reference to one), and `fixN` also provides the type, which we need for
creating variable bindings.

I think we want to use `DefT` some more in the PIR compilation pipeline,
particularly for sharing all the units in `NonStrict`, but I've kept it
simple for now.