### PR TITLE
Remove obsolete Overflow error

### DIFF
--- a/plutus-ir/src/Language/PlutusIR/Parser.hs
+++ b/plutus-ir/src/Language/PlutusIR/Parser.hs
@@ -38,7 +38,6 @@ import           Data.Foldable
 import qualified Data.Map                           as M
 import qualified Data.Text                          as T
 import           Data.Word
-import           GHC.Natural
 
 import qualified Control.Monad.Combinators.NonEmpty as NE
 import           Text.Megaparsec.Char
@@ -50,17 +49,15 @@ import qualified Text.Megaparsec.Char.Lexer         as Lex
 newtype ParserState = ParserState { identifiers :: M.Map T.Text PLC.Unique }
     deriving (Show)
 
-data ParseError = Overflow Natural Integer
-                | UnexpectedKeyword String
+data ParseError = UnexpectedKeyword String
                 | InternalError String
                 deriving (Eq, Ord, Show)
 
 type Error = Parsec.ParseError Char ParseError
 
 instance ShowErrorComponent ParseError where
-    showErrorComponent (Overflow sz i) = "Integer overflow: " ++ show i ++ " does not fit in " ++ show sz ++ " bytes"
     showErrorComponent (UnexpectedKeyword kw) = "Keyword " ++ kw ++ " used as identifier"
-    showErrorComponent (InternalError cause) = "Internal error: " ++ cause
+    showErrorComponent (InternalError cause)  = "Internal error: " ++ cause
 
 initial :: ParserState
 initial = ParserState M.empty


### PR DESCRIPTION
This removes the Overflow error constructor from the PlutusIR parser.  I think that that was left over from when we had sizes (so that the parser could reject things like 321!1), so it's not needed now.  There's a similar thing in PlutusCore which I've removed in a separate PR for the  PLC parser.