### PR TITLE
Make Ada block lowercase

### DIFF
--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -459,7 +459,7 @@ toDefinition (TokenType AdaTokenType) =
   BlockDefinition
     $ merge
         { type: show AdaTokenType
-        , message0: "Ada"
+        , message0: "ada"
         , args0: []
         , colour: "255"
         , output: Just "token"


### PR DESCRIPTION
Ada is meant to be a smart constructor, so having the Blockly block to be uppercase is inconsistent with it. This pull request changes the capitalisation of the label in the Blockly block to be lowercase like the smart constructor.