### PR TITLE
[PLC] [Test] [Evaluation] Failure handling

### DIFF
--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Interesting.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Interesting.hs
@@ -226,16 +226,31 @@ genDivideByZero = do
     let term = mkIterApp () (builtinNameAsTerm op) [i, makeIntConstant 0]
     return $ TermOf term EvaluationFailure
 
+-- | Check that division by zero results in 'Error' even if a function doesn't use that argument.
+genDivideByZeroDrop :: TermGen (EvaluationResult Integer)
+genDivideByZeroDrop = do
+    op <- Gen.element [DivideInteger, QuotientInteger, ModInteger, RemainderInteger]
+    let typedInt = AsKnownType
+        int = toTypeAst typedInt
+    TermOf i iv <- genTermLoose typedInt
+    let term =
+            mkIterApp () (mkIterInst () Function.const [int, int])
+                [ mkIterApp () (builtinNameAsTerm op) [i, makeIntConstant 0]
+                , makeIntConstant iv
+                ]
+    return $ TermOf term EvaluationFailure
+
 -- | Apply a function to all interesting generators and collect the results.
 fromInterestingTermGens :: (forall a. KnownType a => String -> TermGen a -> c) -> [c]
 fromInterestingTermGens f =
-    [ f "overapplication" genOverapplication
-    , f "factorial"       genFactorial
-    , f "fibonacci"       genNaiveFib
-    , f "NatRoundTrip"    genNatRoundtrip
-    , f "ListSum"         genListSum
-    , f "IfIntegers"      genIfIntegers
-    , f "ApplyAdd1"       genApplyAdd1
-    , f "ApplyAdd2"       genApplyAdd2
-    , f "DivideByZero"    genDivideByZero
+    [ f "overapplication"  genOverapplication
+    , f "factorial"        genFactorial
+    , f "fibonacci"        genNaiveFib
+    , f "NatRoundTrip"     genNatRoundtrip
+    , f "ListSum"          genListSum
+    , f "IfIntegers"       genIfIntegers
+    , f "ApplyAdd1"        genApplyAdd1
+    , f "ApplyAdd2"        genApplyAdd2
+    , f "DivideByZero"     genDivideByZero
+    , f "DivideByZeroDrop" genDivideByZeroDrop
     ]

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Emit.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Emit.hs
@@ -44,8 +44,12 @@ newtype EmitHandler r = EmitHandler
     { unEmitHandler :: DynamicBuiltinNameMeanings -> Term TyName Name () -> IO r
     }
 
-feedEmitHandler :: Term TyName Name () -> EmitHandler r -> IO r
-feedEmitHandler term (EmitHandler handler) = handler mempty term
+feedEmitHandler
+    :: DynamicBuiltinNameMeanings
+    -> Term TyName Name ()
+    -> EmitHandler r
+    -> IO r
+feedEmitHandler means term (EmitHandler handler) = handler means term
 
 withEmitHandler :: Evaluator Term m -> (EmitHandler (m EvaluationResultDef) -> IO r2) -> IO r2
 withEmitHandler eval k = k . EmitHandler $ \env -> evaluate . eval env
@@ -66,7 +70,8 @@ withEmitTerm cont (EmitHandler handler) =
 withEmitEvaluateBy
     :: KnownType a
     => Evaluator Term m
+    -> DynamicBuiltinNameMeanings
     -> (Term TyName Name () -> Term TyName Name ())
     -> IO ([a], m EvaluationResultDef)
-withEmitEvaluateBy eval toTerm =
-    withEmitHandler eval . withEmitTerm $ feedEmitHandler . toTerm
+withEmitEvaluateBy eval means toTerm =
+    withEmitHandler eval . withEmitTerm $ feedEmitHandler means . toTerm

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Instances.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Dynamic/Instances.hs
@@ -2,12 +2,14 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE TypeApplications   #-}
 
 module Language.PlutusCore.Constant.Dynamic.Instances
-    ( PlcList (..)
+    ( RawTerm (..)
+    , PlcList (..)
     ) where
 
 import           Language.PlutusCore.Constant.Make
@@ -73,6 +75,18 @@ instance (KnownSymbol text, KnownNat uniq) => KnownType (OpaqueTerm text uniq) w
     makeKnown = unOpaqueTerm
 
     readKnown eval = fmap OpaqueTerm . makeRightReflectT . eval mempty
+
+-- | Very similar to 'OpaqueTerm', except the type is a closed one.
+newtype RawTerm a = RawTerm
+    { unRawTerm :: Term TyName Name ()
+    } deriving newtype (Pretty)
+
+instance KnownType a => KnownType (RawTerm a) where
+    toTypeAst _ = toTypeAst @a Proxy
+
+    makeKnown = unRawTerm
+
+    readKnown eval = fmap RawTerm . makeRightReflectT . eval mempty
 
 instance KnownType Integer where
     toTypeAst _ = TyBuiltin () TyInteger

--- a/language-plutus-core/test/Evaluation/DynamicBuiltins/Definition.hs
+++ b/language-plutus-core/test/Evaluation/DynamicBuiltins/Definition.hs
@@ -15,15 +15,17 @@ import           Language.PlutusCore.Constant.Dynamic
 import           Language.PlutusCore.Generators.Interesting
 import           Language.PlutusCore.MkPlc
 
-import           Language.PlutusCore.StdLib.Data.Bool
+import qualified Language.PlutusCore.StdLib.Data.Bool       as Plc
 import qualified Language.PlutusCore.StdLib.Data.Function   as Plc
 import qualified Language.PlutusCore.StdLib.Data.List       as Plc
+import           Language.PlutusCore.StdLib.Data.Unit
 
 import           Evaluation.DynamicBuiltins.Common
 
+import           Control.Monad.IO.Class
 import           Data.Either                                (isRight)
 import           Data.Proxy
-import           Hedgehog                                   hiding (Size, Var)
+import           Hedgehog                                   hiding (Size, Var, eval)
 import qualified Hedgehog.Gen                               as Gen
 import qualified Hedgehog.Range                             as Range
 import           Test.Tasty
@@ -83,7 +85,7 @@ test_dynamicConst =
         let tC = makeKnown c
             tB = makeKnown b
             char = toTypeAst @Char Proxy
-            runConst con = mkIterApp () (mkIterInst () con [char, bool]) [tC, tB]
+            runConst con = mkIterApp () (mkIterInst () con [char, Plc.bool]) [tC, tB]
             env = insertDynamicBuiltinNameDefinition dynamicConstDefinition mempty
             lhs = typecheckReadKnownCek env $ runConst dynamicConst
             rhs = typecheckReadKnownCek mempty $ runConst Plc.const
@@ -121,11 +123,11 @@ test_dynamicReverse =
         lhs === Right (Right (EvaluationSuccess . PlcList $ Prelude.reverse is))
         lhs === rhs
 
-dynamicCatchFailureName :: DynamicBuiltinName
-dynamicCatchFailureName = DynamicBuiltinName "catchFailure"
+dynamicCatchErrorName :: DynamicBuiltinName
+dynamicCatchErrorName = DynamicBuiltinName "catchError"
 
-dynamicCatchFailureMeaning :: DynamicBuiltinNameMeaning
-dynamicCatchFailureMeaning = DynamicBuiltinNameMeaning sch mean where
+dynamicCatchErrorMeaning :: DynamicBuiltinNameMeaning
+dynamicCatchErrorMeaning = DynamicBuiltinNameMeaning sch mean where
     sch =
         TypeSchemeAllType @"a" @0 Proxy $ \(a :: Proxy a) ->
             Proxy @(EvaluationResult a) `TypeSchemeArrow` a `TypeSchemeArrow` TypeSchemeResult a
@@ -133,26 +135,25 @@ dynamicCatchFailureMeaning = DynamicBuiltinNameMeaning sch mean where
     mean (EvaluationSuccess a) _ = a
     mean EvaluationFailure     b = b
 
-dynamicCatchFailureDefinition :: DynamicBuiltinNameDefinition
-dynamicCatchFailureDefinition =
-    DynamicBuiltinNameDefinition dynamicCatchFailureName dynamicCatchFailureMeaning
+dynamicCatchErrorDefinition :: DynamicBuiltinNameDefinition
+dynamicCatchErrorDefinition =
+    DynamicBuiltinNameDefinition dynamicCatchErrorName dynamicCatchErrorMeaning
 
-dynamicCatchFailure :: Term tyname name ()
-dynamicCatchFailure = dynamicBuiltinNameAsTerm dynamicCatchFailureName
+dynamicCatchError :: Term tyname name ()
+dynamicCatchError = dynamicBuiltinNameAsTerm dynamicCatchErrorName
 
--- | Check that it's possible to catch failures on the Plutus side using a builtin.
-test_dynamicCatchFailure :: TestTree
-test_dynamicCatchFailure =
-    testProperty "dynamicCatchFailure" . property $ do
+-- | Check that it's possible to catch errors on the Plutus side using a builtin.
+test_dynamicCatchError :: TestTree
+test_dynamicCatchError =
+    testProperty "dynamicCatchError" . property $ do
         i <- forAll . Gen.integral $ Range.linear 0 100
         j <- forAll . Gen.integral $ Range.linear 0 100
-        let
-            integer = toTypeAst @Integer Proxy
-            env = insertDynamicBuiltinNameDefinition dynamicCatchFailureDefinition mempty
+        let integer = toTypeAst @Integer Proxy
+            env = insertDynamicBuiltinNameDefinition dynamicCatchErrorDefinition mempty
             lhs =
                 typecheckReadKnownCek env $
-                    -- catchFailure (divideInteger i j) i
-                    mkIterApp () (TyInst () dynamicCatchFailure integer)
+                    -- catchError (divideInteger i j) i
+                    mkIterApp () (TyInst () dynamicCatchError integer)
                         [ mkIterApp () (builtinNameAsTerm DivideInteger)
                             [ makeKnown i
                             , makeKnown j
@@ -162,11 +163,78 @@ test_dynamicCatchFailure =
             res = if j /= 0 then i `div` j else i :: Integer
         lhs === Right (Right (EvaluationSuccess res))
 
+dynamicOnErrorName :: DynamicBuiltinName
+dynamicOnErrorName = DynamicBuiltinName "onError"
+
+dynamicOnErrorMeaning :: DynamicBuiltinNameMeaning
+dynamicOnErrorMeaning = DynamicBuiltinNameMeaning sch mean where
+    sch =
+        TypeSchemeAllType @"a" @0 Proxy $ \(_ :: Proxy a) ->
+            Proxy @(EvaluationResult a) `TypeSchemeArrow`
+            Proxy @(RawTerm (() -> ())) `TypeSchemeArrow`
+            TypeSchemeResult (Proxy @a)
+
+    mean (EvaluationSuccess a) _           = a
+    mean a@EvaluationFailure   (RawTerm f) =
+        -- I made a mistake here, but the type checker didn't catch it.
+        -- We do not type check meanings of builtins. Not sure if it's even possible.
+        let x = toTypeAst $ proxyOf a in
+            OpaqueTerm $ mkIterApp () (mkIterInst () Plc.const [x, unit])
+                [ Error () x
+                , Apply () f unitval
+                ]
+
+    proxyOf :: a -> Proxy a
+    proxyOf _ = Proxy
+
+dynamicOnErrorDefinition :: DynamicBuiltinNameDefinition
+dynamicOnErrorDefinition =
+    DynamicBuiltinNameDefinition dynamicOnErrorName dynamicOnErrorMeaning
+
+dynamicOnError :: Term tyname name ()
+dynamicOnError = dynamicBuiltinNameAsTerm dynamicOnErrorName
+
+-- | Check that it's possible to do something on error on the Plutus side using a builtin.
+test_dynamicOnError :: TestTree
+test_dynamicOnError =
+    testProperty "dynamicOnError" . property $ do
+        i <- forAll . Gen.integral $ Range.linear 0 100
+        j <- forAll . Gen.integral $ Range.linear 0 100
+        let integer = toTypeAst @Integer Proxy
+            env = insertDynamicBuiltinNameDefinition dynamicOnErrorDefinition mempty
+        (is, lhs) <-
+            liftIO . withEmitEvaluateBy typecheckEvaluateCek env $ \emit ->
+                -- onError (divideInteger i j) (\(_ : ()) -> emit i)
+                mkIterApp () (TyInst () dynamicOnError integer)
+                    [ mkIterApp () (builtinNameAsTerm DivideInteger)
+                        [ makeKnown i
+                        , makeKnown j
+                        ]
+                    , runQuote $ do
+                        -- It's safe to prepend a lambda here, because the body can't
+                        -- contain any variables.
+                        u <- freshName () "u"
+                        pure
+                            . LamAbs () u unit
+                            . Apply () emit
+                            $ makeKnown (i :: Integer)
+                    ]
+        if j == 0
+            then do
+                -- @i@ is emitted on failure.
+                lhs === Right EvaluationFailure
+                is === [i]
+            else do
+                -- @i@ is not emitted on success.
+                lhs === Right (EvaluationSuccess . makeKnown $ i `div` j)
+                is === []
+
 test_definition :: TestTree
 test_definition =
     testGroup "definition"
         [ test_dynamicFactorial
         , test_dynamicConst
         , test_dynamicReverse
-        , test_dynamicCatchFailure
+        , test_dynamicCatchError
+        , test_dynamicOnError
         ]


### PR DESCRIPTION
The builtins machinery allows to handle exceptions (i.e. `Error`) _in_ Plutus Core. Didn't expect that, huh?

Unfortunately, the CEK machine does not support this use case. It can be tweaked, but I didn't find a reasonable way of doing so (see comments to the PR), so I do not propose to merge this PR as is, instead I'll rollback the changes to the machine and update the tests just to have them anyway.

(I've written the `dynamicCatchFailure` test case, because I thought the costing PR might break it, but given that the CEK machine doesn't support this use case, no PR can break what is already broken)

It's quite an annoying edge case that the builtins machinery allows to express a certain thing, but the evaluator doesn't support that thing. We can unsupport failulre handling by splitting the `KnownType` type class into two `MakeKnown` and `ReadKnown` classes, but it's ugly and we'll need to delete a couple of existing tests that pass. Not sure what to do here.