### PR TITLE
Improve github controls

### DIFF
--- a/marlowe-playground-client/src/MainFrame.purs
+++ b/marlowe-playground-client/src/MainFrame.purs
@@ -510,8 +510,12 @@ handleGistAction PublishGist =
         assign _createGistResult newResult
         gistId <- hoistMaybe $ preview (_Success <<< gistId <<< _GistId) newResult
         assign _gistUrl (Just gistId)
+        assign _loadGistResult $ Right NotAsked
 
-handleGistAction (SetGistUrl newGistUrl) = assign _gistUrl (Just newGistUrl)
+handleGistAction (SetGistUrl newGistUrl) = do
+  assign _createGistResult NotAsked
+  assign _loadGistResult $ Right NotAsked
+  assign _gistUrl (Just newGistUrl)
 
 handleGistAction LoadGist = do
   res <-

--- a/marlowe-playground-client/src/Simulation.purs
+++ b/marlowe-playground-client/src/Simulation.purs
@@ -38,7 +38,7 @@ import Prelude (class Show, bind, bottom, const, discard, eq, mempty, show, unit
 import Servant.PureScript.Ajax (AjaxError)
 import Simulation.BottomPanel (isContractValid)
 import StaticData as StaticData
-import Types (ActionInput(..), ActionInputId, ChildSlots, FrontendState, HAction(..), HelpContext(..), _Head, _activeMarloweDemo, _authStatus, _createGistResult, _helpContext, _loadGistResult, _marloweEditorKeybindings, _marloweEditorSlot, _marloweState, _pendingInputs, _possibleActions, _showRightPanel, _slot)
+import Types (ActionInput(..), ActionInputId, ChildSlots, FrontendState, HAction(..), HelpContext(..), _Head, _activeMarloweDemo, _authStatus, _createGistResult, _gistUrl, _helpContext, _loadGistResult, _marloweEditorKeybindings, _marloweEditorSlot, _marloweState, _pendingInputs, _possibleActions, _showRightPanel, _slot)
 
 render ::
   forall m.
@@ -74,7 +74,7 @@ render state =
                   ]
               ]
           ]
-      , div [ classes [ panelSubHeaderSide ] ] [ authButton state ]
+      , div [ classes [ panelSubHeaderSide, expanded (state ^. _showRightPanel) ] ] [ authButton state ]
       ]
   , section [ class_ (ClassName "code-panel") ]
       [ div [ classes (codeEditor state) ]
@@ -452,7 +452,7 @@ authButton state =
           , classes [ ClassName "auth-button" ]
           , href "/api/oauth/github"
           ]
-          [ text "Save to github"
+          [ text "Save to GitHub"
           ]
       Success GithubUser -> gist state
       Loading ->
@@ -470,54 +470,102 @@ authButton state =
           ]
           [ icon Spinner ]
 
