### PR TITLE
use-cases: Remove hard-coded hashes from tests

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract/Servant.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Servant.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -32,7 +33,7 @@ import           Servant.Server                     (Application, ServantErr, Se
 import           Language.Plutus.Contract.Record    (Record)
 import qualified Language.Plutus.Contract.Record    as Rec
 import           Language.Plutus.Contract.Request   (Contract (..))
-import           Language.Plutus.Contract.Resumable (ResumableError)
+import           Language.Plutus.Contract.Resumable (ResumableError, ResumableResult (..))
 import qualified Language.Plutus.Contract.Resumable as Resumable
 import           Language.Plutus.Contract.Schema    (Event, Handlers, Input, Output)
 
@@ -110,7 +111,7 @@ runUpdate
     -> Request s
     -> Either (ResumableError e) (Response s)
 runUpdate con (Request o e) =
-    (\(r, h) -> Response (State r) h)
+    (\ResumableResult{wcsRecord, wcsHandlers} -> Response (State wcsRecord) wcsHandlers)
     <$> Resumable.insertAndUpdate (unContract con) (record o) e
 
 initialResponse

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Future.hs
@@ -37,6 +37,7 @@ module Language.PlutusTx.Coordination.Contracts.Future(
     , tokenFor
     , initialState
     , scriptInstance
+    , setupTokens
     ) where
 
 import           Control.Lens                   (prism', review, makeClassyPrisms)

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -21,14 +21,13 @@ import           Ledger                                                (OracleVa
 import qualified Ledger
 import qualified Ledger.Ada                                            as Ada
 import           Ledger.Crypto                                         (PubKey (..))
-import           Ledger.Value                                          (CurrencySymbol, Value, scale)
+import           Ledger.Value                                          (Value, scale)
 
 import           Language.Plutus.Contract.Test
 import qualified Language.PlutusTx                                     as PlutusTx
 import           Language.PlutusTx.Coordination.Contracts.Future       (Future (..), FutureAccounts (..), FutureError,
                                                                         FutureSchema, FutureSetup (..), Role (..))
 import qualified Language.PlutusTx.Coordination.Contracts.Future       as F
-import           Language.PlutusTx.Coordination.Contracts.TokenAccount (Account (..))
 import           Language.PlutusTx.Lattice
 
 tests :: TestTree
@@ -101,10 +100,6 @@ theFuture = Future {
     ftMarginPenalty = penalty
     }
 
--- | This is the address of contract 'theFuture', initialised by wallet 1
-tokenCurrency :: CurrencySymbol
-tokenCurrency = "16e2b431d9907e229c7a27387a15ba667363e230084132292ff9e646e45f1d51"
-
 -- | After this trace, the initial margin of wallet 1, and the two tokens,
 --   are locked by the contract.
 initContract :: MonadEmulator (TraceError FutureError) m => ContractTrace FutureSchema FutureError m a ()
@@ -152,9 +147,8 @@ oracle :: PubKey
 oracle = walletPubKey (Wallet 10)
 
 accounts :: FutureAccounts
-accounts = F.mkAccounts
-            (Account (tokenCurrency, "long"))
-            (Account (tokenCurrency, "short"))
+accounts = 
+    either error id $ evalTrace @FutureSchema @FutureError F.setupTokens (handleBlockchainEvents w1) w1
 
 increaseMargin :: MonadEmulator (TraceError FutureError) m => ContractTrace FutureSchema FutureError m a ()
 increaseMargin = do

--- a/plutus-use-cases/test/Spec/TokenAccount.hs
+++ b/plutus-use-cases/test/Spec/TokenAccount.hs
@@ -64,8 +64,8 @@ tokenName = "test token"
 
 account :: Account
 account =
-    let currencySymbol = "b66fb1a5ce1f188099d40edfc5bc4bacb79e478fc1d3a8c204efd524eaa21e5f"
-    in Account (currencySymbol, tokenName)
+    let con = Accounts.newAccount tokenName (walletPubKey w1) in
+    either error id $ evalTrace @TokenAccountSchema @ContractError con (handleBlockchainEvents w1) w1
 
 theToken :: Value
 theToken = Accounts.accountToken account


### PR DESCRIPTION
Fixes #1730

* Add a quick-and-dirty way to get the result of a contract: `evalTrace`
* Use `evalTrace` in tests to compute the hashes
* Clean up some of the return types in `Language.Plutus.Contract.Resumable`
