### PR TITLE
Improve package documentation

### DIFF
--- a/ARCHITECTURE.adoc
+++ b/ARCHITECTURE.adoc
@@ -57,6 +57,8 @@ up examples to ensure that we have adequate functionality.
 
 include::plutus-contract/ARCHITECTURE.adoc[]
 
+include::plutus-contract-tasty/ARCHITECTURE.adoc[]
+
 include::plutus-use-cases/ARCHITECTURE.adoc[]
 
 include::iots-export/ARCHITECTURE.adoc[]

--- a/ARCHITECTURE.adoc
+++ b/ARCHITECTURE.adoc
@@ -13,29 +13,9 @@ work through those in conceptual order.
 Plutus Core is the language that actually goes on the blockchain. Consequently
 this is the absolute core of the codebase, and everything depends on it.
 
-=== `language-plutus-core`
+include::language-plutus-core/ARCHITECTURE.adoc[]
 
-This package implements the Plutus Core language.
-
-This includes:
-
-- AST types
-- Parser
-- Various checkers including a typechecker
-- Prettyprinter
-- Simple evaluator (see `plutus-core-evaluator` for fancier evaluators)
-- Support for some standard constructs e.g. the encodings of recursive types
-- A number of example programs
-
-=== `plutus-core-intepreter`
-
-This package contains the production evaluator that we use, along with an experimental
-lazy evaluator.
-
-=== `plutus-exe`
-
-This package defines a command-line executable that used to typecheck or
-evaluate Plutus Core programs.
+include::plutus-exe/ARCHITECTURE.adoc[]
 
 == Plutus Tx
 
@@ -44,25 +24,9 @@ Core. This is how users actually write Plutus contracts: they write Haskell
 programs, part of which is compiled into Plutus Core. The rest of the program
 can then use this compiled code when submitting transactions.
 
-=== `plutus-ir`
+include::plutus-ir/ARCHITECTURE.adoc[]
 
-Plutus IR is a higher-level language that sits between Plutus Tx and Plutus
-Core in the compilation pipeline. This package implements the compiler, which
-compiles Plutus IR into Plutus Core.
-
-=== `plutus-tx`
-
-This package provides several things:
-
-- The Plutus Tx compiler, which compiles GHC Core into
-Plutus IR.
-- A GHC Core plugin, which is the mechanism by which people use
-the compiler.
-- A couple of special typeclasses which aid with the interface
-between Haskell and Plutus Tx, and Template Haskell support for
-generating instances.
-- It provides a partial replacement Prelude, since many parts of the
-normal Haskell Prelude cannot be used with Plutus Tx.
+include::plutus-tx/ARCHITECTURE.adoc[]
 
 == Ledger
 
@@ -75,24 +39,9 @@ running on. There are two reasons for this:
 - We want to write tests that simulate the "full" behaviour of contracts, i.e.
   across time, in a multi-agent scenario.
 
-=== `plutus-wallet-api`
+include::plutus-wallet-api/ARCHITECTURE.adoc[]
 
-This package should probably be split in two!
-
-The `ledger` sublibrary defines our model of an Extended UTXO ledger, including:
-
-- The types that describe transactions, pending transactions, keys, currencies, etc.
-- Functions that implement the ledger validation rules.
-
-The rest of the package defines the "wallet API", which was our attempt at
-defining the interface that contracts would use to the wallet. As it turns out,
-we need to do things somewhat differently, and so `plutus-contract` is the
-future, but the functions in here are still used fairly widely.
-
-=== `plutus-emulator`
-
-This package defines the chain emulator, which is used for tests, and to back
-the simulations in the Plutus Playground.
+include::plutus-emulator/ARCHITECTURE.adoc[]
 
 == Contract modelling
 
@@ -106,26 +55,11 @@ including both the on-chain code and the eventual contract application.
 These packages are geared towards providing the tools to do that, and building
 up examples to ensure that we have adequate functionality.
 
-=== `plutus-contract`
+include::plutus-contract/ARCHITECTURE.adoc[]
 
