### PR TITLE
plutus-ir: use fix1, share fixBy

### DIFF
--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Everything.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Everything.hs
@@ -46,7 +46,7 @@ stdLib =
                   , plcTypeFile "Self"   $ _recursiveType selfData
                   , plcTermFile "Unroll" unroll
                   , plcTermFile "Fix"    fix
-                  , plcTermFile "Fix2"   $ (fst $ fixN 2)
+                  , plcTermFile "Fix2"   $ fixN 2 fixBy
                   ]
               , treeFolderContents "Integer"
                   [ plcTermFile "SuccInteger" succInteger

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Tuple.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Meta/Data/Tuple.hs
@@ -26,7 +26,7 @@ import           Language.PlutusCore.Quote
 import           Control.Lens.Indexed      (ifor, itraverse)
 import           Data.Traversable
 
--- | A Plutus Core tuple.
+-- | A Plutus Core (Scott-encoded) tuple.
 data Tuple term ann where
     Tuple :: TermLike term TyName Name =>
         { _tupleElementTypes :: [Type TyName ann] -- ^ The types of elements of a tuple.

--- a/language-plutus-core/test/Evaluation/Golden.hs
+++ b/language-plutus-core/test/Evaluation/Golden.hs
@@ -42,7 +42,7 @@ evenAndOdd = runQuote $ do
     evenF <- FunctionDef () evenn (FunctionType () nat bool) <$> eoFunc true oddd
     oddF  <- FunctionDef () oddd  (FunctionType () nat bool) <$> eoFunc false evenn
 
-    getMutualFixOf () (fst $ fixN 2) [evenF, oddF]
+    getMutualFixOf () (fixN 2 fixBy) [evenF, oddF]
 
 even :: Term TyName Name ()
 even = runQuote $ tupleTermAt () 0 evenAndOdd
@@ -82,7 +82,7 @@ evenAndOddList = runQuote $ do
             LamAbs () t listNat $
             Apply () (Var () evenn) (Var () t)
 
-    getMutualFixOf () (fst $ fixN 2) [evenF, oddF]
+    getMutualFixOf () (fixN 2 fixBy) [evenF, oddF]
 
 evenList :: Term TyName Name ()
 evenList = runQuote $ tupleTermAt () 0 evenAndOddList

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Definitions.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Definitions.hs
@@ -19,8 +19,10 @@ module Language.PlutusIR.Compiler.Definitions (DefT
                                               , defineType
                                               , defineDatatype
                                               , recordAlias
-                                              , lookupType
                                               , lookupTerm
+                                              , lookupOrDefineTerm
+                                              , lookupType
+                                              , lookupOrDefineType
                                               , lookupConstructors
                                               , lookupDestructor) where
 
@@ -134,6 +136,23 @@ defineDatatype name def deps = liftDef $ DefT $ modify $ over datatypeDefs $ Map
 recordAlias :: forall key ann m . MonadDefs key ann m => key -> m ()
 recordAlias name = liftDef @key @ann $ DefT $ modify $ over aliases (Set.insert name)
 
+lookupTerm :: (MonadDefs key ann m) => ann -> key -> m (Maybe (Term TyName Name ann))
+lookupTerm x name = do
+    DefState{_termDefs=ds,_aliases=as} <- liftDef $ DefT get
+    pure $ case Map.lookup name ds of
+        Just (def, _) | not (Set.member name as) -> Just $ mkVar x $ PLC.defVar def
+        _                                        -> Nothing
+
+lookupOrDefineTerm :: (MonadDefs key ann m) => ann -> key -> m (TermDefWithStrictness ann, Set.Set key) -> m (Term TyName Name ann)
+lookupOrDefineTerm x name mdef = do
+    mTerm <- lookupTerm x name
+    case mTerm of
+        Just t -> pure t
+        Nothing -> do
+            (def, deps) <- mdef
+            defineTerm name def deps
+            pure $ mkVar x $ PLC.defVar def
+
 lookupType :: (MonadDefs key ann m) => ann -> key -> m (Maybe (Type TyName ann))
 lookupType x name = do
     DefState{_typeDefs=tys, _datatypeDefs=dtys, _aliases=as} <- liftDef $ DefT get
@@ -143,12 +162,15 @@ lookupType x name = do
             Just (def, _) -> Just $ mkTyVar x $ PLC.defVar def
             Nothing       -> Nothing
 
-lookupTerm :: (MonadDefs key ann m) => ann -> key -> m (Maybe (Term TyName Name ann))
-lookupTerm x name = do
-    DefState{_termDefs=ds,_aliases=as} <- liftDef $ DefT get
-    pure $ case Map.lookup name ds of
-        Just (def, _) | not (Set.member name as) -> Just $ mkVar x $ PLC.defVar def
-        _                                        -> Nothing
+lookupOrDefineType :: (MonadDefs key ann m) => ann -> key -> m (TypeDef TyName ann, Set.Set key) -> m (Type TyName ann)
+lookupOrDefineType x name mdef = do
+    mTy <- lookupType x name
+    case mTy of
+        Just ty -> pure ty
+        Nothing -> do
+            (def, deps) <- mdef
+            defineType name def deps
+            pure $ mkTyVar x $ PLC.defVar def
 
 lookupConstructors :: (MonadDefs key ann m) => ann -> key -> m (Maybe [Term TyName Name ann])
 lookupConstructors x name = do

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Types.hs
@@ -83,7 +83,11 @@ type TermDef tyname name a = PLC.Def (PLC.VarDecl tyname name a) (PIR.Term tynam
 
 -- | We generate some shared definitions compilation, this datatype
 -- defines the "keys" for those definitions.
-data SharedName = FixpointCombinator Integer deriving (Show, Eq, Ord)
+data SharedName =
+    FixpointCombinator Integer
+    | FixBy
+    deriving (Show, Eq, Ord)
 
 toProgramName :: SharedName -> Quote (PLC.Name ())
 toProgramName (FixpointCombinator n) = freshName () ("fix" <> T.pack (show n))
+toProgramName FixBy                  = freshName () "fixBy"

--- a/plutus-ir/test/Spec.hs
+++ b/plutus-ir/test/Spec.hs
@@ -92,6 +92,7 @@ recursion :: TestNested
 recursion = testNested "recursion"
     [ goldenPlcFromPir term "even3"
     , goldenEvalPir term "even3Eval"
+    , goldenPlcFromPir term "stupidZero"
     , goldenPlcFromPir term "mutuallyRecursiveValues"
     ]
 

--- a/plutus-ir/test/recursion/even3.golden
+++ b/plutus-ir/test/recursion/even3.golden
@@ -1,416 +1,429 @@
 (program 1.0.0
   [
     (lam
-      fix2_i0
-      (all a_i0 (type) (all b_i0 (type) (all a_i0 (type) (all b_i0 (type) (fun (all Q_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)) (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)))) (all R_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) R_i1)) R_i1)))))))
+      fixBy_i0
+      (all F_i0 (fun (type) (type)) (fun (fun (all Q_i0 (type) (fun [F_i2 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i2 Q_i1] Q_i1))) (fun (all Q_i0 (type) (fun [F_i2 Q_i1] [F_i2 Q_i1])) (all Q_i0 (type) (fun [F_i2 Q_i1] Q_i1)))))
       [
-        [
+        (lam
+          fix2_i0
+          (all a_i0 (type) (all b_i0 (type) (all a_i0 (type) (all b_i0 (type) (fun (all Q_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)) (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)))) (all R_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) R_i1)) R_i1)))))))
           [
-            {
-              (abs
-                Nat_i0
-                (type)
-                (lam
-                  Zero_i0
-                  Nat_i2
-                  (lam
-                    Suc_i0
-                    (fun Nat_i3 Nat_i3)
+            [
+              [
+                {
+                  (abs
+                    Nat_i0
+                    (type)
                     (lam
-                      match_Nat_i0
-                      (fun Nat_i4 (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i5 out_Nat_i1) out_Nat_i1))))
-                      [
-                        [
+                      Zero_i0
+                      Nat_i2
+                      (lam
+                        Suc_i0
+                        (fun Nat_i3 Nat_i3)
+                        (lam
+                          match_Nat_i0
+                          (fun Nat_i4 (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i5 out_Nat_i1) out_Nat_i1))))
                           [
-                            {
-                              (abs
-                                Bool_i0
-                                (type)
-                                (lam
-                                  True_i0
-                                  Bool_i2
-                                  (lam
-                                    False_i0
-                                    Bool_i3
+                            [
+                              [
+                                {
+                                  (abs
+                                    Bool_i0
+                                    (type)
                                     (lam
-                                      match_Bool_i0
-                                      (fun Bool_i4 (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
-                                      [
+                                      True_i0
+                                      Bool_i2
+                                      (lam
+                                        False_i0
+                                        Bool_i3
                                         (lam
-                                          three_i0
-                                          Nat_i9
+                                          match_Bool_i0
+                                          (fun Bool_i4 (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1))))
                                           [
                                             (lam
-                                              tup_i0
-                                              (all r_i0 (type) (fun (fun (fun Nat_i11 Bool_i7) (fun (fun Nat_i11 Bool_i7) r_i1)) r_i1))
+                                              three_i0
+                                              Nat_i9
                                               [
                                                 (lam
-                                                  even_i0
-                                                  (fun Nat_i11 Bool_i7)
-                                                  [ even_i1 three_i3 ]
+                                                  tup_i0
+                                                  (all r_i0 (type) (fun (fun (fun Nat_i11 Bool_i7) (fun (fun Nat_i11 Bool_i7) r_i1)) r_i1))
+                                                  [
+                                                    (lam
+                                                      even_i0
+                                                      (fun Nat_i11 Bool_i7)
+                                                      [ even_i1 three_i3 ]
+                                                    )
+                                                    [
+                                                      {
+                                                        tup_i1
+                                                        (fun Nat_i10 Bool_i6)
+                                                      }
+                                                      (lam
+                                                        arg_0_i0
+                                                        (fun Nat_i11 Bool_i7)
+                                                        (lam
+                                                          arg_1_i0
+                                                          (fun Nat_i12 Bool_i8)
+                                                          arg_0_i2
+                                                        )
+                                                      )
+                                                    ]
+                                                  ]
                                                 )
                                                 [
                                                   {
-                                                    tup_i1 (fun Nat_i10 Bool_i6)
+                                                    {
+                                                      {
+                                                        { fix2_i10 Nat_i9 }
+                                                        Bool_i5
+                                                      }
+                                                      Nat_i9
+                                                    }
+                                                    Bool_i5
                                                   }
-                                                  (lam
-                                                    arg_0_i0
-                                                    (fun Nat_i11 Bool_i7)
+                                                  (abs
+                                                    Q_i0
+                                                    (type)
                                                     (lam
-                                                      arg_1_i0
-                                                      (fun Nat_i12 Bool_i8)
-                                                      arg_0_i2
+                                                      choose_i0
+                                                      (fun (fun Nat_i11 Bool_i7) (fun (fun Nat_i11 Bool_i7) Q_i2))
+                                                      (lam
+                                                        even_i0
+                                                        (fun Nat_i12 Bool_i8)
+                                                        (lam
+                                                          odd_i0
+                                                          (fun Nat_i13 Bool_i9)
+                                                          [
+                                                            [
+                                                              choose_i3
+                                                              (lam
+                                                                n_i0
+                                                                Nat_i14
+                                                                [
+                                                                  [
+                                                                    {
+                                                                      [
+                                                                        match_Nat_i11
+                                                                        n_i1
+                                                                      ]
+                                                                      Bool_i10
+                                                                    }
+                                                                    True_i9
+                                                                  ]
+                                                                  (lam
+                                                                    pred_i0
+                                                                    Nat_i15
+                                                                    [
+                                                                      odd_i3
+                                                                      pred_i1
+                                                                    ]
+                                                                  )
+                                                                ]
+                                                              )
+                                                            ]
+                                                            (lam
+                                                              n_i0
+                                                              Nat_i14
+                                                              [
+                                                                [
+                                                                  {
+                                                                    [
+                                                                      match_Nat_i11
+                                                                      n_i1
+                                                                    ]
+                                                                    Bool_i10
+                                                                  }
+                                                                  False_i8
+                                                                ]
+                                                                (lam
+                                                                  pred_i0
+                                                                  Nat_i15
+                                                                  [
+                                                                    even_i4
+                                                                    pred_i1
+                                                                  ]
+                                                                )
+                                                              ]
+                                                            )
+                                                          ]
+                                                        )
+                                                      )
                                                     )
                                                   )
                                                 ]
                                               ]
                                             )
                                             [
-                                              {
-                                                {
-                                                  {
-                                                    { fix2_i10 Nat_i9 } Bool_i5
-                                                  }
-                                                  Nat_i9
-                                                }
-                                                Bool_i5
-                                              }
-                                              (abs
-                                                Q_i0
-                                                (type)
-                                                (lam
-                                                  choose_i0
-                                                  (fun (fun Nat_i11 Bool_i7) (fun (fun Nat_i11 Bool_i7) Q_i2))
-                                                  (lam
-                                                    even_i0
-                                                    (fun Nat_i12 Bool_i8)
-                                                    (lam
-                                                      odd_i0
-                                                      (fun Nat_i13 Bool_i9)
-                                                      [
-                                                        [
-                                                          choose_i3
-                                                          (lam
-                                                            n_i0
-                                                            Nat_i14
-                                                            [
-                                                              [
-                                                                {
-                                                                  [
-                                                                    match_Nat_i11
-                                                                    n_i1
-                                                                  ]
-                                                                  Bool_i10
-                                                                }
-                                                                True_i9
-                                                              ]
-                                                              (lam
-                                                                pred_i0
-                                                                Nat_i15
-                                                                [
-                                                                  odd_i3 pred_i1
-                                                                ]
-                                                              )
-                                                            ]
-                                                          )
-                                                        ]
-                                                        (lam
-                                                          n_i0
-                                                          Nat_i14
-                                                          [
-                                                            [
-                                                              {
-                                                                [
-                                                                  match_Nat_i11
-                                                                  n_i1
-                                                                ]
-                                                                Bool_i10
-                                                              }
-                                                              False_i8
-                                                            ]
-                                                            (lam
-                                                              pred_i0
-                                                              Nat_i15
-                                                              [
-                                                                even_i4 pred_i1
-                                                              ]
-                                                            )
-                                                          ]
-                                                        )
-                                                      ]
-                                                    )
-                                                  )
-                                                )
-                                              )
+                                              Suc_i6
+                                              [ Suc_i6 [ Suc_i6 Zero_i7 ] ]
                                             ]
                                           ]
                                         )
-                                        [ Suc_i6 [ Suc_i6 [ Suc_i6 Zero_i7 ] ] ]
-                                      ]
+                                      )
                                     )
                                   )
+                                  (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
+                                }
+                                (abs
+                                  out_Bool_i0
+                                  (type)
+                                  (lam
+                                    case_True_i0
+                                    out_Bool_i2
+                                    (lam case_False_i0 out_Bool_i3 case_True_i2)
+                                  )
+                                )
+                              ]
+                              (abs
+                                out_Bool_i0
+                                (type)
+                                (lam
+                                  case_True_i0
+                                  out_Bool_i2
+                                  (lam case_False_i0 out_Bool_i3 case_False_i1)
                                 )
                               )
+                            ]
+                            (lam
+                              x_i0
                               (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
-                            }
-                            (abs
-                              out_Bool_i0
-                              (type)
-                              (lam
-                                case_True_i0
-                                out_Bool_i2
-                                (lam case_False_i0 out_Bool_i3 case_True_i2)
-                              )
+                              x_i1
                             )
                           ]
-                          (abs
-                            out_Bool_i0
-                            (type)
-                            (lam
-                              case_True_i0
-                              out_Bool_i2
-                              (lam case_False_i0 out_Bool_i3 case_False_i1)
-                            )
-                          )
-                        ]
-                        (lam
-                          x_i0
-                          (all out_Bool_i0 (type) (fun out_Bool_i1 (fun out_Bool_i1 out_Bool_i1)))
-                          x_i1
                         )
-                      ]
+                      )
+                    )
+                  )
+                  (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                }
+                (iwrap
+                  (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
+                  (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))
+                  (abs
+                    out_Nat_i0
+                    (type)
+                    (lam
+                      case_Zero_i0
+                      out_Nat_i2
+                      (lam
+                        case_Suc_i0
+                        (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i3)
+                        case_Zero_i2
+                      )
+                    )
+                  )
+                )
+              ]
+              (lam
+                arg_0_i0
+                (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+                (iwrap
+                  (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
+                  (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))
+                  (abs
+                    out_Nat_i0
+                    (type)
+                    (lam
+                      case_Zero_i0
+                      out_Nat_i2
+                      (lam
+                        case_Suc_i0
+                        (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i3)
+                        [ case_Suc_i1 arg_0_i4 ]
+                      )
                     )
                   )
                 )
               )
+            ]
+            (lam
+              x_i0
               (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-            }
-            (iwrap
-              (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
-              (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))
-              (abs
-                out_Nat_i0
-                (type)
-                (lam
-                  case_Zero_i0
-                  out_Nat_i2
-                  (lam
-                    case_Suc_i0
-                    (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i3)
-                    case_Zero_i2
-                  )
-                )
-              )
+              (unwrap x_i1)
             )
           ]
-          (lam
-            arg_0_i0
-            (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-            (iwrap
-              (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
-              (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))
-              (abs
-                out_Nat_i0
-                (type)
-                (lam
-                  case_Zero_i0
-                  out_Nat_i2
-                  (lam
-                    case_Suc_i0
-                    (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i3)
-                    [ case_Suc_i1 arg_0_i4 ]
-                  )
-                )
-              )
-            )
-          )
-        ]
-        (lam
-          x_i0
-          (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
-          (unwrap x_i1)
         )
-      ]
-    )
-    (abs
-      a_i0
-      (type)
-      (abs
-        b_i0
-        (type)
         (abs
           a_i0
           (type)
           (abs
             b_i0
             (type)
-            (lam
-              f_i0
-              (all Q_i0 (type) (fun (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1)) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1))))
-              [
-                [
-                  {
-                    (abs
-                      F_i0
-                      (fun (type) (type))
+            (abs
+              a_i0
+              (type)
+              (abs
+                b_i0
+                (type)
+                (lam
+                  f_i0
+                  (all Q_i0 (type) (fun (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1)) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1))))
+                  [
+                    [
+                      {
+                        fixBy_i6
+                        (lam X_i0 (type) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) X_i1)))
+                      }
                       (lam
-                        by_i0
-                        (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
-                        [
-                          {
-                            {
-                              (abs
-                                a_i0
-                                (type)
-                                (abs
-                                  b_i0
-                                  (type)
-                                  (lam
-                                    f_i0
-                                    (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
-                                    [
-                                      {
-                                        (abs
-                                          a_i0
-                                          (type)
-                                          (lam
-                                            s_i0
-                                            [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                            [ (unwrap s_i1) s_i1 ]
-                                          )
-                                        )
-                                        (fun a_i3 b_i2)
-                                      }
-                                      (iwrap
-                                        (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
-                                        (fun a_i3 b_i2)
-                                        (lam
-                                          s_i0
-                                          [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
-                                          (lam
-                                            x_i0
-                                            a_i5
-                                            [
-                                              [
-                                                f_i3
-                                                [
-                                                  {
-                                                    (abs
-                                                      a_i0
-                                                      (type)
-                                                      (lam
-                                                        s_i0
-                                                        [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                                        [ (unwrap s_i1) s_i1 ]
-                                                      )
-                                                    )
-                                                    (fun a_i5 b_i4)
-                                                  }
-                                                  s_i2
-                                                ]
-                                              ]
-                                              x_i1
-                                            ]
-                                          )
-                                        )
-                                      )
-                                    ]
-                                  )
-                                )
-                              )
-                              (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
-                            }
-                            (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
-                          }
+                        k_i0
+                        (all Q_i0 (type) (fun (fun (fun a_i7 b_i6) (fun (fun a_i5 b_i4) Q_i1)) Q_i1))
+                        (abs
+                          S_i0
+                          (type)
                           (lam
-                            rec_i0
-                            (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
-                            (lam
-                              h_i0
-                              (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
-                              (abs
-                                R_i0
-                                (type)
+                            h_i0
+                            (fun (fun a_i8 b_i7) (fun (fun a_i6 b_i5) S_i2))
+                            [
+                              [
+                                h_i1
                                 (lam
-                                  fr_i0
-                                  [F_i6 R_i2]
+                                  x_i0
+                                  a_i9
                                   [
-                                    {
-                                      [
-                                        by_i5
-                                        (abs
-                                          Q_i0
-                                          (type)
-                                          (lam
-                                            fq_i0
-                                            [F_i8 Q_i2]
-                                            [
-                                              { [ rec_i6 h_i5 ] Q_i2 }
-                                              [ { h_i5 Q_i2 } fq_i1 ]
-                                            ]
-                                          )
-                                        )
-                                      ]
-                                      R_i2
-                                    }
-                                    fr_i1
+                                    { k_i4 b_i8 }
+                                    (lam
+                                      f_0_i0
+                                      (fun a_i10 b_i9)
+                                      (lam
+                                        f_1_i0 (fun a_i9 b_i8) [ f_0_i2 x_i3 ]
+                                      )
+                                    )
                                   ]
                                 )
-                              )
-                            )
-                          )
-                        ]
-                      )
-                    )
-                    (lam X_i0 (type) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) X_i1)))
-                  }
-                  (lam
-                    k_i0
-                    (all Q_i0 (type) (fun (fun (fun a_i7 b_i6) (fun (fun a_i5 b_i4) Q_i1)) Q_i1))
-                    (abs
-                      S_i0
-                      (type)
-                      (lam
-                        h_i0
-                        (fun (fun a_i8 b_i7) (fun (fun a_i6 b_i5) S_i2))
-                        [
-                          [
-                            h_i1
-                            (lam
-                              x_i0
-                              a_i9
-                              [
-                                { k_i4 b_i8 }
-                                (lam
-                                  f_0_i0
-                                  (fun a_i10 b_i9)
-                                  (lam f_1_i0 (fun a_i9 b_i8) [ f_0_i2 x_i3 ])
-                                )
                               ]
-                            )
-                          ]
-                          (lam
-                            x_i0
-                            a_i7
-                            [
-                              { k_i4 b_i6 }
                               (lam
-                                f_0_i0
-                                (fun a_i10 b_i9)
-                                (lam f_1_i0 (fun a_i9 b_i8) [ f_1_i1 x_i3 ])
+                                x_i0
+                                a_i7
+                                [
+                                  { k_i4 b_i6 }
+                                  (lam
+                                    f_0_i0
+                                    (fun a_i10 b_i9)
+                                    (lam f_1_i0 (fun a_i9 b_i8) [ f_1_i1 x_i3 ])
+                                  )
+                                ]
                               )
                             ]
                           )
-                        ]
+                        )
                       )
-                    )
-                  )
-                ]
-                f_i1
-              ]
+                    ]
+                    f_i1
+                  ]
+                )
+              )
             )
           )
         )
+      ]
+    )
+    (abs
+      F_i0
+      (fun (type) (type))
+      (lam
+        by_i0
+        (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
+        [
+          {
+            {
+              (abs
+                a_i0
+                (type)
+                (abs
+                  b_i0
+                  (type)
+                  (lam
+                    f_i0
+                    (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
+                    [
+                      {
+                        (abs
+                          a_i0
+                          (type)
+                          (lam
+                            s_i0
+                            [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                            [ (unwrap s_i1) s_i1 ]
+                          )
+                        )
+                        (fun a_i3 b_i2)
+                      }
+                      (iwrap
+                        (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
+                        (fun a_i3 b_i2)
+                        (lam
+                          s_i0
+                          [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
+                          (lam
+                            x_i0
+                            a_i5
+                            [
+                              [
+                                f_i3
+                                [
+                                  {
+                                    (abs
+                                      a_i0
+                                      (type)
+                                      (lam
+                                        s_i0
+                                        [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                                        [ (unwrap s_i1) s_i1 ]
+                                      )
+                                    )
+                                    (fun a_i5 b_i4)
+                                  }
+                                  s_i2
+                                ]
+                              ]
+                              x_i1
+                            ]
+                          )
+                        )
+                      )
+                    ]
+                  )
+                )
+              )
+              (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
+            }
+            (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
+          }
+          (lam
+            rec_i0
+            (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
+            (lam
+              h_i0
+              (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
+              (abs
+                R_i0
+                (type)
+                (lam
+                  fr_i0
+                  [F_i6 R_i2]
+                  [
+                    {
+                      [
+                        by_i5
+                        (abs
+                          Q_i0
+                          (type)
+                          (lam
+                            fq_i0
+                            [F_i8 Q_i2]
+                            [ { [ rec_i6 h_i5 ] Q_i2 } [ { h_i5 Q_i2 } fq_i1 ] ]
+                          )
+                        )
+                      ]
+                      R_i2
+                    }
+                    fr_i1
+                  ]
+                )
+              )
+            )
+          )
+        ]
       )
     )
   ]

--- a/plutus-ir/test/recursion/even3Eval.golden
+++ b/plutus-ir/test/recursion/even3Eval.golden
@@ -1,5 +1,5 @@
 (abs
-  out_Bool_90
+  out_Bool_96
   (type)
-  (lam case_True_91 out_Bool_90 (lam case_False_92 out_Bool_90 case_False_92))
+  (lam case_True_97 out_Bool_96 (lam case_False_98 out_Bool_96 case_False_98))
 )

--- a/plutus-ir/test/recursion/mutuallyRecursiveValues.golden
+++ b/plutus-ir/test/recursion/mutuallyRecursiveValues.golden
@@ -1,259 +1,265 @@
 (program 1.0.0
   [
     (lam
-      fix2_i0
-      (all a_i0 (type) (all b_i0 (type) (all a_i0 (type) (all b_i0 (type) (fun (all Q_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)) (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)))) (all R_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) R_i1)) R_i1)))))))
+      fixBy_i0
+      (all F_i0 (fun (type) (type)) (fun (fun (all Q_i0 (type) (fun [F_i2 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i2 Q_i1] Q_i1))) (fun (all Q_i0 (type) (fun [F_i2 Q_i1] [F_i2 Q_i1])) (all Q_i0 (type) (fun [F_i2 Q_i1] Q_i1)))))
       [
         (lam
-          tup_i0
-          (all r_i0 (type) (fun (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) r_i1)) r_i1))
+          fix2_i0
+          (all a_i0 (type) (all b_i0 (type) (all a_i0 (type) (all b_i0 (type) (fun (all Q_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)) (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) Q_i1)))) (all R_i0 (type) (fun (fun (fun a_i5 b_i4) (fun (fun a_i3 b_i2) R_i1)) R_i1)))))))
           [
             (lam
-              x_i0
-              (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-              [ x_i1 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
+              tup_i0
+              (all r_i0 (type) (fun (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) r_i1)) r_i1))
+              [
+                (lam
+                  x_i0
+                  (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                  [ x_i1 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
+                )
+                [
+                  {
+                    tup_i1
+                    (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                  }
+                  (lam
+                    arg_0_i0
+                    (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                    (lam
+                      arg_1_i0
+                      (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                      arg_0_i2
+                    )
+                  )
+                ]
+              ]
             )
             [
               {
-                tup_i1
-                (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                {
+                  {
+                    { fix2_i1 (all a_i0 (type) (fun a_i1 a_i1)) }
+                    (all a_i0 (type) (fun a_i1 a_i1))
+                  }
+                  (all a_i0 (type) (fun a_i1 a_i1))
+                }
+                (all a_i0 (type) (fun a_i1 a_i1))
               }
-              (lam
-                arg_0_i0
-                (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+              (abs
+                Q_i0
+                (type)
                 (lam
-                  arg_1_i0
-                  (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-                  arg_0_i2
+                  choose_i0
+                  (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) Q_i2))
+                  (lam
+                    x_i0
+                    (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                    (lam
+                      y_i0
+                      (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
+                      [
+                        [
+                          choose_i3
+                          (lam
+                            arg_i0
+                            (all a_i0 (type) (fun a_i1 a_i1))
+                            [ y_i2 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
+                          )
+                        ]
+                        (lam
+                          arg_i0
+                          (all a_i0 (type) (fun a_i1 a_i1))
+                          (abs a_i0 (type) (lam x_i0 a_i2 x_i1))
+                        )
+                      ]
+                    )
+                  )
                 )
               )
             ]
           ]
         )
-        [
-          {
-            {
-              {
-                { fix2_i1 (all a_i0 (type) (fun a_i1 a_i1)) }
-                (all a_i0 (type) (fun a_i1 a_i1))
-              }
-              (all a_i0 (type) (fun a_i1 a_i1))
-            }
-            (all a_i0 (type) (fun a_i1 a_i1))
-          }
-          (abs
-            Q_i0
-            (type)
-            (lam
-              choose_i0
-              (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) (fun (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1))) Q_i2))
-              (lam
-                x_i0
-                (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-                (lam
-                  y_i0
-                  (fun (all a_i0 (type) (fun a_i1 a_i1)) (all a_i0 (type) (fun a_i1 a_i1)))
-                  [
-                    [
-                      choose_i3
-                      (lam
-                        arg_i0
-                        (all a_i0 (type) (fun a_i1 a_i1))
-                        [ y_i2 (abs a_i0 (type) (lam x_i0 a_i2 x_i1)) ]
-                      )
-                    ]
-                    (lam
-                      arg_i0
-                      (all a_i0 (type) (fun a_i1 a_i1))
-                      (abs a_i0 (type) (lam x_i0 a_i2 x_i1))
-                    )
-                  ]
-                )
-              )
-            )
-          )
-        ]
-      ]
-    )
-    (abs
-      a_i0
-      (type)
-      (abs
-        b_i0
-        (type)
         (abs
           a_i0
           (type)
           (abs
             b_i0
             (type)
-            (lam
-              f_i0
-              (all Q_i0 (type) (fun (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1)) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1))))
-              [
-                [
-                  {
-                    (abs
-                      F_i0
-                      (fun (type) (type))
+            (abs
+              a_i0
+              (type)
+              (abs
+                b_i0
+                (type)
+                (lam
+                  f_i0
+                  (all Q_i0 (type) (fun (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1)) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) Q_i1))))
+                  [
+                    [
+                      {
+                        fixBy_i6
+                        (lam X_i0 (type) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) X_i1)))
+                      }
                       (lam
-                        by_i0
-                        (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
-                        [
-                          {
-                            {
-                              (abs
-                                a_i0
-                                (type)
-                                (abs
-                                  b_i0
-                                  (type)
-                                  (lam
-                                    f_i0
-                                    (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
-                                    [
-                                      {
-                                        (abs
-                                          a_i0
-                                          (type)
-                                          (lam
-                                            s_i0
-                                            [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                            [ (unwrap s_i1) s_i1 ]
-                                          )
-                                        )
-                                        (fun a_i3 b_i2)
-                                      }
-                                      (iwrap
-                                        (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
-                                        (fun a_i3 b_i2)
-                                        (lam
-                                          s_i0
-                                          [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
-                                          (lam
-                                            x_i0
-                                            a_i5
-                                            [
-                                              [
-                                                f_i3
-                                                [
-                                                  {
-                                                    (abs
-                                                      a_i0
-                                                      (type)
-                                                      (lam
-                                                        s_i0
-                                                        [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                                        [ (unwrap s_i1) s_i1 ]
-                                                      )
-                                                    )
-                                                    (fun a_i5 b_i4)
-                                                  }
-                                                  s_i2
-                                                ]
-                                              ]
-                                              x_i1
-                                            ]
-                                          )
-                                        )
-                                      )
-                                    ]
-                                  )
-                                )
-                              )
-                              (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
-                            }
-                            (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
-                          }
+                        k_i0
+                        (all Q_i0 (type) (fun (fun (fun a_i7 b_i6) (fun (fun a_i5 b_i4) Q_i1)) Q_i1))
+                        (abs
+                          S_i0
+                          (type)
                           (lam
-                            rec_i0
-                            (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
-                            (lam
-                              h_i0
-                              (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
-                              (abs
-                                R_i0
-                                (type)
+                            h_i0
+                            (fun (fun a_i8 b_i7) (fun (fun a_i6 b_i5) S_i2))
+                            [
+                              [
+                                h_i1
                                 (lam
-                                  fr_i0
-                                  [F_i6 R_i2]
+                                  x_i0
+                                  a_i9
                                   [
-                                    {
-                                      [
-                                        by_i5
-                                        (abs
-                                          Q_i0
-                                          (type)
-                                          (lam
-                                            fq_i0
-                                            [F_i8 Q_i2]
-                                            [
-                                              { [ rec_i6 h_i5 ] Q_i2 }
-                                              [ { h_i5 Q_i2 } fq_i1 ]
-                                            ]
-                                          )
-                                        )
-                                      ]
-                                      R_i2
-                                    }
-                                    fr_i1
+                                    { k_i4 b_i8 }
+                                    (lam
+                                      f_0_i0
+                                      (fun a_i10 b_i9)
+                                      (lam
+                                        f_1_i0 (fun a_i9 b_i8) [ f_0_i2 x_i3 ]
+                                      )
+                                    )
                                   ]
                                 )
-                              )
-                            )
-                          )
-                        ]
-                      )
-                    )
-                    (lam X_i0 (type) (fun (fun a_i6 b_i5) (fun (fun a_i4 b_i3) X_i1)))
-                  }
-                  (lam
-                    k_i0
-                    (all Q_i0 (type) (fun (fun (fun a_i7 b_i6) (fun (fun a_i5 b_i4) Q_i1)) Q_i1))
-                    (abs
-                      S_i0
-                      (type)
-                      (lam
-                        h_i0
-                        (fun (fun a_i8 b_i7) (fun (fun a_i6 b_i5) S_i2))
-                        [
-                          [
-                            h_i1
-                            (lam
-                              x_i0
-                              a_i9
-                              [
-                                { k_i4 b_i8 }
-                                (lam
-                                  f_0_i0
-                                  (fun a_i10 b_i9)
-                                  (lam f_1_i0 (fun a_i9 b_i8) [ f_0_i2 x_i3 ])
-                                )
                               ]
-                            )
-                          ]
-                          (lam
-                            x_i0
-                            a_i7
-                            [
-                              { k_i4 b_i6 }
                               (lam
-                                f_0_i0
-                                (fun a_i10 b_i9)
-                                (lam f_1_i0 (fun a_i9 b_i8) [ f_1_i1 x_i3 ])
+                                x_i0
+                                a_i7
+                                [
+                                  { k_i4 b_i6 }
+                                  (lam
+                                    f_0_i0
+                                    (fun a_i10 b_i9)
+                                    (lam f_1_i0 (fun a_i9 b_i8) [ f_1_i1 x_i3 ])
+                                  )
+                                ]
                               )
                             ]
                           )
-                        ]
+                        )
                       )
-                    )
-                  )
-                ]
-                f_i1
-              ]
+                    ]
+                    f_i1
+                  ]
+                )
+              )
             )
           )
         )
+      ]
+    )
+    (abs
+      F_i0
+      (fun (type) (type))
+      (lam
+        by_i0
+        (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
+        [
+          {
+            {
+              (abs
+                a_i0
+                (type)
+                (abs
+                  b_i0
+                  (type)
+                  (lam
+                    f_i0
+                    (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
+                    [
+                      {
+                        (abs
+                          a_i0
+                          (type)
+                          (lam
+                            s_i0
+                            [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                            [ (unwrap s_i1) s_i1 ]
+                          )
+                        )
+                        (fun a_i3 b_i2)
+                      }
+                      (iwrap
+                        (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
+                        (fun a_i3 b_i2)
+                        (lam
+                          s_i0
+                          [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
+                          (lam
+                            x_i0
+                            a_i5
+                            [
+                              [
+                                f_i3
+                                [
+                                  {
+                                    (abs
+                                      a_i0
+                                      (type)
+                                      (lam
+                                        s_i0
+                                        [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                                        [ (unwrap s_i1) s_i1 ]
+                                      )
+                                    )
+                                    (fun a_i5 b_i4)
+                                  }
+                                  s_i2
+                                ]
+                              ]
+                              x_i1
+                            ]
+                          )
+                        )
+                      )
+                    ]
+                  )
+                )
+              )
+              (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
+            }
+            (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
+          }
+          (lam
+            rec_i0
+            (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
+            (lam
+              h_i0
+              (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
+              (abs
+                R_i0
+                (type)
+                (lam
+                  fr_i0
+                  [F_i6 R_i2]
+                  [
+                    {
+                      [
+                        by_i5
+                        (abs
+                          Q_i0
+                          (type)
+                          (lam
+                            fq_i0
+                            [F_i8 Q_i2]
+                            [ { [ rec_i6 h_i5 ] Q_i2 } [ { h_i5 Q_i2 } fq_i1 ] ]
+                          )
+                        )
+                      ]
+                      R_i2
+                    }
+                    fr_i1
+                  ]
+                )
+              )
+            )
+          )
+        ]
       )
     )
   ]

--- a/plutus-ir/test/recursion/stupidZero
+++ b/plutus-ir/test/recursion/stupidZero
@@ -1,0 +1,19 @@
+(let (rec)
+  (datatypebind (datatype
+      (tyvardecl Nat (type))
+      -- no arguments
+      match_Nat
+      (vardecl Zero Nat)
+      (vardecl Suc (fun Nat Nat))))
+(let (nonrec)
+  (termbind (strict) (vardecl three Nat)
+      [Suc [Suc [Suc Zero]]])
+(let (rec)
+  (termbind (strict) (vardecl stupidZero (fun Nat Nat))
+      (lam n Nat
+        [{[match_Nat n] Nat} Zero (lam pred Nat [stupidZero pred])]))
+  [stupidZero three]
+)
+)
+)
+)

--- a/plutus-ir/test/recursion/stupidZero.golden
+++ b/plutus-ir/test/recursion/stupidZero.golden
@@ -1,0 +1,192 @@
+(program 1.0.0
+  [
+    (lam
+      fix1_i0
+      (all a_i0 (type) (all b_i0 (type) (fun (fun (fun a_i2 b_i1) (fun a_i2 b_i1)) (fun a_i2 b_i1))))
+      [
+        [
+          [
+            {
+              (abs
+                Nat_i0
+                (type)
+                (lam
+                  Zero_i0
+                  Nat_i2
+                  (lam
+                    Suc_i0
+                    (fun Nat_i3 Nat_i3)
+                    (lam
+                      match_Nat_i0
+                      (fun Nat_i4 (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i5 out_Nat_i1) out_Nat_i1))))
+                      [
+                        (lam
+                          three_i0
+                          Nat_i5
+                          [
+                            (lam
+                              tup_i0
+                              (all r_i0 (type) (fun (fun (fun Nat_i7 Nat_i7) r_i1) r_i1))
+                              [
+                                (lam
+                                  stupidZero_i0
+                                  (fun Nat_i7 Nat_i7)
+                                  [ stupidZero_i1 three_i3 ]
+                                )
+                                [
+                                  { tup_i1 (fun Nat_i6 Nat_i6) }
+                                  (lam arg_0_i0 (fun Nat_i7 Nat_i7) arg_0_i1)
+                                ]
+                              ]
+                            )
+                            (abs
+                              r_i0
+                              (type)
+                              (lam
+                                f_i0
+                                (fun (fun Nat_i7 Nat_i7) r_i2)
+                                [
+                                  f_i1
+                                  [
+                                    { { fix1_i8 Nat_i7 } Nat_i7 }
+                                    (lam
+                                      stupidZero_i0
+                                      (fun Nat_i8 Nat_i8)
+                                      (lam
+                                        n_i0
+                                        Nat_i9
+                                        [
+                                          [
+                                            { [ match_Nat_i6 n_i1 ] Nat_i9 }
+                                            Zero_i8
+                                          ]
+                                          (lam
+                                            pred_i0
+                                            Nat_i10
+                                            [ stupidZero_i3 pred_i1 ]
+                                          )
+                                        ]
+                                      )
+                                    )
+                                  ]
+                                ]
+                              )
+                            )
+                          ]
+                        )
+                        [ Suc_i2 [ Suc_i2 [ Suc_i2 Zero_i3 ] ] ]
+                      ]
+                    )
+                  )
+                )
+              )
+              (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+            }
+            (iwrap
+              (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
+              (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))
+              (abs
+                out_Nat_i0
+                (type)
+                (lam
+                  case_Zero_i0
+                  out_Nat_i2
+                  (lam
+                    case_Suc_i0
+                    (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i3)
+                    case_Zero_i2
+                  )
+                )
+              )
+            )
+          ]
+          (lam
+            arg_0_i0
+            (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+            (iwrap
+              (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]]))
+              (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))
+              (abs
+                out_Nat_i0
+                (type)
+                (lam
+                  case_Zero_i0
+                  out_Nat_i2
+                  (lam
+                    case_Suc_i0
+                    (fun (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1))))) out_Nat_i3)
+                    [ case_Suc_i1 arg_0_i4 ]
+                  )
+                )
+              )
+            )
+          )
+        ]
+        (lam
+          x_i0
+          (ifix (lam rec_i0 (fun (fun (type) (type)) (type)) (lam f_i0 (fun (type) (type)) [f_i1 [rec_i2 f_i1]])) (lam Nat_i0 (type) (all out_Nat_i0 (type) (fun out_Nat_i1 (fun (fun Nat_i2 out_Nat_i1) out_Nat_i1)))))
+          (unwrap x_i1)
+        )
+      ]
+    )
+    (abs
+      a_i0
+      (type)
+      (abs
+        b_i0
+        (type)
+        (lam
+          f_i0
+          (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
+          [
+            {
+              (abs
+                a_i0
+                (type)
+                (lam
+                  s_i0
+                  [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                  [ (unwrap s_i1) s_i1 ]
+                )
+              )
+              (fun a_i3 b_i2)
+            }
+            (iwrap
+              (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
+              (fun a_i3 b_i2)
+              (lam
+                s_i0
+                [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
+                (lam
+                  x_i0
+                  a_i5
+                  [
+                    [
+                      f_i3
+                      [
+                        {
+                          (abs
+                            a_i0
+                            (type)
+                            (lam
+                              s_i0
+                              [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                              [ (unwrap s_i1) s_i1 ]
+                            )
+                          )
+                          (fun a_i5 b_i4)
+                        }
+                        s_i2
+                      ]
+                    ]
+                    x_i1
+                  ]
+                )
+              )
+            )
+          ]
+        )
+      )
+    )
+  ]
+)

--- a/plutus-tx-plugin/test/Plugin/Data/recursive/sameEmptyRose.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Data/recursive/sameEmptyRose.plc.golden
@@ -2,7 +2,7 @@
   [
     (lam
       fix1_i0
-      (all a_i0 (type) (all b_i0 (type) (fun (all Q_i0 (type) (fun (fun (fun a_i3 b_i2) Q_i1) (fun (fun a_i3 b_i2) Q_i1))) (all R_i0 (type) (fun (fun (fun a_i3 b_i2) R_i1) R_i1)))))
+      (all a_i0 (type) (all b_i0 (type) (fun (fun (fun a_i2 b_i1) (fun a_i2 b_i1)) (fun a_i2 b_i1))))
       [
         [
           {
@@ -74,25 +74,25 @@
                                                             ]
                                                           ]
                                                         )
-                                                        [
-                                                          {
-                                                            {
-                                                              fix1_i13
-                                                              EmptyRose_i5
-                                                            }
-                                                            EmptyRose_i5
-                                                          }
-                                                          (abs
-                                                            Q_i0
-                                                            (type)
-                                                            (lam
-                                                              choose_i0
-                                                              (fun (fun EmptyRose_i7 EmptyRose_i7) Q_i2)
-                                                              (lam
-                                                                go_i0
-                                                                (fun EmptyRose_i8 EmptyRose_i8)
-                                                                [
-                                                                  choose_i2
+                                                        (abs
+                                                          r_i0
+                                                          (type)
+                                                          (lam
+                                                            f_i0
+                                                            (fun (fun EmptyRose_i7 EmptyRose_i7) r_i2)
+                                                            [
+                                                              f_i1
+                                                              [
+                                                                {
+                                                                  {
+                                                                    fix1_i15
+                                                                    EmptyRose_i7
+                                                                  }
+                                                                  EmptyRose_i7
+                                                                }
+                                                                (lam
+                                                                  go_i0
+                                                                  (fun EmptyRose_i8 EmptyRose_i8)
                                                                   (lam
                                                                     x_i0
                                                                     EmptyRose_i9
@@ -120,11 +120,11 @@
                                                                       ]
                                                                     ]
                                                                   )
-                                                                ]
-                                                              )
-                                                            )
+                                                                )
+                                                              ]
+                                                            ]
                                                           )
-                                                        ]
+                                                        )
                                                       ]
                                                     )
                                                     [
@@ -140,25 +140,25 @@
                                                     ]
                                                   ]
                                                 )
-                                                [
-                                                  {
-                                                    {
-                                                      fix1_i11
-                                                      (fun EmptyRose_i3 EmptyRose_i3)
-                                                    }
-                                                    (fun [List_i7 EmptyRose_i3] [List_i7 EmptyRose_i3])
-                                                  }
-                                                  (abs
-                                                    Q_i0
-                                                    (type)
-                                                    (lam
-                                                      choose_i0
-                                                      (fun (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5])) Q_i2)
-                                                      (lam
-                                                        map_i0
-                                                        (fun (fun EmptyRose_i6 EmptyRose_i6) (fun [List_i10 EmptyRose_i6] [List_i10 EmptyRose_i6]))
-                                                        [
-                                                          choose_i2
+                                                (abs
+                                                  r_i0
+                                                  (type)
+                                                  (lam
+                                                    f_i0
+                                                    (fun (fun (fun EmptyRose_i5 EmptyRose_i5) (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5])) r_i2)
+                                                    [
+                                                      f_i1
+                                                      [
+                                                        {
+                                                          {
+                                                            fix1_i13
+                                                            (fun EmptyRose_i5 EmptyRose_i5)
+                                                          }
+                                                          (fun [List_i9 EmptyRose_i5] [List_i9 EmptyRose_i5])
+                                                        }
+                                                        (lam
+                                                          map_i0
+                                                          (fun (fun EmptyRose_i6 EmptyRose_i6) (fun [List_i10 EmptyRose_i6] [List_i10 EmptyRose_i6]))
                                                           (lam
                                                             ds_i0
                                                             (fun EmptyRose_i7 EmptyRose_i7)
@@ -223,11 +223,11 @@
                                                               ]
                                                             )
                                                           )
-                                                        ]
-                                                      )
-                                                    )
+                                                        )
+                                                      ]
+                                                    ]
                                                   )
-                                                ]
+                                                )
                                               ]
                                             )
                                           )
@@ -344,149 +344,53 @@
         (type)
         (lam
           f_i0
-          (all Q_i0 (type) (fun (fun (fun a_i4 b_i3) Q_i1) (fun (fun a_i4 b_i3) Q_i1)))
+          (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
           [
-            [
-              {
-                (abs
-                  F_i0
-                  (fun (type) (type))
-                  (lam
-                    by_i0
-                    (fun (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)) (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1)))
+            {
+              (abs
+                a_i0
+                (type)
+                (lam
+                  s_i0
+                  [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                  [ (unwrap s_i1) s_i1 ]
+                )
+              )
+              (fun a_i3 b_i2)
+            }
+            (iwrap
+              (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
+              (fun a_i3 b_i2)
+              (lam
+                s_i0
+                [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
+                (lam
+                  x_i0
+                  a_i5
+                  [
                     [
-                      {
+                      f_i3
+                      [
                         {
                           (abs
                             a_i0
                             (type)
-                            (abs
-                              b_i0
-                              (type)
-                              (lam
-                                f_i0
-                                (fun (fun a_i3 b_i2) (fun a_i3 b_i2))
-                                [
-                                  {
-                                    (abs
-                                      a_i0
-                                      (type)
-                                      (lam
-                                        s_i0
-                                        [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                        [ (unwrap s_i1) s_i1 ]
-                                      )
-                                    )
-                                    (fun a_i3 b_i2)
-                                  }
-                                  (iwrap
-                                    (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1)))
-                                    (fun a_i3 b_i2)
-                                    (lam
-                                      s_i0
-                                      [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) (fun a_i4 b_i3)]
-                                      (lam
-                                        x_i0
-                                        a_i5
-                                        [
-                                          [
-                                            f_i3
-                                            [
-                                              {
-                                                (abs
-                                                  a_i0
-                                                  (type)
-                                                  (lam
-                                                    s_i0
-                                                    [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
-                                                    [ (unwrap s_i1) s_i1 ]
-                                                  )
-                                                )
-                                                (fun a_i5 b_i4)
-                                              }
-                                              s_i2
-                                            ]
-                                          ]
-                                          x_i1
-                                        ]
-                                      )
-                                    )
-                                  )
-                                ]
-                              )
-                            )
-                          )
-                          (all Q_i0 (type) (fun [F_i3 Q_i1] [F_i3 Q_i1]))
-                        }
-                        (all Q_i0 (type) (fun [F_i3 Q_i1] Q_i1))
-                      }
-                      (lam
-                        rec_i0
-                        (fun (all Q_i0 (type) (fun [F_i4 Q_i1] [F_i4 Q_i1])) (all Q_i0 (type) (fun [F_i4 Q_i1] Q_i1)))
-                        (lam
-                          h_i0
-                          (all Q_i0 (type) (fun [F_i5 Q_i1] [F_i5 Q_i1]))
-                          (abs
-                            R_i0
-                            (type)
                             (lam
-                              fr_i0
-                              [F_i6 R_i2]
-                              [
-                                {
-                                  [
-                                    by_i5
-                                    (abs
-                                      Q_i0
-                                      (type)
-                                      (lam
-                                        fq_i0
-                                        [F_i8 Q_i2]
-                                        [
-                                          { [ rec_i6 h_i5 ] Q_i2 }
-                                          [ { h_i5 Q_i2 } fq_i1 ]
-                                        ]
-                                      )
-                                    )
-                                  ]
-                                  R_i2
-                                }
-                                fr_i1
-                              ]
+                              s_i0
+                              [(lam a_i0 (type) (ifix (lam self_i0 (fun (type) (type)) (lam a_i0 (type) (fun [self_i2 a_i1] a_i1))) a_i1)) a_i2]
+                              [ (unwrap s_i1) s_i1 ]
                             )
                           )
-                        )
-                      )
+                          (fun a_i5 b_i4)
+                        }
+                        s_i2
+                      ]
                     ]
-                  )
-                )
-                (lam X_i0 (type) (fun (fun a_i4 b_i3) X_i1))
-              }
-              (lam
-                k_i0
-                (all Q_i0 (type) (fun (fun (fun a_i5 b_i4) Q_i1) Q_i1))
-                (abs
-                  S_i0
-                  (type)
-                  (lam
-                    h_i0
-                    (fun (fun a_i6 b_i5) S_i2)
-                    [
-                      h_i1
-                      (lam
-                        x_i0
-                        a_i7
-                        [
-                          { k_i4 b_i6 }
-                          (lam f_0_i0 (fun a_i8 b_i7) [ f_0_i1 x_i2 ])
-                        ]
-                      )
-                    ]
-                  )
+                    x_i1
+                  ]
                 )
               )
-            ]
-            f_i1
+            )
           ]
         )
       )

--- a/plutus-tx-plugin/test/Plugin/Data/recursive/sameEmptyRoseEval.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Data/recursive/sameEmptyRoseEval.plc.golden
@@ -1,53 +1,53 @@
 (iwrap
-  (lam rec_98 (fun (fun (type) (type)) (type)) (lam f_99 (fun (type) (type)) [f_99 [rec_98 f_99]]))
-  (lam EmptyRose_100 (type) (all out_EmptyRose_101 (type) (fun (fun [List_55 EmptyRose_100] out_EmptyRose_101) out_EmptyRose_101)))
+  (lam rec_111 (fun (fun (type) (type)) (type)) (lam f_112 (fun (type) (type)) [f_112 [rec_111 f_112]]))
+  (lam EmptyRose_113 (type) (all out_EmptyRose_114 (type) (fun (fun [List_68 EmptyRose_113] out_EmptyRose_114) out_EmptyRose_114)))
   (abs
-    out_EmptyRose_102
+    out_EmptyRose_115
     (type)
     (lam
-      case_EmptyRose_103
-      (fun [List_55 (ifix (lam rec_104 (fun (fun (type) (type)) (type)) (lam f_105 (fun (type) (type)) [f_105 [rec_104 f_105]])) (lam EmptyRose_106 (type) (all out_EmptyRose_107 (type) (fun (fun [List_55 EmptyRose_106] out_EmptyRose_107) out_EmptyRose_107))))] out_EmptyRose_102)
+      case_EmptyRose_116
+      (fun [List_68 (ifix (lam rec_117 (fun (fun (type) (type)) (type)) (lam f_118 (fun (type) (type)) [f_118 [rec_117 f_118]])) (lam EmptyRose_119 (type) (all out_EmptyRose_120 (type) (fun (fun [List_68 EmptyRose_119] out_EmptyRose_120) out_EmptyRose_120))))] out_EmptyRose_115)
       [
-        case_EmptyRose_103
+        case_EmptyRose_116
         (iwrap
-          (lam List_135 (fun (type) (type)) (lam a_136 (type) (all out_List_137 (type) (fun out_List_137 (fun (fun a_136 (fun [List_135 a_136] out_List_137)) out_List_137)))))
-          a_128
+          (lam List_148 (fun (type) (type)) (lam a_149 (type) (all out_List_150 (type) (fun out_List_150 (fun (fun a_149 (fun [List_148 a_149] out_List_150)) out_List_150)))))
+          a_141
           (abs
-            out_List_138
+            out_List_151
             (type)
             (lam
-              case_Nil_139
-              out_List_138
+              case_Nil_152
+              out_List_151
               (lam
-                case_Cons_140
-                (fun a_128 (fun [(lam a_141 (type) (ifix (lam List_142 (fun (type) (type)) (lam a_143 (type) (all out_List_144 (type) (fun out_List_144 (fun (fun a_143 (fun [List_142 a_143] out_List_144)) out_List_144))))) a_141)) a_128] out_List_138))
+                case_Cons_153
+                (fun a_141 (fun [(lam a_154 (type) (ifix (lam List_155 (fun (type) (type)) (lam a_156 (type) (all out_List_157 (type) (fun out_List_157 (fun (fun a_156 (fun [List_155 a_156] out_List_157)) out_List_157))))) a_154)) a_141] out_List_151))
                 [
                   [
-                    case_Cons_140
+                    case_Cons_153
                     (iwrap
-                      (lam rec_98 (fun (fun (type) (type)) (type)) (lam f_99 (fun (type) (type)) [f_99 [rec_98 f_99]]))
-                      (lam EmptyRose_100 (type) (all out_EmptyRose_101 (type) (fun (fun [List_55 EmptyRose_100] out_EmptyRose_101) out_EmptyRose_101)))
+                      (lam rec_111 (fun (fun (type) (type)) (type)) (lam f_112 (fun (type) (type)) [f_112 [rec_111 f_112]]))
+                      (lam EmptyRose_113 (type) (all out_EmptyRose_114 (type) (fun (fun [List_68 EmptyRose_113] out_EmptyRose_114) out_EmptyRose_114)))
                       (abs
-                        out_EmptyRose_102
+                        out_EmptyRose_115
                         (type)
                         (lam
-                          case_EmptyRose_103
-                          (fun [List_55 (ifix (lam rec_104 (fun (fun (type) (type)) (type)) (lam f_105 (fun (type) (type)) [f_105 [rec_104 f_105]])) (lam EmptyRose_106 (type) (all out_EmptyRose_107 (type) (fun (fun [List_55 EmptyRose_106] out_EmptyRose_107) out_EmptyRose_107))))] out_EmptyRose_102)
+                          case_EmptyRose_116
+                          (fun [List_68 (ifix (lam rec_117 (fun (fun (type) (type)) (type)) (lam f_118 (fun (type) (type)) [f_118 [rec_117 f_118]])) (lam EmptyRose_119 (type) (all out_EmptyRose_120 (type) (fun (fun [List_68 EmptyRose_119] out_EmptyRose_120) out_EmptyRose_120))))] out_EmptyRose_115)
                           [
-                            case_EmptyRose_103
+                            case_EmptyRose_116
                             (iwrap
-                              (lam List_118 (fun (type) (type)) (lam a_119 (type) (all out_List_120 (type) (fun out_List_120 (fun (fun a_119 (fun [List_118 a_119] out_List_120)) out_List_120)))))
-                              a_117
+                              (lam List_131 (fun (type) (type)) (lam a_132 (type) (all out_List_133 (type) (fun out_List_133 (fun (fun a_132 (fun [List_131 a_132] out_List_133)) out_List_133)))))
+                              a_130
                               (abs
-                                out_List_121
+                                out_List_134
                                 (type)
                                 (lam
-                                  case_Nil_122
-                                  out_List_121
+                                  case_Nil_135
+                                  out_List_134
                                   (lam
-                                    case_Cons_123
-                                    (fun a_117 (fun [(lam a_124 (type) (ifix (lam List_125 (fun (type) (type)) (lam a_126 (type) (all out_List_127 (type) (fun out_List_127 (fun (fun a_126 (fun [List_125 a_126] out_List_127)) out_List_127))))) a_124)) a_117] out_List_121))
-                                    case_Nil_122
+                                    case_Cons_136
+                                    (fun a_130 (fun [(lam a_137 (type) (ifix (lam List_138 (fun (type) (type)) (lam a_139 (type) (all out_List_140 (type) (fun out_List_140 (fun (fun a_139 (fun [List_138 a_139] out_List_140)) out_List_140))))) a_137)) a_130] out_List_134))
+                                    case_Nil_135
                                   )
                                 )
                               )
@@ -58,44 +58,44 @@
                     )
                   ]
                   (iwrap
-                    (lam List_135 (fun (type) (type)) (lam a_136 (type) (all out_List_137 (type) (fun out_List_137 (fun (fun a_136 (fun [List_135 a_136] out_List_137)) out_List_137)))))
-                    a_128
+                    (lam List_148 (fun (type) (type)) (lam a_149 (type) (all out_List_150 (type) (fun out_List_150 (fun (fun a_149 (fun [List_148 a_149] out_List_150)) out_List_150)))))
+                    a_141
                     (abs
-                      out_List_138
+                      out_List_151
                       (type)
                       (lam
-                        case_Nil_139
-                        out_List_138
+                        case_Nil_152
+                        out_List_151
                         (lam
-                          case_Cons_140
-                          (fun a_128 (fun [(lam a_141 (type) (ifix (lam List_142 (fun (type) (type)) (lam a_143 (type) (all out_List_144 (type) (fun out_List_144 (fun (fun a_143 (fun [List_142 a_143] out_List_144)) out_List_144))))) a_141)) a_128] out_List_138))
+                          case_Cons_153
+                          (fun a_141 (fun [(lam a_154 (type) (ifix (lam List_155 (fun (type) (type)) (lam a_156 (type) (all out_List_157 (type) (fun out_List_157 (fun (fun a_156 (fun [List_155 a_156] out_List_157)) out_List_157))))) a_154)) a_141] out_List_151))
                           [
                             [
-                              case_Cons_140
+                              case_Cons_153
                               (iwrap
-                                (lam rec_98 (fun (fun (type) (type)) (type)) (lam f_99 (fun (type) (type)) [f_99 [rec_98 f_99]]))
-                                (lam EmptyRose_100 (type) (all out_EmptyRose_101 (type) (fun (fun [List_55 EmptyRose_100] out_EmptyRose_101) out_EmptyRose_101)))
+                                (lam rec_111 (fun (fun (type) (type)) (type)) (lam f_112 (fun (type) (type)) [f_112 [rec_111 f_112]]))
+                                (lam EmptyRose_113 (type) (all out_EmptyRose_114 (type) (fun (fun [List_68 EmptyRose_113] out_EmptyRose_114) out_EmptyRose_114)))
                                 (abs
-                                  out_EmptyRose_102
+                                  out_EmptyRose_115
                                   (type)
                                   (lam
-                                    case_EmptyRose_103
-                                    (fun [List_55 (ifix (lam rec_104 (fun (fun (type) (type)) (type)) (lam f_105 (fun (type) (type)) [f_105 [rec_104 f_105]])) (lam EmptyRose_106 (type) (all out_EmptyRose_107 (type) (fun (fun [List_55 EmptyRose_106] out_EmptyRose_107) out_EmptyRose_107))))] out_EmptyRose_102)
+                                    case_EmptyRose_116
+                                    (fun [List_68 (ifix (lam rec_117 (fun (fun (type) (type)) (type)) (lam f_118 (fun (type) (type)) [f_118 [rec_117 f_118]])) (lam EmptyRose_119 (type) (all out_EmptyRose_120 (type) (fun (fun [List_68 EmptyRose_119] out_EmptyRose_120) out_EmptyRose_120))))] out_EmptyRose_115)
                                     [
-                                      case_EmptyRose_103
+                                      case_EmptyRose_116
                                       (iwrap
-                                        (lam List_118 (fun (type) (type)) (lam a_119 (type) (all out_List_120 (type) (fun out_List_120 (fun (fun a_119 (fun [List_118 a_119] out_List_120)) out_List_120)))))
-                                        a_117
+                                        (lam List_131 (fun (type) (type)) (lam a_132 (type) (all out_List_133 (type) (fun out_List_133 (fun (fun a_132 (fun [List_131 a_132] out_List_133)) out_List_133)))))
+                                        a_130
                                         (abs
-                                          out_List_121
+                                          out_List_134
                                           (type)
                                           (lam
-                                            case_Nil_122
-                                            out_List_121
+                                            case_Nil_135
+                                            out_List_134
                                             (lam
-                                              case_Cons_123
-                                              (fun a_117 (fun [(lam a_124 (type) (ifix (lam List_125 (fun (type) (type)) (lam a_126 (type) (all out_List_127 (type) (fun out_List_127 (fun (fun a_126 (fun [List_125 a_126] out_List_127)) out_List_127))))) a_124)) a_117] out_List_121))
-                                              case_Nil_122
+                                              case_Cons_136
+                                              (fun a_130 (fun [(lam a_137 (type) (ifix (lam List_138 (fun (type) (type)) (lam a_139 (type) (all out_List_140 (type) (fun out_List_140 (fun (fun a_139 (fun [List_138 a_139] out_List_140)) out_List_140))))) a_137)) a_130] out_List_134))
+                                              case_Nil_135
                                             )
                                           )
                                         )
@@ -106,18 +106,18 @@
                               )
                             ]
                             (iwrap
-                              (lam List_118 (fun (type) (type)) (lam a_119 (type) (all out_List_120 (type) (fun out_List_120 (fun (fun a_119 (fun [List_118 a_119] out_List_120)) out_List_120)))))
-                              a_117
+                              (lam List_131 (fun (type) (type)) (lam a_132 (type) (all out_List_133 (type) (fun out_List_133 (fun (fun a_132 (fun [List_131 a_132] out_List_133)) out_List_133)))))
+                              a_130
                               (abs
-                                out_List_121
+                                out_List_134
                                 (type)
                                 (lam
-                                  case_Nil_122
-                                  out_List_121
+                                  case_Nil_135
+                                  out_List_134
                                   (lam
-                                    case_Cons_123
-                                    (fun a_117 (fun [(lam a_124 (type) (ifix (lam List_125 (fun (type) (type)) (lam a_126 (type) (all out_List_127 (type) (fun out_List_127 (fun (fun a_126 (fun [List_125 a_126] out_List_127)) out_List_127))))) a_124)) a_117] out_List_121))
-                                    case_Nil_122
+                                    case_Cons_136
+                                    (fun a_130 (fun [(lam a_137 (type) (ifix (lam List_138 (fun (type) (type)) (lam a_139 (type) (all out_List_140 (type) (fun out_List_140 (fun (fun a_139 (fun [List_138 a_139] out_List_140)) out_List_140))))) a_137)) a_130] out_List_134))
+                                    case_Nil_135
                                   )
                                 )
                               )

--- a/plutus-tx-plugin/test/Plugin/Functions/recursive/even3.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/recursive/even3.plc.golden
@@ -1,5 +1,7 @@
 (abs
-  out_Bool_90
+  out_Bool_103
   (type)
-  (lam case_True_91 out_Bool_90 (lam case_False_92 out_Bool_90 case_False_92))
+  (lam
+    case_True_104 out_Bool_103 (lam case_False_105 out_Bool_103 case_False_105)
+  )
 )

--- a/plutus-tx-plugin/test/Plugin/Functions/recursive/even4.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/recursive/even4.plc.golden
@@ -1,5 +1,7 @@
 (abs
-  out_Bool_87
+  out_Bool_100
   (type)
-  (lam case_True_88 out_Bool_87 (lam case_False_89 out_Bool_87 case_True_88))
+  (lam
+    case_True_101 out_Bool_100 (lam case_False_102 out_Bool_100 case_True_101)
+  )
 )

--- a/plutus-tx-plugin/test/TH/all.plc.golden
+++ b/plutus-tx-plugin/test/TH/all.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_173
+  out_Bool_186
   (type)
   (lam
-    case_True_174 out_Bool_173 (lam case_False_175 out_Bool_173 case_True_174)
+    case_True_187 out_Bool_186 (lam case_False_188 out_Bool_186 case_True_187)
   )
 )

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -7,29 +7,29 @@ Events by wallet:
     - {slot:
        Slot: 27}
     - {utxo-at:
-       Utxo at ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69 =
-         12c8fd4448d33cc10c21c1121ed9ce3997b56761267afa755c4e1d54e57db40c!1: PayToScript: 4c592448cff8d2b2ee40a509e1d5224260ef29f5b22cd920616e39cad65f466c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}
-         40bba9774b4e847961264812c75e56889f3ee2659e55d5ee76138162be2c0fde!1: PayToScript: b8324180800f57f26dee2ad65990e0a762a5dab9424d32e49855abd495f7196b Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-         60fa1705710e676d0b736d92131fd94a7ce855d05d25fb35ac3aaa44b7722884!1: PayToScript: 49cd69a6941f191e3d14ce83834e0f2ce175318995b40380854e3201171c0baa Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}
+       Utxo at ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99 =
+         3cae55f82786920c7cb6b7ed7a7b7a9ff5b84ca4f8759fcf3433898d43210dba!1: PayToScript: 4c592448cff8d2b2ee40a509e1d5224260ef29f5b22cd920616e39cad65f466c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}
+         ab5df68931f640de24cc2e7c5d2cd9415464023493ae601d5798d4b75e35cc14!1: PayToScript: 49cd69a6941f191e3d14ce83834e0f2ce175318995b40380854e3201171c0baa Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+         eccbf2065dc6bb81bc5c861ed25d054ad063767213db1655c4db5e916f07882b!1: PayToScript: b8324180800f57f26dee2ad65990e0a762a5dab9424d32e49855abd495f7196b Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}
     - {tx:
-       WriteTxSuccess: 5c8ca315e659ca58b2a25db294e26c9b357e059056ea55891de4d42e407115a3}
+       WriteTxSuccess: b1d63b6be5de66c33417fdd8461e1b023c1af598c7ad93e1fa931aec7d69626c}
   Events for W2:
     - {contribute:
        EndpointValue: Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}}
     - {own-pubkey:
        fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025}
     - {tx:
-       WriteTxSuccess: 40bba9774b4e847961264812c75e56889f3ee2659e55d5ee76138162be2c0fde}
+       WriteTxSuccess: eccbf2065dc6bb81bc5c861ed25d054ad063767213db1655c4db5e916f07882b}
     - {address:
-       ( ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
-       , Tx 40bba9774b4e847961264812c75e56889f3ee2659e55d5ee76138162be2c0fde:
+       ( ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
+       , Tx eccbf2065dc6bb81bc5c861ed25d054ad063767213db1655c4db5e916f07882b:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!8
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9990)]})]}} addressed to
              PubKeyAddress: 03d200a81ee0feace8fb845e5ec950a6f9add83709244f7b81134654139f41a4
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-             ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+             ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -37,15 +37,15 @@ Events by wallet:
            fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     - {address:
-       ( ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
-       , Tx 60fa1705710e676d0b736d92131fd94a7ce855d05d25fb35ac3aaa44b7722884:
+       ( ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
+       , Tx ab5df68931f640de24cc2e7c5d2cd9415464023493ae601d5798d4b75e35cc14:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!3
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9990)]})]}} addressed to
              PubKeyAddress: feb345e86b9c2a7add2bfc695fa8aecd4ac5b0dfaf3a477f6fa968cdd30571c7
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-             ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+             ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -53,15 +53,15 @@ Events by wallet:
            98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     - {address:
-       ( ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
-       , Tx 12c8fd4448d33cc10c21c1121ed9ce3997b56761267afa755c4e1d54e57db40c:
+       ( ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
+       , Tx 3cae55f82786920c7cb6b7ed7a7b7a9ff5b84ca4f8759fcf3433898d43210dba:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!7
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9999)]})]}} addressed to
              PubKeyAddress: 5aebc31421e7af1bdb47326709c27f3fd9381b00b0aca127b8dccd5f8525a538
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} addressed to
-             ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+             ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -74,17 +74,17 @@ Events by wallet:
     - {own-pubkey:
        98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63}
     - {tx:
-       WriteTxSuccess: 60fa1705710e676d0b736d92131fd94a7ce855d05d25fb35ac3aaa44b7722884}
+       WriteTxSuccess: ab5df68931f640de24cc2e7c5d2cd9415464023493ae601d5798d4b75e35cc14}
     - {address:
-       ( ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
-       , Tx 60fa1705710e676d0b736d92131fd94a7ce855d05d25fb35ac3aaa44b7722884:
+       ( ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
+       , Tx ab5df68931f640de24cc2e7c5d2cd9415464023493ae601d5798d4b75e35cc14:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!3
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9990)]})]}} addressed to
              PubKeyAddress: feb345e86b9c2a7add2bfc695fa8aecd4ac5b0dfaf3a477f6fa968cdd30571c7
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-             ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+             ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -92,15 +92,15 @@ Events by wallet:
            98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63
          validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}} )}
     - {address:
-       ( ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
-       , Tx 12c8fd4448d33cc10c21c1121ed9ce3997b56761267afa755c4e1d54e57db40c:
+       ( ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
+       , Tx 3cae55f82786920c7cb6b7ed7a7b7a9ff5b84ca4f8759fcf3433898d43210dba:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!7
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9999)]})]}} addressed to
              PubKeyAddress: 5aebc31421e7af1bdb47326709c27f3fd9381b00b0aca127b8dccd5f8525a538
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} addressed to
-             ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+             ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -113,17 +113,17 @@ Events by wallet:
     - {own-pubkey:
        f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863}
     - {tx:
-       WriteTxSuccess: 12c8fd4448d33cc10c21c1121ed9ce3997b56761267afa755c4e1d54e57db40c}
+       WriteTxSuccess: 3cae55f82786920c7cb6b7ed7a7b7a9ff5b84ca4f8759fcf3433898d43210dba}
     - {address:
-       ( ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
-       , Tx 12c8fd4448d33cc10c21c1121ed9ce3997b56761267afa755c4e1d54e57db40c:
+       ( ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
+       , Tx 3cae55f82786920c7cb6b7ed7a7b7a9ff5b84ca4f8759fcf3433898d43210dba:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!7
          outputs:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9999)]})]}} addressed to
              PubKeyAddress: 5aebc31421e7af1bdb47326709c27f3fd9381b00b0aca127b8dccd5f8525a538
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} addressed to
-             ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+             ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -135,7 +135,7 @@ Contract result by wallet:
       Done
     Wallet: W2
       Running, waiting for input:
