### PR TITLE
Scp 166 - part 1

### DIFF
--- a/marlowe-playground-client/src/HaskellEditor.purs
+++ b/marlowe-playground-client/src/HaskellEditor.purs
@@ -1,6 +1,6 @@
 module HaskellEditor where
 
-import Halogen.Classes (aHorizontal, accentBorderBottom, analysisPanel, blocklyIcon, closeDrawerIcon, footerPanelBg, haskellEditor, isActiveDemo, isActiveTab, jFlexStart, minimizeIcon, noMargins, panelHeader, panelHeaderMain, panelSubHeader, panelSubHeaderMain, smallBtn, spaceLeft)
+import Halogen.Classes (aHorizontal, accentBorderBottom, analysisPanel, closeDrawerIcon, footerPanelBg, haskellEditor, isActiveDemo, isActiveTab, jFlexStart, minimizeIcon, noMargins, panelHeader, panelHeaderMain, panelSubHeader, panelSubHeaderMain, spaceLeft)
 import Data.Array as Array
 import Data.Either (Either(..))
 import Data.Json.JsonEither (JsonEither(..))
@@ -15,11 +15,10 @@ import Halogen (ClassName(..), ComponentHTML)
 import Halogen.HTML (HTML, a, button, code_, div, div_, h4, img, li, pre, pre_, section, small_, text, ul)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Extra (mapComponent)
-import Halogen.HTML.Properties (alt, class_, classes, disabled, enabled, src)
+import Halogen.HTML.Properties (alt, class_, classes, disabled, src)
 import Language.Haskell.Interpreter (CompilationError(..), InterpreterError(..), InterpreterResult(..))
 import Network.RemoteData (RemoteData(..), isLoading, isSuccess)
 import Prelude (const, map, not, show, ($), (<$>), (<<<), (<>), (||))
-import Simulation (isContractValid)
 import StaticData as StaticData
 import Types (ChildSlots, FrontendState, HAction(..), View(..), _compilationResult, _editorPreferences, _haskellEditorSlot, _showBottomPanel)
 
@@ -31,7 +30,7 @@ render ::
 render state =
   [ section [ classes [ panelHeader, aHorizontal ] ]
       [ div [ classes [ panelHeaderMain, aHorizontal, noMargins, accentBorderBottom ] ]
-          [ h4 [] [ text "Marlowe Contract" ] ]
+          [ h4 [] [ text "Haskell Contract" ] ]
       ]
   , section [ classes [ panelSubHeader, aHorizontal ] ]
       [ div [ classes [ panelSubHeaderMain, aHorizontal ] ]
@@ -42,14 +41,6 @@ render state =
               ]
           , ul [ classes [ ClassName "demo-list", aHorizontal ] ]
               (demoScriptLink <$> Array.fromFoldable (Map.keys StaticData.demoFiles))
-          , div [ class_ (ClassName "code-to-blockly-wrap") ]
-              [ button
-                  [ class_ smallBtn
-                  , onClick $ const $ Just $ SetBlocklyCode
-                  , enabled (isContractValid state)
-                  ]
-                  [ img [ class_ (ClassName "blockly-btn-icon"), src blocklyIcon, alt "blockly logo" ] ]
-              ]
           ]
       ]
   , section [ classes (haskellEditor state) ]

--- a/marlowe-playground-client/src/MainFrame.purs
+++ b/marlowe-playground-client/src/MainFrame.purs
@@ -42,7 +42,7 @@ import Halogen.Blockly (BlocklyMessage(..), blockly)
 import Halogen.Classes (aCenter, aHorizontal, btnSecondary, flexCol, hide, iohkIcon, isActiveTab, noMargins, spaceLeft, tabIcon, tabLink, uppercase)
 import Halogen.HTML (ClassName(ClassName), HTML, a, div, h1, header, img, main, nav, p, p_, section, slot, text)
 import Halogen.HTML.Events (onClick)
-import Halogen.HTML.Properties (alt, class_, classes, href, id_, src)
+import Halogen.HTML.Properties (alt, class_, classes, href, id_, src, target)
 import Halogen.Monaco as Monaco
 import Halogen.Query (HalogenM)
 import Halogen.SVG (GradientUnits(..), Translate(..), d, defs, gradientUnits, linearGradient, offset, path, stop, stopColour, svg, transform, x1, x2, y2)
@@ -56,7 +56,7 @@ import Marlowe.Holes (replaceInPositions)
 import Marlowe.Parser (contract, hole, parseTerm)
 import Marlowe.Parser as P
 import Marlowe.Semantics (ChoiceId, Input(..), State(..), inBounds)
