### PR TITLE
scb: Make wallet work more like emulator

### DIFF
--- a/plutus-emulator/src/Wallet/API.hs
+++ b/plutus-emulator/src/Wallet/API.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -90,7 +91,11 @@ import           Wallet.Emulator.Error
 import           Prelude                   hiding (Ordering (..))
 
 createPaymentWithChange :: Member WalletEffect effs => Value -> Eff effs (Set.Set TxIn, Maybe TxOut)
-createPaymentWithChange v = updatePaymentWithChange v (Set.empty, Nothing)
+createPaymentWithChange v =
+    let pmt = Payment{paymentInputs=Set.empty, paymentChangeOutput = Nothing} in
+    do
+        Payment{paymentInputs, paymentChangeOutput} <- updatePaymentWithChange v pmt
+        pure (paymentInputs, paymentChangeOutput)
 
 -- | Transfer some funds to a number of script addresses, returning the
 -- transaction that was submitted.

--- a/plutus-emulator/src/Wallet/Effects.hs
+++ b/plutus-emulator/src/Wallet/Effects.hs
@@ -10,6 +10,7 @@ module Wallet.Effects(
     -- * Wallet effect
     , WalletEffect(..)
     , Payment(..)
+    , emptyPayment
     , submitTxn
     , ownPubKey
     , updatePaymentWithChange
@@ -45,6 +46,10 @@ data Payment =
         , paymentChangeOutput :: Maybe TxOut
         } deriving stock (Eq, Show, Generic)
           deriving anyclass (ToJSON, FromJSON)
+
+-- | A payment with zero inputs and no change output
+emptyPayment :: Payment
+emptyPayment = Payment { paymentInputs = Set.empty, paymentChangeOutput = Nothing }
 
 data WalletEffect r where
     SubmitTxn :: Tx -> WalletEffect ()

--- a/plutus-scb/app/Main.hs
+++ b/plutus-scb/app/Main.hs
@@ -227,10 +227,11 @@ reportContractHistoryParser =
 ------------------------------------------------------------
 runCliCommand :: Config -> Command -> App ()
 runCliCommand _ Migrate = App.migrate
-runCliCommand Config {walletServerConfig, nodeServerConfig} MockWallet =
+runCliCommand Config {walletServerConfig, nodeServerConfig, chainIndexConfig} MockWallet =
     WalletServer.main
         walletServerConfig
         (NodeServer.mscBaseUrl nodeServerConfig)
+        (ChainIndex.ciBaseUrl chainIndexConfig)
 runCliCommand Config {nodeServerConfig} MockNode =
     NodeServer.main nodeServerConfig
 runCliCommand config (ForkCommands commands) =

--- a/plutus-scb/src/Cardano/Wallet/API.hs
+++ b/plutus-scb/src/Cardano/Wallet/API.hs
@@ -5,23 +5,16 @@ module Cardano.Wallet.API
     ( API
     ) where
 
-import           Cardano.Wallet.Types   (WalletId)
-import           Ledger                 (Address, PubKey, TxOutRef, Value)
-import           Ledger.AddressMap      (AddressMap)
-import           Servant.API            ((:<|>), (:>), Capture, Get, JSON, NoContent, Post, ReqBody)
-import           Wallet.Emulator.Wallet (Wallet)
+import           Ledger            (PubKey, Value)
+import           Ledger.AddressMap (UtxoMap)
+import           Ledger.Slot       (Slot)
+import           Ledger.Tx         (Tx)
+import           Servant.API       ((:<|>), (:>), Get, JSON, NoContent, Post, ReqBody)
+import           Wallet.Effects    (Payment)
 
--- | Note: This API uses the wholly-fictitious notion of an "active" wallet.
--- This is purely to fit in easily with the 'WalletEffect's 'ownPubKey'
--- call, which assumes there is a single public key we own. This will
--- have to be revisited later.
 type API