-This package has a new API for defining "contracts": bundled applications that
-interact with a wallet smart contract backend. This is in many ways the
-"successor" to much of `plutus-wallet-api`, and should eventually
-replace much of it.
+include::plutus-use-cases/ARCHITECTURE.adoc[]
 
-=== `plutus-use-cases`
-
-This package contains worked examples of a number of contracts, along with
-tests using the emulator. This should always be our "most real" project: this is
-where we try and do the things that we think people will really try and do.
-
-It has a few other miscellaneous tests and benchmarks that use the use-cases as
-a source of large/real validators.
-
-=== `iots-export`
-
-This package defines a scheme for exporting interfaces to Typescript using IOTS.
-This is used by `plutus-contract` to expose an interface for Typescript clients.
+include::iots-export/ARCHITECTURE.adoc[]
 
 == Marlowe
 
@@ -137,15 +71,9 @@ other code in the repository.
 . The Marlowe Playground shares code and deployment infrastructure with the
 Plutus Playground.
 
-=== `marlowe`
+include::marlowe/ARCHITECTURE.adoc[]
 
-This package contains an implementation of the Marlowe interpreter as a Plutus
-contract.
-
-=== `marlowe-symbolic`
-
-This package contains a web-service for doing static analysis of Marlowe
-programs using symbolic execution.
+include::marlowe-symbolic/ARCHITECTURE.adoc[]
 
 == Playgrounds
 
@@ -153,63 +81,35 @@ The Plutus/Marlowe Playgrounds are our web-based environment for developing and
 testing basic Plutus and Marlowe contracts. That means they're the main way that
 anyone outside the team has interacted with out product!
 
-=== `playground-common`
+include::playground-common/ARCHITECTURE.adoc[]
 
-This package contains some library code which is shared between the Plutus and
-Marlowe Playgrounds.
+include::plutus-playground-lib/ARCHITECTURE.adoc[]
 
-=== `plutus-playground-lib`
+include::plutus-playground-server/ARCHITECTURE.adoc[]
 
-This package contains some library code for the Plutus Playground.
+include::marlowe-playground-server/ARCHITECTURE.adoc[]
 
-=== `plutus-playground-server` and `marlowe-playground-server`
+include::plutus-playground-client/ARCHITECTURE.adoc[]
 
-These packages contain the servers that back the Plutus/Marlowe Playgrounds by
-compiling user code and evaluating their simulations.
+include::marlowe-playground-client/ARCHITECTURE.adoc[]
 
-They also define executables that generate Purescript bindings for the types that
-the Purescript code needs.
+include::web-common/ARCHITECTURE.adoc[]
 
-=== `plutus-playground-client` and `marlowe-playground-client`
+include::deployment/ARCHITECTURE.adoc[]
 
-These contain the Plutus/Marlowe Playground client code, written in Purescript.
-
-=== `web-common`
-
-This contains some Purescript client code that is shared between the Plutus and
-Marlowe Playgrounds.
-
-=== `deployment`
-
-This folder contains the nixops/Terraform code used for deploying the Playgrounds.
-
-=== `deployment-server`
-
-This package contains a small server that handles automatic continuous
-deployment of the alpha Playground whenever PRs are merged.
+include::deployment/ARCHITECTURE.adoc[]
 
 == Documentation
 
-=== `plutus-tutorial` and `marlowe-tutorial`
+include::plutus-tutorial/ARCHITECTURE.adoc[]
 
-These packages contains tutorials for Plutus/Marlowe. The Plutus tutorial is a
-literate Haskell project, the Marlowe one is not (yet).
+include::marlowe-tutorial/ARCHITECTURE.adoc[]
 
-=== `plutus-book`
+include::plutus-book/ARCHITECTURE.adoc[]
 
-This package contains the Plutus Book. It is a literate Haskell project.
+include::example/ARCHITECTURE.adoc[]
 
-=== `example`
-
-This contains an example project that is designed to help people get started if
-they want to use our libraries locally, rather than in the Playground. This can
-otherwise be quite challenging, since our projects aren't on Hackage yet!
-
-=== `docs`
-
-This folder contains a variety of miscellaneous documents.
-
-NOTE: Many of these are quite out of date, but can be useful for reference.
+include::docs/ARCHITECTURE.adoc[]
 
 == Specification and design
 
