### PR TITLE
SCB: Fixing a startup timing issue for the 'all-servers' command.

### DIFF
--- a/plutus-scb/app/Main.hs
+++ b/plutus-scb/app/Main.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE ApplicativeDo       #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE ApplicativeDo         #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
 
 module Main
     ( main
@@ -13,7 +15,9 @@ import qualified Cardano.ChainIndex.Server                       as ChainIndex
 import qualified Cardano.Node.Server                             as NodeServer
 import qualified Cardano.SigningProcess.Server                   as SigningProcess
 import qualified Cardano.Wallet.Server                           as WalletServer
+import           Control.Concurrent                              (MVar, newEmptyMVar)
 import           Control.Concurrent.Async                        (Async, async, waitAny)
+import           Control.Concurrent.ServiceAvailability          (starting)
 import           Control.Lens.Indexed                            (itraverse_)
 import           Control.Monad                                   (void)
 import           Control.Monad.Freer.Extra.Log                   (logInfo)
@@ -183,8 +187,8 @@ allServersParser =
                   [ MockNode
                   , ChainIndex
                   , MockWallet
-                  , SigningProcess
                   , SCBWebserver
+                  , SigningProcess
                   ]))
         (fullDesc <> progDesc "Run all the mock servers needed.")
 
@@ -275,34 +279,47 @@ reportContractHistoryParser =
         (fullDesc <> progDesc "Show the state history of a smart contract.")
 
 ------------------------------------------------------------
-runCliCommand :: LogLevel -> Config -> Command -> App ()
-runCliCommand _ _ Migrate = App.migrate
-runCliCommand _ Config {walletServerConfig, nodeServerConfig, chainIndexConfig} MockWallet =
+-- | Translate the command line configuation into the actual code to be run.
+--
+-- Takes an MVar which can be used as a 'ServiceAvailability' flag.
+--
+
+runCliCommand :: LogLevel -> Config ->  MVar () -> Command -> App ()
+runCliCommand _ _ _ Migrate = App.migrate
+runCliCommand _ Config {walletServerConfig, nodeServerConfig, chainIndexConfig} serviceAvailability MockWallet =
     WalletServer.main
         walletServerConfig
         (NodeServer.mscBaseUrl nodeServerConfig)
         (ChainIndex.ciBaseUrl chainIndexConfig)
-runCliCommand _ Config {nodeServerConfig} MockNode =
-    NodeServer.main nodeServerConfig
-runCliCommand _ config SCBWebserver = SCBServer.main config
-runCliCommand minLogLevel config (ForkCommands commands) =
+        serviceAvailability
+runCliCommand _ Config {nodeServerConfig} serviceAvailability MockNode =
+    NodeServer.main nodeServerConfig serviceAvailability
+runCliCommand _ config serviceAvailability SCBWebserver = SCBServer.main config serviceAvailability
+runCliCommand minLogLevel config serviceAvailability (ForkCommands commands) =
     void . liftIO $ do
         threads <- traverse forkCommand commands
+        putStrLn $ "Started all commands."
         waitAny threads
   where
+
     forkCommand ::  Command -> IO (Async ())
-    forkCommand = async . void . runApp minLogLevel config . runCliCommand minLogLevel config
-runCliCommand _ Config {nodeServerConfig, chainIndexConfig} ChainIndex =
-    ChainIndex.main chainIndexConfig (NodeServer.mscBaseUrl nodeServerConfig)
-runCliCommand _ Config {signingProcessConfig} SigningProcess =
-    SigningProcess.main signingProcessConfig
-runCliCommand _ _ (InstallContract path) = Core.installContract (ContractExe path)
-runCliCommand _ _ (ActivateContract path) = void $ Core.activateContract (ContractExe path)
-runCliCommand _ _ (ContractStatus uuid) = Core.reportContractStatus @ContractExe (ContractInstanceId uuid)
-runCliCommand _ _ ReportInstalledContracts = do
+    forkCommand subcommand = do
+      putStrLn $ "Starting: " <> show subcommand
+      asyncId <- async . void . runApp minLogLevel config . runCliCommand minLogLevel config serviceAvailability $ subcommand
+      putStrLn $ "Started: " <> show subcommand
+      starting serviceAvailability
+      pure asyncId
+runCliCommand _ Config {nodeServerConfig, chainIndexConfig} serviceAvailability ChainIndex =
+    ChainIndex.main chainIndexConfig (NodeServer.mscBaseUrl nodeServerConfig) serviceAvailability
+runCliCommand _ Config {signingProcessConfig} serviceAvailability SigningProcess =
+    SigningProcess.main signingProcessConfig serviceAvailability
+runCliCommand _ _ _ (InstallContract path) = Core.installContract (ContractExe path)
+runCliCommand _ _ _ (ActivateContract path) = void $ Core.activateContract (ContractExe path)
+runCliCommand _ _ _ (ContractStatus uuid) = Core.reportContractStatus @ContractExe (ContractInstanceId uuid)
+runCliCommand _ _ _ ReportInstalledContracts = do
     logInfo "Installed Contracts"
     traverse_ (logInfo . render . pretty) =<< Core.installedContracts @ContractExe
