### PR TITLE
mock node server: Add 'utxo-at' route

### DIFF
--- a/plutus-scb/src/Cardano/Node/API.hs
+++ b/plutus-scb/src/Cardano/Node/API.hs
@@ -5,11 +5,18 @@ module Cardano.Node.API
     ( API
     ) where
 
-import           Ledger      (Slot, Tx)
+import           Data.Map    (Map)
+
+import           Ledger      (Address, Slot, Tx, TxOutRef, TxOut)
 import           Servant.API ((:<|>), (:>), Get, JSON, NoContent, Post, ReqBody)
 
 type API
      = "healthcheck" :> Get '[ JSON] NoContent
        :<|> "mempool" :> ReqBody '[ JSON] Tx :> Post '[ JSON] NoContent
        :<|> "slot" :> Get '[ JSON] Slot
-       :<|> "random-tx" :> Get '[ JSON] Tx
+       :<|> "mock" :> MockAPI
+
+-- Routes that are not guaranteed to exist on the real node
+type MockAPI =
+       "random-tx" :> Get '[ JSON] Tx
+       :<|> "utxo-at" :> ReqBody '[ JSON] Address :> Post '[ JSON] (Map TxOutRef TxOut)

--- a/plutus-scb/src/Cardano/Node/Client.hs
+++ b/plutus-scb/src/Cardano/Node/Client.hs
@@ -3,8 +3,9 @@
 module Cardano.Node.Client where
 
 import           Cardano.Node.API    (API)
+import           Data.Map            (Map)
 import           Data.Proxy          (Proxy (Proxy))
-import           Ledger              (Slot, Tx)
+import           Ledger              (Address, Slot, Tx, TxOutRef, TxOut)
 import           Network.HTTP.Client (defaultManagerSettings, newManager)
 import           Servant             ((:<|>) (..), NoContent)
 import           Servant.Client      (ClientM, client, mkClientEnv, parseBaseUrl, runClientM)
@@ -13,10 +14,11 @@ healthcheck :: ClientM NoContent
 getCurrentSlot :: ClientM Slot
 addTx :: Tx -> ClientM NoContent
 randomTx :: ClientM Tx
-(healthcheck, addTx, getCurrentSlot, randomTx) =
-    (healthcheck_, addTx_, getCurrentSlot_, randomTx_)
+utxoAt :: Address -> ClientM (Map TxOutRef TxOut)
+(healthcheck, addTx, getCurrentSlot, randomTx, utxoAt) =
+    (healthcheck_, addTx_, getCurrentSlot_, randomTx_, utxoAt_)
   where
-    healthcheck_ :<|> addTx_ :<|> getCurrentSlot_ :<|> randomTx_ =
+    healthcheck_ :<|> addTx_ :<|> getCurrentSlot_ :<|> (randomTx_ :<|> utxoAt_) =
         client (Proxy @API)
 
 main :: IO ()


### PR DESCRIPTION
* Add  a `utxo-at` route to get the unspent outputs at an address