@@ -217,32 +117,16 @@ We have done a fair amount of work in specifying and formalizing parts of our
 system. At the moment all of this work also lives in the Plutus repository, and
 we even have some basic testing of the Haskell implementation against the Agda formalization.
 
-=== `metatheory`
+include::metatheory/ARCHITECTURE.adoc[]
 
-This folder contains the Agda formalization of the Plutus Core metatheory,
-including a `plc-agda` executable that is the equivalent of the `plc` executable
-from `plutus-exe`. This is used for some basic tests.
+include::papers/ARCHITECTURE.adoc[]
 
-=== `papers`
+include::plutus-core-spec/ARCHITECTURE.adoc[]
 
-This folder contains our published academic papers.
-
-=== `plutus-core-spec`
-
-This folder contains the Plutus Core specification.
-
-=== `extended-utxo-spec`
-
-This folder contains the Extended UTXO model specification.
-
-NOTE: This is more of a design document, really, it's not aiming for full precision.
+include::extended-utxo-spec/ARCHITECTURE.adoc[]
 
 == Build tooling
 
-=== `nix`
+include::nix/ARCHITECTURE.adoc[]
 
-This contains miscellaneous Nix code.
-
-=== `pkgs`
-
-This contains the generated Nix code representing our Haskell package set.
+include::pkgs/ARCHITECTURE.adoc[]

--- a/deployment-server/ARCHITECTURE.adoc
+++ b/deployment-server/ARCHITECTURE.adoc
@@ -1,0 +1,4 @@
+=== `deployment-server`
+
+This package contains a small server that handles automatic continuous
+deployment of the alpha Playground whenever PRs are merged.

--- a/deployment/ARCHITECTURE.adoc
+++ b/deployment/ARCHITECTURE.adoc
@@ -1,0 +1,3 @@
+=== `deployment`
+
+This folder contains the nixops/Terraform code used for deploying the Playgrounds.

--- a/docs/ARCHITECTURE.adoc
+++ b/docs/ARCHITECTURE.adoc
@@ -1,0 +1,5 @@
+=== `docs`
+
+This folder contains a variety of miscellaneous documents.
+
+NOTE: Many of these are quite out of date, but can be useful for reference.

--- a/example/ARCHITECTURE.adoc
+++ b/example/ARCHITECTURE.adoc
@@ -1,0 +1,5 @@
+=== `example`
+
+This contains an example project that is designed to help people get started if
+they want to use our libraries locally, rather than in the Playground. This can
+otherwise be quite challenging, since our projects aren't on Hackage yet!

--- a/extended-utxo-spec/ARCHITECTURE.adoc
+++ b/extended-utxo-spec/ARCHITECTURE.adoc
@@ -1,0 +1,5 @@
+=== `extended-utxo-spec`
+
+This folder contains the Extended UTXO model specification.
+
+NOTE: This is more of a design document, really, it's not aiming for full precision.

--- a/iots-export/ARCHITECTURE.adoc
+++ b/iots-export/ARCHITECTURE.adoc
@@ -1,0 +1,4 @@
+=== `iots-export`
+
+This package defines a scheme for exporting interfaces to Typescript using IOTS.
+This is used by `plutus-contract` to expose an interface for Typescript clients.

--- a/language-plutus-core/ARCHITECTURE.adoc
+++ b/language-plutus-core/ARCHITECTURE.adoc
@@ -1,0 +1,13 @@
+=== `language-plutus-core`
+
+This package implements the Plutus Core language.
+
+This includes:
+
+- AST types
+- Parser
+- Various checkers including a typechecker
+- Prettyprinter
+- Evaluator
+- Support for some standard constructs e.g. the encodings of recursive types
+- A number of example programs

--- a/marlowe-playground-client/ARCHITECTURE.adoc
+++ b/marlowe-playground-client/ARCHITECTURE.adoc
@@ -1,0 +1,3 @@
+=== `marlowe-playground-client`
+
+The Marlowe Playground client code, written in Purescript.

