### PR TITLE
Change Marlowe Term to include end position

### DIFF
--- a/marlowe-playground-client/grammar.ne
+++ b/marlowe-playground-client/grammar.ne
@@ -72,35 +72,35 @@ someWS -> ws:+
 # none or some whitespace
 manyWS -> ws:*
 
-lparen -> %lparen  manyWS
+lparen -> %lparen  manyWS {% ([t,]) => t %}
 
-rparen ->  manyWS %rparen
+rparen ->  manyWS %rparen {% ([,t]) => t %}
 
 lsquare -> %lsquare manyWS
 
 rsquare ->  manyWS %rsquare
 
-hole -> %hole {% ([hole]) => opts.mkHole(hole.value.substring(1))({row: hole.line, column: hole.col}) %}
+hole -> %hole {% ([hole]) => opts.mkHole(hole.value.substring(1))({startLineNumber: hole.line, startColumn: hole.col, endLineNumber: hole.line, endColumn: hole.col + hole.value.length}) %}
 
 number
    -> %number {% ([n]) => opts.mkBigInteger(n.value) %}
     | lparen %number rparen {% ([,n,]) => opts.mkBigInteger(n.value) %}
 
 timeout
-   -> %number {% ([n]) => opts.mkTimeout(n.value)({row: n.line, column: n.col}) %}
-    | lparen %number rparen {% ([,n,]) => opts.mkTimeout(n.value)({row: n.line, column: n.col}) %}
+   -> %number {% ([n]) => opts.mkTimeout(n.value)({startLineNumber: n.line, startColumn: n.col, endLineNumber: n.line, endColumn: n.col + n.value.toString().length}) %}
+    | lparen %number rparen {% ([start,n,end]) => opts.mkTimeout(n.value)({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 string
    -> %string {% ([s]) => s.value %}
 
 topContract
    -> hole {% ([hole]) => hole %}
-    | "Close" {% ([{line, col}]) => opts.mkTerm(opts.mkClose)({row: line, column: col}) %}
-    | "Pay" someWS accountId someWS payee someWS token someWS value someWS contract {% ([{line, col},,accountId,,payee,,token,,value,,contract]) => opts.mkTerm(opts.mkPay(accountId)(payee)(token)(value)(contract))({row: line, column: col}) %}
-    | "If" someWS observation someWS contract someWS contract {% ([{line, col},,observation,,contract1,,contract2]) => opts.mkTerm(opts.mkIf(observation)(contract1)(contract2))({row: line, column: col}) %}
-    | "When" someWS lsquare cases:* rsquare someWS timeout someWS contract {% ([{line, col},,,cases,,,timeout,,contract]) => opts.mkTerm(opts.mkWhen(cases)(timeout)(contract))({row: line, column: col}) %}
-    | "Let" someWS valueId someWS value someWS contract {% ([{line, col},,valueId,,value,,contract]) => opts.mkTerm(opts.mkLet(valueId)(value)(contract))({row: line, column: col}) %}
-    | "Assert" someWS observation someWS contract {% ([{line, col},,observation,,contract]) => opts.mkTerm(opts.mkAssert(observation)(contract))({row: line, column: col}) %}
+    | "Close" {% ([{line, col}]) => opts.mkTerm(opts.mkClose)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 5}) %}
+    | "Pay" someWS accountId someWS payee someWS token someWS value someWS contract {% ([{line, col},,accountId,,payee,,token,,value,,contract]) => opts.mkTerm(opts.mkPay(accountId)(payee)(token)(value)(contract))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract).endLineNumber, endColumn: opts.getRange(contract).endColumn}) %}
+    | "If" someWS observation someWS contract someWS contract {% ([{line, col},,observation,,contract1,,contract2]) => opts.mkTerm(opts.mkIf(observation)(contract1)(contract2))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract2).endLineNumber, endColumn: opts.getRange(contract2).endColumn}) %}
+    | "When" someWS lsquare cases:* rsquare someWS timeout someWS contract {% ([{line, col},,,cases,,,timeout,,contract]) => opts.mkTerm(opts.mkWhen(cases)(timeout)(contract))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract).endLineNumber, endColumn: opts.getRange(contract).endColumn}) %}
+    | "Let" someWS valueId someWS value someWS contract {% ([{line, col},,valueId,,value,,contract]) => opts.mkTerm(opts.mkLet(valueId)(value)(contract))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract).endLineNumber, endColumn: opts.getRange(contract).endColumn}) %}
+    | "Assert" someWS observation someWS contract {% ([{line, col},,observation,,contract]) => opts.mkTerm(opts.mkAssert(observation)(contract))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract).endLineNumber, endColumn: opts.getRange(contract).endColumn}) %}
 
 cases
    -> hole {% ([hole]) => hole %}
@@ -109,8 +109,8 @@ cases
 
 case
    -> hole {% ([hole]) => hole %}
