### PR TITLE
SCP-787: Merge request handlers in PAB and emulator

### DIFF
--- a/plutus-contract/src/Control/Monad/Freer/Log.hs
+++ b/plutus-contract/src/Control/Monad/Freer/Log.hs
@@ -30,7 +30,7 @@ import           Control.Monad.Freer.Writer              (Writer (..), tell)
 import           Data.Aeson                              (FromJSON, ToJSON)
 import           Data.Foldable                           (traverse_)
 import           Data.Text                               (Text)
-import           Data.Text.Prettyprint.Doc hiding (surround)
+import           Data.Text.Prettyprint.Doc               hiding (surround)
 import qualified Data.Text.Prettyprint.Doc.Render.String as Render
 import qualified Data.Text.Prettyprint.Doc.Render.Text   as Render
 import qualified Debug.Trace                             as Trace

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/WatchAddress.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/WatchAddress.hs
@@ -37,7 +37,7 @@ import qualified Ledger.AddressMap                          as AM
 import           Ledger.Tx                                  (Tx, txOutTxOut, txOutValue)
 import qualified Ledger.Value                               as V
 
-import           Language.Plutus.Contract.Effects.AwaitSlot (HasAwaitSlot, currentSlot, awaitSlot)
+import           Language.Plutus.Contract.Effects.AwaitSlot (HasAwaitSlot, awaitSlot, currentSlot)
 import           Language.Plutus.Contract.Effects.UtxoAt    (HasUtxoAt, utxoAt)
 import           Language.Plutus.Contract.Request           (ContractRow, requestMaybe)
 import           Language.Plutus.Contract.Schema            (Event (..), Handlers (..), Input, Output)

--- a/plutus-contract/src/Language/Plutus/Contract/Trace.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Trace.hs
@@ -73,7 +73,7 @@ module Language.Plutus.Contract.Trace
     , allWallets
     ) where
 
-import Control.Arrow ((>>>), (>>^))
+import           Control.Arrow                                     ((>>>), (>>^))
 import           Control.Lens                                      (at, from, makeClassyPrisms, makeLenses, use, view,
                                                                     (%=))
 import           Control.Monad.Except
@@ -103,7 +103,7 @@ import qualified Language.Plutus.Contract.Types                    as Contract.T
 import qualified Language.Plutus.Contract.Wallet                   as Wallet
 
 import qualified Language.Plutus.Contract.Effects.AwaitSlot        as AwaitSlot
-import Language.Plutus.Contract.Effects.AwaitTxConfirmed (TxConfirmed(..))
+import           Language.Plutus.Contract.Effects.AwaitTxConfirmed (TxConfirmed (..))
 import qualified Language.Plutus.Contract.Effects.AwaitTxConfirmed as AwaitTxConfirmed
 import           Language.Plutus.Contract.Effects.ExposeEndpoint   (HasEndpoint)
 import qualified Language.Plutus.Contract.Effects.ExposeEndpoint   as Endpoint
@@ -113,8 +113,9 @@ import qualified Language.Plutus.Contract.Effects.UtxoAt           as UtxoAt
 import qualified Language.Plutus.Contract.Effects.WatchAddress     as WatchAddress
 import qualified Language.Plutus.Contract.Effects.WriteTx          as WriteTx
 import           Language.Plutus.Contract.Resumable                (Request (..), Requests (..), Response (..))
-import           Language.Plutus.Contract.Trace.RequestHandler     (RequestHandler (..), tryHandler, wrapHandler, maybeToHandler)
-import qualified Language.Plutus.Contract.Trace.RequestHandler as RequestHandler
+import           Language.Plutus.Contract.Trace.RequestHandler     (RequestHandler (..), maybeToHandler, tryHandler,
+                                                                    wrapHandler)
+import qualified Language.Plutus.Contract.Trace.RequestHandler     as RequestHandler
 import           Language.Plutus.Contract.Types                    (ResumableResult (..))
 
 import qualified Ledger.Ada                                        as Ada
@@ -437,7 +438,7 @@ handleSlotNotifications ::
     ( HasAwaitSlot s
     )
     => RequestHandler EmulatedWalletEffects (Handlers s) (Event s)