-runCliCommand _ _ ReportActiveContracts = do
+runCliCommand _ _ _ ReportActiveContracts = do
     logInfo "Active Contracts"
     instances <- Map.toAscList <$> Core.activeContracts @ContractExe
     let format :: (ContractExe, Set ContractInstanceId) -> Doc a
@@ -311,19 +328,19 @@ runCliCommand _ _ ReportActiveContracts = do
                , indent 2 (vsep (pretty <$> Set.toList contractInstanceIds))
                ]
     traverse_ (logInfo . render . format) instances
-runCliCommand _ _ ReportTxHistory = do
+runCliCommand _ _ _ ReportTxHistory = do
     logInfo "Transaction History"
     traverse_ (logInfo . render . pretty) =<< Core.txHistory @ContractExe
-runCliCommand _ _ (UpdateContract uuid endpoint payload) =
+runCliCommand _ _ _ (UpdateContract uuid endpoint payload) =
     void $ Instance.callContractEndpoint @ContractExe (ContractInstanceId uuid) (getEndpointDescription endpoint) payload
-runCliCommand _ _ (ReportContractHistory uuid) = do
+runCliCommand _ _ _ (ReportContractHistory uuid) = do
     logInfo "Contract History"
     contracts <- Core.activeContractHistory @ContractExe (ContractInstanceId uuid)
     itraverse_ logContract contracts
     where
       logContract :: Int -> ContractInstanceState ContractExe -> App ()
       logContract index contract = logInfo $ render $ parens (pretty index) <+> pretty contract
-runCliCommand _ _ PSGenerator {_outputDir} =
+runCliCommand _ _ _ PSGenerator {_outputDir} =
     liftIO $ PSGenerator.generate _outputDir
 
 main :: IO ()
@@ -334,10 +351,11 @@ main = do
             (info (helper <*> versionOption <*> commandLineParser) idm)
     config <- liftIO $ decodeFileThrow configPath
     traverse_ (EKG.forkServer "localhost") ekgPort
+    serviceAvailability <- newEmptyMVar
     result <-
         runApp minLogLevel config $ do
             logInfo $ "Running: " <> Text.pack (show cmd)
-            runCliCommand minLogLevel config cmd
+            runCliCommand minLogLevel config serviceAvailability cmd
     case result of
         Left err -> do
             runStdoutLoggingT $ filterLogger (\_ logLevel -> logLevel >= minLogLevel) $ logErrorS err

--- a/plutus-scb/plutus-scb.cabal
+++ b/plutus-scb/plutus-scb.cabal
@@ -66,6 +66,7 @@ library
         Cardano.Wallet.Types
         Control.Monad.Freer.Extra.Log
         Control.Monad.Freer.Extra.State
+        Control.Concurrent.ServiceAvailability
         Data.Time.Units.Extra
         Plutus.SCB.App
         Plutus.SCB.MockApp

--- a/plutus-scb/src/Cardano/Node/Server.hs
+++ b/plutus-scb/src/Cardano/Node/Server.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications  #-}
@@ -7,24 +8,25 @@ module Cardano.Node.Server
     , MockServerConfig(..)
     ) where
 
-import           Control.Concurrent       (forkIO)
-import           Control.Concurrent.MVar  (MVar, newMVar)
-import           Control.Monad            (void)
-import           Control.Monad.IO.Class   (MonadIO, liftIO)
-import           Control.Monad.Logger     (logInfoN, runStdoutLoggingT)
-import           Data.Proxy               (Proxy (Proxy))
-import qualified Network.Wai.Handler.Warp as Warp
-import           Servant                  ((:<|>) ((:<|>)), Application, hoistServer, serve)
-import           Servant.Client           (BaseUrl (baseUrlPort))
+import           Control.Concurrent                     (MVar, forkIO, newMVar)
+import           Control.Concurrent.ServiceAvailability (ServiceAvailability, available)
+import           Control.Monad                          (void)
+import           Control.Monad.IO.Class                 (MonadIO, liftIO)
+import           Control.Monad.Logger                   (logInfoN, runStdoutLoggingT)
+import           Data.Function                          ((&))
+import           Data.Proxy                             (Proxy (Proxy))
+import qualified Network.Wai.Handler.Warp               as Warp
+import           Servant                                ((:<|>) ((:<|>)), Application, hoistServer, serve)
+import           Servant.Client                         (BaseUrl (baseUrlPort))
 
