### PR TITLE
Sphinx site: build with support for linking into Haddock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ stack.yaml.lock
 # Agda
 *.agdai
 
+# Python
+__pycache__
+
 # Nix
 result*
 pkgs/.cabal

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,6 +21,9 @@ project = 'Plutus Platform'
 copyright = '2020, IOHK'
 author = 'IOHK'
 
+import sys, os
+
+sys.path.append(os.path.abspath('exts'))
 
 # -- General configuration ---------------------------------------------------
 
@@ -28,6 +31,8 @@ author = 'IOHK'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+  'hs_domain',
+  'sphinx.ext.intersphinx'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -38,6 +43,19 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+primary_domain = 'hs'
+
+haddock_mapping = {}
+haddock_dir = os.getenv('SPHINX_HADDOCK_DIR', None)
+if haddock_dir:
+  for entry in os.scandir(haddock_dir):
+    if entry.is_dir():
+      html_dir = os.path.join(entry.path, 'html')
+      inv_file = os.path.join(html_dir, 'objects.inv')
+      if os.path.exists(inv_file):
+        haddock_mapping[entry.name] = (html_dir, inv_file)
+
+intersphinx_mapping = haddock_mapping
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -49,4 +67,4 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -1,8 +1,13 @@
-{ stdenv, pythonPackages, ... }:
+{ stdenv, lib, pythonPackages, sphinxcontrib-domaintools, sphinxcontrib-haddock, combined-haddock, ... }:
 stdenv.mkDerivation {
   name = "plutus-docs";
-  src = ./.;
-  buildInputs = [ pythonPackages.sphinx pythonPackages.sphinx_rtd_theme ];
-  buildPhase = "sphinx-build . $out";
+  src = lib.sourceFilesBySuffices ./. [ ".py" ".rst" ".hs" ];
+  buildInputs = [ pythonPackages.sphinx pythonPackages.sphinx_rtd_theme sphinxcontrib-domaintools sphinxcontrib-haddock ];
+  buildPhase = ''
+    cp -aR ${combined-haddock}/share/doc haddock
+    # -n gives warnings on missing link targets, -W makes warnings into errors
+    SPHINX_HADDOCK_DIR=haddock sphinx-build -j $NIX_BUILD_CORES -n -W . $out
+    cp -aR haddock $out
+  '';
   dontInstall = true;
 }

--- a/doc/exts/hs_domain.py
+++ b/doc/exts/hs_domain.py
@@ -1,0 +1,28 @@
+# This is a copy of the one from the module, it's here so that
+# it's easier for people not using Nix to build the site.
+
+from sphinxcontrib.domaintools import *
+
+def hs_domain():
+    return custom_domain('HaskellDomain',
+        name  = 'hs',
+        label = "Haskell",
+
+        elements = dict(
+            hsobj = dict(
+                objname = "Haskell entity",
+            ),
+            hstype = dict(
+                objname = "Haskell type",
+            ),
+            hsval = dict(
+                objname = "Haskell value",
+            ),
+            hsmod = dict(
+                objname = "Haskell module",
+            ),
+        )
+    )
+
+def setup(app):
+    app.add_domain(hs_domain())

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,2 @@
 sphinx>=2.3
+sphinxcontrib-domaintools>=0.3

--- a/doc/tutorials/plutus-tx.rst
+++ b/doc/tutorials/plutus-tx.rst
@@ -67,7 +67,7 @@ as values.
 The Plutus Tx compiler compiles Haskell *expressions* (not values!), so
 naturally it takes a quote (representing an expression) as an argument.
 The result is a new quote, this time for a Haskell program that
-represents the *compiled* program. In Haskell, the type of ``compile``
+represents the *compiled* program. In Haskell, the type of :hsobj:`Language.PlutusTx.TH.compile`
 is ``TExpQ a → TExpQ (CompiledCode PLC.DefaultUni a)``. This is just
 what we already said:
 