-        {address: [ ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69 ]
+        {address: [ ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99 ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]
@@ -145,7 +145,7 @@ Contract result by wallet:
          utxo-at: []}
     Wallet: W3
       Running, waiting for input:
-        {address: [ ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69 ]
+        {address: [ ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99 ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]
@@ -155,7 +155,7 @@ Contract result by wallet:
          utxo-at: []}
     Wallet: W4
       Running, waiting for input:
-        {address: [ ScriptAddress: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69 ]
+        {address: [ ScriptAddress: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99 ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #2, Tx #0 ====
-TxId:       40bba9774b4e847961264812c75e56889f3ee2659e55d5ee76138162be2c0fde
+TxId:       eccbf2065dc6bb81bc5c861ed25d054ad063767213db1655c4db5e916f07882b
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f58204370a267b70794da50c9eaac3853c3a5b5...
+              Signature: 5f58201e60d061815dff2bc2d76ec8d41089b79d...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 03d200a81ee0feace8fb845e5ec950a6f9add837... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+  Destination:  Script: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
   Value:
     Ada:      Lovelace:  10
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+  Script: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #3, Tx #0 ====
-TxId:       60fa1705710e676d0b736d92131fd94a7ce855d05d25fb35ac3aaa44b7722884
+TxId:       ab5df68931f640de24cc2e7c5d2cd9415464023493ae601d5798d4b75e35cc14
 Fee:        -
 Forge:      -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 5f5820294fe22988a26d5071cf1fcc74f26b0035...
+              Signature: 5f58203715b40af0a588af2892d95e2d64c90056...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: feb345e86b9c2a7add2bfc695fa8aecd4ac5b0df... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+  Destination:  Script: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
   Value:
     Ada:      Lovelace:  10
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+  Script: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
   Value:
     Ada:      Lovelace:  20
 
 ==== Slot #4, Tx #0 ====
-TxId:       12c8fd4448d33cc10c21c1121ed9ce3997b56761267afa755c4e1d54e57db40c
+TxId:       3cae55f82786920c7cb6b7ed7a7b7a9ff5b84ca4f8759fcf3433898d43210dba
 Fee:        -
 Forge:      -
 Signatures  PubKey: f81fb54a825fced95eb033afcd64314075abfb0a...
-              Signature: 5f5820f1bb4ead53aba03cb7823c57112d71a544...
+              Signature: 5f5820014fea237c9d33f3d79c802a3733180604...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 5aebc31421e7af1bdb47326709c27f3fd9381b00... (Wallet 4)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  9999
   
   ---- Output 1 ----
-  Destination:  Script: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+  Destination:  Script: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
   Value:
     Ada:      Lovelace:  1
 
@@ -318,43 +318,43 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+  Script: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
   Value:
     Ada:      Lovelace:  21
 
 ==== Slot #23, Tx #0 ====
-TxId:       5c8ca315e659ca58b2a25db294e26c9b357e059056ea55891de4d42e407115a3
+TxId:       b1d63b6be5de66c33417fdd8461e1b023c1af598c7ad93e1fa931aec7d69626c
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f5820f76366bc42dd36a5cfd356ae8336202266...
+              Signature: 5f582080c006abb74850138e077f98d80c2ddae7...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+  Destination:  Script: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
   Value:
     Ada:      Lovelace:  1
   Source:
-    Tx:     12c8fd4448d33cc10c21c1121ed9ce3997b56761267afa755c4e1d54e57db40c
+    Tx:     3cae55f82786920c7cb6b7ed7a7b7a9ff5b84ca4f8759fcf3433898d43210dba
     Output #1
-    Script: f6f601000003f603f602f6f664666978311907e4...
+    Script: f6f601000003f603f602f6f664666978311907f1...
   
   ---- Input 1 ----
-  Destination:  Script: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+  Destination:  Script: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     40bba9774b4e847961264812c75e56889f3ee2659e55d5ee76138162be2c0fde
+    Tx:     ab5df68931f640de24cc2e7c5d2cd9415464023493ae601d5798d4b75e35cc14
     Output #1
-    Script: f6f601000003f603f602f6f664666978311907e4...
+    Script: f6f601000003f603f602f6f664666978311907f1...
   
   ---- Input 2 ----
-  Destination:  Script: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+  Destination:  Script: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     60fa1705710e676d0b736d92131fd94a7ce855d05d25fb35ac3aaa44b7722884
+    Tx:     eccbf2065dc6bb81bc5c861ed25d054ad063767213db1655c4db5e916f07882b
     Output #1
-    Script: f6f601000003f603f602f6f664666978311907e4...
+    Script: f6f601000003f603f602f6f664666978311907f1...
 
 
 Outputs:
@@ -405,6 +405,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: df00e42e1b1b27d5ade43b542929ad767afe3c211480ed1897b6042894f7bb69
+  Script: 03843952c316b6e263bf5a6d72bc957c7ba876ee53cbb4529600a29bfa934f99
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       83256ef8e4087f8a15f2495b9e7f1cbe711270a0c991b35508738d639efee6fb
+TxId:       25c905ebfabdc31beecc5b07056ebfd4374d402a5328b494b8d257c0051dee5a
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f5820ae1748b66ae9cbddb34e90a8a4aeb09a1c...
+              Signature: 5f5820c0256e7f10d42c0d59770c7c46ba59e526...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 2721f657e9ed91d2fc2a282f7ff5ed81ae48f48b... (Wallet 1)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 35008b77ef05a53e7aabf387ecaae2ad530fdb8d409d709a395dd2214fb05996
+  Destination:  Script: 1ead0306763ebe042e5972d91128793d39894a5b0fe6a1a5e206c4d913179fff
   Value:
     Ada:      Lovelace:  10
 
@@ -170,25 +170,25 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 35008b77ef05a53e7aabf387ecaae2ad530fdb8d409d709a395dd2214fb05996
+  Script: 1ead0306763ebe042e5972d91128793d39894a5b0fe6a1a5e206c4d913179fff
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       cd38eb001e80b2c0ff69b79460fe57c04ec6e2c9d5a31c4357936585b217e20f
+TxId:       cd5cfac4e747130ccec09de16c2b3412bb4ecd4c391a16fd90d5b793a951866c
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f5820923fbe5f2389d1e69128429d2f03b6ca02...
+              Signature: 5f58201774d00c224e59737d83d0bcff332eb224...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 35008b77ef05a53e7aabf387ecaae2ad530fdb8d409d709a395dd2214fb05996
+  Destination:  Script: 1ead0306763ebe042e5972d91128793d39894a5b0fe6a1a5e206c4d913179fff
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     83256ef8e4087f8a15f2495b9e7f1cbe711270a0c991b35508738d639efee6fb
+    Tx:     25c905ebfabdc31beecc5b07056ebfd4374d402a5328b494b8d257c0051dee5a
     Output #1
-    Script: f6f601000003f602f6f664666978311907d403f6...
+    Script: f6f601000003f602f6f664666978311907e103f6...
 
 
 Outputs:
@@ -239,6 +239,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 35008b77ef05a53e7aabf387ecaae2ad530fdb8d409d709a395dd2214fb05996
+  Script: 1ead0306763ebe042e5972d91128793d39894a5b0fe6a1a5e206c4d913179fff
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       bd34df21a41bf3bd8749ee5664c4fff5f22f49c1d5c6edaf4cb4daae07c7ae5c
+TxId:       69af5ee548f4e72a318f4d81e35d9fef3e5e3e31fac71d91514e2d1e2565fd2f
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f5820e7c8ade26b693e114c1b9968f61a73ea6d...
+              Signature: 5f5820524f52018e7e5c24d9fd5889473b165527...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 03d200a81ee0feace8fb845e5ec950a6f9add837... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9940
   
   ---- Output 1 ----
-  Destination:  Script: 8a5395d26b1fcc128d7805145d7e918c8377c8fc87af0b176ff957a8ede26f9f
+  Destination:  Script: f54166b654a2c99bc0309df4d3668eb3790cb239830f5a5dfa81f76414cbc177
   Value:
     Ada:      Lovelace:  60
 
@@ -170,25 +170,25 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 8a5395d26b1fcc128d7805145d7e918c8377c8fc87af0b176ff957a8ede26f9f
+  Script: f54166b654a2c99bc0309df4d3668eb3790cb239830f5a5dfa81f76414cbc177
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #13, Tx #0 ====
-TxId:       a18cb2135fc0e01d4cbb84a9ecae92db04b5bd78eff813ec90d95fe784a836f1
+TxId:       062c479557d6f547544d39a4657ece02686a948499077d1515dd8057b1c84ada
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f5820eab7bbdec6094cae77aa073186c20aad31...
+              Signature: 5f5820fd53ea5b6cfa8ef9e3837786a98664cb8f...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 8a5395d26b1fcc128d7805145d7e918c8377c8fc87af0b176ff957a8ede26f9f
+  Destination:  Script: f54166b654a2c99bc0309df4d3668eb3790cb239830f5a5dfa81f76414cbc177
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     bd34df21a41bf3bd8749ee5664c4fff5f22f49c1d5c6edaf4cb4daae07c7ae5c
+    Tx:     69af5ee548f4e72a318f4d81e35d9fef3e5e3e31fac71d91514e2d1e2565fd2f
     Output #1
-    Script: f6f601000003f603f602f6f6646669783119080c...
+    Script: f6f601000003f603f602f6f66466697831190819...
 
 
 Outputs:
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  10
   
   ---- Output 1 ----
-  Destination:  Script: 8a5395d26b1fcc128d7805145d7e918c8377c8fc87af0b176ff957a8ede26f9f
+  Destination:  Script: f54166b654a2c99bc0309df4d3668eb3790cb239830f5a5dfa81f76414cbc177
   Value:
     Ada:      Lovelace:  50
 
@@ -244,6 +244,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 8a5395d26b1fcc128d7805145d7e918c8377c8fc87af0b176ff957a8ede26f9f
+  Script: f54166b654a2c99bc0309df4d3668eb3790cb239830f5a5dfa81f76414cbc177
   Value:
     Ada:      Lovelace:  50


### PR DESCRIPTION
Fixes #1774, and also I shared `fixBy` since it's used by all `fixN`s.

The first change saves us a few hundred AST nodes for our standard programs, for a modest win. The second one has no effect, since shockingly we have *no* uses of mutually recursive functions in our example usecases. All the recursive functions are self-recursive!