-import           Cardano.Node.API         (API)
-import           Cardano.Node.Follower    (getBlocks, newFollower)
+import           Cardano.Node.API                       (API)
+import           Cardano.Node.Follower                  (getBlocks, newFollower)
 import           Cardano.Node.Mock
-import           Cardano.Node.RandomTx    (genRandomTx)
+import           Cardano.Node.RandomTx                  (genRandomTx)
 import           Cardano.Node.Types
 
-import           Plutus.SCB.Arbitrary     ()
-import           Plutus.SCB.Utils         (tshow)
+import           Plutus.SCB.Arbitrary                   ()
+import           Plutus.SCB.Utils                       (tshow)
 
 app :: MVar AppState -> Application
 app stateVar =
@@ -38,30 +40,34 @@ app stateVar =
           (newFollower :<|> getBlocks)
           )
 
-main :: (MonadIO m) => MockServerConfig -> m ()
+main :: (MonadIO m, ServiceAvailability IO s) => MockServerConfig -> s -> m ()
 main MockServerConfig { mscBaseUrl
                       , mscRandomTxInterval
                       , mscBlockReaper
                       , mscSlotLength
-                      } = runStdoutLoggingT $ do
-    stateVar <- liftIO $ newMVar initialAppState
-    logInfoN "Starting slot coordination thread."
-    void $
-        liftIO $
-        forkIO $ runStdoutLoggingT $ slotCoordinator mscSlotLength stateVar
-    case mscRandomTxInterval of
-        Nothing -> logInfoN "No random transactions will be generated."
-        Just i -> do
-            logInfoN "Starting transaction generator thread."
-            void $
-                liftIO $
-                forkIO $ runStdoutLoggingT $ transactionGenerator i stateVar
-    case mscBlockReaper of
-        Nothing -> logInfoN "Old blocks will be kept in memory forever"
-        Just cfg -> do
-            logInfoN "Starting block reaper thread."
-            void $
-                liftIO $ forkIO $ runStdoutLoggingT $ blockReaper cfg stateVar
-    let mscPort = baseUrlPort mscBaseUrl
-    logInfoN $ "Starting mock node server on port: " <> tshow mscPort
-    liftIO $ Warp.run mscPort $ app stateVar
+                      } serviceAvailability =
+    runStdoutLoggingT $ do
+        stateVar <- liftIO $ newMVar initialAppState
+        logInfoN "Starting slot coordination thread."
+        void $
+            liftIO $
+            forkIO $ runStdoutLoggingT $ slotCoordinator mscSlotLength stateVar
+        case mscRandomTxInterval of
+            Nothing -> logInfoN "No random transactions will be generated."
+            Just i -> do
+                logInfoN "Starting transaction generator thread."
+                void $
+                    liftIO $
+                    forkIO $ runStdoutLoggingT $ transactionGenerator i stateVar
+        case mscBlockReaper of
+            Nothing -> logInfoN "Old blocks will be kept in memory forever"
+            Just cfg -> do
+                logInfoN "Starting block reaper thread."
+                void $
+                    liftIO $
+                    forkIO $ runStdoutLoggingT $ blockReaper cfg stateVar
+        let mscPort = baseUrlPort mscBaseUrl
+        let warpSettings :: Warp.Settings
+            warpSettings = Warp.defaultSettings & Warp.setPort mscPort & Warp.setBeforeMainLoop (available serviceAvailability)
+        logInfoN $ "Starting mock node server on port: " <> tshow mscPort
+        liftIO $ Warp.runSettings warpSettings $ app stateVar

--- a/plutus-scb/src/Cardano/SigningProcess/Server.hs
+++ b/plutus-scb/src/Cardano/SigningProcess/Server.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TypeApplications   #-}
@@ -11,30 +12,32 @@ module Cardano.SigningProcess.Server(
     , main
     ) where
 
