### PR TITLE
SCP-179 - Improvements to linting mechanism

### DIFF
--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -9,7 +9,6 @@ import Data.Foldable (intercalate)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Bounded (genericBottom, genericTop)
 import Data.Generic.Rep.Enum (genericCardinality, genericFromEnum, genericPred, genericSucc, genericToEnum)
-import Data.Generic.Rep.Eq (genericEq)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Map (Map)
 import Data.Map as Map
@@ -233,8 +232,9 @@ data Term a
 
 derive instance genericTerm :: Generic (Term a) _
 
-instance eqTerm :: Eq a => Eq (Term a) where
-  eq a b = genericEq a b
+derive instance eqTerm :: Eq a => Eq (Term a)
+
+derive instance ordTerm :: Ord a => Ord (Term a)
 
 instance showTerm :: Show a => Show (Term a) where
   show (Term a _) = show a
@@ -398,6 +398,10 @@ data AccountId
 
 derive instance genericAccountId :: Generic AccountId _
 
+derive instance eqAccountId :: Eq AccountId
+
+derive instance ordAccountId :: Ord AccountId
+
 instance showAccountId :: Show AccountId where
   show v = genericShow v
 
@@ -423,6 +427,10 @@ data Token
 
 derive instance genericToken :: Generic Token _
 
+derive instance eqToken :: Eq Token
+
+derive instance ordToken :: Ord Token
+
 instance showToken :: Show Token where
   show tok = genericShow tok
 
@@ -447,6 +455,10 @@ data ChoiceId
   = ChoiceId (Term String) (Term Party)
 
 derive instance genericChoiceId :: Generic ChoiceId _
+
+derive instance eqChoiceId :: Eq ChoiceId
+
+derive instance ordChoiceId :: Ord ChoiceId
 
 instance showChoiceId :: Show ChoiceId where
   show v = genericShow v
@@ -498,6 +510,10 @@ data Payee
   | Party (Term Party)
 
 derive instance genericPayee :: Generic Payee _
+
+derive instance eqParty :: Eq Party
+
+derive instance ordParty :: Ord Party
 
 instance showPayee :: Show Payee where
   show v = genericShow v
@@ -555,6 +571,10 @@ data Value
   | UseValue (Term ValueId)
 
 derive instance genericValue :: Generic Value _
+
+derive instance eqValue :: Eq Value
+
+derive instance ordValue :: Ord Value
 
 instance showValue :: Show Value where
   show v = genericShow v

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -250,6 +250,11 @@ instance hasArgsTerm :: Args a => Args (Term a) where
   hasNestedArgs (Term a _) = hasNestedArgs a
   hasNestedArgs _ = false
 
+getPosition :: forall a. Term a -> { row :: Pos, column :: Pos }
+getPosition (Term _ pos) = pos
+
+getPosition (Hole _ _ pos) = pos
+
 -- a concrete type for holes only
 data MarloweHole
   = MarloweHole
@@ -620,6 +625,10 @@ data Observation
   | FalseObs
 
 derive instance genericObservation :: Generic Observation _
+
+derive instance eqObservation :: Eq Observation
+
+derive instance ordObservation :: Ord Observation
 
 instance showObservation :: Show Observation where
   show v = genericShow v

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -371,10 +371,10 @@ negativeDeposit (Term (Deposit _ _ _ value) _) = NegativeDeposit <$> negativeVal
 negativeDeposit _ = Nothing
 
 negativeValue :: Term Value -> Maybe IRange
-negativeValue term@(Term _ pos) = do
+negativeValue term@(Term t pos) = do
   v <- constantValue term
   guard (v < zero)
-  pure (termToRange v pos)
+  pure (termToRange t pos)
 
 negativeValue _ = Nothing
 

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -39,7 +39,7 @@ import Data.String.Regex (match, regex)
 import Data.String.Regex.Flags (noFlags)
 import Data.Symbol (SProxy(..))
 import Data.Traversable (traverse_)
-import Data.Tuple.Nested (type (/\), (/\))
+import Data.Tuple.Nested ((/\))
 import Marlowe.Holes (Action(..), Argument, Case(..), Contract(..), Holes(..), MarloweHole(..), MarloweType(..), Observation(..), Term(..), Value(..), ValueId, constructMarloweType, getHoles, getMarloweConstructors, getPosition, holeSuggestions, insertHole, readMarloweType)
 import Marlowe.Parser (ContractParseError(..), parseContract)
 import Marlowe.Semantics (Rational(..), Slot(..), Timeout, emptyState, evalValue, makeEnvironment)
