### PR TITLE
SCP-391: Don't serialise unit annotations

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -273,19 +273,6 @@ instance Serialise TyDeBruijn where
     encode (TyDeBruijn n) = encode n
     decode = TyDeBruijn <$> decode
 
-instance (Serialise ann) => Serialise (ParseError ann)
-instance ( Closed uni
-         , uni `Everywhere` Serialise
-         , Serialise tyname
-         , Serialise name
-         , Serialise ann
-         ) => Serialise (NormCheckError tyname name uni ann)
-instance (Serialise ann) => Serialise (UniqueError ann)
-instance Serialise UnknownDynamicBuiltinNameError
-instance (Closed uni, uni `Everywhere` Serialise, Serialise ann) => Serialise (InternalTypeError uni ann)
-instance (Closed uni, uni `Everywhere` Serialise, Serialise ann) => Serialise (TypeError uni ann)
-instance (Closed uni, uni `Everywhere` Serialise, Serialise ann) => Serialise (Error uni ann)
-
 
 {- Note [Serialising unit annotations]
 

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -337,13 +337,7 @@ coercions for us.  This is used in `Ledger.Scripts.Script` to
 derive a suitable instance of `Serialise` for scripts. -}
 
 newtype OmitUnitAnnotations uni  = OmitUnitAnnotations { restoreUnitAnnotations :: Program TyName Name uni () }
