### PR TITLE
docs: add a glossary

### DIFF
--- a/GLOSSARY.adoc
+++ b/GLOSSARY.adoc
@@ -19,10 +19,12 @@ PAB to the wallet frontend or other clients.
 [[contract-exe]]Contract executable::
 A compiled executable of a contract application. These are what are actually distributed to users and
 run by the PAB.
+[[context]]Context::
+A data structure containing a summary of the transaction being validated.
 [[currency]]Currency::
 A class of token whose forging is controlled by a particular monetary policy script. On the Cardano ledger there
 is a special currency called Ada which can never be forged and which is controlled separately.
-[[data-value]]Data value::
+[[datum]]Datum::
 The data field on script outputs in the Extended UTXO model.
 [[eutxo]]Extended UTXO Model::
 The ledger model which the Plutus Platform relies on.
@@ -30,12 +32,12 @@ The ledger model which the Plutus Platform relies on.
 This is implemented in the Goguen release of the Cardano blockchain.
 Notable differences from traditional UTXO ledgers are:
 +
-. UTXOs carry an additional data output, called the data value
-. Validators get to see a representation of the transaction being validated, called the pending tx
+. UTXOs carry an additional data output, called the datum
+. Validators get to see a representation of the transaction being validated, called the context
 . The validator script is provided with:
-.. The data value on the spent output
+.. The datum on the spent output
 .. The redeemer provided by the input
-.. The pending tx representing the transaction being validated
+.. The context representing the transaction being validated
 [[forging]]Forging::
 A transaction which forges tokens creates new tokens, providing that the corresponding monetary policy script is
 satisfied. The amount forged can be negative, in which case the tokens will be destroyed instead of created.
@@ -49,8 +51,6 @@ A generic term for a ledger which supports multiple different currencies nativel
 The part of a contract application's code which runs off the chain, usually as a contract application.
 [[on-chain-code]]On-chain code::
 The part of a contract application's code which runs on the chain (i.e. as scripts).
-[[pending-tx]]Pending Tx::
-A data structure containing a summary of the transaction being validated.
 [[pab-client-api]]PAB client API::
 The API that the PAB provides to allow PAB clients to interact with contract application instances. Contract endpoints
 which are exposed by running instances can be called via the client API.
@@ -79,7 +79,7 @@ preferred in cases where humans may want to inspect the program.
 [[plutus-platform]]Plutus Platform::
 The combined software support for writing contract applications, including:
 +
-. The Plutus Application Backedn
+. The Plutus Application Backend
 . The Plutus SDK
 . The support for Plutus scripts on the Cardano chain
 [[plutus-sdk]]Plutus SDK::

