### PR TITLE
Use sha256map, move hashes out of stack.yaml

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -11,6 +11,9 @@ You can get an environment for developing the entire project using
 dependencies present, so is suitable for building the packages with
 e.g. `cabal v2-build`.
 
+For `stack`, you may want to use the Nix integration and point it at `shell.nix`,
+which will make sure you get the right GHC.
+
 NOTE: You may want to consider using https://github.com/target/lorri[lorri] as a
 convenient alternative to running `nix-shell` directly.
 
@@ -39,6 +42,7 @@ bug workarounds.
 === How to setup HIE
 
 Depending on your setup, symlink either `hie-cabal.yaml` or `hie-stack.yaml` to `hie.yaml`.
+The binary itself is provided by the Nix shell environment.
 
 
 [[update-generated]]
@@ -64,7 +68,7 @@ These can be managed normally, but ensure that:
 
 * The specifications remain in sync between `cabal.project` and `stack.yaml`.
 * You update the xref:update-generated[package set].
-* If it is an `extra-dep`, you update the `nix-sha256` comment in `stack.yaml`. For the moment you have to do this by hand, using the
+* If it is an `source-repository-package`/`extra-dep` from Git, you update the `sha256` mapping in `nix/haskell.nix`. For the moment you have to do this by hand, using the
 following command to get the sha: `nix-prefetch-git --quiet <repo-url> <rev> | jq .sha256`.
 
 ==== Nix pins