-     = "wallets" :> (Get '[ JSON] [Wallet]
-                     :<|> "active" :> "pubkey" :> Get '[ JSON] PubKey
-                     :<|> "watched-addresses" :> Get '[ JSON] AddressMap
-                     :<|> "start-watching" :> ReqBody '[ JSON] Address :> Post '[ JSON] NoContent
-                     :<|> (Capture "walletId" WalletId :> ("coin-selections" :> "random" :> ReqBody '[ JSON] Value :> Get '[ JSON] ( [( TxOutRef
-                                                                                                                                      , Value)]
-                                                                                                                                   , Value)
-                                                           :<|> "addresses" :> "new" :> Post '[ JSON] PubKey)
-                           :<|> "value-at" :> ReqBody '[ JSON] Address :> Get '[ JSON] Value))
+    = "submit-txn" :> ReqBody '[JSON] Tx :> Post '[JSON] NoContent
+      :<|> "own-public-key" :> Get '[JSON] PubKey
+      :<|> "update-payment-with-change" :> ReqBody '[JSON] (Value, Payment) :> Post '[JSON] Payment
+      :<|> "wallet-slot" :> Get '[JSON] Slot
+      :<|> "own-outputs" :> Get '[JSON] UtxoMap

--- a/plutus-scb/src/Cardano/Wallet/Client.hs
+++ b/plutus-scb/src/Cardano/Wallet/Client.hs
@@ -10,59 +10,41 @@
 module Cardano.Wallet.Client where
 
 import           Cardano.Wallet.API        (API)
-import           Cardano.Wallet.Types      (WalletId)
-import           Control.Lens
+import           Control.Monad             (void)
 import           Control.Monad.Freer
 import           Control.Monad.Freer.Error (Error, throwError)
 import           Control.Monad.IO.Class    (MonadIO (..))
 import           Data.Proxy                (Proxy (Proxy))
-import           Ledger                    (Address, PubKey, TxOutRef, Value, pubKeyAddress)
-import           Ledger.AddressMap         (AddressMap, UtxoMap, fundsAt)
-import           Servant                   (NoContent)
+import           Ledger                    (PubKey, Value)
+import           Ledger.AddressMap         (UtxoMap)
+import           Ledger.Slot               (Slot)
+import           Ledger.Tx                 (Tx)
+import           Servant                   ((:<|>) (..))
 import           Servant.Client            (ClientEnv, ClientError, ClientM, client, runClientM)
-import           Servant.Extra             (left, right)
-import           Wallet.API                (WalletAPIError)
-import           Wallet.Effects            (NodeClientEffect, WalletEffect (..), getClientSlot, publishTx)
-import           Wallet.Emulator.Wallet    (Payment (..), PaymentArgs (..), Wallet, handleUpdatePaymentWithChange)
+import           Wallet.Effects            (Payment (..), WalletEffect (..))
 
-selectCoins :: WalletId -> Value -> ClientM ([(TxOutRef, Value)], Value)
-allocateAddress :: WalletId -> ClientM PubKey
-getWatchedAddresses :: ClientM AddressMap
-getWallets :: ClientM [Wallet]
-getOwnPubKey :: ClientM PubKey
-startWatching :: Address -> ClientM NoContent
-valueAt :: Address -> ClientM Value
-(getWallets, getOwnPubKey, getWatchedAddresses, startWatching, selectCoins, allocateAddress, valueAt) =
-    ( getWallets_
-    , getOwnPubKey_
-    , getWatchedAddresses_
-    , startWatching_
-    , selectCoins_
-    , allocateAddress_
-    , valueAt_)
+submitTxn :: Tx -> ClientM ()
+ownPublicKey :: ClientM PubKey
+updatePaymentWithChange :: (Value, Payment) -> ClientM Payment
+walletSlot :: ClientM Slot
+ownOutputs :: ClientM UtxoMap
+(submitTxn, ownPublicKey, updatePaymentWithChange, walletSlot, ownOutputs) =
+  ( fmap void submitTxn_
+  , ownPublicKey_
+  , updatePaymentWithChange_
+  , walletSlot_
+  , ownOutputs_)
   where
-    api = client (Proxy @API)
-    getWallets_ = api & left
-    getOwnPubKey_ = api & right & left
-    getWatchedAddresses_ = api & right & right & left
-    startWatching_ = api & right & right & right & left
-    byWalletId = api & right & right & right & right & left
-    selectCoins_ walletId = byWalletId walletId & left
-    allocateAddress_ walletId = byWalletId walletId & right
-    valueAt_ = api & right & right & right & right & right
-
-getOwnOutputs :: ClientM UtxoMap
-getOwnOutputs = do
-    pk <- getOwnPubKey
-    am <- getWatchedAddresses
-    pure $ am ^. fundsAt (pubKeyAddress pk)
+    ( submitTxn_
+      :<|> ownPublicKey_
+      :<|> updatePaymentWithChange_
+      :<|> walletSlot_
+      :<|> ownOutputs_) = client (Proxy @API)
 
 handleWalletClient ::
   forall m effs.
   ( LastMember m effs
   , MonadIO m
-  , Member NodeClientEffect effs
-  , Member (Error WalletAPIError) effs
   , Member (Error ClientError) effs
   )
   => ClientEnv
@@ -74,22 +56,8 @@ handleWalletClient clientEnv =
         runClient a = (sendM $ liftIO $ runClientM a clientEnv) >>= either throwError pure
     in
       interpret $ \case
-        SubmitTxn t -> publishTx t
-        OwnPubKey -> runClient getOwnPubKey
-        UpdatePaymentWithChange vl (oldIns, changeOut) -> do
-            utxo <- runClient getWatchedAddresses
-            pubK <- runClient getOwnPubKey
-            let ownAddress = pubKeyAddress pubK
-                args   = PaymentArgs
-                            { availableFunds = utxo ^. fundsAt ownAddress
-                            , ownPubKey = pubK
-                            , requestedValue = vl
-                            }
-                pmt    = Payment{paymentInputs = oldIns, paymentChangeOutput = changeOut}
-            Payment{paymentInputs, paymentChangeOutput} <- handleUpdatePaymentWithChange args pmt
-            pure (paymentInputs, paymentChangeOutput)
-        WalletSlot -> getClientSlot
-        OwnOutputs -> do
-            pubK <- runClient getOwnPubKey
-            let ownAddress = pubKeyAddress pubK
-            view (at ownAddress . non mempty) <$> runClient getWatchedAddresses
+        SubmitTxn t -> runClient (submitTxn t)
+        OwnPubKey -> runClient ownPublicKey
+        UpdatePaymentWithChange vl pmt -> runClient $ updatePaymentWithChange (vl, pmt)
+        WalletSlot -> runClient walletSlot
+        OwnOutputs -> runClient ownOutputs

--- a/plutus-scb/src/Cardano/Wallet/Mock.hs
+++ b/plutus-scb/src/Cardano/Wallet/Mock.hs
@@ -1,90 +1,40 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE GADTs             #-}
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE MonoLocalBinds    #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
-{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE TypeOperators     #-}
 
 module Cardano.Wallet.Mock where
 
-import           Cardano.Node.Follower           (NodeFollowerEffect, getBlocks, newFollower)
-import           Cardano.Node.Types              (FollowerID)
-import           Cardano.Wallet.Types            (WalletId)
-import           Control.Lens                    (at, ix, makeLenses, non, to, view, (^.))
+import           Cardano.Wallet.Types           (WalletId)
+import           Control.Lens                   (view)
 import           Control.Monad.Freer
-import           Control.Monad.Freer.Error       (Error, runError, throwError)
-import           Control.Monad.Freer.Extra.Log   (Log, logDebug, logInfo)
-import           Control.Monad.Freer.Extra.State (assign, modifying, use)
-import           Control.Monad.Freer.State       (State, gets)
-import           Control.Monad.IO.Class          (MonadIO, liftIO)
-import           Data.Bifunctor                  (Bifunctor (..))
-import qualified Data.ByteString.Lazy            as BSL
-import qualified Data.ByteString.Lazy.Char8      as BSL8
-import qualified Data.Map                        as Map
-import           Data.Text.Encoding              (encodeUtf8)
-import           Language.Plutus.Contract.Trace  (allWallets)
-import           Ledger                          (Address, PubKey, TxOut (..), TxOutRef, TxOutTx (..), Value,
-                                                  pubKeyAddress)
-import           Ledger.AddressMap               (AddressMap, UtxoMap, addAddress)
-import qualified Ledger.AddressMap               as AddressMap
-import           Plutus.SCB.Arbitrary            ()
-import           Plutus.SCB.Utils                (tshow)
-import           Servant                         (NoContent (NoContent), ServerError, err401, err404, err500, errBody)
-import           Test.QuickCheck                 (arbitrary, generate)
-import           Wallet.API                      (WalletAPIError (InsufficientFunds, OtherError, PrivateKeyNotFound))
-import           Wallet.Effects                  (NodeClientEffect, WalletEffect (..))
-import qualified Wallet.Effects                  as W
-import           Wallet.Emulator.Wallet          (Payment (..), PaymentArgs (..), Wallet (Wallet))
-import qualified Wallet.Emulator.Wallet          as EM
+import           Control.Monad.Freer.Error      (Error, runError, throwError)
+import           Control.Monad.Freer.Extra.Log  (Log, logInfo)
+import           Control.Monad.IO.Class         (MonadIO, liftIO)
+import           Data.Bifunctor                 (Bifunctor (..))
+import qualified Data.ByteString.Lazy           as BSL
+import qualified Data.ByteString.Lazy.Char8     as BSL8
+import qualified Data.Map                       as Map
+import           Data.Text.Encoding             (encodeUtf8)
+import           Language.Plutus.Contract.Trace (allWallets)
+import           Ledger                         (Address, PubKey, TxOut (..), TxOutRef, TxOutTx (..), Value)
+import           Ledger.AddressMap              (UtxoMap)
+import qualified Ledger.AddressMap              as AddressMap
+import           Plutus.SCB.Arbitrary           ()
+import           Plutus.SCB.Utils               (tshow)
+import           Servant                        (ServerError, err401, err404, err500, errBody)
+import           Test.QuickCheck                (arbitrary, generate)
+import           Wallet.API                     (WalletAPIError (InsufficientFunds, OtherError, PrivateKeyNotFound))
+import           Wallet.Effects                 (ChainIndexEffect)
+import qualified Wallet.Effects                 as W
+import           Wallet.Emulator.Wallet         (Wallet (Wallet), WalletState (..))
+import qualified Wallet.Emulator.Wallet         as EM
 
-data MockWalletState =
-    MockWalletState
-        { _watchedAddresses :: AddressMap
-        , _followerID       :: Maybe FollowerID
-        }
-    deriving (Show, Eq)
-
-makeLenses 'MockWalletState
-
-handleWallet :: -- TODO: Merge with 'Wallet.Emulator.handleWallet'
-                --       (the 'MockWalletState' and 'WalletState' types are
-                --        different)
-    ( Member (State MockWalletState) effs
-    , Member NodeClientEffect effs
-    , Member (Error WalletAPIError) effs
-    )
-    => Eff (WalletEffect ': effs) ~> Eff effs
-handleWallet = interpret $ \case
-    SubmitTxn tx -> W.publishTx tx
-    OwnPubKey -> return (EM.walletPubKey activeWallet)
-    UpdatePaymentWithChange vl (oldIns, changeOut) -> do
-        utxo <- gets (view watchedAddresses)
-        let pubK = EM.walletPubKey activeWallet
-            args   = PaymentArgs
-                        { availableFunds = utxo ^. AddressMap.fundsAt (pubKeyAddress pubK)
-                        , ownPubKey = pubK
-                        , requestedValue = vl
-                        }
-            pmt    = Payment{paymentInputs = oldIns, paymentChangeOutput = changeOut}
-        Payment{paymentInputs, paymentChangeOutput} <- EM.handleUpdatePaymentWithChange args pmt
-        pure (paymentInputs, paymentChangeOutput)
-    WalletSlot -> W.getClientSlot
-    OwnOutputs ->
-        let address = pubKeyAddress (EM.walletPubKey activeWallet) in
-        view (at address . non mempty) <$> gets (view watchedAddresses)
-
--- TODO Should this call syncstate itself?
-initialState :: MockWalletState
-initialState =
-    MockWalletState
-        { _watchedAddresses =
-              foldr (addAddress . EM.walletAddress) mempty allWallets
-        , _followerID = Nothing
-        }
+initialState :: WalletState
+initialState = WalletState (EM.walletPrivKey activeWallet)
 
 wallets :: (Member Log effs) => Eff effs [Wallet]
 wallets = do
@@ -101,19 +51,19 @@ fromWalletAPIError (OtherError text) =
 
 valueAt ::
     ( Member Log effs
-    , Member (State MockWalletState) effs
+    , Member ChainIndexEffect effs
     )
     => Address
     -> Eff effs Value
 valueAt address = do
     logInfo "valueAt"
-    value <- use (watchedAddresses . to AddressMap.values . ix address)
+    value <- foldMap (txOutValue . txOutTxOut) . view (AddressMap.fundsAt address) <$> W.watchedAddresses
     logInfo $ "valueAt " <> tshow address <> ": " <> tshow value
     pure value
 
 selectCoin ::
     ( Member Log effs
-    , Member (State MockWalletState) effs
+    , Member ChainIndexEffect effs
     , Member (Error ServerError) effs
     )
     => WalletId
@@ -124,7 +74,7 @@ selectCoin walletId target = do
     logInfo $ "  Wallet ID: " <> tshow walletId
     logInfo $ "     Target: " <> tshow target
     let address = EM.walletAddress (Wallet walletId)
-    utxos :: UtxoMap <- use (watchedAddresses . AddressMap.fundsAt address)
+    utxos :: UtxoMap <- view (AddressMap.fundsAt address) <$> W.watchedAddresses
     let funds :: [(TxOutRef, Value)]
         funds = fmap (second (txOutValue . txOutTxOut)) . Map.toList $ utxos
     result <- runM $ runError $ EM.selectCoin funds target
@@ -144,63 +94,5 @@ allocateAddress _ = do
     logInfo "allocateAddress"
     sendM $ liftIO $ generate arbitrary
 
-getOwnPubKey :: Member Log effs => Eff effs PubKey
-getOwnPubKey = do
-    logInfo "getOwnPubKey"
-    pure $ EM.walletPubKey activeWallet
-
 activeWallet :: Wallet
 activeWallet = Wallet 1
-
-getWatchedAddresses ::
-    ( Member Log effs
-    , Member (State MockWalletState) effs
-    )
-    => Eff effs AddressMap
-getWatchedAddresses = do
-    logInfo "getWatchedAddresses"
-    use watchedAddresses
-
-startWatching ::
-    ( Member Log effs
-    , Member (State MockWalletState) effs
-    )
-    => Address
-    -> Eff effs NoContent
-startWatching address = do
-    logInfo "startWatching"
-    modifying watchedAddresses (addAddress address)
-    pure NoContent
-
-------------------------------------------------------------
--- | Synchronise the initial state.
-syncState ::
-    ( Member Log effs
-    , Member NodeFollowerEffect effs
-    , Member (State MockWalletState) effs
-    )
-    => Eff effs ()
-syncState = do
-    logDebug "Synchronizing"
-    fID <- getFollowerID
-    blockchain <- getBlocks fID
-    logDebug $ tshow fID <> " got " <> tshow (length blockchain) <> " blocks."
-    modifying
-        watchedAddresses
-        (\m -> foldl (foldl (flip AddressMap.updateAllAddresses)) m blockchain)
-    logDebug "Synchronized"
-
-getFollowerID ::
-    ( Member Log effs
-    , Member NodeFollowerEffect effs
-    , Member (State MockWalletState) effs
-    )
-    => Eff effs FollowerID
-getFollowerID =
-    use followerID >>= \case
-        Just fID -> pure fID
-        Nothing -> do
-            logDebug "Subscribing"
-            fID <- newFollower
-            assign followerID (Just fID)
-            pure fID


### PR DESCRIPTION
* There were two different handlers of the `WalletEffect` type
  1. `Wallet.Emulator.Wallet.handleWallet`  delegates most of the work to the chain index & node client, using only the wallet's own private key as its state
  2. `Cardano.Wallet.Mock.handleWallet` does not require a chain index but instead keeps its own internal index of the unspent outputs that it cares about.
* Both are valid behaviors, but (1) is simpler because it re-uses the chain index instead of implementing some of the index functionality on its own, so I decided to use `Wallet.Emulator.Wallet.handleWallet` in the SCB, instead of moving the SCB version to the emulator and using it.
* I also changed `Cardano.Wallet.API.API` to mirror the `WalletEffect` methods, just like it is done for the HTTP APIs of the other components in the SCB. In the old version, some of the routes were grouped under a `/${walletID}` URL piece, similar to the `MultiAgent` effect in the emulator. But I think in general we want to have 1 instance of each component per agent in the SCB, instead of emulating different agents in the same component. (The wallet ID parameter wasn't used anyway)