-import MonadApp (class MonadApp, applyTransactions, checkContractForWarnings, getGistByGistId, getOauthStatus, haskellEditorGetValue, haskellEditorHandleAction, haskellEditorResize, haskellEditorSetAnnotations, haskellEditorSetValue, marloweEditorGetValue, marloweEditorMoveCursorToPosition, marloweEditorResize, marloweEditorSetMarkers, marloweEditorSetValue, patchGistByGistId, postContractHaskell, postGist, preventDefault, readFileFromDragEvent, resetContract, resizeBlockly, runHalogenApp, saveBuffer, saveInitialState, saveMarloweBuffer, setBlocklyCode, updateContractInState, updateMarloweState)
+import MonadApp (class MonadApp, applyTransactions, checkContractForWarnings, getGistByGistId, getOauthStatus, haskellEditorGetValue, haskellEditorHandleAction, haskellEditorResize, haskellEditorSetAnnotations, haskellEditorSetValue, marloweEditorGetValue, marloweEditorMoveCursorToPosition, marloweEditorResize, marloweEditorSetMarkers, marloweEditorSetValue, patchGistByGistId, postContractHaskell, postGist, preventDefault, readFileFromDragEvent, resetContract, resizeBlockly, runHalogenApp, saveBuffer, saveInitialState, saveMarloweBuffer, scrollHelpPanel, setBlocklyCode, updateContractInState, updateMarloweState)
 import Network.RemoteData (RemoteData(..), _Success)
 import Prelude (class Show, Unit, add, bind, const, discard, mempty, one, pure, show, unit, zero, ($), (-), (<$>), (<<<), (<>), (==))
 import Servant.PureScript.Ajax (errorToString)
@@ -425,10 +425,13 @@ handleAction (InsertHole constructor firstHole holes) = do
 
 handleAction (ChangeSimulationView view) = do
   assign _simulationBottomPanelView view
+  assign _showBottomPanel true
   marloweEditorResize
   haskellEditorResize
 
-handleAction (ChangeHelpContext help) = assign _helpContext help
+handleAction (ChangeHelpContext help) = do
+  assign _helpContext help
+  scrollHelpPanel
 
 handleAction (ShowRightPanel val) = assign _showRightPanel val
 
@@ -590,7 +593,7 @@ render state =
                 , div [] [ text "Blockly" ]
                 ]
             , div [ class_ (ClassName "nav-bottom-links") ]
