### PR TITLE
Changed PIR compiler to compile lets in their order of definition.

### DIFF
--- a/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
@@ -32,6 +32,23 @@ this, but this does the job.
 Also we should pull out more stuff (e.g. see 'NonStrict' which uses unit).
 -}
 
+{- Note [Right-associative compilation of let-bindings for linear scoping]
+
+The 'foldM' function for lists is left-associative, but we need right-associative for our case, i.e.
+every right let must be wrapped/scoped by its left let
+
+An pseudocode PIR example:
+let b1 = rhs1;
+    b2 = rhs2  (b1 is visible in rhs2);
+in ...
+
+must be treated the same as let b1 = rhs in (let b2 = rhs2 in ... )
+
+Since there is no 'foldrM' in the stdlib, so we first reverse the bindings list,
+and then apply the left-associative 'foldM' on them,
+which yields the same results as doing a right-associative fold.
+-}
+
 data LetKind = RecTerms | NonRecTerms | Types
 
 -- | Compile the let terms out of a 'Term'. Note: the result does *not* have globally unique names.
@@ -43,13 +60,7 @@ compileLets kind t = getEnclosing >>= \p ->
 compileLet :: Compiling m e a => LetKind -> PIRTerm a -> DefT SharedName (Provenance a) m (PIRTerm a)
 compileLet kind = \case
     Let p r bs body -> withEnclosing (const $ LetBinding r p) $ case r of
-            -- NOTE: 'foldM' for lists is left associative, but we need right associative for our case (every right let must be wrapped/scoped by its left let), example:
-            -- let b1 = rhs1;
-            --     b2 = rhs2  (b1 is visible in rhs2);
-            -- in ...
-            -- must be same as let b1 = rhs in (let b2 = rhs2 in ... )
-            -- There is no 'foldrM' in the stdlib, so we first reverse the bindings list and then left-associative 'foldM' on them,
-            -- which is the same as doing a right-associative fold.
+            -- See Note [Right-associative compilation of let-bindings for linear scoping]
             NonRec -> lift $ foldM (compileNonRecBinding kind) body (reverse bs)
             Rec    -> compileRecBindings kind body bs
     x -> pure x

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
@@ -43,7 +43,7 @@ compileLets kind t = getEnclosing >>= \p ->
 compileLet :: Compiling m e a => LetKind -> PIRTerm a -> DefT SharedName (Provenance a) m (PIRTerm a)
 compileLet kind = \case
     Let p r bs body -> withEnclosing (const $ LetBinding r p) $ case r of
-            NonRec -> lift $ foldM (compileNonRecBinding kind) body bs
+            NonRec -> lift $ foldM (compileNonRecBinding kind) body (reverse bs) -- this foldM is foldr 
             Rec    -> compileRecBindings kind body bs
     x -> pure x
 

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Let.hs
@@ -43,7 +43,7 @@ compileLets kind t = getEnclosing >>= \p ->
 compileLet :: Compiling m e a => LetKind -> PIRTerm a -> DefT SharedName (Provenance a) m (PIRTerm a)
 compileLet kind = \case
     Let p r bs body -> withEnclosing (const $ LetBinding r p) $ case r of
-            NonRec -> lift $ foldM (compileNonRecBinding kind) body (reverse bs) -- this foldM is foldr 
+            NonRec -> lift $ foldM (compileNonRecBinding kind) body (reverse bs) -- this foldM is foldr
             Rec    -> compileRecBindings kind body bs
     x -> pure x
 

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -78,6 +78,7 @@ prettyprinting = testNested "prettyprinting"
 lets :: TestNested
 lets = testNested "lets"
     [ goldenPlcFromPir term "letInLet"
+    , goldenPlcFromPir term "letDep"
     ]
 
 datatypes :: TestNested

--- a/plutus-ir/test/lets/letDep
+++ b/plutus-ir/test/lets/letDep
@@ -1,0 +1,5 @@
+(let (nonrec)
+     (termbind (strict) (vardecl i (con integer)) (con 3))
+     (termbind (strict) (vardecl j (con integer)) i)
+     j
+)

--- a/plutus-ir/test/lets/letDep.golden
+++ b/plutus-ir/test/lets/letDep.golden
@@ -1,0 +1,3 @@
+(program 1.0.0
+  [ (lam i_i0 (con integer) [ (lam j_i0 (con integer) j_i1) i_i1 ]) (con 3) ]
+)