-
-instance (Closed uni, uni `Everywhere` Serialise) => Serialise (OmitUnitAnnotations uni) where
-    encode (OmitUnitAnnotations p) = encode (coerce p :: Program TyName Name uni InvisibleUnit)
-    decode = do
-        p :: Program TyName Name uni InvisibleUnit <- decode
-        return $ OmitUnitAnnotations (coerce p :: Program TyName Name uni ())
-
+    deriving Serialise via Program TyName Name uni InvisibleUnit
 
 {-| Convenience functions for serialisation/deserialisation without units -}
 serialiseOmittingUnits :: (Closed uni, uni `Everywhere` Serialise) => Program TyName Name uni () -> BSL.ByteString

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -23,7 +23,6 @@ module Language.PlutusCore.CBOR ( encode
 
 import           Language.PlutusCore.Core
 import           Language.PlutusCore.DeBruijn
-import           Language.PlutusCore.Error
 import           Language.PlutusCore.Lexer.Type
 import           Language.PlutusCore.MkPlc      (TyVarDecl (..), VarDecl (..))
 import           Language.PlutusCore.Name

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -347,7 +347,7 @@ decodePLC = do
       return $ (coerce p :: Program TyName Name uni ())
 
 
-{- A local wrapper type to help us define convenience functions for
+{-| A local wrapper type to help us define convenience functions for
  serialising and deserialising PLC programs, omitting unit
  annotations.  We could define these in terms of encodePLC and
  decodePLC analogously to how `serialise` etc are defined in

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -98,7 +98,7 @@ propCBOR = property $ do
 propCBORnoUnits :: Property
 propCBORnoUnits = property $ do
     prog <- forAllPretty $ runAstGen genProgram
-    Hedgehog.tripping prog serialisePLC deserialisePLCOrFail
+    Hedgehog.tripping prog serialiseOmittingUnits deserialiseRestoringUnitsOrFail
 
 -- Generate a random 'Program', pretty-print it, and parse the pretty-printed
 -- text, hopefully returning the same thing.

--- a/language-plutus-core/test/Spec.hs
+++ b/language-plutus-core/test/Spec.hs
@@ -15,6 +15,7 @@ import           Pretty.Readable
 import           TypeSynthesis.Spec                                         (test_typecheck)
 
 import           Language.PlutusCore
+import           Language.PlutusCore.CBOR
 import           Language.PlutusCore.DeBruijn
 import           Language.PlutusCore.Evaluation.Machine.Cek                 (unsafeEvaluateCek)
 import           Language.PlutusCore.Evaluation.Machine.ExBudgetingDefaults
@@ -94,6 +95,11 @@ propCBOR = property $ do
     prog <- forAllPretty $ runAstGen genProgram
     Hedgehog.tripping prog serialise deserialiseOrFail
 
+propCBORnoUnits :: Property
+propCBORnoUnits = property $ do
+    prog <- forAllPretty $ runAstGen genProgram
+    Hedgehog.tripping prog serialisePLC deserialisePLCOrFail
+
 -- Generate a random 'Program', pretty-print it, and parse the pretty-printed
 -- text, hopefully returning the same thing.
 propParser :: Property
@@ -134,6 +140,7 @@ allTests plcFiles rwFiles typeFiles typeErrorFiles evalFiles = testGroup "all te
     [ tests
     , testProperty "parser round-trip" propParser
     , testProperty "serialization round-trip" propCBOR
+    , testProperty "serialization round-trip without units" propCBORnoUnits
     , testProperty "equality survives renaming" propRename
     , testProperty "equality does not survive mangling" propMangle
     , testGroup "de Bruijn transformation round-trip" $

--- a/plutus-ledger/src/Data/Aeson/Extras.hs
+++ b/plutus-ledger/src/Data/Aeson/Extras.hs
@@ -9,8 +9,7 @@ module Data.Aeson.Extras(
     ) where
 
 import qualified Codec.CBOR.Write       as Write
-import           Codec.Serialise        (deserialiseOrFail)
-import           Codec.Serialise.Class  (Serialise, encode)
+import           Codec.Serialise        (Serialise, deserialiseOrFail, encode)
 import           Control.Monad          ((>=>))
 import qualified Data.Aeson             as Aeson
 import qualified Data.Aeson.Types       as Aeson

--- a/plutus-ledger/src/Ledger/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Scripts.hs
@@ -197,7 +197,7 @@ typecheckScript (unScript -> p) =
             PLC.unNormalized Haskell.<$> PLC.typecheckPipeline config p
 
 instance ToJSON Script where
-    toJSON = JSON.String . JSON.encodeByteString . BSL.toStrict . serialise
+    toJSON = JSON.String . JSON.encodeSerialise
 
 instance FromJSON Script where
     parseJSON = JSON.decodeSerialise

--- a/plutus-ledger/src/Ledger/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Scripts.hs
@@ -90,7 +90,8 @@ import           LedgerBytes                          (LedgerBytes (..))
 newtype Script = Script { unScript :: PLC.Program PLC.TyName PLC.Name PLC.DefaultUni () }
   deriving stock Generic
 
--- Serialise scripts omitting unit annotations
+-- | Serialise scripts omitting unit annotations.
+-- See Note [Serialising Scripts] in Language.PlutusCore.CBOR
 instance Serialise Script where
     encode = encodePLC . unScript
     decode = liftM Script decodePLC

--- a/plutus-ledger/src/Ledger/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Scripts.hs
@@ -57,7 +57,6 @@ import qualified Prelude                              as Haskell
 
 import           Codec.Serialise                      (serialise, Serialise)
 import           Control.DeepSeq                      (NFData)
-import           Control.Monad                        (liftM)
 import           Control.Monad.Except                 (MonadError, runExcept, throwError)
 import           Crypto.Hash                          (Digest, SHA256, hash)
 import           Data.Aeson                           (FromJSON, FromJSONKey, ToJSON, ToJSONKey)

--- a/plutus-ledger/src/Ledger/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Scripts.hs
@@ -89,12 +89,9 @@ import           LedgerBytes                          (LedgerBytes (..))
 -- Note: the program inside the 'Script' should have normalized types.
 newtype Script = Script { unScript :: PLC.Program PLC.TyName PLC.Name PLC.DefaultUni () }
   deriving stock Generic
-
--- | Serialise scripts omitting unit annotations.
+  deriving Serialise via OmitUnitAnnotations PLC.DefaultUni
+-- | Don't include unit annotations in the CBOR when serialising.
 -- See Note [Serialising Scripts] in Language.PlutusCore.CBOR
-instance Serialise Script where
-    encode = encodePLC . unScript
-    decode = liftM Script decodePLC
 
 instance IotsType Script where
   iotsDefinition = iotsDefinition @Haskell.String

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -7,22 +7,22 @@ Events by wallet:
     - {slot:
        Slot: 27}
     - {utxo-at:
-       Utxo at ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3 =
-         410cc907e996e356033118933a2f35e6a6311e47ab75a7dda6c6bb1a48e1dc0b!1: PayToScript: 49cd69a6941f191e3d14ce83834e0f2ce175318995b40380854e3201171c0baa Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-         acd52246b7565c18100f4a3ba07963365ba3697808cf7dccde709a13830dcdb1!1: PayToScript: b8324180800f57f26dee2ad65990e0a762a5dab9424d32e49855abd495f7196b Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-         b88e0662b172159014ba857ad04e0439ee3bd725775790e624037d8e10139d77!1: PayToScript: 4c592448cff8d2b2ee40a509e1d5224260ef29f5b22cd920616e39cad65f466c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}}
+       Utxo at ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539 =
+         5b0f15d459866ec3f0171d832fb616839b308be0e649c1b2155f6c380f66fb42!1: PayToScript: b8324180800f57f26dee2ad65990e0a762a5dab9424d32e49855abd495f7196b Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+         5c4500da9e8ac1bedeaf9c0d50b7aeff42069904e0e12fe571e5945d42407f4e!1: PayToScript: 49cd69a6941f191e3d14ce83834e0f2ce175318995b40380854e3201171c0baa Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+         83256672215df3f261779db6953065156ffa0612668f720eb7f54fe7b723bc19!1: PayToScript: 4c592448cff8d2b2ee40a509e1d5224260ef29f5b22cd920616e39cad65f466c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}}
     - {tx:
-       WriteTxSuccess: f4cd04782c5f1af440f1c86bb0595720e5908948b838279aed53fbedd780db8d}
+       WriteTxSuccess: 20369b1770ba9969b5a00d454f0f2715aa3520d440516e5e39c7e97733e0fe01}
   Events for W2:
     - {contribute:
        EndpointValue: Contribution {contribValue = Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}}}
     - {own-pubkey:
        fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025}
     - {tx:
-       WriteTxSuccess: acd52246b7565c18100f4a3ba07963365ba3697808cf7dccde709a13830dcdb1}
+       WriteTxSuccess: 5b0f15d459866ec3f0171d832fb616839b308be0e649c1b2155f6c380f66fb42}
     - {address:
-       ( ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
-       , Tx acd52246b7565c18100f4a3ba07963365ba3697808cf7dccde709a13830dcdb1:
+       ( ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
+       , Tx 5b0f15d459866ec3f0171d832fb616839b308be0e649c1b2155f6c380f66fb42:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!8
               
@@ -30,7 +30,7 @@ Events by wallet:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9990)]})]}} addressed to
              PubKeyAddress: 03d200a81ee0feace8fb845e5ec950a6f9add83709244f7b81134654139f41a4
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-             ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+             ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -40,8 +40,8 @@ Events by wallet:
          data:
            "\ETX\210\NUL\168\RS\224\254\172\232\251\132^^\201P\166\249\173\216\&7\t$O{\129\DC3FT\DC3\159A\164"} )}
     - {address:
-       ( ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
-       , Tx 410cc907e996e356033118933a2f35e6a6311e47ab75a7dda6c6bb1a48e1dc0b:
+       ( ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
+       , Tx 5c4500da9e8ac1bedeaf9c0d50b7aeff42069904e0e12fe571e5945d42407f4e:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!3
               
@@ -49,7 +49,7 @@ Events by wallet:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9990)]})]}} addressed to
              PubKeyAddress: feb345e86b9c2a7add2bfc695fa8aecd4ac5b0dfaf3a477f6fa968cdd30571c7
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-             ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+             ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -59,8 +59,8 @@ Events by wallet:
          data:
            "\254\179E\232k\156*z\221+\252i_\168\174\205J\197\176\223\175:G\DELo\169h\205\211\ENQq\199"} )}
     - {address:
-       ( ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
-       , Tx b88e0662b172159014ba857ad04e0439ee3bd725775790e624037d8e10139d77:
+       ( ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
+       , Tx 83256672215df3f261779db6953065156ffa0612668f720eb7f54fe7b723bc19:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!7
               
@@ -68,7 +68,7 @@ Events by wallet:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9999)]})]}} addressed to
              PubKeyAddress: 5aebc31421e7af1bdb47326709c27f3fd9381b00b0aca127b8dccd5f8525a538
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} addressed to
-             ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+             ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -83,10 +83,10 @@ Events by wallet:
     - {own-pubkey:
        98a5e3a36e67aaba89888bf093de1ad963e774013b3902bfab356d8b90178a63}
     - {tx:
-       WriteTxSuccess: 410cc907e996e356033118933a2f35e6a6311e47ab75a7dda6c6bb1a48e1dc0b}
+       WriteTxSuccess: 5c4500da9e8ac1bedeaf9c0d50b7aeff42069904e0e12fe571e5945d42407f4e}
     - {address:
-       ( ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
-       , Tx 410cc907e996e356033118933a2f35e6a6311e47ab75a7dda6c6bb1a48e1dc0b:
+       ( ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
+       , Tx 5c4500da9e8ac1bedeaf9c0d50b7aeff42069904e0e12fe571e5945d42407f4e:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!3
               
@@ -94,7 +94,7 @@ Events by wallet:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9990)]})]}} addressed to
              PubKeyAddress: feb345e86b9c2a7add2bfc695fa8aecd4ac5b0dfaf3a477f6fa968cdd30571c7
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-             ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+             ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -104,8 +104,8 @@ Events by wallet:
          data:
            "\254\179E\232k\156*z\221+\252i_\168\174\205J\197\176\223\175:G\DELo\169h\205\211\ENQq\199"} )}
     - {address:
-       ( ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
-       , Tx b88e0662b172159014ba857ad04e0439ee3bd725775790e624037d8e10139d77:
+       ( ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
+       , Tx 83256672215df3f261779db6953065156ffa0612668f720eb7f54fe7b723bc19:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!7
               
@@ -113,7 +113,7 @@ Events by wallet:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9999)]})]}} addressed to
              PubKeyAddress: 5aebc31421e7af1bdb47326709c27f3fd9381b00b0aca127b8dccd5f8525a538
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} addressed to
-             ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+             ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -128,10 +128,10 @@ Events by wallet:
     - {own-pubkey:
        f81fb54a825fced95eb033afcd64314075abfb0abd20a970892503436f34b863}
     - {tx:
-       WriteTxSuccess: b88e0662b172159014ba857ad04e0439ee3bd725775790e624037d8e10139d77}
+       WriteTxSuccess: 83256672215df3f261779db6953065156ffa0612668f720eb7f54fe7b723bc19}
     - {address:
-       ( ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
-       , Tx b88e0662b172159014ba857ad04e0439ee3bd725775790e624037d8e10139d77:
+       ( ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
+       , Tx 83256672215df3f261779db6953065156ffa0612668f720eb7f54fe7b723bc19:
          {inputs:
             - baaf580880e12f5f48fc8a956b83a3706a4ead8df2a09836ef6a262662ca95d7!7
               
@@ -139,7 +139,7 @@ Events by wallet:
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,9999)]})]}} addressed to
              PubKeyAddress: 5aebc31421e7af1bdb47326709c27f3fd9381b00b0aca127b8dccd5f8525a538
            - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} addressed to
