### PR TITLE
Fix haddock for plutus-scb

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -48,7 +48,6 @@ let
             # See https://github.com/input-output-hk/plutus/issues/1213
             marlowe.doHaddock = false;
             plutus-use-cases.doHaddock = false;
-            plutus-scb.doHaddock = false;
             plutus-ledger.doHaddock = false;
             # FIXME: Haddock mysteriously gives a spurious missing-home-modules warning
             plutus-tx-plugin.doHaddock = false;

--- a/plutus-ledger/src/Ledger/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Scripts.hs
@@ -50,7 +50,9 @@ module Ledger.Scripts(
     monetaryPolicyHash,
     -- * Example scripts
     unitRedeemer,
-    unitDatum
+    unitDatum,
+    acceptingValidator,
+    acceptingMonetaryPolicy
     ) where
 
 import qualified Prelude                              as Haskell
@@ -75,7 +77,7 @@ import qualified Language.PlutusCore                  as PLC
 import           Language.PlutusCore.CBOR
 import qualified Language.PlutusCore.Constant.Dynamic as PLC
 import qualified Language.PlutusCore.Pretty           as PLC
-import           Language.PlutusTx                    (CompiledCode, IsData (..), getPlc, makeLift)
+import           Language.PlutusTx                    (CompiledCode, IsData (..), getPlc, makeLift, compile)
 import           Language.PlutusTx.Builtins           as Builtins
 import           Language.PlutusTx.Evaluation         (ErrorWithCause (..), EvaluationError (..), evaluateCekTrace)
 import           Language.PlutusTx.Lift               (liftCode)
@@ -375,6 +377,14 @@ unitDatum = Datum $ toData ()
 -- | @()@ as a redeemer.
 unitRedeemer :: Redeemer
 unitRedeemer = Redeemer $ toData ()
+
+-- | A validator that always succeeds.
+acceptingValidator :: Validator
+acceptingValidator = mkValidatorScript $$(compile [|| (\_ _ _ -> ()) ||])
+
+-- | A monetary policy that always succeeds.
+acceptingMonetaryPolicy :: MonetaryPolicy
+acceptingMonetaryPolicy = mkMonetaryPolicyScript $$(compile [|| (\_ -> ()) ||])
 
 makeLift ''ValidatorHash
 

--- a/plutus-scb/src/Plutus/SCB/Arbitrary.hs
+++ b/plutus-scb/src/Plutus/SCB/Arbitrary.hs
@@ -27,7 +27,6 @@ import           Ledger.Interval                                   (Extended, In
 import           Ledger.Slot                                       (Slot)
 import           Ledger.Tx                                         (TxIn, TxInType, TxOutRef, TxOutType)
 import           Ledger.TxId                                       (TxId)
-import           Ledger.Typed.Scripts                              (wrapValidator)
 import           LedgerBytes                                       (LedgerBytes)
 import qualified LedgerBytes
 import           Plutus.SCB.Events.Contract
@@ -41,8 +40,7 @@ instance Arbitrary LedgerBytes where
     arbitrary = LedgerBytes.fromBytes <$> arbitrary
 
 instance Arbitrary Ledger.MonetaryPolicy where
-    arbitrary = genericArbitrary
-    shrink = genericShrink
+    arbitrary = pure Ledger.acceptingMonetaryPolicy
 
 instance Arbitrary WalletAPIError where
     arbitrary = genericArbitrary
@@ -115,18 +113,12 @@ instance Arbitrary Ledger.DatumHash where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance Arbitrary Ledger.Script where
-    arbitrary = pure $ Ledger.unValidatorScript $ Ledger.mkValidatorScript $$(PlutusTx.compile [|| validator ||])
-      where
-        validator = wrapValidator ((\_ _ _ -> True) :: Integer -> Integer -> Ledger.PendingTx -> Bool)
-
 instance Arbitrary Ledger.Redeemer where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
 instance Arbitrary Ledger.Validator where
-    arbitrary = genericArbitrary
-    shrink = genericShrink
+    arbitrary = pure Ledger.acceptingValidator
 
 instance Arbitrary Ledger.TokenName where
     arbitrary = genericArbitrary


### PR DESCRIPTION
We can fix it to not use the plugin pretty easily, just export some
accepting validators from `Scripts`, which seems handy anyway.