-loadGistButton :: forall p. Either String (RemoteData AjaxError Gist) -> HTML p HAction
-loadGistButton (Left e) =
-  svg [ clazz (ClassName "error-icon"), SVG.width (Px 20), height (Px 20), viewBox (Box { x: 0, y: 0, width: 24, height: 24 }) ]
-    [ path [ fill (Hex "#ff0000"), d "M13,13H11V7H13M12,17.3A1.3,1.3 0 0,1 10.7,16A1.3,1.3 0 0,1 12,14.7A1.3,1.3 0 0,1 13.3,16A1.3,1.3 0 0,1 12,17.3M15.73,3H8.27L3,8.27V15.73L8.27,21H15.73L21,15.73V8.27L15.73,3Z" ] [] ]
-
-loadGistButton (Right (Failure _)) =
-  svg [ clazz (ClassName "error-icon"), SVG.width (Px 20), height (Px 20), viewBox (Box { x: 0, y: 0, width: 24, height: 24 }) ]
-    [ path [ fill (Hex "#ff0000"), d "M13,13H11V7H13M12,17.3A1.3,1.3 0 0,1 10.7,16A1.3,1.3 0 0,1 12,14.7A1.3,1.3 0 0,1 13.3,16A1.3,1.3 0 0,1 12,17.3M15.73,3H8.27L3,8.27V15.73L8.27,21H15.73L21,15.73V8.27L15.73,3Z" ] [] ]
-
-loadGistButton (Right (Success _)) =
-  svg [ clazz (ClassName "arrow-down"), SVG.width (Px 20), height (Px 20), viewBox (Box { x: 0, y: 0, width: 24, height: 24 }) ]
-    [ path [ fill (Hex "#832dc4"), d "M19.92,12.08L12,20L4.08,12.08L5.5,10.67L11,16.17V2H13V16.17L18.5,10.66L19.92,12.08M12,20H2V22H22V20H12Z" ] [] ]
-
-loadGistButton (Right Loading) =
+spinner :: forall p. HTML p HAction
+spinner =
   svg [ clazz (ClassName "spinner"), SVG.width (Px 65), height (Px 65), viewBox (Box { x: 0, y: 0, width: 66, height: 66 }) ]
     [ circle [ clazz (ClassName "path"), fill SVG.None, strokeWidth 6, strokeLinecap Round, cx (Length 33.0), cy (Length 33.0), r (Length 30.0) ] [] ]
 
-loadGistButton (Right NotAsked) =
+arrowDown :: forall p. HTML p HAction
+arrowDown =
   svg [ clazz (ClassName "arrow-down"), SVG.width (Px 20), height (Px 20), viewBox (Box { x: 0, y: 0, width: 24, height: 24 }) ]
     [ path [ fill (Hex "#832dc4"), d "M19.92,12.08L12,20L4.08,12.08L5.5,10.67L11,16.17V2H13V16.17L18.5,10.66L19.92,12.08M12,20H2V22H22V20H12Z" ] [] ]
 
-gistInput :: forall p. Either String (RemoteData AjaxError Gist) -> HTML p HAction
-gistInput (Left _) = input [ HTML.type_ InputText, classes [ ClassName "form-control", ClassName "py-0", ClassName "error" ], HTML.id_ "github-input", placeholder "Gist ID", onValueInput $ Just <<< GistAction <<< SetGistUrl ]
+arrowUp :: forall p. HTML p HAction
+arrowUp =
+  svg [ clazz (ClassName "arrow-up"), SVG.width (Px 20), height (Px 20), viewBox (Box { x: 0, y: 0, width: 24, height: 24 }) ]
+    [ path [ fill (Hex "#832dc4"), d "M4.08,11.92L12,4L19.92,11.92L18.5,13.33L13,7.83V22H11V7.83L5.5,13.33L4.08,11.92M12,4H22V2H2V4H12Z" ] [] ]
 
-gistInput (Right (Failure _)) = input [ HTML.type_ InputText, classes [ ClassName "form-control", ClassName "py-0", ClassName "error" ], HTML.id_ "github-input", placeholder "Gist ID", onValueInput $ Just <<< GistAction <<< SetGistUrl ]
+errorIcon :: forall p. HTML p HAction
+errorIcon =
+  svg [ clazz (ClassName "error-icon"), SVG.width (Px 20), height (Px 20), viewBox (Box { x: 0, y: 0, width: 24, height: 24 }) ]
+    [ path [ fill (Hex "#ff0000"), d "M13,13H11V7H13M12,17.3A1.3,1.3 0 0,1 10.7,16A1.3,1.3 0 0,1 12,14.7A1.3,1.3 0 0,1 13.3,16A1.3,1.3 0 0,1 12,17.3M15.73,3H8.27L3,8.27V15.73L8.27,21H15.73L21,15.73V8.27L15.73,3Z" ] [] ]
 
