### PR TITLE
Cabal improvements

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -53,24 +53,6 @@ You can find the files in link:./nix/stack.materialized[`nix/stack.materialized`
 All you need to do is delete this directory, and then rebuild something. 
 You will see a command on stderr that will tell you how to generate the replacement files.
 
-[[update-freeze]]
-=== How to update `cabal.project.freeze`
-
-The `cabal.project.freeze` file ensures that Cabal users will get the same versions as
-are picked by Stack. The way we ensure this is by running `cabal v2-freeze` in a Nix environment
-based on the package set generated from the Stack configuration. This ensures that Cabal chooses versions
-that match those in the Stackage resolver.
-
-IMPORTANT: This file needs to be regenerated if you change any dependencies in cabal files
-or change the Stackage resolver. To regenerate the file, run `nix-shell --run "cabal v2-freeze"` in the root.
-
-[NOTE]
-====
-The `nix-shell` invocation will *build* all the dependencies of the project, so if you
-have just made a substantial change (e.g. changing the snapshot), then you may want to
-push your change to a PR so Hydra will build it before doing this step.
-====
-
 === How to update one of our pinned dependencies
 
 ==== Haskell pins

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,5 @@
+index-state: 2020-02-20T00:00:00Z
+
 packages: language-plutus-core
           marlowe
           plutus-ledger

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
+# Bump this if you need newer packages
 index-state: 2020-02-20T00:00:00Z
 
 packages: language-plutus-core

--- a/cabal.project
+++ b/cabal.project
@@ -48,11 +48,6 @@ source-repository-package
   tag: 9ca1112093c5ffd356fc99c7dafa080e686dd748
 
 source-repository-package
-  type: git
-  location: https://github.com/shmish111/github.git
-  tag: cc27b9de4d5d0939235fa9a8b418de3ea4807bab
-
-source-repository-package
    type: git
    location: https://github.com/michaelpj/slack-web.git
    tag: 6ff88895c5da593e7bd09a46d7002441817aa6f8

--- a/lib.nix
+++ b/lib.nix
@@ -1,6 +1,4 @@
 let
-  # The Hackage index-state we use for things
-  index-state = "2020-02-20T00:00:00Z";
 
   unfreePredicate = pkg:
       let unfreePkgs = [ "kindlegen" ]; in
@@ -10,4 +8,4 @@ let
 
   comp = f: g: (v: f(g v));
 
-in { inherit index-state unfreePredicate comp; }
+in { inherit unfreePredicate comp; }


### PR DESCRIPTION
- Pin the index state, this means we don't need a freeze file any more.
- Get the index state from the cabal file for our other stuff.
- Remove a rogue source dependency that was breaking things.