### PR TITLE
Use default values instead of holes for strings and numbers

### DIFF
--- a/marlowe-playground-client/grammar.ne
+++ b/marlowe-playground-client/grammar.ne
@@ -81,20 +81,22 @@ rsquare ->  manyWS %rsquare
 hole -> %hole {% ([hole]) => opts.mkHole(hole.value.substring(1))({row: hole.line, column: hole.col}) %}
 
 number
-   -> hole {% ([hole]) => hole %}
-    | %number {% ([n]) => opts.mkTerm(opts.mkBigInteger(n.value))({row: n.line, column: n.col}) %}
-    | lparen %number rparen {% ([,n,]) => opts.mkTerm(opts.mkBigInteger(n.value))({row: n.line, column: n.col}) %}
+   -> %number {% ([n]) => opts.mkBigInteger(n.value) %}
+    | lparen %number rparen {% ([,n,]) => opts.mkBigInteger(n.value) %}
+
+timeout
+   -> %number {% ([n]) => opts.mkTimeout(n.value)({row: n.line, column: n.col}) %}
+    | lparen %number rparen {% ([,n,]) => opts.mkTimeout(n.value)({row: n.line, column: n.col}) %}
 
 string
-   -> hole {% ([hole]) => hole %}
-    | %string {% ([s]) => opts.mkTerm(s.value)({row: s.line, column: s.col}) %}
+   -> %string {% ([s]) => s.value %}
 
 topContract
    -> hole {% ([hole]) => hole %}
     | "Close" {% ([{line, col}]) => opts.mkTerm(opts.mkClose)({row: line, column: col}) %}
     | "Pay" someWS accountId someWS payee someWS token someWS value someWS contract {% ([{line, col},,accountId,,payee,,token,,value,,contract]) => opts.mkTerm(opts.mkPay(accountId)(payee)(token)(value)(contract))({row: line, column: col}) %}
     | "If" someWS observation someWS contract someWS contract {% ([{line, col},,observation,,contract1,,contract2]) => opts.mkTerm(opts.mkIf(observation)(contract1)(contract2))({row: line, column: col}) %}
-    | "When" someWS lsquare cases:* rsquare someWS number someWS contract {% ([{line, col},,,cases,,,timeout,,contract]) => opts.mkTerm(opts.mkWhen(cases)(timeout)(contract))({row: line, column: col}) %}
+    | "When" someWS lsquare cases:* rsquare someWS timeout someWS contract {% ([{line, col},,,cases,,,timeout,,contract]) => opts.mkTerm(opts.mkWhen(cases)(timeout)(contract))({row: line, column: col}) %}
     | "Let" someWS valueId someWS value someWS contract {% ([{line, col},,valueId,,value,,contract]) => opts.mkTerm(opts.mkLet(valueId)(value)(contract))({row: line, column: col}) %}
 
 cases

--- a/marlowe-playground-client/grammar.ne
+++ b/marlowe-playground-client/grammar.ne
@@ -137,8 +137,7 @@ choiceId
 
 # FIXME: There is a difference between the Haskell pretty printer and the purescript parser
 valueId
-   -> hole {% ([hole]) => hole %}
-    | %string {% ([{value,line,col}]) => opts.mkTerm(opts.mkValueId(value))({row: line, column: col}) %}
+   -> %string {% ([{value,line,col}]) => opts.mkTermWrapper(opts.mkValueId(value))({row: line, column: col}) %}
 # valueId -> lparen %VALUE_ID someWS string rparen
 
 accountId

