### PR TITLE
emulator: Add slot number field to chain state

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Trace.hs
@@ -104,7 +104,6 @@ import           Language.Plutus.Contract.Resumable                (ResumableErr
 import qualified Ledger.Ada                                        as Ada
 import           Ledger.Address                                    (Address)
 import qualified Ledger.AddressMap                                 as AM
-import qualified Ledger.Blockchain                                 as Blockchain
 import           Ledger.Slot                                       (Slot (..))
 import           Ledger.Tx                                         (Tx, txId)
 import           Ledger.TxId                                       (TxId)
@@ -514,7 +513,7 @@ addBlocksUntil
     => Slot
     -> ContractTrace s e m a ()
 addBlocksUntil sl = do
-    currentSlot <- lift $ gets (Blockchain.lastSlot . view (EM.chainState . EM.chainNewestFirst))
+    currentSlot <- lift $ use (EM.chainState . EM.currentSlot)
     let Slot missing = sl - currentSlot
     addBlocks (max 0 missing)
 

--- a/plutus-emulator/src/Wallet/Emulator/Types.hs
+++ b/plutus-emulator/src/Wallet/Emulator/Types.hs
@@ -67,6 +67,7 @@ module Wallet.Emulator.Types(
     walletClientStates,
     index,
     chainState,
+    currentSlot,
     MonadEmulator,
     processEmulated,
     runWalletActionAndProcessPending,

--- a/plutus-wallet-api/ledger/Ledger/Blockchain.hs
+++ b/plutus-wallet-api/ledger/Ledger/Blockchain.hs
@@ -5,7 +5,6 @@ module Ledger.Blockchain (
     Block,
     Blockchain,
     ValidationData(..),
-    lastSlot,
     transaction,
     out,
     value,
@@ -26,7 +25,6 @@ import           Data.Maybe     (listToMaybe)
 
 import           Ledger.Crypto
 import           Ledger.Scripts
-import           Ledger.Slot    (Slot (..))
 import           Ledger.Tx
 import           Ledger.TxId
 import           Ledger.Value   (Value)
@@ -36,12 +34,6 @@ import           Ledger.Value   (Value)
 type Block = [Tx]
 -- | A blockchain, which is just a list of blocks, starting with the newest.
 type Blockchain = [Block]
-
--- | The slot number of the last slot of a blockchain. Assumes that each slot
---   has precisely one block. This is true in the
---   emulator but not necessarily on the real chain.
-lastSlot :: Blockchain -> Slot
-lastSlot = Slot . fromIntegral . length
 
 -- | Lookup a transaction in a 'Blockchain' by its id.
 transaction :: Blockchain -> TxId -> Maybe Tx

--- a/plutus-wallet-api/src/Wallet/Generators.hs
+++ b/plutus-wallet-api/src/Wallet/Generators.hs
@@ -243,7 +243,7 @@ assertValid tx mc = Hedgehog.assert $ isNothing $ validateMockchain mc tx
 -- | Validate a transaction in a mockchain.
 validateMockchain :: Mockchain -> Tx -> Maybe Index.ValidationError
 validateMockchain (Mockchain blck _) tx = either Just (const Nothing) result where
-    h      = lastSlot [blck]
+    h      = 1
     idx    = Index.initialise [blck]
     result = Index.runValidation (Index.validateTransaction h tx) idx
 


### PR DESCRIPTION
* To get the current slot we previously simply counted the number of blocks in the blockchain. This is bad because (a) querying for the current slot should be done in constant time and (b) it assumes that there is exactly one block per slot
* (a) hasn't mattered so far because our tests usually don't go above 20 blocks, but it could become quite annoying in the SCB. And it has been bugging me for a while.
* This PR fixes (a) and makes it easier to fix (b) in the future