@@ -504,9 +504,6 @@ lintValue env t@(Term (UseValue hole) pos) = do
 lintValue env hole@(Hole _ _ pos) = do
   modifying _holes (insertHole hole)
   pure (ValueSimp pos false hole)
-
-collectFromTuples :: forall a b. Array (a /\ b) -> Array a /\ Array b
-collectFromTuples = foldMap (\(a /\ b) -> [ a ] /\ [ b ])
 
 lintCase :: LintEnv -> Term Case -> CMS.State State Unit
 lintCase env t@(Term (Case action contract) pos) = do

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -379,11 +379,9 @@ lintObservation env t@(Term (ValueEQ a b) pos) = do
       markSimplification constToVal SimplifiableValue b sb
       pure (ValueSimp pos false t)
 
-lintObservation env t@(Term TrueObs pos) = do
-  pure (ConstantSimp pos false true)
+lintObservation env t@(Term TrueObs pos) = pure (ConstantSimp pos false true)
 
-lintObservation env t@(Term FalseObs pos) = do
-  pure (ConstantSimp pos false false)
+lintObservation env t@(Term FalseObs pos) = pure (ConstantSimp pos false false)
 
 lintObservation env hole@(Hole _ _ pos) = do
   modifying _holes (insertHole hole)
@@ -396,8 +394,7 @@ lintValue env t@(Term (AvailableMoney acc token) pos) = do
   modifying _holes gatherHoles
   pure (ValueSimp pos false t)
 
-lintValue env (Term (Constant (Term v pos2)) pos) = do
-  pure (ConstantSimp pos false v)
+lintValue env (Term (Constant (Term v pos2)) pos) = pure (ConstantSimp pos false v)
 
 lintValue env t@(Term (Constant h@(Hole _ _ _)) pos) = do
   modifying _holes (insertHole h)
@@ -498,8 +495,7 @@ lintValue env t@(Term SlotIntervalStart pos) = pure (ValueSimp pos false t)
 
 lintValue env t@(Term SlotIntervalEnd pos) = pure (ValueSimp pos false t)
 
-lintValue env t@(Term (UseValue (Term valueId pos2)) pos) = do
-  pure (ValueSimp pos false t)
+lintValue env t@(Term (UseValue (Term valueId pos2)) pos) = pure (ValueSimp pos false t)
 
 lintValue env t@(Term (UseValue hole) pos) = do
   modifying _holes (insertHole hole)

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -217,7 +217,7 @@ constToVal x = Term (Constant (Term x { row: 0, column: 0 })) { row: 0, column: 
 lint :: Term Contract -> State
 lint contract = state
   where
-  (_ /\ state) = CMS.runState (lintContract mempty contract) mempty
+  state = CMS.execState (lintContract mempty contract) mempty
 
 lintContract :: LintEnv -> Term Contract -> CMS.State State Unit
 lintContract env (Term Close _) = pure unit

--- a/marlowe-playground-client/src/Marlowe/Semantics.purs
+++ b/marlowe-playground-client/src/Marlowe/Semantics.purs
@@ -476,6 +476,9 @@ instance showEnvironment :: Show Environment where
 _slotInterval :: Lens' Environment SlotInterval
 _slotInterval = _Newtype <<< prop (SProxy :: SProxy "slotInterval")
 
+makeEnvironment :: BigInteger -> BigInteger -> Environment
+makeEnvironment l h = Environment { slotInterval: SlotInterval (Slot h) (Slot l) }
+
 data Input
   = IDeposit AccountId Party Token BigInteger
   | IChoice ChoiceId ChosenNum

--- a/marlowe-playground-client/webpack.config.js
+++ b/marlowe-playground-client/webpack.config.js
@@ -107,7 +107,7 @@ module.exports = {
             static: path.resolve(__dirname, './static'),
             src: path.resolve(__dirname, './src')
         },
-        extensions: ['.purs', '.js', 'ts', 'tsx']
+        extensions: ['.purs', '.js', '.ts', '.tsx']
     },
 
     resolveLoader: {


### PR DESCRIPTION
Refine linting mechanism to include constant simplification suggestions, unreachable `Case` and `Contract` and to use a `State` monad and separate `Environment`.