### PR TITLE
Reduce number of max inputs per transaction to 1 in Marlowe symbolic

### DIFF
--- a/marlowe-symbolic/src/Language/Marlowe/Analysis/FSSemantics.hs
+++ b/marlowe-symbolic/src/Language/Marlowe/Analysis/FSSemantics.hs
@@ -669,7 +669,7 @@ applyAll :: SymVal a => Bounds
          -> SEnvironment -> SState -> Contract -> SList NInput
          -> (SApplyAllResult -> DetApplyAllResult -> SBV a) -> SBV a
 applyAll bnds env state c l =
-  applyAllAux (numActions bnds) bnds 0 0 env state c l [] []
+  applyAllAux 1 bnds 0 0 env state c l [] []
 
 -- PROCESS
 


### PR DESCRIPTION
See issue #1782.
Deployed in https://pablo.marlowe.iohkdev.io/