### PR TITLE
 SCP-660: metadata for endpoints 

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract.hs
+++ b/plutus-contract/src/Language/Plutus/Contract.hs
@@ -27,6 +27,7 @@ module Language.Plutus.Contract(
     , HasEndpoint
     , Endpoint
     , endpoint
+    , endpointWithMeta
     -- * Blockchain events
     , HasWatchAddress
     , WatchAddress

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/ExposeEndpoint.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/ExposeEndpoint.hs
@@ -60,7 +60,7 @@ instance Pretty ActiveEndpoint where
   pretty ActiveEndpoint{aeDescription, aeMetadata} =
     indent 2 $ vsep
       [ "Endpoint:" <+> pretty aeDescription
-      , "Data:" <+> viaShow aeMetadata
+      , "Metadata:" <+> viaShow aeMetadata
       ]
 
 type Endpoint l a = l .== (EndpointValue a, ActiveEndpoint)

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/ExposeEndpoint.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/ExposeEndpoint.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DataKinds           #-}
@@ -7,7 +5,9 @@
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE DerivingVia         #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedLabels    #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
@@ -15,7 +15,7 @@
 module Language.Plutus.Contract.Effects.ExposeEndpoint where
 
 import           Data.Aeson                       (FromJSON, ToJSON)
-import qualified Data.Aeson as JSON
+import qualified Data.Aeson                       as JSON
 import           Data.Maybe                       (isJust)
 import           Data.Proxy
 import           Data.Row
@@ -73,7 +73,7 @@ endpoint
      )
   => Contract s e a
 endpoint = unEndpointValue <$> request @l @_ @_ @s s where
-  s = ActiveEndpoint 
+  s = ActiveEndpoint
         { aeDescription = EndpointDescription $ symbolVal (Proxy @l)
         , aeMetadata    = Nothing
         }
@@ -88,7 +88,7 @@ endpointWithMeta
   => b
   -> Contract s e a
 endpointWithMeta b = unEndpointValue <$> request @l @_ @_ @s s where
-  s = ActiveEndpoint 
+  s = ActiveEndpoint
         { aeDescription = EndpointDescription $ symbolVal (Proxy @l)
         , aeMetadata    = Just $ JSON.toJSON b
         }

--- a/plutus-scb/app/PSGenerator.hs
+++ b/plutus-scb/app/PSGenerator.hs
@@ -54,7 +54,6 @@ import qualified Plutus.SCB.Webserver.API                          as API
 import qualified Plutus.SCB.Webserver.Server                       as Webserver
 import           Plutus.SCB.Webserver.Types                        (ChainReport, ContractReport,
                                                                     ContractSignatureResponse, FullReport)
