### PR TITLE
Various marlowe playground layout improvements

### DIFF
--- a/marlowe-playground-client/src/HaskellEditor.purs
+++ b/marlowe-playground-client/src/HaskellEditor.purs
@@ -89,15 +89,15 @@ bottomPanel state =
     [ div [ classes (footerPanelBg state HaskellEditor <> isActiveTab state HaskellEditor) ]
         [ section [ classes [ ClassName "panel-header", aHorizontal ] ]
             [ div [ classes [ ClassName "panel-sub-header-main", aHorizontal, accentBorderBottom ] ]
-                [ div
+                [ div [ class_ (ClassName "minimize-icon-container") ]
+                    [ a [ onClick $ const $ Just $ ShowBottomPanel (state ^. _showBottomPanel <<< to not) ]
+                        [ img [ classes (minimizeIcon state), src closeDrawerArrowIcon, alt "close drawer icon" ] ]
+                    ]
+                , div
                     [ classes ([ ClassName "panel-tab", aHorizontal, ClassName "haskell-buttons" ])
                     ]
                     [ button [ onClick $ const $ Just CompileHaskellProgram ] [ text (if state ^. _compilationResult <<< to isLoading then "Compiling..." else "Compile") ]
                     , sendResultButton state
-                    ]
-                , div []
-                    [ a [ onClick $ const $ Just $ ShowBottomPanel (state ^. _showBottomPanel <<< to not) ]
-                        [ img [ classes (minimizeIcon state), src closeDrawerArrowIcon, alt "close drawer icon" ] ]
                     ]
                 ]
             ]

--- a/marlowe-playground-client/src/Simulation.purs
+++ b/marlowe-playground-client/src/Simulation.purs
@@ -74,7 +74,11 @@ render state =
                   ]
               ]
           ]
-      , div [ classes [ panelSubHeaderSide, expanded (state ^. _showRightPanel) ] ] [ authButton state ]
+      , div [ classes [ panelSubHeaderSide, expanded (state ^. _showRightPanel) ] ]
+          [ a [ classes [ (ClassName "drawer-icon-click") ], onClick $ const $ Just $ ShowRightPanel (not showRightPanel) ]
+              [ img [ src closeDrawerIcon, class_ (ClassName "drawer-icon") ] ]
+          , authButton state
+          ]
       ]
   , section [ class_ (ClassName "code-panel") ]
       [ div [ classes (codeEditor state) ]
@@ -83,6 +87,8 @@ render state =
       ]
   ]
   where
+  showRightPanel = state ^. _showRightPanel
+
   isBlocklyEnabled = view (_marloweState <<< _Head <<< _editorErrors <<< to Array.null) state
 
   demoScriptLink key =
@@ -126,9 +132,7 @@ sidebar state =
     showRightPanel = state ^. _showRightPanel
   in
     aside [ classes [ (ClassName "sidebar-composer"), expanded showRightPanel ] ]