-    | "Case" someWS action someWS contract {% ([{line, col},,action,,contract]) => opts.mkTerm(opts.mkCase(action)(contract))({row: line, column: col}) %}
-    | lparen case rparen {% ([,case_,]) => case_ %}
+    | "Case" someWS action someWS contract {% ([{line, col},,action,,contract]) => opts.mkTerm(opts.mkCase(action)(contract))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract).endLineNumber, endColumn: opts.getRange(contract).endColumn}) %}
+    | lparen "Case" someWS action someWS contract rparen {% ([start,,,action,,contract,end]) => opts.mkTerm(opts.mkCase(action)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 bounds
    -> hole {% ([hole]) => hole %}
@@ -119,27 +119,31 @@ bounds
 
 bound
    -> hole {% ([hole]) => hole %}
-    | "Bound" someWS number someWS number {% ([{line, col},,bottom,,top]) => opts.mkTerm(opts.mkBound(bottom)(top))({row: line, column: col}) %}
+    | "Bound" someWS number someWS number {% ([{line, col},,bottom,,top]) => opts.mkTerm(opts.mkBound(bottom)(top))({startLineNumber: line, startColumn: col, endLineNumber: top.line, endColumn: top.col + top.value.toString().length}) %}
     | lparen bound rparen {% ([,bound,]) => bound %}
 
 action
    -> hole {% ([hole]) => hole %}
-    | lparen "Deposit" someWS accountId someWS party someWS token someWS value rparen {% ([,{line, col},,accountId,,party,,token,,value,]) => opts.mkTerm(opts.mkDeposit(accountId)(party)(token)(value))({row: line, column: col}) %}
-    | lparen "Choice" someWS choiceId someWS lsquare bounds:* rsquare rparen {% ([,{line, col},,choiceId,,,bounds,,]) => opts.mkTerm(opts.mkChoice(choiceId)(bounds))({row: line, column: col}) %}
-    | lparen "Notify" someWS observation rparen {% ([,{line, col},,observation,]) => opts.mkTerm(opts.mkNotify(observation))({row: line, column: col}) %}
+    | lparen "Deposit" someWS accountId someWS party someWS token someWS value rparen {% ([start,{line, col},,accountId,,party,,token,,value,end]) => opts.mkTerm(opts.mkDeposit(accountId)(party)(token)(value))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Choice" someWS choiceId someWS lsquare bounds:* rsquare rparen {% ([start,{line, col},,choiceId,,,bounds,,end]) => opts.mkTerm(opts.mkChoice(choiceId)(bounds))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Notify" someWS observation rparen {% ([start,{line, col},,observation,end]) => opts.mkTerm(opts.mkNotify(observation))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
-# Beacause top level contracts don't have parenthesis we need to duplicate the lower-level contracts that don't have parenthesis here
+# Beacause top level contracts don't have parenthesis we need to duplicate the lower-level contracts in order to get the start and end positions
 contract
    -> hole {% ([hole]) => hole %}
-    | "Close" {% ([{line,col}]) => opts.mkTerm(opts.mkClose)({row: line, column: col}) %}
-    | lparen topContract rparen {% ([,contract,]) => contract %}
+    | "Close" {% ([{line,col}]) => opts.mkTerm(opts.mkClose)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 5}) %}
+    | lparen "Pay" someWS accountId someWS payee someWS token someWS value someWS contract rparen {% ([start,{line, col},,accountId,,payee,,token,,value,,contract,end]) => opts.mkTerm(opts.mkPay(accountId)(payee)(token)(value)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "If" someWS observation someWS contract someWS contract rparen {% ([start,{line, col},,observation,,contract1,,contract2,end]) => opts.mkTerm(opts.mkIf(observation)(contract1)(contract2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "When" someWS lsquare cases:* rsquare someWS timeout someWS contract rparen {% ([start,{line, col},,,cases,,,timeout,,contract,end]) => opts.mkTerm(opts.mkWhen(cases)(timeout)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Let" someWS valueId someWS value someWS contract rparen {% ([start,{line, col},,valueId,,value,,contract,end]) => opts.mkTerm(opts.mkLet(valueId)(value)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Assert" someWS observation someWS contract rparen {% ([start,{line, col},,observation,,contract,end]) => opts.mkTerm(opts.mkAssert(observation)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 choiceId
    -> lparen %CHOICE_ID someWS string someWS party rparen {% ([,{line,col},,cid,,party,]) => opts.mkChoiceId(cid)(party) %}
 
 # FIXME: There is a difference between the Haskell pretty printer and the purescript parser
 valueId
-   -> %string {% ([{value,line,col}]) => opts.mkTermWrapper(opts.mkValueId(value))({row: line, column: col}) %}
+   -> %string {% ([{value,line,col}]) => opts.mkTermWrapper(opts.mkValueId(value))({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + value.length}) %}
 # valueId -> lparen %VALUE_ID someWS string rparen
 
 accountId
@@ -147,47 +151,47 @@ accountId
 
 token
    -> hole {% ([hole]) => hole %}
-    | lparen %TOKEN someWS string someWS string rparen {% ([,{line,col},,a,,b,]) => opts.mkTerm(opts.mkToken(a)(b))({row: line, column: col}) %}
+    | lparen %TOKEN someWS string someWS string rparen {% ([start,{line,col},,a,,b,end]) => opts.mkTerm(opts.mkToken(a)(b))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 party
    -> hole {% ([hole]) => hole %}
-    | lparen "PK" someWS string rparen {% ([,{line,col},,k,]) => opts.mkTerm(opts.mkPK(k))({row: line, column: col}) %}
-    | lparen "Role" someWS string rparen {% ([,{line,col},,k,]) => opts.mkTerm(opts.mkRole(k))({row: line, column: col}) %}
+    | lparen "PK" someWS string rparen {% ([start,{line,col},,k,end]) => opts.mkTerm(opts.mkPK(k))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Role" someWS string rparen {% ([start,{line,col},,k,end]) => opts.mkTerm(opts.mkRole(k))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 payee
    -> hole {% ([hole]) => hole %}
-    | lparen "Account" someWS accountId rparen {% ([,{line,col},,accountId,]) => opts.mkTerm(opts.mkAccount(accountId))({row: line, column: col}) %}
-    | lparen "Party" someWS party rparen {% ([,{line,col},,party,]) => opts.mkTerm(opts.mkParty(party))({row: line, column: col}) %}
+    | lparen "Account" someWS accountId rparen {% ([start,{line,col},,accountId,end]) => opts.mkTerm(opts.mkAccount(accountId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Party" someWS party rparen {% ([start,{line,col},,party,end]) => opts.mkTerm(opts.mkParty(party))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 observation
    -> hole {% ([hole]) => hole %}
-    | lparen "AndObs" someWS observation someWS observation rparen {% ([,{line,col},,o1,,o2,]) => opts.mkTerm(opts.mkAndObs(o1)(o2))({row: line, column: col}) %}
-    | lparen "OrObs" someWS observation someWS observation rparen {% ([,{line,col},,o1,,o2,]) => opts.mkTerm(opts.mkOrObs(o1)(o2))({row: line, column: col}) %}
-    | lparen "NotObs" someWS observation rparen {% ([,{line,col},,o1,]) => opts.mkTerm(opts.mkNotObs(o1))({row: line, column: col}) %}
-    | lparen "ChoseSomething" someWS choiceId rparen {% ([,{line,col},,choiceId,]) => opts.mkTerm(opts.mkChoseSomething(choiceId))({row: line, column: col}) %}
-    | lparen "ValueGE" someWS value someWS value rparen {% ([,{line,col},,v1,,v2,]) => opts.mkTerm(opts.mkValueGE(v1)(v2))({row: line, column: col}) %}
-    | lparen "ValueGT" someWS value someWS value rparen {% ([,{line,col},,v1,,v2,]) => opts.mkTerm(opts.mkValueGT(v1)(v2))({row: line, column: col}) %}
-    | lparen "ValueLT" someWS value someWS value rparen {% ([,{line,col},,v1,,v2,]) => opts.mkTerm(opts.mkValueLT(v1)(v2))({row: line, column: col}) %}
-    | lparen "ValueLE" someWS value someWS value rparen {% ([,{line,col},,v1,,v2,]) => opts.mkTerm(opts.mkValueLE(v1)(v2))({row: line, column: col}) %}
-    | lparen "ValueEQ" someWS value someWS value rparen {% ([,{line,col},,v1,,v2,]) => opts.mkTerm(opts.mkValueEQ(v1)(v2))({row: line, column: col}) %}
-    | "TrueObs" {% ([{line,col}]) => opts.mkTerm(opts.mkTrueObs)({row: line, column: col}) %}
-    | "FalseObs" {% ([{line,col}]) => opts.mkTerm(opts.mkFalseObs)({row: line, column: col}) %}
+    | lparen "AndObs" someWS observation someWS observation rparen {% ([start,{line,col},,o1,,o2,end]) => opts.mkTerm(opts.mkAndObs(o1)(o2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "OrObs" someWS observation someWS observation rparen {% ([start,{line,col},,o1,,o2,end]) => opts.mkTerm(opts.mkOrObs(o1)(o2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "NotObs" someWS observation rparen {% ([start,{line,col},,o1,end]) => opts.mkTerm(opts.mkNotObs(o1))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ChoseSomething" someWS choiceId rparen {% ([start,{line,col},,choiceId,end]) => opts.mkTerm(opts.mkChoseSomething(choiceId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ValueGE" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkValueGE(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ValueGT" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkValueGT(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ValueLT" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkValueLT(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ValueLE" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkValueLE(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ValueEQ" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkValueEQ(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | "TrueObs" {% ([{line,col}]) => opts.mkTerm(opts.mkTrueObs)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 7}) %}
+    | "FalseObs" {% ([{line,col}]) => opts.mkTerm(opts.mkFalseObs)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 8}) %}
 
 rational
     -> hole {% ([hole]) => hole %}
-    | number manyWS %ratio manyWS number {%([num,,,,denom,]) => opts.mkTerm(opts.mkRational(num)(denom))({row: num.line, column: num.col}) %}
+    | number manyWS %ratio manyWS number {%([num,,,,denom]) => opts.mkTerm(opts.mkRational(num)(denom))({startLineNumber: num.line, startColumn: num.col, endLineNumber: denom.line, endColumn: denom.col + denom.value.toString().length}) %}
 
 value
    -> hole {% ([hole]) => hole %}
-    | lparen "AvailableMoney" someWS accountId someWS token rparen {% ([,{line,col},,accountId,,token,]) => opts.mkTerm(opts.mkAvailableMoney(accountId)(token))({row: line, column: col}) %}
-    | lparen "Constant" someWS number rparen {% ([,{line,col},,number,]) => opts.mkTerm(opts.mkConstant(number))({row: line, column: col}) %}
-    | lparen "NegValue" someWS value rparen {% ([,{line,col},,value,]) => opts.mkTerm(opts.mkNegValue(value))({row: line, column: col}) %}
-    | lparen "AddValue" someWS value someWS value rparen {% ([,{line,col},,v1,,v2,]) => opts.mkTerm(opts.mkAddValue(v1)(v2))({row: line, column: col}) %}
-    | lparen "SubValue" someWS value someWS value rparen {% ([,{line,col},,v1,,v2,]) => opts.mkTerm(opts.mkSubValue(v1)(v2))({row: line, column: col}) %}
-    | lparen "MulValue" someWS value someWS value rparen {% ([,{line,col},,v1,,v2,]) => opts.mkTerm(opts.mkMulValue(v1)(v2))({row: line, column: col}) %}
-    | lparen "Scale" someWS lparen rational rparen someWS value rparen {% ([,{line,col},,,ratio,,,v,]) => opts.mkTerm(opts.mkScale(ratio)(v))({row: line, column: col}) %}
-    | lparen "ChoiceValue" someWS choiceId rparen {% ([,{line,col},,choiceId,]) => opts.mkTerm(opts.mkChoiceValue(choiceId))({row: line, column: col}) %}
-    | "SlotIntervalStart" {% ([{line,col}]) => opts.mkTerm(opts.mkSlotIntervalStart)({row: line, column: col}) %}
-    | "SlotIntervalEnd" {% ([{line,col}]) => opts.mkTerm(opts.mkSlotIntervalEnd)({row: line, column: col}) %}
-    | lparen "UseValue" someWS valueId rparen {% ([,{line,col},,valueId,]) => opts.mkTerm(opts.mkUseValue(valueId))({row: line, column: col}) %}
-    | lparen "Cond" someWS observation someWS value someWS value rparen {% ([,{line,col},,oo,,v1,,v2,]) => opts.mkTerm(opts.mkCond(oo)(v1)(v2))({row: line, column: col}) %}
+    | lparen "AvailableMoney" someWS accountId someWS token rparen {% ([start,{line,col},,accountId,,token,end]) => opts.mkTerm(opts.mkAvailableMoney(accountId)(token))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Constant" someWS number rparen {% ([start,{line,col},,number,end]) => opts.mkTerm(opts.mkConstant(number))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "NegValue" someWS value rparen {% ([start,{line,col},,value,end]) => opts.mkTerm(opts.mkNegValue(value))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "AddValue" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkAddValue(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "SubValue" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkSubValue(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "MulValue" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkMulValue(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Scale" someWS lparen rational rparen someWS value rparen {% ([start,{line,col},,,ratio,,,v,end]) => opts.mkTerm(opts.mkScale(ratio)(v))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ChoiceValue" someWS choiceId rparen {% ([start,{line,col},,choiceId,end]) => opts.mkTerm(opts.mkChoiceValue(choiceId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | "SlotIntervalStart" {% ([{line,col}]) => opts.mkTerm(opts.mkSlotIntervalStart)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 17}) %}
+    | "SlotIntervalEnd" {% ([{line,col}]) => opts.mkTerm(opts.mkSlotIntervalEnd)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 15}) %}
+    | lparen "UseValue" someWS valueId rparen {% ([start,{line,col},,valueId,end]) => opts.mkTerm(opts.mkUseValue(valueId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Cond" someWS observation someWS value someWS value rparen {% ([start,{line,col},,oo,,v1,,v2,end]) => opts.mkTerm(opts.mkCond(oo)(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}

--- a/marlowe-playground-client/src/Halogen/Blockly.purs
+++ b/marlowe-playground-client/src/Halogen/Blockly.purs
@@ -21,7 +21,7 @@ import Halogen.HTML (HTML, button, div, text)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes, id_, ref)
 import Marlowe.Blockly (buildBlocks, buildGenerator)
-import Marlowe.Holes (Term(..))
+import Marlowe.Holes (Term(..), emptyRange)
 import Marlowe.Parser as Parser
 import Prelude (Unit, bind, const, discard, map, pure, show, unit, ($), (<<<), (<>))
 import Text.Extra as Text
@@ -100,7 +100,7 @@ handleQuery (SetCode code next) = do
       let
         contract = case Parser.parseContract code of
           Right c -> c
-          Left _ -> Hole bs.rootBlockName Proxy { row: 0, column: 0 }
+          Left _ -> Hole bs.rootBlockName Proxy emptyRange
       pure $ ST.run (buildBlocks newBlock bs contract)
   assign _errorMessage Nothing
   pure $ Just next

--- a/marlowe-playground-client/src/Halogen/Blockly.purs
+++ b/marlowe-playground-client/src/Halogen/Blockly.purs
@@ -21,9 +21,9 @@ import Halogen.HTML (HTML, button, div, text)
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (class_, classes, id_, ref)
 import Marlowe.Blockly (buildBlocks, buildGenerator)
-import Marlowe.Holes (Term(..), emptyRange)
+import Marlowe.Holes (Term(..))
 import Marlowe.Parser as Parser
-import Prelude (Unit, bind, const, discard, map, pure, show, unit, ($), (<<<), (<>))
+import Prelude (Unit, bind, const, discard, map, pure, show, unit, zero, ($), (<<<), (<>))
 import Text.Extra as Text
 import Text.Pretty (pretty)
 import Type.Proxy (Proxy(..))
@@ -100,7 +100,7 @@ handleQuery (SetCode code next) = do
       let
         contract = case Parser.parseContract code of
           Right c -> c
-          Left _ -> Hole bs.rootBlockName Proxy emptyRange
+          Left _ -> Hole bs.rootBlockName Proxy zero
       pure $ ST.run (buildBlocks newBlock bs contract)
   assign _errorMessage Nothing
   pure $ Just next

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -25,7 +25,7 @@ import Data.Traversable (traverse, traverse_)
 import Data.Tuple (Tuple(..))
 import Halogen.HTML (HTML)
 import Halogen.HTML.Properties (id_)
-import Marlowe.Holes (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), mkDefaultTerm, mkDefaultTermWrapper)
+import Marlowe.Holes (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), emptyRange, mkDefaultTerm, mkDefaultTermWrapper)
 import Marlowe.Parser as Parser
 import Marlowe.Semantics (Rational(..))
 import Record (merge)
@@ -1037,7 +1037,7 @@ class HasBlockDefinition a b | a -> b where
 
 baseContractDefinition :: Generator -> Block -> Either String (Term Contract)
 baseContractDefinition g block = case statementToCode g block (show BaseContractType) of
-  Either.Left _ -> pure $ Hole "contract" Proxy { row: 0, column: 0 }
+  Either.Left _ -> pure $ Hole "contract" Proxy emptyRange
   Either.Right s -> parse (mkDefaultTerm <$> Parser.contract) s
 
 getAllBlocks :: Block -> Array Block
@@ -1075,7 +1075,7 @@ boundsDefinition g block = traverse (boundDefinition g) (getAllBlocks block)
 
 statementToTerm :: forall a. Generator -> Block -> String -> Parser a -> Either String (Term a)
 statementToTerm g block name p = case statementToCode g block name of
-  Either.Left _ -> pure $ Hole name Proxy { row: 0, column: 0 }
+  Either.Left _ -> pure $ Hole name Proxy emptyRange
   Either.Right s -> parse (mkDefaultTerm <$> p) s
 
 instance hasBlockDefinitionAction :: HasBlockDefinition ActionType (Term Case) where
@@ -1100,7 +1100,7 @@ instance hasBlockDefinitionAction :: HasBlockDefinition ActionType (Term Case) w
     let
       mTopboundBlock = getBlockInputConnectedTo boundsInput
     bounds <- case mTopboundBlock of
-      Either.Left _ -> pure [ Hole "bounds" Proxy { row: 0, column: 0 } ]
+      Either.Left _ -> pure [ Hole "bounds" Proxy emptyRange ]
       Either.Right topboundBlock -> boundsDefinition g topboundBlock
     contract <- statementToTerm g block "contract" Parser.contract
     pure $ mkDefaultTerm (Case (mkDefaultTerm (Choice choiceId bounds)) contract)
@@ -1123,7 +1123,7 @@ instance hasBlockDefinitionPayee :: HasBlockDefinition PayeeType (Term Payee) wh
 instance hasBlockDefinitionParty :: HasBlockDefinition PartyType (Term Party) where
   blockDefinition PKPartyType g block = do
     case getFieldValue block "pubkey" of
-      Either.Left _ -> pure $ Hole "n" Proxy { row: 0, column: 0 }
+      Either.Left _ -> pure $ Hole "n" Proxy emptyRange
       Either.Right pk -> pure $ mkDefaultTerm (PK pk)
   blockDefinition RolePartyType g block = do
     role <- getFieldValue block "role"

--- a/marlowe-playground-client/src/Marlowe/Blockly.purs
+++ b/marlowe-playground-client/src/Marlowe/Blockly.purs
@@ -25,7 +25,7 @@ import Data.Traversable (traverse, traverse_)
 import Data.Tuple (Tuple(..))
 import Halogen.HTML (HTML)
 import Halogen.HTML.Properties (id_)
-import Marlowe.Holes (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), emptyRange, mkDefaultTerm, mkDefaultTermWrapper)
+import Marlowe.Holes (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), mkDefaultTerm, mkDefaultTermWrapper)
 import Marlowe.Parser as Parser
 import Marlowe.Semantics (Rational(..))
 import Record (merge)
@@ -1037,7 +1037,7 @@ class HasBlockDefinition a b | a -> b where
 
 baseContractDefinition :: Generator -> Block -> Either String (Term Contract)
 baseContractDefinition g block = case statementToCode g block (show BaseContractType) of
-  Either.Left _ -> pure $ Hole "contract" Proxy emptyRange
+  Either.Left _ -> pure $ Hole "contract" Proxy zero
   Either.Right s -> parse (mkDefaultTerm <$> Parser.contract) s
 
 getAllBlocks :: Block -> Array Block
@@ -1075,7 +1075,7 @@ boundsDefinition g block = traverse (boundDefinition g) (getAllBlocks block)
 
 statementToTerm :: forall a. Generator -> Block -> String -> Parser a -> Either String (Term a)
 statementToTerm g block name p = case statementToCode g block name of
-  Either.Left _ -> pure $ Hole name Proxy emptyRange
+  Either.Left _ -> pure $ Hole name Proxy zero
   Either.Right s -> parse (mkDefaultTerm <$> p) s
 
 instance hasBlockDefinitionAction :: HasBlockDefinition ActionType (Term Case) where
@@ -1100,7 +1100,7 @@ instance hasBlockDefinitionAction :: HasBlockDefinition ActionType (Term Case) w
     let
       mTopboundBlock = getBlockInputConnectedTo boundsInput
     bounds <- case mTopboundBlock of
-      Either.Left _ -> pure [ Hole "bounds" Proxy emptyRange ]
+      Either.Left _ -> pure [ Hole "bounds" Proxy zero ]
       Either.Right topboundBlock -> boundsDefinition g topboundBlock
     contract <- statementToTerm g block "contract" Parser.contract
     pure $ mkDefaultTerm (Case (mkDefaultTerm (Choice choiceId bounds)) contract)
@@ -1123,7 +1123,7 @@ instance hasBlockDefinitionPayee :: HasBlockDefinition PayeeType (Term Payee) wh
 instance hasBlockDefinitionParty :: HasBlockDefinition PartyType (Term Party) where
   blockDefinition PKPartyType g block = do
     case getFieldValue block "pubkey" of
-      Either.Left _ -> pure $ Hole "n" Proxy emptyRange
+      Either.Left _ -> pure $ Hole "n" Proxy zero
       Either.Right pk -> pure $ mkDefaultTerm (PK pk)
   blockDefinition RolePartyType g block = do
     role <- getFieldValue block "role"

--- a/marlowe-playground-client/src/Marlowe/Gen.purs
+++ b/marlowe-playground-client/src/Marlowe/Gen.purs
@@ -12,7 +12,7 @@ import Data.Char.Gen (genAlpha, genDigitChar)
 import Data.Foldable (class Foldable)
 import Data.NonEmpty (NonEmpty, foldl1, (:|))
 import Data.String.CodeUnits (fromCharArray)
-import Marlowe.Holes (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), MarloweType(..), Observation(..), Party(..), Payee(..), Range, Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), emptyRange, mkArgName)
+import Marlowe.Holes (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), MarloweType(..), Observation(..), Party(..), Payee(..), Range, Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), mkArgName)
 import Marlowe.Semantics (Rational(..), CurrencySymbol, Input(..), PubKey, Slot(..), SlotInterval(..), TokenName, TransactionInput(..), TransactionWarning(..))
 import Marlowe.Semantics as S
 import Text.Parsing.StringParser (Pos)
@@ -49,7 +49,7 @@ genSlot :: forall m. MonadGen m => MonadRec m => m Slot
 genSlot = Slot <$> genBigInteger
 
 genTimeout :: forall m. MonadGen m => MonadRec m => m (TermWrapper Slot)
-genTimeout = TermWrapper <$> genSlot <*> pure emptyRange
+genTimeout = TermWrapper <$> genSlot <*> pure zero
 
 genValueId :: forall m. MonadGen m => MonadRec m => MonadReader Boolean m => m ValueId
 genValueId = ValueId <$> genString
@@ -109,11 +109,11 @@ genHole name = do
 genTerm :: forall m a. MonadGen m => MonadRec m => MonadReader Boolean m => String -> m a -> m (Term a)
 genTerm name g = do
   withHoles <- ask
-  oneOf $ (Term <$> g <*> pure emptyRange) :| (if withHoles then [ genHole name ] else [])
+  oneOf $ (Term <$> g <*> pure zero) :| (if withHoles then [ genHole name ] else [])
 
 genTermWrapper :: forall m a. MonadGen m => MonadRec m => MonadReader Boolean m => m a -> m (TermWrapper a)
 genTermWrapper g = do
-  TermWrapper <$> g <*> pure emptyRange
+  TermWrapper <$> g <*> pure zero
 
 genAccountId :: forall m. MonadGen m => MonadRec m => MonadReader Boolean m => m AccountId
 genAccountId = do

--- a/marlowe-playground-client/src/Marlowe/Gen.purs
+++ b/marlowe-playground-client/src/Marlowe/Gen.purs
@@ -12,7 +12,7 @@ import Data.Char.Gen (genAlpha, genDigitChar)
 import Data.Foldable (class Foldable)
 import Data.NonEmpty (NonEmpty, foldl1, (:|))
 import Data.String.CodeUnits (fromCharArray)
-import Marlowe.Holes (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), MarloweType(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), mkArgName)
+import Marlowe.Holes (AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), MarloweType(..), Observation(..), Party(..), Payee(..), Range, Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), emptyRange, mkArgName)
 import Marlowe.Semantics (Rational(..), CurrencySymbol, Input(..), PubKey, Slot(..), SlotInterval(..), TokenName, TransactionInput(..), TransactionWarning(..))
 import Marlowe.Semantics as S
 import Text.Parsing.StringParser (Pos)
@@ -49,7 +49,7 @@ genSlot :: forall m. MonadGen m => MonadRec m => m Slot
 genSlot = Slot <$> genBigInteger
 
 genTimeout :: forall m. MonadGen m => MonadRec m => m (TermWrapper Slot)
-genTimeout = TermWrapper <$> genSlot <*> pure { row: 0, column: 0 }
+genTimeout = TermWrapper <$> genSlot <*> pure emptyRange
 
 genValueId :: forall m. MonadGen m => MonadRec m => MonadReader Boolean m => m ValueId
 genValueId = ValueId <$> genString
@@ -91,22 +91,29 @@ genBound = do
 genPosition :: forall m. MonadGen m => MonadRec m => m Pos
 genPosition = chooseInt 0 1000
 
+genRange :: forall m. MonadGen m => MonadRec m => m Range
+genRange = do
+  startLineNumber <- genPosition
+  startColumn <- genPosition
+  endLineNumber <- genPosition
+  endColumn <- genPosition
+  pure { startLineNumber, startColumn, endLineNumber, endColumn }
+
 genHole :: forall m a. MonadGen m => MonadRec m => String -> m (Term a)
 genHole name = do
   -- name <- suchThat genString (\s -> s /= "")
   proxy <- pure (Proxy :: Proxy a)
-  row <- genPosition
-  column <- genPosition
-  pure $ Hole name proxy { row, column }
+  range <- genRange
+  pure $ Hole name proxy range
 
 genTerm :: forall m a. MonadGen m => MonadRec m => MonadReader Boolean m => String -> m a -> m (Term a)
 genTerm name g = do
   withHoles <- ask
-  oneOf $ (Term <$> g <*> pure { row: 0, column: 0 }) :| (if withHoles then [ genHole name ] else [])
+  oneOf $ (Term <$> g <*> pure emptyRange) :| (if withHoles then [ genHole name ] else [])
 
 genTermWrapper :: forall m a. MonadGen m => MonadRec m => MonadReader Boolean m => m a -> m (TermWrapper a)
 genTermWrapper g = do
-  TermWrapper <$> g <*> pure { row: 0, column: 0 }
+  TermWrapper <$> g <*> pure emptyRange
 
 genAccountId :: forall m. MonadGen m => MonadRec m => MonadReader Boolean m => m AccountId
 genAccountId = do

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -253,7 +253,7 @@ constructMarloweType constructorName (MarloweHole { range: { startColumn, startL
       let
         newArgs = getMarloweConstructors marloweType
 
-        hole = MarloweHole { name, marloweType, range: emptyRange }
+        hole = MarloweHole { name, marloweType, range: zero }
       in
         constructMarloweType name hole newArgs
 
@@ -267,14 +267,6 @@ type Range
     , endLineNumber :: Int
     , endColumn :: Int
     }
-
-emptyRange :: Range
-emptyRange =
-  { startLineNumber: 0
-  , startColumn: 0
-  , endLineNumber: 0
-  , endColumn: 0
-  }
 
 -- We need to compare the fields in the correct order
 compareRange :: Range -> Range -> Ordering
@@ -312,7 +304,7 @@ mkHole :: forall a. String -> Range -> Term a
 mkHole name range = Hole name Proxy range
 
 mkDefaultTerm :: forall a. a -> Term a
-mkDefaultTerm a = Term a emptyRange
+mkDefaultTerm a = Term a zero
 
 class HasMarloweHoles a where
   getHoles :: a -> Holes -> Holes
@@ -380,7 +372,7 @@ instance termWrapperHasContractData :: HasContractData a => HasContractData (Ter
   gatherContractData (TermWrapper a _) s = gatherContractData a s
 
 mkDefaultTermWrapper :: forall a. a -> TermWrapper a
-mkDefaultTermWrapper a = TermWrapper a emptyRange
+mkDefaultTermWrapper a = TermWrapper a zero
 
 -- special case
 instance fromTermRational :: FromTerm Rational Rational where

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -1,11 +1,12 @@
 module Marlowe.Holes where
 
 import Prelude
-import Data.Array (foldMap, foldl, mapWithIndex)
+import Data.Array (foldMap)
 import Data.Array as Array
 import Data.BigInteger (BigInteger)
 import Data.Enum (class BoundedEnum, class Enum, upFromIncluding)
 import Data.Foldable (intercalate)
+import Data.Function (on)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Bounded (genericBottom, genericTop)
 import Data.Generic.Rep.Enum (genericCardinality, genericFromEnum, genericPred, genericSucc, genericToEnum)
@@ -18,19 +19,15 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (class Newtype)
 import Data.Set (Set)
 import Data.Set as Set
-import Data.String (Pattern(..), contains, length, splitAt, toLower)
+import Data.String (Pattern(..), contains, splitAt, toLower)
 import Data.String.CodeUnits (dropRight)
-import Data.String.Extra (unlines)
 import Data.Symbol (SProxy(..))
 import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
-import Data.Tuple.Nested ((/\))
 import Marlowe.Semantics (PubKey, Rational(..), Slot, TokenName)
 import Marlowe.Semantics as S
 import Monaco (CompletionItem, IRange, completionItemKind)
 import Text.Extra as Text
-import Text.Parsing.StringParser (Pos)
-import Text.Parsing.StringParser.Basic (lines, replaceInPosition)
 import Text.Pretty (class Args, class Pretty, genericHasArgs, genericHasNestedArgs, genericPretty, hasArgs, hasNestedArgs, pretty)
 import Text.Pretty as P
 import Type.Proxy (Proxy(..))
@@ -227,10 +224,10 @@ getConstructorFromMarloweType t = case Set.toUnfoldable $ Map.keys (getMarloweCo
 -- | Creates a String consisting of the data constructor name followed by argument holes
 --   e.g. "When [ ?case_10 ] ?timeout_11 ?contract_12"
 constructMarloweType :: String -> MarloweHole -> Map String (Array Argument) -> String
-constructMarloweType constructorName (MarloweHole { row, column }) m = case Map.lookup constructorName m of
+constructMarloweType constructorName (MarloweHole { range: { startColumn, startLineNumber } }) m = case Map.lookup constructorName m of
   Nothing -> ""
   Just [] -> constructorName
-  Just vs -> parens row column $ constructorName <> " " <> intercalate " " (map showArgument vs)
+  Just vs -> parens startLineNumber startColumn $ constructorName <> " " <> intercalate " " (map showArgument vs)
   where
   showArgument EmptyArrayArg = "[]"
 
@@ -256,7 +253,7 @@ constructMarloweType constructorName (MarloweHole { row, column }) m = case Map.
       let
         newArgs = getMarloweConstructors marloweType
 
-        hole = MarloweHole { name, marloweType, row: 0, column: 0 }
+        hole = MarloweHole { name, marloweType, range: emptyRange }
       in
         constructMarloweType name hole newArgs
 
@@ -264,15 +261,32 @@ constructMarloweType constructorName (MarloweHole { row, column }) m = case Map.
 
   parens _ _ text = "(" <> text <> ")"
 
-mkHole :: forall a. String -> { row :: Pos, column :: Pos } -> Term a
-mkHole name position = Hole name Proxy position
+type Range
+  = { startLineNumber :: Int
+    , startColumn :: Int
+    , endLineNumber :: Int
+    , endColumn :: Int
+    }
 
-mkDefaultTerm :: forall a. a -> Term a
-mkDefaultTerm a = Term a { row: 0, column: 0 }
+emptyRange :: Range
+emptyRange =
+  { startLineNumber: 0
+  , startColumn: 0
+  , endLineNumber: 0
+  , endColumn: 0
+  }
+
+-- We need to compare the fields in the correct order
+compareRange :: Range -> Range -> Ordering
+compareRange =
+  compare `on` _.startColumn
+    <> compare `on` _.startLineNumber
+    <> compare `on` _.endLineNumber
+    <> compare `on` _.endColumn
 
 data Term a
-  = Term a { row :: Pos, column :: Pos }
-  | Hole String (Proxy a) { row :: Pos, column :: Pos }
+  = Term a Range
+  | Hole String (Proxy a) Range
 
 derive instance genericTerm :: Generic (Term a) _
 
@@ -293,6 +307,12 @@ instance hasArgsTerm :: Args a => Args (Term a) where
   hasArgs _ = false
   hasNestedArgs (Term a _) = hasNestedArgs a
   hasNestedArgs _ = false
+
+mkHole :: forall a. String -> Range -> Term a
+mkHole name range = Hole name Proxy range
+
+mkDefaultTerm :: forall a. a -> Term a
+mkDefaultTerm a = Term a emptyRange
 
 class HasMarloweHoles a where
   getHoles :: a -> Holes -> Holes
@@ -323,13 +343,17 @@ instance termFromTerm :: FromTerm a b => FromTerm (Term a) b where
   fromTerm (Term a _) = fromTerm a
   fromTerm _ = Nothing
 
-getPosition :: forall a. Term a -> { row :: Pos, column :: Pos }
-getPosition (Term _ pos) = pos
+-- FIXME: I need to add the end position to Term in the entire project
+-- in the nearley parser I can get this info by finding the position of the last paren
+-- once I've done this I can fix the markers which actually have the incorrect range
+getRange :: forall a. Term a -> Range
+getRange (Term _ range) = range
 
-getPosition (Hole _ _ pos) = pos
+getRange (Hole _ _ range) = range
 
+-- A TermWrapper is like a Term but doesn't have a Hole constructor
 data TermWrapper a
-  = TermWrapper a { row :: Pos, column :: Pos }
+  = TermWrapper a Range
 
 derive instance genericTermWrapper :: Generic a r => Generic (TermWrapper a) _
 
@@ -356,7 +380,7 @@ instance termWrapperHasContractData :: HasContractData a => HasContractData (Ter
   gatherContractData (TermWrapper a _) s = gatherContractData a s
 
 mkDefaultTermWrapper :: forall a. a -> TermWrapper a
-mkDefaultTermWrapper a = TermWrapper a { row: 0, column: 0 }
+mkDefaultTermWrapper a = TermWrapper a emptyRange
 
 -- special case
 instance fromTermRational :: FromTerm Rational Rational where
@@ -367,8 +391,7 @@ data MarloweHole
   = MarloweHole
     { name :: String
     , marloweType :: MarloweType
-    , row :: Pos
-    , column :: Pos
+    , range :: Range
     }
 
 derive instance genericMarloweHole :: Generic MarloweHole _
@@ -376,7 +399,7 @@ derive instance genericMarloweHole :: Generic MarloweHole _
 derive instance eqMarloweHole :: Eq MarloweHole
 
 instance ordMarloweHole :: Ord MarloweHole where
-  compare (MarloweHole { row: la, column: ca }) (MarloweHole { row: lb, column: cb }) = if la == lb then compare ca cb else compare la lb
+  compare (MarloweHole { range: a }) (MarloweHole { range: b }) = compareRange a b
 
 instance showMarloweHole :: Show MarloweHole where
   show = genericShow
@@ -450,9 +473,9 @@ derive newtype instance monoidHoles :: Monoid Holes
 insertHole :: forall a. IsMarloweType a => Term a -> Holes -> Holes
 insertHole (Term _ _) m = m
 
-insertHole (Hole name proxy { row, column }) (Holes m) = Holes $ Map.alter f name m
+insertHole (Hole name proxy range) (Holes m) = Holes $ Map.alter f name m
   where
-  marloweHole = MarloweHole { name, marloweType: (marloweType proxy), row, column }
+  marloweHole = MarloweHole { name, marloweType: (marloweType proxy), range }
 
   f v = Just (Set.insert marloweHole $ fromMaybe mempty v)
 
@@ -904,34 +927,3 @@ termToValue _ = Nothing
 
 class FromTerm a b where
   fromTerm :: a -> Maybe b
-
--- Replace all holes of a certain name with the value
-replaceInPositions :: String -> MarloweHole -> Array MarloweHole -> String -> String
-replaceInPositions constructor firstHole@(MarloweHole { marloweType, name }) holes currentContract = unlines $ mapWithIndex go (lines currentContract)
-  where
-  go :: Int -> String -> String
-  go idx currentLine =
-    let
-      m = getMarloweConstructors marloweType
-
-      holeString = constructMarloweType constructor firstHole m
-
-      stringLengthDifference = (length holeString) - (length name)
-
-      (final /\ _) =
-        foldl
-          ( \(currString /\ currLength) hole@(MarloweHole { name, row, column }) ->
-              if row == (idx + 1) then
-                let
-                  newString = replaceInPosition { start: column - 1 + currLength, end: column + currLength + (length name), string: currString, replacement: holeString }
-
-                  newLength = currLength + stringLengthDifference
-                in
-                  (newString /\ newLength)
-              else
-                (currString /\ currLength)
-          )
-          (currentLine /\ 0)
-          holes
-    in
-      final

--- a/marlowe-playground-client/src/Marlowe/Linter.purs
+++ b/marlowe-playground-client/src/Marlowe/Linter.purs
@@ -42,7 +42,7 @@ import Data.Symbol (SProxy(..))
 import Data.Traversable (traverse_)
 import Data.Tuple.Nested (type (/\), (/\))
 import Help (holeText)
-import Marlowe.Holes (Action(..), Argument, Case(..), Contract(..), Holes(..), MarloweHole(..), MarloweType, Observation(..), Term(..), TermWrapper(..), Value(..), Range, constructMarloweType, emptyRange, fromTerm, getHoles, getMarloweConstructors, getRange, holeSuggestions, insertHole, readMarloweType)
+import Marlowe.Holes (Action(..), Argument, Case(..), Contract(..), Holes(..), MarloweHole(..), MarloweType, Observation(..), Term(..), TermWrapper(..), Value(..), Range, constructMarloweType, fromTerm, getHoles, getMarloweConstructors, getRange, holeSuggestions, insertHole, readMarloweType)
 import Marlowe.Parser (ContractParseError(..), parseContract)
 import Marlowe.Semantics (Rational(..), Slot(..), _accounts, _boundValues, _choices, emptyState, evalValue, makeEnvironment)
 import Marlowe.Semantics as Semantics
@@ -245,12 +245,12 @@ markSimplification f c oriVal x
   | otherwise = pure unit
 
 constToObs :: Boolean -> Term Observation
-constToObs true = Term TrueObs emptyRange
+constToObs true = Term TrueObs zero
 
-constToObs false = Term FalseObs emptyRange
+constToObs false = Term FalseObs zero
 
 constToVal :: BigInteger -> Term Value
-constToVal x = Term (Constant x) emptyRange
+constToVal x = Term (Constant x) zero
 
 addMoneyToEnvAccount :: BigInteger -> Semantics.AccountId -> Semantics.Token -> LintEnv -> LintEnv
 addMoneyToEnvAccount amountToAdd accTerm tokenTerm = over _deposits (Map.alter (addMoney amountToAdd) (accTerm /\ tokenTerm))

--- a/marlowe-playground-client/src/Marlowe/Parser.purs
+++ b/marlowe-playground-client/src/Marlowe/Parser.purs
@@ -16,10 +16,10 @@ import Data.Maybe (Maybe(..))
 import Data.String (length)
 import Data.String.CodeUnits (fromCharArray)
 import Data.Unit (Unit, unit)
-import Marlowe.Holes (class FromTerm, AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Range, Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), emptyRange, fromTerm, getRange, mkHole)
+import Marlowe.Holes (class FromTerm, AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Range, Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), fromTerm, getRange, mkHole)
 import Marlowe.Semantics (CurrencySymbol, Rational(..), PubKey, Slot(..), SlotInterval(..), TransactionInput(..), TransactionWarning(..), TokenName)
 import Marlowe.Semantics as S
-import Prelude (class Show, bind, const, discard, pure, show, void, ($), (*>), (-), (<$>), (<$), (<*), (<*>), (<<<))
+import Prelude (class Show, bind, const, discard, pure, show, void, zero, ($), (*>), (-), (<$), (<$>), (<*), (<*>), (<<<))
 import Text.Parsing.StringParser (Parser(..), fail, runParser)
 import Text.Parsing.StringParser.Basic (integral, parens, someWhiteSpace, whiteSpaceChar)
 import Text.Parsing.StringParser.CodeUnits (alphaNum, char, skipSpaces, string)
@@ -176,7 +176,7 @@ hole =
 
       end = suffix.pos
     -- this position info is incorrect however we don't use it anywhere at this time
-    pure { result: Hole name Proxy emptyRange, suffix }
+    pure { result: Hole name Proxy zero, suffix }
   where
   nameChars = alphaNum <|> char '_'
 
@@ -189,7 +189,7 @@ term' (Parser p) =
 
       end = suffix.pos
     -- this position info is incorrect however we don't use it anywhere at this time
-    pure { result: Term result emptyRange, suffix }
+    pure { result: Term result zero, suffix }
 
 termWrapper :: forall a. Parser a -> Parser (TermWrapper a)
 termWrapper (Parser p) =
@@ -200,7 +200,7 @@ termWrapper (Parser p) =
 
       end = suffix.pos
     -- this position info is incorrect however we don't use it anywhere at this time
-    pure { result: TermWrapper result emptyRange, suffix }
+    pure { result: TermWrapper result zero, suffix }
 
 parseTerm :: forall a. Parser a -> Parser (Term a)
 parseTerm p = hole <|> (term' p)

--- a/marlowe-playground-client/src/Monaco.purs
+++ b/marlowe-playground-client/src/Monaco.purs
@@ -149,6 +149,9 @@ type Marker r
 type IMarkerData
   = Record (Marker ())
 
+getRange :: IMarkerData -> IRange
+getRange { startLineNumber, startColumn, endLineNumber, endColumn } = { startLineNumber, startColumn, endLineNumber, endColumn }
+
 type IMarker
   = Record (Marker ( owner :: String, resource :: Uri ))
 

--- a/marlowe-playground-client/src/Simulation/Types.purs
+++ b/marlowe-playground-client/src/Simulation/Types.purs
@@ -22,7 +22,6 @@ import Halogen as H
 import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
 import Help (HelpContext(..))
-import Marlowe.Holes (MarloweHole)
 import Marlowe.Semantics (Bound, ChoiceId, ChosenNum, Contract, Input, PubKey)
 import Marlowe.Symbolic.Types.Response (Result)
 import Network.RemoteData (RemoteData(..))
@@ -148,7 +147,6 @@ data Action
   | ResetSimulator
   | Undo
   | SelectHole (Maybe String)
-  | InsertHole String MarloweHole (Array MarloweHole)
   -- simulation view
   | ChangeSimulationView BottomPanelView
   | ChangeHelpContext HelpContext
@@ -180,7 +178,6 @@ instance isEventAction :: IsEvent Action where
   toEvent ResetSimulator = Just $ defaultEvent "ResetSimulator"
   toEvent Undo = Just $ defaultEvent "Undo"
   toEvent (SelectHole _) = Just $ defaultEvent "SelectHole"
-  toEvent (InsertHole _ _ _) = Just $ defaultEvent "InsertHole"
   toEvent (ChangeSimulationView view) = Just $ (defaultEvent "ChangeSimulationView") { label = Just $ show view }
   toEvent (ChangeHelpContext help) = Just $ (defaultEvent "ChangeHelpContext") { label = Just $ show help }
   toEvent (GistAction _) = Just $ defaultEvent "GistAction"

--- a/marlowe-playground-client/test/Marlowe/BlocklyTests.purs
+++ b/marlowe-playground-client/test/Marlowe/BlocklyTests.purs
@@ -51,7 +51,7 @@ mkTestState = do
   pure { blocklyState: blocklyState, generator: generator }
 
 -- Here we keep using `show` because the Term range is intentionally incorrect when converting from blockly
--- It uses emptyRange to create a dummy range. By using `show` we can reasonably compare contracts
+-- It uses zero to create a dummy range. By using `show` we can reasonably compare contracts
 c2b2c :: GenWithHoles Result
 c2b2c = do
   contract <- genTerm "contract" genContract

--- a/marlowe-playground-client/test/Marlowe/BlocklyTests.purs
+++ b/marlowe-playground-client/test/Marlowe/BlocklyTests.purs
@@ -10,7 +10,7 @@ import Control.Monad.Reader (runReaderT)
 import Control.Monad.ST (ST)
 import Control.Monad.ST as ST
 import Control.Monad.ST.Ref as STRef
-import Data.Bifunctor (lmap)
+import Data.Bifunctor (lmap, rmap)
 import Data.Either (Either, note)
 import Data.Foldable (for_)
 import Data.Maybe (Maybe(..))
@@ -50,17 +50,19 @@ mkTestState = do
     generator = buildGenerator blocklyState
   pure { blocklyState: blocklyState, generator: generator }
 
+-- Here we keep using `show` because the Term range is intentionally incorrect when converting from blockly
+-- It uses emptyRange to create a dummy range. By using `show` we can reasonably compare contracts
 c2b2c :: GenWithHoles Result
 c2b2c = do
   contract <- genTerm "contract" genContract
   let
-    positionedContract = lmap show $ Parser.parseContract (stripParens $ show contract)
+    positionedContract = rmap show $ lmap show $ Parser.parseContract (stripParens $ show contract)
 
     -- Unfortunately quickcheck runs the concrete Gen monad and it would need to be re-written to use MonadGen
     -- https://github.com/purescript/purescript-quickcheck/blob/v5.0.0/src/Test/QuickCheck.purs#L97
     -- I made the executive decision that it's not worth my time to do it in this specific case hence unsafePerformEffect
     -- I have created https://github.com/purescript/purescript-quickcheck/issues/102
-    result = unsafePerformEffect $ runContract contract
+    result = rmap show $ unsafePerformEffect $ runContract contract
   pure (result === positionedContract)
 
 runContract :: Term Contract -> Effect (Either String (Term Contract))

--- a/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
+++ b/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
@@ -8,13 +8,13 @@ import Data.Enum (upFromIncluding)
 import Data.Map as Map
 import Data.Set as Set
 import Data.Traversable (traverse_)
-import Marlowe.Holes (MarloweHole(..), MarloweType(..), getMarloweConstructors, marloweHoleToSuggestionText)
+import Marlowe.Holes (MarloweHole(..), MarloweType(..), emptyRange, getMarloweConstructors, marloweHoleToSuggestionText)
 import Marlowe.Parser (parse)
 import Marlowe.Parser as Parser
 import Test.Unit (TestSuite, failure, success, suite, test)
 
 mkHole :: MarloweType -> MarloweHole
-mkHole marloweType = MarloweHole { name: mempty, row: zero, column: zero, marloweType }
+mkHole marloweType = MarloweHole { name: mempty, range: emptyRange, marloweType }
 
 holeSuggestions :: Boolean -> MarloweHole -> Array String
 holeSuggestions stripParens marloweHole@(MarloweHole { name, marloweType }) =

--- a/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
+++ b/marlowe-playground-client/test/Marlowe/CompletionItemsTests.purs
@@ -8,13 +8,13 @@ import Data.Enum (upFromIncluding)
 import Data.Map as Map
 import Data.Set as Set
 import Data.Traversable (traverse_)
-import Marlowe.Holes (MarloweHole(..), MarloweType(..), emptyRange, getMarloweConstructors, marloweHoleToSuggestionText)
+import Marlowe.Holes (MarloweHole(..), MarloweType(..), getMarloweConstructors, marloweHoleToSuggestionText)
 import Marlowe.Parser (parse)
 import Marlowe.Parser as Parser
 import Test.Unit (TestSuite, failure, success, suite, test)
 
 mkHole :: MarloweType -> MarloweHole
-mkHole marloweType = MarloweHole { name: mempty, range: emptyRange, marloweType }
+mkHole marloweType = MarloweHole { name: mempty, range: zero, marloweType }
 
 holeSuggestions :: Boolean -> MarloweHole -> Array String
 holeSuggestions stripParens marloweHole@(MarloweHole { name, marloweType }) =


### PR DESCRIPTION
This is part one of SCP-905, we need to get the start position and end position of all terms when parsing, this way we can use the monaco API to do replacements which requires the rang that you are replacing. Once this is merged we can do any sort of refactoring of Marlowe we want, such as removing dead code.