### PR TITLE
Take cabal-install from nixpkgs as dev cabal for now

### DIFF
--- a/nix/haskell-extra.nix
+++ b/nix/haskell-extra.nix
@@ -6,6 +6,8 @@
 ############################################################################
 { pkgs, index-state }:
 {
+  # FIXME: this cabal can't be used for development purposes until
+  # https://github.com/input-output-hk/haskell.nix/issues/422 is fixed
   cabal-install = pkgs.haskell-nix.hackage-package {
     name = "cabal-install";
     version = "2.4.1.0";

--- a/shell.nix
+++ b/shell.nix
@@ -11,9 +11,12 @@ with packageSet; haskell.packages.shellFor {
     pkgs.z3
     pkgs.sqlite-analyzer
     pkgs.sqlite-interactive
+    # Take cabal from nixpkgs for now, see below
+    pkgs.cabal-install
 
     # Extra dev packages acquired from elsewhere
-    dev.packages.cabal-install
+    # FIXME: Can't use this cabal until https://github.com/input-output-hk/haskell.nix/issues/422 is fixed
+    #dev.packages.cabal-install
     dev.packages.hlint
     dev.packages.stylish-haskell
     dev.packages.purty


### PR DESCRIPTION
Until https://github.com/input-output-hk/haskell.nix/issues/422 is
fixed, we can't use the one we build with `haskell.nix`.

This does bump us to using `cabal-install` 3.0.0.0, but that seems to be
fine. As a bonus, this version makes `v2` commands the default!