### PR TITLE
SCP-424: Add index for `NextTxAt` effect

### DIFF
--- a/nix/stack.materialized/plutus-contract.nix
+++ b/nix/stack.materialized/plutus-contract.nix
@@ -61,6 +61,7 @@
           (hsPkgs."prettyprinter" or (errorHandler.buildDepError "prettyprinter"))
           (hsPkgs."semigroups" or (errorHandler.buildDepError "semigroups"))
           (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+          (hsPkgs."fingertree" or (errorHandler.buildDepError "fingertree"))
           ] ++ (pkgs.lib).optionals (!(compiler.isGhcjs && true || system.isGhcjs)) [
           (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
           (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
@@ -84,6 +85,7 @@
           "Language/Plutus/Contract/State"
           "Language/Plutus/Contract/Schema"
           "Language/Plutus/Contract/Trace"
+          "Language/Plutus/Contract/Trace/RequestHandler"
           "Language/Plutus/Contract/IOTS"
           "Language/Plutus/Contract/Servant"
           "Language/Plutus/Contract/Resumable"
@@ -99,6 +101,7 @@
           "Wallet/Emulator/Generators"
           "Wallet/Emulator/Chain"
           "Wallet/Emulator/ChainIndex"
+          "Wallet/Emulator/ChainIndex/Index"
           "Wallet/Emulator/Error"
           "Wallet/Emulator/NodeClient"
           "Wallet/Emulator/MultiAgent"

--- a/playground-common/src/Playground/Interpreter/Util.hs
+++ b/playground-common/src/Playground/Interpreter/Util.hs
@@ -181,8 +181,6 @@ triggerEvents ::
     -> ContractTrace s e m a ()
 triggerEvents w = do
     handleBlockchainEvents w
-    notifyInterestingAddresses w
-    notifySlot w
 
 toInitialDistribution :: [SimulatorWallet] -> Map Wallet Value
 toInitialDistribution = Map.fromList . fmap (\(SimulatorWallet w v) -> (w, v))

--- a/playground-common/src/Playground/Interpreter/Util.hs
+++ b/playground-common/src/Playground/Interpreter/Util.hs
@@ -32,8 +32,7 @@ import           Language.Plutus.Contract.Test                   (renderTraceCon
 import           Language.Plutus.Contract.Trace                  (ContractTrace, ContractTraceState,
                                                                   TraceError (TContractError), addBlocks,
                                                                   addBlocksUntil, addNamedEvent, handleBlockchainEvents,
-                                                                  notifyInterestingAddresses, notifySlot, payToWallet,
-                                                                  runTraceWithDistribution)
+                                                                  payToWallet, runTraceWithDistribution)
 import           Ledger                                          (Blockchain, PubKey, TxOut (txOutValue), pubKeyHash,
                                                                   txOutTxOut)
 import           Ledger.AddressMap                               (fundsAt)

--- a/plutus-contract/plutus-contract.cabal
+++ b/plutus-contract/plutus-contract.cabal
@@ -52,6 +52,7 @@ library
         Language.Plutus.Contract.State
         Language.Plutus.Contract.Schema
         Language.Plutus.Contract.Trace
+        Language.Plutus.Contract.Trace.RequestHandler
         Language.Plutus.Contract.IOTS
         Language.Plutus.Contract.Servant
         Language.Plutus.Contract.Resumable
@@ -67,6 +68,7 @@ library
         Wallet.Emulator.Generators
         Wallet.Emulator.Chain
         Wallet.Emulator.ChainIndex
+        Wallet.Emulator.ChainIndex.Index
         Wallet.Emulator.Error
         Wallet.Emulator.NodeClient
         Wallet.Emulator.MultiAgent
@@ -111,7 +113,8 @@ library
         freer-simple -any,
         prettyprinter >=1.1.0.1,
         semigroups -any,
-        cryptonite >=0.25
+        cryptonite >=0.25,
+        fingertree -any
 
     if !(impl(ghcjs) || os(ghcjs))
         exposed-modules:

--- a/plutus-contract/src/Language/Plutus/Contract/Checkpoint.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Checkpoint.hs
@@ -36,7 +36,7 @@ import           Data.Map                  (Map)
 import qualified Data.Map                  as Map
 import           Data.Text                 (Text)
 import qualified Data.Text                 as Text
-import           Data.Text.Prettyprint.Doc (Pretty (..), colon, viaShow, vsep, (<+>))
+import           Data.Text.Prettyprint.Doc (Pretty (..), colon, vsep, (<+>))
 import           GHC.Generics              (Generic)
 
 -- $checkpoints
@@ -70,7 +70,7 @@ newtype CheckpointStore = CheckpointStore { unCheckpointStore :: Map CheckpointK
 
 instance Pretty CheckpointStore where
     pretty (CheckpointStore mp) =
-        let p k v = pretty k <> colon <+> viaShow v in
+        let p k v = pretty k <> colon <+> (pretty . take 100 . show) v in
         vsep (uncurry p <$> Map.toList mp)
 
 _CheckpointStore :: Iso' CheckpointStore (Map CheckpointKey Value)

--- a/plutus-contract/src/Language/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Trace/RequestHandler.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia        #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE RankNTypes         #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE TypeOperators      #-}
+module Language.Plutus.Contract.Trace.RequestHandler(
+    RequestHandler(..)
+    , tryHandler
+    , wrapHandler
+    , extract
+    , maybeToHandler
+    ) where
+
+import           Control.Applicative                (Alternative (empty))
+import           Control.Arrow                      (Kleisli (..))
+import           Control.Lens
+import           Control.Monad                      (foldM)
+import           Control.Monad.Freer
+import           Control.Monad.Freer.NonDet         (NonDet)
+import qualified Control.Monad.Freer.NonDet         as NonDet
+import           Data.Monoid                        (Alt (..), Ap (..))
+
+import           Language.Plutus.Contract.Resumable (Request (..), Response (..))
+
+
+-- | Request handlers that can choose whether to handle an effect (using
+--   'Alternative'). This is useful if 'req' is a sum type.
+newtype RequestHandler effs req resp = RequestHandler { unRequestHandler :: req -> Eff (NonDet ': effs) resp }
+    deriving stock (Functor)
+    deriving (Profunctor) via (Kleisli (Eff (NonDet ': effs)))
+    deriving (Semigroup, Monoid) via (Ap ((->) req) (Alt (Eff (NonDet ': effs)) resp))
+
+
+-- Try the handler on the requests until it succeeds for the first time, then stop.
+tryHandler ::
+    forall effs req resp
+    . RequestHandler effs req resp
+    -> [req]
+    -> Eff effs (Maybe resp)
+tryHandler (RequestHandler h) requests =
+    foldM (\e i -> maybe (NonDet.makeChoiceA @Maybe $ h i) (pure . Just) e) Nothing requests
+
+extract :: Alternative f => Prism' a b -> a -> f b
+extract p = maybe empty pure . preview p
+
+wrapHandler :: RequestHandler effs req resp -> RequestHandler effs (Request req) (Response resp)
+wrapHandler (RequestHandler h) = RequestHandler $ \Request{rqID, itID, rqRequest} -> do
+    r <- h rqRequest
+    pure $ Response{rspRqID = rqID, rspResponse = r, rspItID = itID }
+
+maybeToHandler :: (req -> Maybe resp) -> RequestHandler effs req resp
+maybeToHandler f = RequestHandler $ maybe empty pure . f

--- a/plutus-contract/src/Wallet/Effects.hs
+++ b/plutus-contract/src/Wallet/Effects.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE GADTs              #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TemplateHaskell    #-}
 module Wallet.Effects(
     WalletEffects
@@ -25,18 +27,22 @@ module Wallet.Effects(
     , addSignatures
     -- * Chain index
     , ChainIndexEffect(..)
+    , AddressChangeRequest(..)
+    , AddressChangeResponse(..)
     , startWatching
     , watchedAddresses
     , confirmedBlocks
     , transactionConfirmed
+    , nextTx
     ) where
 
-import           Control.Monad.Freer.TH (makeEffect)
-import           Data.Aeson             (FromJSON, ToJSON)
-import qualified Data.Set               as Set
-import           GHC.Generics           (Generic)
-import           Ledger                 (Address, PubKey, PubKeyHash, Slot, Tx, TxId, TxIn, TxOut, Value)
-import           Ledger.AddressMap      (AddressMap, UtxoMap)
+import           Control.Monad.Freer.TH    (makeEffect)
+import           Data.Aeson                (FromJSON, ToJSON)
+import qualified Data.Set                  as Set
+import           Data.Text.Prettyprint.Doc
+import           GHC.Generics              (Generic)
+import           Ledger                    (Address, PubKey, PubKeyHash, Slot, Tx, TxId, TxIn, TxOut, Value, txId)
+import           Ledger.AddressMap         (AddressMap, UtxoMap)
 
 -- | A payment consisting of a set of inputs to be spent, and
 --   an optional change output. The size of the payment is the
@@ -70,16 +76,54 @@ data SigningProcessEffect r where
     AddSignatures :: [PubKeyHash] -> Tx -> SigningProcessEffect Tx
 makeEffect ''SigningProcessEffect
 
--- | Access a (plutus-specific) chain index. The chain index keeps track of the
---   datums that are associated with unspent transaction outputs. Addresses that
---   are of interest need to be added with 'startWatching' before their outputs
---   show up in the 'AddressMap' returned by 'watchedAddresses'.
+-- | Information about transactions that spend or produce an output at
+--   an address in a slot.
+data AddressChangeResponse =
+    AddressChangeResponse
+        { acrAddress :: Address -- ^ The address
+        , acrSlot    :: Slot -- ^ The slot
+        , acrTxns    :: [Tx] -- ^ Transactions that were validated in the slot and spent or produced at least one output at the address.
+        }
+        deriving stock (Eq, Generic, Show)
+        deriving anyclass (ToJSON, FromJSON)
+
+instance Pretty AddressChangeResponse where
+    pretty AddressChangeResponse{acrAddress, acrTxns, acrSlot} =
+        hang 2 $ vsep
+            [ "Address:" <+> pretty acrAddress
+            , "Slot:" <+> pretty acrSlot
+            , "Tx IDs:" <+> pretty (txId <$> acrTxns)
+            ]
+
+-- | Request for information about transactions that spend or produce
+--   outputs at a specific address in a slot.
+data AddressChangeRequest =
+    AddressChangeRequest
+        { acreqSlot    :: Slot -- ^ The slot
+        , acreqAddress :: Address -- ^ The address
+        }
+        deriving stock (Eq, Generic, Show, Ord)
+        deriving anyclass (ToJSON, FromJSON)
+
+instance Pretty AddressChangeRequest where
+    pretty AddressChangeRequest{acreqSlot, acreqAddress} =
+        hang 2 $ vsep
+            [ "Slot:" <+> pretty acreqSlot
+            , "Address:" <+> pretty acreqAddress
+            ]
+
+{-| Access the chain index. The chain index keeps track of the
+    datums that are associated with unspent transaction outputs. Addresses that
+    are of interest need to be added with 'startWatching' before their outputs
+    show up in the 'AddressMap' returned by 'watchedAddresses'.
+-}
 data ChainIndexEffect r where
     StartWatching :: Address -> ChainIndexEffect ()
     WatchedAddresses :: ChainIndexEffect AddressMap
     ConfirmedBlocks :: ChainIndexEffect [[Tx]]
     -- TODO: In the future we should have degrees of confirmation
     TransactionConfirmed :: TxId -> ChainIndexEffect Bool
+    NextTx :: AddressChangeRequest -> ChainIndexEffect AddressChangeResponse
 makeEffect ''ChainIndexEffect
 
 -- | Effects that allow contracts to interact with the blockchain

--- a/plutus-contract/src/Wallet/Emulator/ChainIndex.hs
+++ b/plutus-contract/src/Wallet/Emulator/ChainIndex.hs
@@ -1,14 +1,17 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DerivingVia          #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-# OPTIONS_GHC -Wno-orphans  #-}
 module Wallet.Emulator.ChainIndex where
 
@@ -17,21 +20,27 @@ import           Control.Monad.Freer
 import           Control.Monad.Freer.State
 import           Control.Monad.Freer.TH
 import           Control.Monad.Freer.Writer
-import           Data.Aeson                 (FromJSON, ToJSON)
-import           Data.Semigroup.Generic     (GenericSemigroupMonoid (..))
-import           Data.Set                   (Set)
-import qualified Data.Set                   as Set
+import           Data.Aeson                       (FromJSON, ToJSON)
+import           Data.Foldable                    (traverse_)
+import           Data.Map.Strict                  (Map)
+import qualified Data.Map.Strict                  as Map
+import           Data.Semigroup                   (Max (..))
+import           Data.Semigroup.Generic           (GenericSemigroupMonoid (..))
 import           Data.Text.Prettyprint.Doc
-import           GHC.Generics               (Generic)
-import           Wallet.Effects             (ChainIndexEffect (..))
-import           Wallet.Emulator.NodeClient (ChainClientNotification (..))
+import           GHC.Generics                     (Generic)
+import           Wallet.Effects                   (AddressChangeRequest (..), AddressChangeResponse (..),
+                                                   ChainIndexEffect (..))
+import           Wallet.Emulator.ChainIndex.Index (ChainIndex, ChainIndexItem (..))
+import qualified Wallet.Emulator.ChainIndex.Index as Index
+import           Wallet.Emulator.NodeClient       (ChainClientNotification (..))
 
-import           Ledger.Address             (Address)
-import           Ledger.AddressMap          (AddressMap)
-import qualified Ledger.AddressMap          as AM
-import           Ledger.Blockchain          (Blockchain)
-import           Ledger.Tx                  (txId)
-import           Ledger.TxId                (TxId)
+import           Ledger.Address                   (Address)
+import           Ledger.AddressMap                (AddressMap)
+import qualified Ledger.AddressMap                as AM
+import           Ledger.Blockchain                (Blockchain)
+import           Ledger.Slot                      (Slot)
+import           Ledger.Tx                        (txId)
+import           Ledger.TxId                      (TxId)
 
 data ChainIndexControlEffect r where
     ChainIndexNotify :: ChainClientNotification -> ChainIndexControlEffect ()
@@ -39,19 +48,21 @@ makeEffect ''ChainIndexControlEffect
 
 data ChainIndexEvent =
     AddressStartWatching Address
-    | ReceiveBlockNotification
+    | ReceiveBlockNotification Int
     deriving stock (Eq, Show, Generic)
     deriving anyclass (FromJSON, ToJSON)
 
 instance Pretty ChainIndexEvent where
-    pretty (AddressStartWatching addr) = "StartWatching:" <+> pretty addr
-    pretty ReceiveBlockNotification    = "ReceiveBlockNotification"
+    pretty (AddressStartWatching addr)  = "StartWatching:" <+> pretty addr
+    pretty (ReceiveBlockNotification i) = "ReceiveBlockNotification:" <+> pretty i <+> " transactions."
 
 data ChainIndexState =
     ChainIndexState
-        { _idxWatchedAddresses      :: AddressMap
-        , _idxConfirmedTransactions :: Set TxId
-        , _idxConfirmedBlocks       :: Blockchain
+        { _idxWatchedAddresses      :: AddressMap -- ^ Utxo set annotated with datums
+        , _idxConfirmedTransactions :: Map TxId Slot -- ^ Transactions with confirmation date
+        , _idxConfirmedBlocks       :: Blockchain -- ^ The blockchain
+        , _idxCurrentSlot           :: Maybe (Max Slot) -- ^ The current slot
+        , _idxIdx                   :: ChainIndex  -- ^ Transactions indexed by time and address
         }
         deriving stock (Eq, Show, Generic)
         deriving (Semigroup, Monoid) via (GenericSemigroupMonoid ChainIndexState)
@@ -64,13 +75,19 @@ handleChainIndexControl
     :: (Members ChainIndexEffs effs)
     => Eff (ChainIndexControlEffect ': effs) ~> Eff effs
 handleChainIndexControl = interpret $ \case
-    ChainIndexNotify (SlotChanged _) -> pure () -- todo: Keep a map of txns indexed by slot
-    ChainIndexNotify (BlockValidated txns) ->
-        tell [ReceiveBlockNotification] >> (modify $ \s ->
-            s & idxWatchedAddresses %~ (\am -> foldl (\am' t -> AM.updateAllAddresses t am') am txns)
-            & idxConfirmedTransactions <>~ foldMap (Set.singleton . txId) txns
-            & idxConfirmedBlocks <>~ pure txns
-            )
+    ChainIndexNotify (SlotChanged sl) -> modify (idxCurrentSlot .~ Just (Max sl))
+    ChainIndexNotify (BlockValidated txns) -> do
+        tell [ReceiveBlockNotification (length txns)]
+        modify (idxConfirmedBlocks <>~ pure txns)
+        (cs, addressMap) <- (,) <$> gets _idxCurrentSlot <*> gets _idxWatchedAddresses
+        let currentSlot = maybe 0 getMax cs
+        flip traverse_ txns $ \txn -> do
+            let i = txId txn
+                itm = ChainIndexItem{ciSlot=currentSlot, ciTx = txn, ciTxId = i}
+            modify $ \s ->
+                s & idxWatchedAddresses %~ AM.updateAllAddresses txn
+                  & idxConfirmedTransactions %~ Map.insert i currentSlot
+                  & idxIdx %~ Index.insert addressMap itm
 
 handleChainIndex
     :: (Members ChainIndexEffs effs)
@@ -80,4 +97,9 @@ handleChainIndex = interpret $ \case
         s & idxWatchedAddresses %~ AM.addAddress addr)
     WatchedAddresses -> gets _idxWatchedAddresses
     ConfirmedBlocks -> gets _idxConfirmedBlocks
-    TransactionConfirmed txid -> Set.member txid <$> gets _idxConfirmedTransactions
+    TransactionConfirmed txid ->
+        Map.member txid <$> gets _idxConfirmedTransactions
+    NextTx AddressChangeRequest{acreqSlot, acreqAddress} -> do
+        idx <- gets _idxIdx
+        let txns = Index.transactionsAt idx acreqSlot acreqAddress
+        pure $ AddressChangeResponse{acrAddress=acreqAddress, acrSlot=acreqSlot,acrTxns = txns}

--- a/plutus-contract/src/Wallet/Emulator/ChainIndex/Index.hs
+++ b/plutus-contract/src/Wallet/Emulator/ChainIndex/Index.hs
@@ -26,6 +26,9 @@ import           Ledger.TxId       (TxId)
 
 -- | The slot in which a transaction was added to the chain.
 newtype TxSlot = TxSlot
+    {- This is the 'Measure' of 'ChainIndexItem', but the class has a 'Monoid'
+       superclass. But 'Max' is only a 'Semigroup' so we add the 'Maybe'.
+    -}
     { unTxSlot :: Maybe (Max Slot)
     } deriving stock (Eq, Show, Generic)
       deriving newtype (Semigroup, Monoid)
@@ -43,7 +46,7 @@ instance Measured TxSlot ChainIndexItem where
             { unTxSlot = Just (Max ciSlot)
             }
 
--- | A list of transactions at an address, sorted by slot number
+-- | A list of transactions that touch an address, sorted by slot number
 newtype AddressIndex = AddressIndex{ unAddressIndex :: FingerTree TxSlot ChainIndexItem }
     deriving (Eq, Show)
 

--- a/plutus-contract/src/Wallet/Emulator/ChainIndex/Index.hs
+++ b/plutus-contract/src/Wallet/Emulator/ChainIndex/Index.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DerivingStrategies    #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+
+-- | This module implements an index of transactions
+--   by slot and addresses
+module Wallet.Emulator.ChainIndex.Index where
+
+import           Data.FingerTree   (FingerTree, Measured (..), (|>))
+import qualified Data.FingerTree   as FingerTree
+import           Data.Foldable     (foldl', toList)
+import           Data.Map.Strict   (Map)
+import qualified Data.Map.Strict   as Map
+import           Data.Maybe        (fromMaybe)
+import           Data.Semigroup    (Max (..))
+import           GHC.Generics      (Generic)
+
+import           Ledger.Address    (Address)
+import           Ledger.AddressMap (AddressMap)
+import qualified Ledger.AddressMap as AM
+import           Ledger.Slot       (Slot)
+import           Ledger.Tx         (Tx)
+import           Ledger.TxId       (TxId)
+
+-- | The slot in which a transaction was added to the chain.
+newtype TxSlot = TxSlot
+    { unTxSlot :: Maybe (Max Slot)
+    } deriving stock (Eq, Show, Generic)
+      deriving newtype (Semigroup, Monoid)
+
+-- | A transaction with extra information, for the chain index.
+data ChainIndexItem = ChainIndexItem
+    { ciSlot :: !Slot -- ^ The slot in which the transaction was added to the chain
+    , ciTx   :: !Tx -- ^ The transaction
+    , ciTxId :: !TxId -- ^ Hash of the transaction
+    } deriving stock (Eq, Show)
+
+instance Measured TxSlot ChainIndexItem where
+    measure ChainIndexItem{ciSlot} =
+        TxSlot
+            { unTxSlot = Just (Max ciSlot)
+            }
+
+-- | A list of transactions at an address, sorted by slot number
+newtype AddressIndex = AddressIndex{ unAddressIndex :: FingerTree TxSlot ChainIndexItem }
+    deriving (Eq, Show)
+
+instance Semigroup AddressIndex where
+    -- Warning: @l <> r@ keeps the order of slots, but inside each slot
+    -- all transactions of @l@ will appear before all transactions of @r@.
+    -- TODO: We should probably keep track of block numbers as well as slot numbers!
+    l <> (AddressIndex r) = foldl' (flip insertAI) l (toList r)
+
+instance Monoid AddressIndex where
+    mappend = (<>)
+    mempty  = AddressIndex mempty
+
+-- | Insert a new item into the chain index.
+insertAI :: ChainIndexItem -> AddressIndex -> AddressIndex
+insertAI itm ix =
+    let (AddressIndex before, AddressIndex after) = split (ciSlot itm) ix
+    in AddressIndex $ (before |> itm) <> after
+
+-- | Split the address index into two. The first of the results
+--   has all entries up to and including the slot. The second result has all
+--   entries after the given slot.
+split :: Slot -> AddressIndex -> (AddressIndex, AddressIndex)
+split sl (AddressIndex ix) =
+    let
+        gt TxSlot{unTxSlot} = maybe False (\(Max sl') -> sl' > sl) unTxSlot
+        (before, after) = FingerTree.split gt ix
+    in (AddressIndex before, AddressIndex after)
+
+newtype ChainIndex = ChainIndex { unChainIndex :: Map Address AddressIndex }
+    deriving (Eq,Show, Generic)
+
+-- | An empty chain index.
+emptyCI :: ChainIndex
+emptyCI = ChainIndex mempty
+
+instance Semigroup ChainIndex where
+    ChainIndex l <> ChainIndex r =
+        ChainIndex $ Map.unionWith (<>) l r
+
+instance Monoid ChainIndex where
+    mappend = (<>)
+    mempty = ChainIndex mempty
+
+-- | Insert a transaction into the 'ChainIndex'
+insert :: AddressMap -> ChainIndexItem -> ChainIndex -> ChainIndex
+insert am item (ChainIndex ci) =
+    let keys = toList (AM.addressesTouched am (ciTx item))
+        alt = Just . insertAI item . fromMaybe mempty
+    in ChainIndex (foldl' (\ci' addr -> Map.alter alt addr ci') ci keys)
+
+-- | All transactions that modify the address, from a given slot onwards
+transactionsAt :: ChainIndex -> Slot -> Address -> [Tx]
+transactionsAt (ChainIndex mp) sl addr =
+    fmap ciTx
+    $ toList
+    $ unAddressIndex
+    $ fst
+    $ split sl
+    $ snd
+    $ split (pred sl)
+    $ Map.findWithDefault mempty addr mp

--- a/plutus-playground-client/src/Chain.purs
+++ b/plutus-playground-client/src/Chain.purs
@@ -80,9 +80,9 @@ evaluationPane state evaluationResult@(EvaluationResult { emulatorLog, emulatorT
     ]
 
 emulatorEventPane :: forall i p. EmulatorEvent -> HTML p i
-emulatorEventPane (ChainIndexEvent _ ReceiveBlockNotification) =
+emulatorEventPane (ChainIndexEvent _ (ReceiveBlockNotification numTransactions)) =
   div_
-    [ text "Chain index receive block notification" ]
+    [ text $ "Chain index receive block notification. " <> show numTransactions <> " transactions." ]
 
 emulatorEventPane (ChainIndexEvent _ (AddressStartWatching address)) =
   div_

--- a/plutus-playground-server/test/Playground/UsecasesSpec.hs
+++ b/plutus-playground-server/test/Playground/UsecasesSpec.hs
@@ -139,7 +139,7 @@ vestingTest =
             , sourceCode = vesting
             , program = toJSONString expressions
             }
-    vestFundsEval = mkEvaluation [vestFunds w2]
+    vestFundsEval = mkEvaluation [vestFunds w2, AddBlocks 1]
     vestAndPartialRetrieveEval =
         mkEvaluation
             [vestFunds w2, AddBlocks 20, retrieveFunds w1 5, AddBlocks 1]
@@ -156,11 +156,11 @@ gameTest =
         "game"
         [ compilationChecks game
         , testCase "should keep the funds" $
-          evaluate (mkEvaluation [lock w2 "abcde" twoAda, guess w1 "ade"]) >>=
+          evaluate (mkEvaluation [lock w2 "abcde" twoAda, AddBlocks 1, guess w1 "ade", AddBlocks 1]) >>=
           hasFundsDistribution
               [mkSimulatorWallet w1 tenAda, mkSimulatorWallet w2 (adaValueOf 8)]
         , testCase "should unlock the funds" $
-          evaluate (mkEvaluation [lock w2 "abcde" twoAda, guess w1 "abcde"]) >>=
+          evaluate (mkEvaluation [lock w2 "abcde" twoAda, AddBlocks 1, guess w1 "abcde", AddBlocks 1]) >>=
           hasFundsDistribution
               [ mkSimulatorWallet w1 (adaValueOf 12)
               , mkSimulatorWallet w2 (adaValueOf 8)
@@ -265,6 +265,7 @@ crowdfundingTest =
                       , contribute w4 $ lovelaceValueOf 9
                       , AddBlocks 1
                       , AddBlocksUntil 40
+                      , AddBlocks 1
                       ]
             , sourceCode
             }

--- a/plutus-scb/app/PSGenerator.hs
+++ b/plutus-scb/app/PSGenerator.hs
@@ -56,6 +56,8 @@ import           Servant.PureScript                                (HasBridge, S
                                                                     defaultSettings, languageBridge,
                                                                     writeAPIModuleWithSettings, _generateSubscriberAPI)
 import           System.FilePath                                   ((</>))
+import           Wallet.Effects                                    (AddressChangeRequest (..),
+                                                                    AddressChangeResponse (..))
 import qualified Wallet.Emulator.Chain                             as Chain
 
 myBridge :: BridgePart
@@ -115,6 +117,8 @@ myTypes =
     , (order <*> (genericShow <*> mkSumType)) (Proxy @RequestID)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @(Request A))
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @(Responses A))
+    , (equal <*> (genericShow <*> mkSumType)) (Proxy @AddressChangeRequest)
+    , (equal <*> (genericShow <*> mkSumType)) (Proxy @AddressChangeResponse)
     ]
 
 mySettings :: Settings

--- a/plutus-scb/src/Cardano/ChainIndex/API.hs
+++ b/plutus-scb/src/Cardano/ChainIndex/API.hs
@@ -7,6 +7,7 @@ import           Ledger            (Address, TxId)
 import           Ledger.AddressMap (AddressMap)
 import           Ledger.Blockchain (Block)
 import           Servant.API       ((:<|>), (:>), Get, JSON, NoContent, Post, ReqBody)
+import           Wallet.Effects    (AddressChangeRequest, AddressChangeResponse)
 
 type API
      = "healthcheck" :> Get '[ JSON] NoContent
@@ -14,3 +15,4 @@ type API
      :<|> "watched-addresses" :> Get '[ JSON] AddressMap
      :<|> "confirmed-blocks" :> Get '[ JSON] [Block]
      :<|> "transaction-confirmed" :> ReqBody '[ JSON] TxId :> Post '[ JSON] Bool
+     :<|> "next-tx" :> ReqBody '[ JSON] AddressChangeRequest :> Post '[ JSON] AddressChangeResponse

--- a/plutus-scb/src/Cardano/ChainIndex/Client.hs
+++ b/plutus-scb/src/Cardano/ChainIndex/Client.hs
@@ -20,17 +20,18 @@ import           Ledger.Blockchain         (Block)
 import           Servant                   ((:<|>) (..), NoContent)
 import           Servant.Client            (ClientEnv, ClientError, ClientM, client, runClientM)
 
-import           Wallet.Effects            (ChainIndexEffect (..))
+import           Wallet.Effects            (AddressChangeRequest, AddressChangeResponse, ChainIndexEffect (..))
 
 healthCheck :: ClientM NoContent
 startWatching :: Address -> ClientM NoContent
 watchedAddresses :: ClientM AddressMap
 confirmedBlocks :: ClientM [Block]
 transactionConfirmed :: TxId -> ClientM Bool
-(healthCheck, startWatching, watchedAddresses, confirmedBlocks, transactionConfirmed) =
-  (healthCheck_, startWatching_, watchedAddresses_, confirmedBlocks_, txConfirmed_)
+nextTx :: AddressChangeRequest -> ClientM AddressChangeResponse
+(healthCheck, startWatching, watchedAddresses, confirmedBlocks, transactionConfirmed, nextTx) =
+  (healthCheck_, startWatching_, watchedAddresses_, confirmedBlocks_, txConfirmed_, nextTx_)
   where
-    healthCheck_ :<|> startWatching_ :<|> watchedAddresses_ :<|> confirmedBlocks_ :<|> txConfirmed_  =
+    healthCheck_ :<|> startWatching_ :<|> watchedAddresses_ :<|> confirmedBlocks_ :<|> txConfirmed_  :<|> nextTx_ =
         client (Proxy @API)
 
 handleChainIndexClient ::
@@ -51,3 +52,4 @@ handleChainIndexClient clientEnv =
         WatchedAddresses -> runClient watchedAddresses
         ConfirmedBlocks -> runClient confirmedBlocks
         TransactionConfirmed txid -> runClient (transactionConfirmed txid)
+        NextTx req -> runClient (nextTx req)

--- a/plutus-scb/src/Cardano/ChainIndex/Server.hs
+++ b/plutus-scb/src/Cardano/ChainIndex/Server.hs
@@ -60,7 +60,7 @@ app stateVar =
     hoistServer
         (Proxy @API)
         (processIndexEffects stateVar)
-        (healthcheck :<|> startWatching :<|> watchedAddresses :<|> confirmedBlocks :<|> WalletEffects.transactionConfirmed)
+        (healthcheck :<|> startWatching :<|> watchedAddresses :<|> confirmedBlocks :<|> WalletEffects.transactionConfirmed :<|> WalletEffects.nextTx)
 
 main :: (MonadIO m) => ChainIndexConfig -> BaseUrl -> m ()
 main ChainIndexConfig{ciBaseUrl} nodeBaseUrl = runStdoutLoggingT $ do

--- a/plutus-scb/src/Plutus/SCB/Arbitrary.hs
+++ b/plutus-scb/src/Plutus/SCB/Arbitrary.hs
@@ -32,6 +32,7 @@ import           Test.QuickCheck.Arbitrary.Generic                 (Arbitrary, a
                                                                     genericShrink, shrink)
 import           Test.QuickCheck.Instances                         ()
 import           Wallet                                            (WalletAPIError)
+import           Wallet.Effects                                    (AddressChangeRequest (..))
 
 instance Arbitrary LedgerBytes where
     arbitrary = LedgerBytes.fromBytes <$> arbitrary
@@ -131,6 +132,9 @@ instance Arbitrary Ledger.Value where
 
 instance (Arbitrary k, Arbitrary v) => Arbitrary (AssocMap.Map k v) where
     arbitrary = AssocMap.fromList <$> arbitrary
+
+instance Arbitrary AddressChangeRequest where
+    arbitrary =  AddressChangeRequest <$> arbitrary <*> arbitrary
 
 instance Arbitrary ContractSCBRequest where
     arbitrary =

--- a/plutus-scb/src/Plutus/SCB/Events/Contract.hs
+++ b/plutus-scb/src/Plutus/SCB/Events/Contract.hs
@@ -59,7 +59,6 @@ import           Ledger.Address                                    (Address)
 import           Ledger.Constraints.OffChain                       (UnbalancedTx)
 import           Ledger.Crypto                                     (PubKey)
 import           Ledger.Slot                                       (Slot)
-import           Ledger.Tx                                         (Tx)
 
 import           Language.Plutus.Contract.Effects.AwaitSlot        (WaitingForSlot)
 import           Language.Plutus.Contract.Effects.AwaitTxConfirmed (TxConfirmed (..))
@@ -69,6 +68,7 @@ import           Language.Plutus.Contract.Effects.OwnPubKey        (OwnPubKeyReq
 import           Language.Plutus.Contract.Effects.UtxoAt           (UtxoAtAddress)
 
 import           Plutus.SCB.Utils                                  (abbreviate)
+import           Wallet.Effects                                    (AddressChangeRequest, AddressChangeResponse)
 
 -- $contract-events
 -- The events that compiled Plutus contracts are concerned with. For each type
@@ -118,7 +118,7 @@ data ContractSCBRequest =
   | UserEndpointRequest ActiveEndpoint -- ^ Expose a named endpoint to the user. The endpoints' schemas can be obtained statically from the contract (using 'Language.Plutus.Contract.IOTS.rowSchema'), so they are not included in the message.
   | OwnPubkeyRequest OwnPubKeyRequest -- ^ Request a public key. It is expected that the wallet treats any outputs locked by this public key as part of its own funds.
   | UtxoAtRequest Address -- ^ Get the unspent transaction outputs at the address.
-  | NextTxAtRequest Address -- ^ Wait for the next transaction that modifies the UTXO at the address and return it. TODO: confirmation levels
+  | NextTxAtRequest AddressChangeRequest -- ^ Wait for the next transaction that modifies the UTXO at the address and return it.
   | WriteTxRequest UnbalancedTx -- ^ Submit an unbalanced transaction to the SCB.
   deriving  (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -155,7 +155,7 @@ data ContractResponse =
   | UserEndpointResponse EndpointDescription (EndpointValue Value)
   | OwnPubkeyResponse PubKey
   | UtxoAtResponse UtxoAtAddress
-  | NextTxAtResponse (Address, Tx)
+  | NextTxAtResponse AddressChangeResponse
   | WriteTxResponse W.WriteTxResponse
   deriving  (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -166,7 +166,7 @@ instance Pretty ContractResponse where
         UserEndpointResponse n r       -> "UserEndpoint:" <+> pretty n <+> pretty r
         OwnPubkeyResponse pk           -> "OwnPubKey:" <+> pretty pk
         UtxoAtResponse utxo            -> "UtxoAt:" <+> pretty utxo
-        NextTxAtResponse (address, tx) -> "NextTxAt:" <+> pretty address <+> pretty tx
+        NextTxAtResponse rsp        -> "NextTxAt:" <+> pretty rsp
         WriteTxResponse w           -> "WriteTx:" <+> pretty w
         AwaitTxConfirmedResponse w  -> "AwaitTxConfirmed:" <+> pretty w
 

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Crowdfunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Crowdfunding.hs
@@ -263,6 +263,7 @@ makeContribution
 makeContribution w v =
     Trace.callEndpoint @"contribute" w Contribution{contribValue=v}
         >> Trace.handleBlockchainEvents w
+        >> Trace.addBlocks 1
 
 -- | Run a successful campaign with contributions from wallets 2, 3 and 4.
 successfulCampaign
@@ -273,6 +274,6 @@ successfulCampaign =
         >> makeContribution (Trace.Wallet 2) (Ada.lovelaceValueOf 10)
         >> makeContribution (Trace.Wallet 3) (Ada.lovelaceValueOf 10)
         >> makeContribution (Trace.Wallet 4) (Ada.lovelaceValueOf 1)
-        >> Trace.addBlocks 18
-        >> Trace.notifySlot (Trace.Wallet 1)
+        >> Trace.addBlocksUntil 20
         >> Trace.handleBlockchainEvents (Trace.Wallet 1)
+        >> Trace.addBlocks 1

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Currency.hs
@@ -38,7 +38,7 @@ import           Language.Plutus.Contract                        as Contract
 import qualified Language.PlutusTx                               as PlutusTx
 import qualified Language.PlutusTx.AssocMap                      as AssocMap
 import           Ledger                                          (CurrencySymbol, PubKeyHash, TxId, TxOutRef (..),
-                                                                  pubKeyHash, scriptCurrencySymbol)
+                                                                  pubKeyHash, scriptCurrencySymbol, txId)
 import qualified Ledger.Ada                                      as Ada
 import qualified Ledger.Constraints                              as Constraints
 import           Ledger.Scripts
@@ -164,7 +164,8 @@ forgeContract pk amounts = mapError (review _CurrencyError) $ do
                         <> Constraints.unspentOutputs (Map.singleton txOutRef txOutTx)
     let forgeTx = Constraints.mustSpendScriptOutput txOutRef unitRedeemer
                     <> Constraints.mustForgeValue (forgedValue theCurrency)
-    _ <- submitTxConstraintsWith @Scripts.Any lookups forgeTx
+    tx <- submitTxConstraintsWith @Scripts.Any lookups forgeTx
+    _ <- awaitTxConfirmed (txId tx)
     pure theCurrency
 
 -- | Monetary policy for a currency that has a fixed amount of tokens issued

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -151,6 +151,7 @@ lockTrace =
     let w1 = Trace.Wallet 1 in
     Trace.callEndpoint @"lock" w1 (LockParams "secret" (Ada.lovelaceValueOf 10))
         >> Trace.handleBlockchainEvents w1
+        >> Trace.addBlocks 1
 
 guessTrace
     :: ( MonadEmulator (TraceError e) m )
@@ -160,6 +161,7 @@ guessTrace =
     lockTrace
         >> Trace.callEndpoint @"guess" w2 (GuessParams "secret")
         >> Trace.handleBlockchainEvents w2
+        >> Trace.addBlocks 1
 
 guessWrongTrace
     :: ( MonadEmulator (TraceError e) m )
@@ -169,3 +171,4 @@ guessWrongTrace =
     lockTrace
         >> Trace.callEndpoint @"guess" w2 (GuessParams "SECRET")
         >> Trace.handleBlockchainEvents w2
+        >> Trace.addBlocks 1

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -117,6 +117,7 @@ tests = testGroup "crowdfunding"
             >> Trace.notifySlot w2
             >> Trace.notifySlot w3
             >> traverse_ Trace.handleBlockchainEvents [w2, w3]
+            >> Trace.addBlocks 1
 
     , Lib.goldenPir "test/Spec/crowdfunding.pir" $$(PlutusTx.compile [|| mkValidator ||])
     ,   let

--- a/plutus-use-cases/test/Spec/Currency.hs
+++ b/plutus-use-cases/test/Spec/Currency.hs
@@ -16,12 +16,12 @@ tests = testGroup "currency"
     [ checkPredicate "can create a new currency"
         theContract
         (assertDone w1 (const True) "currency contract not done")
-        (handleBlockchainEvents (Wallet 1))
+        (handleBlockchainEvents (Wallet 1) >> addBlocks 1 >> handleBlockchainEvents (Wallet 1) >> addBlocks 1 >> handleBlockchainEvents (Wallet 1))
 
     , checkPredicate "script size is reasonable"
         theContract
         (assertDone w1 ((25000 >=) . Ledger.scriptSize . Ledger.unMonetaryPolicyScript . Cur.curPolicy) "script too large")
-        (handleBlockchainEvents (Wallet 1))
+        (handleBlockchainEvents (Wallet 1) >> addBlocks 1 >> handleBlockchainEvents (Wallet 1) >> addBlocks 1 >> handleBlockchainEvents (Wallet 1))
 
     ]
 

--- a/plutus-use-cases/test/Spec/GameStateMachine.hs
+++ b/plutus-use-cases/test/Spec/GameStateMachine.hs
@@ -38,8 +38,11 @@ tests =
         /\ walletFundsChange w1 (Ada.lovelaceValueOf (-4) <> gameTokenVal))
         ( successTrace
         >> payToWallet w2 w1 gameTokenVal
+        >> addBlocks 1
+        >> handleBlockchainEvents w1
         >> callEndpoint @"guess" w1 GuessArgs{guessArgsOldSecret="new secret", guessArgsNewSecret="hello", guessArgsValueTakenOut=Ada.lovelaceValueOf 4}
         >> handleBlockchainEvents w1
+        >> addBlocks 1
         )
 
     , checkPredicate @GameStateMachineSchema "run a failed trace"
@@ -49,9 +52,14 @@ tests =
         /\ walletFundsChange w1 (Ada.lovelaceValueOf (-8)))
         ( callEndpoint @"lock" w1 LockArgs{lockArgsSecret="hello", lockArgsValue= Ada.lovelaceValueOf 8}
         >> handleBlockchainEvents w1
+        >> addBlocks 1
+        >> handleBlockchainEvents w1
+        >> addBlocks 1
         >> payToWallet w1 w2 gameTokenVal
+        >> addBlocks 1
         >> callEndpoint @"guess" w2 GuessArgs{guessArgsOldSecret="hola", guessArgsNewSecret="new secret", guessArgsValueTakenOut=Ada.lovelaceValueOf 3}
-        >> handleBlockchainEvents w2)
+        >> handleBlockchainEvents w2
+        >> addBlocks 1)
 
 
     , Lib.goldenPir "test/Spec/gameStateMachine.pir" $$(PlutusTx.compile [|| mkValidator ||])
@@ -77,10 +85,14 @@ successTrace :: MonadEmulator (TraceError e) m => ContractTrace GameStateMachine
 successTrace = do
     callEndpoint @"lock" w1 LockArgs{lockArgsSecret="hello", lockArgsValue= Ada.lovelaceValueOf 8}
     handleBlockchainEvents w1
+    addBlocks 1
     handleBlockchainEvents w1
+    addBlocks 1
     payToWallet w1 w2 gameTokenVal
+    addBlocks 1
     callEndpoint @"guess" w2 GuessArgs{guessArgsOldSecret="hello", guessArgsNewSecret="new secret", guessArgsValueTakenOut=Ada.lovelaceValueOf 3}
     handleBlockchainEvents w2
+    addBlocks 1
 
 gameTokenVal :: Value
 gameTokenVal =

--- a/plutus-use-cases/test/Spec/MultiSig.hs
+++ b/plutus-use-cases/test/Spec/MultiSig.hs
@@ -25,9 +25,11 @@ tests = testGroup "multisig"
         (assertFailedTransaction (\_ err -> case err of {ScriptFailure (EvaluationError ["not enough signatures"]) -> True; _ -> False  }))
         (callEndpoint @"lock" w1 (multiSig, Ada.lovelaceValueOf 10)
         >> handleBlockchainEvents w1
+        >> addBlocks 1
         >> callEndpoint @"unlock" w1 (multiSig, fmap (Ledger.pubKeyHash . walletPubKey) [w1, w2])
         >> setSigningProcess w1 (signWallets [w1, w2])
         >> handleBlockchainEvents w1
+        >> addBlocks 1
         )
 
     , checkPredicate @MultiSigSchema @ContractError "3 out of 5"

--- a/plutus-use-cases/test/Spec/PubKey.hs
+++ b/plutus-use-cases/test/Spec/PubKey.hs
@@ -39,5 +39,5 @@ tests = testGroup "pubkey"
   [ checkPredicate "works like a public key output"
       theContract
       (walletFundsChange w1 mempty /\ assertDone w1 (const True) "pubkey contract not done")
-      (handleBlockchainEvents (Wallet 1))
+      (handleBlockchainEvents (Wallet 1) >> addBlocks 1 >> handleBlockchainEvents (Wallet 1) >> addBlocks 1)
   ]

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -36,7 +36,9 @@ tests =
         con
         (walletFundsChange wallet2 (Numeric.negate $ totalAmount vesting))
         ( callEndpoint @"vest funds" wallet2 ()
-        >> handleBlockchainEvents wallet2)
+        >> handleBlockchainEvents wallet2
+        >> addBlocks 1
+        )
 
     , checkPredicate "retrieve some funds"
         con
@@ -67,8 +69,9 @@ tests =
         >> addBlocks 20
         >> callEndpoint @"retrieve funds" wallet1 (totalAmount vesting)
         >> notifySlot wallet1
+        >> handleBlockchainEvents wallet1
         >> addBlocks 1
-        >> handleBlockchainEvents wallet1)
+        )
 
     , Lib.goldenPir "test/Spec/vesting.pir" $$(PlutusTx.compile [|| validate ||])
     , HUnit.testCase "script size is reasonable" (Lib.reasonable (vestingScript vesting) 33000)
@@ -94,6 +97,7 @@ retrieveFundsTrace = do
     callEndpoint @"retrieve funds" wallet1 (Ada.lovelaceValueOf 10)
     addBlocks 1
     handleBlockchainEvents wallet1
+    addBlocks 1
 
 expectedError :: TraceError VestingError
 expectedError =

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -100,7 +100,7 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
 
-==== Slot #2, Tx #0 ====
+==== Slot #1, Tx #0 ====
 TxId:       8a4cd97044142d4cf3e2136ee06e0013967d5a87ae72c48f8051703631e9ed05
 Fee:        -
 Forge:      -
@@ -174,7 +174,7 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10
 
-==== Slot #3, Tx #0 ====
+==== Slot #2, Tx #0 ====
 TxId:       0e01b64274027bd12a1c8579d3a50f1c67bedfb35d370819df86f172448a3c0f
 Fee:        -
 Forge:      -
@@ -248,7 +248,7 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  20
 
-==== Slot #4, Tx #0 ====
+==== Slot #3, Tx #0 ====
 TxId:       d3699882826a5ec9812dba56b696167e4bb780873031735fd5e7a69ca6fee32e
 Fee:        -
 Forge:      -
@@ -322,7 +322,7 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  21
 
-==== Slot #23, Tx #0 ====
+==== Slot #20, Tx #0 ====
 TxId:       b3f9625d8b107afced2297ec29de44a07364caaba347419a2228de97f7e83001
 Fee:        -
 Forge:      -

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -174,7 +174,7 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  60
 
-==== Slot #13, Tx #0 ====
+==== Slot #12, Tx #0 ====
 TxId:       68c627774eff2be9492b6c6c36c59d6f814c17eec131249188b86e58685e416f
 Fee:        -
 Forge:      -


### PR DESCRIPTION
* Add `Wallet.Emulator.ChainIndex.Index` with an index for answering `AddressChangeRequest`  queries.
* Add a `NextTx :: AddressChangeRequest -> ChainIndexEffect AddressChangeResponse` constructor to `ChainIndexEffect`, and update the implementation of `handleChainIndex` to populate the index and use it to answer requests
* Update emulator & SCB to actually use the index
  * In the emulator we previously pushed `AddressChange` notifications each time a transaction was added to the chain. This needed to be changed to the pull-based model that we use for all other requests. In order to do that, I decided to pull the  `RequestHandler` type from the SCB into the emulator, and change `handleBlockchainEvents` to use that. Now we have more shared code, and a much simpler `handleBlockchainEvents`, but some of the tests required a few more `addBlocks` calls. This is because the old version of `handleBlockchainEvents` sneakily added blocks to the blockchain sometimes.
  * In the SCB the `NextTxAt` request handler simply wasn't implemented, so the change was straightforward. I added a test for the currency contract that creates a simple currency, which involves `NextTxAt`.

## Future work:

The following would be nice to do, but not right now due to time constraints for the recording.

* Think about the naming of the `NextTxAt` effect. You can still use it to be notified of the next transaction, but it's actually more of a "transactions in this slot for this address" effect
* Merge the request handlers in `plutus-contract` and `plutus-scb`. They are mostly the same, but the ones in `plutus-scb` also use the `Log` effect, which we would have to bring into the emulator.
* Occasionally drop old transactions from the chain index. Otherwise it will keep a record of every transaction it has ever seen.