### PR TITLE
Add standard dynamic builtins to plc-exe

### DIFF
--- a/language-plutus-core/exe/Main.hs
+++ b/language-plutus-core/exe/Main.hs
@@ -258,9 +258,9 @@ runTypecheck :: TypecheckOptions -> IO ()
 runTypecheck (TypecheckOptions inp fmt) = do
   prog <- getProg inp fmt
   case PLC.runQuoteT $ do
-            types <- PLC.getStringBuiltinTypes ()
-            PLC.typecheckPipeline (PLC.TypeCheckConfig types) (void prog)
-     of
+    types <- PLC.getStringBuiltinTypes ()
+    PLC.typecheckPipeline (PLC.TypeCheckConfig types) (void prog)
+    of
        Left (e :: PLC.Error PLC.DefaultUni ()) -> do
            putStrLn $ PLC.displayPlcDef e
            exitFailure

--- a/language-plutus-core/exe/Main.hs
+++ b/language-plutus-core/exe/Main.hs
@@ -257,9 +257,8 @@ getProg inp fmt =
 ---------------- Typechecking ----------------
 
 runTypecheck :: TypecheckOptions -> IO ()
-runTypecheck (TypecheckOptions inp fmt) = do
-    let meanings = PLC.getStringBuiltinMeanings @ (PLC.Term PLC.TyName PLC.Name PLC.DefaultUni PLC.ExMemory)
-    case PLC.runQuoteT $ PLC.dynamicBuiltinNameMeaningsToTypes () meanings of
+runTypecheck (TypecheckOptions inp fmt) =
+    case PLC.runQuoteT $ PLC.getStringBuiltinTypes () of
       Left (e :: PLC.Error PLC.DefaultUni ()) -> do
           T.putStrLn $ PLC.displayPlcDef e
           exitFailure


### PR DESCRIPTION
The `plc` command was just running with an empty set of dynamic builtins, meaning that it couldn't typecheck or run programs involving the standard dynamic builtins.  I noticed this yesterday when Nikos was asking about a related problem.  I'm sure I've added this at least once or twice before, but I think it's perhaps been accidentally reverted.

Anyway, this is just a small PR to add those builtins.  It turned out to be quite tricky to get the types to work, and I had to add a cal  to `runQuoteT` at one point.  I'm not sure whether or not this is safe...