@@ -74,6 +78,15 @@ We pin versions of some git repositories that are used by Nix, for example `nixp
 These are specified in link:./nix/sources.json[`sources.json`]. This file is managed by
 https://github.com/nmattia/niv[`niv`]. You can edit it by hand, but I wouldn't recommend it.
 See the `niv` website for usage instructions.
+
+=== How to update the Hackage index state
+
+The Hackage index state is pinned to a particular time in `cabal.project`. This helps with
+reproducibility. If you want to use a Hackage package from after that time, you need to bump
+the pinned index state (not a big deal).
+
+You may also need to update `hackage.nix`, which is a Nix representation of Hackage. This also needs
+to be newer than the index state. From inside a Nix shell, run `niv update hackage.nix`.
 
 === How to add a new package to the repository
 
@@ -86,7 +99,6 @@ order:
 . Update the xref:update-generated[package set ].
 . Check that you can run `nix build -f default.nix haskell.projectPackages.<package name>`
 successfully.
-. If the package is from a newer hackage than is in our `index-state`, update the `index-state` field in `cabal.project`. You may also need to update `haskell.nix`: `nix-shell -p niv --run "niv update haskell.nix"`.
 
 === Code style
 

--- a/marlowe-symbolic/lambda.nix
+++ b/marlowe-symbolic/lambda.nix
@@ -26,7 +26,7 @@ let
     configureFlags = old.configureFlags ++ [ "no-shared" ];
   });
   gmp6 = pkgs.gmp6.override { withStatic = true; };
-  zlib = pkgs.zlib.static;
+  zlib = pkgs.zlib.override { static = true; };
   ncurses = pkgs.ncurses.override { enableStatic = true; };
   libffi = pkgs.libffi.overrideAttrs (old: { dontDisableStatic = true; });
   numactl = pkgs.numactl.overrideAttrs (_: { configureFlags = "--enable-static"; });

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,7 +8,12 @@ let
   sources = import ./sources.nix { inherit pkgs; }
     // sourcesOverride;
   iohkNix = import sources.iohk-nix {};
-  haskellNix = import sources."haskell.nix" {};
+  haskellNix = import sources."haskell.nix" {
+    sourcesOverride = {
+      hackage = sources."hackage.nix";
+      stackage = sources."stackage.nix";
+    };
+  };
   # Use our own nixpkgs
   nixpkgs = sources.nixpkgs;
 

--- a/nix/haskell-extra.nix
+++ b/nix/haskell-extra.nix
@@ -45,7 +45,7 @@
           }."${location}"."${tag}";
         inherit index-state checkMaterialization;
         # Invalidate and update if you change the version
-        plan-sha256 = "0v9r3d11y595w7zrn7zrcxbcvjph5q8qj4fnig4sff99wcm038ab";
+        plan-sha256 = "16b8ccn52fs8vn03iysmrna265rkcybhy6py356qr127wrv7ka56";
         compiler-nix-name = "ghc883";
         modules = [{
           # Tests don't pass for some reason, but this is a somewhat random revision.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -25,6 +25,17 @@ let
     materialized = ./stack.materialized;
     # If true, we check that the generated files are correct. Set in the CI so we don't make mistakes.
     inherit checkMaterialization;
+    sha256map = {
+      "https://github.com/shmish111/purescript-bridge.git"."28c37771ef30b0d751960c061ef95627f05d290e" = "0n6q7g2w1xafngd3dwbbmfxfn018fmq61db7mymplbrww8ld1cp3";
+      "https://github.com/shmish111/servant-purescript.git"."ece5d1dad16a5731ac22040075615803796c7c21" = "1axcbsaym64q67hvjc7b3izd48cgqwi734l7f7m22jpdc80li5f6";
+      "https://github.com/input-output-hk/cardano-crypto.git"."2547ad1e80aeabca2899951601079408becbc92c" = "1p2kg2w02q5w1cvqzhfhqmxviy4xrzada3mmb096j2n6hfr20kri";
+      "https://github.com/michaelpj/unlit.git"."9ca1112093c5ffd356fc99c7dafa080e686dd748" = "145sffn8gbdn6xp9q5b75yd3m46ql5bnc02arzmpfs6wgjslfhff";
+      "https://github.com/raduom/ouroboros-network"."af744374a05d6a5eb76713b399595131e2a24c38" = "1fljr384bkyg0lj46bkgdplp9dzwkb9dz1r6j863niyvm3q50h66";
+      "https://github.com/input-output-hk/cardano-prelude"."bd7eb69d27bfaee46d435bc1d2720520b1446426" = "1cmxh1gk7lvgs6bfr8v6k2lpjxmk0qam58clvdvxkybrlbh186ps";
+      "https://github.com/input-output-hk/cardano-base"."5035c9ed95e9d47f050314a7d96b1b2043288f61" = "103z0009sz586f2mvnmwl2hp9n94qy0n72ik521xhq7zmfwyv3m7";
+      "https://github.com/raduom/cardano-ledger-specs"."2cac85306d8b3e07006e9081f36ce7ebf2d9d0a3" = "0w6z1va6a93f818m9byh49yxkkpd9q3xlxk5irpq3d42vmfpy447";
+      "https://github.com/raduom/iohk-monitoring-framework"."b5c035ad4e226d634242ad5979fa677921181435" = "19v32drfb7wy1yqpbxlqvgii0i7s2j89s05lqskx6855yn0calq4";
+      };
     modules = [
         {
           # Borrowed from https://github.com/input-output-hk/haskell.nix/pull/427

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -69,10 +69,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5272327b81ed355bbed5659b8d303cf2979b6953",
-        "sha256": "0182ys095dfx02vl2a20j1hz92dx3mfgz2a6fhn31bqlp1wa8hlq",
+        "rev": "db31e48c5c8d99dcaf4e5883a96181f6ac4ad6f6",
+        "sha256": "1j5j7vbnq2i5zyl8498xrf490jca488iw6hylna3lfwji6rlcaqr",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5272327b81ed355bbed5659b8d303cf2979b6953.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/db31e48c5c8d99dcaf4e5883a96181f6ac4ad6f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nodejs-headers": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -30,10 +30,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e2a39958269b186b1e83cf2a3fd7f0edadba7652",
-        "sha256": "0b21jkza5crv8shml6xgkyphsyxanimi5m0c8js97w4vb08wg5cz",
+        "rev": "285b4ae6ef222c299c100ae0d89e5060f6b0c879",
+        "sha256": "0dppnh7iigyxm5904g6a8m919zixsad3hbr8y6bphqia28glm0fa",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/e2a39958269b186b1e83cf2a3fd7f0edadba7652.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/285b4ae6ef222c299c100ae0d89e5060f6b0c879.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -24,6 +24,18 @@
         "type": "tarball",
         "url": "https://github.com/justinwoo/easy-purescript-nix/archive/d4879bfd2b595d7fbd37da1a7bea5d0361975eb3.tar.gz"
     },
+    "hackage.nix": {
+        "branch": "master",
+        "description": "Automatically generated Nix expressions for Hackage",
+        "homepage": "",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "4020c8c5bedc373a38f333353fd19b1988c230b5",
+        "sha256": "045jbij0j0pngs17kk7fnkir3f3zwxrps28cly5a27q2z5556n4h",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/4020c8c5bedc373a38f333353fd19b1988c230b5.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "haskell.nix": {
         "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
@@ -82,5 +94,17 @@
         "type": "file",
         "url": "https://nodejs.org/download/release/v10.9.0/node-v10.9.0-headers.tar.gz",
         "url_template": "https://nodejs.org/download/release/<rev>/node-<rev>-headers.tar.gz"
+    },
+    "stackage.nix": {
+        "branch": "master",
+        "description": "Automatically generated Nix expressions of Stackage snapshots",
+        "homepage": "",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "bf7a672e8c31a98086265b43f3003acb4d0f22b0",
+        "sha256": "10v973r5xzqr2akiqx2a3j0fv5fgl75zzyxv949rsr0hqj18vnyi",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/stackage.nix/archive/bf7a672e8c31a98086265b43f3003acb4d0f22b0.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -57,17 +57,13 @@ extra-deps:
 # Needs some patches, but upstream seems to be fairly dead (no activity in > 1 year)
 - git: https://github.com/shmish111/purescript-bridge.git
   commit: 28c37771ef30b0d751960c061ef95627f05d290e
-  # nix-sha256: 0n6q7g2w1xafngd3dwbbmfxfn018fmq61db7mymplbrww8ld1cp3
 - git: https://github.com/shmish111/servant-purescript.git
   commit: ece5d1dad16a5731ac22040075615803796c7c21
-  # nix-sha256: 1axcbsaym64q67hvjc7b3izd48cgqwi734l7f7m22jpdc80li5f6
 - git: https://github.com/input-output-hk/cardano-crypto.git
   commit: 2547ad1e80aeabca2899951601079408becbc92c
-  # nix-sha256: 1p2kg2w02q5w1cvqzhfhqmxviy4xrzada3mmb096j2n6hfr20kri
 # Needs a fix (https://github.com/wenkokke/unlit/pull/11) and a Hackage release
 - git: https://github.com/michaelpj/unlit.git
   commit: 9ca1112093c5ffd356fc99c7dafa080e686dd748
-  # nix-sha256: 145sffn8gbdn6xp9q5b75yd3m46ql5bnc02arzmpfs6wgjslfhff
 ## Node protocols
 - canonical-json-0.6.0.0@sha256:9021f435ccb884a3b4c55bcc6b50eb19d5fc3cc3f29d5fcbdef016f5bbae23a2,3488
 - cborg-0.2.2.0@sha256:eaee50d09d766af95ba18348e4fc230243033b98633ed46ccb5ae85efef7dc6c,4779
@@ -77,7 +73,6 @@ extra-deps:
 # be properly updated to GHC-8.8.X
 - git: https://github.com/raduom/ouroboros-network
   commit: af744374a05d6a5eb76713b399595131e2a24c38
-  # nix-sha256: 1fljr384bkyg0lj46bkgdplp9dzwkb9dz1r6j863niyvm3q50h66
   subdirs:
     - typed-protocols
     - typed-protocols-examples
@@ -89,13 +84,11 @@ extra-deps:
     - Win32-network
 - git: https://github.com/input-output-hk/cardano-prelude
   commit: bd7eb69d27bfaee46d435bc1d2720520b1446426
-  # nix-sha256: 1cmxh1gk7lvgs6bfr8v6k2lpjxmk0qam58clvdvxkybrlbh186ps
   subdirs:
     - .
     - test
 - git: https://github.com/input-output-hk/cardano-base
   commit: 5035c9ed95e9d47f050314a7d96b1b2043288f61
-  # nix-sha256: 103z0009sz586f2mvnmwl2hp9n94qy0n72ik521xhq7zmfwyv3m7
   subdirs:
     - binary
     - binary/test
@@ -106,7 +99,6 @@ extra-deps:
 # be properly updated to GHC-8.8.X
 - git: https://github.com/raduom/cardano-ledger-specs
   commit: 2cac85306d8b3e07006e9081f36ce7ebf2d9d0a3
-  # nix-sha256: 0w6z1va6a93f818m9byh49yxkkpd9q3xlxk5irpq3d42vmfpy447
   subdirs:
     - byron/chain/executable-spec
     - byron/ledger/executable-spec
@@ -119,7 +111,6 @@ extra-deps:
 # be properly updated to GHC-8.8.X
 - git: https://github.com/raduom/iohk-monitoring-framework
   commit: b5c035ad4e226d634242ad5979fa677921181435
-  # nix-sha256: 19v32drfb7wy1yqpbxlqvgii0i7s2j89s05lqskx6855yn0calq4
   subdirs:
     - contra-tracer
 


### PR DESCRIPTION
They're only needed by Nix, better to keep them with the Nix configuration,
rather than in magic comments.

Also will make it easier to switch to using the cabal build later.

(Annoyingly needs a haskell.nix bump for the `sha256map` argument.)