### PR TITLE
SCP-730 - Improve monaco type-ahead

### DIFF
--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -634,15 +634,15 @@ lintAction env hole@(Hole _ _ _) = do
   modifying _holes (insertHole hole)
   pure NoEffect
 
-suggestions :: Boolean -> String -> IRange -> Array CompletionItem
-suggestions stripParens contract range =
+suggestions :: String -> Boolean -> String -> IRange -> Array CompletionItem
+suggestions original stripParens contract range =
   fromMaybe [] do
     parsedContract <- hush $ parseContract contract
     let
       (Holes holes) = view _holes ((lint (emptyState zero)) parsedContract)
     v <- Map.lookup "monaco_suggestions" holes
     { head } <- Array.uncons $ Set.toUnfoldable v
-    pure $ holeSuggestions stripParens range head
+    pure $ holeSuggestions original stripParens range head
 
 -- FIXME: We have multiple model markers, 1 per quick fix. This is wrong though, we need only 1 but in MarloweCodeActionProvider we want to run the code
 -- to generate the quick fixes from this single model marker

--- a/marlowe-playground-client/src/Marlowe/Monaco.js
+++ b/marlowe-playground-client/src/Marlowe/Monaco.js
@@ -8,7 +8,7 @@ exports.hoverProvider_ = function (hoverProvider) {
 }
 
 exports.completionItemProvider_ = function (suggestionsProvider) {
-    let uncurriedSuggestions = (stripParens, contract, range) => suggestionsProvider(stripParens)(contract)(range);
+    let uncurriedSuggestions = (word, stripParens, contract, range) => suggestionsProvider(word)(stripParens)(contract)(range);
     return new monaco.MarloweCompletionItemProvider(uncurriedSuggestions);
 }
 

--- a/marlowe-playground-client/src/Marlowe/Monaco.purs
+++ b/marlowe-playground-client/src/Marlowe/Monaco.purs
@@ -20,7 +20,7 @@ import Monaco (CodeAction, CodeActionProvider, CompletionItem, CompletionItemPro
 
 foreign import hoverProvider_ :: Fn1 (String -> { contents :: Array IMarkdownString }) HoverProvider
 
-foreign import completionItemProvider_ :: Fn1 (Boolean -> String -> IRange -> Array CompletionItem) CompletionItemProvider
+foreign import completionItemProvider_ :: Fn1 (String -> Boolean -> String -> IRange -> Array CompletionItem) CompletionItemProvider
 
 foreign import codeActionProvider_ :: Fn1 (Uri -> Array IMarkerData -> Array CodeAction) CodeActionProvider
 

--- a/marlowe-playground-client/src/Marlowe/Monaco.ts
+++ b/marlowe-playground-client/src/Marlowe/Monaco.ts
@@ -19,14 +19,23 @@ export class MarloweHoverProvider implements monaco.languages.HoverProvider {
 export class MarloweCompletionItemProvider implements monaco.languages.CompletionItemProvider {
 
   // This enables us to pass in a function from PureScript that provides suggestions based on a contract string
-  suggestionsProvider: (Boolean, string, IRange) => Array<monaco.languages.CompletionItem>
+  suggestionsProvider: (String, Boolean, string, IRange) => Array<monaco.languages.CompletionItem>
 
   constructor(suggestionsProvider) {
     this.suggestionsProvider = suggestionsProvider;
   }
 
   provideCompletionItems(model: monaco.editor.ITextModel, position: monaco.Position, context: monaco.languages.CompletionContext, token: monaco.CancellationToken): monaco.languages.ProviderResult<monaco.languages.CompletionList> {
-    const word = model.getWordAtPosition(position);
+    var word = model.getWordAtPosition(position);
+    // if the word is empty then we need an extra space in the contract that we generate
+    const emptyWordHack = word == null ? " " : ""
+    if (word == null) {
+      word = {
+        word: "*",
+        startColumn: position.column,
+        endColumn: position.column,
+      }
+    }
     const stripParens = word.startColumn == 1 && position.lineNumber == 1;
     const wordStart = model.getOffsetAt(position);
     const wordEnd = wordStart + word.word.length;
@@ -35,7 +44,7 @@ export class MarloweCompletionItemProvider implements monaco.languages.Completio
 
     // we replace the word at the cursor with a hole with a special name so that the contract is parsable
     // if the contract is not valid then we won't get any suggestions
-    const contract = startOfContract + "?monaco_suggestions" + endOfContract;
+    const contract = startOfContract + emptyWordHack + "?monaco_suggestions" + endOfContract;
 
     const range = {
       startLineNumber: position.lineNumber,
@@ -44,7 +53,7 @@ export class MarloweCompletionItemProvider implements monaco.languages.Completio
       endColumn: word.endColumn
     }
 
-    return { suggestions: this.suggestionsProvider(stripParens, contract, range) };
+    return { suggestions: this.suggestionsProvider(word.word, stripParens, contract, range) };
   }
 
 }

--- a/marlowe-playground-client/src/Monaco.purs
+++ b/marlowe-playground-client/src/Monaco.purs
@@ -129,6 +129,9 @@ type CompletionItem
     , kind :: CompletionItemKind
     , insertText :: String
     , range :: IRange
+    , filterText :: String
+    , sortText :: String
+    , preselect :: Boolean
     }
 
 type Marker r

--- a/marlowe-playground-client/src/Simulation/BottomPanel.purs
+++ b/marlowe-playground-client/src/Simulation/BottomPanel.purs
@@ -20,7 +20,7 @@ import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\))
 import Halogen.Classes (aHorizontal, accentBorderBottom, active, activeClass, closeDrawerArrowIcon, first, flex, flexLeft, flexTen, footerPanelBg, minimizeIcon, rTable, rTable6cols, rTableCell, rTableDataRow, rTableEmptyRow, spanText, underline)
 import Halogen.Classes as Classes
-import Halogen.HTML (AttrName(..), ClassName(..), HTML, a, a_, attr, b_, button, code_, div, h2, h3, img, li, li_, ol, pre, section, span_, strong_, text, ul, ul_)
+import Halogen.HTML (ClassName(..), HTML, a, a_, b_, button, code_, div, h2, h3, img, li, li_, ol, pre, section, span_, strong_, text, ul, ul_)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (alt, class_, classes, enabled, src)
 import Marlowe.Parser (transactionInputList, transactionWarningList)


### PR DESCRIPTION
Here we change the type-ahead so that it includes all constructors for a data type, not just the one that starts with what you typed.

It places the one you started typing at the top of the list of suggestions though and makes sure it is selected.


![captured](https://user-images.githubusercontent.com/934267/86943128-6d95cb80-c11c-11ea-974d-52174216e0da.gif)