@@ -78,19 +78,19 @@ what we already said:
 
 .. note::
 
-   ``CompiledCode`` has a type parameter ``a`` as well, which
+   :hsobj:`Language.PlutusTx.CompiledCode` has a type parameter ``a`` as well, which
    corresponds to the type of the original expression. This lets us
    "remember" what the original type of the Haskell program that we
    compiled was.
 
-Since ``compile`` produces a quote, to use the result we need to splice
+Since :hsobj:`Language.PlutusTx.TH.compile` produces a quote, to use the result we need to splice
 it back into our program. When you compile the main program, the Plutus
 Tx compiler will run and the compiled program will be inserted into the
 main program.
 
 This is all the Template Haskell you need to know! We almost always use
 the same, very simple pattern, which is to make a quote, immediately
-call ``compile`` and then splice the result back in, so once you are
+call :hsobj:`Language.PlutusTx.TH.compile` and then splice the result back in, so once you are
 used to that you can mostly ignore it.
 
 .. _writing_basic_plutustx_programs:
@@ -125,7 +125,7 @@ inspect at runtime to see the generated Plutus Core (or to put it on the
 blockchain).
 
 We also see the standard usage pattern here: a TH quote, wrapped in a
-call to ``compile``, wrapped in a ``$$`` splice. This is how we write
+call to :hsobj:`Language.PlutusTx.TH.compile`, wrapped in a ``$$`` splice. This is how we write
 all of our Plutus Tx programs.
 
 Here’s a slightly more complex program, namely the identity function on
@@ -200,7 +200,7 @@ definition.
 The Plutus Tx Prelude
 ---------------------
 
-The ``Language.PlutusTx.Prelude`` module is a drop-in replacement for
+The :hsmod:`Language.PlutusTx.Prelude` module is a drop-in replacement for
 the normal Haskell Prelude, but with some functions and typeclasses
 redefined to be easier for the Plutus Tx compiler to handle (i.e.
 ``INLINABLE``).
@@ -212,13 +212,13 @@ so you can use them in normal Haskell code too, although the Haskell
 Prelude versions will probably perform better.
 
 To use the Plutus Tx Prelude, use the ``NoImplicitPrelude`` language
-pragma, and import ``Language.PlutusTx.Prelude``.
+pragma, and import :hsmod:`Language.PlutusTx.Prelude`.
 
 Plutus Tx has some builtin types and functions available for working
 with primitive data (integers and bytestrings), as well as a few special
 functions. These builtins are also exported from the Plutus Tx Prelude.
 
-The ``error`` builtin deserves a special mention. ``error`` causes the
+The :hsobj:`Language.PlutusTx.Builtins.error` builtin deserves a special mention. :hsobj:`Language.PlutusTx.Builtins.error` causes the
 transaction to abort when it is evaluated, which one way to trigger
 validation failure.
 
@@ -267,16 +267,15 @@ it.
    :start-after: BLOCK9
    :end-before: BLOCK10
 
-We lifted the argument using the ``liftCode`` function. In order to use
-this, a type must have an instance of the ``Lift`` class. In practice,
-you should generate these with the ``makeLift`` TH function from
-``Language.PlutusTx.Lift``.
+We lifted the argument using the :hsobj:`Language.PlutusTx.liftCode` function. In order to use
+this, a type must have an instance of the :hsobj:`Language.PlutusTx.Lift` class. In practice,
+you should generate these with the :hsobj:`Language.PlutusTx.makeLift` TH function from.
 
 .. note::
 
-   ``liftCode`` is a little "unsafe" because it ignores any errors that
+   :hsobj:`Language.PlutusTx.liftCode` is a little "unsafe" because it ignores any errors that
    might occur from lifting something that isn’t supported. There is a
