### PR TITLE
fix deployment

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -21,7 +21,7 @@ let
     };
     # This turns the output into a fixed-output derivation, which speeds things
     # up, but means we need to invalidate this hash when we change stack.yaml.
-    stack-sha256 = "1jzlddl4hrgc2qypwma2rn86anya1kakkdxffrh20gmy3b7azd55";
+    stack-sha256 = "1k75ivlwjkcmgi7cm1vfdh2fl9h4n9vl5sl04f8gpplf6gkb0akx";
     modules = [
         {
           # Borrowed from https://github.com/input-output-hk/haskell.nix/pull/427


### PR DESCRIPTION
I'm afraid I'm out of my depth here, this came up in the deployment server with:
```
building all machine configurations...
trace: [alex-plan-to-nix-pkgs] cabal new-configure --with-ghc=ghc --with-ghc-pkg=ghc-pkg
trace: [happy-plan-to-nix-pkgs] cabal new-configure --with-ghc=ghc --with-ghc-pkg=ghc-pkg
trace: [hscolour-plan-to-nix-pkgs] cabal new-configure --with-ghc=ghc --with-ghc-pkg=ghc-pkg
trace: To materialize, point `materialized` to a copy of /nix/store/q09xn5njhi80cb4fjb2x59i0vmgxlnzh-stack-to-nix-pkgs
building '/nix/store/17djfqkhw7rm69pc8xyya01pnd9my8vv-stack-to-nix-pkgs.drv'...
substituteStream(): WARNING: pattern '/nix/store/y28jgvngfk5v0b2mnzixnxbklywqsyla-plutus' doesn't match anything in file '/nix/store/q09xn5njhi80cb4fjb2x59i0vmgxlnzh-stack-to-nix-pkgs/pkgs.nix'
substituteStream(): WARNING: pattern '/nix/store/y28jgvngfk5v0b2mnzixnxbklywqsyla-plutus' doesn't match anything in file '/nix/store/q09xn5njhi80cb4fjb2x59i0vmgxlnzh-stack-to-nix-pkgs/default.nix'
hash mismatch in fixed-output derivation '/nix/store/kmj7hkmhpmb84129w05kkincnwm2b0dq-stack-to-nix-pkgs':
  wanted: sha256:1jzlddl4hrgc2qypwma2rn86anya1kakkdxffrh20gmy3b7azd55
  got:    sha256:1k75ivlwjkcmgi7cm1vfdh2fl9h4n9vl5sl04f8gpplf6gkb0akx
error: build of '/nix/store/17djfqkhw7rm69pc8xyya01pnd9my8vv-stack-to-nix-pkgs.drv' failed
(use '--show-trace' to show detailed location information)
Traceback (most recent call last):
  File \"/nix/store/hwcnfx27ym6fgfqdxs68ac1d7ckgla9m-nixops-1.6.1/bin/..nixops-wrapped-wrapped\", line 990, in <module>
    args.op()
  File \"/nix/store/hwcnfx27ym6fgfqdxs68ac1d7ckgla9m-nixops-1.6.1/bin/..nixops-wrapped-wrapped\", line 411, in op_deploy
    max_concurrent_activate=args.max_concurrent_activate)
  File \"/nix/store/hwcnfx27ym6fgfqdxs68ac1d7ckgla9m-nixops-1.6.1/lib/python2.7/site-packages/nixops/deployment.py\", line 1056, in deploy
    self.run_with_notify('deploy', lambda: self._deploy(**kwargs))
  File \"/nix/store/hwcnfx27ym6fgfqdxs68ac1d7ckgla9m-nixops-1.6.1/lib/python2.7/site-packages/nixops/deployment.py\", line 1045, in run_with_notify
    f()
  File \"/nix/store/hwcnfx27ym6fgfqdxs68ac1d7ckgla9m-nixops-1.6.1/lib/python2.7/site-packages/nixops/deployment.py\", line 1056, in <lambda>
    self.run_with_notify('deploy', lambda: self._deploy(**kwargs))
  File \"/nix/store/hwcnfx27ym6fgfqdxs68ac1d7ckgla9m-nixops-1.6.1/lib/python2.7/site-packages/nixops/deployment.py\", line 996, in _deploy
    self.configs_path = self.build_configs(dry_run=dry_run, repair=repair, include=include, exclude=exclude)
  File \"/nix/store/hwcnfx27ym6fgfqdxs68ac1d7ckgla9m-nixops-1.6.1/lib/python2.7/site-packages/nixops/deployment.py\", line 664, in build_configs
    raise Exception(\"unable to build all machine configurations\")
Exception: unable to build all machine configurations
```
I can reproduce this failure by deploying manually from `origin/master` and with the change I can deploy manually successfully from `origin/fix-build` however the hercules build are failing but I don't understand why.