### PR TITLE
SCB: Bugfix for the command line parser.

### DIFF
--- a/plutus-scb/app/Main.hs
+++ b/plutus-scb/app/Main.hs
@@ -235,7 +235,7 @@ reportTxHistoryParser =
 
 scbWebserverParser :: Mod CommandFields Command
 scbWebserverParser =
-    command "tx" $
+    command "webserver" $
     info
         (pure SCBWebserver)
         (fullDesc <> progDesc "Start the SCB backend webserver.")


### PR DESCRIPTION
Looks like a copy & paste error confused the "start webserver" and
"report TX history" commands.