### PR TITLE
SCB: Fixing a problem with the chainindex startup sequence.

### DIFF
--- a/plutus-scb/app/Main.hs
+++ b/plutus-scb/app/Main.hs
@@ -181,8 +181,8 @@ allServersParser =
         (pure
              (ForkCommands
                   [ MockNode
-                  , MockWallet
                   , ChainIndex
+                  , MockWallet
                   , SigningProcess
                   , SCBWebserver
                   ]))


### PR DESCRIPTION
We have a constraint that the wallet needs to call startWatching on
the chain index before the chain index sees the first transaction.

I've address this by making the index not bother to fetch new blocks
when there are no watched addresses. Same effect, and feels like a
logical thing to do regardless.