### PR TITLE
Build `shell.nix` in CI

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -23,6 +23,8 @@ in dimension "System" (systems genericPkgs) (systemName: system:
     platformFilter = platformFilterGeneric pkgs system;
   in filterAttrsOnlyRecursive (_: v: platformFilter v) {
     inherit (packageSet) docs papers dev tests plutus-playground marlowe-playground plutus-scb marlowe-symbolic-lambda;
+    # build the shell expression to be sure it works on all platforms
+    shell = import ./shell.nix { inherit packageSet; };
     haskell =
       let
         # These functions pull out from the Haskell package set either all the components of a particular type, or

--- a/release.nix
+++ b/release.nix
@@ -40,6 +40,9 @@ in lib.fix (jobsets: ciJobsets // {
       ++ (allJobs ["linux" "plutus-scb"] jobsets)
       # Developer scripts so they're definitely cached
       ++ (allJobs ["linux" "dev" "scripts"] jobsets)
-      ++ (allJobs ["darwin" "dev" "scripts"] jobsets);
+      ++ (allJobs ["darwin" "dev" "scripts"] jobsets)
+      # Shell environment so it never breaks
+      ++ (if (lib.hasAttrByPath ["linux" "shell"] jobsets) then [jobsets.linux.shell] else [])
+      ++ (if (lib.hasAttrByPath ["darwin" "shell"] jobsets) then [jobsets.darwin.shell] else []);
   });
 })

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@
 }:
 with packageSet;
 let
+  # For Sphinx, and ad-hoc usage
   pyEnv = pkgs.python3.withPackages (ps: [ packageSet.sphinxcontrib-haddock.sphinxcontrib-domaintools ps.sphinx ps.sphinx_rtd_theme ]);
 in haskell.packages.shellFor {
   nativeBuildInputs = [
@@ -16,8 +17,10 @@ in haskell.packages.shellFor {
     # Broken on 20.03, needs a backport
     # pkgs.sqlite-analyzer
     pkgs.sqlite-interactive
+
     # Take cabal from nixpkgs for now, see below
     pkgs.cabal-install
+    pkgs.stack
 
     pyEnv
 
@@ -36,11 +39,9 @@ in haskell.packages.shellFor {
     dev.packages.purty
     dev.packages.purs
     dev.packages.spago
-    pkgs.stack
     dev.scripts.fixStylishHaskell
     dev.scripts.fixPurty
     dev.scripts.updateClientDeps
-    pkgs.python3 # for @reactormonk who's running a python web server
   ] ++ (pkgs.stdenv.lib.optionals (!pkgs.stdenv.isDarwin) [
     # This breaks compilation of R on macOS. The latest version of R
     # does compile, so we can remove it when we upgrade to 20.09.


### PR DESCRIPTION
For some reason I had previously felt like it was unhygienic to build the shell expression in CI, but on reflection I think it's just a good idea, and the best way to ensure that the actual shell expression continues to build on all platforms.