-   ``safeLiftCode`` if you want to explicitly handle these.
+   :hsobj:`Language.PlutusTx.safeLiftCode` if you want to explicitly handle these.
 
 The combined program applies the original compiled lambda to the lifted
 value (notice that the lambda is a bit complicated now since we have

--- a/nix/haddock-combine.nix
+++ b/nix/haddock-combine.nix
@@ -1,4 +1,4 @@
-{ runCommand, lib, ghc }:
+{ runCommand, lib, ghc, sphinxcontrib-haddock }:
 { hspkgs # Haskell packages to make documentation for. Only those with a "doc" output will be used.
   # Note: we do not provide arbitrary additional Haddock options, as these would not be
   # applied consistently, since we're reusing the already built Haddock for the packages.
@@ -46,14 +46,19 @@ in runCommand "haddock-join" { buildInputs = [ hsdocs ]; } ''
   # we can just use the enclosing directory).
   interfaceOpts=()
   for interfaceFile in $(find . -name "*.haddock"); do
+    # this is '$PACKAGE/html'
     docdir=$(dirname $interfaceFile)
     interfaceOpts+=("--read-interface=$docdir,$interfaceFile")
+
+    # Jam this in here for now
+    ${sphinxcontrib-haddock}/bin/haddock_inventory $docdir
   done
 
   # Generate the contents and index
   ${ghc}/bin/haddock \
     --gen-contents \
     --gen-index \
+    --quickjump \
     ${lib.optionalString (prologue != null) "--prologue ${prologue}"} \
     "''${interfaceOpts[@]}"
 ''

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -42,10 +42,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "285b4ae6ef222c299c100ae0d89e5060f6b0c879",
-        "sha256": "0dppnh7iigyxm5904g6a8m919zixsad3hbr8y6bphqia28glm0fa",
+        "rev": "4dbc429b81c78c637c95c040693ce5fe0d640c28",
+        "sha256": "1lhn0cwwjrvh5cxwx288927kgjh0ilgpqf2cdqazp5g95iwp5plv",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/285b4ae6ef222c299c100ae0d89e5060f6b0c879.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/4dbc429b81c78c637c95c040693ce5fe0d640c28.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -95,6 +95,19 @@
         "url": "https://nodejs.org/download/release/v10.9.0/node-v10.9.0-headers.tar.gz",
         "url_template": "https://nodejs.org/download/release/<rev>/node-<rev>-headers.tar.gz"
     },
+    "sphinxcontrib-haddock": {
+        "branch": "master",
+        "description": "Tools for using Haddock with Sphinx",
+        "homepage": null,
+        "owner": "michaelpj",
+        "repo": "sphinxcontrib-haddock",
+        "rev": "f3956b3256962b2d27d5a4e96edb7951acf5de34",
+        "sha256": "0mlxa5zzgdka0c6sj7pp4cfvc8rcrd8g2z2113vp614l43g17miv",
+        "type": "tarball",
+        "builtin": false,
+        "url": "https://github.com/michaelpj/sphinxcontrib-haddock/archive/f3956b3256962b2d27d5a4e96edb7951acf5de34.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "stackage.nix": {
         "branch": "master",
         "description": "Automatically generated Nix expressions of Stackage snapshots",

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 }:
 with packageSet;
 let
-  pyEnv = pkgs.python3.withPackages (ps: [ ps.sphinx ps.sphinx_rtd_theme ]);
+  pyEnv = pkgs.python3.withPackages (ps: [ packageSet.sphinxcontrib-haddock.sphinxcontrib-domaintools ps.sphinx ps.sphinx_rtd_theme ]);
 in haskell.packages.shellFor {
   nativeBuildInputs = [
     # From nixpkgs


### PR DESCRIPTION
This uses https://github.com/michaelpj/sphinxcontrib-haddock to build intersphinx inventories for our Haddock and wire them all up in the build.

This means that we can do things like `:hs:hsobj:Language.PlutusTx.compile` and have it go to the corresponding Haddock, with an error if it can't find it. Some examples are in there already.