-import           Control.Concurrent.MVar        (MVar, newMVar, putMVar, takeMVar)
-import           Control.Monad.Freer            (Eff, run)
-import           Control.Monad.Freer.Error      (Error)
-import qualified Control.Monad.Freer.Error      as Eff
-import           Control.Monad.Freer.State      (State)
-import qualified Control.Monad.Freer.State      as Eff
-import           Control.Monad.IO.Class         (MonadIO (..))
-import           Control.Monad.Logger           (logInfoN, runStdoutLoggingT)
-import           Data.Aeson                     (FromJSON, ToJSON)
-import           Data.Proxy                     (Proxy (..))
-import           GHC.Generics                   (Generic)
-import qualified Network.Wai.Handler.Warp       as Warp
+import           Control.Concurrent.MVar                (MVar, newMVar, putMVar, takeMVar)
+import           Control.Concurrent.ServiceAvailability (ServiceAvailability, available)
+import           Control.Monad.Freer                    (Eff, run)
+import           Control.Monad.Freer.Error              (Error)
+import qualified Control.Monad.Freer.Error              as Eff
+import           Control.Monad.Freer.State              (State)
+import qualified Control.Monad.Freer.State              as Eff
+import           Control.Monad.IO.Class                 (MonadIO (..))
+import           Control.Monad.Logger                   (logInfoN, runStdoutLoggingT)
+import           Data.Aeson                             (FromJSON, ToJSON)
+import           Data.Function                          ((&))
+import           Data.Proxy                             (Proxy (..))
+import           GHC.Generics                           (Generic)
+import qualified Network.Wai.Handler.Warp               as Warp
 
-import           Servant                        (Application, hoistServer, serve)
-import           Servant.Client                 (BaseUrl (baseUrlPort))
-import qualified Wallet.API                     as WAPI
-import           Wallet.Effects                 (SigningProcessEffect)
-import qualified Wallet.Effects                 as WE
-import           Wallet.Emulator.SigningProcess (SigningProcess)
-import qualified Wallet.Emulator.SigningProcess as SP
-import           Wallet.Emulator.Wallet         (Wallet)
+import           Servant                                (Application, hoistServer, serve)
+import           Servant.Client                         (BaseUrl (baseUrlPort))
+import qualified Wallet.API                             as WAPI
+import           Wallet.Effects                         (SigningProcessEffect)
+import qualified Wallet.Effects                         as WE
+import           Wallet.Emulator.SigningProcess         (SigningProcess)
+import qualified Wallet.Emulator.SigningProcess         as SP
+import           Wallet.Emulator.Wallet                 (Wallet)
 
-import           Cardano.SigningProcess.API     (API)
-import           Plutus.SCB.Utils               (tshow)
+import           Cardano.SigningProcess.API             (API)
+import           Plutus.SCB.Utils                       (tshow)
 
 -- $ signingProcess
 -- The signing process that adds signatures to transactions.
@@ -59,12 +62,14 @@ app stateVar =
         (processSigningProcessEffects stateVar)
         (uncurry WE.addSignatures)
 
-main :: (MonadIO m) => SigningProcessConfig -> m ()
-main SigningProcessConfig{spWallet, spBaseUrl} = runStdoutLoggingT $ do
+main :: ServiceAvailability IO s => (MonadIO m) => SigningProcessConfig -> s -> m ()
+main SigningProcessConfig{spWallet, spBaseUrl} serviceAvailability = runStdoutLoggingT $ do
     stateVar <- liftIO $ newMVar (SP.defaultSigningProcess spWallet)
     let spPort = baseUrlPort spBaseUrl
+    let warpSettings :: Warp.Settings
+        warpSettings = Warp.defaultSettings & Warp.setPort spPort & Warp.setBeforeMainLoop (available serviceAvailability)
     logInfoN $ "Starting signing process on port: " <> tshow spPort
-    liftIO $ Warp.run spPort $ app stateVar
+    liftIO $ Warp.runSettings warpSettings $ app stateVar
 
 type SigningProcessEffects =
     '[ SigningProcessEffect, State SigningProcess, Error WAPI.WalletAPIError]

--- a/plutus-scb/src/Cardano/Wallet/Server.hs
+++ b/plutus-scb/src/Cardano/Wallet/Server.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE TypeApplications      #-}
 
 module Cardano.Wallet.Server
@@ -11,33 +12,39 @@ module Cardano.Wallet.Server
     , Config(..)
     ) where
 