-             ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+             ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
          forge: Value {getValue = Map {unMap = []}}
          fee: Value {getValue = Map {unMap = []}}
          mps:
@@ -153,7 +153,7 @@ Contract result by wallet:
       Done
     Wallet: W2
       Running, waiting for input:
-        {address: [ ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3 ]
+        {address: [ ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539 ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]
@@ -163,7 +163,7 @@ Contract result by wallet:
          utxo-at: []}
     Wallet: W3
       Running, waiting for input:
-        {address: [ ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3 ]
+        {address: [ ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539 ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]
@@ -173,7 +173,7 @@ Contract result by wallet:
          utxo-at: []}
     Wallet: W4
       Running, waiting for input:
-        {address: [ ScriptAddress: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3 ]
+        {address: [ ScriptAddress: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539 ]
          contribute: []
          own-pubkey: NotWaitingForPubKey
          schedule collection: [ExposeEndpoint: schedule collection]

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #2, Tx #0 ====
-TxId:       acd52246b7565c18100f4a3ba07963365ba3697808cf7dccde709a13830dcdb1
+TxId:       5b0f15d459866ec3f0171d832fb616839b308be0e649c1b2155f6c380f66fb42
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f58206a7f58a796d6811ec4ef07677de365d51c...
+              Signature: 5f5820735a61271352b7d482035f19b68d6ee2ba...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 03d200a81ee0feace8fb845e5ec950a6f9add837... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+  Destination:  Script: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
   Value:
     Ada:      Lovelace:  10
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+  Script: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #3, Tx #0 ====
-TxId:       410cc907e996e356033118933a2f35e6a6311e47ab75a7dda6c6bb1a48e1dc0b
+TxId:       5c4500da9e8ac1bedeaf9c0d50b7aeff42069904e0e12fe571e5945d42407f4e
 Fee:        -
 Forge:      -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 5f58205762532c85997ab554ca43bdf3bba303ea...
+              Signature: 5f582021e9fa25c06fb29da07a1b332f2f5510bc...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: feb345e86b9c2a7add2bfc695fa8aecd4ac5b0df... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+  Destination:  Script: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
   Value:
     Ada:      Lovelace:  10
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+  Script: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
   Value:
     Ada:      Lovelace:  20
 
 ==== Slot #4, Tx #0 ====
-TxId:       b88e0662b172159014ba857ad04e0439ee3bd725775790e624037d8e10139d77
+TxId:       83256672215df3f261779db6953065156ffa0612668f720eb7f54fe7b723bc19
 Fee:        -
 Forge:      -
 Signatures  PubKey: f81fb54a825fced95eb033afcd64314075abfb0a...
-              Signature: 5f582010f0f99b82c6660ede96faeabc07ad4b69...
+              Signature: 5f5820d6ea398a041da83bc542d68ed9697cd218...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 5aebc31421e7af1bdb47326709c27f3fd9381b00... (Wallet 4)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  9999
   
   ---- Output 1 ----
-  Destination:  Script: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+  Destination:  Script: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
   Value:
     Ada:      Lovelace:  1
 
@@ -318,43 +318,43 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+  Script: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
   Value:
     Ada:      Lovelace:  21
 
 ==== Slot #23, Tx #0 ====
-TxId:       f4cd04782c5f1af440f1c86bb0595720e5908948b838279aed53fbedd780db8d
+TxId:       20369b1770ba9969b5a00d454f0f2715aa3520d440516e5e39c7e97733e0fe01
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f5820d2213d57b688765e4f8e33902dc46910b0...
+              Signature: 5f5820e719a635bd26dbdd01608553607aa0c923...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+  Destination:  Script: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     410cc907e996e356033118933a2f35e6a6311e47ab75a7dda6c6bb1a48e1dc0b
+    Tx:     5b0f15d459866ec3f0171d832fb616839b308be0e649c1b2155f6c380f66fb42
     Output #1
-    Script: f6f601000003f603f602f66466697831182903f6...
+    Script: 01000003030264666978311829036161182a0003...
   
   ---- Input 1 ----
-  Destination:  Script: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+  Destination:  Script: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     acd52246b7565c18100f4a3ba07963365ba3697808cf7dccde709a13830dcdb1
+    Tx:     5c4500da9e8ac1bedeaf9c0d50b7aeff42069904e0e12fe571e5945d42407f4e
     Output #1
-    Script: f6f601000003f603f602f66466697831182903f6...
+    Script: 01000003030264666978311829036161182a0003...
   
   ---- Input 2 ----
-  Destination:  Script: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+  Destination:  Script: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
   Value:
     Ada:      Lovelace:  1
   Source:
-    Tx:     b88e0662b172159014ba857ad04e0439ee3bd725775790e624037d8e10139d77
+    Tx:     83256672215df3f261779db6953065156ffa0612668f720eb7f54fe7b723bc19
     Output #1
-    Script: f6f601000003f603f602f66466697831182903f6...
+    Script: 01000003030264666978311829036161182a0003...
 
 
 Outputs:
@@ -405,6 +405,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: c88dd5dafcd623608faf567140d0eb32fec158b8ffa18979c19d031a22cc3bb3
+  Script: 72a9e44654aac63929204243a61d55f5d6711b1cf751a3472414de1e441e1539
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       d7bbcd5f34fddcca68ad9a2a88609b73e900e4fbba2440ad358e905e7322c7bb
+TxId:       0b68c6d8106bff83c8941dab0217e04dcd372d4446f4988aedcd5cd4f3187f4c
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f5820fc61d40e274d06e1f47aab0d98f4946939...
+              Signature: 5f582069cf4141f93986727481859e6eb16ee906...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 2721f657e9ed91d2fc2a282f7ff5ed81ae48f48b... (Wallet 1)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 2c34889dfb710e9cf3f93e6ec0f956aff0f3deb47286f7866b51b110b5614d06
+  Destination:  Script: 86eb18bb173383836844d5f2e45695e9f858f176f165b787791aafb64cf123ce
   Value:
     Ada:      Lovelace:  10
 
@@ -170,25 +170,25 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 2c34889dfb710e9cf3f93e6ec0f956aff0f3deb47286f7866b51b110b5614d06
+  Script: 86eb18bb173383836844d5f2e45695e9f858f176f165b787791aafb64cf123ce
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       f068e37e287c8afcf0d946e5ad6223f4a7ebedb94bcd3469009ce781b1f962ce
+TxId:       00cd52960c945107ac50f5f624f96584529caf3b20286276271ec2e15f8ff60b
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f58203a2f9dc20709ac6dc739289aacf13e408d...
+              Signature: 5f582009c1c17a3a599f3b50dc5787f2cc1542b1...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 2c34889dfb710e9cf3f93e6ec0f956aff0f3deb47286f7866b51b110b5614d06
+  Destination:  Script: 86eb18bb173383836844d5f2e45695e9f858f176f165b787791aafb64cf123ce
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     d7bbcd5f34fddcca68ad9a2a88609b73e900e4fbba2440ad358e905e7322c7bb
+    Tx:     0b68c6d8106bff83c8941dab0217e04dcd372d4446f4988aedcd5cd4f3187f4c
     Output #1
-    Script: f6f601000003f603f602f66466697831182903f6...
+    Script: 01000003030264666978311829036161182a0003...
 
 
 Outputs:
@@ -239,6 +239,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 2c34889dfb710e9cf3f93e6ec0f956aff0f3deb47286f7866b51b110b5614d06
+  Script: 86eb18bb173383836844d5f2e45695e9f858f176f165b787791aafb64cf123ce
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       c111ccf69b4fff47a1a000421cda42789365e5e6dee4d67b94cc20c7bad36341
+TxId:       237a09941186e106ee57af42bbe9a82cefe20c54d1523dafad3667ab62dc75bf
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f582027c8812415469dcf428f0968632b419729...
+              Signature: 5f5820ada10cfd681ece1b8cc4283ab6fd248f0f...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 03d200a81ee0feace8fb845e5ec950a6f9add837... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9940
   
   ---- Output 1 ----
-  Destination:  Script: feb7e23b088a67f4f91442c3c094301b1b91d542e22c7c908ef4632cb0d66f95
+  Destination:  Script: f36a17dc1fc65507e1947eb00b60730e4094890a8f829052a6e31146b386a2d0
   Value:
     Ada:      Lovelace:  60
 
@@ -170,25 +170,25 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: feb7e23b088a67f4f91442c3c094301b1b91d542e22c7c908ef4632cb0d66f95
+  Script: f36a17dc1fc65507e1947eb00b60730e4094890a8f829052a6e31146b386a2d0
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #13, Tx #0 ====
-TxId:       df3fafd5105726317dfb4d904556f620fa682d113f7fa081472dbe1d4377e26a
+TxId:       d2b36c0f46267e27df04480cfa846f0ac3330a3843d1972a7d69d6bdf78c828c
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f582063b3b8b965a50920fe350f6dcac873ec08...
+              Signature: 5f58205db3cb16e8cc29cea10fc6cd5a191217e7...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: feb7e23b088a67f4f91442c3c094301b1b91d542e22c7c908ef4632cb0d66f95
+  Destination:  Script: f36a17dc1fc65507e1947eb00b60730e4094890a8f829052a6e31146b386a2d0
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     c111ccf69b4fff47a1a000421cda42789365e5e6dee4d67b94cc20c7bad36341
+    Tx:     237a09941186e106ee57af42bbe9a82cefe20c54d1523dafad3667ab62dc75bf
     Output #1
-    Script: f6f601000003f603f602f66466697831182903f6...
+    Script: 01000003030264666978311829036161182a0003...
 
 
 Outputs:
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  10
   
   ---- Output 1 ----
-  Destination:  Script: feb7e23b088a67f4f91442c3c094301b1b91d542e22c7c908ef4632cb0d66f95
+  Destination:  Script: f36a17dc1fc65507e1947eb00b60730e4094890a8f829052a6e31146b386a2d0
   Value:
     Ada:      Lovelace:  50
 
@@ -244,6 +244,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: feb7e23b088a67f4f91442c3c094301b1b91d542e22c7c908ef4632cb0d66f95
+  Script: f36a17dc1fc65507e1947eb00b60730e4094890a8f829052a6e31146b386a2d0
   Value:
     Ada:      Lovelace:  50


### PR DESCRIPTION
This updates the serialisation code so that unit annotations aren't included in CBOR.  See #1818 and https://jira.iohk.io/browse/SCP-391.  This replaces #1991.  See in particular the notes at the end of CBOR.hs.



@j-mueller : is there anywhere else that we have to worry about serialising Plutus Core? Anything that's not wrapped in a Script will be serialised inefficiently.