### PR TITLE
scb: Add a chain index & node follower protocol

### DIFF
--- a/plutus-playground-client/src/Chain.purs
+++ b/plutus-playground-client/src/Chain.purs
@@ -79,7 +79,7 @@ evaluationPane state evaluationResult@(EvaluationResult { emulatorLog, emulatorT
 emulatorEventPane :: forall i p. EmulatorEvent -> HTML p i
 emulatorEventPane (ChainIndexEvent _ ReceiveBlockNotification) =
   div_
-    [ text "Chain index receive block notification"]
+    [ text "Chain index receive block notification" ]
 
 emulatorEventPane (ChainIndexEvent _ (AddressStartWatching address)) =
   div_

--- a/plutus-playground-client/src/Chain.purs
+++ b/plutus-playground-client/src/Chain.purs
@@ -77,6 +77,10 @@ evaluationPane state evaluationResult@(EvaluationResult { emulatorLog, emulatorT
     ]
 
 emulatorEventPane :: forall i p. EmulatorEvent -> HTML p i
+emulatorEventPane (ChainIndexEvent _ ReceiveBlockNotification) =
+  div_
+    [ text "Chain index receive block notification"]
+
 emulatorEventPane (ChainIndexEvent _ (AddressStartWatching address)) =
   div_
     [ text $ "Submitting transaction: " <> show address ]

--- a/plutus-scb/plutus-scb.cabal
+++ b/plutus-scb/plutus-scb.cabal
@@ -50,6 +50,7 @@ library
         Cardano.ChainIndex.Types
         Cardano.Node.API
         Cardano.Node.Client
+        Cardano.Node.Follower
         Cardano.Node.Mock
         Cardano.Node.RandomTx
         Cardano.Node.Server

--- a/plutus-scb/plutus-scb.cabal
+++ b/plutus-scb/plutus-scb.cabal
@@ -45,6 +45,9 @@ common lang
 library
     import: lang
     exposed-modules:
+        Cardano.ChainIndex.API
+        Cardano.ChainIndex.Server
+        Cardano.ChainIndex.Types
         Cardano.Node.API
         Cardano.Node.Client
         Cardano.Node.Mock

--- a/plutus-scb/plutus-scb.yaml.sample
+++ b/plutus-scb/plutus-scb.yaml.sample
@@ -12,3 +12,6 @@ nodeServerConfig:
   mscBlockReaper:
     brcInterval: 600
     brcBlocksToKeep: 100
+
+chainIndexConfig:
+  ciBaseUrl: http://localhost:8083

--- a/plutus-scb/src/Cardano/ChainIndex/API.hs
+++ b/plutus-scb/src/Cardano/ChainIndex/API.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.ChainIndex.API where
+
+import           Ledger            (Address)
+import           Ledger.AddressMap (AddressMap)
+import           Servant.API       ((:<|>), (:>), Get, JSON, NoContent, Post, ReqBody)
+
+type API
+     = "healthcheck" :> Get '[ JSON] NoContent
+     :<|> "start-watching" :> ReqBody '[ JSON] Address :> Post '[ JSON] NoContent
+     :<|> "watched-addresses" :> Get '[ JSON] AddressMap

--- a/plutus-scb/src/Cardano/ChainIndex/Server.hs
+++ b/plutus-scb/src/Cardano/ChainIndex/Server.hs
@@ -19,14 +19,15 @@ import qualified Control.Monad.Freer.State     as Eff
 import           Control.Monad.Freer.Writer
 import qualified Control.Monad.Freer.Writer    as Eff
 import           Control.Monad.IO.Class        (MonadIO (..))
-import           Control.Monad.Logger          (MonadLogger, logInfoN)
+import           Control.Monad.Logger          (MonadLogger, logDebugN, logInfoN, runStdoutLoggingT)
+import           Data.Foldable                 (traverse_)
 import           Data.Proxy                    (Proxy (Proxy))
 import qualified Data.Sequence                 as Seq
 import           Data.Time.Units               (Second, toMicroseconds)
 import           Network.HTTP.Client           (defaultManagerSettings, newManager)
 import           Network.Wai.Handler.Warp      (run)
 import           Servant                       ((:<|>) ((:<|>)), Application, NoContent (NoContent), hoistServer, serve)
-import           Servant.Client                (BaseUrl (baseUrlPort), ClientEnv, mkClientEnv)
+import           Servant.Client                (BaseUrl (baseUrlPort), ClientEnv, mkClientEnv, runClientM)
 
 import           Ledger.Address                (Address)
 import           Ledger.AddressMap             (AddressMap)
@@ -34,8 +35,10 @@ import           Plutus.SCB.Utils              (tshow)
 
 import           Cardano.ChainIndex.API
 import           Cardano.ChainIndex.Types
+import qualified Cardano.Node.Client           as NodeClient
 import           Wallet.Emulator.ChainIndex    (ChainIndexEffect, ChainIndexEvent, ChainIndexState)
 import qualified Wallet.Emulator.ChainIndex    as ChainIndex
+import           Wallet.Emulator.NodeClient    (Notification (..))
 
 -- $chainIndex
 -- The SCB chain index that keeps track of transaction data (UTXO set enriched
@@ -59,7 +62,7 @@ main ChainIndexConfig{ciBaseUrl} nodeBaseUrl = do
             pure $ mkClientEnv nodeManager nodeBaseUrl
     mVarState <- liftIO $ newMVar initialAppState
     logInfoN "Starting node client thread"
-    void $ liftIO $ forkIO $ updateThread 10 mVarState nodeClientEnv
+    void $ liftIO $ forkIO $ runStdoutLoggingT $ updateThread 10 mVarState nodeClientEnv
     liftIO $ run port $ app mVarState
 
 healthcheck :: Monad m => m NoContent
@@ -73,7 +76,7 @@ watchedAddresses = ChainIndex.watchedAddresses
 
 -- | Get the latest transactions from the node and update the index accordingly
 updateThread ::
-    MonadIO m
+    (MonadIO m, MonadLogger m)
     => Second
     -- ^ Interval between two queries for new blocks
     -> MVar AppState
@@ -81,9 +84,17 @@ updateThread ::
     -> ClientEnv
     -- ^ Servant client for the node API
     -> m ()
-updateThread updateInterval mv _ =
+updateThread updateInterval mv nodeClientEnv = do
+    logInfoN "Obtaining follower ID"
+    followerID <- liftIO $ runClientM NodeClient.newFollower nodeClientEnv >>= either (error . show) pure
+    logInfoN $ "Follower ID: " <> tshow followerID
     forever $ do
-        void $ processIndexEffects mv (pure ())
+        logInfoN "Asking the node for new blocks"
+        newBlocks <- liftIO $ runClientM (NodeClient.getBlocks followerID) nodeClientEnv >>= either (error . show) pure
+        logInfoN $ "Received " <> tshow (length newBlocks) <> " blocks"
+        logDebugN $ tshow newBlocks
+        let notifications = BlockValidated <$> newBlocks
+        traverse_ (processIndexEffects mv . ChainIndex.chainIndexNotify) notifications
         liftIO $ threadDelay $ fromIntegral $ toMicroseconds updateInterval
 
 type ChainIndexEffects m

--- a/plutus-scb/src/Cardano/ChainIndex/Server.hs
+++ b/plutus-scb/src/Cardano/ChainIndex/Server.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE MonoLocalBinds    #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+module Cardano.ChainIndex.Server(
+    -- $chainIndex
+    main
+    , ChainIndexConfig(..)
+    ) where
+import           Control.Concurrent            (forkIO, threadDelay)
+import           Control.Concurrent.MVar       (MVar, newMVar, putMVar, takeMVar)
+import           Control.Monad                 (forever, void)
+import           Control.Monad.Freer           hiding (run)
+import           Control.Monad.Freer.Extra.Log
+import           Control.Monad.Freer.State
+import qualified Control.Monad.Freer.State     as Eff
+import           Control.Monad.Freer.Writer
+import qualified Control.Monad.Freer.Writer    as Eff
+import           Control.Monad.IO.Class        (MonadIO (..))
+import           Control.Monad.Logger          (MonadLogger, logInfoN)
+import           Data.Proxy                    (Proxy (Proxy))
+import qualified Data.Sequence                 as Seq
+import           Data.Time.Units               (Second, toMicroseconds)
+import           Network.HTTP.Client           (defaultManagerSettings, newManager)
+import           Network.Wai.Handler.Warp      (run)
+import           Servant                       ((:<|>) ((:<|>)), Application, NoContent (NoContent), hoistServer, serve)
+import           Servant.Client                (BaseUrl (baseUrlPort), ClientEnv, mkClientEnv)
+
+import           Ledger.Address                (Address)
+import           Ledger.AddressMap             (AddressMap)
+import           Plutus.SCB.Utils              (tshow)
+
+import           Cardano.ChainIndex.API
+import           Cardano.ChainIndex.Types
+import           Wallet.Emulator.ChainIndex    (ChainIndexEffect, ChainIndexEvent, ChainIndexState)
+import qualified Wallet.Emulator.ChainIndex    as ChainIndex
+
+-- $chainIndex
+-- The SCB chain index that keeps track of transaction data (UTXO set enriched
+-- with data values)
+
+app :: MVar AppState -> Application
+app stateVar =
+    serve (Proxy @API) $
+    hoistServer
+        (Proxy @API)
+        (processIndexEffects stateVar)
+        (healthcheck :<|> startWatching :<|> watchedAddresses)
+
+main :: (MonadIO m, MonadLogger m) => ChainIndexConfig -> BaseUrl -> m ()
+main ChainIndexConfig{ciBaseUrl} nodeBaseUrl = do
+    let port = baseUrlPort ciBaseUrl
+    logInfoN $ "Starting chain index on port: " <> tshow port
+    nodeClientEnv <-
+        liftIO $ do
+            nodeManager <- newManager defaultManagerSettings
+            pure $ mkClientEnv nodeManager nodeBaseUrl
+    mVarState <- liftIO $ newMVar initialAppState
+    logInfoN "Starting node client thread"
+    void $ liftIO $ forkIO $ updateThread 10 mVarState nodeClientEnv
+    liftIO $ run port $ app mVarState
+
+healthcheck :: Monad m => m NoContent
+healthcheck = pure NoContent
+
+startWatching :: (Member ChainIndexEffect effs) => Address -> Eff effs NoContent
+startWatching addr = ChainIndex.startWatching addr >> pure NoContent
+
+watchedAddresses :: (Member ChainIndexEffect effs) => Eff effs AddressMap
+watchedAddresses = ChainIndex.watchedAddresses
+
+-- | Get the latest transactions from the node and update the index accordingly
+updateThread ::
+    MonadIO m
+    => Second
+    -- ^ Interval between two queries for new blocks
+    -> MVar AppState
+    -- ^ State of the chain index
+    -> ClientEnv
+    -- ^ Servant client for the node API
+    -> m ()
+updateThread updateInterval mv _ =
+    forever $ do
+        void $ processIndexEffects mv (pure ())
+        liftIO $ threadDelay $ fromIntegral $ toMicroseconds updateInterval
+
+type ChainIndexEffects m
+     = '[ ChainIndexEffect, State ChainIndexState, Writer [ChainIndexEvent], Log, m]
+
+processIndexEffects ::
+    MonadIO m
+    => MVar AppState
+    -> Eff (ChainIndexEffects IO) a
+    -> m a
+processIndexEffects stateVar eff = do
+    AppState{_indexState, _indexEvents} <- liftIO $ takeMVar stateVar
+    ((result, newState), events) <- liftIO
+                            $ runM
+                            $ runStderrLog
+                            $ Eff.runWriter
+                            $ Eff.runState _indexState
+                            $ ChainIndex.handleChainIndex eff
+    liftIO $ putMVar stateVar AppState{_indexState=newState, _indexEvents=_indexEvents <> Seq.fromList events }
+    pure result

--- a/plutus-scb/src/Cardano/ChainIndex/Types.hs
+++ b/plutus-scb/src/Cardano/ChainIndex/Types.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveAnyClass  #-}
+{-# LANGUAGE DeriveGeneric   #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Cardano.ChainIndex.Types where
+
+import           Control.Lens               (makeLenses)
+import           Data.Sequence              (Seq)
+import           Servant.Client             (BaseUrl)
+
+import           Wallet.Emulator.ChainIndex (ChainIndexEvent, ChainIndexState)
+
+data AppState =
+    AppState
+        { _indexState  :: ChainIndexState
+        , _indexEvents :: Seq ChainIndexEvent
+        }
+
+initialAppState :: AppState
+initialAppState = AppState mempty mempty
+
+newtype ChainIndexConfig =
+    ChainIndexConfig
+        { ciBaseUrl :: BaseUrl
+        }
+
+makeLenses ''AppState
+makeLenses ''ChainIndexConfig

--- a/plutus-scb/src/Cardano/ChainIndex/Types.hs
+++ b/plutus-scb/src/Cardano/ChainIndex/Types.hs
@@ -1,11 +1,14 @@
-{-# LANGUAGE DeriveAnyClass  #-}
-{-# LANGUAGE DeriveGeneric   #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TemplateHaskell    #-}
 
 module Cardano.ChainIndex.Types where
 
 import           Control.Lens               (makeLenses)
+import           Data.Aeson                 (FromJSON, ToJSON)
 import           Data.Sequence              (Seq)
+import           GHC.Generics               (Generic)
 import           Servant.Client             (BaseUrl)
 
 import           Wallet.Emulator.ChainIndex (ChainIndexEvent, ChainIndexState)
@@ -23,6 +26,8 @@ newtype ChainIndexConfig =
     ChainIndexConfig
         { ciBaseUrl :: BaseUrl
         }
+    deriving stock (Show, Eq, Generic)
+    deriving anyclass (FromJSON, ToJSON)
 
 makeLenses ''AppState
 makeLenses ''ChainIndexConfig

--- a/plutus-scb/src/Cardano/Node/API.hs
+++ b/plutus-scb/src/Cardano/Node/API.hs
@@ -7,8 +7,9 @@ module Cardano.Node.API
 
 import           Data.Map              (Map)
 
-import           Ledger                (Address, Blockchain, Slot, Tx, TxOut, TxOutRef)
-import           Servant.API           ((:<|>), (:>), Get, JSON, NoContent, Post, ReqBody)
+import           Cardano.Node.Types    (FollowerID)
+import           Ledger                (Address, Block, Blockchain, Slot, Tx, TxOut, TxOutRef)
+import           Servant.API           ((:<|>), (:>), Capture, Get, JSON, NoContent, Post, Put, ReqBody)
 import           Wallet.Emulator.Chain (ChainEvent)
 
 type API
@@ -16,10 +17,16 @@ type API
        :<|> "mempool" :> ReqBody '[ JSON] Tx :> Post '[ JSON] NoContent
        :<|> "slot" :> Get '[ JSON] Slot
        :<|> "mock" :> MockAPI
+       :<|> "follower" :> FollowerAPI
 
 -- Routes that are not guaranteed to exist on the real node
 type MockAPI
      = "random-tx" :> Get '[ JSON] Tx
        :<|> "utxo-at" :> ReqBody '[ JSON] Address :> Post '[ JSON] (Map TxOutRef TxOut)
-       :<|> "blockchain" :> Get '[ JSON] Blockchain
+       :<|> "blockchain" :> Get '[ JSON] Blockchain -- TODO: This should be replaced by the followe API
        :<|> "consume-event-history" :> Post '[ JSON] [ChainEvent]
+
+-- Protocol 1 of the node (node followers can request new blocks)
+type FollowerAPI
+    = "add" :> Put '[ JSON] FollowerID
+        :<|> Capture "follower-id" FollowerID :> "blocks" :> Post '[ JSON] [Block]

--- a/plutus-scb/src/Cardano/Node/Client.hs
+++ b/plutus-scb/src/Cardano/Node/Client.hs
@@ -3,9 +3,10 @@
 module Cardano.Node.Client where
 
 import           Cardano.Node.API      (API)
+import           Cardano.Node.Types    (FollowerID)
 import           Data.Map              (Map)
 import           Data.Proxy            (Proxy (Proxy))
-import           Ledger                (Address, Blockchain, Slot, Tx, TxOut, TxOutRef)
+import           Ledger                (Address, Block, Blockchain, Slot, Tx, TxOut, TxOutRef)
 import           Servant               ((:<|>) (..), NoContent)
 import           Servant.Client        (ClientM, client)
 import           Wallet.Emulator.Chain (ChainEvent)
@@ -17,14 +18,19 @@ randomTx :: ClientM Tx
 utxoAt :: Address -> ClientM (Map TxOutRef TxOut)
 blockchain :: ClientM Blockchain
 consumeEventHistory :: ClientM [ChainEvent]
-(healthcheck, addTx, getCurrentSlot, randomTx, utxoAt, blockchain, consumeEventHistory) =
+newFollower :: ClientM FollowerID
+getBlocks :: FollowerID -> ClientM [Block]
+(healthcheck, addTx, getCurrentSlot, randomTx, utxoAt, blockchain, consumeEventHistory, newFollower, getBlocks) =
     ( healthcheck_
     , addTx_
     , getCurrentSlot_
     , randomTx_
     , utxoAt_
     , blockchain_
-    , consumeEventHistory_)
+    , consumeEventHistory_
+    , newFollower_
+    , getBlocks_
+    )
   where
-    healthcheck_ :<|> addTx_ :<|> getCurrentSlot_ :<|> (randomTx_ :<|> utxoAt_ :<|> blockchain_ :<|> consumeEventHistory_) =
+    healthcheck_ :<|> addTx_ :<|> getCurrentSlot_ :<|> (randomTx_ :<|> utxoAt_ :<|> blockchain_ :<|> consumeEventHistory_) :<|> (newFollower_ :<|> getBlocks_) =
         client (Proxy @API)

--- a/plutus-scb/src/Cardano/Node/Follower.hs
+++ b/plutus-scb/src/Cardano/Node/Follower.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TypeOperators     #-}
+
+module Cardano.Node.Follower where
+
+import           Control.Lens
+import           Control.Monad.Freer
+import           Control.Monad.Freer.Extra.Log
+import           Control.Monad.Freer.State
+import           Control.Monad.Freer.TH        (makeEffect)
+
+import qualified Data.Map                      as Map
+
+import           Cardano.Node.Types            (FollowerID, NodeFollowerState, _NodeFollowerState)
+import           Ledger                        (Block)
+import           Plutus.SCB.Utils              (tshow)
+import           Wallet.Emulator.Chain         (ChainState)
+import qualified Wallet.Emulator.Chain         as Chain
+
+data NodeFollowerEffect r where
+    NewFollower :: NodeFollowerEffect FollowerID
+    GetBlocks :: FollowerID -> NodeFollowerEffect [Block]
+
+makeEffect ''NodeFollowerEffect
+
+handleNodeFollower ::
+    ( Member (State ChainState) effs
+    , Member (State NodeFollowerState) effs
+    , Member Log effs)
+    => Eff (NodeFollowerEffect ': effs) ~> Eff effs
+handleNodeFollower = interpret $ \case
+    NewFollower -> do
+        logInfo "New follower ID"
+        gets (succ . view (_NodeFollowerState . to (fmap fst <$> Map.lookupMax) .  non 0))
+    GetBlocks i -> do
+        logDebug $ "Get blocks for " <> tshow i
+        lastBlock <- gets (view (_NodeFollowerState . at i . non 0))
+        logDebug $ "Last block: " <> tshow lastBlock
+        chain <- gets (view Chain.chainNewestFirst)
+        let newLastBlock = length chain
+        logDebug $ "New last block: " <> tshow newLastBlock
+        modify (set (_NodeFollowerState . at i) (Just newLastBlock))
+        pure $ take (newLastBlock - lastBlock) $ reverse chain

--- a/plutus-scb/src/Cardano/Node/RandomTx.hs
+++ b/plutus-scb/src/Cardano/Node/RandomTx.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeOperators     #-}
 
 module Cardano.Node.RandomTx(
@@ -18,6 +19,7 @@ import           Control.Monad.Freer           (Eff, LastMember, Member)
 import qualified Control.Monad.Freer           as Eff
 import           Control.Monad.Freer.State     (State)
 import qualified Control.Monad.Freer.State     as Eff
+import           Control.Monad.Freer.TH        (makeEffect)
 import           Control.Monad.IO.Class        (MonadIO, liftIO)
 import           Control.Monad.Primitive       (PrimMonad, PrimState)
 import           Data.List.NonEmpty            (NonEmpty (..))
@@ -47,8 +49,7 @@ import           Control.Monad.Freer.Extra.Log
 data GenRandomTx r where
     GenRandomTx :: GenRandomTx Tx
 
-genRandomTx :: Member GenRandomTx effs => Eff effs Tx
-genRandomTx = Eff.send GenRandomTx
+makeEffect ''GenRandomTx
 
 runGenRandomTx ::
        ( Member (State ChainState) effs

--- a/plutus-scb/src/Cardano/Node/Server.hs
+++ b/plutus-scb/src/Cardano/Node/Server.hs
@@ -18,6 +18,7 @@ import           Servant                  ((:<|>) ((:<|>)), Application, hoistSe
 import           Servant.Client           (BaseUrl (baseUrlPort))
 
 import           Cardano.Node.API         (API)
+import           Cardano.Node.Follower    (getBlocks, newFollower)
 import           Cardano.Node.Mock
 import           Cardano.Node.RandomTx    (genRandomTx)
 import           Cardano.Node.Types
@@ -33,7 +34,9 @@ app stateVar =
         (runStdoutLoggingT . processChainEffects stateVar)
         (healthcheck :<|> addTx :<|> getCurrentSlot :<|>
          (genRandomTx :<|> utxoAt :<|> blockchain :<|>
-          consumeEventHistory stateVar))
+          consumeEventHistory stateVar) :<|>
+          (newFollower :<|> getBlocks)
+          )
 
 main :: (MonadIO m, MonadLogger m) => MockServerConfig -> m ()
 main MockServerConfig { mscBaseUrl

--- a/plutus-scb/src/Plutus/SCB/Types.hs
+++ b/plutus-scb/src/Plutus/SCB/Types.hs
@@ -6,9 +6,9 @@
 
 module Plutus.SCB.Types where
 
+import qualified Cardano.ChainIndex.Types           as ChainIndex
 import qualified Cardano.Node.Server                as NodeServer
 import qualified Cardano.Wallet.Server              as WalletServer
-import qualified Cardano.ChainIndex.Types           as ChainIndex
 import           Data.Aeson                         (FromJSON, ToJSON)
 import qualified Data.Aeson                         as Aeson
 import qualified Data.Aeson.Encode.Pretty           as JSON

--- a/plutus-scb/src/Plutus/SCB/Types.hs
+++ b/plutus-scb/src/Plutus/SCB/Types.hs
@@ -8,6 +8,7 @@ module Plutus.SCB.Types where
 
 import qualified Cardano.Node.Server                as NodeServer
 import qualified Cardano.Wallet.Server              as WalletServer
+import qualified Cardano.ChainIndex.Types           as ChainIndex
 import           Data.Aeson                         (FromJSON, ToJSON)
 import qualified Data.Aeson                         as Aeson
 import qualified Data.Aeson.Encode.Pretty           as JSON
@@ -106,5 +107,6 @@ data Config =
         { dbConfig           :: DbConfig
         , walletServerConfig :: WalletServer.Config
         , nodeServerConfig   :: NodeServer.MockServerConfig
+        , chainIndexConfig   :: ChainIndex.ChainIndexConfig
         }
     deriving (Show, Eq, Generic, FromJSON)


### PR DESCRIPTION
* Add a chain index that keeps track of unspent outputs and the transactions that produced them (so that we can get data values, etc. from them)
* Add a stateful chain follower protocol to the mock node, so that we can query for the most recent blocks only and don't need to transmit the entire blockchain every time