### PR TITLE
Bump dev cabal to 3.2 and use multiple subdirs feature

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -161,126 +161,53 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
   tag: 5035c9ed95e9d47f050314a7d96b1b2043288f61
-  subdir: binary
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-base
-  tag: 5035c9ed95e9d47f050314a7d96b1b2043288f61
-  subdir: slotting
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-prelude
-  tag: bd7eb69d27bfaee46d435bc1d2720520b1446426
+  subdir: 
+    binary 
+    slotting 
+    cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
   tag: bd7eb69d27bfaee46d435bc1d2720520b1446426
-  subdir: test
+  subdir: 
+    . 
+    test
 
 source-repository-package
   type: git
   location: https://github.com/raduom/ouroboros-network
   tag: af744374a05d6a5eb76713b399595131e2a24c38
-  subdir: typed-protocols
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/ouroboros-network
-  tag: af744374a05d6a5eb76713b399595131e2a24c38
-  subdir: typed-protocols-examples
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/ouroboros-network
-  tag: af744374a05d6a5eb76713b399595131e2a24c38
-  subdir: ouroboros-network
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/ouroboros-network
-  tag: af744374a05d6a5eb76713b399595131e2a24c38
-  subdir: ouroboros-network-framework
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/ouroboros-network
-  tag: af744374a05d6a5eb76713b399595131e2a24c38
-  subdir: io-sim
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/ouroboros-network
-  tag: af744374a05d6a5eb76713b399595131e2a24c38
-  subdir: io-sim-classes
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/ouroboros-network
-  tag: af744374a05d6a5eb76713b399595131e2a24c38
-  subdir: network-mux
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/ouroboros-network
-  tag: af744374a05d6a5eb76713b399595131e2a24c38
-  subdir: Win32-network
+  subdir: 
+    typed-protocols 
+    typed-protocols-examples 
+    ouroboros-network 
+    ouroboros-network-framework 
+    io-sim 
+    io-sim-classes 
+    network-mux 
+    Win32-network
 
 source-repository-package
   type: git
   location: https://github.com/raduom/iohk-monitoring-framework
   tag: b5c035ad4e226d634242ad5979fa677921181435
-  subdir: iohk-monitoring
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/iohk-monitoring-framework
-  tag: b5c035ad4e226d634242ad5979fa677921181435
-  subdir: tracer-transformers
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/iohk-monitoring-framework
-  tag: b5c035ad4e226d634242ad5979fa677921181435
-  subdir: contra-tracer
+  subdir: 
+    iohk-monitoring 
+    tracer-transformers 
+    contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/raduom/cardano-ledger-specs
   tag: 2cac85306d8b3e07006e9081f36ce7ebf2d9d0a3
-  subdir: byron/chain/executable-spec
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/cardano-ledger-specs
-  tag: 2cac85306d8b3e07006e9081f36ce7ebf2d9d0a3
-  subdir: byron/ledger/executable-spec
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/cardano-ledger-specs
-  tag: 2cac85306d8b3e07006e9081f36ce7ebf2d9d0a3
-  subdir: semantics/executable-spec
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/cardano-ledger-specs
-  tag: 2cac85306d8b3e07006e9081f36ce7ebf2d9d0a3
-  subdir: shelley/chain-and-ledger/dependencies/non-integer
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/cardano-ledger-specs
-  tag: 2cac85306d8b3e07006e9081f36ce7ebf2d9d0a3
-  subdir: shelley/chain-and-ledger/executable-spec
-
-source-repository-package
-  type: git
-  location: https://github.com/raduom/cardano-ledger-specs
-  tag: 2cac85306d8b3e07006e9081f36ce7ebf2d9d0a3
-  subdir: shelley/chain-and-ledger/executable-spec/test
+  subdir: 
+    byron/chain/executable-spec 
+    byron/ledger/executable-spec 
+    semantics/executable-spec 
+    shelley/chain-and-ledger/dependencies/non-integer
+    shelley/chain-and-ledger/executable-spec 
+    shelley/chain-and-ledger/executable-spec/test
 
 -- The following two dependencies are not mirrored in the
 -- stack.yaml file, but they are needed regardless by cabal.
@@ -288,11 +215,5 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/goblins
   tag: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-base
-  tag: 5035c9ed95e9d47f050314a7d96b1b2043288f61
-  subdir: cardano-crypto-class
 
 -- / Node protocols

--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -3,7 +3,7 @@ pkgs.recurseIntoAttrs (rec {
   # Packages which are useful during development, but we don't depend upon directly to build our stuff
   packages = pkgs.recurseIntoAttrs {
     # See comment on the definition about it not working
-    #cabal-install = haskell.extraPackages.cabal-install.components.exes.cabal;
+    cabal-install = haskell.extraPackages.cabal-install.components.exes.cabal;
     stylish-haskell = haskell.extraPackages.stylish-haskell.components.exes.stylish-haskell;
     hlint = haskell.extraPackages.hlint.components.exes.hlint;
     haskell-language-server = haskell.extraPackages.haskell-language-server.components.exes.haskell-language-server;

--- a/nix/haskell-extra.nix
+++ b/nix/haskell-extra.nix
@@ -6,15 +6,12 @@
 ############################################################################
 { pkgs, index-state, checkMaterialization }:
 {
-  # FIXME: this cabal can't be used for development purposes until
-  # https://github.com/input-output-hk/haskell.nix/issues/422 is fixed
-  # Also need to pick a version that builds properly
   cabal-install = pkgs.haskell-nix.hackage-package {
     name = "cabal-install";
-    version = "3.0.0.0";
+    version = "3.2.0.0";
     inherit index-state checkMaterialization;
     # Invalidate and update if you change the version or index-state
-    plan-sha256 = "08zkccwygm4g83chyiwbskkjfclm22vmhbx2s2rh0lvjkclqy6qc";
+    plan-sha256 = "1pah0hdljyppj51dwa0s8yjmi9dv75xqsk6fghlsz7a3r0dchcss";
   };
   stylish-haskell = pkgs.haskell-nix.hackage-package {
     name = "stylish-haskell";

--- a/shell.nix
+++ b/shell.nix
@@ -18,8 +18,6 @@ in haskell.packages.shellFor {
     # pkgs.sqlite-analyzer
     pkgs.sqlite-interactive
 
-    # Take cabal from nixpkgs for now, see below
-    pkgs.cabal-install
     pkgs.stack
 
     pyEnv
@@ -30,8 +28,7 @@ in haskell.packages.shellFor {
     pkgs.aws_shell
 
     # Extra dev packages acquired from elsewhere
-    # FIXME: Can't use this cabal until https://github.com/input-output-hk/haskell.nix/issues/422 is fixed
-    #dev.packages.cabal-install
+    dev.packages.cabal-install
     dev.packages.hlint
     dev.packages.stylish-haskell
     dev.packages.haskell-language-server


### PR DESCRIPTION
- The haskell.nix cabal now works, so that's nice.
- We can use the nice multiple-subdirs feature in cabal.project to cut
out a lot of repetition.

Note we get annoying warnings about extraneous version ranges due to
https://github.com/haskell/cabal/issues/5119.

(I noticed this issue was marked as fixed for 3.2, thought I'd try it, and lo and behold it works. Seems nice.)