### PR TITLE
Change PIR.Let constructor to take a NonEmpty list

### DIFF
--- a/plutus-ir/plutus-ir.cabal
+++ b/plutus-ir/plutus-ir.cabal
@@ -72,7 +72,8 @@ library
         text -any,
         transformers -any,
         algebraic-graphs >= 0.3,
-        megaparsec -any
+        megaparsec -any,
+        parser-combinators >= 0.4.0
 
 test-suite plutus-ir-test
     type: exitcode-stdio-1.0

--- a/plutus-ir/src/Language/PlutusIR.hs
+++ b/plutus-ir/src/Language/PlutusIR.hs
@@ -46,7 +46,7 @@ import qualified Data.Text                  as T
 
 import           GHC.Generics               (Generic)
 
-import Data.List.NonEmpty (NonEmpty)
+import           Data.List.NonEmpty         (NonEmpty)
 
 
 -- Datatypes

--- a/plutus-ir/src/Language/PlutusIR/Analysis/Dependencies.hs
+++ b/plutus-ir/src/Language/PlutusIR/Analysis/Dependencies.hs
@@ -18,6 +18,8 @@ import           Control.Monad.Reader
 import qualified Algebra.Graph.Class               as G
 import qualified Data.Set                          as Set
 
+import qualified Data.List.NonEmpty as NE
+
 -- | A node in a dependency graph. Either a specific 'PLC.Unique', or a specific
 -- node indicating the root of the graph. We need the root node because when computing the
 -- dependency graph of, say, a term, there will not be a binding for the term itself which
@@ -124,7 +126,7 @@ termDeps = \case
     Let _ _ bs t -> do
         bGraphs <- traverse bindingDeps bs
         bodyGraph <- termDeps t
-        pure $ G.overlays $ bGraphs ++ [bodyGraph]
+        pure . G.overlays . NE.toList $ bodyGraph NE.<| bGraphs
     Var _ n -> recordDeps [n ^. PLC.unique . coerced]
     x -> do
         tds <- traverse termDeps (x ^.. termSubterms)

--- a/plutus-ir/src/Language/PlutusIR/Analysis/Dependencies.hs
+++ b/plutus-ir/src/Language/PlutusIR/Analysis/Dependencies.hs
@@ -18,7 +18,7 @@ import           Control.Monad.Reader
 import qualified Algebra.Graph.Class               as G
 import qualified Data.Set                          as Set
 
-import qualified Data.List.NonEmpty as NE
+import qualified Data.List.NonEmpty                as NE
 
 -- | A node in a dependency graph. Either a specific 'PLC.Unique', or a specific
 -- node indicating the root of the graph. We need the root node because when computing the

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
@@ -23,6 +23,8 @@ import           Control.Monad.Error.Lens
 import qualified Data.Text                              as T
 import           Data.Traversable
 
+import qualified Data.List.NonEmpty as NE
+
 -- Utilities
 
 -- | @replaceFunTyTarget X (A->..->Z) = (A->..->X)@
@@ -394,8 +396,7 @@ compileDatatype r body d@(Datatype _ tn _ destr constrs) = do
     -- See note [Abstract data types]
     pure $ PIR.mkIterApp p (PIR.mkIterInst p (PIR.mkIterTyAbs tyVars (PIR.mkIterLamAbs vars body)) tys) vals
 
-compileRecDatatypes :: Compiling m e uni a => PIRTerm uni a -> [Datatype TyName Name uni (Provenance a)] -> m (PIRTerm uni a)
+compileRecDatatypes :: Compiling m e uni a => PIRTerm uni a -> NE.NonEmpty (Datatype TyName Name uni (Provenance a)) -> m (PIRTerm uni a)
 compileRecDatatypes body ds = case ds of
-    []  -> pure body
-    [d] -> compileDatatype Rec body d
+    d NE.:| [] -> compileDatatype Rec body d
     _   -> getEnclosing >>= \p -> throwing _Error $ UnsupportedError p "Mutually recursive datatypes"

--- a/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
+++ b/plutus-ir/src/Language/PlutusIR/Compiler/Datatype.hs
@@ -23,7 +23,7 @@ import           Control.Monad.Error.Lens
 import qualified Data.Text                              as T
 import           Data.Traversable
 
-import qualified Data.List.NonEmpty as NE
+import qualified Data.List.NonEmpty                     as NE
 
 -- Utilities
 
@@ -399,4 +399,4 @@ compileDatatype r body d@(Datatype _ tn _ destr constrs) = do
 compileRecDatatypes :: Compiling m e uni a => PIRTerm uni a -> NE.NonEmpty (Datatype TyName Name uni (Provenance a)) -> m (PIRTerm uni a)
 compileRecDatatypes body ds = case ds of
     d NE.:| [] -> compileDatatype Rec body d
