### PR TITLE
scb: Add a type parameter for contracts

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -22,7 +22,7 @@ let
     };
     # This turns the output into a fixed-output derivation, which speeds things
     # up, but means we need to invalidate this hash when we change stack.yaml.
-    stack-sha256 = "0z94zz98pni4a72mm4446yhh875fn1q4577d5zy3ivr5y7zmcl7i";
+    # stack-sha256 = "0i4w89q34k6nf3k6kjiq8yzz6bhyz68psmlqisa4dczv517wp5i5";
     inherit checkMaterialization;
     modules = [
         {

--- a/plutus-scb/app/Main.hs
+++ b/plutus-scb/app/Main.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Main
     ( main
@@ -34,7 +35,7 @@ import           Options.Applicative           (CommandFields, Mod, Parser, argu
 import           Plutus.SCB.App                (App, runApp)
 import qualified Plutus.SCB.App                as App
 import qualified Plutus.SCB.Core               as Core
-import           Plutus.SCB.Types              (Config (Config), chainIndexConfig, nodeServerConfig,
+import           Plutus.SCB.Types              (Config (Config), ContractExe (..), chainIndexConfig, nodeServerConfig,
                                                 signingProcessConfig, walletServerConfig)
 import           Plutus.SCB.Utils              (logErrorS, render)
 import           System.Exit                   (ExitCode (ExitFailure), exitSuccess, exitWith)
@@ -245,26 +246,26 @@ runCliCommand Config {nodeServerConfig, chainIndexConfig} ChainIndex =
     ChainIndex.main chainIndexConfig (NodeServer.mscBaseUrl nodeServerConfig)
 runCliCommand Config {signingProcessConfig} SigningProcess =
     SigningProcess.main signingProcessConfig
-runCliCommand _ (InstallContract path) = Core.installContract path
-runCliCommand _ (ActivateContract path) = void $ Core.activateContract path
-runCliCommand _ (ContractStatus uuid) = Core.reportContractStatus uuid
+runCliCommand _ (InstallContract path) = Core.installContract (ContractExe path)
+runCliCommand _ (ActivateContract path) = void $ Core.activateContract (ContractExe path)
+runCliCommand _ (ContractStatus uuid) = Core.reportContractStatus @ContractExe uuid
 runCliCommand _ ReportInstalledContracts = do
     logInfo "Installed Contracts"
-    traverse_ (logInfo . render . pretty) =<< Core.installedContracts
+    traverse_ (logInfo . render . pretty) =<< Core.installedContracts @ContractExe
 runCliCommand _ ReportActiveContracts = do
     logInfo "Active Contracts"
-    traverse_ (logInfo . render . pretty) =<< Core.activeContracts
+    traverse_ (logInfo . render . pretty) =<< Core.activeContracts @ContractExe
 runCliCommand _ ReportTxHistory = do
     logInfo "Transaction History"
-    traverse_ (logInfo . render . pretty) =<< Core.txHistory
+    traverse_ (logInfo . render . pretty) =<< Core.txHistory @ContractExe
 runCliCommand _ (UpdateContract uuid endpoint payload) =
-    Core.updateContract uuid endpoint payload
+    Core.updateContract @ContractExe uuid endpoint payload
 runCliCommand _ (ReportContractHistory uuid) = do
     logInfo "Contract History"
     itraverse_
         (\index contract ->
              logInfo $ render (parens (pretty index) <+> pretty contract)) =<<
-        Core.activeContractHistory uuid
+        Core.activeContractHistory @ContractExe uuid
 
 main :: IO ()
 main = do

--- a/plutus-scb/plutus-scb.cabal
+++ b/plutus-scb/plutus-scb.cabal
@@ -217,4 +217,5 @@ test-suite plutus-scb-test
         tasty-hunit -any,
         tasty-quickcheck -any,
         text -any,
-        transformers -any
+        transformers -any,
+        prettyprinter -any

--- a/plutus-scb/src/Plutus/SCB/Command.hs
+++ b/plutus-scb/src/Plutus/SCB/Command.hs
@@ -32,9 +32,9 @@ import           Plutus.SCB.Events (ChainEvent (NodeEvent, UserEvent), NodeEvent
                                     UserEvent (ContractStateTransition, InstallContract))
 import qualified Plutus.SCB.Events as Events
 import           Plutus.SCB.Query  (nullProjection)
-import           Plutus.SCB.Types  (ActiveContractState, Contract)
+import           Plutus.SCB.Types  (ActiveContractState)
 
-installCommand :: Aggregate () ChainEvent Contract
+installCommand :: Aggregate () (ChainEvent t) t
 installCommand =
     Aggregate
         { aggregateProjection = nullProjection
@@ -42,26 +42,26 @@ installCommand =
               \() contract -> [UserEvent $ InstallContract contract]
         }
 
-saveBalancedTx :: Aggregate () ChainEvent Ledger.Tx
+saveBalancedTx :: forall t. Aggregate () (ChainEvent t) Ledger.Tx
 saveBalancedTx = Aggregate {aggregateProjection, aggregateCommandHandler}
   where
     aggregateProjection = nullProjection
     aggregateCommandHandler _ txn = [Events.WalletEvent $ Events.BalancedTx txn]
 
-saveBalancedTxResult :: Aggregate () ChainEvent Ledger.Tx
+saveBalancedTxResult :: forall t. Aggregate () (ChainEvent t) Ledger.Tx
 saveBalancedTxResult = Aggregate {aggregateProjection, aggregateCommandHandler}
   where
     aggregateProjection = nullProjection
     aggregateCommandHandler _ tx = [Events.NodeEvent $ Events.SubmittedTx tx]
 
-saveContractState :: Aggregate () ChainEvent ActiveContractState
+saveContractState :: forall t. Aggregate () (ChainEvent t) (ActiveContractState t)
 saveContractState =
     Aggregate {aggregateProjection = nullProjection, aggregateCommandHandler}
   where
     aggregateCommandHandler _ state =
         [UserEvent $ ContractStateTransition state]
 
-saveBlock :: Aggregate () ChainEvent [Ledger.Tx]
+saveBlock :: forall t. Aggregate () (ChainEvent t) [Ledger.Tx]
 saveBlock =
     Aggregate {aggregateProjection = nullProjection, aggregateCommandHandler}
   where

--- a/plutus-scb/src/Plutus/SCB/Effects/Contract.hs
+++ b/plutus-scb/src/Plutus/SCB/Effects/Contract.hs
@@ -15,11 +15,12 @@ import qualified Data.Aeson             as JSON
 
 import           Plutus.SCB.Types       (PartiallyDecodedResponse)
 
-data ContractCommand
-    = InitContract FilePath
-    | UpdateContract FilePath JSON.Value
+-- | Commands to update a contract. 't' identifies the contract.
+data ContractCommand t
+    = InitContract t
+    | UpdateContract t JSON.Value
     deriving (Show, Eq)
 
-data ContractEffect r where
-    InvokeContract :: ContractCommand -> ContractEffect PartiallyDecodedResponse
+data ContractEffect t r where
+    InvokeContract :: ContractCommand t -> ContractEffect  t PartiallyDecodedResponse
 makeEffect ''ContractEffect

--- a/plutus-scb/src/Plutus/SCB/Events.hs
+++ b/plutus-scb/src/Plutus/SCB/Events.hs
@@ -25,12 +25,12 @@ import           Plutus.SCB.Events.User     as Events.User
 import           Plutus.SCB.Events.Wallet   as Events.Wallet
 
 -- | A structure which ties together all possible event types into one parent.
-data ChainEvent
+data ChainEvent t
     = RecordRequest
           !(Events.Contract.RequestEvent Events.Contract.ContractRequest)
     | RecordResponse
           !(Events.Contract.ResponseEvent Events.Contract.ContractResponse)
-    | UserEvent !Events.User.UserEvent
+    | UserEvent !(Events.User.UserEvent t)
     | NodeEvent !Events.Node.NodeEvent
     | WalletEvent !Events.Wallet.WalletEvent
     deriving (Show, Eq, Generic)

--- a/plutus-scb/src/Plutus/SCB/Events/User.hs
+++ b/plutus-scb/src/Plutus/SCB/Events/User.hs
@@ -6,10 +6,12 @@ module Plutus.SCB.Events.User where
 
 import           Data.Aeson       (FromJSON, ToJSON)
 import           GHC.Generics     (Generic)
-import           Plutus.SCB.Types (ActiveContractState, Contract)
+import           Plutus.SCB.Types (ActiveContractState)
 
-data UserEvent
-    = InstallContract !Contract
-    | ContractStateTransition !ActiveContractState
+-- | Users can install contracts and transition them to a new state.
+--   Contracts are identified by values of 't'.
+data UserEvent t
+    = InstallContract !t
+    | ContractStateTransition !(ActiveContractState t)
     deriving (Show, Eq, Generic)
     deriving anyclass (FromJSON, ToJSON)

--- a/plutus-scb/src/Plutus/SCB/Types.hs
+++ b/plutus-scb/src/Plutus/SCB/Types.hs
@@ -28,29 +28,29 @@ import           Ledger.Constraints                         (UnbalancedTx)
 import           Servant.Client                             (ClientError)
 import           Wallet.API                                 (WalletAPIError)
 
-newtype Contract =
-    Contract
+newtype ContractExe =
+    ContractExe
         { contractPath :: FilePath
         }
     deriving (Show, Eq, Ord, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
-instance Pretty Contract where
-    pretty Contract {contractPath} = "Path:" <+> pretty contractPath
+instance Pretty ContractExe where
+    pretty ContractExe {contractPath} = "Path:" <+> pretty contractPath
 
-data ActiveContract =
+data ActiveContract t =
     ActiveContract
-        { activeContractId   :: UUID
-        , activeContractPath :: FilePath
+        { activeContractInstanceId :: UUID
+        , activeContractDefinition :: t
         }
     deriving (Show, Eq, Ord, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
-instance Pretty ActiveContract where
-    pretty ActiveContract {activeContractId, activeContractPath} =
+instance Pretty t => Pretty (ActiveContract t) where
+    pretty ActiveContract {activeContractInstanceId, activeContractDefinition} =
         vsep
-            [ "UUID:" <+> pretty (show activeContractId)
-            , "Path:" <+> pretty activeContractPath
+            [ "UUID:" <+> pretty (show activeContractInstanceId)
+            , "Definition:" <+> pretty activeContractDefinition
             ]
 
 data SCBError
@@ -90,15 +90,15 @@ instance Pretty PartiallyDecodedResponse where
             , indent 2 $ pretty $ take 120 $ BS8.unpack $ JSON.encodePretty hooks
             ]
 
-data ActiveContractState =
+data ActiveContractState t =
     ActiveContractState
-        { activeContract           :: ActiveContract
+        { activeContract           :: ActiveContract t
         , partiallyDecodedResponse :: PartiallyDecodedResponse
         }
     deriving (Show, Eq, Generic)
     deriving anyclass (ToJSON, FromJSON)
 
-instance Pretty ActiveContractState where
+instance Pretty t => Pretty (ActiveContractState t) where
     pretty ActiveContractState {activeContract, partiallyDecodedResponse} =
         vsep
             [ "Contract:"

--- a/plutus-scb/test/Plutus/SCB/Effects/ContractTest.hs
+++ b/plutus-scb/test/Plutus/SCB/Effects/ContractTest.hs
@@ -1,46 +1,60 @@
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs            #-}
-{-# LANGUAGE LambdaCase       #-}
-{-# LANGUAGE TypeOperators    #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE TypeOperators              #-}
 module Plutus.SCB.Effects.ContractTest(
-    handleContractTest
+    TestContracts(..)
+    , handleContractTest
     ) where
 
 import           Control.Monad.Freer
 import           Control.Monad.Freer.Error                     (Error, throwError)
+import           Control.Monad.Freer.State
 import           Data.Aeson                                    as JSON
 import           Data.Aeson.Types                              as JSON
 import           Data.Bifunctor                                (Bifunctor (..))
+import           Data.Map                                      (Map)
+import qualified Data.Map                                      as Map
 import           Data.Text                                     (Text)
 import qualified Data.Text                                     as Text
+import           Data.Text.Prettyprint.Doc
 
 import           Plutus.SCB.Effects.Contract                   (ContractCommand (..), ContractEffect (..))
 import           Plutus.SCB.Types                              (SCBError (..))
 
+import           Language.Plutus.Contract.Request              (Contract)
 import           Language.Plutus.Contract.Resumable            (ResumableError)
 import           Language.Plutus.Contract.Servant              (initialResponse, runUpdate)
 import qualified Language.PlutusTx.Coordination.Contracts.Game as Contracts.Game
 
+data TestContracts = Game | Currency
+    deriving (Eq, Ord, Show)
+
+instance Pretty TestContracts where
+    pretty = viaShow
+
 -- | A mock/test handler for 'ContractEffect'
 handleContractTest ::
     (Member (Error SCBError) effs)
-    => Eff (ContractEffect ': effs)
+    => Eff (ContractEffect TestContracts ': effs)
     ~> Eff effs
 handleContractTest = interpret $ \case
-    InvokeContract (InitContract "game") ->
+    InvokeContract (InitContract Game) ->
         either throwError pure $ do
             value <- fromResumable $ initialResponse Contracts.Game.game
             fromString $ JSON.eitherDecode (JSON.encode value)
-    InvokeContract (UpdateContract "game" payload) ->
+    InvokeContract (UpdateContract Game payload) ->
         either throwError pure $ do
             request <- fromString $ JSON.parseEither JSON.parseJSON payload
             value <- fromResumable $ runUpdate Contracts.Game.game request
             fromString $ JSON.eitherDecode (JSON.encode value)
     InvokeContract (InitContract contractPath) ->
-        throwError $ ContractNotFound contractPath
+        throwError $ ContractNotFound (show contractPath)
     InvokeContract (UpdateContract contractPath _) ->
-        throwError $ ContractNotFound contractPath
+        throwError $ ContractNotFound (show contractPath)
 
 fromString :: Either String a -> Either SCBError a
 fromString = first (ContractCommandError 0 . Text.pack)

--- a/plutus-scb/test/Plutus/SCB/Effects/MultiAgent.hs
+++ b/plutus-scb/test/Plutus/SCB/Effects/MultiAgent.hs
@@ -45,7 +45,7 @@ import qualified Cardano.Node.Types              as NF
 import qualified Cardano.Node.Types              as NodeServer
 
 import           Plutus.SCB.Effects.Contract     (ContractEffect (..))
-import           Plutus.SCB.Effects.ContractTest (handleContractTest)
+import           Plutus.SCB.Effects.ContractTest (TestContracts (..), handleContractTest)
 import           Plutus.SCB.Effects.EventLog     (EventLogEffect)
 import           Plutus.SCB.Effects.UUID         (UUIDEffect)
 import           Plutus.SCB.Events               (ChainEvent)
@@ -95,12 +95,12 @@ agentState wallet = at wallet . anon (emptyAgentState wallet) (const False)
 
 type SCBClientEffects =
     '[WalletEffect
-    , ContractEffect
+    , ContractEffect TestContracts
     , NodeClientEffect
     , ChainIndexEffect
     , SigningProcessEffect
     , UUIDEffect
-    , EventLogEffect ChainEvent
+    , EventLogEffect (ChainEvent TestContracts)
     , NodeFollowerEffect
     , Error WalletAPIError
     , Error SCBError
@@ -124,7 +124,7 @@ type MultiAgentEffs =
     , Chain.ChainEffect
     , Error SCBError
     , Writer [EmulatorEvent]
-    , EventLogEffect ChainEvent
+    , EventLogEffect (ChainEvent TestContracts)
     , UUIDEffect
     ]
 


### PR DESCRIPTION
* Add a type parameter for the type of contract identifiers to the SCB
* In the actual application this is instantiated to `ContractExe`, ie. the
  location of the executable in the file system.
* In the tests we can use a type like `data TestContracts = Game |
  Currency` which is nicer than working with magic strings.