-handleSlotNotifications = 
+handleSlotNotifications =
     maybeToHandler AwaitSlot.request
     >>> RequestHandler.handleSlotNotifications
     >>^ AwaitSlot.event
@@ -592,7 +593,7 @@ handlePendingTransactions ::
     ( HasWriteTx s
     )
     => RequestHandler EmulatedWalletEffects (Handlers s) (Event s)
-handlePendingTransactions = 
+handlePendingTransactions =
     maybeToHandler WriteTx.pendingTransaction
     >>> RequestHandler.handlePendingTransactions
     >>^ WriteTx.event . view (from WriteTx.writeTxResponse)
@@ -603,25 +604,25 @@ handleUtxoQueries ::
     ( HasUtxoAt s
     )
     => RequestHandler EmulatedWalletEffects (Handlers s) (Event s)
-handleUtxoQueries = 
+handleUtxoQueries =
     maybeToHandler UtxoAt.utxoAtRequest
     >>> RequestHandler.handleUtxoQueries
     >>^ UtxoAt.event
-    
+
 handleTxConfirmedQueries ::
     ( HasTxConfirmation s
     )
     => RequestHandler EmulatedWalletEffects (Handlers s) (Event s)
-handleTxConfirmedQueries = 
+handleTxConfirmedQueries =
     maybeToHandler AwaitTxConfirmed.txId
     >>> RequestHandler.handleTxConfirmedQueries
-    >>^ AwaitTxConfirmed.event . unTxConfirmed 
+    >>^ AwaitTxConfirmed.event . unTxConfirmed
 
 handleNextTxAtQueries
     :: ( HasWatchAddress s
        )
     => RequestHandler EmulatedWalletEffects (Handlers s) (Event s)
-handleNextTxAtQueries = 
+handleNextTxAtQueries =
     maybeToHandler WatchAddress.watchAddressRequest
     >>> RequestHandler.handleNextTxAtQueries
     >>^ WatchAddress.event

--- a/plutus-contract/src/Language/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Trace/RequestHandler.hs
@@ -134,7 +134,9 @@ handleUtxoQueries = RequestHandler $ \addr ->
     surroundDebug "handleUtxoQueries" $ do
         Wallet.Effects.startWatching addr
         AddressMap utxoSet <- Wallet.Effects.watchedAddresses
-        maybe empty (pure . UtxoAtAddress addr) $ Map.lookup addr utxoSet
+        case Map.lookup addr utxoSet of
+            Nothing -> empty
+            Just s  -> pure (UtxoAtAddress addr s)
 
 handleTxConfirmedQueries ::
     forall effs.

--- a/plutus-contract/src/Language/Plutus/Contract/Trace/RequestHandler.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Trace/RequestHandler.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia        #-}
@@ -11,25 +14,49 @@ module Language.Plutus.Contract.Trace.RequestHandler(
     , wrapHandler
     , extract
     , maybeToHandler
+    -- * handlers for common requests
+    , handleOwnPubKey
+    , handleSlotNotifications
+    , handlePendingTransactions
+    , handleUtxoQueries
+    , handleTxConfirmedQueries
+    , handleNextTxAtQueries
     ) where
 
 import           Control.Applicative                (Alternative (empty))
-import           Control.Arrow                      (Kleisli (..))
+import           Control.Arrow                      (Arrow, Kleisli (..))
+import Control.Category (Category)
+import Data.Foldable (traverse_)
+import qualified Ledger.AddressMap as AM
 import           Control.Lens
-import           Control.Monad                      (foldM)
+import           Control.Monad                      (foldM, guard)
 import           Control.Monad.Freer
+import qualified Control.Monad.Freer.Error                         as Eff
 import           Control.Monad.Freer.NonDet         (NonDet)
 import qualified Control.Monad.Freer.NonDet         as NonDet
+import qualified Data.Map as Map
 import           Data.Monoid                        (Alt (..), Ap (..))
+import qualified Data.Text as Text
 
 import           Language.Plutus.Contract.Resumable (Request (..), Response (..))