-    _   -> getEnclosing >>= \p -> throwing _Error $ UnsupportedError p "Mutually recursive datatypes"
+    _          -> getEnclosing >>= \p -> throwing _Error $ UnsupportedError p "Mutually recursive datatypes"

--- a/plutus-ir/src/Language/PlutusIR/Generators/AST.hs
+++ b/plutus-ir/src/Language/PlutusIR/Generators/AST.hs
@@ -79,7 +79,7 @@ genTerm = simpleRecursive nonRecursive recursive where
     unwrapGen = Unwrap () <$> genTerm
     wrapGen = IWrap () <$> genType <*> genType <*> genTerm
     errorGen = Error () <$> genType
-    letGen = Let () <$> genRecursivity <*> Gen.list (Range.linear 1 10) genBinding <*> genTerm
+    letGen = Let () <$> genRecursivity <*> Gen.nonEmpty (Range.linear 1 10) genBinding <*> genTerm
     recursive = [absGen, instGen, lamGen, applyGen, unwrapGen, wrapGen, letGen]
     nonRecursive = [varGen, Constant () <$> genConstant, Builtin () <$> genBuiltin, errorGen]
 

--- a/plutus-ir/src/Language/PlutusIR/MkPir.hs
+++ b/plutus-ir/src/Language/PlutusIR/MkPir.hs
@@ -11,6 +11,9 @@ import           Language.PlutusIR
 
 import           Language.PlutusCore.MkPlc as MkPlc
 
+import qualified Data.List.NonEmpty as NE
+
+
 -- | A datatype definition as a type variable.
 type DatatypeDef tyname name uni a = Def (TyVarDecl tyname a) (Datatype tyname name uni a)
 
@@ -22,4 +25,4 @@ mkLet
     -> [Binding tyname name uni a]
     -> Term tyname name uni a
     -> Term tyname name uni a
-mkLet x r bs t = if null bs then t else Let x r bs t
+mkLet x r bs t = if null bs then t else Let x r (NE.fromList bs) t

--- a/plutus-ir/src/Language/PlutusIR/MkPir.hs
+++ b/plutus-ir/src/Language/PlutusIR/MkPir.hs
@@ -11,7 +11,7 @@ import           Language.PlutusIR
 
 import           Language.PlutusCore.MkPlc as MkPlc
 
-import qualified Data.List.NonEmpty as NE
+import qualified Data.List.NonEmpty        as NE
 
 
 -- | A datatype definition as a type variable.
@@ -25,4 +25,6 @@ mkLet
     -> [Binding tyname name uni a]
     -> Term tyname name uni a
     -> Term tyname name uni a
-mkLet x r bs t = if null bs then t else Let x r (NE.fromList bs) t
+mkLet x r bs t =  case NE.nonEmpty bs of
+  Nothing  -> t;
+  Just bs' -> Let x r bs' t

--- a/plutus-ir/src/Language/PlutusIR/Optimizer/DeadCode.hs
+++ b/plutus-ir/src/Language/PlutusIR/Optimizer/DeadCode.hs
@@ -20,6 +20,7 @@ import qualified Data.Set                                as Set
 
 import qualified Algebra.Graph                           as G
 import qualified Algebra.Graph.ToGraph                   as T
+import qualified Data.List.NonEmpty as NE
 
 -- | Remove all the dead let bindings in a term.
 removeDeadBindings
@@ -68,5 +69,5 @@ processTerm
     -> m (Term tyname name uni a)
 processTerm = \case
     -- throw away dead bindings
-    Let x r bs t -> mkLet x r <$> filterM liveBinding bs <*> pure t
+    Let x r bs t -> mkLet x r <$> filterM liveBinding (NE.toList bs) <*> pure t
     x -> pure x

--- a/plutus-ir/src/Language/PlutusIR/Optimizer/DeadCode.hs
+++ b/plutus-ir/src/Language/PlutusIR/Optimizer/DeadCode.hs
@@ -20,7 +20,7 @@ import qualified Data.Set                                as Set
 
 import qualified Algebra.Graph                           as G
 import qualified Algebra.Graph.ToGraph                   as T
-import qualified Data.List.NonEmpty as NE
+import qualified Data.List.NonEmpty                      as NE
 
 -- | Remove all the dead let bindings in a term.
 removeDeadBindings

--- a/plutus-ir/src/Language/PlutusIR/Parser.hs
+++ b/plutus-ir/src/Language/PlutusIR/Parser.hs
@@ -42,6 +42,10 @@ import           GHC.Natural
 
 import           Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as Lex
