### PR TITLE
PAB: Add 'AtomicSwap' contract for testing/demo purposes

### DIFF
--- a/nix/stack.materialized/plutus-scb.nix
+++ b/nix/stack.materialized/plutus-scb.nix
@@ -120,6 +120,7 @@
           "Plutus/SCB/Core/Projections"
           "Plutus/SCB/Effects/Contract"
           "Plutus/SCB/Effects/ContractTest"
+          "Plutus/SCB/Effects/ContractTest/AtomicSwap"
           "Plutus/SCB/Effects/EventLog"
           "Plutus/SCB/Effects/MultiAgent"
           "Plutus/SCB/Effects/UUID"
@@ -191,6 +192,15 @@
             ];
           buildable = true;
           hsSourceDirs = [ "currency-contract" ];
+          mainPath = [ "Main.hs" ];
+          };
+        "plutus-atomic-swap" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-scb" or (errorHandler.buildDepError "plutus-scb"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "atomic-swap-contract" ];
           mainPath = [ "Main.hs" ];
           };
         };

--- a/plutus-scb/app/PSGenerator.hs
+++ b/plutus-scb/app/PSGenerator.hs
@@ -50,8 +50,8 @@ import qualified Plutus.SCB.MockApp                                as MockApp
 import           Plutus.SCB.Types                                  (ContractExe)
 import qualified Plutus.SCB.Webserver.API                          as API
 import qualified Plutus.SCB.Webserver.Server                       as Webserver