--- a/plutus-ir/test/recursion/even3.golden
+++ b/plutus-ir/test/recursion/even3.golden
@@ -20,45 +20,45 @@
                       match_Nat_i0
                       (fun Nat_i4 (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i5 out_Nat_i1) out_Nat_i1))))
                       [
-                        (lam
-                          three_i0
-                          Nat_i5
+                        [
                           [
-                            [
-                              [
-                                {
-                                  (abs
-                                    Bool_i0
-                                    (type)
+                            {
+                              (abs
+                                Bool_i0
+                                (type)
+                                (lam
+                                  True_i0
+                                  Bool_i2
+                                  (lam
+                                    False_i0
+                                    Bool_i3
                                     (lam
-                                      True_i0
-                                      Bool_i2
-                                      (lam
-                                        False_i0
-                                        Bool_i3
+                                      match_Bool_i0
+                                      (fun Bool_i4 (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                      [
                                         (lam
-                                          match_Bool_i0
-                                          (fun Bool_i4 (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
+                                          three_i0
+                                          Nat_i9
                                           [
                                             (lam
                                               tup_i0
-                                              (all r_i0 (type) (fun (fun (fun Nat_i11 Bool_i6) (fun (fun Nat_i11 Bool_i6) r_i1)) r_i1))
+                                              (all r_i0 (type) (fun (fun (fun Nat_i11 Bool_i7) (fun (fun Nat_i11 Bool_i7) r_i1)) r_i1))
                                               [
                                                 (lam
                                                   even_i0
-                                                  (fun Nat_i11 Bool_i6)
-                                                  [ even_i1 three_i7 ]
+                                                  (fun Nat_i11 Bool_i7)
+                                                  [ even_i1 three_i3 ]
                                                 )
                                                 [
                                                   {
-                                                    tup_i1 (fun Nat_i10 Bool_i5)
+                                                    tup_i1 (fun Nat_i10 Bool_i6)
                                                   }
                                                   (lam
                                                     arg_0_i0
-                                                    (fun Nat_i11 Bool_i6)
+                                                    (fun Nat_i11 Bool_i7)
                                                     (lam
                                                       arg_1_i0
-                                                      (fun Nat_i12 Bool_i7)
+                                                      (fun Nat_i12 Bool_i8)
                                                       arg_0_i2
                                                     )
                                                   )
@@ -69,24 +69,24 @@
                                               {
                                                 {
                                                   {
-                                                    { fix2_i10 Nat_i9 } Bool_i4
+                                                    { fix2_i10 Nat_i9 } Bool_i5
                                                   }
                                                   Nat_i9
                                                 }
-                                                Bool_i4
+                                                Bool_i5
                                               }
                                               (abs
                                                 Q_i0
                                                 (type)
                                                 (lam
                                                   choose_i0
-                                                  (fun (fun Nat_i11 Bool_i6) (fun (fun Nat_i11 Bool_i6) Q_i2))
+                                                  (fun (fun Nat_i11 Bool_i7) (fun (fun Nat_i11 Bool_i7) Q_i2))
                                                   (lam
                                                     even_i0
-                                                    (fun Nat_i12 Bool_i7)
+                                                    (fun Nat_i12 Bool_i8)
                                                     (lam
                                                       odd_i0
-                                                      (fun Nat_i13 Bool_i8)
+                                                      (fun Nat_i13 Bool_i9)
                                                       [
                                                         [
                                                           choose_i3
@@ -100,9 +100,9 @@
                                                                     match_Nat_i11
                                                                     n_i1
                                                                   ]
-                                                                  Bool_i9
+                                                                  Bool_i10
                                                                 }
-                                                                True_i8
+                                                                True_i9
                                                               ]
                                                               (lam
                                                                 pred_i0
@@ -124,9 +124,9 @@
                                                                   match_Nat_i11
                                                                   n_i1
                                                                 ]
-                                                                Bool_i9
+                                                                Bool_i10
                                                               }
-                                                              False_i7
+                                                              False_i8
                                                             ]
                                                             (lam
                                                               pred_i0
@@ -145,39 +145,39 @@
                                             ]
                                           ]
                                         )
-                                      )
+                                        [ Suc_i6 [ Suc_i6 [ Suc_i6 Zero_i7 ] ] ]
+                                      ]
                                     )
                                   )
-                                  (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
-                                }
-                                (abs
-                                  out_Bool_i0
-                                  (type)
-                                  (lam
-                                    case_True_i0
-                                    out_Bool_i2
-                                    (lam case_False_i0 out_Bool_i3 case_True_i2)
-                                  )
-                                )
-                              ]
-                              (abs
-                                out_Bool_i0
-                                (type)
-                                (lam
-                                  case_True_i0
-                                  out_Bool_i2
-                                  (lam case_False_i0 out_Bool_i3 case_False_i1)
                                 )
                               )
-                            ]
-                            (lam
-                              x_i0
                               (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
-                              x_i1
+                            }
+                            (abs
+                              out_Bool_i0
+                              (type)
+                              (lam
+                                case_True_i0
+                                out_Bool_i2
+                                (lam case_False_i0 out_Bool_i3 case_True_i2)
+                              )
                             )
                           ]
+                          (abs
+                            out_Bool_i0
+                            (type)
+                            (lam
+                              case_True_i0
+                              out_Bool_i2
+                              (lam case_False_i0 out_Bool_i3 case_False_i1)
+                            )
+                          )
+                        ]
+                        (lam
+                          x_i0
+                          (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
+                          x_i1
                         )
-                        [ Suc_i2 [ Suc_i2 [ Suc_i2 Zero_i3 ] ] ]
                       ]
                     )
                   )


### PR DESCRIPTION
This allows PlutusIR's Let non-rec bindings  to be scoped in a linear order fashion.

This partially resolves the feature #1683 .

Example:

```
let b1 = rhs1
     b2 = rhs2  (b1 is visible in rhs2)
```