### PR TITLE
Add all components to required job

### DIFF
--- a/language-plutus-core/bench/Bench.hs
+++ b/language-plutus-core/bench/Bench.hs
@@ -26,7 +26,7 @@ traceBuiltins = getStringBuiltinTypes ()
 main :: IO ()
 main =
     defaultMain [ env largeTypeFiles $ \ ~(f, g, h) ->
-                    let mkBench = bench "pretty" . nf (fmap prettyPlcDefText) . parse
+                    let mkBench = bench "pretty" . nf (fmap (show . prettyPlcDef)) . parse
                     in
 
                     bgroup "prettyprint" $ mkBench <$> [f, g, h]

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -71,8 +71,13 @@ let
 
             # Relies on cabal-doctest, just turn it off in the Nix build
             prettyprinter-configurable.components.tests.prettyprinter-configurable-doctest.buildable = lib.mkForce false;
-            language-plutus-core.components.benchmarks.language-plutus-core-create-cost-model.build-tools =
-              lib.mkForce [(pkgs.rWrapper.override { packages = with pkgs.rPackages; [tidyverse dplyr stringr MASS]; } )];
+
+            language-plutus-core.components.benchmarks.language-plutus-core-create-cost-model = {
+              # Need a suitably wrapped R
+              build-tools = lib.mkForce [(pkgs.rWrapper.override { packages = with pkgs.rPackages; [tidyverse dplyr stringr MASS]; } )];
+              # Seems to be broken on darwin for some reason
+              platforms = lib.platforms.linux;
+            };
 
             # Werror everything. This is a pain, see https://github.com/input-output-hk/haskell.nix/issues/519
             deployment-server.package.ghcOptions = "-Werror";

--- a/release.nix
+++ b/release.nix
@@ -30,8 +30,8 @@ in lib.fix (jobsets: ciJobsets // {
       (allJobs ["linux" "tests"] jobsets)
       ++ (allJobs ["darwin" "tests"] jobsets)
       # Haskell tests
-      ++ (allJobs ["linux" "haskell" "checks"] jobsets)
-      ++ (allJobs ["darwin" "haskell" "checks"] jobsets)
+      ++ (allJobs ["linux" "haskell" ] jobsets)
+      ++ (allJobs ["darwin" "haskell" ] jobsets)
       # Various things that mostly just need to build on linux
       ++ (allJobs ["linux" "docs"] jobsets)
       ++ (allJobs ["linux" "papers"] jobsets)


### PR DESCRIPTION
Things not required by tests (e.g. benchmarks or exes) weren't required, so could get through being broken.