### PR TITLE
A few minor improvements to ci.nix

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -3,7 +3,7 @@ let
   systems = {"x86_64-linux" = {}; "x86_64-darwin" = {};};
 in dimension "System" systems (system: _:
   let
-    packageSet = import ./default.nix { inherit system; checkMaterialization = false; };
+    packageSet = import ./default.nix { inherit system; checkMaterialization = true; };
     pkgs = packageSet.pkgs;
     lib = pkgs.lib;
     collectChecks = _: ps: pkgs.recurseIntoAttrs (builtins.mapAttrs (_: p: p.checks) ps);

--- a/ci.nix
+++ b/ci.nix
@@ -1,7 +1,18 @@
+# 'supportedSystems' restricts the set of systems that we will evaluate for. Useful when you're evaluting
+# on a machine with e.g. no way to build the Darwin IFDs you need!
+{ supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
+}:
 let
   inherit (import ./nix/dimension.nix) dimension;
-  systems = {"x86_64-linux" = {}; "x86_64-darwin" = {};};
-in dimension "System" systems (system: _:
+  systems = nixpkgs: nixpkgs.lib.filterAttrs (_: v: builtins.elem v supportedSystems) {
+    # I wanted to take these from 'lib.systems.examples', but apparently there isn't one for linux!
+    linux = "x86_64-linux";
+    darwin = "x86_64-darwin";
+  };
+  sources = import ./nix/sources.nix;
+  # Useful for generic library functions: do not use for anything platform dependent
+  genericPkgs = import sources.nixpkgs {};
+in dimension "System" (systems genericPkgs) (systemName: system:
   let
     packageSet = import ./default.nix { inherit system; checkMaterialization = true; };
     pkgs = packageSet.pkgs;

--- a/default.nix
+++ b/default.nix
@@ -31,8 +31,8 @@ let
 
   iohkNix = import sources.iohk-nix {
     inherit system config;
-    # FIXME: should be 'nixpkgsOverride = sources.nixpkgs', but see https://github.com/input-output-hk/iohk-nix/pull/215
-    nixpkgsJsonOverride = ./nixpkgs.json;
+    # Make iohk-nix use our nixpkgs
+    sourcesOverride = { inherit (sources) nixpkgs; };
   };
 
   pkgsMusl = import ./nix/default.nix {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -56,10 +56,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "b34f11f205afbd11a69cab45d57cd8ebb2746713",
-        "sha256": "14cnfw479gha7ljifai9zchmpsq4652f3q2vvsibslfd6sgnl4js",
+        "rev": "24ddc8f531f320c9e2394d205d0df39857222901",
+        "sha256": "0x6zyh18c96a2kkchfmany475d8rb8qkmg1bd7y8xk6fb2vpad62",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/b34f11f205afbd11a69cab45d57cd8ebb2746713.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/24ddc8f531f320c9e2394d205d0df39857222901.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix-gitignore": {

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -1,7 +1,0 @@
-{
-  "url": "https://github.com/NixOS/nixpkgs",
-  "rev": "6d9a4a615ee2706047c2cec3acc61d2cfbffdb0b",
-  "date": "2019-10-24T03:55:17-04:00",
-  "sha256": "1zgwp31nqh7glh7l2i0n5vic5jv1683l6lvc7r7wdmkbsbkmig1p",
-  "fetchSubmodules": false
-}

--- a/release.nix
+++ b/release.nix
@@ -21,7 +21,7 @@ in
 
 # The revision passed in by Hydra, if there is one
 let rev = if builtins.isNull plutus then null else plutus.rev;
-    ci = import ./ci.nix;
+    ci = import ./ci.nix { inherit supportedSystems; };
 
 in with (import (fixedNixpkgs + "/pkgs/top-level/release-lib.nix") {
   inherit supportedSystems scrubJobs;


### PR DESCRIPTION
- Set `checkMaterialization` there too
- Support `supportedSystems`, which is handy (stole this from the `haskell.nix` `ci.nix` where I implemented it before)