--- a/marlowe-playground-server/ARCHITECTURE.adoc
+++ b/marlowe-playground-server/ARCHITECTURE.adoc
@@ -1,0 +1,7 @@
+=== `marlowe-playground-server`
+
+This packages contains the server that backs the Marlowe Playground by
+compiling user code and evaluating their simulations.
+
+It also defines an executable that generates Purescript bindings for the types that
+the Purescript code needs.

--- a/marlowe-symbolic/ARCHITECTURE.adoc
+++ b/marlowe-symbolic/ARCHITECTURE.adoc
@@ -1,0 +1,4 @@
+=== `marlowe-symbolic`
+
+This package contains a web-service for doing static analysis of Marlowe
+programs using symbolic execution.

--- a/marlowe-tutorial/ARCHITECTURE.adoc
+++ b/marlowe-tutorial/ARCHITECTURE.adoc
@@ -1,0 +1,3 @@
+=== `marlowe-tutorial`
+
+This package contains a tutorial for Marlowe.

--- a/marlowe/ARCHITECTURE.adoc
+++ b/marlowe/ARCHITECTURE.adoc
@@ -1,0 +1,4 @@
+=== `marlowe`
+
+This package contains an implementation of the Marlowe interpreter as a Plutus
+contract.

--- a/metatheory/ARCHITECTURE.adoc
+++ b/metatheory/ARCHITECTURE.adoc
@@ -1,0 +1,5 @@
+=== `metatheory`
+
+This folder contains the Agda formalization of the Plutus Core metatheory,
+including a `plc-agda` executable that is the equivalent of the `plc` executable
+from `plutus-exe`. This is used for some basic tests.

--- a/nix/ARCHITECTURE.adoc
+++ b/nix/ARCHITECTURE.adoc
@@ -1,0 +1,3 @@
+=== `nix`
+
+This contains miscellaneous Nix code.

--- a/papers/ARCHITECTURE.adoc
+++ b/papers/ARCHITECTURE.adoc
@@ -1,0 +1,3 @@
+=== `papers`
+
+This folder contains our published academic papers.

--- a/pkgs/ARCHITECTURE.adoc
+++ b/pkgs/ARCHITECTURE.adoc
@@ -1,0 +1,3 @@
+=== `pkgs`
+
+This contains the generated Nix code representing our Haskell package set.

--- a/playground-common/ARCHITECTURE.adoc
+++ b/playground-common/ARCHITECTURE.adoc
@@ -1,0 +1,4 @@
+=== `playground-common`
+
+This package contains some library code which is shared between the Plutus and
+Marlowe Playgrounds.

--- a/plutus-book/ARCHITECTURE.adoc
+++ b/plutus-book/ARCHITECTURE.adoc
@@ -1,0 +1,3 @@
+=== `plutus-book`
+
+This package contains the Plutus Book. It is a literate Haskell project.

--- a/plutus-contract-tasty/ARCHITECTURE.adoc
+++ b/plutus-contract-tasty/ARCHITECTURE.adoc
@@ -1,0 +1,3 @@
+=== `plutus-contract-tasty`
+
+Implements the `Language.Plutus.Contract.Test.TracePredicate` type. Trace predicates are expectations about the mockchain after running a contract trace. They can be turned into unit tests (with `tasty-hunit`) and produce useful debug output about the trace and the state of the contract.

--- a/plutus-contract/ARCHITECTURE.adoc
+++ b/plutus-contract/ARCHITECTURE.adoc
@@ -1,7 +1,13 @@
-
 === `plutus-contract`
 
 This package has a new API for defining "contracts": bundled applications that
 interact with a wallet smart contract backend. This is in many ways the
 "successor" to much of `plutus-wallet-api`, and should eventually
 replace much of it.
+
+Noteworthy modules:
+
+* `Language.Plutus.Contract`: Exports the `Contract` type which encodes the client (off-chain) part of Plutus contracts, including blockchain queries, user-facing endpoints, and the ability to submit transactions to the ledger
+* `Language.Plutus.Contract.StateMachine`: State machine client library, building on the `Contract` type and on the (mostly) on-chain code in `Language.PlutusTx.StateMachine`
+* `Language.Plutus.Contract.Trace`: The `ContractTrace` type for describing sequences of emulator actions that can be used in the Playgound and in unit tests.
+* `Language.Plutus.Contract.App`: Exposes a wrapper to turn `Contract` values into standalone executables, to be consumed by the SCB