+
+import Ledger (PubKey, Slot, Tx, Address, TxId)
+import           Ledger.AddressMap                          (AddressMap(..))
+import           Ledger.Constraints.OffChain (UnbalancedTx(unBalancedTxTx))
+import Control.Monad.Freer.Log (Log, surroundDebug, logWarn, logDebug)
+import qualified Wallet.Effects
+import Language.Plutus.Contract.Effects.UtxoAt (UtxoAtAddress(..))
+import Language.Plutus.Contract.Effects.AwaitTxConfirmed (TxConfirmed(..))
+import Wallet.Effects (WalletEffect, SigningProcessEffect, ChainIndexEffect, AddressChangeRequest(..), AddressChangeResponse)
+import           Wallet.API                                        (WalletAPIError)
+import qualified Language.Plutus.Contract.Wallet                   as Wallet
 
 
 -- | Request handlers that can choose whether to handle an effect (using
 --   'Alternative'). This is useful if 'req' is a sum type.
 newtype RequestHandler effs req resp = RequestHandler { unRequestHandler :: req -> Eff (NonDet ': effs) resp }
     deriving stock (Functor)
-    deriving (Profunctor) via (Kleisli (Eff (NonDet ': effs)))
+    deriving (Profunctor, Category, Arrow) via (Kleisli (Eff (NonDet ': effs)))
     deriving (Semigroup, Monoid) via (Ap ((->) req) (Alt (Eff (NonDet ': effs)) resp))
 
 
@@ -52,3 +79,82 @@ wrapHandler (RequestHandler h) = RequestHandler $ \Request{rqID, itID, rqRequest
 
 maybeToHandler :: (req -> Maybe resp) -> RequestHandler effs req resp
 maybeToHandler f = RequestHandler $ maybe empty pure . f
+
+-- handlers for common requests
+
+handleOwnPubKey ::
+    forall a effs.
+    ( Member WalletEffect effs
+    , Member Log effs
+    )
+    => RequestHandler effs a PubKey
+handleOwnPubKey = 
+    RequestHandler $ \_ ->
+        surroundDebug "handleOwnPubKey" Wallet.Effects.ownPubKey
+
+handleSlotNotifications ::
+    forall effs.
+    ( Member WalletEffect effs
+    , Member Log effs
+    )
+    => RequestHandler effs Slot Slot
+handleSlotNotifications =
+    RequestHandler $ \targetSlot -> 
+        surroundDebug "handleSlotNotifications" $ do
+            currentSlot <- Wallet.Effects.walletSlot
+            logDebug $ Text.pack $ "targetSlot: " <> show targetSlot <> "; current slot: " <> show currentSlot
+            guard (currentSlot >= targetSlot)
+            pure currentSlot
+
+handlePendingTransactions ::
+    forall effs.
+    ( Member WalletEffect effs
+    , Member Log effs
+    , Member SigningProcessEffect effs
+    , Member ChainIndexEffect effs
+    )
+    => RequestHandler effs UnbalancedTx (Either WalletAPIError Tx)
+handlePendingTransactions =
+    RequestHandler $ \unbalancedTx ->
+        surroundDebug "handlePendingTransactions" $ do
+        logDebug "Start watching contract addresses."
+        wa <- Wallet.Effects.watchedAddresses
+        traverse_ Wallet.Effects.startWatching (AM.addressesTouched wa (unBalancedTxTx unbalancedTx))
+        (Right <$> Wallet.handleTx unbalancedTx) `Eff.handleError` (\err -> logWarn "handleTxFailed" >> pure (Left err))
+
+handleUtxoQueries ::
+    forall effs.
+    ( Member Log effs
+    , Member ChainIndexEffect effs
+    )
+    => RequestHandler effs Address UtxoAtAddress
+handleUtxoQueries = RequestHandler $ \addr ->
+    surroundDebug "handleUtxoQueries" $ do
+        Wallet.Effects.startWatching addr
+        AddressMap utxoSet <- Wallet.Effects.watchedAddresses
+        maybe empty (pure . UtxoAtAddress addr) $ Map.lookup addr utxoSet
+
+handleTxConfirmedQueries ::
+    forall effs.
+    ( Member Log effs
+    , Member ChainIndexEffect effs
+    )
+    => RequestHandler effs TxId TxConfirmed
+handleTxConfirmedQueries = RequestHandler $ \txid ->
+    surroundDebug "handleTxConfirmedQueries" $ do
+        conf <- Wallet.Effects.transactionConfirmed txid
+        guard conf
+        pure (TxConfirmed txid)
+
+handleNextTxAtQueries ::
+    forall effs.
+    ( Member Log effs
+    , Member WalletEffect effs
+    , Member ChainIndexEffect effs
+    )
+    => RequestHandler effs AddressChangeRequest AddressChangeResponse
+handleNextTxAtQueries = RequestHandler $ \req ->
+    surroundDebug "handleNextTxAtQueries" $ do
+        sl <- Wallet.Effects.walletSlot
+        guard (sl >= acreqSlot req)
+        Wallet.Effects.nextTx req

--- a/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Wallet.hs
@@ -14,7 +14,7 @@ module Language.Plutus.Contract.Wallet(
     ) where
 
 import           Control.Lens
-import           Control.Monad.Freer         (Eff, Member, Members)
+import           Control.Monad.Freer         (Eff, Member)
 import           Control.Monad.Freer.Error   (Error)
 import           Control.Monad.Freer.Log     (Log, logDebug, logInfo)
 import           Data.Bifunctor              (second)
@@ -181,6 +181,6 @@ addOutputs pk vl tx = tx & over Tx.outputs (pko :) where
 
 -- | Balance an unabalanced transaction, sign it, and submit
 --   it to the chain in the context of a wallet.
-handleTx :: (Members WalletEffects effs, Member Log effs, Member (Error WalletAPIError) effs) => UnbalancedTx -> Eff effs Tx
+handleTx :: (Member WalletEffect effs, Member ChainIndexEffect effs, Member SigningProcessEffect effs, Member Log effs, Member (Error WalletAPIError) effs) => UnbalancedTx -> Eff effs Tx
 handleTx utx =
     balanceWallet utx >>= addSignatures (Set.toList $ unBalancedTxRequiredSignatories utx) >>= WAPI.signTxAndSubmit

--- a/plutus-scb/src/Cardano/Node/Types.hs
+++ b/plutus-scb/src/Cardano/Node/Types.hs
@@ -17,8 +17,8 @@ import           GHC.Generics                   (Generic)
 import qualified Language.Plutus.Contract.Trace as Trace
 import           Servant                        (FromHttpApiData, ToHttpApiData)
 import           Servant.Client                 (BaseUrl)
+import           Wallet.Emulator                (Wallet)
 import qualified Wallet.Emulator                as EM
-import Wallet.Emulator (Wallet)
 import           Wallet.Emulator.Chain          (ChainEvent, ChainState)
 import qualified Wallet.Emulator.MultiAgent     as MultiAgent
 

--- a/plutus-scb/src/Plutus/SCB/Core/ContractInstance.hs
+++ b/plutus-scb/src/Plutus/SCB/Core/ContractInstance.hs
@@ -26,10 +26,11 @@ module Plutus.SCB.Core.ContractInstance(
     , callContractEndpoint
     ) where
 
+import Control.Arrow ((>>>), (>>^))
 import           Control.Lens
-import           Control.Monad                                     (guard, void, when)
+import           Control.Monad                                     (void, when)
 import           Control.Monad.Freer
-import           Control.Monad.Freer.Error                         (Error, runError, throwError)
+import           Control.Monad.Freer.Error                         (Error, throwError)
 import           Control.Monad.Freer.Extra.Log
 import qualified Data.Aeson                                        as JSON
 import           Data.Foldable                                     (traverse_)
@@ -41,24 +42,16 @@ import qualified Data.Text                                         as Text
 import           Data.Text.Prettyprint.Doc                         (Pretty, pretty, (<+>))
 
 import           Language.Plutus.Contract.Effects.AwaitSlot        (WaitingForSlot (..))
-import           Language.Plutus.Contract.Effects.AwaitTxConfirmed (TxConfirmed (..))
 import           Language.Plutus.Contract.Effects.ExposeEndpoint   (ActiveEndpoint (..), EndpointDescription (..),
                                                                     EndpointValue (..))
-import           Language.Plutus.Contract.Effects.UtxoAt           (UtxoAtAddress (..))
 import           Language.Plutus.Contract.Effects.WriteTx          (WriteTxResponse (..))
 import           Language.Plutus.Contract.Resumable                (Request (..), Response (..))
 import           Language.Plutus.Contract.Trace.RequestHandler     (RequestHandler (..), extract, tryHandler,
-                                                                    wrapHandler)
-import           Language.Plutus.Contract.Wallet                   (balanceWallet)
+                                                                    wrapHandler, maybeToHandler)
+import qualified Language.Plutus.Contract.Trace.RequestHandler as RequestHandler
 
-import qualified Ledger
-import qualified Ledger.AddressMap                                 as AM
-import           Ledger.Constraints.OffChain                       (UnbalancedTx (..))
-import           Wallet.API                                        (signWithOwnPublicKey)
-import           Wallet.Effects                                    (AddressChangeRequest (..), ChainIndexEffect,
-                                                                    SigningProcessEffect, WalletEffect, nextTx,
-                                                                    ownPubKey, startWatching, submitTxn,
-                                                                    transactionConfirmed, walletSlot, watchedAddresses)
+import           Wallet.Effects                                    (ChainIndexEffect,
+                                                                    SigningProcessEffect, WalletEffect)
 
 import           Plutus.SCB.Command                                (saveBalancedTx, saveBalancedTxResult,
                                                                     saveContractState, sendContractEvent)
@@ -295,12 +288,9 @@ processOwnPubkeyRequests ::
     , Member WalletEffect effs
     )
     => RequestHandler effs ContractSCBRequest ContractResponse
-processOwnPubkeyRequests = RequestHandler $ \req -> do
-        _ <- extract Events.Contract._OwnPubkeyRequest req
-        logInfo "processOwnPubkeyRequests start"
-        pk <- ownPubKey
-        logInfo "processOwnPubkeyRequests end"
-        pure (OwnPubkeyResponse pk)
+processOwnPubkeyRequests = 
+    maybeToHandler (extract Events.Contract._OwnPubkeyRequest) >>>
+        fmap OwnPubkeyResponse RequestHandler.handleOwnPubKey
 
 processAwaitSlotRequests ::
     forall effs.
@@ -308,14 +298,10 @@ processAwaitSlotRequests ::
     , Member WalletEffect effs
     )
     => RequestHandler effs ContractSCBRequest ContractResponse
-processAwaitSlotRequests = RequestHandler $ \req -> do
-    WaitingForSlot targetSlot <- extract Events.Contract._AwaitSlotRequest req
-    logInfo "processAwaitSlotRequests start"
-    currentSlot <- walletSlot
-    logDebug . render $ "targetSlot:" <+> pretty targetSlot <+> "current slot:" <+> pretty currentSlot
-    guard (currentSlot >= targetSlot)
-    logInfo "processAwaitSlotRequests end"
-    pure $ AwaitSlotResponse currentSlot
+processAwaitSlotRequests = 
+    maybeToHandler (fmap unWaitingForSlot . extract Events.Contract._AwaitSlotRequest)
+    >>> RequestHandler.handleSlotNotifications
+    >>^ AwaitSlotResponse 
 
 processUtxoAtRequests ::
     forall effs.
@@ -323,17 +309,10 @@ processUtxoAtRequests ::
     , Member Log effs
     )
     => RequestHandler effs ContractSCBRequest ContractResponse
-processUtxoAtRequests = RequestHandler $ \req -> do
-    address <- extract Events.Contract._UtxoAtRequest req
-    logDebug . render $ "processUtxoAtRequest" <+> pretty address
-    utxos <- watchedAddresses
-    startWatching address
-    let response = UtxoAtAddress
-            { address = address
-            , utxo    = view (AM.fundsAt address) utxos
-            }
-    logInfo "processUtxoAtRequests end"
-    pure $ UtxoAtResponse response
+processUtxoAtRequests = 
+    maybeToHandler (extract Events.Contract._UtxoAtRequest)
+    >>> RequestHandler.handleUtxoQueries
+    >>^ UtxoAtResponse
 
 processWriteTxRequests ::
     forall t effs.
@@ -344,32 +323,20 @@ processWriteTxRequests ::
     , Member SigningProcessEffect effs
     )
     => RequestHandler effs ContractSCBRequest ContractResponse
-processWriteTxRequests = RequestHandler $ \req -> do
-    -- logDebug . render $ "The request is a" <+> pretty req
-    unbalancedTx <- extract Events.Contract._WriteTxRequest req
-    logInfo "processWriteTxRequests start"
-    logInfo "Start watching contract addresses."
-    wa <- watchedAddresses
-    traverse_ startWatching (AM.addressesTouched wa (unBalancedTxTx unbalancedTx))
-    logInfo $ "Balancing unbalanced TX: " <> tshow unbalancedTx
-    r <- runError $ do
-            balancedTx <- balanceWallet unbalancedTx
-            signedTx <- signWithOwnPublicKey balancedTx
-            logInfo $ "Storing signed TX: " <> tshow signedTx
-            void $ runCommand (saveBalancedTx @t) WalletEventSource balancedTx
-            logInfo $ "Submitting signed TX: " <> tshow signedTx
-            balanceResult <- submitTx signedTx
-            void $ runCommand (saveBalancedTxResult @t) NodeEventSource balanceResult
-            pure balanceResult
-    let response = either WriteTxFailed WriteTxSuccess r
-    logInfo . render $ "processWriteTxRequest result:" <+> pretty response
-    logInfo "processWriteTxRequests end"
-    pure (WriteTxResponse response)
+processWriteTxRequests = 
+    let store result = case result of
+            Left err -> pure (Left err)
+            Right signedTx -> do
+                logInfo $ "Storing signed TX: " <> tshow signedTx
+                void $ runCommand (saveBalancedTx @t) WalletEventSource signedTx
+                void $ runCommand (saveBalancedTxResult @t) NodeEventSource signedTx
+                pure (Right signedTx)
+    in
 
--- | A wrapper around the NodeAPI function that returns some more
--- useful evidence of the work done.
-submitTx :: (Member WalletEffect effs) => Ledger.Tx -> Eff effs Ledger.Tx
-submitTx tx = submitTxn tx >> pure tx
+    maybeToHandler (extract Events.Contract._WriteTxRequest)
+    >>> RequestHandler.handlePendingTransactions
+    >>> RequestHandler store
+    >>^ WriteTxResponse . either WriteTxFailed WriteTxSuccess
 
 processNextTxAtRequests ::
     forall effs.
@@ -378,15 +345,10 @@ processNextTxAtRequests ::
     , Member ChainIndexEffect effs
     )
     => RequestHandler effs ContractSCBRequest ContractResponse
-processNextTxAtRequests = RequestHandler $ \req -> do
-    request <- extract Events.Contract._NextTxAtRequest req
-    logInfo "processNextTxAtRequests start"
-    logDebug . render $ "processNextTxAtRequest" <+> pretty request
-    slot <- walletSlot
-    guard $ slot > acreqSlot request
-    response <- nextTx request
-    logInfo "processNextTxAtRequests end"
-    pure $ NextTxAtResponse response
+processNextTxAtRequests = 
+    maybeToHandler (extract Events.Contract._NextTxAtRequest)
+    >>> RequestHandler.handleNextTxAtQueries
+    >>^ NextTxAtResponse
 
 processTxConfirmedRequests ::
     forall effs.
@@ -394,15 +356,10 @@ processTxConfirmedRequests ::
     , Member Log effs
     )
     => RequestHandler effs ContractSCBRequest ContractResponse
-processTxConfirmedRequests = RequestHandler $ \req -> do
-    txid <- extract Events.Contract._AwaitTxConfirmedRequest req
-    logInfo "processTxConfirmedRequests start"
-    logDebug . render $ "processTxConfirmedRequest" <+> pretty txid
-    confirmed <- transactionConfirmed txid
-    logDebug . render $ "confirmed" <+> pretty confirmed
-    guard confirmed
-    logInfo "processTxConfirmedRequests end"
-    pure $ AwaitTxConfirmedResponse $ TxConfirmed txid
+processTxConfirmedRequests = 
+    maybeToHandler (extract Events.Contract._AwaitTxConfirmedRequest)
+    >>> RequestHandler.handleTxConfirmedQueries
+    >>^ AwaitTxConfirmedResponse
 
 callContractEndpoint ::
     forall t a effs.


### PR DESCRIPTION
The code that uses `WalletEffects` to deal with contracts' requests was duplicated, this PR fixes it.