### PR TITLE
Set checkMaterialization when building in the CI

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -3,7 +3,7 @@ let
   systems = {"x86_64-linux" = {}; "x86_64-darwin" = {};};
 in dimension "System" systems (system: _:
   let
-    packageSet = import ./default.nix { inherit system; };
+    packageSet = import ./default.nix { inherit system; checkMaterialization = false; };
     pkgs = packageSet.pkgs;
     lib = pkgs.lib;
     collectChecks = _: ps: pkgs.recurseIntoAttrs (builtins.mapAttrs (_: p: p.checks) ps);

--- a/default.nix
+++ b/default.nix
@@ -17,6 +17,9 @@
 
 # An explicit git rev to use, passed when we are in Hydra
 , rev ? null
+# Whether to check that the pinned shas for haskell.nix are correct. We want this to be
+# false, generally, since it does more work, but we set it to true in the CI
+, checkMaterialization ? false
 }:
 
 
@@ -66,16 +69,16 @@ in rec {
 
   haskell = rec {
     # All the packages defined by our project, including dependencies
-    packages = import ./nix/haskell.nix { inherit (pkgs) lib stdenv pkgs haskell-nix buildPackages; inherit metatheory; };
+    packages = import ./nix/haskell.nix { inherit (pkgs) lib stdenv pkgs haskell-nix buildPackages; inherit metatheory checkMaterialization; };
     # Just the packages in the project
     projectPackages =
       pkgs.haskell-nix.haskellLib.selectProjectPackages packages
       # Need to list this manually to work around https://github.com/input-output-hk/haskell.nix/issues/464
       // { inherit (packages) plc-agda; };
     # All the packages defined by our project, built for musl
-    muslPackages = import ./nix/haskell.nix { inherit (pkgsMusl) lib stdenv pkgs haskell-nix buildPackages; inherit metatheory; };
+    muslPackages = import ./nix/haskell.nix { inherit (pkgsMusl) lib stdenv pkgs haskell-nix buildPackages; inherit metatheory checkMaterialization; };
     # Extra Haskell packages which we use but aren't part of the main project definition.
-    extraPackages = pkgs.callPackage ./nix/haskell-extra.nix { inherit (localLib) index-state; };
+    extraPackages = pkgs.callPackage ./nix/haskell-extra.nix { inherit (localLib) index-state; inherit checkMaterialization; };
   };
 
   tests = import ./nix/tests/default.nix {

--- a/nix/haskell-extra.nix
+++ b/nix/haskell-extra.nix
@@ -4,28 +4,28 @@
 #
 # These are for e.g. developer usage, or for running formatting tests.
 ############################################################################
-{ pkgs, index-state }:
+{ pkgs, index-state, checkMaterialization }:
 {
   # FIXME: this cabal can't be used for development purposes until
   # https://github.com/input-output-hk/haskell.nix/issues/422 is fixed
   cabal-install = pkgs.haskell-nix.hackage-package {
     name = "cabal-install";
     version = "2.4.1.0";
-    inherit index-state;
+    inherit index-state checkMaterialization;
     # Invalidate and update if you change the version or index-state
     plan-sha256 = "1qpjwpsg4pmva6zkxnax8yrn2vxgff2syshfmr3as9hbkxhy9d4k";
   };
   stylish-haskell = pkgs.haskell-nix.hackage-package {
     name = "stylish-haskell";
     version = "0.9.2.2";
-    inherit index-state;
+    inherit index-state checkMaterialization;
     # Invalidate and update if you change the version or index-state
     plan-sha256 = "1k0vh1zy7qw178lpd2r7clz17xihwnb2fq35rkkhwq9pi1y9fw2y";
   };
   hlint = pkgs.haskell-nix.hackage-package {
     name = "hlint";
     version = "2.1.12";
-    inherit index-state;
+    inherit index-state checkMaterialization;
     # Invalidate and update if you change the version or index-state
     plan-sha256 = "1bhcagbdbfg543hzmqp9f4s1f9v326544xrr42q60y4bjkddix6q";
   };
@@ -39,6 +39,7 @@
         };
         # Invalidate and update if you change the version
         stack-sha256 = "0ivcggb31sl5a405gifb1d8yl1p4mam9b1hzmrgsjn04c8d67w09";
+        inherit checkMaterialization;
         pkg-def-extras = [
           # Workaround for https://github.com/input-output-hk/haskell.nix/issues/214
           (hackage: {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -7,6 +7,7 @@
 , haskell-nix
 , buildPackages
 , metatheory
+, checkMaterialization
 }:
 
 let
@@ -22,6 +23,7 @@ let
     # This turns the output into a fixed-output derivation, which speeds things
     # up, but means we need to invalidate this hash when we change stack.yaml.
     stack-sha256 = "1k75ivlwjkcmgi7cm1vfdh2fl9h4n9vl5sl04f8gpplf6gkb0akx";
+    inherit checkMaterialization;
     modules = [
         {
           # Borrowed from https://github.com/input-output-hk/haskell.nix/pull/427

--- a/release.nix
+++ b/release.nix
@@ -30,7 +30,7 @@ in with (import (fixedNixpkgs + "/pkgs/top-level/release-lib.nix") {
 });
 
 let
-  packageSet = import ./. { inherit rev; };
+  packageSet = import ./. { inherit rev; checkMaterialization = true; };
   # Makes a tree of attributes where some nodes are replaced with just the
   # list of systems which we want to the hydra jobs to run on.
   mapDerivationsToSystemsRecursive = sys:


### PR DESCRIPTION
When set, this actually does the full IFD and checks that the hashes
we've given are correct. This is helpful, but we only set it on the CI
build to keep saving us time locally.