### PR TITLE
added runGuardedStep

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/StateMachine.hs
@@ -33,7 +33,7 @@ import           Control.Lens
 import           Control.Monad.Error.Lens
 import           Data.Text                        (Text)
 import qualified Data.Text                        as Text
-import           Data.Void                        (absurd, Void)
+import           Data.Void                        (Void, absurd)
 
 import           Language.Plutus.Contract
 import qualified Language.PlutusTx                as PlutusTx

--- a/plutus-contract/src/Language/Plutus/Contract/StateMachine.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/StateMachine.hs
@@ -134,9 +134,9 @@ runGuardedStep ::
     , HasOwnPubKey schema
     , HasTxConfirmation schema
     )
-    => StateMachineClient state input
-    -> input
-    -> (UnbalancedTx -> state -> state -> Maybe a)
+    => StateMachineClient state input              -- ^ The state machine
+    -> input                                       -- ^ The input to apply to the state machine
+    -> (UnbalancedTx -> state -> state -> Maybe a) -- ^ The guard to check before running the step
     -> Contract schema e (Either a state)
 runGuardedStep smc input guard = do
     let StateMachineInstance{stateMachine} = scInstance smc


### PR DESCRIPTION
One of the things that are problematic in Ethereum is that when you submit a transaction, you can't know the state of the contract at the point in time when your transaction will be processed. In Plutus, on the other hand, you construct the full transaction before submitting it, so if something has changed in the meantime, your transaction will simply be rejected. That's very good!
However, I noticed that the state machine mechanism provided in the Plutus libraries partially gives away this advantage: Even though the wallet has the full information when it constructs the transaction for a transition step, it does not (easily) allow to not proceed (depending on the state it finds).
I suggest to provide an extended version of `Language.Plutus.Contract.StateMachine.runStep`,  `runGuardedStep`, that takes an additional predicate, which is checked before actually submitting the transaction.

The old `runStep` simply uses `runGuardedStep`  with the predicate that constantly returns `Nothing` and allows the transaction to be submitted.

(Of course such checks could be incorporated in the on-chain part of the state machine, `transition` or `check`, but that assumes that the author of the contract wants those checks to run. In reality, author and client of a given contract can be two parties with opposing interests, so I feel the client needs a way to incorporate checks the author did not include - be it due to an oversight or on purpose.)

I think this is a realistic scenario: There is some "legacy" contract (a state machine) already deployed to the blockchain, and I want to interact with it, but I'm not totally happy with it and want more control over when to actually submit my transaction. I can't change the validator, but I don't have to, provided I "drill into" my wallet code.