--- a/marlowe-playground-client/src/Help.purs
+++ b/marlowe-playground-client/src/Help.purs
@@ -38,27 +38,6 @@ holeText marloweType text = "Found a hole of type " <> dropEnd 4 (show marloweTy
   dropEnd n = fromCodePointArray <<< Array.dropEnd n <<< toCodePointArray
 
 marloweTypeMarkerText :: MarloweType -> String
-marloweTypeMarkerText StringType =
-  """Found a hole of type String
-
-A string is any text enclosed by double quotes, e.g. "my string".
-
-Replace this hole with a string.
-"""
-
-marloweTypeMarkerText BigIntegerType =
-  """Found a hole of type Integer
-
-Replace this hole with an integer, e.g. 10
-"""
-
-marloweTypeMarkerText SlotType =
-  """
-The slot number. This is a good proxy for time, since on the Cardano blockchain slots pass at a constant rate.
-
-Replace this hole with an integer, e.g. 10
-"""
-
 marloweTypeMarkerText AccountIdType =
   holeText AccountIdType
     """

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -25,6 +25,7 @@ import Data.Traversable (traverse, traverse_)
 import Data.Tuple (Tuple(..))
 import Halogen.HTML (HTML)
 import Halogen.HTML.Properties (id_)
+import Marlowe.Holes (Timeout(..))
 import Marlowe.Parser as Parser
 import Marlowe.Semantics (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Payee(..), Party(..), Rational(..), Token(..), Value(..), ValueId(..))
 import Record (merge)
@@ -1054,9 +1055,9 @@ instance hasBlockDefinitionContract :: HasBlockDefinition ContractType Contract 
     cases <- case eTopCaseBlock of
       Either.Right topCaseBlock -> casesDefinition g topCaseBlock
       Either.Left _ -> pure []
-    timeout <- parse Parser.timeout =<< getFieldValue block "timeout"
+    (Timeout slot _) <- parse Parser.timeout =<< getFieldValue block "timeout"
     contract <- parse (Parser.parseToValue Parser.contract) =<< statementToCode g block "contract"
-    pure (When cases timeout contract)
+    pure (When cases slot contract)
   blockDefinition LetContractType g block = do
     valueId <- ValueId <$> getFieldValue block "value_id"
     value <- parse (Parser.parseToValue Parser.value) =<< statementToCode g block "value"

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -25,7 +25,7 @@ import Data.Traversable (traverse, traverse_)
 import Data.Tuple (Tuple(..))
 import Halogen.HTML (HTML)
 import Halogen.HTML.Properties (id_)
-import Marlowe.Holes (Timeout(..))
+import Marlowe.Holes (TermWrapper(..))
 import Marlowe.Parser as Parser
 import Marlowe.Semantics (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Payee(..), Party(..), Rational(..), Token(..), Value(..), ValueId(..))
 import Record (merge)
@@ -1055,7 +1055,7 @@ instance hasBlockDefinitionContract :: HasBlockDefinition ContractType Contract 
     cases <- case eTopCaseBlock of
       Either.Right topCaseBlock -> casesDefinition g topCaseBlock
       Either.Left _ -> pure []
-    (Timeout slot _) <- parse Parser.timeout =<< getFieldValue block "timeout"
+    (TermWrapper slot _) <- parse Parser.timeout =<< getFieldValue block "timeout"
     contract <- parse (Parser.parseToValue Parser.contract) =<< statementToCode g block "contract"
     pure (When cases slot contract)
   blockDefinition LetContractType g block = do

--- a/marlowe-playground-client/src/Marlowe/Gen.purs
+++ b/marlowe-playground-client/src/Marlowe/Gen.purs
@@ -12,7 +12,7 @@ import Data.Char.Gen (genAlpha, genDigitChar)
 import Data.Foldable (class Foldable)
 import Data.NonEmpty (NonEmpty, foldl1, (:|))
 import Data.String.CodeUnits (fromCharArray)
-import Marlowe.Holes (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Timeout(..), Token(..), Value(..), ValueId(..))
+import Marlowe.Holes (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..))
 import Marlowe.Semantics (Rational(..), CurrencySymbol, Input(..), PubKey, Slot(..), SlotInterval(..), TokenName, TransactionInput(..), TransactionWarning(..))
 import Marlowe.Semantics as S
 import Text.Parsing.StringParser (Pos)
@@ -38,8 +38,8 @@ genRational = do
 genSlot :: forall m. MonadGen m => MonadRec m => m Slot
 genSlot = Slot <$> genBigInteger
 
-genTimeout :: forall m. MonadGen m => MonadRec m => m Timeout
-genTimeout = Timeout <$> genSlot <*> pure { row: 0, column: 0 }
+genTimeout :: forall m. MonadGen m => MonadRec m => m (TermWrapper Slot)
+genTimeout = TermWrapper <$> genSlot <*> pure { row: 0, column: 0 }
 
 genValueId :: forall m. MonadGen m => MonadRec m => MonadAsk Boolean m => m ValueId
 genValueId = ValueId <$> genString

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -41,7 +41,7 @@ import Data.Symbol (SProxy(..))
 import Data.Traversable (traverse_)
 import Data.Tuple.Nested ((/\))
 import Help (marloweTypeMarkerText)
-import Marlowe.Holes (Action(..), Argument, Case(..), Contract(..), Holes(..), MarloweHole(..), MarloweType(..), Observation(..), Term(..), TermWrapper(..), Timeout(..), Value(..), ValueId, constructMarloweType, getHoles, getMarloweConstructors, getPosition, holeSuggestions, insertHole, readMarloweType)
+import Marlowe.Holes (Action(..), Argument, Case(..), Contract(..), Holes(..), MarloweHole(..), MarloweType, Observation(..), Term(..), TermWrapper(..), Timeout(..), Value(..), ValueId, constructMarloweType, getHoles, getMarloweConstructors, getPosition, holeSuggestions, insertHole, readMarloweType)
 import Marlowe.Parser (ContractParseError(..), parseContract)
 import Marlowe.Semantics (Rational(..), Slot(..), emptyState, evalValue, makeEnvironment)
 import Marlowe.Semantics as S
@@ -615,9 +615,6 @@ provideCodeActions uri markers' =
     Left _ -> []
     Right r -> case readMarloweType =<< (join <<< (flip index 1)) =<< match r (source <> "Type") of
       Nothing -> []
-      Just BigIntegerType -> []
-      Just StringType -> []
-      Just SlotType -> []
       Just marloweType ->
         let
           m = getMarloweConstructors marloweType

--- a/marlowe-playground-client/test/Main.purs
+++ b/marlowe-playground-client/test/Main.purs
@@ -7,6 +7,7 @@ import Marlowe.BlocklyTests as BlocklyTests
 import Marlowe.ContractTests as ContractTests
 import Marlowe.LintTests as LintTests
 import Marlowe.ParserTests as ParserTests
+import Marlowe.CompletionItemsTests as CompletionItemsTests
 import Test.Unit.Main (runTest)
 
 foreign import forDeps :: Effect Unit
@@ -19,3 +20,4 @@ main =
     ContractTests.all
     BlocklyTests.all
     LintTests.all
+    CompletionItemsTests.all

--- a/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
+++ b/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
@@ -1,0 +1,61 @@
+module Marlowe.CompletionItemsTests where
+
+import Prelude
+import Data.Array as Array
+import Data.Either (isRight)
+import Data.Map as Map
+import Data.Set as Set
+import Marlowe.Holes (MarloweHole(..), MarloweType(..), constructMarloweType, getMarloweConstructors)
+import Marlowe.Parser (parse)
+import Marlowe.Parser as Parser
+import Test.Unit (TestSuite, failure, success, suite, test)
+import Text.Parsing.StringParser (Parser)
+
+mkHole :: MarloweType -> MarloweHole
+mkHole marloweType = MarloweHole { name: mempty, row: zero, column: zero, marloweType }
+
+marloweHoleToSuggestion :: MarloweHole -> String -> String
+marloweHoleToSuggestion firstHole@(MarloweHole { marloweType }) constructorName =
+  let
+    m = getMarloweConstructors marloweType
+  in
+    constructMarloweType constructorName firstHole m
+
+holeSuggestions :: MarloweHole -> Array String
+holeSuggestions marloweHole@(MarloweHole { name, marloweType }) =
+  let
+    marloweHoles = getMarloweConstructors marloweType
+  in
+    map (marloweHoleToSuggestion marloweHole) $ Set.toUnfoldable $ Map.keys marloweHoles
+
+mkTest :: forall a. Show a => MarloweType -> Parser a -> TestSuite
+mkTest marloweType parser = do
+  test (show marloweType) do
+    let
+      items = holeSuggestions (mkHole marloweType)
+
+      parsed = map (parse parser) items
+    if Array.all isRight parsed then
+      success
+    else
+      failure $ "expected all parsable but got " <> show parsed <> " for items " <> show items
+
+all :: TestSuite
+all =
+  suite "Completion Items Tests" do
+    -- Note that we don't test the following because they are never used in code generation
+    -- StringType
+    -- BigIntegerType
+    -- SlotType
+    mkTest AccountIdType Parser.accountId'
+    mkTest ChoiceIdType Parser.choiceId'
+    mkTest ValueIdType Parser.valueId
+    mkTest ActionType Parser.action
+    mkTest PayeeType Parser.payee
+    mkTest CaseType Parser.case'
+    mkTest ValueType Parser.value
+    mkTest ObservationType Parser.observation
+    mkTest ContractType Parser.contract
+    mkTest BoundType Parser.bound
+    mkTest TokenType Parser.token
+    mkTest PartyType Parser.party

--- a/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
+++ b/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
@@ -2,60 +2,73 @@ module Marlowe.CompletionItemsTests where
 
 import Prelude
 import Data.Array as Array
-import Data.Either (isRight)
+import Data.Bifunctor (lmap)
+import Data.Either (Either, isRight)
+import Data.Enum (upFromIncluding)
 import Data.Map as Map
 import Data.Set as Set
-import Marlowe.Holes (MarloweHole(..), MarloweType(..), constructMarloweType, getMarloweConstructors)
+import Data.Traversable (traverse_)
+import Marlowe.Holes (MarloweHole(..), MarloweType(..), getMarloweConstructors, marloweHoleToSuggestionText)
 import Marlowe.Parser (parse)
 import Marlowe.Parser as Parser
 import Test.Unit (TestSuite, failure, success, suite, test)
-import Text.Parsing.StringParser (Parser)
 
 mkHole :: MarloweType -> MarloweHole
 mkHole marloweType = MarloweHole { name: mempty, row: zero, column: zero, marloweType }
 
-marloweHoleToSuggestion :: MarloweHole -> String -> String
-marloweHoleToSuggestion firstHole@(MarloweHole { marloweType }) constructorName =
-  let
-    m = getMarloweConstructors marloweType
-  in
-    constructMarloweType constructorName firstHole m
-
-holeSuggestions :: MarloweHole -> Array String
-holeSuggestions marloweHole@(MarloweHole { name, marloweType }) =
+holeSuggestions :: Boolean -> MarloweHole -> Array String
+holeSuggestions stripParens marloweHole@(MarloweHole { name, marloweType }) =
   let
     marloweHoles = getMarloweConstructors marloweType
   in
-    map (marloweHoleToSuggestion marloweHole) $ Set.toUnfoldable $ Map.keys marloweHoles
+    map (marloweHoleToSuggestionText stripParens marloweHole) $ Set.toUnfoldable $ Map.keys marloweHoles
 
-mkTest :: forall a. Show a => MarloweType -> Parser a -> TestSuite
-mkTest marloweType parser = do
+-- | For each constructor of a particular type we generate a string that might have holes in it
+--   We then parse that string to ensure that we have produced something valid
+mkTest :: forall a. Show a => Boolean -> MarloweType -> (String -> Either String a) -> TestSuite
+mkTest stripParens marloweType parser = do
   test (show marloweType) do
     let
-      items = holeSuggestions (mkHole marloweType)
+      items = holeSuggestions stripParens (mkHole marloweType)
 
-      parsed = map (parse parser) items
+      parsed = map parser items
     if Array.all isRight parsed then
       success
     else
       failure $ "expected all parsable but got " <> show parsed <> " for items " <> show items
 
+-- | We use this testFor function in combination with `upFromIncluding bottom` in order to ensure 
+--   that we have written a test for every MarloweType
+testFor :: MarloweType -> TestSuite
+testFor AccountIdType = mkTest false AccountIdType (parse Parser.accountId')
+
+testFor ChoiceIdType = mkTest false ChoiceIdType (parse Parser.choiceId')
+
+testFor ValueIdType = mkTest false ValueIdType (parse Parser.valueId)
+
+testFor ActionType = mkTest false ActionType (parse Parser.action)
+
+testFor PayeeType = mkTest false PayeeType (parse Parser.payee)
+
+testFor CaseType = mkTest false CaseType (parse Parser.case')
+
+testFor ValueType = mkTest false ValueType (parse Parser.value)
+
+testFor ObservationType = mkTest false ObservationType (parse Parser.observation)
+
+testFor ContractType = mkTest false ContractType (parse Parser.contract)
+
+testFor BoundType = mkTest false BoundType (parse Parser.bound)
+
+testFor TokenType = mkTest false TokenType (parse Parser.token)
+
+testFor PartyType = mkTest false PartyType (parse Parser.party)
+
 all :: TestSuite
 all =
   suite "Completion Items Tests" do
-    -- Note that we don't test the following because they are never used in code generation
-    -- StringType
-    -- BigIntegerType
-    -- SlotType
-    mkTest AccountIdType Parser.accountId'
-    mkTest ChoiceIdType Parser.choiceId'
-    mkTest ValueIdType Parser.valueId
-    mkTest ActionType Parser.action
-    mkTest PayeeType Parser.payee
-    mkTest CaseType Parser.case'
-    mkTest ValueType Parser.value
-    mkTest ObservationType Parser.observation
-    mkTest ContractType Parser.contract
-    mkTest BoundType Parser.bound
-    mkTest TokenType Parser.token
-    mkTest PartyType Parser.party
+    let
+      (types :: Array MarloweType) = upFromIncluding bottom
+    traverse_ testFor types
+    -- We do an extra test for the nearley parser since it is not tested in the testFor tests
+    mkTest true ContractType $ lmap show <<< Parser.parseContract


### PR DESCRIPTION
This will make it possible to have holes in Blockly since its not possible to have null values (hence a hole) for strings and numbers.

Note that for linting to work correctly, Marlowe.Holes.Timeout records its position.