-import           Plutus.SCB.Webserver.Types                        (ContractReport, ChainReport, ContractSignatureResponse,
-                                                                    FullReport)
+import           Plutus.SCB.Webserver.Types                        (ChainReport, ContractReport,
+                                                                    ContractSignatureResponse, FullReport)
 import qualified PSGenerator.Common
 import           Servant.PureScript                                (HasBridge, Settings, apiModuleName, defaultBridge,
                                                                     defaultSettings, languageBridge,

--- a/plutus-scb/atomic-swap-contract/Main.hs
+++ b/plutus-scb/atomic-swap-contract/Main.hs
@@ -1,0 +1,11 @@
+module Main
+    ( main
+    ) where
+
+import           Data.Bifunctor                             (first)
+import           Plutus.SCB.ContractCLI                     (commandLineApp)
+import           Plutus.SCB.Effects.ContractTest.AtomicSwap (atomicSwap)
+import           Plutus.SCB.Utils                           (tshow)
+
+main :: IO ()
+main = commandLineApp $ first tshow $ atomicSwap

--- a/plutus-scb/plutus-scb.cabal
+++ b/plutus-scb/plutus-scb.cabal
@@ -78,6 +78,7 @@ library
         Plutus.SCB.Core.Projections
         Plutus.SCB.Effects.Contract
         Plutus.SCB.Effects.ContractTest
+        Plutus.SCB.Effects.ContractTest.AtomicSwap
         Plutus.SCB.Effects.EventLog
         Plutus.SCB.Effects.MultiAgent
         Plutus.SCB.Effects.UUID
@@ -213,6 +214,18 @@ executable plutus-currency
         base >=4.9 && <5,
         plutus-scb -any,
         plutus-use-cases -any
+
+executable plutus-atomic-swap
+    main-is: Main.hs
+    hs-source-dirs: atomic-swap-contract
+    other-modules:
+    default-language: Haskell2010
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Wcompat
+                 -Wincomplete-uni-patterns -Wincomplete-record-updates
+                 -Wno-missing-import-lists -Wredundant-constraints -O0
+    build-depends:
+        base >=4.9 && <5,
+        plutus-scb -any
 
 test-suite plutus-scb-test
     default-language: Haskell2010

--- a/plutus-scb/src/Plutus/SCB/Effects/ContractTest.hs
+++ b/plutus-scb/src/Plutus/SCB/Effects/ContractTest.hs
@@ -44,10 +44,11 @@ import qualified Language.Plutus.Contract.State                    as ContractSt
 import qualified Language.PlutusTx.Coordination.Contracts.Currency as Contracts.Currency
 import qualified Language.PlutusTx.Coordination.Contracts.Game     as Contracts.Game
 import           Playground.Schema                                 (endpointsToSchemas)
+import qualified Plutus.SCB.Effects.ContractTest.AtomicSwap        as Contracts.AtomicSwap
 
 import qualified Debug.Trace                                       as Trace
 
-data TestContracts = Game | Currency
+data TestContracts = Game | Currency | AtomicSwap
     deriving (Eq, Ord, Show, Generic)
     deriving anyclass (FromJSON, ToJSON)
 
@@ -61,17 +62,21 @@ handleContractTest ::
     ~> Eff effs
 handleContractTest = interpret $ \case
     InvokeContract (InitContract c) -> fmap ContractHandlersResponse <$> case c of
-        Game     -> doContractInit game
-        Currency -> doContractInit currency
+        Game       -> doContractInit game
+        Currency   -> doContractInit currency
+        AtomicSwap -> doContractInit swp
     InvokeContract (UpdateContract c p) -> fmap ContractHandlersResponse <$> case c of
-        Game     -> doContractUpdate game p
-        Currency -> doContractUpdate currency p
+        Game       -> doContractUpdate game p
+        Currency   -> doContractUpdate currency p
+        AtomicSwap -> doContractUpdate swp p
     ExportSchema t -> case t of
-        Game     -> pure $ endpointsToSchemas @(Contracts.Game.GameSchema .\\ BlockchainActions)
-        Currency -> pure $ endpointsToSchemas @(Contracts.Currency.CurrencySchema .\\ BlockchainActions)
+        Game       -> pure $ endpointsToSchemas @(Contracts.Game.GameSchema .\\ BlockchainActions)
+        Currency   -> pure $ endpointsToSchemas @(Contracts.Currency.CurrencySchema .\\ BlockchainActions)
+        AtomicSwap -> pure $ endpointsToSchemas @(Contracts.AtomicSwap.AtomicSwapSchema .\\ BlockchainActions)
     where
         game = first tshow $ Contracts.Game.game @ContractError
         currency = first tshow $ void Contracts.Currency.forgeCurrency
+        swp = first tshow $ Contracts.AtomicSwap.atomicSwap
 
 doContractInit ::
     forall schema effs.

--- a/plutus-scb/src/Plutus/SCB/Effects/ContractTest/AtomicSwap.hs
+++ b/plutus-scb/src/Plutus/SCB/Effects/ContractTest/AtomicSwap.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE TypeOperators      #-}
+module Plutus.SCB.Effects.ContractTest.AtomicSwap(
+    AtomicSwapParams(..),
+    AtomicSwapError(..),
+    AsAtomicSwapError(..),
+    AtomicSwapSchema,
+    atomicSwap
+    ) where
+
+import           Control.Lens
+import           Control.Monad                                   (void)
+import           Data.Aeson                                      (FromJSON, ToJSON)
+import           GHC.Generics                                    (Generic)
+import           IOTS                                            (IotsType)
+import           Language.PlutusTx.Coordination.Contracts.Escrow (EscrowParams (..))
+import qualified Language.PlutusTx.Coordination.Contracts.Escrow as Escrow
+import           Schema                                          (ToSchema)
+
+import           Language.Plutus.Contract
+import           Ledger                                          (PubKey, Slot, Value)
+import qualified Ledger
+
+-- | Describes an exchange of two
+--   'Value' amounts between two parties
+--   identified by public keys
+data AtomicSwapParams =
+    AtomicSwapParams
+        { value1   :: Value -- ^ The amount paid to the hash of 'pubKey1'
+        , value2   :: Value -- ^ The amount paid to the hash of 'pubKey2'
+        , pubKey1  :: PubKey -- ^ The first party in the atomic swap
+        , pubKey2  :: PubKey -- ^ The second party in the atomic swap
+        , deadline :: Slot -- ^ Last slot in which the swap can be executed.
+        }
+        deriving stock (Eq, Show, Generic)
+        deriving anyclass (ToJSON, FromJSON, IotsType, ToSchema)
+
+mkEscrowParams :: AtomicSwapParams -> EscrowParams t
+mkEscrowParams AtomicSwapParams{value1,value2,pubKey1,pubKey2,deadline} =
+    EscrowParams
+        { escrowDeadline = deadline
+        , escrowTargets =
+                [ Escrow.payToPubKeyTarget (Ledger.pubKeyHash pubKey1) value1
+                , Escrow.payToPubKeyTarget (Ledger.pubKeyHash pubKey2) value2
+                ]
+        }
+
+type AtomicSwapSchema =
+    BlockchainActions
+        .\/ Endpoint "atomic-swap" AtomicSwapParams
+
+data AtomicSwapError =
+    EscrowError Escrow.EscrowError
+    | OtherAtomicSwapError ContractError
+    | NotInvolvedError PubKey AtomicSwapParams -- ^ When the wallet's public key doesn't match either of the two keys specified in the 'AtomicSwapParams'
+    deriving (Show)
+
+makeClassyPrisms ''AtomicSwapError
+instance AsContractError AtomicSwapError where
+    _ContractError = _OtherAtomicSwapError
+
+-- | Perform the atomic swap. Needs to be called by both of the two parties
+--   involved.
+atomicSwap :: Contract AtomicSwapSchema AtomicSwapError ()
+atomicSwap = do
+    p <- endpoint @"atomic-swap"
+
+    let params = mkEscrowParams p
+        go pk
+            | pk == pubKey1 p =
+                -- there are two paying transactions and one redeeming transaction.
+                -- The redeeming tx is submitted by party 1.
+                -- TODO: Change 'payRedeemRefund' to check before paying into the
+                -- address, so that the last paying transaction can also be the
+                -- redeeming transaction.
+                void $ mapError EscrowError (Escrow.payRedeemRefund params (value2 p))
+            | pk == pubKey2 p =
+                void $ mapError EscrowError (Escrow.pay (Escrow.scriptInstance params) params (value1 p)) >>= awaitTxConfirmed
+            | otherwise = throwError (NotInvolvedError pk p)
+
+    ownPubKey >>= go


### PR DESCRIPTION
* Adds a simple atomic swap contract (based on `Language.PlutusTx.Coordination.Contracts.Escrow`) that demonstrates the atomic, decentralised exchange of on-chain assets