-import qualified Cardano.ChainIndex.Client     as ChainIndexClient
-import qualified Cardano.Node.Client           as NodeClient
-import           Cardano.Wallet.API            (API)
+import qualified Cardano.ChainIndex.Client              as ChainIndexClient
+import qualified Cardano.Node.Client                    as NodeClient
+import           Cardano.Wallet.API                     (API)
 import           Cardano.Wallet.Mock
-import           Cardano.Wallet.Types          (Config (..))
-import           Control.Concurrent.MVar       (MVar, newMVar, putMVar, takeMVar)
-import           Control.Monad                 ((>=>))
-import qualified Control.Monad.Except          as MonadError
-import           Control.Monad.Freer           (Eff, runM)
-import           Control.Monad.Freer.Error     (Error, handleError, runError, throwError)
-import           Control.Monad.Freer.Extra.Log (Log, runStderrLog)
-import           Control.Monad.Freer.State     (State, runState)
-import           Control.Monad.IO.Class        (MonadIO, liftIO)
-import qualified Data.ByteString.Lazy.Char8    as Char8
-import           Data.Proxy                    (Proxy (Proxy))
-import           Network.HTTP.Client           (defaultManagerSettings, newManager)
-import           Network.Wai.Handler.Warp      (run)
-import           Plutus.SCB.Arbitrary          ()
-import           Servant                       ((:<|>) ((:<|>)), Application, Handler (Handler), NoContent (..),
-                                                ServerError (..), err400, err500, hoistServer, serve)
-import           Servant.Client                (BaseUrl (baseUrlPort), ClientEnv, ClientError, mkClientEnv)
+import           Cardano.Wallet.Types                   (Config (..))
+import           Control.Concurrent.MVar                (MVar, newMVar, putMVar, takeMVar)
+import           Control.Concurrent.ServiceAvailability (ServiceAvailability, available)
+import           Control.Monad                          ((>=>))
+import qualified Control.Monad.Except                   as MonadError
+import           Control.Monad.Freer                    (Eff, runM)
+import           Control.Monad.Freer.Error              (Error, handleError, runError, throwError)
+import           Control.Monad.Freer.Extra.Log          (Log, runStderrLog)
+import           Control.Monad.Freer.State              (State, runState)
+import           Control.Monad.IO.Class                 (MonadIO, liftIO)
+import           Control.Monad.Logger                   (logInfoN, runStdoutLoggingT)
+import qualified Data.ByteString.Lazy.Char8             as Char8
+import           Data.Function                          ((&))
+import           Data.Proxy                             (Proxy (Proxy))
+import           Network.HTTP.Client                    (defaultManagerSettings, newManager)
+import qualified Network.Wai.Handler.Warp               as Warp
+import           Plutus.SCB.Arbitrary                   ()
+import           Plutus.SCB.Utils                       (tshow)
+import           Servant                                ((:<|>) ((:<|>)), Application, Handler (Handler),
+                                                         NoContent (..), ServerError (..), err400, err500, hoistServer,
+                                                         serve)
+import           Servant.Client                         (BaseUrl (baseUrlPort), ClientEnv, ClientError, mkClientEnv)
 
-import           Wallet.Effects                (ChainIndexEffect, NodeClientEffect, WalletEffect, ownOutputs, ownPubKey,
-                                                startWatching, submitTxn, updatePaymentWithChange, walletSlot)
-import           Wallet.Emulator.Error         (WalletAPIError)
-import           Wallet.Emulator.Wallet        (WalletState)
-import qualified Wallet.Emulator.Wallet        as Wallet
+import           Wallet.Effects                         (ChainIndexEffect, NodeClientEffect, WalletEffect, ownOutputs,
+                                                         ownPubKey, startWatching, submitTxn, updatePaymentWithChange,
+                                                         walletSlot)
+import           Wallet.Emulator.Error                  (WalletAPIError)
+import           Wallet.Emulator.Wallet                 (WalletState)
+import qualified Wallet.Emulator.Wallet                 as Wallet
 
 type AppEffects m = '[WalletEffect, NodeClientEffect, ChainIndexEffect, State WalletState, Log, Error WalletAPIError, Error ClientError, Error ServerError, m]
 
@@ -91,8 +98,8 @@ app nodeClientEnv chainIndexEnv mVarState =
     (submitTxn >=> const (pure NoContent)) :<|> ownPubKey :<|> uncurry updatePaymentWithChange :<|>
     walletSlot :<|> ownOutputs
 