--- a/plutus-contract/ARCHITECTURE.adoc
+++ b/plutus-contract/ARCHITECTURE.adoc
@@ -1,0 +1,7 @@
+
+=== `plutus-contract`
+
+This package has a new API for defining "contracts": bundled applications that
+interact with a wallet smart contract backend. This is in many ways the
+"successor" to much of `plutus-wallet-api`, and should eventually
+replace much of it.

--- a/plutus-core-spec/ARCHITECTURE.adoc
+++ b/plutus-core-spec/ARCHITECTURE.adoc
@@ -1,0 +1,3 @@
+=== `plutus-core-spec`
+
+This folder contains the Plutus Core specification.

--- a/plutus-emulator/ARCHITECTURE.adoc
+++ b/plutus-emulator/ARCHITECTURE.adoc
@@ -1,0 +1,4 @@
+=== `plutus-emulator`
+
+This package defines the chain emulator, which is used for tests, and to back
+the simulations in the Plutus Playground.

--- a/plutus-exe/ARCHITECTURE.adoc
+++ b/plutus-exe/ARCHITECTURE.adoc
@@ -1,0 +1,4 @@
+=== `plutus-exe`
+
+This package defines a command-line executable that used to typecheck or
+evaluate Plutus Core programs.

--- a/plutus-ir/ARCHITECTURE.adoc
+++ b/plutus-ir/ARCHITECTURE.adoc
@@ -1,0 +1,5 @@
+=== `plutus-ir`
+
+Plutus IR is a higher-level language that sits between Plutus Tx and Plutus
+Core in the compilation pipeline. This package implements the compiler, which
+compiles Plutus IR into Plutus Core.

--- a/plutus-playground-client/ARCHITECTURE.adoc
+++ b/plutus-playground-client/ARCHITECTURE.adoc
@@ -1,0 +1,3 @@
+=== `plutus-playground-client`
+
+The Plutus Playground client code, written in Purescript.

--- a/plutus-playground-lib/ARCHITECTURE.adoc
+++ b/plutus-playground-lib/ARCHITECTURE.adoc
@@ -1,0 +1,3 @@
+=== `plutus-playground-lib`
+
+This package contains some library code for the Plutus Playground.

--- a/plutus-playground-server/ARCHITECTURE.adoc
+++ b/plutus-playground-server/ARCHITECTURE.adoc
@@ -1,0 +1,7 @@
+=== `plutus-playground-server`
+
+This packages contains the server that backs the Plutus Playground by
+compiling user code and evaluating their simulations.
+
+It also defines an executable that generate Purescript bindings for the types that
+the Purescript code needs.

--- a/plutus-tutorial/ARCHITECTURE.adoc
+++ b/plutus-tutorial/ARCHITECTURE.adoc
@@ -1,0 +1,4 @@
+=== `plutus-tutorial`
+
+This package contains a tutorial for Plutus. It is a
+literate Haskell project.

--- a/plutus-tx/ARCHITECTURE.adoc
+++ b/plutus-tx/ARCHITECTURE.adoc
@@ -1,0 +1,13 @@
+=== `plutus-tx`
+
+This package provides several things:
+
+- The Plutus Tx compiler, which compiles GHC Core into
+Plutus IR.
+- A GHC Core plugin, which is the mechanism by which people use
+the compiler.
+- A couple of special typeclasses which aid with the interface
+between Haskell and Plutus Tx, and Template Haskell support for
+generating instances.
+- It provides a partial replacement Prelude, since many parts of the
+normal Haskell Prelude cannot be used with Plutus Tx.

