### PR TITLE
SCP-644 - Simplify Scale implementation

### DIFF
--- a/marlowe/test/OldAnalysis/FSSemantics.hs
+++ b/marlowe/test/OldAnalysis/FSSemantics.hs
@@ -139,6 +139,7 @@ data Value = AvailableMoney AccountId
            | AddValue Value Value
            | SubValue Value Value
            | MulValue Value Value
+           | Scale Rational Value
            | ChoiceValue ChoiceId
            | SlotIntervalStart
            | SlotIntervalEnd
@@ -323,6 +324,10 @@ evalValue bnds env state value =
     AddValue lhs rhs         -> go lhs + go rhs
     SubValue lhs rhs         -> go lhs - go rhs
     MulValue lhs rhs         -> go lhs * go rhs
+    Scale s rhs              -> let (n, d) = (numerator s, denominator s)
+                                    nn = go rhs * literal n
+                                    (q, r) = nn `sQuotRem` literal d in
+                                ite (abs r * 2 .< literal (abs d)) q (q + signum nn * literal (signum d))
     ChoiceValue (ChoiceId c p) -> SM.maybe (literal 0)
                                            id
                                            (IntegerArray.lookup c $ choice state)

--- a/marlowe/test/Spec.hs
+++ b/marlowe/test/Spec.hs
@@ -18,5 +18,7 @@ tests = testGroup "Marlowe"
 --                                           Spec.Marlowe.Marlowe.prop_showWorksForContracts
                             ]
     , testGroup "Static Analysis"
-        [ testProperty "No false positives" Spec.Marlowe.Marlowe.prop_noFalsePositives ]
+        [ testProperty "No false positives" Spec.Marlowe.Marlowe.prop_noFalsePositives
+--        , testProperty "Same as old implementation" Spec.Marlowe.Marlowe.runManuallySameAsOldImplementation
+        ]
     ]

--- a/marlowe/test/Spec/Marlowe/Marlowe.hs
+++ b/marlowe/test/Spec/Marlowe/Marlowe.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -w #-}
 module Spec.Marlowe.Marlowe
-    ( prop_noFalsePositives, tests, prop_showWorksForContracts
+    ( prop_noFalsePositives, tests, prop_showWorksForContracts, runManuallySameAsOldImplementation
     )
 where
 
@@ -304,7 +304,6 @@ valuesFormAbelianGroup = property $ do
         -- substraction works
         eval (SubValue (AddValue a b) b) === eval a
 
-
 scaleRoundingTest :: Property
 scaleRoundingTest = property $ do
     let eval = evalValue (Environment (Slot 10, Slot 1000)) (emptyState (Slot 10))
@@ -313,8 +312,9 @@ scaleRoundingTest = property $ do
             n <- amount
             d <- suchThat amount (/= 0)
             return (n, d)
-    forAll gen $ \(n, d) -> eval (Scale (n P.% d) (Constant 1)) === round (n % d)
-
+    forAll gen $ \(n, d) -> eval (Scale (n P.% d) (Constant 1)) === halfAwayRound (n % d)
+    where
+      halfAwayRound fraction = let (n,f) = properFraction fraction in n + round (f + 1) - 1
 
 scaleMulTest :: Property
 scaleMulTest = property $ do


### PR DESCRIPTION
Simplify implementation of Scale, and change it to `Round half away from zero`.
Also added detection for shadowed `Let` variables in new static analysis implementation.