### PR TITLE
Bugfix for the latest contract status map.

### DIFF
--- a/plutus-scb-client/src/MainFrame.purs
+++ b/plutus-scb-client/src/MainFrame.purs
@@ -44,7 +44,8 @@ import Schema.Types (formArgumentToJson, toArgument)
 import Schema.Types as Schema
 import Servant.PureScript.Ajax (AjaxError)
 import Servant.PureScript.Settings (SPSettings_, defaultSettings)
-import Types (EndpointForm, HAction(..), Query, State(..), View(..), WebData, _annotatedBlockchain, _chainReport, _chainState, _contractInstanceIdString, _contractReport, _contractSignatures, _contractStates, _csContract, _currentView, _fullReport)
+import Types (EndpointForm, HAction(..), Query, State(..), View(..), WebData, _annotatedBlockchain, _chainReport, _chainState, _contractInstanceIdString, _contractReport, _contractSignatures, _contractStat
+es, _csContract, _currentView, _fullReport)
 import Validation (_argument)
 import View as View
 


### PR DESCRIPTION
It was always returning the first status, not the last.

As part of this, I've merged two similar queries and made them a little
easier to work with.