-      [ a [ classes [ (ClassName "drawer-icon-click") ], onClick $ const $ Just $ ShowRightPanel (not showRightPanel) ]
-          [ img [ src closeDrawerIcon, class_ (ClassName "drawer-icon") ] ]
-      , div [ class_ aHorizontal ]
+      [ div [ class_ aHorizontal ]
           [ h6 [ classes [ ClassName "input-composer-heading", noMargins ] ]
               [ small [ classes [ textSecondaryColor, bold, uppercase ] ] [ text "Input Composer" ] ]
           , a [ onClick $ const $ Just $ ChangeHelpContext InputComposerHelp ] [ img [ src infoIcon, alt "info book icon" ] ]
@@ -447,14 +451,16 @@ authButton state =
           [ idPublishGist
           , classes []
           ]
-          [ text "Failure" ]
+          [ text "Failed to login" ]
       Success Anonymous ->
-        a
-          [ idPublishGist
-          , classes [ ClassName "auth-button" ]
-          , href "/api/oauth/github"
-          ]
-          [ text "Save to GitHub"
+        div [ class_ (ClassName "auth-button-container") ]
+          [ a
+              [ idPublishGist
+              , classes [ ClassName "auth-button" ]
+              , href "/api/oauth/github"
+              ]
+              [ text "Save to GitHub"
+              ]
           ]
       Success GithubUser -> gist state
       Loading ->
@@ -536,7 +542,7 @@ gistInput state _ =
 
 gist :: forall p. FrontendState -> HTML p HAction
 gist state =
-  div [ classes [ ClassName "github-gist-panel", aHorizontal ] ]
+  div [ classes [ ClassName "github-gist-panel", aHorizontal, expanded (state ^. _showRightPanel) ] ]
     [ div [ classes [ ClassName "input-group-text", ClassName "upload-btn", ClassName "tooltip" ], onClick $ const $ Just $ GistAction PublishGist ]
         [ span [ class_ (ClassName "tooltiptext") ] [ publishTooltip publishStatus ]
         , gistButtonIcon arrowUp publishStatus

--- a/marlowe-playground-client/src/Simulation/BottomPanel.purs
+++ b/marlowe-playground-client/src/Simulation/BottomPanel.purs
@@ -43,7 +43,13 @@ bottomPanel state =
             [ div [ classes (footerPanelBg state Simulation <> isActiveTab state Simulation) ]
                 [ section [ classes [ ClassName "panel-header", aHorizontal ] ]
                     [ div [ classes ([ ClassName "panel-sub-header-main", aHorizontal ] <> (if state ^. _showBottomPanel then [ accentBorderBottom ] else [])) ]
-                        [ ul [ classes [ ClassName "demo-list", aHorizontal ] ]
+                        [ ul [ class_ (ClassName "start-item") ]
+                            [ li [ class_ (ClassName "minimize-icon-container") ]
+                                [ a [ onClick $ const $ Just $ ShowBottomPanel (state ^. _showBottomPanel <<< to not) ]
+                                    [ img [ classes (minimizeIcon state), src closeDrawerArrowIcon, alt "close drawer icon" ] ]
+                                ]
+                            ]
+                        , ul [ classes [ ClassName "demo-list", aHorizontal ] ]
                             [ li
                                 [ classes ((if hasRuntimeWarnings || hasRuntimeError then [ ClassName "error-tab" ] else []) <> isActive CurrentStateView)
                                 , onClick $ const $ Just $ ChangeSimulationView CurrentStateView
@@ -70,10 +76,6 @@ bottomPanel state =
                                 [ text "Contract Expiration: ", state ^. (_marloweState <<< _Head <<< _contract <<< to contractMaxTime <<< to text) ]
                             , li [ classes [ ClassName "space-left", Classes.stateLabel ] ]
                                 [ text "Current Blocks: ", state ^. (_marloweState <<< _Head <<< _slot <<< to show <<< to text) ]
-                            , li [ class_ (ClassName "space-left") ]
-                                [ a [ onClick $ const $ Just $ ShowBottomPanel (state ^. _showBottomPanel <<< to not) ]
-                                    [ img [ classes (minimizeIcon state), src closeDrawerArrowIcon, alt "close drawer icon" ] ]
-                                ]
                             ]
                         ]
                     ]

--- a/marlowe-playground-client/static/css/main-tabs.css
+++ b/marlowe-playground-client/static/css/main-tabs.css
@@ -49,12 +49,12 @@
 }
 
 .simulation-tab .tab-icon {
-  background: url(../images/simulation-icon-grey.svg) 24px center no-repeat;
+  background: url(../images/simulation-icon-grey.svg) 29px center no-repeat;
   background-size: 50px;
 }
 
 .simulation-tab.active .tab-icon {
-  background: url(../images/simulation-icon.svg) center center no-repeat;
+  background: url(../images/simulation-icon.svg) 30px center no-repeat;
   background-size: 50px;
 }
 

--- a/marlowe-playground-client/static/css/main.scss
+++ b/marlowe-playground-client/static/css/main.scss
@@ -55,9 +55,11 @@ a:hover {
     display: none;
 }
 
+.auth-button-container {
+    margin-top: 5px;
+}
 .auth-button {
-    padding: 0.5rem 1.5rem;
-    position: relative;
+    padding: 0.4rem 1.5rem;
     cursor: pointer;
     top: 0.5rem;
     background: var(--gradient-bg);

--- a/marlowe-playground-client/static/css/panel-mobile.css
+++ b/marlowe-playground-client/static/css/panel-mobile.css
@@ -1,8 +1,13 @@
-@media (max-width:1200px) {
+@media (max-width:1360px) {
 
+  .expanded a .drawer-icon {
+    transform: rotate(0deg);
+  }
+  
   .drawer-icon {
     display: block;
     margin-left: auto;
+    transform: rotate(180deg);
   }
 
   .drawer-icon-click {
@@ -10,6 +15,7 @@
     height: 30px;
     width: 30px;
     z-index: 999;
+    margin-right: 1rem;
   }
 
   .composer ul {
@@ -46,10 +52,11 @@
 
   .panel-sub-header .panel-sub-header-side {
     position: absolute;
+    display: flex;
     top: 0;
     right: 0;
     width: 200px;
-    padding-left: 2.5rem;
+    padding-left: 0.5rem;
     background: var(--bg-light);
     box-shadow: var(--box-shadow-left);
     z-index: 1;
@@ -57,8 +64,22 @@
     transition: transform .3s ease-in-out;
   }
 
+  .panel-sub-header-main {
+    padding-right: 2rem;
+  }
+
   .github-gist-panel {
     width: 29rem;
+    display: none;
+  }
+
+  .github-gist-panel.expanded {
+    display: inherit;
+    margin-top: -13px;
+  }
+
+  #publish-gist {
+    height: 30px;
   }
 
   .panel-header .panel-header-side.expanded,

--- a/marlowe-playground-client/static/css/panels.css
+++ b/marlowe-playground-client/static/css/panels.css
@@ -29,6 +29,7 @@
 
 .panel-sub-header-main {
   display: flex;
+  justify-content: flex-start;
   font-weight: bold;
   color: var(--text-color-inactive);
 }
@@ -62,6 +63,10 @@
 
 .demo-list li.active {
   color: var(--secondary-color);
+}
+
+.minimize-icon-container {
+  padding-top: 6px;
 }
 
 .demo-arrow,
@@ -284,14 +289,13 @@ button.minus-btn:hover {
 }
 
 .footer-panel-bg.expanded {
-  /* height: 13rem; */
   padding: 0.5rem 2rem;
-  min-height: 13rem;
-  height: 13rem;
+  min-height: 16rem;
+  height: 16rem;
 }
 
 .expanded>.panel-contents {
-  height: 8rem;
+  height: 12rem;
   overflow-x: scroll;
   display: block;
 }
@@ -360,6 +364,7 @@ button.minus-btn:hover {
 
 .haskell-buttons {
   width: 17rem;
+  margin-left: 1rem;
 }
 
 .drawer-icon-click {


### PR DESCRIPTION
- stop simulation tab icon moving
- move bottom panel minimize button to left so that it is visible when covered by right panel
- make width breakpoint earlier so that transaction composer doesn't get squashed
- hide gist buttons when right panel contracted
- make sure "to blockly" button not hidden when right panel contracted
- make bottom panel a bit bigger

![sim-tab](https://user-images.githubusercontent.com/934267/81202916-a6d78100-8f9d-11ea-9297-47218dc6b8e0.gif)

![changes](https://user-images.githubusercontent.com/934267/81202785-768fe280-8f9d-11ea-8d7b-048413dac83a.gif)