-
 import qualified PSGenerator.Common
 import           Servant.PureScript                                (HasBridge, Settings, apiModuleName, defaultBridge,
                                                                     defaultSettings, languageBridge,

--- a/plutus-scb/src/Plutus/SCB/Arbitrary.hs
+++ b/plutus-scb/src/Plutus/SCB/Arbitrary.hs
@@ -158,7 +158,7 @@ instance Arbitrary EndpointDescription where
     arbitrary = EndpointDescription <$> arbitrary
 
 instance Arbitrary ActiveEndpoint where
-    arbitrary = ActiveEndpoint . EndpointDescription <$> arbitrary
+    arbitrary = ActiveEndpoint . EndpointDescription <$> arbitrary <*> arbitrary
 
 instance Arbitrary WaitingForSlot where
     arbitrary = WaitingForSlot <$> arbitrary

--- a/plutus-scb/src/Plutus/SCB/Core/ContractInstance.hs
+++ b/plutus-scb/src/Plutus/SCB/Core/ContractInstance.hs
@@ -394,7 +394,7 @@ callContractEndpoint inst endpointName endpointValue = do
     logInfo . render $ "calling endpoint" <+> pretty endpointName <+> "on instance" <+> pretty inst
     state <- fmap (hooks . csCurrentState) <$> runGlobalQuery (Query.contractState @t)
     let activeEndpoints =
-            filter ((==) (EndpointDescription endpointName) . unActiveEndpoints . rqRequest)
+            filter ((==) (EndpointDescription endpointName) . aeDescription . rqRequest)
             $ mapMaybe (traverse (preview Events.Contract._UserEndpointRequest))
             $ Map.findWithDefault [] inst state
 

--- a/plutus-scb/src/Plutus/SCB/Events/Contract.hs
+++ b/plutus-scb/src/Plutus/SCB/Events/Contract.hs
@@ -130,7 +130,7 @@ newtype ContractHandlersResponse = ContractHandlersResponse { unContractHandlers
 
 instance FromJSON ContractHandlersResponse where
     parseJSON = JSON.withObject "ContractHandlersResponse" $ \v -> ContractHandlersResponse <$> do
-        tag <- v .: "tag"
+        (tag :: Text.Text) <- v .: "tag"
         case tag of
             "slot"            -> AwaitSlotRequest <$> v .: "value"
             "tx-confirmation" -> AwaitTxConfirmedRequest <$> v .: "value"
@@ -138,7 +138,7 @@ instance FromJSON ContractHandlersResponse where
             "utxo-at"         -> UtxoAtRequest <$> v.: "value"
             "address"         -> NextTxAtRequest <$> v .: "value"
             "tx"              -> WriteTxRequest <$> v .: "value"
-            _                 -> pure . UserEndpointRequest . ActiveEndpoint . EndpointDescription $ tag
+            _                 -> UserEndpointRequest <$> v .: "value"
 
 instance Pretty ContractSCBRequest where
     pretty = \case

--- a/plutus-scb/test/Plutus/SCB/Events/ContractSpec.hs
+++ b/plutus-scb/test/Plutus/SCB/Events/ContractSpec.hs
@@ -14,7 +14,7 @@ import           Data.Bifunctor                                  (first)
 import qualified Data.ByteString.Lazy.Char8                      as BSL
 import           Data.Proxy                                      (Proxy (Proxy))
 import           GHC.TypeLits                                    (symbolVal)
-import           Language.Plutus.Contract.Effects.ExposeEndpoint (ActiveEndpoint (ActiveEndpoint),
+import           Language.Plutus.Contract.Effects.ExposeEndpoint (ActiveEndpoint (..),
                                                                   EndpointDescription (EndpointDescription))
 import qualified Language.Plutus.Contract.Schema                 as Schema
 import           Language.PlutusTx.Coordination.Contracts.Game   (GameSchema, game)
@@ -36,7 +36,9 @@ jsonTests =
               handlers =
                   Schema.initialise @GameSchema @"guess" @_ $
                   ActiveEndpoint
-                      (EndpointDescription (symbolVal (Proxy @"guess")))
+                      { aeDescription = EndpointDescription (symbolVal (Proxy @"guess"))
+                      , aeMetadata    = Nothing
+                      }
               response :: Either String ContractHandlersResponse
               response = JSON.eitherDecode $ JSON.encode handlers
            in assertRight response

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -5,9 +5,11 @@ Events by wallet:
     - Iteration: 1
     Requests:
         2: {schedule collection:
-            ActiveEndpoint: ExposeEndpoint: schedule collection}
+              Endpoint: schedule collection
+              Data: Nothing}
         1: {contribute:
-            ActiveEndpoint: ExposeEndpoint: contribute}
+              Endpoint: contribute
+              Data: Nothing}
       Response:
         (2, {schedule collection: EndpointValue: ()})
     - Iteration: 2
@@ -55,9 +57,11 @@ Events by wallet:
     - Iteration: 1
     Requests:
         2: {schedule collection:
-            ActiveEndpoint: ExposeEndpoint: schedule collection}
+              Endpoint: schedule collection
+              Data: Nothing}
         1: {contribute:
-            ActiveEndpoint: ExposeEndpoint: contribute}
+              Endpoint: contribute
+              Data: Nothing}
       Response:
         ( 1
         , {contribute:
@@ -95,9 +99,11 @@ Events by wallet:
     - Iteration: 1
     Requests:
         2: {schedule collection:
-            ActiveEndpoint: ExposeEndpoint: schedule collection}
+              Endpoint: schedule collection
+              Data: Nothing}
         1: {contribute:
-            ActiveEndpoint: ExposeEndpoint: contribute}
+              Endpoint: contribute
+              Data: Nothing}
       Response:
         ( 1
         , {contribute:
@@ -135,9 +141,11 @@ Events by wallet:
     - Iteration: 1
     Requests:
         2: {schedule collection:
-            ActiveEndpoint: ExposeEndpoint: schedule collection}
+              Endpoint: schedule collection
+              Data: Nothing}
         1: {contribute:
-            ActiveEndpoint: ExposeEndpoint: contribute}
+              Endpoint: contribute
+              Data: Nothing}
       Response:
         ( 1
         , {contribute:

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -6,10 +6,10 @@ Events by wallet:
     Requests:
         2: {schedule collection:
               Endpoint: schedule collection
-              Data: Nothing}
+              Metadata: Nothing}
         1: {contribute:
               Endpoint: contribute
-              Data: Nothing}
+              Metadata: Nothing}
       Response:
         (2, {schedule collection: EndpointValue: ()})
     - Iteration: 2
@@ -58,10 +58,10 @@ Events by wallet:
     Requests:
         2: {schedule collection:
               Endpoint: schedule collection
-              Data: Nothing}
+              Metadata: Nothing}
         1: {contribute:
               Endpoint: contribute
-              Data: Nothing}
+              Metadata: Nothing}
       Response:
         ( 1
         , {contribute:
@@ -100,10 +100,10 @@ Events by wallet:
     Requests:
         2: {schedule collection:
               Endpoint: schedule collection
-              Data: Nothing}
+              Metadata: Nothing}
         1: {contribute:
               Endpoint: contribute
-              Data: Nothing}
+              Metadata: Nothing}
       Response:
         ( 1
         , {contribute:
@@ -142,10 +142,10 @@ Events by wallet:
     Requests:
         2: {schedule collection:
               Endpoint: schedule collection
-              Data: Nothing}
+              Metadata: Nothing}
         1: {contribute:
               Endpoint: contribute
-              Data: Nothing}
+              Metadata: Nothing}
       Response:
         ( 1
         , {contribute:


### PR DESCRIPTION
* Add a field `aeMetadata :: Maybe JSON.Value` field to the `EndpointDescription` type
* This field can be used to pass arbitrary JSON values to the user when exposing an endpoint

I thought about adding a type variable for the metadata, but: (1) we already have enough type parameters, (2) we don't do anything with the metadata on the contract side, it exists only to carry information for the frontaned and (3) whatever value we put in there we will have to serialise to JSON anyway.