### PR TITLE
Splitting the WalletAPI class up into WalletAPI and NodeAPI.

### DIFF
--- a/marlowe/src/Language/Marlowe/Client.hs
+++ b/marlowe/src/Language/Marlowe/Client.hs
@@ -33,7 +33,7 @@ import           Ledger.Scripts             (RedeemerValue (..), Validator, vali
 import qualified Ledger.Typed.Scripts       as Scripts
 import qualified Ledger.Value               as Val
 import           Ledger.Validation
-import           Wallet                     (WalletAPI (..), WalletAPIError, createPaymentWithChange, createTxAndSubmit,
+import           Wallet                     (WalletAPI (..), NodeAPI (..), WalletAPIError, createPaymentWithChange, createTxAndSubmit,
                                              throwOtherError)
 
 {-| Create a Marlowe contract.
@@ -41,7 +41,8 @@ import           Wallet                     (WalletAPI (..), WalletAPIError, cre
  -}
 createContract :: (
     MonadError WalletAPIError m,
-    WalletAPI m)
+    WalletAPI m,
+    NodeAPI m)
     => MarloweParams
     -> Contract
     -> m (MarloweData, Tx)
@@ -70,7 +71,8 @@ createContract params contract = do
  -}
 deposit :: (
     MonadError WalletAPIError m,
-    WalletAPI m)
+    WalletAPI m,
+    NodeAPI m)
     => Tx
     -> MarloweParams
     -> MarloweData
@@ -86,7 +88,8 @@ deposit tx params marloweData accountId token amount = do
 {-| Notify a contract -}
 notify :: (
     MonadError WalletAPIError m,
-    WalletAPI m)
+    WalletAPI m,
+    NodeAPI m)
     => Tx
     -> MarloweParams
     -> MarloweData
@@ -97,7 +100,8 @@ notify tx params marloweData = applyInputs tx params marloweData [INotify]
 {-| Make a 'choice' identified as 'choiceId'. -}
 makeChoice :: (
     MonadError WalletAPIError m,
-    WalletAPI m)
+    WalletAPI m,
+    NodeAPI m)
     => Tx
     -> MarloweParams
     -> MarloweData
@@ -122,7 +126,8 @@ makeChoice tx params marloweData choiceId choice =
 -}
 makeProgress :: (
     MonadError WalletAPIError m,
-    WalletAPI m)
+    WalletAPI m,
+    NodeAPI m)
     => Tx
     -> MarloweParams
     -> MarloweData
@@ -136,7 +141,8 @@ makeProgress tx params marloweData = applyInputs tx params marloweData []
 -}
 applyInputs :: (
     MonadError WalletAPIError m,
-    WalletAPI m)
+    WalletAPI m,
+    NodeAPI m)
     => Tx
     -> MarloweParams
     -> MarloweData

--- a/plutus-emulator/src/Wallet/Emulator/Wallet.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Wallet.hs
@@ -153,13 +153,15 @@ handleWallet = interpret $ \case
 
 -- HACK: these shouldn't exist, but WalletAPI needs to die first
 instance (Member WalletEffect effs) => WAPI.WalletAPI (Eff effs) where
-    submitTxn = submitTxn
     ownPubKey = ownPubKey
     sign = sign
     updatePaymentWithChange = updatePaymentWithChange
     watchedAddresses = watchedAddresses
     -- TODO: Remove or rework. This is a noop, since the wallet client watches all addresses currently.
     startWatching _ = pure ()
+
+instance (Member WalletEffect effs) => WAPI.NodeAPI (Eff effs) where
+    submitTxn = submitTxn
     slot = walletSlot
 
 instance (Member (Error WAPI.WalletAPIError) effs) => E.MonadError WAPI.WalletAPIError (Eff effs) where

--- a/plutus-wallet-api/src/Wallet/Typed/API.hs
+++ b/plutus-wallet-api/src/Wallet/Typed/API.hs
@@ -17,7 +17,7 @@ import           Ledger.Tx
 import qualified Ledger.Typed.Scripts as Scripts
 import qualified Ledger.Typed.Tx      as Typed
 import           Ledger.Value
-import           Wallet.API           (SlotRange, WalletAPI, WalletAPIError)
+import           Wallet.API           (NodeAPI, SlotRange, WalletAPI, WalletAPIError)
 import qualified Wallet.API           as WAPI
 
 import           Control.Lens
@@ -31,7 +31,7 @@ import qualified Data.Text            as T
 
 signTxAndSubmit
     :: forall ins outs m .
-    (Monad m, WalletAPI m, MonadError WalletAPIError m)
+    (Monad m, WalletAPI m, NodeAPI m, MonadError WalletAPIError m)
     => Typed.TypedTx ins outs
     -> m (Typed.TypedTx ins outs)
 signTxAndSubmit tx = do
@@ -58,7 +58,7 @@ makeScriptPayment ct range v ds = do
 
 payToScript
     :: forall a m .
-    (WalletAPI m, MonadError WalletAPIError m, PlutusTx.IsData (Scripts.DataType a))
+    (WalletAPI m, NodeAPI m, MonadError WalletAPIError m, PlutusTx.IsData (Scripts.DataType a))
     => Scripts.ScriptInstance a
     -> SlotRange
     -> Value
@@ -68,7 +68,7 @@ payToScript ct range v ds = makeScriptPayment ct range v ds >>= signTxAndSubmit
 
 payToScript_
     :: forall a m .
-    (WalletAPI m, MonadError WalletAPIError m, PlutusTx.IsData (Scripts.DataType a))
+    (WalletAPI m, NodeAPI m, MonadError WalletAPIError m, PlutusTx.IsData (Scripts.DataType a))
     => Scripts.ScriptInstance a
     -> SlotRange
     -> Value


### PR DESCRIPTION
This gives a bit more clarity on which parts rely on the wallet, and
which actually need a node.