+import qualified Control.Monad.Combinators.NonEmpty as NE
+
+
+
 
 newtype ParserState = ParserState { identifiers :: M.Map T.Text PLC.Unique }
     deriving (Show)
@@ -301,7 +305,7 @@ errorTerm :: Parametric
 errorTerm _tm = PIR.error <$> reservedWord "error" <*> typ
 
 letTerm :: Parser (Term TyName Name PLC.DefaultUni SourcePos)
-letTerm = Let <$> reservedWord "let" <*> recursivity <*> some (try binding) <*> term
+letTerm = Let <$> reservedWord "let" <*> recursivity <*> NE.some (try binding) <*> term
 
 appTerm :: Parametric
 appTerm tm = PIR.mkIterApp <$> getSourcePos <*> tm <*> some tm

--- a/plutus-ir/src/Language/PlutusIR/Parser.hs
+++ b/plutus-ir/src/Language/PlutusIR/Parser.hs
@@ -18,31 +18,31 @@ module Language.PlutusIR.Parser
     , SourcePos
     ) where
 
-import           Prelude                    hiding (fail)
+import           Prelude                            hiding (fail)
 
-import           Control.Applicative        hiding (many, some)
-import           Control.Monad.State        hiding (fail)
+import           Control.Applicative                hiding (many, some)
+import           Control.Monad.State                hiding (fail)
 
-import qualified Language.PlutusCore        as PLC
-import qualified Language.PlutusCore.MkPlc  as PLC
-import           Language.PlutusIR          as PIR
-import qualified Language.PlutusIR.MkPir    as PIR
-import           PlutusPrelude              (prettyText)
-import           Text.Megaparsec            hiding (ParseError, State, parse)
-import qualified Text.Megaparsec            as Parsec
+import qualified Language.PlutusCore                as PLC
+import qualified Language.PlutusCore.MkPlc          as PLC
+import           Language.PlutusIR                  as PIR
+import qualified Language.PlutusIR.MkPir            as PIR
+import           PlutusPrelude                      (prettyText)
+import           Text.Megaparsec                    hiding (ParseError, State, parse)
+import qualified Text.Megaparsec                    as Parsec
 
-import           Data.ByteString.Internal   (c2w)
-import qualified Data.ByteString.Lazy       as BSL
+import           Data.ByteString.Internal           (c2w)
+import qualified Data.ByteString.Lazy               as BSL
 import           Data.Char
 import           Data.Foldable
-import qualified Data.Map                   as M
-import qualified Data.Text                  as T
+import qualified Data.Map                           as M
+import qualified Data.Text                          as T
 import           Data.Word
 import           GHC.Natural
 
-import           Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as Lex
 import qualified Control.Monad.Combinators.NonEmpty as NE
+import           Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer         as Lex
 
 
 

--- a/plutus-ir/src/Language/PlutusIR/Transform/Rename.hs
+++ b/plutus-ir/src/Language/PlutusIR/Transform/Rename.hs
@@ -19,6 +19,8 @@ import           Control.Monad.Reader
 import           Control.Monad.Trans.Class           (lift)
 import           Control.Monad.Trans.Cont            (ContT (..))
 
