### PR TITLE
fix nix build

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -22,7 +22,7 @@ let
     };
     # This turns the output into a fixed-output derivation, which speeds things
     # up, but means we need to invalidate this hash when we change stack.yaml.
-    stack-sha256 = "1k75ivlwjkcmgi7cm1vfdh2fl9h4n9vl5sl04f8gpplf6gkb0akx";
+    stack-sha256 = "0dw0rq95jyrl1czqhjiy2x400zs7pywb2dqaj9w5p4ym1ipxvsr0";
     inherit checkMaterialization;
     modules = [
         {


### PR DESCRIPTION
@michaelpj this has happened again, any idea how it is managing to get into master? 

This looks to be the PR that causes it this time https://github.com/input-output-hk/plutus/pull/1923 which looks like things will break any time a cabal file is changed?