### PR TITLE
haskell.nix: materialize the Nix files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,3 @@ marlowe-playground-server/playground.yaml
 /plutus-scb.yaml
 /scb-core.db*
 hie.yaml
-/nix/stack.materialized/

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -44,54 +44,14 @@ bug workarounds.
 === How to update the generated Haskell package set
 
 The Nix code that builds all the Haskell packages and their dependencies is generated automatically.
-However, to avoid doing too much work all the time,
-we have *pinned* it with the hash of the result of the generation process.
+However, to avoid doing too much work all the time, we have checked the generated output in.
 
-IMPORTANT: This hash needs to be regenerated if you change any dependencies in cabal files
-or change the Stackage resolver.
+IMPORTANT: These files needs to be regenerated if you change any dependencies in cabal files or change the Stackage resolver. 
+But the CI will tell you if you've failed to do so.
 
-You can find the hash in link:./nix/haskell.nix[`nix/haskell.nix`]. All you need to do is comment out the
-`stack-sha256` attribute, and rebuild something. You will see a command on stderr that will tell you
-how to generate the replacement hash.
-
-[[update-materialized]]
-=== Speed up Nix development by materializing the package set
-
-When you ask Nix to build a Haskell package, it recalculates the
-Haskell package set to use as an input. Even if this set hasn't
-changed, and everything is already available on local disk, the
-recalculation itself can take a significant amount of time.
-
-Thankfully we can cache that recalculation using https://github.com/input-output-hk/haskell.nix/blob/master/docs/user-guide/materialization.md[haskell.nix's materialization feature]. To do this:
-
-* Build once. Look for the build message that says:
-
-....
-trace: To materialize, point `materialized` to a copy of /nix/store/<somehash>-stack-to-nix-pkgs
-....
-
-* Note the exact path. Make a local copy of it:
-
-[source,sh]
-----
-cp -R /nix/store/<somehash>-stack-to-nix-pkgs nix/stack.materialized
-----
-
-NOTE: This must be a copy, not a symlink.
-
-* Edit `nix/haskell.nix`. Below the `stack-sha256` attribute add:
-
-[source,sh]
-----
-  materialized = ./stack.materialized;
-----
-
-The next time you build nix should use the materialized package set,
-the, "trace: To materialize..." message should disappear and your
-build should be noticiably faster.
-
-NOTE: Do not commit these changes! They should only be local to your machine.
-
+You can find the files in link:./nix/stack.materialized[`nix/stack.materialized`]. 
+All you need to do is delete this directory, and then rebuild something. 
+You will see a command on stderr that will tell you how to generate the replacement files.
 
 [[update-freeze]]
 === How to update `cabal.project.freeze`

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -20,11 +20,10 @@ let
       # particularly bad on Hercules, see https://github.com/hercules-ci/support/issues/40
       name = "plutus";
     };
-    # This turns the output into a fixed-output derivation, which speeds things
-    # up, but means we need to invalidate this hash when we change stack.yaml.
-    stack-sha256 = "1q17rcnlkv898hrpjx384knhg514w13chlbbxb0jahxm3k5zc9mk";
-    # See ../CONTRIBUTING.doc for help with materlialization
-    materialized = if builtins.pathExists ./stack.materialized then ./stack.materialized else null;
+    # These files need to be regenerated when you change the cabal files or stack resolver.
+    # See ../CONTRIBUTING.doc for more information.
+    materialized = ./stack.materialized;
+    # If true, we check that the generated files are correct. Set in the CI so we don't make mistakes.
     inherit checkMaterialization;
     modules = [
         {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -30,10 +30,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3bd01577a6866957863079e2969334db5e729f6f",
-        "sha256": "10hl67d8rzl01hm7sch2d6sj5s0aiy1j17y069zx1f2bqg9s5yzx",
+        "rev": "701c83fb43179d303c06a3f60003ae68597ccebc",
+        "sha256": "0afpvi2av0y6fk97kd9mx8bprvfyiizxp22qrgar2ph9mfvaixdm",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/3bd01577a6866957863079e2969334db5e729f6f.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/701c83fb43179d303c06a3f60003ae68597ccebc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/nix/stack.materialized/.stack-to-nix.cache
+++ b/nix/stack.materialized/.stack-to-nix.cache
@@ -1,0 +1,5 @@
+https://github.com/shmish111/purescript-bridge.git 28c37771ef30b0d751960c061ef95627f05d290e . 0n6q7g2w1xafngd3dwbbmfxfn018fmq61db7mymplbrww8ld1cp3 purescript-bridge .stack-to-nix.cache.0
+https://github.com/shmish111/servant-purescript.git ece5d1dad16a5731ac22040075615803796c7c21 . 1axcbsaym64q67hvjc7b3izd48cgqwi734l7f7m22jpdc80li5f6 servant-purescript .stack-to-nix.cache.1
+https://github.com/input-output-hk/cardano-crypto.git 2547ad1e80aeabca2899951601079408becbc92c . 1p2kg2w02q5w1cvqzhfhqmxviy4xrzada3mmb096j2n6hfr20kri cardano-crypto .stack-to-nix.cache.2
+https://github.com/michaelpj/unlit.git 9ca1112093c5ffd356fc99c7dafa080e686dd748 . 145sffn8gbdn6xp9q5b75yd3m46ql5bnc02arzmpfs6wgjslfhff unlit .stack-to-nix.cache.3
+https://github.com/michaelpj/slack-web.git 6ff88895c5da593e7bd09a46d7002441817aa6f8 . 1115jngzx2hbvznhnrnm4qs9vn6hsjklxwiwa5i11npr2kxd5rm2 slack-web .stack-to-nix.cache.4

--- a/nix/stack.materialized/.stack-to-nix.cache.0
+++ b/nix/stack.materialized/.stack-to-nix.cache.0
@@ -1,0 +1,89 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "purescript-bridge"; version = "0.13.1.0"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "robert . klotzner A T gmx . at";
+      author = "Robert Klotzner";
+      homepage = "";
+      url = "";
+      synopsis = "Generate PureScript data types from Haskell data types";
+      description = "";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."wl-pprint-text" or (buildDepError "wl-pprint-text"))
+          (hsPkgs."generic-deriving" or (buildDepError "generic-deriving"))
+          ];
+        buildable = true;
+        };
+      tests = {
+        "tests" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."purescript-bridge" or (buildDepError "purescript-bridge"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."wl-pprint-text" or (buildDepError "wl-pprint-text"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."hspec-expectations-pretty-diff" or (buildDepError "hspec-expectations-pretty-diff"))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault /nix/store/k471bw0gdbsfqnlx194jndbkviqcrb5v-purescript-bridge-28c3777;
+    }

--- a/nix/stack.materialized/.stack-to-nix.cache.1
+++ b/nix/stack.materialized/.stack-to-nix.cache.1
@@ -1,0 +1,98 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "servant-purescript"; version = "0.9.0.2"; };
+      license = "BSD-3-Clause";
+      copyright = "Copyright: (c) 2016 Robert Klotzner";
+      maintainer = "robert Dot klotzner A T gmx Dot at";
+      author = "Robert Klotzner";
+      homepage = "https://github.com/eskimor/servant-purescript#readme";
+      url = "";
+      synopsis = "Generate PureScript accessor functions for you servant API";
+      description = "Please see README.md";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."http-types" or (buildDepError "http-types"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."mainland-pretty" or (buildDepError "mainland-pretty"))
+          (hsPkgs."purescript-bridge" or (buildDepError "purescript-bridge"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."servant-foreign" or (buildDepError "servant-foreign"))
+          (hsPkgs."servant-server" or (buildDepError "servant-server"))
+          (hsPkgs."servant-subscriber" or (buildDepError "servant-subscriber"))
+          (hsPkgs."text" or (buildDepError "text"))
+          ];
+        buildable = true;
+        };
+      tests = {
+        "servant-purescript-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."mainland-pretty" or (buildDepError "mainland-pretty"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."purescript-bridge" or (buildDepError "purescript-bridge"))
+            (hsPkgs."servant" or (buildDepError "servant"))
+            (hsPkgs."servant-foreign" or (buildDepError "servant-foreign"))
+            (hsPkgs."servant-purescript" or (buildDepError "servant-purescript"))
+            (hsPkgs."servant-subscriber" or (buildDepError "servant-subscriber"))
+            (hsPkgs."text" or (buildDepError "text"))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault /nix/store/frf1fqadrmjh1xyidhclj4f44pd2iz9i-servant-purescript-ece5d1d;
+    }

--- a/nix/stack.materialized/.stack-to-nix.cache.2
+++ b/nix/stack.materialized/.stack-to-nix.cache.2
@@ -1,0 +1,127 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { golden-tests = false; golden-tests-exe = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "cardano-crypto"; version = "1.1.0"; };
+      license = "MIT";
+      copyright = "2016-2017 IOHK";
+      maintainer = "contact@typed.io";
+      author = "Vincent Hanquez";
+      homepage = "https://github.com/input-output-hk/cardano-crypto#readme";
+      url = "";
+      synopsis = "Cryptography primitives for cardano";
+      description = "";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."basement" or (buildDepError "basement"))
+          (hsPkgs."foundation" or (buildDepError "foundation"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."integer-gmp" or (buildDepError "integer-gmp"))
+          ];
+        buildable = true;
+        };
+      exes = {
+        "golden-tests" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."basement" or (buildDepError "basement"))
+            (hsPkgs."foundation" or (buildDepError "foundation"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            ] ++ (pkgs.lib).optional (flags.golden-tests-exe) (hsPkgs."inspector" or (buildDepError "inspector"));
+          buildable = if flags.golden-tests-exe then true else false;
+          };
+        };
+      tests = {
+        "cardano-crypto-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."basement" or (buildDepError "basement"))
+            (hsPkgs."foundation" or (buildDepError "foundation"))
+            ];
+          buildable = true;
+          };
+        "cardano-crypto-golden-tests" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."basement" or (buildDepError "basement"))
+            (hsPkgs."foundation" or (buildDepError "foundation"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            ] ++ (pkgs.lib).optional (flags.golden-tests) (hsPkgs."inspector" or (buildDepError "inspector"));
+          buildable = if flags.golden-tests then true else false;
+          };
+        };
+      benchmarks = {
+        "cardano-crypto-bench" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."gauge" or (buildDepError "gauge"))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault /nix/store/bvxsj0yv59b5k3yzsgbl2082i97lc5z8-cardano-crypto-2547ad1;
+    }

--- a/nix/stack.materialized/.stack-to-nix.cache.3
+++ b/nix/stack.materialized/.stack-to-nix.cache.3
@@ -1,0 +1,79 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "unlit"; version = "0.4.0.1"; };
+      license = "BSD-3-Clause";
+      copyright = "2014 (c) Wen Kokke";
+      maintainer = "wen.kokke@gmail.com";
+      author = "Wen Kokke";
+      homepage = "";
+      url = "";
+      synopsis = "Tool to convert literate code between styles or to code.";
+      description = "Tool to convert literate code between styles or to code.\nUsage:\n\n> unlit\n>   -f STYLE_NAME  --from=STYLE_NAME    Source style (all, bird, haskell, latex, markdown, tildefence, backtickfence)\n>   -t STYLE_NAME  --to=STYLE_NAME      Target style (bird, latex, tildefence, backtickfence, code)\n>   -i FILE        --input=FILE         Input file (optional)\n>   -o FILE        --output=FILE        Output file (optional)\n>   -l LANGUAGE    --language=LANGUAGE  Programming language (restrict fenced code blocks)\n>   -h             --help               Show help\n>   -v             --version            Show version\n";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."text" or (buildDepError "text"))
+          ];
+        buildable = true;
+        };
+      exes = {
+        "unlit" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."unlit" or (buildDepError "unlit"))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault /nix/store/181ykhfirmrnd6yvvlr02yfc01m0acrp-unlit-9ca1112;
+    }

