### PR TITLE
Use Sphinx site in Plutus Playground doc

### DIFF
--- a/deployment/nixops/server.nix
+++ b/deployment/nixops/server.nix
@@ -13,17 +13,15 @@
                             ''
                             machine_role{role="nginx"} 1
                             '';
-    docs = if serviceName == "plutus-playground" then plutus.docs.plutus-tutorial else plutus.docs.marlowe-tutorial;
+    docs = if serviceName == "plutus-playground" then plutus.docs.site else plutus.docs.marlowe-tutorial;
     documentation-site =
       let
         adjustedTutorial = docs.override { marlowePlaygroundUrl = "https://${machines.environment}.${machines.marloweTld}";
                                            plutusPlaygroundUrl = "https://${machines.environment}.${machines.plutusTld}";
-                                           haddockUrl = "../haddock";
                                          };
       in pkgs.runCommand "documentation-site" {} ''
         mkdir -p $out
         cp -aR ${adjustedTutorial} $out/tutorial
-        cp -aR ${plutus.docs.combined-haddock}/share/doc $out/haddock
       '';
   in
   {
@@ -116,9 +114,6 @@
             '';
           };
           "/tutorial/" = {
-            root = "${documentation-site}/";
-          };
-          "/haddock/" = {
             root = "${documentation-site}/";
           };
           "/+" = {


### PR DESCRIPTION
Rather than broken link to the old `plutus-tutorial` attribute.

Also, the haddock goes alongside it instead of being deployed separately
now, might need to revisit later, but this should work for now.

Meant to fix this before, forgot. FYI @shmish111 , not sure how to test this so may just merge and see if it succeeds.