### PR TITLE
Formatter tests shouldn't always succeed!

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -22,7 +22,7 @@ in dimension "System" (systems genericPkgs) (systemName: system:
     lib = pkgs.lib;
     platformFilter = platformFilterGeneric pkgs system;
   in filterAttrsOnlyRecursive (_: v: platformFilter v) {
-    inherit (packageSet) docs papers dev plutus-playground marlowe-playground plutus-scb marlowe-symbolic-lambda;
+    inherit (packageSet) docs papers dev tests plutus-playground marlowe-playground plutus-scb marlowe-symbolic-lambda;
     haskell =
       let
         # These functions pull out from the Haskell package set either all the components of a particular type, or

--- a/nix/tests/purty.nix
+++ b/nix/tests/purty.nix
@@ -7,16 +7,15 @@ let
    filter = with lib;
     name: type: let baseName = baseNameOf (toString name); in (
       (type == "regular" && hasSuffix ".purs" baseName) ||
-      (type == "directory" && (baseName != "generated" 
-                            && baseName != "output" 
-                            && baseName != "node_modules" 
-                            && baseName != ".psc-package" 
+      (type == "directory" && (baseName != "generated"
+                            && baseName != "output"
+                            && baseName != "node_modules"
+                            && baseName != ".psc-package"
                             && baseName != ".spago"))
     );
   };
 in
 runCommand "purty-check" {
-  succeedOnFailure = true;
   buildInputs = [ purty diffutils glibcLocales ];
 } ''
   set +e

--- a/nix/tests/stylish-haskell.nix
+++ b/nix/tests/stylish-haskell.nix
@@ -13,7 +13,6 @@ let
   };
 in
 runCommand "stylish-check" {
-  succeedOnFailure = true;
   buildInputs = [ stylish-haskell diffutils glibcLocales ];
 } ''
   set +e

--- a/plutus-contract/src/Language/Plutus/Contract/Effects/WatchAddress.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Effects/WatchAddress.hs
@@ -37,7 +37,7 @@ import qualified Ledger.AddressMap                          as AM
 import           Ledger.Tx                                  (Tx, txOutTxOut, txOutValue)
 import qualified Ledger.Value                               as V
 
-import           Language.Plutus.Contract.Effects.AwaitSlot (HasAwaitSlot, currentSlot, awaitSlot)
+import           Language.Plutus.Contract.Effects.AwaitSlot (HasAwaitSlot, awaitSlot, currentSlot)
 import           Language.Plutus.Contract.Effects.UtxoAt    (HasUtxoAt, utxoAt)
 import           Language.Plutus.Contract.Request           (ContractRow, requestMaybe)
 import           Language.Plutus.Contract.Schema            (Event (..), Handlers (..), Input, Output)

--- a/plutus-scb/src/Cardano/Node/Types.hs
+++ b/plutus-scb/src/Cardano/Node/Types.hs
@@ -17,8 +17,8 @@ import           GHC.Generics                   (Generic)
 import qualified Language.Plutus.Contract.Trace as Trace
 import           Servant                        (FromHttpApiData, ToHttpApiData)
 import           Servant.Client                 (BaseUrl)
+import           Wallet.Emulator                (Wallet)
 import qualified Wallet.Emulator                as EM
-import Wallet.Emulator (Wallet)
 import           Wallet.Emulator.Chain          (ChainEvent, ChainState)
 import qualified Wallet.Emulator.MultiAgent     as MultiAgent
 


### PR DESCRIPTION
I'm not really sure what was going on here: I think when these used to be checked by buildkite the main point of the hydra job was to build the diff as an output so people can apply it. I'm pretty sure we don't want this any more.