### PR TITLE
Update terminology in EUTXO paper

### DIFF
--- a/papers/eutxo/eutxo.bib
+++ b/papers/eutxo/eutxo.bib
@@ -3,8 +3,8 @@
                Simon J. Thompson},
   title     = {Marlowe: Financial Contracts on Blockchain},
   booktitle = {Leveraging Applications of Formal Methods, Verification and Validation.
-               Industrial Practice - 8th International Symposium, ISoLA 2018, Limassol,
-               Cyprus, November 5-9, 2018, Proceedings, Part {IV}},
+               Industrial Practice --- 8th International Symposium, ISoLA 2018, Limassol,
+               Cyprus, November 5--9, 2018, Proceedings, Part {IV}},
   pages     = {356--375},
   year      = {2018},
   crossref  = {DBLP:conf/isola/2018-4},
@@ -35,7 +35,7 @@
 @inproceedings{fsolidm,
   author    = {Anastasia Mavridou and
                Aron Laszka},
-  title     = {Designing Secure Ethereum Smart Contracts: {A} Finite State Machine
+  title     = {Designing Secure {Ethereum} Smart Contracts: {A} Finite State Machine
                Based Approach},
   booktitle = {Financial Cryptography and Data Security - 22nd International Conference,
                {FC} 2018, Nieuwpoort, Cura{\c{c}}ao, February 26 - March 2, 2018,
@@ -218,8 +218,8 @@ article{bitcoin-model,
 @proceedings{DBLP:conf/fc/2018,
   editor    = {Sarah Meiklejohn and
                Kazue Sako},
-  title     = {Financial Cryptography and Data Security - 22nd International Conference,
-               {FC} 2018, Nieuwpoort, Cura{\c{c}}ao, February 26 - March 2, 2018,
+  title     = {Financial Cryptography and Data Security --- 22nd International Conference,
+               {FC} 2018, Nieuwpoort, Cura{\c{c}}ao, February 26--March 2, 2018,
                Revised Selected Papers},
   series    = {Lecture Notes in Computer Science},
   volume    = {10957},
@@ -314,7 +314,7 @@ article{bitcoin-model,
 }
 
 @misc{DAO-attack,
-  title={The Story of the {DAO} -- Its History and Consequences},
+  title={The Story of the {DAO} --- Its History and Consequences},
   author={Falkon, Samuel},
   howpublished={\url{https://medium.com/swlh/the-story-of-the-dao-its-history-and-consequences-71e6a8a551ee}},
   date={24th December},

--- a/papers/eutxo/eutxo.tex
+++ b/papers/eutxo/eutxo.tex
@@ -79,8 +79,8 @@
 
 \newcommand{\script}{\ensuremath{\s{Script}}}
 \newcommand{\scriptAddr}{\msf{scriptAddr}}
-\newcommand{\ptx}{\ensuremath{\s{TxInfo}}}
-\newcommand{\toPtx}{\msf{toTxInfo}}
+\newcommand{\ctx}{\ensuremath{\s{Context}}}
+\newcommand{\toCtx}{\msf{toContext}}
 
 \newcommand{\toData}{\msf{toData}}
 \newcommand{\fromData}{\msf{fromData}}
@@ -100,10 +100,10 @@
 \newcommand{\val}{\mi{value}}  %% \value is already defined
 
 \newcommand{\validator}{\mi{validator}}
-\newcommand{\redeemerVal}{\mi{redeemer}}
-\newcommand{\dataVal}{\mi{data}}
-\newcommand{\dataHsh}{\mi{dataHash}}
-\newcommand{\dataWits}{\mi{dataWitnesses}}
+\newcommand{\redeemer}{\mi{redeemer}}
+\newcommand{\datum}{\mi{datum}}
+\newcommand{\datumHsh}{\mi{datumHash}}
+\newcommand{\datumWits}{\mi{datumWitnesses}}
 \newcommand{\hashData}{\msf{dataHash}}
 \newcommand{\validityInterval}{\mi{validityInterval}}
 \newcommand{\Data}{\ensuremath{\s{Data}}}
@@ -252,7 +252,7 @@
   keeping the semantic simplicity of the \UTXO{} model.
 
   In this paper, we answer this question affirmatively. We present
-  \emph{\ExUTXO{} (\EUTXO{})}, an extension to Bitcoin's \UTXO{} model
+  \emph{\ExUTXO{}} (\emph{\EUTXO{}}), an extension to Bitcoin's \UTXO{} model
   that supports a substantially more
   expressive form of \emph{validation scripts}, including scripts that
   implement general state machines and enforce invariants across

--- a/papers/eutxo/formal-model.tex
+++ b/papers/eutxo/formal-model.tex
@@ -5,7 +5,7 @@
 \label{sec:basic-notation}
 Figure~\ref{fig:basic-types} defines some basic types and
 notation used in the rest of the paper; we have generally followed the
-notation established by Zahnentferner~\cite{Zahnentferner18-UTxO}.
+notation established by Zahnentferner in~\cite{Zahnentferner18-UTxO}.
 
 \begin{ruledfigure}{!ht}
   \begin{displaymath}
@@ -31,9 +31,10 @@ notation established by Zahnentferner~\cite{Zahnentferner18-UTxO}.
 
 \subsubsection{The \Data{} type.}
 \label{sec:data}
-We will make particular use of a primitive type \Data{} which can be used to pass information
-into scripts. This is intended to be any relatively standard structured
-data format, for example JSON or CBOR~\cite{cbor}.
+We will make particular use of a primitive type \Data{} which can be
+used to pass information into scripts. This is intended to be any
+relatively standard structured data format, for example JSON or
+CBOR~\cite{cbor}.
 
 The specific choice of type does not matter for this paper, so we have left it
 abstract. The intention is that this should
@@ -46,20 +47,18 @@ language we have corresponding \toData{} and \fromData{} functions.
 
 \subsection{\EUTXO{}: Enhanced scripting}
 \label{sec:eutxo}
-The \EUTXO{} model adds a number of new features to the model
-proposed in Zahnentferner~\cite{Zahnentferner18-UTxO}.
-
-The first change is that as well as the validator we allow transaction
-outputs to carry a piece of data called the \emph{datum}, which is
-passed in as an additional argument during validation.  This allows a
-contract to carry some state (the datum) without changing its ``code''
-(the validator). We will use this to carry the state of our state
-machines (see Section~\ref{sec:informal-eutxo}).
+Our first change to the standard UTXO model is that as well as the
+validator we allow transaction outputs to carry a piece of data called
+the \emph{datum} (or \emph{datum object}), which is passed in as an
+additional argument during validation.  This allows a contract to
+carry some state (the datum) without changing its ``code'' (the
+validator). We will use this to carry the state of our state machines
+(see Section~\ref{sec:informal-eutxo}).
 
 The second change is that the validator receives some information
 about the transaction that is being validated. This information, which
-we call the \textit{validation context}, is passed in as an additional
-argument of type \ctx{}. The information supplied in the validation
+we call the \textit{context}, is passed in as an additional
+argument of type \ctx{}. The information supplied in the 
 context enables the validator to enforce much stronger conditions than
 is possible with a bare \UTXO{} model --- in particular, it can
 inspect the \emph{outputs} of the current transaction, which is

--- a/papers/eutxo/formal-model.tex
+++ b/papers/eutxo/formal-model.tex
@@ -49,20 +49,22 @@ language we have corresponding \toData{} and \fromData{} functions.
 The \EUTXO{} model adds a number of new features to the model
 proposed in Zahnentferner~\cite{Zahnentferner18-UTxO}.
 
-The first change is that we allow transaction outputs to carry a \emph{data value}
-along with the validator, which is passed in as an additional argument during
-validation.
-This allows a contract to carry some state (the data) without changing
-its ``code'' (the validator). We will use this to carry the state of our
-state machines (see Section~\ref{sec:informal-eutxo}).
+The first change is that as well as the validator we allow transaction
+outputs to carry a piece of data called the \emph{datum}, which is
+passed in as an additional argument during validation.  This allows a
+contract to carry some state (the datum) without changing its ``code''
+(the validator). We will use this to carry the state of our state
+machines (see Section~\ref{sec:informal-eutxo}).
 
-The second change is that the validator receives some information about the
-transaction that is being validated. This information is passed in as an
-additional argument of type \ptx{}. The additional information enables the
-validator to enforce much stronger conditions than is possible with a bare
-\UTXO{} model --- in particular, it can inspect the \emph{outputs}
-of the current transaction, which is essential for ensuring contract
-continuity (see Section~\ref{sec:informal-eutxo}).
+The second change is that the validator receives some information
+about the transaction that is being validated. This information, which
+we call the \textit{validation context}, is passed in as an additional
+argument of type \ctx{}. The information supplied in the validation
+context enables the validator to enforce much stronger conditions than
+is possible with a bare \UTXO{} model --- in particular, it can
+inspect the \emph{outputs} of the current transaction, which is
+essential for ensuring contract continuity (see
+Section~\ref{sec:informal-eutxo}).
 
 The third change is that we provide some access to time by adding a
 \emph{validity interval} to transactions.
@@ -71,8 +73,8 @@ during which a transaction can be processed (a generalisation of a ``time-to-liv
 Thus, any scripts which run during validation can assume that the current tick
 is within that interval, but do not know the precise value of the current tick.
 
-Finally, we represent all the arguments to the validator (redeemer, data value,
-\ptx) as values of type \Data{}. Clients are therefore responsible for encoding
+Finally, we represent all the arguments to the validator (redeemer, datum,
+\ctx) as values of type \Data{}. Clients are therefore responsible for encoding
 whatever types they would like to use into \Data{} (and decoding them inside the
 validator script).
 
@@ -109,21 +111,21 @@ the ledger (``ledger primitives'').
     \txId : \eutxotx \rightarrow \TxId && \mbox{a function computing the identifier of a transaction}\\
     \script && \mbox{the (opaque) type of scripts}\\
     \scriptAddr : \script \rightarrow \Address && \mbox{the address of a script}\\
-    \hashData : \Data \rightarrow \DataHash && \mbox{the hash of a data value}\\
+    \hashData : \Data \rightarrow \DataHash && \mbox{the hash of an object of type\Data}\\
     \llbracket \_ \rrbracket : \script \rightarrow \Data \times \Data \times
     \Data \rightarrow \B && \mbox{applying a script to its arguments}\\
     \\
     \multicolumn{3}{l}{\textsc{Defined types}}\\
     \s{Output } &=&(\val: \qty,\\
                 & &\ \addr: \Address,\\
-                & &\ \dataHsh: \DataHash)\\
+                & &\ \datumHsh: \DataHash)\\
     \\
     \s{OutputRef } &=&(\txrefid: \TxId, \idx: \N)\\
     \\
     \s{Input } &=&(\outputref: \s{OutputRef},\\
                & &\ \validator: \script,\\
-               & &\ \dataVal: \Data,\\
-               & &\ \redeemerVal: \Data)\\
+               & &\ \datum: \Data,\\
+               & &\ \redeemer: \Data)\\
      \\
      \eutxotx\s{ } &=&(\inputs: \Set{\s{Input}},\\
                    & &\ \outputs: \List{\s{Output}},\\
@@ -165,33 +167,34 @@ are conceptually symmetrical:
   just their address and value.
 \end{itemize}
 
-\paragraph{The location of validators and data values.} Validator scripts and data values are
-provided as parts of transaction \emph{inputs}, even though they are
-conceptually part of the output being spent. The output instead specifies them
-by providing the corresponding address or hash.\footnote{That these match up is
-  enforced by Rules~\ref{rule:validator-scripts-hash} and \ref{rule:data-values-hash} in
-Figure~\ref{fig:eutxo-validity}.}
+\paragraph{The location of validators and datum objects.} Validator scripts
+and full datum objects are provided as parts of transaction \emph{inputs},
+even though they are conceptually part of the output being spent. The
+output instead specifies them by providing the corresponding address
+or hash.\footnote{That these match up is enforced by
+  Rules~\ref{rule:validator-scripts-hash} and
+  \ref{rule:datums-hash} in Figure~\ref{fig:eutxo-validity}.}
 
 This strategy reduces memory requirements, since
 the \UTXO{} set must be kept in memory for rapid access while validating
 transactions. Hence it is desirable to keep outputs small --- in
 our system they are constant size.
 Providing the much larger validator script only at the point where it is needed
-is thus a helpful saving. The same considerations apply to data values.
+is thus a helpful saving. The same considerations apply to datum objects.
 
-An important question is how the person who spends an output \emph{knows} what
-validator and data value to provide in order to match the hashes on the output.
+An important question is how the person who spends an output \emph{knows} which
+validator and datum to provide in order to match the hashes on the output.
 This can always be accomplished via some off-chain mechanism, but we may
 want to include some on-chain way of accomplishing this.\footnote{\Cardano{} will provide
 a mechanism in this vein.} However, this is not directly relevant to this paper,
 so we have omitted it.
 
 \paragraph{Fees, forge, and additional metadata.}  Transactions will typically
-have additional metadata, such as transaction fees or a ``forge'' field that
-allows value to be created or destroyed. These are irrelevant to this paper,
-so have been omitted.\footnote{
-Adding such fields might require updating Rule~\ref{rule:value-is-preserved} to ensure values are preserved.
-}
+have additional metadata, such as transaction fees or a ``forge''
+field that allows value to be created or destroyed. These are
+irrelevant to this paper, so have been omitted.\footnote{ Adding such
+  fields might require amending Rule~\ref{rule:value-is-preserved}
+  below to ensure value preservation.  }
 
 \paragraph{Ledger structure.} We model a ledger as a simple
 list of transactions: a real blockchain ledger will be more complex
@@ -199,74 +202,73 @@ than this, but the only property that we really require is that
 transactions in the ledger have some kind of address which allows them
 to be uniquely identified and retrieved.
 
-\subsection{The \ptx{} type}
-\label{sec:pendingtx}
+\subsection{The \ctx{} type}
+\label{sec:validation-context}
 Recall from the introduction to Section~\ref{sec:eutxo} that when a
 transaction input is being validated, the validator script is supplied
-with an object of type \ptx{} (encoded as \Data{}) which contains information about the
-pending transaction.  The \ptx{} type is defined in
-Figure~\ref{fig:ptx-1-types}, along with some related types.
+with an object of type \ctx{} (encoded as \Data{}) which contains
+information about the current transaction.  The \ctx{} type is defined
+in Figure~\ref{fig:ptx-1-types}, along with some related types.
 
 \begin{ruledfigure}{!ht}
   \begin{displaymath}
   \begin{array}{rll}
     \s{OutputInfo } &=&(\val: \qty,\\
                     & &\ \i{validatorHash}: \Address,\\
-                    & &\ \dataHsh: \DataHash)\\
+                    & &\ \datumHsh: \DataHash)\\
     \\
     \s{InputInfo } &=&(\outputref: \s{OutputRef},\\
                    & &\ \i{validatorHash}: \Address,\\
-                   & &\ \i{dataVal}: \Data,\\
+                   & &\ \i{datum}: \Data,\\
                    & &\ \i{redeemer}: \Data,\\
                    & &\ \val: \qty)\\
      \\
-     \ptx\s{ } &=&(\i{inputInfo}: \Set{\s{InputInfo}},\\
+     \ctx\s{ } &=&(\i{inputInfo}: \Set{\s{InputInfo}},\\
                & &\ \i{outputInfo}: \List{\s{OutputInfo}},\\
                & &\ \i{validityInterval}: \Interval{\tick},\\
                & &\ \i{thisInput}: \N)\\
      \\
   \end{array}
   \end{displaymath}
-  \caption{The \ptx{} type for the \EUTXO{} model}
+  \caption{The \ctx{} type for the \EUTXO{} model}
   \label{fig:ptx-1-types}
 \end{ruledfigure}
 
-\paragraph{The contents of \ptx{}.}
-The \ptx{} type is a summary of the information contained in the $\eutxotx$ type in
+\paragraph{The contents of \ctx{}.}
+The \ctx{} type is a summary of the information contained in the $\eutxotx$ type in
 Figure~\ref{fig:eutxo-types}, situated in the context of a validating
 transaction, and made suitable for consumption in a script. That results in the following changes:
 \begin{enumerate}
 \item The \s{InputInfo} type is augmented with information that comes
   from the output being spent, specifically the value attached to that output.
-\item The \ptx{} type includes an index that indicates the input currently
+\item The \ctx{} type includes an index that indicates the input currently
   being validated. This allows scripts to identify their own address, for example.
 \item Validators are included as their addresses, rather than as scripts. This
   allows easy equality comparisons without requiring script languages to be able
   to represent their own programs.
 \end{enumerate}
-\noindent We assume that there is a function $\toPtx: \eutxotx \times
-  \s{Input} \times \s{Ledger} \rightarrow \ptx$ which summarises a
+\noindent We assume that there is a function $\toCtx: \eutxotx \times
+  \s{Input} \times \s{Ledger} \rightarrow \ctx$ which summarises a
 transaction in the context of an input and a ledger state.
 %% kwxm: moved this out of the figure because adding the Ledger
 %% parameter pushed everything too far to the right.
 
 \paragraph{Determinism.}
-The information provided by \ptx{}
-is entirely determined by the transaction itself. This means that
-script execution during validation is entirely deterministic, and can be
-simulated accurately by the user \emph{before} submitting a transaction.
-
-Hence both the outcome of script execution and the amount of resources
-consumed can be determined ahead of time. This is helpful
-for systems that charge for script execution, since users can reliably compute
-how much they will need to pay ahead of time.
+The information provided by \ctx{} is entirely determined by the
+transaction itself. This means that script execution during validation
+is entirely deterministic, and can be simulated accurately by the user
+\emph{before} submitting a transaction: thus both the outcome of
+script execution and the amount of resources consumed can be
+determined ahead of time. This is helpful for systems that charge for
+script execution, since users can reliably compute how much they will
+need to pay ahead of time.
 
 A common way for systems to violate this property is by providing
-access to some piece of mutable information, like a the current time
+access to some piece of mutable information, such as the current time
 (in our system, the current tick has this role). Scripts can then
 branch on this information, leading to non-deterministic behaviour. We
 sidestep this issue with the validation interval mechanism (see the
-introduction in Section~\ref{sec:eutxo}).
+introduction to Section~\ref{sec:eutxo}).
 
 \begin{ruledfigure}{!ht}
   \begin{displaymath}
@@ -351,7 +353,7 @@ $l^{\prime}$ valid and $t$ valid for $l^{\prime}$.
   \textbf{All inputs validate}
   \begin{displaymath}
     \textrm{For all } i \in t.\inputs,\ \llbracket
-    i.\validator\rrbracket (i.\dataVal,\, i.\redeemerVal,\,  \toData(\toPtx(t,i,l))) = \true.
+    i.\validator\rrbracket (i.\datum,\, i.\redeemer,\,  \toData(\toCtx(t,i,l))) = \true.
   \end{displaymath}
 
 \item
@@ -362,10 +364,10 @@ $l^{\prime}$ valid and $t$ valid for $l^{\prime}$.
   \end{displaymath}
 
 \item
-  \label{rule:data-values-hash}
-  \textbf{Data values match output hashes}
+  \label{rule:datums-hash}
+  \textbf{Each datum matches its output hash}
   \begin{displaymath}
-    \textrm{For all } i \in t.\inputs,\ \hashData(i.\dataVal) = \getSpent(i, l).\dataHsh
+    \textrm{For all } i \in t.\inputs,\ \hashData(i.\datum) = \getSpent(i, l).\datumHsh
   \end{displaymath}
 
 \end{enumerate}

--- a/papers/eutxo/formal-verification.tex
+++ b/papers/eutxo/formal-verification.tex
@@ -42,7 +42,7 @@ the typical textbook description of Mealy Machines in the following aspects:
   be able to enforce it on the blockchain level. Therefore, each
   contract should first establish some initial trust to bootstrap the
   process.
-  One possible avenue for overcoming this limitation is to built a notion of \textit{trace simulation}
+  One possible avenue for overcoming this limitation is to build a notion of \textit{trace simulation}
   on top of the current relation between single states,
   thus guaranteeing that only valid sequences starting from initial states appear on the ledger.
   For instance, this could be used to establish inductive properties of a state machine and
@@ -68,7 +68,7 @@ the typical textbook description of Mealy Machines in the following aspects:
 
 We want to compile a smart contract $\mathcal{C}$ defined as a \CEM{} into
 a smart contract that runs on the chain. The idea is to derive a
-validator script from the step function, using the data value to hold the
+validator script from the step function, using the datum to hold the
 state of the machine, and the redeemer to provide the transition signal.
 A valid transition in a \CEM{}
 will correspond to a single valid transaction on the chain. The
@@ -112,7 +112,7 @@ We refer to these two properties as soundness and completeness below.
 While state machines correspond to automata, the automata theoretic
 notion of equivalence --- trace equivalence --- is too coarse when we
 consider state machines as running processes. Instead we use
-bisimulation which was developed in concurrency theory for exactly
+bisimulation, which was developed in concurrency theory for exactly
 this purpose, to capture when processes behave the
 same~\cite{sangiorgi}. We consider both the state machine and the
 ledger itself to be running processes.
@@ -172,7 +172,7 @@ We also require that the omitted constraints are satisfiable in the
 current ledger and the target state is not a final one, since there
 would be no corresponding output in the ledger to witness
 $\Sim{l'}{s'}$.  We could instead augment the definition of
-correspondence to account for final states, but we refrained from
+correspondence to account for final states, but we have refrained from
 doing so for the sake of simplicity.
 
 \begin{proposition}[Completeness]

--- a/papers/eutxo/informal-eutxo.tex
+++ b/papers/eutxo/informal-eutxo.tex
@@ -9,9 +9,28 @@ Given that we can regard the individual transactions in a continuous chain of tr
 \item we need to be able to enforce that the same contract code is used along the entire sequence of transactions --- we call this \emph{contract continuity}.
 \end{inparaenum}
 
-To maintain the machine state, we extend \UTXO{} outputs from being a pair of a validator $\nu$ and a cryptocurrency value $\val$ to being a triple \((\nu, \val, \delta)\) of validator, value, and data value $\delta$, where $\delta$ contains arbitrary contract-specific data. Furthermore, to enable validators to enforce contract continuity, we pass the entirety of the transaction that attempts to spend the output locked by a validator to the validator invocation. Thus, a validator can inspect the transaction that attempts to spend its output and, in particular, ensure that the contract output of that transaction uses validator code belonging to the same contract --- often, this will be the same validator. Overall, to check that an input with redeemer $\rho$ that is part of the transaction $\mi{tx}$ is entitled to spend an output \((\nu, \val, \delta)\), we check that \(\nu(\val, \delta, \rho, \mi{tx}) = \true\).
+To maintain the machine state, we extend \UTXO{} outputs from being a
+pair of a validator $\nu$ and a cryptocurrency value $\val$ to being a
+triple \((\nu, \val, \delta)\) of validator, value, and a
+\textit{datum} $\delta$, where $\delta$ contains arbitrary
+contract-specific data. Furthermore, to enable validators to enforce
+contract continuity, we pass the entirety of the transaction that
+attempts to spend the output locked by a validator to the validator
+invocation. Thus a validator can inspect the transaction that
+attempts to spend its output and, in particular, it can ensure that the
+contract output of that transaction uses validator code belonging to
+the same contract --- often, this will be the same validator. Overall,
+to check that an input with redeemer $\rho$ that is part of the
+transaction $\mi{tx}$ is entitled to spend an output \((\nu, \val,
+\delta)\), we check that \(\nu(\val, \delta, \rho, \mi{tx}) = \true\).
 
-As we are allowing arbitrary data in $\delta$ and enable the validator $\nu$ to impose arbitrary validity constraints on the consuming transaction $\mi{tx}$, the resulting \ExUTXO{} (\EUTXO{}) model goes beyond enabling state machines. However, in this paper, we restrict ourselves to the implementation of state machines and leave the investigation of further-reaching computational patterns to future work.
+As we are allowing arbitrary data in $\delta$ and we enable the validator
+$\nu$ to impose arbitrary validity constraints on the consuming
+transaction $\mi{tx}$, the resulting \ExUTXO{} (\EUTXO{}) model goes
+beyond enabling state machines. However, in this paper we restrict
+ourselves to the implementation of state machines and leave the
+investigation of further-reaching computational patterns to future
+work.
 
 \begin{figure}[t]
   \centering 
@@ -20,9 +39,28 @@ As we are allowing arbitrary data in $\delta$ and enable the validator $\nu$ to 
   \label{fig:multisig-machine}
 \end{figure}
 %
-As a simple example of a state machine contract consider an $n$ out of $m$ multi-signature contract. Specifically, we have a given amount $\val_\msc$ of some cryptocurrency and we require the approval of at least $n$ out of an a priori fixed set of $m >= n$ owners to spend $\val_\msc$. With plain \UTXO{} (e.g., on Bitcoin), a multi-signature scheme requires out-of-band (off-chain) communication to collect all $n$ signatures to spend $\val_\msc$. On Ethereum, and also in the \EUTXO{} model, we can collect the signatures on-chain, without any out-of-band communication. To do so, we use a state machine operating according to the transition diagram in Figure~\ref{fig:multisig-machine}, where we assume that the threshold $n$ and authorised signatures $\sigs_\auth$ with \(|\sigs_\auth| = m\) are baked into the contract code.
+As a simple example of a state machine contract consider an $n$--of--$m$
+multi-signature contract. Specifically, we have a given amount
+$\val_\msc$ of some cryptocurrency and we require the approval of at
+least $n$ out of an a priori fixed set of $m \geq n$ owners to spend
+$\val_\msc$. With plain \UTXO{} (e.g., on Bitcoin), a multi-signature
+scheme requires out-of-band (off-chain) communication to collect all
+$n$ signatures to spend $\val_\msc$. On Ethereum, and also in the
+\EUTXO{} model, we can collect the signatures on-chain, without any
+out-of-band communication. To do so, we use a state machine operating
+according to the transition diagram in
+Figure~\ref{fig:multisig-machine}, where we assume that the threshold
+$n$ and authorised signatures $\sigs_\auth$ with \(|\sigs_\auth| = m\)
+are baked into the contract code.
 
-In its implementation in the \EUTXO{} model, we use a validator function $\nu_\msc$ accompanied by the data value $\rho_\msc$ to lock $\val_\msc$. The data value $\rho_\msc$ stores the machine state, which is of the form \(\Holding\) when only holding the locked value or \(\Collecting{(\val, \kappa, d)}{\sigs}\) when collecting signatures $\sigs$ for a payment of $\val$ to $\kappa$ by the deadline $d$. The initial output for the contract is \((\nu_\msc, \val_\msc, \Holding)\).
+In its implementation in the \EUTXO{} model, we use a validator
+function $\nu_\msc$ accompanied by the datum $\delta_\msc$ to lock
+$\val_\msc$. The datum $\delta_\msc$ stores the machine state,
+which is of the form \(\Holding\) when only holding the locked value
+or \(\Collecting{(\val, \kappa, d)}{\sigs}\) when collecting
+signatures $\sigs$ for a payment of $\val$ to $\kappa$ by the deadline
+$d$. The initial output for the contract is \((\nu_\msc, \val_\msc,
+\Holding)\).
 
 The validator $\nu_\msc$ implements the state transition diagram from
 Figure~\ref{fig:multisig-machine} by using the redeemer of the spending input to determine the transition that needs to be taken. That redeemer (state machine input) can take four forms: 
@@ -33,6 +71,14 @@ Figure~\ref{fig:multisig-machine} by using the redeemer of the spending input to
 \item $\Cancel$ to cancel a proposal after its deadline expired, and 
 \item $\Pay$ to make a payment once all required signatures have been collected. 
 \end{inparaenum}
-It then validates that the spending transaction $\mi{tx}$ is a valid representation of the newly reached machine state. This implies that $\mi{tx}$ needs to keep $\val_\msc$ locked by $\nu_\msc$ and that the state in the data value $\rho'_\msc$ needs to be the successor state of $\rho_\msc$ according to the transition diagram.
+It then validates that the spending transaction $\mi{tx}$ is a valid
+representation of the newly reached machine state. This implies that
+$\mi{tx}$ needs to keep $\val_\msc$ locked by $\nu_\msc$ and that the
+state in the datum $\delta^{\prime}_\msc$ needs to be the successor state
+of $\delta_\msc$ according to the transition diagram.
 
-The increased expressiveness of the \EUTXO{} model goes far beyond simple contracts such as this on-chain multi-signature contract. For example, the complete functionality of the Marlowe domain-specific language for financial contracts~\cite{marlowe} has been successfully implemented as a state machine on the \EUTXO{} model.
+The increased expressiveness of the \EUTXO{} model goes far beyond
+simple contracts such as this on-chain multi-signature contract. For
+example, the complete functionality of the Marlowe domain-specific
+language for financial contracts~\cite{marlowe} has been successfully
+implemented as a state machine on the \EUTXO{} model.

--- a/papers/eutxo/intro.tex
+++ b/papers/eutxo/intro.tex
@@ -5,7 +5,7 @@ a graph-based ledger model built on the concept of \emph{\UTXO{}s} (\emph{unspen
   transaction outputs})~\cite{formal-model-of-bitcoin-transactions,Zahnentferner18-UTxO}. Individual \emph{transactions} consist of a list of \emph{inputs} and a list of \emph{outputs}, where outputs represent a specific \emph{value} (of a cryptocurrency) that is available to be spent by inputs of subsequent transactions. Each output can be spent by (i.e., connect to) exactly one input. Moreover, we don't admit cycles in these connections, and hence we can regard a collection of transactions spending from each other as a directed acyclic graph, where a transaction with $m$ inputs and $n$ outputs is represented by a node in the graph with $m$ edges in and $n$ edges out.
 The sum of the values consumed by a transaction's inputs must equal the sum of the values provided by its outputs, thus value is conserved.
 
-Whether an output can be consumed by an input is determined by a function $\nu$ attached to the output, which we call the output's \emph{validator}. A transaction input proves its eligibility to spent an output by providing a \emph{redeemer} value $\rho$, such that \(\nu(\rho) = \true\) --- redeemers are often called \emph{witnesses} in Bitcoin. In the simplest case, the redeemer is a cryptographic hash of the spending transaction signed by an authorised spender's private key, which is checked by the validator, which embeds the corresponding public key. More sophisticated protocols are possible by using more complex validator functions and redeemers --- see \cite{bitml} for a high-level model of what is possible with the functionality provided by Bitcoin.
+Whether an output can be consumed by an input is determined by a function $\nu$ attached to the output, which we call the output's \emph{validator}. A transaction input proves its eligibility to spent an output by providing a \emph{redeemer} object $\rho$, such that \(\nu(\rho) = \true\); redeemers are often called \emph{witnesses} in Bitcoin. In the simplest case, the redeemer is a cryptographic hash of the spending transaction signed by an authorised spender's private key, which is checked by the validator, which embeds the corresponding public key. More sophisticated protocols are possible by using more complex validator functions and redeemers --- see \cite{bitml} for a high-level model of what is possible with the functionality provided by Bitcoin.
 
 The benefit of this graph-based approach to a cryptocurrency ledger is that it plays well with the concurrent and distributed nature of blockchains. In particular, it forgoes any notion of shared mutable state, which is known to lead to highly complex semantics in the face of concurrent and distributed computations involving that shared mutable state.
 
@@ -23,14 +23,14 @@ More specifically, we make the following contributions:
 \begin{itemize}
 \item We propose the \emph{\EUTXO{} model}, informally in Section~\ref{sec:informal-eutxo} and formally in Section~\ref{sec:formal-model}.
 \item We demonstrate that the \EUTXO{} model supports the implementation of a specific form of state machines (\emph{Constraint Emitting Machines}, or \CEM{}s), which the basic \UTXO{} model does not support, in Section~\ref{sec:expressiveness}.
-\item We provide a formalisation of both the \EUTXO{} model
+\item We provide formalisations of both the \EUTXO{} model
   and Constraint Emitting Machines. We prove a weak bisimulation
   between the two using the Agda proof
   assistant\site{https://github.com/\GitUser/formal-utxo/tree/\AgdaCommit}, building on
   previous work by Melkonian et al.~\cite{formal-eutxo}.
 \end{itemize}
 
-Section~\ref{sec:related} summarises related work.
+\noindent Section~\ref{sec:related} summarises related work.
 
 The \EUTXO{} model will be used in the ledger of \Cardano{}, a major blockchain
 system currently being developed by IOHK.

--- a/papers/eutxo/related-work.tex
+++ b/papers/eutxo/related-work.tex
@@ -1,11 +1,12 @@
 \section{Related work}
 \label{sec:related}
 
-Bitcoin Covenants~\cite{moser2016bitcoin} allow Bitcoin transactions to
-restrict how the transferred value can be used in the future, including propagating
-themselves to ongoing outputs. This provides contract continuity and allows the
-implementation of simple state machines. Our work is inspired by Covenants, although
-our addition of a data value is novel and simplifies the state passing.
+Bitcoin Covenants~\cite{moser2016bitcoin} allow Bitcoin transactions
+to restrict how the transferred value can be used in the future,
+including propagating themselves to ongoing outputs. This provides
+contract continuity and allows the implementation of simple state
+machines. Our work is inspired by Covenants, although our addition of
+a datum is novel and simplifies the state passing.
 
 The Bitcoin Modelling Language (BitML)~\cite{bitml} is an idealistic process calculus
 that specifically targets smart contracts running on Bitcoin.
@@ -19,7 +20,7 @@ authors~\cite{formal-model-of-bitcoin-transactions};
 one of our main contributions is an extended version of such an abstract model,
 which also accounts for the added functionality apparent in \Cardano{}.
 
-Ethereum and its smart contract language, Solidity~\cite{Solidity} are powerful
+Ethereum and its smart contract language, Solidity~\cite{Solidity}, are powerful
 enough to implement state machines, due to their native support for
 global contract instances and state. However, this approach has some major downsides,
 notably that contract state is global, and must be kept indefinitely by all core nodes.


### PR DESCRIPTION
This updates the EUTXO paper to use "datum" instead of "data value" and "Context" instead of "TxInfo" (previously "PendingTx"), as decided in the Plutus call of 25th February 2020.  


Please don't merge this just yet: let's make sure that everyone approves first.