### PR TITLE
Replacing some stock Show instances with `deriving via LedgerBytes` ones.

### DIFF
--- a/plutus-ledger/src/Ledger/Crypto.hs
+++ b/plutus-ledger/src/Ledger/Crypto.hs
@@ -60,21 +60,21 @@ import           Servant.API                (FromHttpApiData (parseUrlPiece), To
 
 -- | A cryptographic public key.
 newtype PubKey = PubKey { getPubKey :: LedgerBytes }
-    deriving stock (Show, Eq, Ord, Generic)
+    deriving stock (Eq, Ord, Generic)
     deriving anyclass ( ToJSON, FromJSON, Newtype, ToJSONKey, FromJSONKey, IotsType)
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
     deriving IsString via LedgerBytes
-    deriving Pretty via LedgerBytes
+    deriving (Show, Pretty) via LedgerBytes
 makeLift ''PubKey
 
 -- | The hash of a public key. This is frequently used to identify the public key, rather than the key itself.
 newtype PubKeyHash = PubKeyHash { getPubKeyHash :: BSL.ByteString }
-    deriving stock (Show, Eq, Ord, Generic)
+    deriving stock (Eq, Ord, Generic)
     deriving anyclass ( ToJSON, FromJSON, Newtype, ToJSONKey, FromJSONKey, IotsType)
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData, Hashable)
     -- TODO: this should be here, but it upsets marlowe a bit. Should be fixed in the future.
     --deriving IsString via LedgerBytes
-    deriving Pretty via LedgerBytes
+    deriving (Show, Pretty) via LedgerBytes
 makeLift ''PubKeyHash
 
 -- | Compute the hash of a public key.
@@ -86,10 +86,10 @@ pubKeyHash pk = PubKeyHash $ BSL.fromStrict $ BA.convert h' where
 
 -- | A cryptographic private key.
 newtype PrivateKey = PrivateKey { getPrivateKey :: LedgerBytes }
-    deriving stock (Show, Eq, Ord, Generic)
+    deriving stock (Eq, Ord, Generic)
     deriving anyclass ( ToJSON, FromJSON, Newtype, ToJSONKey, FromJSONKey)
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
-    deriving Pretty via LedgerBytes
+    deriving (Show, Pretty) via LedgerBytes
 
 makeLift ''PrivateKey
 
@@ -101,10 +101,10 @@ instance FromHttpApiData PrivateKey where
 
 -- | A message with a cryptographic signature.
 newtype Signature = Signature { getSignature :: Builtins.ByteString }
-    deriving stock (Show, Eq, Ord, Generic)
+    deriving stock (Eq, Ord, Generic)
     deriving anyclass (IotsType)
     deriving newtype (P.Eq, P.Ord, Serialise, PlutusTx.IsData)
-    deriving Pretty via LedgerBytes
+    deriving (Show, Pretty) via LedgerBytes
 
 instance ToJSON Signature where
   toJSON signature =

--- a/plutus-ledger/src/Ledger/TxId.hs
+++ b/plutus-ledger/src/Ledger/TxId.hs
@@ -25,7 +25,7 @@ newtype TxId = TxId { getTxId :: BSL.ByteString }
     deriving (Eq, Ord, Generic)
     deriving anyclass (ToJSON, FromJSON, IotsType)
     deriving newtype (PlutusTx.Eq, PlutusTx.Ord, Serialise)
-    deriving (Pretty, Show) via LedgerBytes
+    deriving (Show, Pretty) via LedgerBytes
 
 PlutusTx.makeLift ''TxId
 PlutusTx.makeIsData ''TxId


### PR DESCRIPTION
These types print as a garble of escape codes without it.