+import Data.List.NonEmpty (NonEmpty)
+
 {- Note [Renaming of mutually recursive bindings]
 The 'RenameM' monad is a newtype wrapper around @ReaderT renaming Quote@, so in order to bring
 a name into the scope we need to use the following pattern:
@@ -105,8 +107,8 @@ renameBindingCM = \case
 withFreshenedBindings
     :: (PLC.HasUniques (Term tyname name uni ann), PLC.MonadQuote m)
     => Recursivity
-    -> [Binding tyname name uni ann]
-    -> ([Binding tyname name uni ann] -> PLC.ScopedRenameT m c)
+    -> NonEmpty (Binding tyname name uni ann)
+    -> (NonEmpty (Binding tyname name uni ann) -> PLC.ScopedRenameT m c)
     -> PLC.ScopedRenameT m c
 withFreshenedBindings recy binds cont = case recy of
     -- Bring each binding in scope, rename its RHS straight away, collect all the results and

--- a/plutus-ir/src/Language/PlutusIR/Transform/Rename.hs
+++ b/plutus-ir/src/Language/PlutusIR/Transform/Rename.hs
@@ -19,7 +19,7 @@ import           Control.Monad.Reader
 import           Control.Monad.Trans.Class           (lift)
 import           Control.Monad.Trans.Cont            (ContT (..))
 
-import Data.List.NonEmpty (NonEmpty)
+import           Data.List.NonEmpty                  (NonEmpty)
 
 {- Note [Renaming of mutually recursive bindings]
 The 'RenameM' monad is a newtype wrapper around @ReaderT renaming Quote@, so in order to bring

--- a/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Expr.hs
@@ -397,7 +397,7 @@ compileExpr e = withContextM 2 (sdToTxt $ "Compiling expr:" GHC.<+> GHC.ppr e) $
             withVarScoped b $ \v -> do
                 let binds = pure $ PIR.TermBind () (if nonStrict then PIR.NonStrict else PIR.Strict) v arg'
                 body' <- compileExpr body
-                pure $ PIR.mkLet () PIR.NonRec binds body'
+                pure $ PIR.Let () PIR.NonRec binds body'
         GHC.Let (GHC.Rec bs) body ->
             withVarsScoped (fmap fst bs) $ \vars -> do
                 -- the bindings are scope in both the body and the args
@@ -456,8 +456,8 @@ compileExpr e = withContextM 2 (sdToTxt $ "Compiling expr:" GHC.<+> GHC.ppr e) $
                 mainCase <- maybeForce lazyCase applied
 
                 -- See Note [At patterns]
-                let binds = [ PIR.TermBind () PIR.Strict v scrutinee' ]
-                pure $ PIR.mkLet () PIR.NonRec binds mainCase
+                let binds = pure $ PIR.TermBind () PIR.Strict v scrutinee'
+                pure $ PIR.Let () PIR.NonRec binds mainCase
         -- we can use source notes to get a better context for the inner expression
         -- these are put in when you compile with -g
         GHC.Tick GHC.SourceNote{GHC.sourceSpan=src} body ->

--- a/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Expr.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Expr.hs
@@ -395,9 +395,9 @@ compileExpr e = withContextM 2 (sdToTxt $ "Compiling expr:" GHC.<+> GHC.ppr e) $
             -- See Note [Non-strict let-bindings]
             let nonStrict = not $ PIR.isTermValue arg'
             withVarScoped b $ \v -> do
-                let binds = [ PIR.TermBind () (if nonStrict then PIR.NonStrict else PIR.Strict) v arg' ]
+                let binds = pure $ PIR.TermBind () (if nonStrict then PIR.NonStrict else PIR.Strict) v arg'
                 body' <- compileExpr body
-                pure $ PIR.Let () PIR.NonRec binds body'
+                pure $ PIR.mkLet () PIR.NonRec binds body'
         GHC.Let (GHC.Rec bs) body ->
             withVarsScoped (fmap fst bs) $ \vars -> do
                 -- the bindings are scope in both the body and the args
@@ -408,7 +408,7 @@ compileExpr e = withContextM 2 (sdToTxt $ "Compiling expr:" GHC.<+> GHC.ppr e) $
                     let nonStrict = not $ PIR.isTermValue arg'
                     pure $ PIR.TermBind () (if nonStrict then PIR.NonStrict else PIR.Strict) v arg'
                 body' <- compileExpr body
-                pure $ PIR.Let () PIR.Rec binds body'
+                pure $ PIR.mkLet () PIR.Rec binds body'
         -- See Note [Default-only cases]
         GHC.Case scrutinee b _ [a@(_, _, body)] | GHC.isDefaultAlt a -> do
             -- See Note [At patterns]
@@ -417,7 +417,7 @@ compileExpr e = withContextM 2 (sdToTxt $ "Compiling expr:" GHC.<+> GHC.ppr e) $
                 body' <- compileExpr body
                 -- See Note [At patterns]
                 let binds = [ PIR.TermBind () PIR.Strict v scrutinee' ]
-                pure $ PIR.Let () PIR.NonRec binds body'
+                pure $ PIR.mkLet () PIR.NonRec binds body'
         GHC.Case scrutinee b t alts -> do
             -- See Note [At patterns]
             scrutinee' <- compileExpr scrutinee
@@ -457,7 +457,7 @@ compileExpr e = withContextM 2 (sdToTxt $ "Compiling expr:" GHC.<+> GHC.ppr e) $
 
                 -- See Note [At patterns]
                 let binds = [ PIR.TermBind () PIR.Strict v scrutinee' ]
-                pure $ PIR.Let () PIR.NonRec binds mainCase
+                pure $ PIR.mkLet () PIR.NonRec binds mainCase
         -- we can use source notes to get a better context for the inner expression
         -- these are put in when you compile with -g
         GHC.Tick GHC.SourceNote{GHC.sourceSpan=src} body ->


### PR DESCRIPTION
We do not allow empty lets in Plutus IR.
This PR restricts it at the typelevel.

However, GHC allows empty lets. The `mkLet` smart constructor makes sure that empty ghc lets are skipped.