-                [ a [ href "./tutorial", classes [ btnSecondary, aHorizontal, ClassName "open-link-icon" ] ] [ text "Tutorial" ]
+                [ a [ href "./tutorial", target "_blank", classes [ btnSecondary, aHorizontal, ClassName "open-link-icon" ] ] [ text "Tutorial" ]
                 , p_ [ text "Privacy Policy" ]
                 , p_
                     [ text "by "

--- a/marlowe-playground-client/src/MonadApp.purs
+++ b/marlowe-playground-client/src/MonadApp.purs
@@ -47,7 +47,14 @@ import Servant.PureScript.Ajax (AjaxError)
 import Servant.PureScript.Settings (SPSettings_)
 import StaticData (bufferLocalStorageKey, marloweBufferLocalStorageKey)
 import Types (ActionInput(..), ActionInputId, ChildSlots, FrontendState, HAction, MarloweState, Message(..), WebData, _Head, _blocklySlot, _contract, _currentMarloweState, _editorErrors, _editorWarnings, _haskellEditorSlot, _holes, _marloweEditorSlot, _marloweState, _moneyInContract, _oldContract, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError, _transactionWarnings, actionToActionInput, emptyMarloweState)
+import Web.DOM.Document as D
+import Web.DOM.Element (scrollHeight, setScrollTop)
+import Web.DOM.Element as E
+import Web.DOM.HTMLCollection as WC
+import Web.HTML as Web
 import Web.HTML.Event.DragEvent (DragEvent)
+import Web.HTML.HTMLDocument (toDocument)
+import Web.HTML.Window as W
 import WebSocket (WebSocketRequestMessage(..))
 
 class
@@ -79,6 +86,7 @@ class
   resizeBlockly :: m (Maybe Unit)
   setBlocklyCode :: String -> m Unit
   checkContractForWarnings :: String -> String -> m Unit
+  scrollHelpPanel :: m Unit
 
 newtype HalogenApp m a
   = HalogenApp (HalogenM FrontendState HAction ChildSlots Message m a)
@@ -156,6 +164,17 @@ instance monadAppHalogenApp ::
     let
       msgString = unsafeStringify <<< encode $ CheckForWarnings contract state
     wrap $ raise (WebsocketMessage msgString)
+  scrollHelpPanel =
+    wrap
+      $ liftEffect do
+          window <- Web.window
+          document <- toDocument <$> W.document window
+          mSidePanel <- WC.item 0 =<< D.getElementsByClassName "sidebar-composer" document
+          case mSidePanel of
+            Nothing -> pure unit
+            Just sidePanel -> do
+              scrollHeight <- E.scrollHeight sidePanel
+              setScrollTop scrollHeight sidePanel
 
 -- I don't quite understand why but if you try to use MonadApp methods in HalogenApp methods you
 -- blow the stack so we have 2 methods pulled out here. I think this just ensures they are run

--- a/marlowe-playground-client/src/Simulation.purs
+++ b/marlowe-playground-client/src/Simulation.purs
@@ -34,13 +34,9 @@ import Monaco as Monaco
 import Network.RemoteData (RemoteData(..))
 import Prelude (class Show, bind, const, mempty, show, unit, ($), (/=), (<$>), (<<<), (<>), (>))
 import Servant.PureScript.Ajax (AjaxError)
+import Simulation.BottomPanel (isContractValid)
 import StaticData as StaticData
 import Types (ActionInput(..), ActionInputId, ChildSlots, FrontendState, HAction(..), HelpContext(..), _Head, _authStatus, _contract, _createGistResult, _editorErrors, _editorPreferences, _helpContext, _loadGistResult, _marloweEditorSlot, _marloweState, _pendingInputs, _possibleActions, _showRightPanel, _slot)
-
-isContractValid :: FrontendState -> Boolean
-isContractValid state =
-  view (_marloweState <<< _Head <<< _contract) state /= Nothing
-    && view (_marloweState <<< _Head <<< _editorErrors <<< to Array.null) state
 
 render ::
   forall m.

--- a/marlowe-playground-client/src/Simulation/BottomPanel.purs
+++ b/marlowe-playground-client/src/Simulation/BottomPanel.purs
@@ -7,7 +7,7 @@ import Data.Either (Either(..))
 import Data.Eq (eq, (==))
 import Data.Foldable (foldMap)
 import Data.HeytingAlgebra (not, (||))
-import Data.Lens (to, (^.))
+import Data.Lens (to, view, (^.))
 import Data.List (List, toUnfoldable)
 import Data.List as List
 import Data.Map as Map
@@ -23,9 +23,14 @@ import Marlowe.Parser (transactionInputList, transactionWarningList)
 import Marlowe.Semantics (AccountId(..), Assets(..), ChoiceId(..), Input(..), Payee(..), Payment(..), Slot(..), SlotInterval(..), Token(..), TransactionInput(..), TransactionWarning(..), ValueId(..), _accounts, _boundValues, _choices, maxTime)
 import Marlowe.Symbolic.Types.Response as R
 import Network.RemoteData (RemoteData(..), isLoading)
-import Prelude (bind, const, mempty, pure, show, zero, ($), (<<<), (<>))
+import Prelude (bind, const, mempty, pure, show, zero, ($), (<<<), (<>), (/=), (&&))
 import Text.Parsing.StringParser (runParser)
 import Types (FrontendState, HAction(..), SimulationBottomPanelView(MarloweErrorsView, MarloweWarningsView, StaticAnalysisView, CurrentStateView), View(Simulation), _Head, _analysisState, _contract, _editorErrors, _editorWarnings, _marloweState, _payments, _showBottomPanel, _simulationBottomPanelView, _slot, _state, _transactionError, _transactionWarnings)
+
+isContractValid :: FrontendState -> Boolean
+isContractValid state =
+  (view (_marloweState <<< _Head <<< _contract) state /= Nothing)
+    && (view (_marloweState <<< _Head <<< _editorErrors <<< to Array.null) state)
 
 bottomPanel :: forall p. FrontendState -> HTML p HAction
 bottomPanel state =
@@ -283,8 +288,13 @@ panelContents state StaticAnalysisView =
     [ classes [ ClassName "panel-sub-header", aHorizontal, Classes.panelContents ]
     ]
     [ analysisResultPane state
-    , button [ onClick $ const $ Just $ AnalyseContract, enabled (state ^. _analysisState <<< to isLoading <<< to not) ] [ text "Analyse" ]
+    , button [ onClick $ const $ Just $ AnalyseContract, enabled enabled', classes (if enabled' then [] else [ ClassName "disabled" ]) ]
+        [ text (if loading then "Analysing..." else "Analyse") ]
     ]
+  where
+  loading = state ^. _analysisState <<< to isLoading
+
+  enabled' = not loading && isContractValid state
 
 panelContents state MarloweWarningsView =
   section
@@ -366,7 +376,7 @@ analysisResultPane state =
                   ]
               ]
           ]
-      _ -> text "Analysing..."
+      Loading -> text ""
 
 displayTransactionList :: forall p. String -> HTML p HAction
 displayTransactionList transactionList = case runParser transactionInputList transactionList of

--- a/marlowe-playground-client/test/Marlowe/ContractTests.purs
+++ b/marlowe-playground-client/test/Marlowe/ContractTests.purs
@@ -68,6 +68,7 @@ instance monadAppState :: MonadApp MockApp where
   resizeBlockly = pure Nothing
   setBlocklyCode _ = pure unit
   checkContractForWarnings _ _ = pure unit
+  scrollHelpPanel = pure unit
 
 updateContractInStateImpl :: String -> MockApp Unit
 updateContractInStateImpl contract = modifying _currentMarloweState (updatePossibleActions <<< updateContractInStateP contract)


### PR DESCRIPTION
Splitting this issue in an effort to keep PRs small.

- make bottom panel pop up when you click on one of the tabs
- rename incorrect heading in Haskell panel
- make help dialogue scroll into view when you click on a help ball
- tutorial link should open a new tab

Deployed to https://david.marlowe.iohkdev.io/