--- a/nix/stack.materialized/.stack-to-nix.cache.4
+++ b/nix/stack.materialized/.stack-to-nix.cache.4
@@ -1,0 +1,96 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.20";
+      identifier = { name = "slack-web"; version = "0.2.0.12"; };
+      license = "MIT";
+      copyright = "2017 Juan Pedro Villa Isaza";
+      maintainer = "Juan Pedro Villa Isaza <jpvillaisaza@gmail.com>";
+      author = "Juan Pedro Villa Isaza <jpvillaisaza@gmail.com>";
+      homepage = "https://github.com/jpvillaisaza/slack-web";
+      url = "";
+      synopsis = "Bindings for the Slack web API";
+      description = "Haskell bindings for the Slack web API.";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."http-api-data" or (buildDepError "http-api-data"))
+          (hsPkgs."http-client" or (buildDepError "http-client"))
+          (hsPkgs."http-client-tls" or (buildDepError "http-client-tls"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."servant-client" or (buildDepError "servant-client"))
+          (hsPkgs."servant-client-core" or (buildDepError "servant-client-core"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."errors" or (buildDepError "errors"))
+          (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
+          ];
+        buildable = true;
+        };
+      tests = {
+        "tests" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."errors" or (buildDepError "errors"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."http-api-data" or (buildDepError "http-api-data"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault /nix/store/l99d716zpbcw9qpbz5k7niblaxdpwa5f-slack-web-6ff8889;
+    }

--- a/nix/stack.materialized/default.nix
+++ b/nix/stack.materialized/default.nix
@@ -1,0 +1,77 @@
+{
+  extras = hackage:
+    {
+      packages = {
+        "aws-lambda-haskell-runtime" = (((hackage.aws-lambda-haskell-runtime)."2.0.4").revisions).default;
+        "binary-instances" = (((hackage.binary-instances)."1.0.0.1").revisions).default;
+        "composition-prelude" = (((hackage.composition-prelude)."2.0.2.1").revisions).default;
+        "constraints-extras" = (((hackage.constraints-extras)."0.3.0.2").revisions).default;
+        "dependent-map" = (((hackage.dependent-map)."0.3").revisions).default;
+        "dependent-sum" = (((hackage.dependent-sum)."0.6.2.0").revisions).default;
+        "dependent-sum-template" = (((hackage.dependent-sum-template)."0.1.0.3").revisions).default;
+        "deriving-aeson" = (((hackage.deriving-aeson)."0.2.3").revisions).default;
+        "ekg" = (((hackage.ekg)."0.4.0.15").revisions).default;
+        "ekg-core" = (((hackage.ekg-core)."0.1.1.7").revisions).default;
+        "ekg-json" = (((hackage.ekg-json)."0.1.0.6").revisions).default;
+        "eventful-memory" = (((hackage.eventful-memory)."0.2.0").revisions).default;
+        "eventful-sqlite" = (((hackage.eventful-sqlite)."0.2.0").revisions).default;
+        "github" = (((hackage.github)."0.24").revisions).default;
+        "github-webhooks" = (((hackage.github-webhooks)."0.12.0").revisions).default;
+        "monoidal-containers" = (((hackage.monoidal-containers)."0.6.0.1").revisions).default;
+        "monad-stm" = (((hackage.monad-stm)."0.1.0.2").revisions).default;
+        "prometheus" = (((hackage.prometheus)."2.1.3").revisions).default;
+        "row-types" = (((hackage.row-types)."0.3.1.0").revisions).default;
+        "th-utilities" = (((hackage.th-utilities)."0.2.4.0").revisions).default;
+        "servant-options" = (((hackage.servant-options)."0.1.0.0").revisions).default;
+        "sbv" = (((hackage.sbv)."8.6").revisions).default;
+        "time-out" = (((hackage.time-out)."0.2").revisions)."b9a6b4dee64f030ecb2a25dca0faff39b3cb3b5fefbb8af3cdec4142bfd291f2";
+        "time-interval" = (((hackage.time-interval)."0.1.1").revisions)."7bfd3601853d1af7caa18248ec10b01701d035ac274a93bb4670fea52a14d4e8";
+        "time-units" = (((hackage.time-units)."1.0.0").revisions)."27cf54091c4a0ca73d504fc11d5c31ab4041d17404fe3499945e2055697746c1";
+        "servant-github-webhook" = (((hackage.servant-github-webhook)."0.4.1.0").revisions)."6ac456ccc6a2a96b30a7b80cd91b121f1b7e9bd33635641a6afbd6137700a753";
+        "random-strings" = (((hackage.random-strings)."0.1.1.0").revisions)."935a7a23dab45411960df77636a29b44ce42b89eeb15f2b1e809d771491fa677";
+        "wl-pprint" = (((hackage.wl-pprint)."1.2.1").revisions)."aea676cff4a062d7d912149d270e33f5bb0c01b68a9db46ff13b438141ff4b7c";
+        "eventful-sql-common" = (((hackage.eventful-sql-common)."0.2.0").revisions).r0;
+        language-plutus-core = ./language-plutus-core.nix;
+        plutus-ir = ./plutus-ir.nix;
+        plutus-tx = ./plutus-tx.nix;
+        plutus-tx-plugin = ./plutus-tx-plugin.nix;
+        plutus-use-cases = ./plutus-use-cases.nix;
+        playground-common = ./playground-common.nix;
+        marlowe = ./marlowe.nix;
+        marlowe-hspec = ./marlowe-hspec.nix;
+        marlowe-playground-server = ./marlowe-playground-server.nix;
+        plc-agda = ./plc-agda.nix;
+        plutus-ledger = ./plutus-ledger.nix;
+        plutus-playground-server = ./plutus-playground-server.nix;
+        plutus-playground-lib = ./plutus-playground-lib.nix;
+        plutus-tutorial = ./plutus-tutorial.nix;
+        plutus-book = ./plutus-book.nix;
+        plutus-contract = ./plutus-contract.nix;
+        plutus-contract-tasty = ./plutus-contract-tasty.nix;
+        plutus-scb = ./plutus-scb.nix;
+        plutus-emulator = ./plutus-emulator.nix;
+        deployment-server = ./deployment-server.nix;
+        iots-export = ./iots-export.nix;
+        marlowe-symbolic = ./marlowe-symbolic.nix;
+        purescript-bridge = ./.stack-to-nix.cache.0;
+        servant-purescript = ./.stack-to-nix.cache.1;
+        cardano-crypto = ./.stack-to-nix.cache.2;
+        unlit = ./.stack-to-nix.cache.3;
+        slack-web = ./.stack-to-nix.cache.4;
+        };
+      };
+  resolver = "lts-15.6";
+  modules = [
+    ({ lib, ... }:
+      { packages = {}; })
+    {
+      packages = {
+        "eventful-sql-common" = {
+          package = {
+            ghcOptions = "-XDerivingStrategies -XStandaloneDeriving -XUndecidableInstances";
+            };
+          };
+        };
+      }
+    ];
+  }

--- a/nix/stack.materialized/deployment-server.nix
+++ b/nix/stack.materialized/deployment-server.nix
@@ -1,0 +1,123 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.0";
+      identifier = { name = "deployment-server"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "david.smith@tweag.io";
+      author = "David Smith";
+      homepage = "";
+      url = "";
+      synopsis = "";
+      description = "Continuous Delivery server for Plutus Playgrounds";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [ "README.md" ];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."github" or (buildDepError "github"))
+          (hsPkgs."github-webhooks" or (buildDepError "github-webhooks"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."newtype-generics" or (buildDepError "newtype-generics"))
+          (hsPkgs."optparse-generic" or (buildDepError "optparse-generic"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."servant-github-webhook" or (buildDepError "servant-github-webhook"))
+          (hsPkgs."servant-server" or (buildDepError "servant-server"))
+          (hsPkgs."temporary" or (buildDepError "temporary"))
+          (hsPkgs."typed-process" or (buildDepError "typed-process"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."wai" or (buildDepError "wai"))
+          ];
+        buildable = true;
+        modules = [ "Deploy/Server" "Deploy/Types" "Deploy/Worker" ];
+        hsSourceDirs = [ "src" ];
+        };
+      exes = {
+        "deployment-server-exe" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."deployment-server" or (buildDepError "deployment-server"))
+            (hsPkgs."newtype-generics" or (buildDepError "newtype-generics"))
+            (hsPkgs."optparse-generic" or (buildDepError "optparse-generic"))
+            (hsPkgs."servant-github-webhook" or (buildDepError "servant-github-webhook"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."warp" or (buildDepError "warp"))
+            ];
+          buildable = true;
+          modules = [ "Paths_deployment_server" ];
+          hsSourceDirs = [ "app" ];
+          mainPath = [ "Main.hs" ];
+          };
+        };
+      tests = {
+        "deployment-server-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."deployment-server" or (buildDepError "deployment-server"))
+            ];
+          buildable = true;
+          modules = [ "Paths_deployment_server" ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./deployment-server;
+    }

--- a/nix/stack.materialized/iots-export.nix
+++ b/nix/stack.materialized/iots-export.nix
@@ -1,0 +1,111 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.12";
+      identifier = { name = "iots-export"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "kris.jenkins@tweag.com";
+      author = "Kris Jenkins";
+      homepage = "";
+      url = "";
+      synopsis = "Tools to export Haskell to IOTS";
+      description = "Tools to export Haskell to IOTS";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [
+        "test/IOTS/fullContract.ts"
+        "test/IOTS/functionList.ts"
+        "test/IOTS/functionMaybe.ts"
+        "test/IOTS/functionTuple.ts"
+        "test/IOTS/response.ts"
+        "test/IOTS/simpleSum.ts"
+        "test/IOTS/singleFieldless.ts"
+        "test/IOTS/tester.ts"
+        "test/IOTS/thing.ts"
+        "test/IOTS/user.ts"
+        "test/IOTS/vestingTranche.ts"
+        ];
+      extraSrcFiles = [ "README.md" ];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."wl-pprint-text" or (buildDepError "wl-pprint-text"))
+          ];
+        buildable = true;
+        modules = [ "IOTS/Leijen" "IOTS/Tree" "IOTS" ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "iots-export-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-golden" or (buildDepError "tasty-golden"))
+            (hsPkgs."iots-export" or (buildDepError "iots-export"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."wl-pprint-text" or (buildDepError "wl-pprint-text"))
+            ];
+          buildable = true;
+          modules = [ "IOTSSpec" ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./iots-export;
+    }

--- a/nix/stack.materialized/language-plutus-core.nix
+++ b/nix/stack.materialized/language-plutus-core.nix
@@ -1,0 +1,349 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.0";
+      identifier = { name = "language-plutus-core"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "vanessa.mchale@iohk.io";
+      author = "Vanessa McHale";
+      homepage = "";
+      url = "";
+      synopsis = "Language library for Plutus Core";
+      description = "Pretty-printer, parser, and typechecker for Plutus Core.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [
+        "src/costModel.json"
+        "language-plutus-core/src/costModel.json"
+        ];
+      extraTmpFiles = [];
+      extraDocFiles = [ "README.md" ];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."array" or (buildDepError "array"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bimap" or (buildDepError "bimap"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."composition-prelude" or (buildDepError "composition-prelude"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."dependent-map" or (buildDepError "dependent-map"))
+          (hsPkgs."dependent-sum" or (buildDepError "dependent-sum"))
+          (hsPkgs."dependent-sum-template" or (buildDepError "dependent-sum-template"))
+          (hsPkgs."deriving-aeson" or (buildDepError "deriving-aeson"))
+          (hsPkgs."deriving-compat" or (buildDepError "deriving-compat"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."mmorph" or (buildDepError "mmorph"))
+          (hsPkgs."monoidal-containers" or (buildDepError "monoidal-containers"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+          (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."semigroups" or (buildDepError "semigroups"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."tasty" or (buildDepError "tasty"))
+          (hsPkgs."tasty-golden" or (buildDepError "tasty-golden"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."th-lift" or (buildDepError "th-lift"))
+          (hsPkgs."th-lift-instances" or (buildDepError "th-lift-instances"))
+          (hsPkgs."th-utilities" or (buildDepError "th-utilities"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          ];
+        build-tools = [
+          (hsPkgs.buildPackages.alex or (pkgs.buildPackages.alex or (buildToolDepError "alex")))
+          (hsPkgs.buildPackages.happy or (pkgs.buildPackages.happy or (buildToolDepError "happy")))
+          ];
+        buildable = true;
+        modules = [
+          "Data/Aeson/THReader"
+          "Language/PlutusCore/Pretty/ConfigName"
+          "Language/PlutusCore/Core/Type"
+          "Language/PlutusCore/Core/Plated"
+          "Language/PlutusCore/Core/Instance/Eq"
+          "Language/PlutusCore/Core/Instance/Pretty/Classic"
+          "Language/PlutusCore/Core/Instance/Pretty/Common"
+          "Language/PlutusCore/Core/Instance/Pretty/Default"
+          "Language/PlutusCore/Core/Instance/Pretty/Plc"
+          "Language/PlutusCore/Core/Instance/Pretty/Readable"
+          "Language/PlutusCore/Core/Instance/Pretty"
+          "Language/PlutusCore/Core/Instance/Recursive"
+          "Language/PlutusCore/Core/Instance"
+          "Language/PlutusCore/Constant/Apply"
+          "Language/PlutusCore/Constant/Dynamic/BuiltinName"
+          "Language/PlutusCore/Constant/Dynamic/Call"
+          "Language/PlutusCore/Constant/Dynamic/Emit"
+          "Language/PlutusCore/Constant/Dynamic/OnChain"
+          "Language/PlutusCore/Constant/Dynamic/OffChain"
+          "Language/PlutusCore/Constant/Function"
+          "Language/PlutusCore/Constant/Name"
+          "Language/PlutusCore/Constant/Typed"
+          "Language/PlutusCore/Lexer/Type"
+          "Language/PlutusCore/Eq"
+          "Language/PlutusCore/Mark"
+          "Language/PlutusCore/Pretty/Classic"
+          "Language/PlutusCore/Pretty/ConfigName"
+          "Language/PlutusCore/Pretty/Default"
+          "Language/PlutusCore/Pretty/Plc"
+          "Language/PlutusCore/Pretty/PrettyConst"
+          "Language/PlutusCore/Pretty/Readable"
+          "Language/PlutusCore/Pretty/Utils"
+          "Language/PlutusCore/Universe/Core"
+          "Language/PlutusCore/Universe/Default"
+          "Language/PlutusCore/Error"
+          "Language/PlutusCore/Size"
+          "Language/PlutusCore/TypeCheck/Internal"
+          "Language/PlutusCore/TypeCheck"
+          "Language/PlutusCore/Analysis/Definitions"
+          "Language/PlutusCore/Examples/Data/InterList"
+          "Language/PlutusCore/Examples/Data/TreeForest"
+          "Language/PlutusCore/Generators/Internal/Denotation"
+          "Language/PlutusCore/Generators/Internal/Dependent"
+          "Language/PlutusCore/Generators/Internal/Entity"
+          "Language/PlutusCore/Generators/Internal/TypeEvalCheck"
+          "Language/PlutusCore/Generators/Internal/TypedBuiltinGen"
+          "Language/PlutusCore/Generators/Internal/Utils"
+          "Data/Functor/Foldable/Monadic"
+          "Data/Text/Prettyprint/Doc/Custom"
+          "Language/PlutusCore"
+          "Language/PlutusCore/Quote"
+          "Language/PlutusCore/MkPlc"
+          "Language/PlutusCore/Evaluation/Machine/Ck"
+          "Language/PlutusCore/Evaluation/Machine/Cek"
+          "Language/PlutusCore/Evaluation/Machine/ExBudgeting"
+          "Language/PlutusCore/Evaluation/Machine/ExBudgetingDefaults"
+          "Language/PlutusCore/Evaluation/Machine/Exception"
+          "Language/PlutusCore/Evaluation/Machine/ExMemory"
+          "Language/PlutusCore/Evaluation/Evaluator"
+          "Language/PlutusCore/Evaluation/Result"
+          "Language/PlutusCore/Check/Value"
+          "Language/PlutusCore/Check/Normal"
+          "Language/PlutusCore/CBOR"
+          "Language/PlutusCore/Constant"
+          "Language/PlutusCore/Constant/Dynamic"
+          "Language/PlutusCore/Universe"
+          "Language/PlutusCore/Rename/Internal"
+          "Language/PlutusCore/Rename/Monad"
+          "Language/PlutusCore/Rename"
+          "Language/PlutusCore/Normalize"
+          "Language/PlutusCore/Normalize/Internal"
+          "Language/PlutusCore/Pretty"
+          "Language/PlutusCore/View"
+          "Language/PlutusCore/Subst"
+          "Language/PlutusCore/Name"
+          "Language/PlutusCore/Core"
+          "Language/PlutusCore/DeBruijn"
+          "Language/PlutusCore/Check/Uniques"
+          "Language/PlutusCore/FsTree"
+          "Language/PlutusCore/StdLib/Data/Bool"
+          "Language/PlutusCore/StdLib/Data/ChurchNat"
+          "Language/PlutusCore/StdLib/Data/Function"
+          "Language/PlutusCore/StdLib/Data/Integer"
+          "Language/PlutusCore/StdLib/Data/List"
+          "Language/PlutusCore/StdLib/Data/Nat"
+          "Language/PlutusCore/StdLib/Data/Sum"
+          "Language/PlutusCore/StdLib/Data/Unit"
+          "Language/PlutusCore/StdLib/Data/ScottUnit"
+          "Language/PlutusCore/StdLib/Everything"
+          "Language/PlutusCore/StdLib/Meta"
+          "Language/PlutusCore/StdLib/Meta/Data/Tuple"
+          "Language/PlutusCore/StdLib/Meta/Data/Function"
+          "Language/PlutusCore/StdLib/Type"
+          "Language/PlutusCore/Examples/Everything"
+          "Language/PlutusCore/Generators"
+          "Language/PlutusCore/Generators/AST"
+          "Language/PlutusCore/Generators/Interesting"
+          "Language/PlutusCore/Generators/Test"
+          "Language/PlutusCore/Lexer"
+          "Language/PlutusCore/Parser"
+          "PlutusPrelude"
+          "Common"
+          "Data/ByteString/Lazy/Hash"
+          "PlcTestUtils"
+          "Crypto"
+          ];
+        hsSourceDirs = [
+          "src"
+          "prelude"
+          "stdlib"
+          "examples"
+          "generators"
+          "common"
+          ];
+        };
+      exes = {
+        "language-plutus-core-generate-evaluation-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."text" or (buildDepError "text"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "generate-evaluation-test" ];
+          mainPath = [ "Main.hs" ];
+          };
+        "plc" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "exe" ];
+          mainPath = [ "Main.hs" ];
+          };
+        };
+      tests = {
+        "language-plutus-core-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."mmorph" or (buildDepError "mmorph"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-golden" or (buildDepError "tasty-golden"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."tuple" or (buildDepError "tuple"))
+            ];
+          buildable = true;
+          modules = [
+            "Evaluation/ApplyBuiltinName"
+            "Evaluation/DynamicBuiltins/Common"
+            "Evaluation/DynamicBuiltins/Definition"
+            "Evaluation/DynamicBuiltins/Logging"
+            "Evaluation/DynamicBuiltins/MakeRead"
+            "Evaluation/DynamicBuiltins"
+            "Evaluation/Golden"
+            "Evaluation/Machines"
+            "Evaluation/Spec"
+            "Normalization/Check"
+            "Normalization/Type"
+            "Pretty/Readable"
+            "Check/Spec"
+            "TypeSynthesis/Spec"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      benchmarks = {
+        "language-plutus-core-bench" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."criterion" or (buildDepError "criterion"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "bench" ];
+          };
+        "language-plutus-core-weigh" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."weigh" or (buildDepError "weigh"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "weigh" ];
+          };
+        "language-plutus-core-budgeting-bench" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."criterion" or (buildDepError "criterion"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."integer-gmp" or (buildDepError "integer-gmp"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "budgeting-bench" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./language-plutus-core;
+    }

--- a/nix/stack.materialized/marlowe-hspec.nix
+++ b/nix/stack.materialized/marlowe-hspec.nix
@@ -1,0 +1,94 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "marlowe-hspec"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "";
+      author = "David Smith";
+      homepage = "";
+      url = "";
+      synopsis = "";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [ "README.md" ];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."HUnit" or (buildDepError "HUnit"))
+          (hsPkgs."hspec-expectations" or (buildDepError "hspec-expectations"))
+          (hsPkgs."marlowe" or (buildDepError "marlowe"))
+          (hsPkgs."marlowe-symbolic" or (buildDepError "marlowe-symbolic"))
+          ];
+        buildable = true;
+        modules = [ "Test/Hspec/Marlowe" ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "marlowe-hspec-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."HUnit" or (buildDepError "HUnit"))
+            (hsPkgs."marlowe" or (buildDepError "marlowe"))
+            (hsPkgs."marlowe-hspec" or (buildDepError "marlowe-hspec"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./marlowe-hspec;
+    }

--- a/nix/stack.materialized/marlowe-playground-server.nix
+++ b/nix/stack.materialized/marlowe-playground-server.nix
@@ -1,0 +1,186 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "marlowe-playground-server"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "";
+      author = "Pablo Lamela";
+      homepage = "";
+      url = "";
+      synopsis = "";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [ "README.md" ];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cookie" or (buildDepError "cookie"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."file-embed" or (buildDepError "file-embed"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."http-client" or (buildDepError "http-client"))
+          (hsPkgs."http-client-tls" or (buildDepError "http-client-tls"))
+          (hsPkgs."http-conduit" or (buildDepError "http-conduit"))
+          (hsPkgs."http-types" or (buildDepError "http-types"))
+          (hsPkgs."playground-common" or (buildDepError "playground-common"))
+          (hsPkgs."jwt" or (buildDepError "jwt"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."marlowe" or (buildDepError "marlowe"))
+          (hsPkgs."marlowe-symbolic" or (buildDepError "marlowe-symbolic"))
+          (hsPkgs."monad-logger" or (buildDepError "monad-logger"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."newtype-generics" or (buildDepError "newtype-generics"))
+          (hsPkgs."process" or (buildDepError "process"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."servant-client" or (buildDepError "servant-client"))
+          (hsPkgs."servant-client-core" or (buildDepError "servant-client-core"))
+          (hsPkgs."servant-purescript" or (buildDepError "servant-purescript"))
+          (hsPkgs."servant-server" or (buildDepError "servant-server"))
+          (hsPkgs."servant-websockets" or (buildDepError "servant-websockets"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."temporary" or (buildDepError "temporary"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."uuid" or (buildDepError "uuid"))
+          (hsPkgs."websockets" or (buildDepError "websockets"))
+          ];
+        buildable = true;
+        modules = [
+          "Server"
+          "API"
+          "Interpreter"
+          "WebSocket"
+          "Marlowe/Contracts"
+          "Marlowe/Config"
+          ];
+        hsSourceDirs = [ "src" "contracts" ];
+        };
+      exes = {
+        "marlowe-playground-server" = {
+          depends = [
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."data-default-class" or (buildDepError "data-default-class"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."http-client" or (buildDepError "http-client"))
+            (hsPkgs."http-client-tls" or (buildDepError "http-client-tls"))
+            (hsPkgs."http-types" or (buildDepError "http-types"))
+            (hsPkgs."playground-common" or (buildDepError "playground-common"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."marlowe" or (buildDepError "marlowe"))
+            (hsPkgs."marlowe-playground-server" or (buildDepError "marlowe-playground-server"))
+            (hsPkgs."marlowe-symbolic" or (buildDepError "marlowe-symbolic"))
+            (hsPkgs."monad-logger" or (buildDepError "monad-logger"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."prometheus" or (buildDepError "prometheus"))
+            (hsPkgs."purescript-bridge" or (buildDepError "purescript-bridge"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."servant-client" or (buildDepError "servant-client"))
+            (hsPkgs."servant-foreign" or (buildDepError "servant-foreign"))
+            (hsPkgs."servant-server" or (buildDepError "servant-server"))
+            (hsPkgs."servant-purescript" or (buildDepError "servant-purescript"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."wai" or (buildDepError "wai"))
+            (hsPkgs."wai-cors" or (buildDepError "wai-cors"))
+            (hsPkgs."wai-extra" or (buildDepError "wai-extra"))
+            (hsPkgs."warp" or (buildDepError "warp"))
+            (hsPkgs."yaml" or (buildDepError "yaml"))
+            ];
+          buildable = true;
+          modules = [
+            "Webserver"
+            "PSGenerator"
+            "Types"
+            "Escrow"
+            "CouponBondGuaranteed"
+            "ZeroCouponBond"
+            "Swap"
+            ];
+          hsSourceDirs = [ "app" "contracts" ];
+          mainPath = [ "Main.hs" ];
+          };
+        };
+      tests = {
+        "marlowe-playground-server-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."playground-common" or (buildDepError "playground-common"))
+            (hsPkgs."marlowe-playground-server" or (buildDepError "marlowe-playground-server"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."raw-strings-qq" or (buildDepError "raw-strings-qq"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./marlowe-playground-server;
+    }

--- a/nix/stack.materialized/marlowe-symbolic.nix
+++ b/nix/stack.materialized/marlowe-symbolic.nix
@@ -1,0 +1,123 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "marlowe-symbolic"; version = "0.3.0.0"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "alexander.nemish@iohk.io";
+      author = "Alexander Nemish";
+      homepage = "";
+      url = "";
+      synopsis = "";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [ "README.md" ];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."aws-lambda-haskell-runtime" or (buildDepError "aws-lambda-haskell-runtime"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."http-client" or (buildDepError "http-client"))
+          (hsPkgs."http-client-tls" or (buildDepError "http-client-tls"))
+          (hsPkgs."marlowe" or (buildDepError "marlowe"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."sbv" or (buildDepError "sbv"))
+          (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+          (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+          (hsPkgs."process" or (buildDepError "process"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."servant-client" or (buildDepError "servant-client"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."utf8-string" or (buildDepError "utf8-string"))
+          (hsPkgs."wl-pprint" or (buildDepError "wl-pprint"))
+          ];
+        buildable = true;
+        modules = [
+          "App"
+          "Marlowe/Symbolic/Types/Request"
+          "Marlowe/Symbolic/Types/Response"
+          "Marlowe/Symbolic/Types/API"
+          "Language/Marlowe/Analysis/FSSemantics"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "marlowe-symbolic-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."marlowe" or (buildDepError "marlowe"))
+            (hsPkgs."marlowe-symbolic" or (buildDepError "marlowe-symbolic"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."sbv" or (buildDepError "sbv"))
+            (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            ];
+          buildable = true;
+          modules = [
+            "Tests"
+            "OldAnalysis/FSMap"
+            "OldAnalysis/FSSemantics"
+            "OldAnalysis/FSSet"
+            "OldAnalysis/IntegerArray"
+            "OldAnalysis/MkSymb"
+            "OldAnalysis/Numbering"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./marlowe-symbolic;
+    }

--- a/nix/stack.materialized/marlowe.nix
+++ b/nix/stack.materialized/marlowe.nix
@@ -1,0 +1,128 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { defer-plugin-errors = false; };
+    package = {
+      specVersion = "2.0";
+      identifier = { name = "marlowe"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "alexander.nemish@iohk.io";
+      author = "Alexander Nemish";
+      homepage = "";
+      url = "";
+      synopsis = "Marlowe: financial contracts on Cardano Computation Layer";
+      description = "A reference implementation of Marlowe, domain-specific language targeted at\nthe execution of financial contracts in the style of Peyton Jones et al\non Cardano Computation Layer.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [ "README.md" ];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."deriving-aeson" or (buildDepError "deriving-aeson"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."newtype-generics" or (buildDepError "newtype-generics"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+          (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+          (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."vector" or (buildDepError "vector"))
+          (hsPkgs."wl-pprint" or (buildDepError "wl-pprint"))
+          (hsPkgs."freer-simple" or (buildDepError "freer-simple"))
+          ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"));
+        build-tools = [
+          (hsPkgs.buildPackages.unlit or (pkgs.buildPackages.unlit or (buildToolDepError "unlit")))
+          ];
+        buildable = true;
+        modules = [
+          "Language/Marlowe"
+          "Language/Marlowe/Semantics"
+          "Language/Marlowe/Client"
+          "Language/Marlowe/Util"
+          "Language/Marlowe/Pretty"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "marlowe-test" = {
+          depends = [
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."freer-simple" or (buildDepError "freer-simple"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."marlowe" or (buildDepError "marlowe"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+            ];
+          buildable = true;
+          modules = [ "Spec/Marlowe/Common" "Spec/Marlowe/Marlowe" ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./marlowe;
+    }

--- a/nix/stack.materialized/playground-common.nix
+++ b/nix/stack.materialized/playground-common.nix
@@ -1,0 +1,159 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.0";
+      identifier = { name = "playground-common"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "";
+      author = "David Smith";
+      homepage = "";
+      url = "";
+      synopsis = "";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [ "test/oAuthToken1.json" ];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."aeson-casing" or (buildDepError "aeson-casing"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cookie" or (buildDepError "cookie"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."deriving-compat" or (buildDepError "deriving-compat"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."file-embed" or (buildDepError "file-embed"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."http-client" or (buildDepError "http-client"))
+          (hsPkgs."http-client-tls" or (buildDepError "http-client-tls"))
+          (hsPkgs."http-types" or (buildDepError "http-types"))
+          (hsPkgs."http-conduit" or (buildDepError "http-conduit"))
+          (hsPkgs."jwt" or (buildDepError "jwt"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."monad-logger" or (buildDepError "monad-logger"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."newtype-generics" or (buildDepError "newtype-generics"))
+          (hsPkgs."process" or (buildDepError "process"))
+          (hsPkgs."prometheus" or (buildDepError "prometheus"))
+          (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+          (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+          (hsPkgs."purescript-bridge" or (buildDepError "purescript-bridge"))
+          (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."servant-client" or (buildDepError "servant-client"))
+          (hsPkgs."servant-purescript" or (buildDepError "servant-purescript"))
+          (hsPkgs."servant-server" or (buildDepError "servant-server"))
+          (hsPkgs."servant-websockets" or (buildDepError "servant-websockets"))
+          (hsPkgs."temporary" or (buildDepError "temporary"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."time-out" or (buildDepError "time-out"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."wai" or (buildDepError "wai"))
+          (hsPkgs."wl-pprint-text" or (buildDepError "wl-pprint-text"))
+          ];
+        buildable = true;
+        modules = [
+          "Git/TH"
+          "Auth"
+          "Auth/Types"
+          "Control/Monad/Except/Extras"
+          "Control/Monad/Now"
+          "Control/Monad/Trace"
+          "Control/Monad/Web"
+          "Gist"
+          "Git"
+          "Language/Haskell/Interpreter"
+          "PSGenerator/Common"
+          "Servant/Extra"
+          "Servant/Prometheus"
+          "System/IO/Extras"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "playground-common-test" = {
+          depends = [
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."playground-common" or (buildDepError "playground-common"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."wl-pprint-text" or (buildDepError "wl-pprint-text"))
+            ];
+          buildable = true;
+          modules = [
+            "Paths_playground_common"
+            "Auth/TypesSpec"
+            "Language/Haskell/InterpreterSpec"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./playground-common;
+    }

--- a/nix/stack.materialized/plc-agda.nix
+++ b/nix/stack.materialized/plc-agda.nix
@@ -1,0 +1,537 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = { name = "plc-agda"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "james.chapman@iohk.io";
+      author = "James Chapman";
+      homepage = "https://github.com/input-output-hk/plutus";
+      url = "";
+      synopsis = "Command line tool for running plutus core programs";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [ "README.md" ];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      exes = {
+        "plc-agda" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."ieee754" or (buildDepError "ieee754"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            ];
+          buildable = true;
+          modules = [
+            "Raw"
+            "Scoped"
+            "Opts"
+            "MAlonzo/Code/Main"
+            "MAlonzo/Code/Agda/Builtin/Bool"
+            "MAlonzo/Code/Agda/Builtin/Char"
+            "MAlonzo/Code/Agda/Builtin/Equality"
+            "MAlonzo/Code/Agda/Builtin/IO"
+            "MAlonzo/Code/Agda/Builtin/Int"
+            "MAlonzo/Code/Agda/Builtin/List"
+            "MAlonzo/Code/Agda/Builtin/Nat"
+            "MAlonzo/Code/Agda/Builtin/Sigma"
+            "MAlonzo/Code/Agda/Builtin/String"
+            "MAlonzo/Code/Agda/Builtin/Unit"
+            "MAlonzo/Code/Agda/Primitive"
+            "MAlonzo/Code/Algebra"
+            "MAlonzo/Code/Algebra/FunctionProperties/Consequences"
+            "MAlonzo/Code/Algebra/Morphism"
+            "MAlonzo/Code/Algebra/Properties/BooleanAlgebra"
+            "MAlonzo/Code/Algebra/Properties/DistributiveLattice"
+            "MAlonzo/Code/Algebra/Properties/Lattice"
+            "MAlonzo/Code/Algebra/Properties/Semilattice"
+            "MAlonzo/Code/Algebra/Structures"
+            "MAlonzo/Code/Builtin"
+            "MAlonzo/Code/Builtin/Constant/Term"
+            "MAlonzo/Code/Builtin/Constant/Type"
+            "MAlonzo/Code/Builtin/Signature"
+            "MAlonzo/Code/Category/Applicative/Indexed"
+            "MAlonzo/Code/Category/Functor"
+            "MAlonzo/Code/Category/Monad/Indexed"
+            "MAlonzo/Code/Data/Bool/Base"
+            "MAlonzo/Code/Data/Bool/Properties"
+            "MAlonzo/Code/Data/Char/Properties"
+            "MAlonzo/Code/Data/Digit"
+            "MAlonzo/Code/Data/Empty"
+            "MAlonzo/Code/Data/Empty/Irrelevant"
+            "MAlonzo/Code/Data/Fin/Base"
+            "MAlonzo/Code/Data/Integer"
+            "MAlonzo/Code/Data/Integer/Base"
+            "MAlonzo/Code/Data/Integer/Properties"
+            "MAlonzo/Code/Data/List/Base"
+            "MAlonzo/Code/Data/List/NonEmpty"
+            "MAlonzo/Code/Data/List/Properties"
+            "MAlonzo/Code/Data/List/Relation/Binary/Lex/Core"
+            "MAlonzo/Code/Data/List/Relation/Binary/Lex/Strict"
+            "MAlonzo/Code/Data/List/Relation/Binary/Pointwise"
+            "MAlonzo/Code/Data/List/Relation/Unary/All"
+            "MAlonzo/Code/Data/List/Relation/Unary/Any"
+            "MAlonzo/Code/Data/Maybe/Base"
+            "MAlonzo/Code/Data/Nat/Base"
+            "MAlonzo/Code/Data/Nat/DivMod"
+            "MAlonzo/Code/Data/Nat/DivMod/Core"
+            "MAlonzo/Code/Data/Nat/Properties"
+            "MAlonzo/Code/Data/Nat/Show"
+            "MAlonzo/Code/Data/Product"
+            "MAlonzo/Code/Data/Sign"
+            "MAlonzo/Code/Data/String/Base"
+            "MAlonzo/Code/Data/String/Properties"
+            "MAlonzo/Code/Data/Sum/Base"
+            "MAlonzo/Code/Data/These"
+            "MAlonzo/Code/Data/Vec"
+            "MAlonzo/Code/Function/Bijection"
+            "MAlonzo/Code/Function/Equality"
+            "MAlonzo/Code/Function/Equivalence"
+            "MAlonzo/Code/Function/Injection"
+            "MAlonzo/Code/Function/Inverse"
+            "MAlonzo/Code/Function/LeftInverse"
+            "MAlonzo/Code/Function/Surjection"
+            "MAlonzo/Code/Induction"
+            "MAlonzo/Code/Induction/WellFounded"
+            "MAlonzo/Code/Level"
+            "MAlonzo/Code/Raw"
+            "MAlonzo/Code/Relation/Binary"
+            "MAlonzo/Code/Relation/Binary/Consequences"
+            "MAlonzo/Code/Relation/Binary/Construct/NaturalOrder/Left"
+            "MAlonzo/Code/Relation/Binary/Construct/NonStrictToStrict"
+            "MAlonzo/Code/Relation/Binary/Construct/On"
+            "MAlonzo/Code/Relation/Binary/Core"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous/Construct/Trivial"
+            "MAlonzo/Code/Relation/Binary/Lattice"
+            "MAlonzo/Code/Relation/Binary/Properties/Poset"
+            "MAlonzo/Code/Relation/Binary/Properties/Preorder"
+            "MAlonzo/Code/Relation/Binary/PropositionalEquality"
+            "MAlonzo/Code/Relation/Binary/PropositionalEquality/Core"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Base/Single"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Base/Triple"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Setoid"
+            "MAlonzo/Code/Relation/Nullary"
+            "MAlonzo/Code/Relation/Nullary/Decidable"
+            "MAlonzo/Code/Relation/Nullary/Negation"
+            "MAlonzo/Code/Relation/Nullary/Product"
+            "MAlonzo/Code/Relation/Nullary/Sum"
+            "MAlonzo/Code/Relation/Unary/Properties"
+            "MAlonzo/Code/Algebra/Bundles"
+            "MAlonzo/Code/Data/Nat/Divisibility/Core"
+            "MAlonzo/Code/Data/Sign/Base"
+            "MAlonzo/Code/Data/These/Base"
+            "MAlonzo/Code/Data/Vec/Base"
+            "MAlonzo/Code/Data/Vec/Bounded/Base"
+            "MAlonzo/Code/Relation/Binary/Bundles"
+            "MAlonzo/Code/Relation/Binary/Definitions"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous/Bundles"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous/Structures"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Base/Partial"
+            "MAlonzo/Code/Relation/Binary/Reasoning/PartialSetoid"
+            "MAlonzo/Code/Relation/Binary/Structures"
+            "MAlonzo/Code/Relation/Nullary/Decidable/Core"
+            "MAlonzo/Code/Relation/Nullary/Reflects"
+            "MAlonzo/Code/Scoped"
+            "MAlonzo/Code/Scoped/Reduction"
+            "MAlonzo/Code/Scoped/RenamingSubstitution"
+            "MAlonzo/Code/Type"
+            "MAlonzo/Code/Utils"
+            "MAlonzo/RTE"
+            "MAlonzo/Code/Algorithmic"
+            "MAlonzo/Code/Algorithmic/CK"
+            "MAlonzo/Code/Check"
+            "MAlonzo/Code/Scoped/CK"
+            "MAlonzo/Code/Scoped/Extrication"
+            "MAlonzo/Code/Type/BetaNBE"
+            "MAlonzo/Code/Type/BetaNBE/Completeness"
+            "MAlonzo/Code/Type/BetaNBE/Soundness"
+            "MAlonzo/Code/Type/BetaNBE/Stability"
+            "MAlonzo/Code/Type/BetaNBE/RenamingSubstitution"
+            "MAlonzo/Code/Type/BetaNormal"
+            "MAlonzo/Code/Type/BetaNormal/Equality"
+            "MAlonzo/Code/Type/Equality"
+            "MAlonzo/Code/Type/RenamingSubstitution"
+            "MAlonzo/Code/Algorithmic/Reduction"
+            "MAlonzo/Code/Algorithmic/RenamingSubstitution"
+            "MAlonzo/Code/Scoped/Erasure"
+            "MAlonzo/Code/Untyped"
+            "MAlonzo/Code/Untyped/Reduction"
+            "MAlonzo/Code/Untyped/RenamingSubstitution"
+            ];
+          mainPath = [ "Main.hs" ];
+          };
+        };
+      tests = {
+        "test-plc-agda" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."process" or (buildDepError "process"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."ieee754" or (buildDepError "ieee754"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.language-plutus-core or (pkgs.buildPackages.language-plutus-core or (buildToolDepError "language-plutus-core")))
+            ];
+          buildable = true;
+          modules = [
+            "Raw"
+            "Scoped"
+            "Opts"
+            "MAlonzo/Code/Main"
+            "MAlonzo/Code/Agda/Builtin/Bool"
+            "MAlonzo/Code/Agda/Builtin/Char"
+            "MAlonzo/Code/Agda/Builtin/Equality"
+            "MAlonzo/Code/Agda/Builtin/IO"
+            "MAlonzo/Code/Agda/Builtin/Int"
+            "MAlonzo/Code/Agda/Builtin/List"
+            "MAlonzo/Code/Agda/Builtin/Nat"
+            "MAlonzo/Code/Agda/Builtin/Sigma"
+            "MAlonzo/Code/Agda/Builtin/String"
+            "MAlonzo/Code/Agda/Builtin/Unit"
+            "MAlonzo/Code/Agda/Primitive"
+            "MAlonzo/Code/Algebra"
+            "MAlonzo/Code/Algebra/FunctionProperties/Consequences"
+            "MAlonzo/Code/Algebra/Morphism"
+            "MAlonzo/Code/Algebra/Properties/BooleanAlgebra"
+            "MAlonzo/Code/Algebra/Properties/DistributiveLattice"
+            "MAlonzo/Code/Algebra/Properties/Lattice"
+            "MAlonzo/Code/Algebra/Properties/Semilattice"
+            "MAlonzo/Code/Algebra/Structures"
+            "MAlonzo/Code/Builtin"
+            "MAlonzo/Code/Builtin/Constant/Term"
+            "MAlonzo/Code/Builtin/Constant/Type"
+            "MAlonzo/Code/Builtin/Signature"
+            "MAlonzo/Code/Category/Applicative/Indexed"
+            "MAlonzo/Code/Category/Functor"
+            "MAlonzo/Code/Category/Monad/Indexed"
+            "MAlonzo/Code/Data/Bool/Base"
+            "MAlonzo/Code/Data/Bool/Properties"
+            "MAlonzo/Code/Data/Char/Properties"
+            "MAlonzo/Code/Data/Digit"
+            "MAlonzo/Code/Data/Empty"
+            "MAlonzo/Code/Data/Empty/Irrelevant"
+            "MAlonzo/Code/Data/Fin/Base"
+            "MAlonzo/Code/Data/Integer"
+            "MAlonzo/Code/Data/Integer/Base"
+            "MAlonzo/Code/Data/Integer/Properties"
+            "MAlonzo/Code/Data/List/Base"
+            "MAlonzo/Code/Data/List/NonEmpty"
+            "MAlonzo/Code/Data/List/Properties"
+            "MAlonzo/Code/Data/List/Relation/Binary/Lex/Core"
+            "MAlonzo/Code/Data/List/Relation/Binary/Lex/Strict"
+            "MAlonzo/Code/Data/List/Relation/Binary/Pointwise"
+            "MAlonzo/Code/Data/List/Relation/Unary/All"
+            "MAlonzo/Code/Data/List/Relation/Unary/Any"
+            "MAlonzo/Code/Data/Maybe/Base"
+            "MAlonzo/Code/Data/Nat/Base"
+            "MAlonzo/Code/Data/Nat/DivMod"
+            "MAlonzo/Code/Data/Nat/DivMod/Core"
+            "MAlonzo/Code/Data/Nat/Properties"
+            "MAlonzo/Code/Data/Nat/Show"
+            "MAlonzo/Code/Data/Product"
+            "MAlonzo/Code/Data/Sign"
+            "MAlonzo/Code/Data/String/Base"
+            "MAlonzo/Code/Data/String/Properties"
+            "MAlonzo/Code/Data/Sum/Base"
+            "MAlonzo/Code/Data/These"
+            "MAlonzo/Code/Data/Vec"
+            "MAlonzo/Code/Function/Bijection"
+            "MAlonzo/Code/Function/Equality"
+            "MAlonzo/Code/Function/Equivalence"
+            "MAlonzo/Code/Function/Injection"
+            "MAlonzo/Code/Function/Inverse"
+            "MAlonzo/Code/Function/LeftInverse"
+            "MAlonzo/Code/Function/Surjection"
+            "MAlonzo/Code/Induction"
+            "MAlonzo/Code/Induction/WellFounded"
+            "MAlonzo/Code/Level"
+            "MAlonzo/Code/Raw"
+            "MAlonzo/Code/Relation/Binary"
+            "MAlonzo/Code/Relation/Binary/Consequences"
+            "MAlonzo/Code/Relation/Binary/Construct/NaturalOrder/Left"
+            "MAlonzo/Code/Relation/Binary/Construct/NonStrictToStrict"
+            "MAlonzo/Code/Relation/Binary/Construct/On"
+            "MAlonzo/Code/Relation/Binary/Core"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous/Construct/Trivial"
+            "MAlonzo/Code/Relation/Binary/Lattice"
+            "MAlonzo/Code/Relation/Binary/Properties/Poset"
+            "MAlonzo/Code/Relation/Binary/Properties/Preorder"
+            "MAlonzo/Code/Relation/Binary/PropositionalEquality"
+            "MAlonzo/Code/Relation/Binary/PropositionalEquality/Core"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Base/Single"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Base/Triple"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Setoid"
+            "MAlonzo/Code/Relation/Nullary"
+            "MAlonzo/Code/Relation/Nullary/Decidable"
+            "MAlonzo/Code/Relation/Nullary/Negation"
+            "MAlonzo/Code/Relation/Nullary/Product"
+            "MAlonzo/Code/Relation/Nullary/Sum"
+            "MAlonzo/Code/Relation/Unary/Properties"
+            "MAlonzo/Code/Algebra/Bundles"
+            "MAlonzo/Code/Data/Nat/Divisibility/Core"
+            "MAlonzo/Code/Data/Sign/Base"
+            "MAlonzo/Code/Data/These/Base"
+            "MAlonzo/Code/Data/Vec/Base"
+            "MAlonzo/Code/Data/Vec/Bounded/Base"
+            "MAlonzo/Code/Relation/Binary/Bundles"
+            "MAlonzo/Code/Relation/Binary/Definitions"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous/Bundles"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous/Structures"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Base/Partial"
+            "MAlonzo/Code/Relation/Binary/Reasoning/PartialSetoid"
+            "MAlonzo/Code/Relation/Binary/Structures"
+            "MAlonzo/Code/Relation/Nullary/Decidable/Core"
+            "MAlonzo/Code/Relation/Nullary/Reflects"
+            "MAlonzo/Code/Scoped"
+            "MAlonzo/Code/Scoped/Reduction"
+            "MAlonzo/Code/Scoped/RenamingSubstitution"
+            "MAlonzo/Code/Type"
+            "MAlonzo/Code/Utils"
+            "MAlonzo/RTE"
+            "MAlonzo/Code/Algorithmic"
+            "MAlonzo/Code/Algorithmic/CK"
+            "MAlonzo/Code/Check"
+            "MAlonzo/Code/Scoped/CK"
+            "MAlonzo/Code/Scoped/Extrication"
+            "MAlonzo/Code/Type/BetaNBE"
+            "MAlonzo/Code/Type/BetaNBE/Completeness"
+            "MAlonzo/Code/Type/BetaNBE/Soundness"
+            "MAlonzo/Code/Type/BetaNBE/Stability"
+            "MAlonzo/Code/Type/BetaNBE/RenamingSubstitution"
+            "MAlonzo/Code/Type/BetaNormal"
+            "MAlonzo/Code/Type/BetaNormal/Equality"
+            "MAlonzo/Code/Type/Equality"
+            "MAlonzo/Code/Type/RenamingSubstitution"
+            "MAlonzo/Code/Algorithmic/Reduction"
+            "MAlonzo/Code/Algorithmic/RenamingSubstitution"
+            "MAlonzo/Code/Scoped/Erasure"
+            "MAlonzo/Code/Untyped"
+            "MAlonzo/Code/Untyped/Reduction"
+            "MAlonzo/Code/Untyped/RenamingSubstitution"
+            ];
+          mainPath = [ "TestSimple.hs" ];
+          };
+        "test2-plc-agda" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."Cabal" or (buildDepError "Cabal"))
+            (hsPkgs."process" or (buildDepError "process"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."ieee754" or (buildDepError "ieee754"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.language-plutus-core or (pkgs.buildPackages.language-plutus-core or (buildToolDepError "language-plutus-core")))
+            ];
+          buildable = true;
+          modules = [
+            "Raw"
+            "Scoped"
+            "Opts"
+            "MAlonzo/Code/Main"
+            "MAlonzo/Code/Agda/Builtin/Bool"
+            "MAlonzo/Code/Agda/Builtin/Char"
+            "MAlonzo/Code/Agda/Builtin/Equality"
+            "MAlonzo/Code/Agda/Builtin/IO"
+            "MAlonzo/Code/Agda/Builtin/Int"
+            "MAlonzo/Code/Agda/Builtin/List"
+            "MAlonzo/Code/Agda/Builtin/Nat"
+            "MAlonzo/Code/Agda/Builtin/Sigma"
+            "MAlonzo/Code/Agda/Builtin/String"
+            "MAlonzo/Code/Agda/Builtin/Unit"
+            "MAlonzo/Code/Agda/Primitive"
+            "MAlonzo/Code/Algebra"
+            "MAlonzo/Code/Algebra/FunctionProperties/Consequences"
+            "MAlonzo/Code/Algebra/Morphism"
+            "MAlonzo/Code/Algebra/Properties/BooleanAlgebra"
+            "MAlonzo/Code/Algebra/Properties/DistributiveLattice"
+            "MAlonzo/Code/Algebra/Properties/Lattice"
+            "MAlonzo/Code/Algebra/Properties/Semilattice"
+            "MAlonzo/Code/Algebra/Structures"
+            "MAlonzo/Code/Builtin"
+            "MAlonzo/Code/Builtin/Constant/Term"
+            "MAlonzo/Code/Builtin/Constant/Type"
+            "MAlonzo/Code/Builtin/Signature"
+            "MAlonzo/Code/Category/Applicative/Indexed"
+            "MAlonzo/Code/Category/Functor"
+            "MAlonzo/Code/Category/Monad/Indexed"
+            "MAlonzo/Code/Data/Bool/Base"
+            "MAlonzo/Code/Data/Bool/Properties"
+            "MAlonzo/Code/Data/Char/Properties"
+            "MAlonzo/Code/Data/Digit"
+            "MAlonzo/Code/Data/Empty"
+            "MAlonzo/Code/Data/Empty/Irrelevant"
+            "MAlonzo/Code/Data/Fin/Base"
+            "MAlonzo/Code/Data/Integer"
+            "MAlonzo/Code/Data/Integer/Base"
+            "MAlonzo/Code/Data/Integer/Properties"
+            "MAlonzo/Code/Data/List/Base"
+            "MAlonzo/Code/Data/List/NonEmpty"
+            "MAlonzo/Code/Data/List/Properties"
+            "MAlonzo/Code/Data/List/Relation/Binary/Lex/Core"
+            "MAlonzo/Code/Data/List/Relation/Binary/Lex/Strict"
+            "MAlonzo/Code/Data/List/Relation/Binary/Pointwise"
+            "MAlonzo/Code/Data/List/Relation/Unary/All"
+            "MAlonzo/Code/Data/List/Relation/Unary/Any"
+            "MAlonzo/Code/Data/Maybe/Base"
+            "MAlonzo/Code/Data/Nat/Base"
+            "MAlonzo/Code/Data/Nat/DivMod"
+            "MAlonzo/Code/Data/Nat/DivMod/Core"
+            "MAlonzo/Code/Data/Nat/Properties"
+            "MAlonzo/Code/Data/Nat/Show"
+            "MAlonzo/Code/Data/Product"
+            "MAlonzo/Code/Data/Sign"
+            "MAlonzo/Code/Data/String/Base"
+            "MAlonzo/Code/Data/String/Properties"
+            "MAlonzo/Code/Data/Sum/Base"
+            "MAlonzo/Code/Data/These"
+            "MAlonzo/Code/Data/Vec"
+            "MAlonzo/Code/Function/Bijection"
+            "MAlonzo/Code/Function/Equality"
+            "MAlonzo/Code/Function/Equivalence"
+            "MAlonzo/Code/Function/Injection"
+            "MAlonzo/Code/Function/Inverse"
+            "MAlonzo/Code/Function/LeftInverse"
+            "MAlonzo/Code/Function/Surjection"
+            "MAlonzo/Code/Induction"
+            "MAlonzo/Code/Induction/WellFounded"
+            "MAlonzo/Code/Level"
+            "MAlonzo/Code/Algebra/Bundles"
+            "MAlonzo/Code/Data/Nat/Divisibility/Core"
+            "MAlonzo/Code/Data/Sign/Base"
+            "MAlonzo/Code/Data/These/Base"
+            "MAlonzo/Code/Data/Vec/Base"
+            "MAlonzo/Code/Data/Vec/Bounded/Base"
+            "MAlonzo/Code/Relation/Binary/Bundles"
+            "MAlonzo/Code/Relation/Binary/Definitions"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous/Bundles"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous/Structures"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Base/Partial"
+            "MAlonzo/Code/Relation/Binary/Reasoning/PartialSetoid"
+            "MAlonzo/Code/Relation/Binary/Structures"
+            "MAlonzo/Code/Relation/Nullary/Decidable/Core"
+            "MAlonzo/Code/Relation/Nullary/Reflects"
+            "MAlonzo/Code/Raw"
+            "MAlonzo/Code/Relation/Binary"
+            "MAlonzo/Code/Relation/Binary/Consequences"
+            "MAlonzo/Code/Relation/Binary/Construct/NaturalOrder/Left"
+            "MAlonzo/Code/Relation/Binary/Construct/NonStrictToStrict"
+            "MAlonzo/Code/Relation/Binary/Construct/On"
+            "MAlonzo/Code/Relation/Binary/Core"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous"
+            "MAlonzo/Code/Relation/Binary/Indexed/Heterogeneous/Construct/Trivial"
+            "MAlonzo/Code/Relation/Binary/Lattice"
+            "MAlonzo/Code/Relation/Binary/Properties/Poset"
+            "MAlonzo/Code/Relation/Binary/Properties/Preorder"
+            "MAlonzo/Code/Relation/Binary/PropositionalEquality"
+            "MAlonzo/Code/Relation/Binary/PropositionalEquality/Core"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Base/Single"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Base/Triple"
+            "MAlonzo/Code/Relation/Binary/Reasoning/Setoid"
+            "MAlonzo/Code/Relation/Nullary"
+            "MAlonzo/Code/Relation/Nullary/Decidable"
+            "MAlonzo/Code/Relation/Nullary/Negation"
+            "MAlonzo/Code/Relation/Nullary/Product"
+            "MAlonzo/Code/Relation/Nullary/Sum"
+            "MAlonzo/Code/Relation/Unary/Properties"
+            "MAlonzo/Code/Scoped"
+            "MAlonzo/Code/Scoped/Reduction"
+            "MAlonzo/Code/Scoped/RenamingSubstitution"
+            "MAlonzo/Code/Type"
+            "MAlonzo/Code/Utils"
+            "MAlonzo/RTE"
+            "MAlonzo/Code/Algorithmic"
+            "MAlonzo/Code/Algorithmic/CK"
+            "MAlonzo/Code/Check"
+            "MAlonzo/Code/Scoped/CK"
+            "MAlonzo/Code/Scoped/Extrication"
+            "MAlonzo/Code/Type/BetaNBE"
+            "MAlonzo/Code/Type/BetaNBE/Completeness"
+            "MAlonzo/Code/Type/BetaNBE/Soundness"
+            "MAlonzo/Code/Type/BetaNBE/Stability"
+            "MAlonzo/Code/Type/BetaNBE/RenamingSubstitution"
+            "MAlonzo/Code/Type/BetaNormal"
+            "MAlonzo/Code/Type/BetaNormal/Equality"
+            "MAlonzo/Code/Type/Equality"
+            "MAlonzo/Code/Type/RenamingSubstitution"
+            "MAlonzo/Code/Algorithmic/Reduction"
+            "MAlonzo/Code/Algorithmic/RenamingSubstitution"
+            "MAlonzo/Code/Scoped/Erasure"
+            "MAlonzo/Code/Untyped"
+            "MAlonzo/Code/Untyped/Reduction"
+            "MAlonzo/Code/Untyped/RenamingSubstitution"
+            ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./metatheory;
+    }

--- a/nix/stack.materialized/plutus-book.nix
+++ b/nix/stack.materialized/plutus-book.nix
@@ -1,0 +1,67 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { defer-plugin-errors = false; };
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-book"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "michael.peyton-jones@iohk.io";
+      author = "Michael Peyton Jones";
+      homepage = "";
+      url = "";
+      synopsis = "The Plutus Book";
+      description = "The Plutus Book";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [ "README.adoc" ];
+      };
+    components = { "library" = { buildable = true; }; };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-book;
+    }

--- a/nix/stack.materialized/plutus-contract-tasty.nix
+++ b/nix/stack.materialized/plutus-contract-tasty.nix
@@ -1,0 +1,121 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-contract-tasty"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jann.mueller@iohk.io";
+      author = "Jann Müller";
+      homepage = "https://github.com/iohk/plutus#readme";
+      url = "";
+      synopsis = "";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+          (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+          (hsPkgs."iots-export" or (buildDepError "iots-export"))
+          (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."semigroupoids" or (buildDepError "semigroupoids"))
+          (hsPkgs."profunctors" or (buildDepError "profunctors"))
+          (hsPkgs."transformers-base" or (buildDepError "transformers-base"))
+          (hsPkgs."monad-control" or (buildDepError "monad-control"))
+          (hsPkgs."mmorph" or (buildDepError "mmorph"))
+          (hsPkgs."tasty" or (buildDepError "tasty"))
+          (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+          (hsPkgs."row-types" or (buildDepError "row-types"))
+          (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+          ];
+        buildable = true;
+        modules = [ "Language/Plutus/Contract/Test" ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "plutus-contract-tasty-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."extensible-effects" or (buildDepError "extensible-effects"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."plutus-contract-tasty" or (buildDepError "plutus-contract-tasty"))
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"));
+          buildable = true;
+          modules = [ "Spec/Contract" ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-contract-tasty;
+    }

--- a/nix/stack.materialized/plutus-contract.nix
+++ b/nix/stack.materialized/plutus-contract.nix
@@ -1,0 +1,168 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-contract"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jann.mueller@iohk.io";
+      author = "Jann Müller";
+      homepage = "https://github.com/iohk/plutus#readme";
+      url = "";
+      synopsis = "";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+          (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+          (hsPkgs."iots-export" or (buildDepError "iots-export"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."servant-server" or (buildDepError "servant-server"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."semigroupoids" or (buildDepError "semigroupoids"))
+          (hsPkgs."profunctors" or (buildDepError "profunctors"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."warp" or (buildDepError "warp"))
+          (hsPkgs."transformers-base" or (buildDepError "transformers-base"))
+          (hsPkgs."monad-control" or (buildDepError "monad-control"))
+          (hsPkgs."mmorph" or (buildDepError "mmorph"))
+          (hsPkgs."row-types" or (buildDepError "row-types"))
+          (hsPkgs."freer-simple" or (buildDepError "freer-simple"))
+          (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+          ];
+        buildable = true;
+        modules = [
+          "Data/Row/Extras"
+          "Language/Plutus/Contract"
+          "Language/Plutus/Contract/App"
+          "Language/Plutus/Contract/Effects/AwaitSlot"
+          "Language/Plutus/Contract/Effects/AwaitTxConfirmed"
+          "Language/Plutus/Contract/Effects/ExposeEndpoint"
+          "Language/Plutus/Contract/Effects/OwnPubKey"
+          "Language/Plutus/Contract/Effects/UtxoAt"
+          "Language/Plutus/Contract/Effects/WatchAddress"
+          "Language/Plutus/Contract/Effects/WriteTx"
+          "Language/Plutus/Contract/Request"
+          "Language/Plutus/Contract/Constraints"
+          "Language/Plutus/Contract/Schema"
+          "Language/Plutus/Contract/Trace"
+          "Language/Plutus/Contract/Record"
+          "Language/Plutus/Contract/IOTS"
+          "Language/Plutus/Contract/Servant"
+          "Language/Plutus/Contract/Resumable"
+          "Language/Plutus/Contract/StateMachine"
+          "Language/Plutus/Contract/StateMachine/OnChain"
+          "Language/Plutus/Contract/Tx"
+          "Language/Plutus/Contract/Util"
+          "Language/Plutus/Contract/Wallet"
+          "Language/Plutus/Contract/Typed/Tx"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "contract-doctests" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.unlit or (pkgs.buildPackages.unlit or (buildToolDepError "unlit")))
+            (hsPkgs.buildPackages.doctest or (pkgs.buildPackages.doctest or (buildToolDepError "doctest")))
+            ];
+          buildable = true;
+          modules = [ "ContractAPI" ];
+          hsSourceDirs = [ "doctest" "doc" ];
+          mainPath = [ "Main.hs" ];
+          };
+        "plutus-contract-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."extensible-effects" or (buildDepError "extensible-effects"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            ];
+          buildable = true;
+          modules = [ "Spec/Rows" "Spec/State" ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-contract;
+    }

--- a/nix/stack.materialized/plutus-emulator.nix
+++ b/nix/stack.materialized/plutus-emulator.nix
@@ -1,0 +1,153 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-emulator"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jann.mueller@iohk.io";
+      author = "Michael Peyton Jones, Jann Mueller";
+      homepage = "";
+      url = "";
+      synopsis = "Plutus emulator of the extended UTXO model with scripts";
+      description = "Plutus emulator of the extended UTXO model with scripts";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [ "README.md" ];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+          (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."conduit" or (buildDepError "conduit"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."iots-export" or (buildDepError "iots-export"))
+          (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."natural-transformation" or (buildDepError "natural-transformation"))
+          (hsPkgs."operational" or (buildDepError "operational"))
+          (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."servant-client" or (buildDepError "servant-client"))
+          (hsPkgs."servant-server" or (buildDepError "servant-server"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."deriving-compat" or (buildDepError "deriving-compat"))
+          (hsPkgs."newtype-generics" or (buildDepError "newtype-generics"))
+          (hsPkgs."http-api-data" or (buildDepError "http-api-data"))
+          (hsPkgs."freer-simple" or (buildDepError "freer-simple"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          ];
+        buildable = true;
+        modules = [
+          "Wallet/Emulator"
+          "Wallet/Emulator/Types"
+          "Wallet/Emulator/Generators"
+          "Wallet/Emulator/Chain"
+          "Wallet/Emulator/ChainIndex"
+          "Wallet/Emulator/Error"
+          "Wallet/Emulator/NodeClient"
+          "Wallet/Emulator/MultiAgent"
+          "Wallet/Emulator/SigningProcess"
+          "Wallet/Emulator/Wallet"
+          "Wallet/Rollup"
+          "Wallet/Rollup/Types"
+          "Wallet/Rollup/Render"
+          "Wallet"
+          "Wallet/API"
+          "Wallet/Effects"
+          "Wallet/Graph"
+          "Control/Monad/Freer/Extras"
+          "Control/Monad/Freer/Log"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "plutus-emulator-test" = {
+          depends = [
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."freer-simple" or (buildDepError "freer-simple"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"));
+          buildable = true;
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-emulator;
+    }

--- a/nix/stack.materialized/plutus-ir.nix
+++ b/nix/stack.materialized/plutus-ir.nix
@@ -1,0 +1,138 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.0";
+      identifier = { name = "plutus-ir"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "michael.peyton-jones@iohk.io";
+      author = "Michael Peyton Jones";
+      homepage = "";
+      url = "";
+      synopsis = "Plutus IR language";
+      description = "Plutus IR language library and compiler to Plutus Core.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [ "README.md" ];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."mmorph" or (buildDepError "mmorph"))
+          (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+          (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."algebraic-graphs" or (buildDepError "algebraic-graphs"))
+          (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
+          (hsPkgs."parser-combinators" or (buildDepError "parser-combinators"))
+          ];
+        buildable = true;
+        modules = [
+          "Language/PlutusIR/Analysis/Dependencies"
+          "Language/PlutusIR/Analysis/Usages"
+          "Language/PlutusIR/Compiler/Error"
+          "Language/PlutusIR/Compiler/Let"
+          "Language/PlutusIR/Compiler/Datatype"
+          "Language/PlutusIR/Compiler/Provenance"
+          "Language/PlutusIR/Compiler/Recursion"
+          "Language/PlutusIR/Compiler/Types"
+          "Language/PlutusIR/Compiler/Lower"
+          "Language/PlutusIR"
+          "Language/PlutusIR/Compiler"
+          "Language/PlutusIR/Compiler/Names"
+          "Language/PlutusIR/Compiler/Definitions"
+          "Language/PlutusIR/Generators/AST"
+          "Language/PlutusIR/Parser"
+          "Language/PlutusIR/MkPir"
+          "Language/PlutusIR/Value"
+          "Language/PlutusIR/Optimizer/DeadCode"
+          "Language/PlutusIR/Transform/Substitute"
+          "Language/PlutusIR/Transform/ThunkRecursions"
+          "Language/PlutusIR/Transform/Rename"
+          "Language/PlutusIR/Transform/NonStrict"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "plutus-ir-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."plutus-ir" or (buildDepError "plutus-ir"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."mmorph" or (buildDepError "mmorph"))
+            (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
+            ];
+          buildable = true;
+          modules = [ "OptimizerSpec" "TransformSpec" "ParserSpec" "TestLib" ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-ir;
+    }

--- a/nix/stack.materialized/plutus-ledger.nix
+++ b/nix/stack.materialized/plutus-ledger.nix
@@ -1,0 +1,158 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { defer-plugin-errors = false; };
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-ledger"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "michael.peyton-jones@iohk.io";
+      author = "Michael Peyton Jones, Jann Mueller";
+      homepage = "";
+      url = "";
+      synopsis = "Wallet API";
+      description = "Plutus ledger library";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [ "README.md" ];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."plutus-ir" or (buildDepError "plutus-ir"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."iots-export" or (buildDepError "iots-export"))
+          (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."natural-transformation" or (buildDepError "natural-transformation"))
+          (hsPkgs."operational" or (buildDepError "operational"))
+          (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"))
+          (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+          (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."deriving-compat" or (buildDepError "deriving-compat"))
+          (hsPkgs."newtype-generics" or (buildDepError "newtype-generics"))
+          (hsPkgs."http-api-data" or (buildDepError "http-api-data"))
+          (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."freer-simple" or (buildDepError "freer-simple"))
+          ];
+        buildable = true;
+        modules = [
+          "Data/Aeson/Extras"
+          "Data/Text/Prettyprint/Doc/Extras"
+          "Ledger"
+          "Ledger/Ada"
+          "Ledger/Address"
+          "Ledger/AddressMap"
+          "Ledger/Blockchain"
+          "Ledger/Constraints"
+          "Ledger/Constraints/OffChain"
+          "Ledger/Constraints/OnChain"
+          "Ledger/Constraints/TxConstraints"
+          "Ledger/Crypto"
+          "Ledger/Generators"
+          "Ledger/Oracle"
+          "Ledger/Orphans"
+          "Ledger/Slot"
+          "Ledger/Scripts"
+          "Ledger/Tx"
+          "Ledger/TxId"
+          "Ledger/Validation"
+          "Ledger/Index"
+          "Ledger/Interval"
+          "Ledger/Value"
+          "LedgerBytes"
+          "Ledger/Tokens"
+          "Ledger/Typed/Scripts"
+          "Ledger/Typed/Scripts/Validators"
+          "Ledger/Typed/Tx"
+          "Ledger/Typed/TypeUtils"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "plutus-ledger-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-ledger;
+    }

--- a/nix/stack.materialized/plutus-playground-lib.nix
+++ b/nix/stack.materialized/plutus-playground-lib.nix
@@ -1,0 +1,139 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.0";
+      identifier = { name = "plutus-playground-lib"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "2018 IOHK";
+      maintainer = "kris.jenkins@tweag.io";
+      author = "Kris Jenkins";
+      homepage = "https://github.com/iohk/plutus#readme";
+      url = "";
+      synopsis = "";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."freer-simple" or (buildDepError "freer-simple"))
+          (hsPkgs."deriving-compat" or (buildDepError "deriving-compat"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."insert-ordered-containers" or (buildDepError "insert-ordered-containers"))
+          (hsPkgs."iots-export" or (buildDepError "iots-export"))
+          (hsPkgs."playground-common" or (buildDepError "playground-common"))
+          (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."newtype-generics" or (buildDepError "newtype-generics"))
+          (hsPkgs."row-types" or (buildDepError "row-types"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+          (hsPkgs."plutus-contract-tasty" or (buildDepError "plutus-contract-tasty"))
+          (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+          (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+          (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."wl-pprint-text" or (buildDepError "wl-pprint-text"))
+          ];
+        buildable = true;
+        modules = [
+          "Playground/Schema"
+          "Playground/Contract"
+          "Playground/API"
+          "Playground/Types"
+          "Playground/TH"
+          "Playground/Interpreter/Util"
+          "Schema"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "plutus-playground-lib-test" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."iots-export" or (buildDepError "iots-export"))
+            (hsPkgs."playground-common" or (buildDepError "playground-common"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+            (hsPkgs."plutus-playground-lib" or (buildDepError "plutus-playground-lib"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."freer-simple" or (buildDepError "freer-simple"))
+            ];
+          buildable = true;
+          modules = [ "Playground/THSpec" "Playground/TypesSpec" "SchemaSpec" ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-playground-lib;
+    }

--- a/nix/stack.materialized/plutus-playground-server.nix
+++ b/nix/stack.materialized/plutus-playground-server.nix
@@ -1,0 +1,281 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { defer-plugin-errors = false; };
+    package = {
+      specVersion = "2.0";
+      identifier = { name = "plutus-playground-server"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "kris.jenkins@tweag.io";
+      author = "Kris Jenkins";
+      homepage = "https://github.com/iohk/plutus#readme";
+      url = "";
+      synopsis = "";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [
+        "usecases/Crowdfunding.hs"
+        "usecases/ErrorHandling.hs"
+        "usecases/Game.hs"
+        "usecases/Vesting.hs"
+        "usecases/Starter.hs"
+        "test/gists1.json"
+        ];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cookie" or (buildDepError "cookie"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."exceptions" or (buildDepError "exceptions"))
+          (hsPkgs."file-embed" or (buildDepError "file-embed"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."http-client" or (buildDepError "http-client"))
+          (hsPkgs."http-client-tls" or (buildDepError "http-client-tls"))
+          (hsPkgs."http-conduit" or (buildDepError "http-conduit"))
+          (hsPkgs."http-types" or (buildDepError "http-types"))
+          (hsPkgs."iots-export" or (buildDepError "iots-export"))
+          (hsPkgs."jwt" or (buildDepError "jwt"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."monad-logger" or (buildDepError "monad-logger"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."newtype-generics" or (buildDepError "newtype-generics"))
+          (hsPkgs."playground-common" or (buildDepError "playground-common"))
+          (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+          (hsPkgs."plutus-playground-lib" or (buildDepError "plutus-playground-lib"))
+          (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+          (hsPkgs."process" or (buildDepError "process"))
+          (hsPkgs."regex-compat" or (buildDepError "regex-compat"))
+          (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+          (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+          (hsPkgs."row-types" or (buildDepError "row-types"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."servant-client" or (buildDepError "servant-client"))
+          (hsPkgs."servant-client-core" or (buildDepError "servant-client-core"))
+          (hsPkgs."servant-purescript" or (buildDepError "servant-purescript"))
+          (hsPkgs."servant-server" or (buildDepError "servant-server"))
+          (hsPkgs."temporary" or (buildDepError "temporary"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"));
+        buildable = true;
+        modules = [
+          "Playground/Server"
+          "Playground/Interpreter"
+          "Playground/Usecases"
+          "Crowdfunding"
+          "CrowdfundingSimulations"
+          "ErrorHandling"
+          "ErrorHandlingSimulations"
+          "Game"
+          "GameSimulations"
+          "SimulationUtils"
+          "Starter"
+          "StarterSimulations"
+          "Vesting"
+          "VestingSimulations"
+          ];
+        hsSourceDirs = [ "src" "usecases" ];
+        };
+      sublibs = {
+        "plutus-playground-usecases" = {
+          depends = [
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."insert-ordered-containers" or (buildDepError "insert-ordered-containers"))
+            (hsPkgs."iots-export" or (buildDepError "iots-export"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."playground-common" or (buildDepError "playground-common"))
+            (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."plutus-playground-lib" or (buildDepError "plutus-playground-lib"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+            (hsPkgs."row-types" or (buildDepError "row-types"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"));
+          buildable = true;
+          modules = [
+            "Crowdfunding"
+            "CrowdfundingSimulations"
+            "ErrorHandling"
+            "ErrorHandlingSimulations"
+            "Game"
+            "GameSimulations"
+            "SimulationUtils"
+            "Starter"
+            "StarterSimulations"
+            "Vesting"
+            "VestingSimulations"
+            ];
+          hsSourceDirs = [ "usecases" ];
+          };
+        };
+      exes = {
+        "plutus-playground-server" = {
+          depends = [
+            (hsPkgs."adjunctions" or (buildDepError "adjunctions"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."aeson-pretty" or (buildDepError "aeson-pretty"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."exceptions" or (buildDepError "exceptions"))
+            (hsPkgs."data-default-class" or (buildDepError "data-default-class"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."http-types" or (buildDepError "http-types"))
+            (hsPkgs."iots-export" or (buildDepError "iots-export"))
+            (hsPkgs."playground-common" or (buildDepError "playground-common"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."monad-logger" or (buildDepError "monad-logger"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."plutus-playground-lib" or (buildDepError "plutus-playground-lib"))
+            (hsPkgs."plutus-playground-server" or (buildDepError "plutus-playground-server"))
+            (hsPkgs."plutus-playground-usecases" or (buildDepError "plutus-playground-usecases"))
+            (hsPkgs."prometheus" or (buildDepError "prometheus"))
+            (hsPkgs."purescript-bridge" or (buildDepError "purescript-bridge"))
+            (hsPkgs."servant" or (buildDepError "servant"))
+            (hsPkgs."servant-foreign" or (buildDepError "servant-foreign"))
+            (hsPkgs."servant-purescript" or (buildDepError "servant-purescript"))
+            (hsPkgs."servant-server" or (buildDepError "servant-server"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."wai" or (buildDepError "wai"))
+            (hsPkgs."wai-cors" or (buildDepError "wai-cors"))
+            (hsPkgs."wai-extra" or (buildDepError "wai-extra"))
+            (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+            (hsPkgs."row-types" or (buildDepError "row-types"))
+            (hsPkgs."warp" or (buildDepError "warp"))
+            (hsPkgs."yaml" or (buildDepError "yaml"))
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"));
+          buildable = true;
+          modules = [
+            "Webserver"
+            "Types"
+            "PSGenerator"
+            "Crowdfunding"
+            "CrowdfundingSimulations"
+            "ErrorHandling"
+            "ErrorHandlingSimulations"
+            "Game"
+            "GameSimulations"
+            "SimulationUtils"
+            "Starter"
+            "StarterSimulations"
+            "Vesting"
+            "VestingSimulations"
+            ];
+          hsSourceDirs = [ "app" "usecases" ];
+          mainPath = [
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) "";
+          };
+        };
+      tests = {
+        "plutus-playground-server-test" = {
+          depends = [
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-golden" or (buildDepError "tasty-golden"))
+            (hsPkgs."insert-ordered-containers" or (buildDepError "insert-ordered-containers"))
+            (hsPkgs."playground-common" or (buildDepError "playground-common"))
+            (hsPkgs."iots-export" or (buildDepError "iots-export"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."plutus-playground-lib" or (buildDepError "plutus-playground-lib"))
+            (hsPkgs."plutus-playground-server" or (buildDepError "plutus-playground-server"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-playground-usecases" or (buildDepError "plutus-playground-usecases"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"));
+          buildable = true;
+          modules = [
+            "GistSpec"
+            "Paths_plutus_playground_server"
+            "Playground/InterpreterSpec"
+            "Playground/UsecasesSpec"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-playground-server;
+    }

--- a/nix/stack.materialized/plutus-scb.nix
+++ b/nix/stack.materialized/plutus-scb.nix
@@ -1,0 +1,253 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { defer-plugin-errors = false; };
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-scb"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jann.mueller@iohk.io";
+      author = "Jann Müller";
+      homepage = "https://github.com/iohk/plutus#readme";
+      url = "";
+      synopsis = "";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+          (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+          (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"))
+          (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+          (hsPkgs."iots-export" or (buildDepError "iots-export"))
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."aeson-pretty" or (buildDepError "aeson-pretty"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."errors" or (buildDepError "errors"))
+          (hsPkgs."eventful-core" or (buildDepError "eventful-core"))
+          (hsPkgs."eventful-memory" or (buildDepError "eventful-memory"))
+          (hsPkgs."eventful-sql-common" or (buildDepError "eventful-sql-common"))
+          (hsPkgs."eventful-sqlite" or (buildDepError "eventful-sqlite"))
+          (hsPkgs."freer-simple" or (buildDepError "freer-simple"))
+          (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
+          (hsPkgs."http-client" or (buildDepError "http-client"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."monad-logger" or (buildDepError "monad-logger"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+          (hsPkgs."persistent" or (buildDepError "persistent"))
+          (hsPkgs."persistent-sqlite" or (buildDepError "persistent-sqlite"))
+          (hsPkgs."playground-common" or (buildDepError "playground-common"))
+          (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+          (hsPkgs."process" or (buildDepError "process"))
+          (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+          (hsPkgs."random" or (buildDepError "random"))
+          (hsPkgs."row-types" or (buildDepError "row-types"))
+          (hsPkgs."scientific" or (buildDepError "scientific"))
+          (hsPkgs."servant" or (buildDepError "servant"))
+          (hsPkgs."servant-client" or (buildDepError "servant-client"))
+          (hsPkgs."servant-server" or (buildDepError "servant-server"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."unliftio-core" or (buildDepError "unliftio-core"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."uuid" or (buildDepError "uuid"))
+          (hsPkgs."vector" or (buildDepError "vector"))
+          (hsPkgs."warp" or (buildDepError "warp"))
+          (hsPkgs."yaml" or (buildDepError "yaml"))
+          (hsPkgs."mwc-random" or (buildDepError "mwc-random"))
+          (hsPkgs."primitive" or (buildDepError "primitive"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          ];
+        buildable = true;
+        modules = [
+          "Servant/Extra"
+          "Cardano/ChainIndex/API"
+          "Cardano/ChainIndex/Client"
+          "Cardano/ChainIndex/Server"
+          "Cardano/ChainIndex/Types"
+          "Cardano/Node/API"
+          "Cardano/Node/Client"
+          "Cardano/Node/Follower"
+          "Cardano/Node/Mock"
+          "Cardano/Node/RandomTx"
+          "Cardano/Node/Server"
+          "Cardano/Node/Types"
+          "Cardano/SigningProcess/API"
+          "Cardano/SigningProcess/Server"
+          "Cardano/SigningProcess/Client"
+          "Cardano/Wallet/API"
+          "Cardano/Wallet/Client"
+          "Cardano/Wallet/Mock"
+          "Cardano/Wallet/Server"
+          "Cardano/Wallet/Types"
+          "Control/Monad/Freer/Extra/Log"
+          "Control/Monad/Freer/Extra/State"
+          "Data/Time/Units/Extra"
+          "Plutus/SCB/App"
+          "Plutus/SCB/Arbitrary"
+          "Plutus/SCB/Command"
+          "Plutus/SCB/ContractCLI"
+          "Plutus/SCB/Core"
+          "Plutus/SCB/Effects/Contract"
+          "Plutus/SCB/Effects/EventLog"
+          "Plutus/SCB/Effects/UUID"
+          "Plutus/SCB/Webserver/Types"
+          "Plutus/SCB/Webserver/API"
+          "Plutus/SCB/Webserver/Server"
+          "Plutus/SCB/Events"
+          "Plutus/SCB/Query"
+          "Plutus/SCB/Relation"
+          "Plutus/SCB/Types"
+          "Plutus/SCB/Utils"
+          "Plutus/SCB/Events/Contract"
+          "Plutus/SCB/Events/Node"
+          "Plutus/SCB/Events/User"
+          "Plutus/SCB/Events/Wallet"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      exes = {
+        "plutus-scb" = {
+          depends = [
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."aeson-pretty" or (buildDepError "aeson-pretty"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."ekg" or (buildDepError "ekg"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."freer-simple" or (buildDepError "freer-simple"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."monad-logger" or (buildDepError "monad-logger"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
+            (hsPkgs."playground-common" or (buildDepError "playground-common"))
+            (hsPkgs."plutus-scb" or (buildDepError "plutus-scb"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+            (hsPkgs."purescript-bridge" or (buildDepError "purescript-bridge"))
+            (hsPkgs."servant-purescript" or (buildDepError "servant-purescript"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."unliftio-core" or (buildDepError "unliftio-core"))
+            (hsPkgs."uuid" or (buildDepError "uuid"))
+            (hsPkgs."yaml" or (buildDepError "yaml"))
+            ];
+          buildable = true;
+          modules = [ "PSGenerator" ];
+          hsSourceDirs = [ "app" ];
+          mainPath = [ "Main.hs" ];
+          };
+        "plutus-contract" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."plutus-scb" or (buildDepError "plutus-scb"))
+            (hsPkgs."plutus-use-cases" or (buildDepError "plutus-use-cases"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "contract" ];
+          mainPath = [ "Main.hs" ];
+          };
+        };
+      tests = {
+        "plutus-scb-test" = {
+          depends = [
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."aeson-pretty" or (buildDepError "aeson-pretty"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."eventful-core" or (buildDepError "eventful-core"))
+            (hsPkgs."eventful-memory" or (buildDepError "eventful-memory"))
+            (hsPkgs."freer-simple" or (buildDepError "freer-simple"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."monad-logger" or (buildDepError "monad-logger"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+            (hsPkgs."plutus-scb" or (buildDepError "plutus-scb"))
+            (hsPkgs."plutus-use-cases" or (buildDepError "plutus-use-cases"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+            (hsPkgs."servant-client" or (buildDepError "servant-client"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+            ];
+          buildable = true;
+          modules = [
+            "Plutus/SCB/CoreSpec"
+            "Plutus/SCB/RelationSpec"
+            "Plutus/SCB/TestApp"
+            "Plutus/SCB/Effects/ContractTest"
+            "Plutus/SCB/Effects/MultiAgent"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-scb;
+    }

--- a/nix/stack.materialized/plutus-tutorial.nix
+++ b/nix/stack.materialized/plutus-tutorial.nix
@@ -1,0 +1,93 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { defer-plugin-errors = false; };
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-tutorial"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jann.mueller@iohk.io";
+      author = "Michael Peyton Jones, Jann Mueller";
+      homepage = "";
+      url = "";
+      synopsis = "PlutusTx tutorial";
+      description = "A tutorial for PlutusTx.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [ "README.adoc" ];
+      };
+    components = {
+      exes = {
+        "tutorial-doctests" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"));
+          build-tools = [
+            (hsPkgs.buildPackages.unlit or (pkgs.buildPackages.unlit or (buildToolDepError "unlit")))
+            (hsPkgs.buildPackages.doctest or (pkgs.buildPackages.doctest or (buildToolDepError "doctest")))
+            ];
+          buildable = true;
+          modules = [ "Tutorial/PlutusTx" ];
+          hsSourceDirs = [ "doctest" "doc" ];
+          mainPath = ([
+            "Main.hs"
+            ] ++ (pkgs.lib).optional (flags.defer-plugin-errors) "") ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) "";
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-tutorial;
+    }

--- a/nix/stack.materialized/plutus-tx-plugin.nix
+++ b/nix/stack.materialized/plutus-tx-plugin.nix
@@ -1,0 +1,146 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-tx-plugin"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "michael.peyton-jones@iohk.io";
+      author = "Michael Peyton Jones";
+      homepage = "";
+      url = "";
+      synopsis = "The Plutus Tx compiler and GHC plugin";
+      description = "The Plutus Tx compiler and GHC plugin.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [ "README.md" ];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."extra" or (buildDepError "extra"))
+          (hsPkgs."ghc" or (buildDepError "ghc"))
+          (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."plutus-ir" or (buildDepError "plutus-ir"))
+          (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+          ];
+        buildable = true;
+        modules = [
+          "Language/PlutusTx/PLCTypes"
+          "Language/PlutusTx/PIRTypes"
+          "Language/PlutusTx/Compiler/Error"
+          "Language/PlutusTx/Compiler/Binders"
+          "Language/PlutusTx/Compiler/Builtins"
+          "Language/PlutusTx/Compiler/Laziness"
+          "Language/PlutusTx/Compiler/Expr"
+          "Language/PlutusTx/Compiler/Names"
+          "Language/PlutusTx/Compiler/Kind"
+          "Language/PlutusTx/Compiler/Primitives"
+          "Language/PlutusTx/Compiler/Type"
+          "Language/PlutusTx/Compiler/Types"
+          "Language/PlutusTx/Compiler/Utils"
+          "Language/PlutusTx/Plugin"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      tests = {
+        "plutus-tx-tests" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."integer-gmp" or (buildDepError "integer-gmp"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"))
+            (hsPkgs."plutus-ir" or (buildDepError "plutus-ir"))
+            (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."serialise" or (buildDepError "serialise"))
+            (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            ];
+          buildable = true;
+          modules = [
+            "Lift/Spec"
+            "Plugin/Spec"
+            "Plugin/Basic/Spec"
+            "Plugin/Data/Spec"
+            "Plugin/Errors/Spec"
+            "Plugin/Functions/Spec"
+            "Plugin/Laziness/Spec"
+            "Plugin/Primitives/Spec"
+            "Plugin/Typeclasses/Spec"
+            "Plugin/Typeclasses/Lib"
+            "Plugin/Lib"
+            "StdLib/Spec"
+            "TH/Spec"
+            "TH/TestTH"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-tx-plugin;
+    }

--- a/nix/stack.materialized/plutus-tx.nix
+++ b/nix/stack.materialized/plutus-tx.nix
@@ -1,0 +1,123 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-tx"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "michael.peyton-jones@iohk.io";
+      author = "Michael Peyton Jones";
+      homepage = "";
+      url = "";
+      synopsis = "Libraries for Plutus Tx and its prelude";
+      description = "Libraries for Plutus Tx and its prelude";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [ "README.md" ];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."th-abstraction" or (buildDepError "th-abstraction"))
+          (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."plutus-ir" or (buildDepError "plutus-ir"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."serialise" or (buildDepError "serialise"))
+          (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          ];
+        build-tools = [
+          (hsPkgs.buildPackages.doctest or (pkgs.buildPackages.doctest or (buildToolDepError "doctest")))
+          ];
+        buildable = true;
+        modules = [
+          "Language/PlutusTx/IsData/Instances"
+          "Language/PlutusTx/IsData/TH"
+          "Language/PlutusTx/Lift/THUtils"
+          "Language/PlutusTx/Lift/Instances"
+          "Language/PlutusTx"
+          "Language/PlutusTx/TH"
+          "Language/PlutusTx/Prelude"
+          "Language/PlutusTx/Evaluation"
+          "Language/PlutusTx/Applicative"
+          "Language/PlutusTx/Bool"
+          "Language/PlutusTx/IsData"
+          "Language/PlutusTx/IsData/Class"
+          "Language/PlutusTx/Eq"
+          "Language/PlutusTx/Functor"
+          "Language/PlutusTx/Lattice"
+          "Language/PlutusTx/List"
+          "Language/PlutusTx/Ord"
+          "Language/PlutusTx/Maybe"
+          "Language/PlutusTx/Numeric"
+          "Language/PlutusTx/Ratio"
+          "Language/PlutusTx/Semigroup"
+          "Language/PlutusTx/Monoid"
+          "Language/PlutusTx/AssocMap"
+          "Language/PlutusTx/These"
+          "Language/PlutusTx/Code"
+          "Language/PlutusTx/Data"
+          "Language/PlutusTx/Lift"
+          "Language/PlutusTx/Lift/Class"
+          "Language/PlutusTx/Builtins"
+          "Language/PlutusTx/Plugin/Utils"
+          "Language/PlutusTx/Utils"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-tx;
+    }

--- a/nix/stack.materialized/plutus-use-cases.nix
+++ b/nix/stack.materialized/plutus-use-cases.nix
@@ -1,0 +1,193 @@
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { defer-plugin-errors = false; };
+    package = {
+      specVersion = "2.0";
+      identifier = { name = "plutus-use-cases"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "jann.mueller@iohk.io";
+      author = "Manuel M T Chakravarty, Jann Müller";
+      homepage = "";
+      url = "";
+      synopsis = "Collection of smart contracts to develop the plutus/wallet interface";
+      description = "Collection of smart contracts to develop the plutus/wallet interface.";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [ "README.md" ];
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."iots-export" or (buildDepError "iots-export"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+          (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+          (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+          (hsPkgs."plutus-playground-lib" or (buildDepError "plutus-playground-lib"))
+          (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+          (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+          ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"));
+        buildable = true;
+        modules = [
+          "Language/PlutusTx/Coordination/Contracts"
+          "Language/PlutusTx/Coordination/Contracts/TokenAccount"
+          "Language/PlutusTx/Coordination/Contracts/Crowdfunding"
+          "Language/PlutusTx/Coordination/Contracts/Currency"
+          "Language/PlutusTx/Coordination/Contracts/Escrow"
+          "Language/PlutusTx/Coordination/Contracts/Future"
+          "Language/PlutusTx/Coordination/Contracts/Game"
+          "Language/PlutusTx/Coordination/Contracts/GameStateMachine"
+          "Language/PlutusTx/Coordination/Contracts/ErrorHandling"
+          "Language/PlutusTx/Coordination/Contracts/MultiSig"
+          "Language/PlutusTx/Coordination/Contracts/MultiSigStateMachine"
+          "Language/PlutusTx/Coordination/Contracts/PubKey"
+          "Language/PlutusTx/Coordination/Contracts/Vesting"
+          "Language/PlutusTx/Coordination/Contracts/Swap"
+          ];
+        hsSourceDirs = [ "src" ];
+        };
+      exes = {
+        "contract-guessing-game" = {
+          depends = [
+            (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+            (hsPkgs."plutus-use-cases" or (buildDepError "plutus-use-cases"))
+            (hsPkgs."base" or (buildDepError "base"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "exe/game" ];
+          mainPath = [ "Main.hs" ];
+          };
+        "contract-crowdfunding" = {
+          depends = [
+            (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+            (hsPkgs."plutus-use-cases" or (buildDepError "plutus-use-cases"))
+            (hsPkgs."base" or (buildDepError "base"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "exe/crowdfunding" ];
+          mainPath = [ "Main.hs" ];
+          };
+        };
+      tests = {
+        "plutus-use-cases-test" = {
+          depends = [
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."plutus-contract" or (buildDepError "plutus-contract"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."plutus-use-cases" or (buildDepError "plutus-use-cases"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            (hsPkgs."plutus-contract-tasty" or (buildDepError "plutus-contract-tasty"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."prettyprinter" or (buildDepError "prettyprinter"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-hedgehog" or (buildDepError "tasty-hedgehog"))
+            (hsPkgs."tasty-golden" or (buildDepError "tasty-golden"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"));
+          buildable = true;
+          modules = [
+            "Spec/Crowdfunding"
+            "Spec/Currency"
+            "Spec/ErrorHandling"
+            "Spec/Escrow"
+            "Spec/Future"
+            "Spec/Game"
+            "Spec/GameStateMachine"
+            "Spec/Lib"
+            "Spec/MultiSig"
+            "Spec/MultiSigStateMachine"
+            "Spec/PubKey"
+            "Spec/Rollup"
+            "Spec/TokenAccount"
+            "Spec/Vesting"
+            ];
+          hsSourceDirs = [ "test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      benchmarks = {
+        "plutus-use-cases-bench" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."criterion" or (buildDepError "criterion"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."language-plutus-core" or (buildDepError "language-plutus-core"))
+            (hsPkgs."lens" or (buildDepError "lens"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."plutus-tx" or (buildDepError "plutus-tx"))
+            (hsPkgs."plutus-use-cases" or (buildDepError "plutus-use-cases"))
+            (hsPkgs."plutus-ledger" or (buildDepError "plutus-ledger"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."plutus-emulator" or (buildDepError "plutus-emulator"))
+            ] ++ (pkgs.lib).optional (!(compiler.isGhcjs && true || system.isGhcjs)) (hsPkgs."plutus-tx-plugin" or (buildDepError "plutus-tx-plugin"));
+          buildable = true;
+          modules = [ "Scott" "Recursion" "IFix" "Opt" ];
+          hsSourceDirs = [ "bench" ];
+          };
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-use-cases;
+    }


### PR DESCRIPTION
I've given in: let's just check in the generated Nix files.

Why?
- It makes all of our Nix commands faster.
- It's less conflict-y than having the sha (now that https://github.com/input-output-hk/haskell.nix/pull/563 is merged) 
    - This was happening a *lot*
    - The generated files should merge reasonably well, I hope.
- The files aren't *that* big.

Should make @krisajenkins and @shmish111 happy :)