-main :: (MonadIO m) => Config -> BaseUrl -> BaseUrl -> m ()
-main Config {baseUrl} nodeBaseUrl chainIndexBaseUrl = do
+main :: (MonadIO m, ServiceAvailability IO s) => Config -> BaseUrl -> BaseUrl -> s -> m ()
+main Config {baseUrl} nodeBaseUrl chainIndexBaseUrl serviceAvailability = runStdoutLoggingT $ do
     let port = baseUrlPort baseUrl
     nodeClientEnv <-
         liftIO $ do
@@ -108,4 +115,7 @@ main Config {baseUrl} nodeBaseUrl chainIndexBaseUrl = do
             $ flip handleError (error . show @ClientError)
             $ ChainIndexClient.handleChainIndexClient chainIndexEnv
             $ startWatching (Wallet.ownAddress initialState)
-    liftIO $ run port $ app nodeClientEnv chainIndexEnv mVarState
+    let warpSettings :: Warp.Settings
+        warpSettings = Warp.defaultSettings & Warp.setPort port & Warp.setBeforeMainLoop (available serviceAvailability)
+    logInfoN $ "Starting wallet server on port: " <> tshow port
+    liftIO $ Warp.runSettings warpSettings $ app nodeClientEnv chainIndexEnv mVarState

--- a/plutus-scb/src/Control/Concurrent/ServiceAvailability.hs
+++ b/plutus-scb/src/Control/Concurrent/ServiceAvailability.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+module Control.Concurrent.ServiceAvailability where
+
+import           Control.Concurrent (MVar, putMVar, takeMVar)
+
+-- | A semaphore-like construct whereby a service can signal to
+-- another thread that it's finished its startup phase, and is now
+-- available to use.
+class ServiceAvailability m a where
+  available :: a -> m ()
+  starting :: a -> m ()
+
+instance ServiceAvailability IO (MVar ()) where
+  available mvar = putMVar mvar ()
+  starting = takeMVar

--- a/plutus-scb/src/Plutus/SCB/Webserver/Server.hs
+++ b/plutus-scb/src/Plutus/SCB/Webserver/Server.hs
@@ -15,6 +15,7 @@ module Plutus.SCB.Webserver.Server
     , contractSchema
     ) where
 
+import           Control.Concurrent.ServiceAvailability          (ServiceAvailability, available)
 import           Control.Monad.Except                            (ExceptT (ExceptT))
 import           Control.Monad.Freer                             (Eff, Member)
 import           Control.Monad.Freer.Error                       (Error, throwError)
@@ -24,6 +25,7 @@ import           Control.Monad.Logger                            (LogLevel (Leve
 import qualified Data.Aeson                                      as JSON
 import           Data.Bifunctor                                  (first)
 import qualified Data.ByteString.Lazy.Char8                      as LBS
+import           Data.Function                                   ((&))
 import           Data.Map                                        (Map)
 import qualified Data.Map                                        as Map
 import           Data.Proxy                                      (Proxy (Proxy))
@@ -34,7 +36,7 @@ import           Eventful                                        (streamEventEve
 import           Language.Plutus.Contract.Effects.ExposeEndpoint (EndpointDescription (EndpointDescription))
 import           Ledger                                          (PubKeyHash)
 import           Ledger.Blockchain                               (Blockchain)
-import           Network.Wai.Handler.Warp                        (run)
+import qualified Network.Wai.Handler.Warp                        as Warp
 import           Plutus.SCB.App                                  (App, runApp)
 import           Plutus.SCB.Arbitrary                            ()
 import           Plutus.SCB.Core                                 (runGlobalQuery)
@@ -178,8 +180,10 @@ app config = serve api $ hoistServer api (asHandler config) handler
   where
     api = Proxy @("api" :> API ContractExe)
 
-main :: Config -> App ()
-main config = do
+main :: ServiceAvailability IO s => Config -> s -> App ()
+main config serviceAvailability = do
     let port = baseUrlPort $ baseUrl $ scbWebserverConfig config
+    let warpSettings :: Warp.Settings
+        warpSettings = Warp.defaultSettings & Warp.setPort port & Warp.setBeforeMainLoop (available serviceAvailability)
     logInfo $ "Starting SCB backend server on port: " <> tshow port
-    liftIO $ run port $ app config
+    liftIO $ Warp.runSettings warpSettings $ app config


### PR DESCRIPTION
There's a some of the test servers we start need another server to be
available first. But just forking the threads in the right order isn't
enough to guarantee availability. What we really need is to start each
server and have it tell us when it's ready to serve requests.

This commit accomplishes that, by passing a semophore to the server
threads and having them flag up when they're available.