-gistInput _ = input [ HTML.type_ InputText, classes [ ClassName "form-control", ClassName "py-0" ], HTML.id_ "github-input", placeholder "Gist ID", onValueInput $ Just <<< GistAction <<< SetGistUrl ]
+gistButtonIcon :: forall p. HTML p HAction -> Either String (RemoteData AjaxError Gist) -> HTML p HAction
+gistButtonIcon _ (Left _) = errorIcon
+
+gistButtonIcon _ (Right (Failure _)) = errorIcon
+
+gistButtonIcon arrow (Right (Success _)) = arrow
+
+gistButtonIcon _ (Right Loading) = spinner
+
+gistButtonIcon arrow (Right NotAsked) = arrow
+
+gistInput :: forall p. FrontendState -> Either String (RemoteData AjaxError Gist) -> HTML p HAction
+gistInput state (Left _) =
+  input
+    [ HTML.type_ InputText
+    , classes [ ClassName "form-control", ClassName "py-0", ClassName "error" ]
+    , HTML.id_ "github-input"
+    , placeholder "Gist ID"
+    , value (state ^. _gistUrl <<< to (fromMaybe ""))
+    , onValueInput $ Just <<< GistAction <<< SetGistUrl
+    ]
+
+gistInput state (Right (Failure _)) =
+  input
+    [ HTML.type_ InputText
+    , classes [ ClassName "form-control", ClassName "py-0", ClassName "error" ]
+    , HTML.id_ "github-input"
+    , placeholder "Gist ID"
+    , value (state ^. _gistUrl <<< to (fromMaybe ""))
+    , onValueInput $ Just <<< GistAction <<< SetGistUrl
+    ]
+
+gistInput state _ =
+  input
+    [ HTML.type_ InputText
+    , classes [ ClassName "form-control", ClassName "py-0" ]
+    , HTML.id_ "github-input"
+    , placeholder "Gist ID"
+    , value (state ^. _gistUrl <<< to (fromMaybe ""))
+    , onValueInput $ Just <<< GistAction <<< SetGistUrl
+    ]
 
 gist :: forall p. FrontendState -> HTML p HAction
 gist state =
   div [ classes [ ClassName "github-gist-panel", aHorizontal ] ]
     [ div [ classes [ ClassName "input-group-text", ClassName "upload-btn", ClassName "tooltip" ], onClick $ const $ Just $ GistAction PublishGist ]
-        [ span [ class_ (ClassName "tooltiptext") ] [ text "Publish To Github Gist" ]
-        , svg [ SVG.style "width:20px;height:20px", SVG.viewBox (Box { x: 0, y: 0, width: 24, height: 24 }) ]
-            [ path [ fill (Hex "#832dc4"), d "M4.08,11.92L12,4L19.92,11.92L18.5,13.33L13,7.83V22H11V7.83L5.5,13.33L4.08,11.92M12,4H22V2H2V4H12Z" ] [] ]
+        [ span [ class_ (ClassName "tooltiptext") ] [ publishTooltip publishStatus ]
+        , gistButtonIcon arrowUp publishStatus
         ]
     , label [ classes [ ClassName "sr-only", active ], HTML.for "github-input" ] [ text "Enter Github Gist" ]
     , div [ classes (map ClassName [ "input-group", "mb-2", "mr-sm-2" ]) ]
-        [ gistInput loadStatus
+        [ gistInput state loadStatus
         , div [ class_ (ClassName "input-group-append") ]
-            [ div [ classes [ ClassName "input-group-text", ClassName "download-btn", ClassName "tooltip" ], onClick $ const $ Just $ GistAction LoadGist ]
-                [ span [ class_ (ClassName "tooltiptext") ] [ text "Load From Github Gist" ]
-                , loadGistButton loadStatus
+            [ div
+                [ classes [ ClassName "input-group-text", ClassName "download-btn", ClassName "tooltip" ]
+                , onClick $ const $ Just $ GistAction LoadGist
+                ]
+                [ span [ class_ (ClassName "tooltiptext") ] [ loadTooltip loadStatus ]
+                , gistButtonIcon arrowDown loadStatus
                 ]
             ]
         ]
     ]
   where
-  publishStatus = state ^. _createGistResult
+  publishStatus = state ^. _createGistResult <<< to Right
 
   loadStatus = state ^. _loadGistResult
+
+  publishTooltip (Left _) = text "Failed to publish gist"
+
+  publishTooltip (Right (Failure _)) = text "Failed to publish gist"
+
+  publishTooltip _ = text "Publish To Github Gist"
+
+  loadTooltip (Left _) = text "Failed to load gist"
+
+  loadTooltip (Right (Failure _)) = text "Failed to load gist"
+
+  loadTooltip _ = text "Load From Github Gist"

--- a/marlowe-playground-client/static/css/github-input.css
+++ b/marlowe-playground-client/static/css/github-input.css
@@ -84,7 +84,24 @@
 }
 
 .upload-btn {
-  margin-right: 1rem;
+  margin-right: 0.5rem;
+  min-height: 31px;
+  min-width: 46px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.download-btn {
+  height: 32px;
+  min-width: 46px;
+}
+
+#github-input {
+  font-size: small;
+  width: 100%;
+  height: 32px;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .spinner {

--- a/marlowe-playground-client/static/css/main.scss
+++ b/marlowe-playground-client/static/css/main.scss
@@ -114,8 +114,8 @@ a:hover {
 }
 
 .upload-btn>.tooltiptext {
-    left: 0;
-    top: 40px;
+    left: 70%;
+    top: 50px;
 }
 
 .upload-btn>.tooltiptext::after {
@@ -123,7 +123,7 @@ a:hover {
 }
 
 .download-btn>.tooltiptext {
-    left: 65px;
+    right: 0px;
     top: 112%;
 }
 

--- a/marlowe-playground-client/static/css/panel-mobile.css
+++ b/marlowe-playground-client/static/css/panel-mobile.css
@@ -1,4 +1,4 @@
-@media (max-width:1024px) {
+@media (max-width:1200px) {
 
   .drawer-icon {
     display: block;
@@ -40,10 +40,25 @@
     transition: transform .3s ease-in-out;
   }
 
+  .panel-sub-header .panel-sub-header-side.expanded {
+    width: 500px;
+  }
+
   .panel-sub-header .panel-sub-header-side {
     position: absolute;
-    width: 0;
-    padding: 0;
+    top: 0;
+    right: 0;
+    width: 200px;
+    padding-left: 2.5rem;
+    background: var(--bg-light);
+    box-shadow: var(--box-shadow-left);
+    z-index: 1;
+    transform: translateX(95%);
+    transition: transform .3s ease-in-out;
+  }
+
+  .github-gist-panel {
+    width: 29rem;
   }
 
   .panel-header .panel-header-side.expanded,

--- a/marlowe-playground-client/static/css/panels.css
+++ b/marlowe-playground-client/static/css/panels.css
@@ -128,7 +128,7 @@
 .panel-header-side,
 .panel-sub-header-side {
   padding-left: 20px;
-  padding-top: 10px;
+  padding-top: 12px;
 }
 
 .sidebar-composer {


### PR DESCRIPTION
Deployed to https://david.marlowe.iohkdev.io/

* controls are now a bit smaller so whole gist id fits in
* loading/publishing controls have improved icons, they don't resize etc
* tooltip contains errors
* after an error, when you start typing in the input box the errors are removed
* controls now get hidden with the side panel on smaller screens
* made the side panel hide on a wider screen, it was unusable between 1025px and 1200px

## smaller content
<img width="542" alt="gist1" src="https://user-images.githubusercontent.com/934267/79383536-b97d0e00-7f3b-11ea-92c5-e8fe89173f09.png">

## hidden when the screen is narrow
<img width="386" alt="gist3" src="https://user-images.githubusercontent.com/934267/79383545-bbdf6800-7f3b-11ea-9229-c7c7563bfdbe.png">

## expands with the side panel
<img width="627" alt="gist2" src="https://user-images.githubusercontent.com/934267/79383542-bb46d180-7f3b-11ea-96f3-56d3e9536671.png">