--- a/GLOSSARY.adoc
+++ b/GLOSSARY.adoc
@@ -1,0 +1,105 @@
+[glossary]
+= Glossary
+:reproducible:
+
+[[address]]Address::
+The address of an UTXO says where the output is "going". The address stipulates the conditions for unlocking the
+output. This can be a public key hash, or (in the Extended UTXO model) a script hash.
+[[contract-application]]Contract application::
+An application written against the contract application API, which runs in the PAB.
+[[contract-api]]Contract application API::
+The API that provides an interface between a contract application and the PAB. Also allows the contract to
+declare contract endpoints that will be forwarded on to PAB clients via the application interface.
+[[contract-instance]]Contract application instance::
+A configured, running instance of a contract application. Configuration and initialization may require additional
+parameters to be set by the user. Has its state and lifecycle managed by the PAB.
+[[contract-endpoint]]Contract endpoint::
+An interface point exposed by a contract application as part of its own API. These are forwarded on by the
+PAB to the wallet frontend or other clients.
+[[contract-exe]]Contract executable::
+A compiled executable of a contract application. These are what are actually distributed to users and
+run by the PAB.
+[[currency]]Currency::
+A class of token whose forging is controlled by a particular monetary policy script. On the Cardano ledger there
+is a special currency called Ada which can never be forged and which is controlled separately.
+[[data-value]]Data value::
+The data field on script outputs in the Extended UTXO model.
+[[eutxo]]Extended UTXO Model::
+The ledger model which the Plutus Platform relies on.
++
+This is implemented in the Goguen release of the Cardano blockchain.
+Notable differences from traditional UTXO ledgers are:
++
+. UTXOs carry an additional data output, called the data value
+. Validators get to see a representation of the transaction being validated, called the pending tx
+. The validator script is provided with:
+.. The data value on the spent output
+.. The redeemer provided by the input
+.. The pending tx representing the transaction being validated
+[[forging]]Forging::
+A transaction which forges tokens creates new tokens, providing that the corresponding monetary policy script is
+satisfied. The amount forged can be negative, in which case the tokens will be destroyed instead of created.
+[[marlowe]]Marlowe::
+A domain-specific language for writing financial contract applications.
+[[mps]]Monetary policy script::
+A script which must be satisfied in order for a transaction to forge tokens of the corresponding currency.
+[[multicurrency]]Multicurrency::
+A generic term for a ledger which supports multiple different currencies natively.
+[[off-chain-code]]Off-chain code::
+The part of a contract application's code which runs off the chain, usually as a contract application.
+[[on-chain-code]]On-chain code::
+The part of a contract application's code which runs on the chain (i.e. as scripts).
+[[pending-tx]]Pending Tx::
+A data structure containing a summary of the transaction being validated.
+[[pab-client-api]]PAB client API::
+The API that the PAB provides to allow PAB clients to interact with contract application instances. Contract endpoints
+which are exposed by running instances can be called via the client API.
+[[pab-client]]PAB client::
+A program which interacts with a contract application instance via the PAB's client API. Examples of PAB
+clients include:
++
+. Wallet frontends such as Daedalus.
+. Other user software which uses the contract application as part of a wider system.
+[[pab]]Plutus Application Backend (PAB)::
+The component which manages contract applications run on users' machines. It handles:
++
+. Interactions with the node
+. Interactions with the wallet backend
+. Interactions with the wallet frontend
+. State management
+. Tracking historical chain information
+[[plutus-core]]Plutus Core::
+The programming language in which scripts on the Cardano blockchain are written. Plutus Core is a
+small functional programming language -- a formal specification is available with further details.
+Plutus Core is not read or written by humans, it is a compilation target for other languages.
+[[plutus-ir]]Plutus IR::
+An intermediate language that compiles to Plutus Core. Plutus IR is not used by users, but rather as a compilation
+target on the way to Plutus Core. However, it is significantly more human-readable than Plutus Core, so should be
+preferred in cases where humans may want to inspect the program.
+[[plutus-platform]]Plutus Platform::
+The combined software support for writing contract applications, including:
++
+. The Plutus Application Backedn
+. The Plutus SDK
+. The support for Plutus scripts on the Cardano chain
+[[plutus-sdk]]Plutus SDK::
+The libraries and development tooling for writing contract applications in Haskell.
+[[plutus-tx]]Plutus Tx::
+The libraries and compiler for compiling Haskell into Plutus Core to form the on-chain part of a contract application.
+[[redeemer]]Redeemer::
+The argument to the validator script which is provided by the transaction which spends a script output.
+[[script]]Script::
+A generic term for an executable program used in the ledger. In the Cardano blockchain, these are
+written in Plutus Core.
+[[script-output]]Script output::
+A UTXO locked by a script.
+[[token]]Token::
+A generic term for a native tradeable asset in the ledger.
+[[utxo]]UTXO::
+An "unspent transaction output". Transactions produce these, and they are consumed when
+they are spent by another transaction. Typically, some kind of evidence is required to be
+able to spend a UTXO, such as a signature from a public key, or (in the Extended UTXO Model)
+satisfying a script.
+[[validator]]Validator script::
+The script attached to a script output in the Extended UTXO model. Must be run and return positively in order for
+the output to be spent. Determines the address of the output.

--- a/README.adoc
+++ b/README.adoc
@@ -101,6 +101,10 @@ for using the Plutus Platform to write smart contracts.
 
 To build a full HTML version of the tutorial that you can view locally, build the `docs.plutus-tutorial` xref:building-with-nix[using Nix].
 
+=== How to learn about the terminology we use
+
+There is a comprehensive glossary in link:GLOSSARY{outfilesuffix}[GLOSSARY].
+
 === Where to find the changelog
 
 The changelog is stored in link:./CHANGELOG.md[CHANGELOG].


### PR DESCRIPTION
My goal with this is that it should be an authoritative source for the
words we use for things. So if we change something here we should also
rename it in the rest of the codebase.

With that in mind, we shouldn't merge this until we've resolved some of
the ongoing naming discussions.