--- a/plutus-use-cases/ARCHITECTURE.adoc
+++ b/plutus-use-cases/ARCHITECTURE.adoc
@@ -1,0 +1,8 @@
+=== `plutus-use-cases`
+
+This package contains worked examples of a number of contracts, along with
+tests using the emulator. This should always be our "most real" project: this is
+where we try and do the things that we think people will really try and do.
+
+It has a few other miscellaneous tests and benchmarks that use the use-cases as
+a source of large/real validators.

--- a/plutus-use-cases/ARCHITECTURE.adoc
+++ b/plutus-use-cases/ARCHITECTURE.adoc
@@ -6,3 +6,21 @@ where we try and do the things that we think people will really try and do.
 
 It has a few other miscellaneous tests and benchmarks that use the use-cases as
 a source of large/real validators.
+
+The following contracts are implemented:
+
+* `Crowdfunding`: A crowdfunding campaign
+* `Currency`: A custom currency with a monetary policy that allows the forging of a fixed amount of units
+* `ErrorHandling`: Demonstrates how to deal with errors in Plutus contracts
+* `Escrow`: A general-purpose escrow contract
+* `Future`: A tokenised financial contract (future), using the state machine library
+* `Game`: A guessing game
+* `GameStateMachine`: Tokenised guessing game written as a state machine
+* `MultiSig`: Implements an n-out-of-m multisig contract
+* `MultiSigStateMachine`: A multisig contract written as a state machine
+* `PubKey`: A "pay-to-pubkey" transaction output implemented as a Plutus contract
+* `Swap`: A financial contract (swap)
+* `TokenAccount`: Plutus implementation of an account that can be unlocked with a token
+* `Vesting`: A simple vesting scheme. Money is locked by a contract and may only be retrieved after some time has passed.
+
+The test suite includes unit tests for all contracts

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Escrow.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Escrow.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeFamilies      #-}
--- | An general-purpose escrow contract in Plutus
+-- | A general-purpose escrow contract in Plutus
 module Language.PlutusTx.Coordination.Contracts.Escrow(
     -- $escrow
     Escrow

--- a/plutus-wallet-api/ARCHITECTURE.adoc
+++ b/plutus-wallet-api/ARCHITECTURE.adoc
@@ -1,4 +1,3 @@
-
 === `plutus-wallet-api`
 
 This package should probably be split in two!
@@ -12,3 +11,5 @@ The rest of the package defines the "wallet API", which was our attempt at
 defining the interface that contracts would use to the wallet. As it turns out,
 we need to do things somewhat differently, and so `plutus-contract` is the
 future, but the functions in here are still used fairly widely.
+
+`Language.PlutusTx.StateMachine` defines the `StateMachine` type. State machines are an abstraction that lets you write contracts as transition functions `State -> Input -> State`, hiding some of the details of the script validation mechanism. Not all contracts can be written as state machines, but those that can are often easier to understand and test because they don't have to deal with the pending transaction directly. (The off-chain part of the state machine library lives in the `plutus-contract` package)

--- a/plutus-wallet-api/ARCHITECTURE.adoc
+++ b/plutus-wallet-api/ARCHITECTURE.adoc
@@ -1,0 +1,14 @@
+
+=== `plutus-wallet-api`
+
+This package should probably be split in two!
+
+The `ledger` sublibrary defines our model of an Extended UTXO ledger, including:
+
+- The types that describe transactions, pending transactions, keys, currencies, etc.
+- Functions that implement the ledger validation rules.
+
+The rest of the package defines the "wallet API", which was our attempt at
+defining the interface that contracts would use to the wallet. As it turns out,
+we need to do things somewhat differently, and so `plutus-contract` is the
+future, but the functions in here are still used fairly widely.

--- a/web-common/ARCHITECTURE.adoc
+++ b/web-common/ARCHITECTURE.adoc
@@ -1,0 +1,4 @@
+=== `web-common`
+
+This contains some Purescript client code that is shared between the Plutus and
+Marlowe Playgrounds.


### PR DESCRIPTION
Implements #1776 

* Move project-specific documentation from the top-level ARCHITECTURE
  document to per-package documents
* Delete references to `plutus-core-interpreter` and `plutus-evaluators`
  which don't exist
* Describe the most important modules in `plutus-contract` and `plutus-use-cases`