### PR TITLE
PLC/PIR: variables are values

### DIFF
--- a/language-plutus-core/plutus-ir-test/transform/letFloat/mutuallyRecursiveValues.golden
+++ b/language-plutus-core/plutus-ir-test/transform/letFloat/mutuallyRecursiveValues.golden
@@ -1,9 +1,10 @@
 (let
   (rec)
+  (termbind (strict) (vardecl x (all a (type) (fun a a))) y)
   (termbind
     (strict)
     (vardecl y (all a (type) (fun a a)))
     (abs a (type) (lam z a [ { x a } z ]))
   )
-  (let (rec) (termbind (strict) (vardecl x (all a (type) (fun a a))) y) x)
+  x
 )

--- a/language-plutus-core/plutus-ir-test/transform/letFloat/nonrecToRec.golden
+++ b/language-plutus-core/plutus-ir-test/transform/letFloat/nonrecToRec.golden
@@ -1,10 +1,7 @@
 (let
   (rec)
   (termbind (nonstrict) (vardecl r (con integer)) i)
-  (termbind
-    (nonstrict)
-    (vardecl i (con integer))
-    (let (nonrec) (termbind (strict) (vardecl j (con integer)) r) j)
-  )
+  (termbind (nonstrict) (vardecl i (con integer)) j)
+  (termbind (strict) (vardecl j (con integer)) r)
   (con 3)
 )

--- a/language-plutus-core/plutus-ir/Language/PlutusIR/Value.hs
+++ b/language-plutus-core/plutus-ir/Language/PlutusIR/Value.hs
@@ -4,11 +4,15 @@ module Language.PlutusIR.Value (isTermValue) where
 import           Language.PlutusIR
 
 -- | Whether the given PIR term is (will compile to) a PLC term value. Very similar to
--- the PLC definition.
+-- the PLC definition. Crucially, evaluating a value should return the value immediately,
+-- and it should not be possible for it to loop or throw error.
 isTermValue :: Term tyname name uni a -> Bool
 isTermValue = \case
     LamAbs {} -> True
     TyAbs {} -> True
     Constant {} -> True
+    -- Variables are values: they can only refer to entries in the environment, which
+    -- are always values
+    Var {} -> True
     IWrap _ _ _ t -> isTermValue t
     _ -> False

--- a/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Check/Value.hs
@@ -16,4 +16,7 @@ termValue (IWrap _ _ _ term) = termValue term
 termValue LamAbs {}          = pure ()
 termValue TyAbs {}           = pure ()
 termValue Constant {}        = pure ()
+-- Variables are values: they can only refer to entries in the environment, which
+-- are always values
+termValue Var{}              = pure ()
 termValue t                  = Left $ BadTerm (termAnn t) t "term value"

--- a/plutus-tx-plugin/test/Plugin/Data/monomorphic/strictPattern.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Data/monomorphic/strictPattern.plc.golden
@@ -24,11 +24,8 @@
             (let
               (nonrec)
               (termbind (strict) (vardecl dt a) dt)
-              (let
-                (nonrec)
-                (termbind (strict) (vardecl dt a) dt)
-                [ [ { StrictPattern a } dt ] dt ]
-              )
+              (termbind (strict) (vardecl dt a) dt)
+              [ [ { StrictPattern a } dt ] dt ]
             )
           )
         )

--- a/plutus-tx-plugin/test/Plugin/Errors/literalCaseOther.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Errors/literalCaseOther.plc.golden
@@ -66,7 +66,7 @@
                                                                   [
                                                                     (lam
                                                                       fIsStringAType_i0
-                                                                      (fun (all a_i0 (type) (fun a_i1 a_i1)) [(lam a_i0 (type) (fun [List_i7 (con char)] a_i1)) AType_i17])
+                                                                      [(lam a_i0 (type) (fun [List_i7 (con char)] a_i1)) AType_i17]
                                                                       [
                                                                         (lam
                                                                           fromString_i0
@@ -91,18 +91,7 @@
                                                                                               fromString_i2
                                                                                               AType_i19
                                                                                             }
-                                                                                            [
-                                                                                              fIsStringAType_i3
-                                                                                              (abs
-                                                                                                a_i0
-                                                                                                (type)
-                                                                                                (lam
-                                                                                                  x_i0
-                                                                                                  a_i2
-                                                                                                  x_i1
-                                                                                                )
-                                                                                              )
-                                                                                            ]
+                                                                                            fIsStringAType_i3
                                                                                           ]
                                                                                           [
                                                                                             [
@@ -155,18 +144,7 @@
                                                                                           fromString_i3
                                                                                           AType_i20
                                                                                         }
-                                                                                        [
-                                                                                          fIsStringAType_i4
-                                                                                          (abs
-                                                                                            a_i0
-                                                                                            (type)
-                                                                                            (lam
-                                                                                              x_i0
-                                                                                              a_i2
-                                                                                              x_i1
-                                                                                            )
-                                                                                          )
-                                                                                        ]
+                                                                                        fIsStringAType_i4
                                                                                       ]
                                                                                       {
                                                                                         Nil_i8
@@ -196,11 +174,7 @@
                                                                         )
                                                                       ]
                                                                     )
-                                                                    (lam
-                                                                      arg_i0
-                                                                      (all a_i0 (type) (fun a_i1 a_i1))
-                                                                      cfromString_i2
-                                                                    )
+                                                                    cfromString_i1
                                                                   ]
                                                                 )
                                                                 (lam
@@ -300,21 +274,14 @@
                                                       thunk_i0
                                                       Unit_i10
                                                       [
-                                                        [
-                                                          {
-                                                            [
-                                                              AType_match_i11
-                                                              ds_i2
-                                                            ]
-                                                            (fun Unit_i10 Bool_i7)
-                                                          }
-                                                          (lam
-                                                            thunk_i0
-                                                            Unit_i11
-                                                            True_i7
-                                                          )
-                                                        ]
-                                                        Unit_i9
+                                                        {
+                                                          [
+                                                            AType_match_i11
+                                                            ds_i2
+                                                          ]
+                                                          Bool_i7
+                                                        }
+                                                        True_i6
                                                       ]
                                                     )
                                                   ]

--- a/plutus-tx-plugin/test/Plugin/Functions/unfoldings/allDirect.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/unfoldings/allDirect.plc.golden
@@ -24,20 +24,7 @@
           [
             [
               [ { [ Bool_match ds ] (fun Unit Bool) } (lam thunk Unit False) ]
-              (lam
-                thunk
-                Unit
-                [
-                  [
-                    [
-                      { [ Bool_match ds ] (fun Unit Bool) }
-                      (lam thunk Unit False)
-                    ]
-                    (lam thunk Unit True)
-                  ]
-                  Unit
-                ]
-              )
+              (lam thunk Unit [ [ { [ Bool_match ds ] Bool } False ] True ])
             ]
             Unit
           ]
@@ -84,26 +71,16 @@
                 l
                 [List a]
                 [
-                  [
-                    [
-                      { [ { Nil_match a } l ] (fun Unit Bool) }
-                      (lam thunk Unit True)
-                    ]
+                  [ { [ { Nil_match a } l ] Bool } True ]
+                  (lam
+                    h
+                    a
                     (lam
-                      h
-                      a
-                      (lam
-                        t
-                        [List a]
-                        (lam
-                          thunk
-                          Unit
-                          [ [ andDirect [ p h ] ] [ [ { allDirect a } p ] t ] ]
-                        )
-                      )
+                      t
+                      [List a]
+                      [ [ andDirect [ p h ] ] [ [ { allDirect a } p ] t ] ]
                     )
-                  ]
-                  Unit
+                  )
                 ]
               )
             )

--- a/plutus-tx-plugin/test/Plugin/Functions/unfoldings/andDirect.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/unfoldings/andDirect.plc.golden
@@ -24,20 +24,7 @@
           [
             [
               [ { [ Bool_match ds ] (fun Unit Bool) } (lam thunk Unit False) ]
-              (lam
-                thunk
-                Unit
-                [
-                  [
-                    [
-                      { [ Bool_match ds ] (fun Unit Bool) }
-                      (lam thunk Unit False)
-                    ]
-                    (lam thunk Unit True)
-                  ]
-                  Unit
-                ]
-              )
+              (lam thunk Unit [ [ { [ Bool_match ds ] Bool } False ] True ])
             ]
             Unit
           ]

--- a/plutus-tx-plugin/test/Plugin/Functions/unfoldings/andExternal.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/unfoldings/andExternal.plc.golden
@@ -2,9 +2,6 @@
   (let
     (nonrec)
     (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-    )
-    (datatypebind
       (datatype
         (tyvardecl Bool (type))
         
@@ -15,21 +12,7 @@
     (termbind
       (strict)
       (vardecl andExternal (fun Bool (fun Bool Bool)))
-      (lam
-        a
-        Bool
-        (lam
-          b
-          Bool
-          [
-            [
-              [ { [ Bool_match a ] (fun Unit Bool) } (lam thunk Unit b) ]
-              (lam thunk Unit False)
-            ]
-            Unit
-          ]
-        )
-      )
+      (lam a Bool (lam b Bool [ [ { [ Bool_match a ] Bool } b ] False ]))
     )
     [ [ andExternal True ] False ]
   )

--- a/plutus-tx-plugin/test/Plugin/Functions/unfoldings/nandDirect.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/unfoldings/nandDirect.plc.golden
@@ -24,20 +24,7 @@
           [
             [
               [ { [ Bool_match ds ] (fun Unit Bool) } (lam thunk Unit False) ]
-              (lam
-                thunk
-                Unit
-                [
-                  [
-                    [
-                      { [ Bool_match ds ] (fun Unit Bool) }
-                      (lam thunk Unit False)
-                    ]
-                    (lam thunk Unit True)
-                  ]
-                  Unit
-                ]
-              )
+              (lam thunk Unit [ [ { [ Bool_match ds ] Bool } False ] True ])
             ]
             Unit
           ]

--- a/plutus-tx-plugin/test/Plugin/Laziness/joinError.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Laziness/joinError.plc.golden
@@ -31,19 +31,7 @@
             [
               [
                 { [ Bool_match x ] (fun Unit Unit) }
-                (lam
-                  thunk
-                  Unit
-                  [
-                    [
-                      [
-                        { [ Bool_match y ] (fun Unit Unit) }
-                        (lam thunk Unit joinError)
-                      ]
-                      (lam thunk Unit Unit)
-                    ]
-                    Unit
-                  ]
+                (lam thunk Unit [ [ { [ Bool_match y ] Unit } joinError ] Unit ]
                 )
               ]
               (lam thunk Unit Unit)

--- a/plutus-tx-plugin/test/Plugin/Laziness/joinErrorEval.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Laziness/joinErrorEval.plc.golden
@@ -1,1 +1,1 @@
-(abs out_Unit_36 (type) (lam case_Unit_37 out_Unit_36 case_Unit_37))
+Failure

--- a/plutus-tx-plugin/test/Plugin/Primitives/and.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/and.plc.golden
@@ -2,9 +2,6 @@
   (let
     (nonrec)
     (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-    )
-    (datatypebind
       (datatype
         (tyvardecl Bool (type))
         
@@ -12,20 +9,6 @@
         (vardecl True Bool) (vardecl False Bool)
       )
     )
-    (lam
-      ds
-      Bool
-      (lam
-        ds
-        Bool
-        [
-          [
-            [ { [ Bool_match ds ] (fun Unit Bool) } (lam thunk Unit ds) ]
-            (lam thunk Unit False)
-          ]
-          Unit
-        ]
-      )
-    )
+    (lam ds Bool (lam ds Bool [ [ { [ Bool_match ds ] Bool } ds ] False ]))
   )
 )

--- a/plutus-tx-plugin/test/Plugin/Primitives/ifThenElse.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/ifThenElse.plc.golden
@@ -29,9 +29,6 @@
         )
       )
     )
-    (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-    )
     (lam
       ds
       (con integer)
@@ -39,17 +36,7 @@
         ds
         (con integer)
         [
-          [
-            [
-              {
-                [ Bool_match [ [ equalsInteger ds ] ds ] ]
-                (fun Unit (con integer))
-              }
-              (lam thunk Unit ds)
-            ]
-            (lam thunk Unit ds)
-          ]
-          Unit
+          [ { [ Bool_match [ [ equalsInteger ds ] ds ] ] (con integer) } ds ] ds
         ]
       )
     )

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/compareTest.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/compareTest.plc.golden
@@ -82,16 +82,9 @@
                 Unit
                 [
                   [
-                    [
-                      {
-                        [ Bool_match [ [ lessThanEqInteger x ] y ] ]
-                        (fun Unit Ordering)
-                      }
-                      (lam thunk Unit LT)
-                    ]
-                    (lam thunk Unit GT)
+                    { [ Bool_match [ [ lessThanEqInteger x ] y ] ] Ordering } LT
                   ]
-                  Unit
+                  GT
                 ]
               )
             ]
@@ -112,17 +105,8 @@
           y
           (con integer)
           [
-            [
-              [
-                {
-                  [ Bool_match [ [ lessThanEqInteger x ] y ] ]
-                  (fun Unit (con integer))
-                }
-                (lam thunk Unit y)
-              ]
-              (lam thunk Unit x)
-            ]
-            Unit
+            [ { [ Bool_match [ [ lessThanEqInteger x ] y ] ] (con integer) } y ]
+            x
           ]
         )
       )
@@ -139,17 +123,8 @@
           y
           (con integer)
           [
-            [
-              [
-                {
-                  [ Bool_match [ [ lessThanEqInteger x ] y ] ]
-                  (fun Unit (con integer))
-                }
-                (lam thunk Unit x)
-              ]
-              (lam thunk Unit y)
-            ]
-            Unit
+            [ { [ Bool_match [ [ lessThanEqInteger x ] y ] ] (con integer) } x ]
+            y
           ]
         )
       )
@@ -310,18 +285,15 @@
               [
                 [
                   [
-                    [
-                      {
-                        [ Ordering_match [ [ [ { compare a } dOrd ] a ] b ] ]
-                        (fun Unit Ordering)
-                      }
-                      (lam thunk Unit EQ)
-                    ]
-                    (lam thunk Unit LT)
+                    {
+                      [ Ordering_match [ [ [ { compare a } dOrd ] a ] b ] ]
+                      Ordering
+                    }
+                    EQ
                   ]
-                  (lam thunk Unit GT)
+                  LT
                 ]
-                Unit
+                GT
               ]
             )
           )

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/multiFunction.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/multiFunction.plc.golden
@@ -2,9 +2,6 @@
   (let
     (nonrec)
     (datatypebind
-      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-    )
-    (datatypebind
       (datatype
         (tyvardecl Bool (type))
         
@@ -15,21 +12,7 @@
     (termbind
       (strict)
       (vardecl bad_name (fun Bool (fun Bool Bool)))
-      (lam
-        l
-        Bool
-        (lam
-          r
-          Bool
-          [
-            [
-              [ { [ Bool_match l ] (fun Unit Bool) } (lam thunk Unit r) ]
-              (lam thunk Unit False)
-            ]
-            Unit
-          ]
-        )
-      )
+      (lam l Bool (lam r Bool [ [ { [ Bool_match l ] Bool } r ] False ]))
     )
     (datatypebind
       (datatype
@@ -144,6 +127,9 @@
         [ [ { [ Person_match ds ] (con integer) } (con 35) ] (con 30) ]
       )
     )
+    (datatypebind
+      (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+    )
     (termbind
       (strict)
       (vardecl clikesAnimal (fun Person (fun Animal Bool)))
@@ -157,20 +143,7 @@
             [
               [
                 { [ Person_match ds ] (fun Unit Bool) }
-                (lam
-                  thunk
-                  Unit
-                  [
-                    [
-                      [
-                        { [ Animal_match ds ] (fun Unit Bool) }
-                        (lam thunk Unit True)
-                      ]
-                      (lam thunk Unit False)
-                    ]
-                    Unit
-                  ]
-                )
+                (lam thunk Unit [ [ { [ Animal_match ds ] Bool } True ] False ])
               ]
               (lam thunk Unit False)
             ]

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/partialApplication.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/partialApplication.plc.golden
@@ -82,16 +82,9 @@
                 Unit
                 [
                   [
-                    [
-                      {
-                        [ Bool_match [ [ lessThanEqInteger x ] y ] ]
-                        (fun Unit Ordering)
-                      }
-                      (lam thunk Unit LT)
-                    ]
-                    (lam thunk Unit GT)
+                    { [ Bool_match [ [ lessThanEqInteger x ] y ] ] Ordering } LT
                   ]
-                  Unit
+                  GT
                 ]
               )
             ]

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/sizedBasic.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/sizedBasic.plc.golden
@@ -7,7 +7,7 @@
       (lam x (con integer) x)
     )
     (termbind
-      (nonstrict)
+      (strict)
       (vardecl
         fSizedInteger [(lam a (type) (fun a (con integer))) (con integer)]
       )

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/sizedPair.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/sizedPair.plc.golden
@@ -52,7 +52,7 @@
       )
     )
     (termbind
-      (nonstrict)
+      (strict)
       (vardecl
         fSizedTuple2
         (all a (type) (all b (type) (fun [(lam a (type) (fun a (con integer))) a] (fun [(lam a (type) (fun a (con integer))) b] [(lam a (type) (fun a (con integer))) [[Tuple2 a] b]]))))
@@ -65,7 +65,7 @@
       (lam x (con integer) x)
     )
     (termbind
-      (nonstrict)
+      (strict)
       (vardecl
         fSizedInteger [(lam a (type) (fun a (con integer))) (con integer)]
       )

--- a/plutus-use-cases/test/Spec/crowdfunding.pir
+++ b/plutus-use-cases/test/Spec/crowdfunding.pir
@@ -277,29 +277,19 @@
                             l
                             [List a]
                             [
-                              [
-                                [
-                                  { [ { Nil_match a } l ] (fun Unit b) }
-                                  (lam thunk Unit acc)
-                                ]
+                              [ { [ { Nil_match a } l ] b } acc ]
+                              (lam
+                                x
+                                a
                                 (lam
-                                  x
-                                  a
-                                  (lam
-                                    xs
-                                    [List a]
-                                    (lam
-                                      thunk
-                                      Unit
-                                      [
-                                        [ f x ]
-                                        [ [ [ { { foldr a } b } f ] acc ] xs ]
-                                      ]
-                                    )
-                                  )
+                                  xs
+                                  [List a]
+                                  [
+                                    [ f x ]
+                                    [ [ [ { { foldr a } b } f ] acc ] xs ]
+                                  ]
                                 )
-                              ]
-                              Unit
+                              )
                             ]
                           )
                         )
@@ -1425,207 +1415,116 @@
                                 [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
                                 [
                                   [
-                                    [
-                                      {
-                                        [
-                                          {
-                                            Nil_match
-                                            [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                          }
-                                          xs
-                                        ]
-                                        (fun Unit Bool)
-                                      }
-                                      (lam thunk Unit True)
-                                    ]
-                                    (lam
-                                      ds
-                                      [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                      (lam
+                                    {
+                                      [
+                                        {
+                                          Nil_match
+                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                        }
                                         xs
-                                        [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
-                                        (lam
-                                          thunk
-                                          Unit
+                                      ]
+                                      Bool
+                                    }
+                                    True
+                                  ]
+                                  (lam
+                                    ds
+                                    [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                    (lam
+                                      xs
+                                      [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
+                                      [
+                                        {
                                           [
                                             {
-                                              [
-                                                {
-                                                  {
-                                                    Tuple2_match
-                                                    (con bytestring)
-                                                  }
-                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                }
-                                                ds
-                                              ]
-                                              Bool
+                                              { Tuple2_match (con bytestring) }
+                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
                                             }
-                                            (lam
-                                              ds
-                                              (con bytestring)
-                                              (lam
-                                                x
-                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                (let
-                                                  (rec)
-                                                  (termbind
-                                                    (strict)
-                                                    (vardecl
-                                                      go
-                                                      (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] Bool)
-                                                    )
-                                                    (lam
-                                                      xs
-                                                      [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                            ds
+                                          ]
+                                          Bool
+                                        }
+                                        (lam
+                                          ds
+                                          (con bytestring)
+                                          (lam
+                                            x
+                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
+                                            (let
+                                              (rec)
+                                              (termbind
+                                                (strict)
+                                                (vardecl
+                                                  go
+                                                  (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] Bool)
+                                                )
+                                                (lam
+                                                  xs
+                                                  [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                  [
+                                                    [
                                                       [
-                                                        [
+                                                        {
                                                           [
                                                             {
-                                                              [
-                                                                {
-                                                                  Nil_match
-                                                                  [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                }
-                                                                xs
-                                                              ]
-                                                              (fun Unit Bool)
+                                                              Nil_match
+                                                              [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
                                                             }
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              [ go xs ]
-                                                            )
+                                                            xs
                                                           ]
+                                                          (fun Unit Bool)
+                                                        }
+                                                        (lam
+                                                          thunk Unit [ go xs ]
+                                                        )
+                                                      ]
+                                                      (lam
+                                                        ds
+                                                        [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
+                                                        (lam
+                                                          xs
+                                                          [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
                                                           (lam
-                                                            ds
-                                                            [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                            (lam
-                                                              xs
-                                                              [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
-                                                              (lam
-                                                                thunk
-                                                                Unit
+                                                            thunk
+                                                            Unit
+                                                            [
+                                                              {
                                                                 [
                                                                   {
-                                                                    [
-                                                                      {
-                                                                        {
-                                                                          Tuple2_match
-                                                                          (con bytestring)
-                                                                        }
-                                                                        [[These (con integer)] (con integer)]
-                                                                      }
-                                                                      ds
-                                                                    ]
-                                                                    Bool
+                                                                    {
+                                                                      Tuple2_match
+                                                                      (con bytestring)
+                                                                    }
+                                                                    [[These (con integer)] (con integer)]
                                                                   }
-                                                                  (lam
-                                                                    ds
-                                                                    (con bytestring)
-                                                                    (lam
-                                                                      x
-                                                                      [[These (con integer)] (con integer)]
+                                                                  ds
+                                                                ]
+                                                                Bool
+                                                              }
+                                                              (lam
+                                                                ds
+                                                                (con bytestring)
+                                                                (lam
+                                                                  x
+                                                                  [[These (con integer)] (con integer)]
+                                                                  [
+                                                                    [
                                                                       [
-                                                                        [
+                                                                        {
                                                                           [
                                                                             {
-                                                                              [
-                                                                                {
-                                                                                  {
-                                                                                    These_match
-                                                                                    (con integer)
-                                                                                  }
-                                                                                  (con integer)
-                                                                                }
-                                                                                x
-                                                                              ]
-                                                                              Bool
+                                                                              {
+                                                                                These_match
+                                                                                (con integer)
+                                                                              }
+                                                                              (con integer)
                                                                             }
-                                                                            (lam
-                                                                              b
-                                                                              (con integer)
-                                                                              [
-                                                                                [
-                                                                                  [
-                                                                                    {
-                                                                                      [
-                                                                                        Bool_match
-                                                                                        [
-                                                                                          [
-                                                                                            f
-                                                                                            (con
-                                                                                              0
-                                                                                            )
-                                                                                          ]
-                                                                                          b
-                                                                                        ]
-                                                                                      ]
-                                                                                      (fun Unit Bool)
-                                                                                    }
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        go
-                                                                                        xs
-                                                                                      ]
-                                                                                    )
-                                                                                  ]
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    False
-                                                                                  )
-                                                                                ]
-                                                                                Unit
-                                                                              ]
-                                                                            )
+                                                                            x
                                                                           ]
-                                                                          (lam
-                                                                            a
-                                                                            (con integer)
-                                                                            (lam
-                                                                              b
-                                                                              (con integer)
-                                                                              [
-                                                                                [
-                                                                                  [
-                                                                                    {
-                                                                                      [
-                                                                                        Bool_match
-                                                                                        [
-                                                                                          [
-                                                                                            f
-                                                                                            a
-                                                                                          ]
-                                                                                          b
-                                                                                        ]
-                                                                                      ]
-                                                                                      (fun Unit Bool)
-                                                                                    }
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        go
-                                                                                        xs
-                                                                                      ]
-                                                                                    )
-                                                                                  ]
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    False
-                                                                                  )
-                                                                                ]
-                                                                                Unit
-                                                                              ]
-                                                                            )
-                                                                          )
-                                                                        ]
+                                                                          Bool
+                                                                        }
                                                                         (lam
-                                                                          a
+                                                                          b
                                                                           (con integer)
                                                                           [
                                                                             [
@@ -1636,11 +1535,11 @@
                                                                                     [
                                                                                       [
                                                                                         f
-                                                                                        a
+                                                                                        (con
+                                                                                          0
+                                                                                        )
                                                                                       ]
-                                                                                      (con
-                                                                                        0
-                                                                                      )
+                                                                                      b
                                                                                     ]
                                                                                   ]
                                                                                   (fun Unit Bool)
@@ -1664,27 +1563,106 @@
                                                                           ]
                                                                         )
                                                                       ]
+                                                                      (lam
+                                                                        a
+                                                                        (con integer)
+                                                                        (lam
+                                                                          b
+                                                                          (con integer)
+                                                                          [
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    Bool_match
+                                                                                    [
+                                                                                      [
+                                                                                        f
+                                                                                        a
+                                                                                      ]
+                                                                                      b
+                                                                                    ]
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  [
+                                                                                    go
+                                                                                    xs
+                                                                                  ]
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                False
+                                                                              )
+                                                                            ]
+                                                                            Unit
+                                                                          ]
+                                                                        )
+                                                                      )
+                                                                    ]
+                                                                    (lam
+                                                                      a
+                                                                      (con integer)
+                                                                      [
+                                                                        [
+                                                                          [
+                                                                            {
+                                                                              [
+                                                                                Bool_match
+                                                                                [
+                                                                                  [
+                                                                                    f
+                                                                                    a
+                                                                                  ]
+                                                                                  (con
+                                                                                    0
+                                                                                  )
+                                                                                ]
+                                                                              ]
+                                                                              (fun Unit Bool)
+                                                                            }
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              [
+                                                                                go
+                                                                                xs
+                                                                              ]
+                                                                            )
+                                                                          ]
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            False
+                                                                          )
+                                                                        ]
+                                                                        Unit
+                                                                      ]
                                                                     )
-                                                                  )
-                                                                ]
+                                                                  ]
+                                                                )
                                                               )
-                                                            )
+                                                            ]
                                                           )
-                                                        ]
-                                                        Unit
-                                                      ]
-                                                    )
-                                                  )
-                                                  [ go x ]
+                                                        )
+                                                      )
+                                                    ]
+                                                    Unit
+                                                  ]
                                                 )
                                               )
+                                              [ go x ]
                                             )
-                                          ]
+                                          )
                                         )
-                                      )
+                                      ]
                                     )
-                                  ]
-                                  Unit
+                                  )
                                 ]
                               )
                             )
@@ -1721,22 +1699,12 @@
                                   ds
                                   [List a]
                                   [
-                                    [
-                                      [
-                                        { [ { Nil_match a } ds ] (fun Unit b) }
-                                        (lam thunk Unit z)
-                                      ]
-                                      (lam
-                                        y
-                                        a
-                                        (lam
-                                          ys
-                                          [List a]
-                                          (lam thunk Unit [ [ k y ] [ go ys ] ])
-                                        )
-                                      )
-                                    ]
-                                    Unit
+                                    [ { [ { Nil_match a } ds ] b } z ]
+                                    (lam
+                                      y
+                                      a
+                                      (lam ys [List a] [ [ k y ] [ go ys ] ])
+                                    )
                                   ]
                                 )
                               )
@@ -2087,63 +2055,58 @@
                                                 Unit
                                                 [
                                                   [
-                                                    [
-                                                      {
+                                                    {
+                                                      [
+                                                        {
+                                                          Maybe_match
+                                                          (con bytestring)
+                                                        }
                                                         [
-                                                          {
-                                                            Maybe_match
-                                                            (con bytestring)
-                                                          }
                                                           [
+                                                            {
+                                                              find
+                                                              (con bytestring)
+                                                            }
                                                             [
-                                                              {
-                                                                find
-                                                                (con bytestring)
-                                                              }
+                                                              equalsByteString
                                                               [
-                                                                equalsByteString
-                                                                [
-                                                                  {
-                                                                    [
-                                                                      Campaign_match
-                                                                      w
-                                                                    ]
-                                                                    (con bytestring)
-                                                                  }
+                                                                {
+                                                                  [
+                                                                    Campaign_match
+                                                                    w
+                                                                  ]
+                                                                  (con bytestring)
+                                                                }
+                                                                (lam
+                                                                  ds
+                                                                  (con integer)
                                                                   (lam
                                                                     ds
-                                                                    (con integer)
+                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                     (lam
                                                                       ds
-                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                      (con integer)
                                                                       (lam
                                                                         ds
-                                                                        (con integer)
-                                                                        (lam
-                                                                          ds
-                                                                          (con bytestring)
-                                                                          ds
-                                                                        )
+                                                                        (con bytestring)
+                                                                        ds
                                                                       )
                                                                     )
                                                                   )
-                                                                ]
+                                                                )
                                                               ]
                                                             ]
-                                                            ww
                                                           ]
+                                                          ww
                                                         ]
-                                                        (fun Unit Bool)
-                                                      }
-                                                      (lam
-                                                        ds
-                                                        (con bytestring)
-                                                        (lam thunk Unit True)
-                                                      )
-                                                    ]
-                                                    (lam thunk Unit False)
+                                                      ]
+                                                      Bool
+                                                    }
+                                                    (lam
+                                                      ds (con bytestring) True
+                                                    )
                                                   ]
-                                                  Unit
+                                                  False
                                                 ]
                                               )
                                             ]
@@ -2192,24 +2155,40 @@
                                               [
                                                 [
                                                   [
-                                                    [
-                                                      {
+                                                    {
+                                                      [
+                                                        {
+                                                          Extended_match
+                                                          (con integer)
+                                                        }
+                                                        v
+                                                      ]
+                                                      Bool
+                                                    }
+                                                    (lam
+                                                      ipv
+                                                      (con integer)
+                                                      [
                                                         [
-                                                          {
-                                                            Extended_match
-                                                            (con integer)
-                                                          }
-                                                          v
-                                                        ]
-                                                        (fun Unit Bool)
-                                                      }
-                                                      (lam
-                                                        ipv
-                                                        (con integer)
-                                                        (lam
-                                                          thunk
-                                                          Unit
                                                           [
+                                                            {
+                                                              [
+                                                                Bool_match
+                                                                [
+                                                                  [
+                                                                    equalsInteger
+                                                                    ipv
+                                                                  ]
+                                                                  h
+                                                                ]
+                                                              ]
+                                                              (fun Unit Bool)
+                                                            }
+                                                            (lam thunk Unit j)
+                                                          ]
+                                                          (lam
+                                                            thunk
+                                                            Unit
                                                             [
                                                               [
                                                                 {
@@ -2217,76 +2196,27 @@
                                                                     Bool_match
                                                                     [
                                                                       [
-                                                                        equalsInteger
+                                                                        lessThanEqInteger
                                                                         ipv
                                                                       ]
                                                                       h
                                                                     ]
                                                                   ]
-                                                                  (fun Unit Bool)
+                                                                  Bool
                                                                 }
-                                                                (lam
-                                                                  thunk
-                                                                  Unit
-                                                                  (let
-                                                                    (nonrec)
-                                                                    (termbind
-                                                                      (strict)
-                                                                      (vardecl
-                                                                        wild
-                                                                        Bool
-                                                                      )
-                                                                      in
-                                                                    )
-                                                                    j
-                                                                  )
-                                                                )
+                                                                j
                                                               ]
-                                                              (lam
-                                                                thunk
-                                                                Unit
-                                                                [
-                                                                  [
-                                                                    [
-                                                                      {
-                                                                        [
-                                                                          Bool_match
-                                                                          [
-                                                                            [
-                                                                              lessThanEqInteger
-                                                                              ipv
-                                                                            ]
-                                                                            h
-                                                                          ]
-                                                                        ]
-                                                                        (fun Unit Bool)
-                                                                      }
-                                                                      (lam
-                                                                        thunk
-                                                                        Unit
-                                                                        j
-                                                                      )
-                                                                    ]
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      False
-                                                                    )
-                                                                  ]
-                                                                  Unit
-                                                                ]
-                                                              )
+                                                              False
                                                             ]
-                                                            Unit
-                                                          ]
-                                                        )
-                                                      )
-                                                    ]
-                                                    (lam thunk Unit j)
+                                                          )
+                                                        ]
+                                                        Unit
+                                                      ]
+                                                    )
                                                   ]
-                                                  (lam thunk Unit False)
+                                                  j
                                                 ]
-                                                Unit
+                                                False
                                               ]
                                             )
                                           )
@@ -2315,23 +2245,34 @@
                                       [
                                         [
                                           [
-                                            [
-                                              {
+                                            {
+                                              [
+                                                { Extended_match (con integer) }
+                                                ww
+                                              ]
+                                              Bool
+                                            }
+                                            (lam
+                                              ipv
+                                              (con integer)
+                                              [
                                                 [
-                                                  {
-                                                    Extended_match (con integer)
-                                                  }
-                                                  ww
-                                                ]
-                                                (fun Unit Bool)
-                                              }
-                                              (lam
-                                                ipv
-                                                (con integer)
-                                                (lam
-                                                  thunk
-                                                  Unit
                                                   [
+                                                    {
+                                                      [
+                                                        Bool_match
+                                                        [
+                                                          [ equalsInteger l ]
+                                                          ipv
+                                                        ]
+                                                      ]
+                                                      (fun Unit Bool)
+                                                    }
+                                                    (lam thunk Unit j)
+                                                  ]
+                                                  (lam
+                                                    thunk
+                                                    Unit
                                                     [
                                                       [
                                                         {
@@ -2339,67 +2280,27 @@
                                                             Bool_match
                                                             [
                                                               [
-                                                                equalsInteger l
+                                                                lessThanEqInteger
+                                                                l
                                                               ]
                                                               ipv
                                                             ]
                                                           ]
-                                                          (fun Unit Bool)
+                                                          Bool
                                                         }
-                                                        (lam
-                                                          thunk
-                                                          Unit
-                                                          (let
-                                                            (nonrec)
-                                                            (termbind
-                                                              (strict)
-                                                              (vardecl wild Bool
-                                                              )
-                                                              ww
-                                                            )
-                                                            j
-                                                          )
-                                                        )
+                                                        j
                                                       ]
-                                                      (lam
-                                                        thunk
-                                                        Unit
-                                                        [
-                                                          [
-                                                            [
-                                                              {
-                                                                [
-                                                                  Bool_match
-                                                                  [
-                                                                    [
-                                                                      lessThanEqInteger
-                                                                      l
-                                                                    ]
-                                                                    ipv
-                                                                  ]
-                                                                ]
-                                                                (fun Unit Bool)
-                                                              }
-                                                              (lam thunk Unit j)
-                                                            ]
-                                                            (lam
-                                                              thunk Unit False
-                                                            )
-                                                          ]
-                                                          Unit
-                                                        ]
-                                                      )
+                                                      False
                                                     ]
-                                                    Unit
-                                                  ]
-                                                )
-                                              )
-                                            ]
-                                            (lam thunk Unit False)
+                                                  )
+                                                ]
+                                                Unit
+                                              ]
+                                            )
                                           ]
-                                          (lam thunk Unit j)
+                                          False
                                         ]
-                                        Unit
+                                        j
                                       ]
                                     )
                                   )
@@ -2552,31 +2453,22 @@
                                         (vardecl j Bool)
                                         [
                                           [
-                                            [
-                                              {
+                                            {
+                                              [
+                                                { Maybe_match (con bytestring) }
                                                 [
-                                                  {
-                                                    Maybe_match (con bytestring)
-                                                  }
                                                   [
-                                                    [
-                                                      { find (con bytestring) }
-                                                      [ equalsByteString w ]
-                                                    ]
-                                                    ww
+                                                    { find (con bytestring) }
+                                                    [ equalsByteString w ]
                                                   ]
+                                                  ww
                                                 ]
-                                                (fun Unit Bool)
-                                              }
-                                              (lam
-                                                ds
-                                                (con bytestring)
-                                                (lam thunk Unit True)
-                                              )
-                                            ]
-                                            (lam thunk Unit False)
+                                              ]
+                                              Bool
+                                            }
+                                            (lam ds (con bytestring) True)
                                           ]
-                                          Unit
+                                          False
                                         ]
                                       )
                                       (termbind
@@ -2636,86 +2528,64 @@
                                                         (lam
                                                           thunk
                                                           Unit
-                                                          (let
-                                                            (nonrec)
-                                                            (termbind
-                                                              (strict)
-                                                              (vardecl wild Bool
-                                                              )
-                                                              ww
-                                                            )
-                                                            [
-                                                              {
-                                                                [
-                                                                  {
-                                                                    UpperBound_match
-                                                                    (con integer)
-                                                                  }
-                                                                  ww
-                                                                ]
-                                                                Bool
-                                                              }
+                                                          [
+                                                            {
+                                                              [
+                                                                {
+                                                                  UpperBound_match
+                                                                  (con integer)
+                                                                }
+                                                                ww
+                                                              ]
+                                                              Bool
+                                                            }
+                                                            (lam
+                                                              v
+                                                              [Extended (con integer)]
                                                               (lam
-                                                                v
-                                                                [Extended (con integer)]
-                                                                (lam
-                                                                  in
-                                                                  Bool
+                                                                in
+                                                                Bool
+                                                                [
                                                                   [
                                                                     [
                                                                       [
-                                                                        [
-                                                                          {
-                                                                            [
-                                                                              {
-                                                                                Extended_match
-                                                                                (con integer)
-                                                                              }
-                                                                              v
-                                                                            ]
-                                                                            (fun Unit Bool)
-                                                                          }
-                                                                          (lam
-                                                                            default_arg0
-                                                                            (con integer)
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              j
-                                                                            )
-                                                                          )
-                                                                        ]
+                                                                        {
+                                                                          [
+                                                                            {
+                                                                              Extended_match
+                                                                              (con integer)
+                                                                            }
+                                                                            v
+                                                                          ]
+                                                                          (fun Unit Bool)
+                                                                        }
                                                                         (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          j
+                                                                          default_arg0
+                                                                          (con integer)
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            j
+                                                                          )
                                                                         )
                                                                       ]
                                                                       (lam
                                                                         thunk
                                                                         Unit
-                                                                        (let
-                                                                          (nonrec
-                                                                          )
-                                                                          (termbind
-                                                                            (strict
-                                                                            )
-                                                                            (vardecl
-                                                                              wild
-                                                                              Bool
-                                                                            )
-                                                                            in
-                                                                          )
-                                                                          j
-                                                                        )
+                                                                        j
                                                                       )
                                                                     ]
-                                                                    Unit
+                                                                    (lam
+                                                                      thunk
+                                                                      Unit
+                                                                      j
+                                                                    )
                                                                   ]
-                                                                )
+                                                                  Unit
+                                                                ]
                                                               )
-                                                            ]
-                                                          )
+                                                            )
+                                                          ]
                                                         )
                                                       ]
                                                       (lam
@@ -2790,20 +2660,7 @@
                                                                           (lam
                                                                             thunk
                                                                             Unit
-                                                                            (let
-                                                                              (nonrec
-                                                                              )
-                                                                              (termbind
-                                                                                (strict
-                                                                                )
-                                                                                (vardecl
-                                                                                  wild
-                                                                                  Bool
-                                                                                )
-                                                                                in
-                                                                              )
-                                                                              j
-                                                                            )
+                                                                            j
                                                                           )
                                                                         ]
                                                                         Unit
@@ -2870,19 +2727,7 @@
                                                         ]
                                                         (lam thunk Unit j)
                                                       ]
-                                                      (lam
-                                                        thunk
-                                                        Unit
-                                                        (let
-                                                          (nonrec)
-                                                          (termbind
-                                                            (strict)
-                                                            (vardecl wild Bool)
-                                                            in
-                                                          )
-                                                          j
-                                                        )
-                                                      )
+                                                      (lam thunk Unit j)
                                                     ]
                                                     Unit
                                                   ]

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -21,25 +21,25 @@ Events by wallet:
     - Iteration: 3
     Requests:
         4: {utxo-at:
-            ScriptAddress: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5}
+            ScriptAddress: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87}
       Response:
         ( 4
         , {utxo-at:
-           Utxo at ScriptAddress: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5 =
-             22037c4240c09d86f7617323d1b41ab8e8f2d3f6cbb04db1e446d3b0c616cbed!1: PayToScript: 49cd69a6941f191e3d14ce83834e0f2ce175318995b40380854e3201171c0baa Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-             27b285df0f32a6b17d0af0ae6331953c87466d71ff316864dca84a6de6e6812d!1: PayToScript: b8324180800f57f26dee2ad65990e0a762a5dab9424d32e49855abd495f7196b Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-             ec7d2e1d35bb8b99594d3641531209d1c891d84b5fa7525886e3aa4965bdc98c!1: PayToScript: 4c592448cff8d2b2ee40a509e1d5224260ef29f5b22cd920616e39cad65f466c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}} )
+           Utxo at ScriptAddress: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87 =
+             81803ed7ab4212645ba302c7ed06a921b06c4f41d81a4a00d97be34315d28a5a!1: PayToScript: 49cd69a6941f191e3d14ce83834e0f2ce175318995b40380854e3201171c0baa Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+             9253d436cea207978e86b84b751f0bb1ebff9c01025d28fd7171586f1a00ae4a!1: PayToScript: b8324180800f57f26dee2ad65990e0a762a5dab9424d32e49855abd495f7196b Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+             d5c424d255c7d92327084fee7e06c6ea86bbb10ce28c20dc0b1154c6aa14fb09!1: PayToScript: 4c592448cff8d2b2ee40a509e1d5224260ef29f5b22cd920616e39cad65f466c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}} )
     - Iteration: 4
     Requests:
         5: {tx:
             Tx:
-              Tx e681789c1e486a280e09d611a8912058b5e2e34a977d3f5f3b8dbf531900be26:
+              Tx 3c36e313a969a633a4bbf996be086c88ec7210b9285bb03b94dc595243eb3955:
                 {inputs:
-                   - 22037c4240c09d86f7617323d1b41ab8e8f2d3f6cbb04db1e446d3b0c616cbed!1
+                   - 81803ed7ab4212645ba302c7ed06a921b06c4f41d81a4a00d97be34315d28a5a!1
                      Redeemer: <>
-                   - 27b285df0f32a6b17d0af0ae6331953c87466d71ff316864dca84a6de6e6812d!1
+                   - 9253d436cea207978e86b84b751f0bb1ebff9c01025d28fd7171586f1a00ae4a!1
                      Redeemer: <>
-                   - ec7d2e1d35bb8b99594d3641531209d1c891d84b5fa7525886e3aa4965bdc98c!1
+                   - d5c424d255c7d92327084fee7e06c6ea86bbb10ce28c20dc0b1154c6aa14fb09!1
                      Redeemer: <>
                 outputs:
                 forge: Value {getValue = Map {unMap = []}}
@@ -52,7 +52,7 @@ Events by wallet:
       Response:
         ( 5
         , {tx:
-           WriteTxSuccess: 2d83b74095a10e377641e5a06c975340283702c6697cc9fea9d1d78aead15207} )
+           WriteTxSuccess: 73e8e250c29d3ba19491bcffa45af2e9608e8a9e65dd94e22a3edce818f66266} )
   Events for W2:
     - Iteration: 1
     Requests:
@@ -78,11 +78,11 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx 1982433fbb33995be509ec55affa5f94ce4510c44fa4e55de1f912a42db2a9c6:
+              Tx 42342dce312368b5f8971c606ed0b4356b8380b4992c9fc1c95e00289603aa9f:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-                    ScriptAddress: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+                    ScriptAddress: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
@@ -94,7 +94,7 @@ Events by wallet:
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: 27b285df0f32a6b17d0af0ae6331953c87466d71ff316864dca84a6de6e6812d} )
+           WriteTxSuccess: 9253d436cea207978e86b84b751f0bb1ebff9c01025d28fd7171586f1a00ae4a} )
   Events for W3:
     - Iteration: 1
     Requests:
@@ -120,11 +120,11 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx 19240ed559733cdeff2d4009a6232c5d045db224767c507e7feed2397716b136:
+              Tx 45b0e33e5e19ccabb14f0c939a54aa46b0bd4247aa74b715ffb4f944b6bda92c:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-                    ScriptAddress: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+                    ScriptAddress: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
@@ -136,7 +136,7 @@ Events by wallet:
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: 22037c4240c09d86f7617323d1b41ab8e8f2d3f6cbb04db1e446d3b0c616cbed} )
+           WriteTxSuccess: 81803ed7ab4212645ba302c7ed06a921b06c4f41d81a4a00d97be34315d28a5a} )
   Events for W4:
     - Iteration: 1
     Requests:
@@ -162,11 +162,11 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx d6765cd9fe51048ff2cd8dcda8608d7e6cdf3761ea41e736b1b45e358572b1be:
+              Tx 9e8e3dee4e9ed2f2a8bc6d96b1bd46c2f69d52a3a7d30322efce07cc332918b4:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} addressed to
-                    ScriptAddress: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+                    ScriptAddress: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
@@ -178,7 +178,7 @@ Events by wallet:
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: ec7d2e1d35bb8b99594d3641531209d1c891d84b5fa7525886e3aa4965bdc98c} )
+           WriteTxSuccess: d5c424d255c7d92327084fee7e06c6ea86bbb10ce28c20dc0b1154c6aa14fb09} )
 Contract result by wallet:
     Wallet: W1
       Done

--- a/plutus-use-cases/test/Spec/future.pir
+++ b/plutus-use-cases/test/Spec/future.pir
@@ -635,29 +635,19 @@
                             l
                             [List a]
                             [
-                              [
-                                [
-                                  { [ { Nil_match a } l ] (fun Unit b) }
-                                  (lam thunk Unit acc)
-                                ]
+                              [ { [ { Nil_match a } l ] b } acc ]
+                              (lam
+                                x
+                                a
                                 (lam
-                                  x
-                                  a
-                                  (lam
-                                    xs
-                                    [List a]
-                                    (lam
-                                      thunk
-                                      Unit
-                                      [
-                                        [ f x ]
-                                        [ [ [ { { foldr a } b } f ] acc ] xs ]
-                                      ]
-                                    )
-                                  )
+                                  xs
+                                  [List a]
+                                  [
+                                    [ f x ]
+                                    [ [ [ { { foldr a } b } f ] acc ] xs ]
+                                  ]
                                 )
-                              ]
-                              Unit
+                              )
                             ]
                           )
                         )
@@ -4474,207 +4464,121 @@
                                     [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
                                     [
                                       [
-                                        [
-                                          {
-                                            [
-                                              {
-                                                Nil_match
-                                                [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                              }
-                                              xs
-                                            ]
-                                            (fun Unit Bool)
-                                          }
-                                          (lam thunk Unit True)
-                                        ]
-                                        (lam
-                                          ds
-                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                          (lam
+                                        {
+                                          [
+                                            {
+                                              Nil_match
+                                              [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                            }
                                             xs
-                                            [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
-                                            (lam
-                                              thunk
-                                              Unit
+                                          ]
+                                          Bool
+                                        }
+                                        True
+                                      ]
+                                      (lam
+                                        ds
+                                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                        (lam
+                                          xs
+                                          [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
+                                          [
+                                            {
                                               [
                                                 {
-                                                  [
-                                                    {
-                                                      {
-                                                        Tuple2_match
-                                                        (con bytestring)
-                                                      }
-                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                    }
-                                                    ds
-                                                  ]
-                                                  Bool
+                                                  {
+                                                    Tuple2_match
+                                                    (con bytestring)
+                                                  }
+                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
                                                 }
-                                                (lam
-                                                  ds
-                                                  (con bytestring)
-                                                  (lam
-                                                    x
-                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                    (let
-                                                      (rec)
-                                                      (termbind
-                                                        (strict)
-                                                        (vardecl
-                                                          go
-                                                          (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] Bool)
-                                                        )
-                                                        (lam
-                                                          xs
-                                                          [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                ds
+                                              ]
+                                              Bool
+                                            }
+                                            (lam
+                                              ds
+                                              (con bytestring)
+                                              (lam
+                                                x
+                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
+                                                (let
+                                                  (rec)
+                                                  (termbind
+                                                    (strict)
+                                                    (vardecl
+                                                      go
+                                                      (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] Bool)
+                                                    )
+                                                    (lam
+                                                      xs
+                                                      [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                      [
+                                                        [
                                                           [
-                                                            [
+                                                            {
                                                               [
                                                                 {
-                                                                  [
-                                                                    {
-                                                                      Nil_match
-                                                                      [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                    }
-                                                                    xs
-                                                                  ]
-                                                                  (fun Unit Bool)
+                                                                  Nil_match
+                                                                  [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
                                                                 }
-                                                                (lam
-                                                                  thunk
-                                                                  Unit
-                                                                  [ go xs ]
-                                                                )
+                                                                xs
                                                               ]
+                                                              (fun Unit Bool)
+                                                            }
+                                                            (lam
+                                                              thunk
+                                                              Unit
+                                                              [ go xs ]
+                                                            )
+                                                          ]
+                                                          (lam
+                                                            ds
+                                                            [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
+                                                            (lam
+                                                              xs
+                                                              [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
                                                               (lam
-                                                                ds
-                                                                [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                (lam
-                                                                  xs
-                                                                  [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
-                                                                  (lam
-                                                                    thunk
-                                                                    Unit
+                                                                thunk
+                                                                Unit
+                                                                [
+                                                                  {
                                                                     [
                                                                       {
-                                                                        [
-                                                                          {
-                                                                            {
-                                                                              Tuple2_match
-                                                                              (con bytestring)
-                                                                            }
-                                                                            [[These (con integer)] (con integer)]
-                                                                          }
-                                                                          ds
-                                                                        ]
-                                                                        Bool
+                                                                        {
+                                                                          Tuple2_match
+                                                                          (con bytestring)
+                                                                        }
+                                                                        [[These (con integer)] (con integer)]
                                                                       }
-                                                                      (lam
-                                                                        ds
-                                                                        (con bytestring)
-                                                                        (lam
-                                                                          x
-                                                                          [[These (con integer)] (con integer)]
+                                                                      ds
+                                                                    ]
+                                                                    Bool
+                                                                  }
+                                                                  (lam
+                                                                    ds
+                                                                    (con bytestring)
+                                                                    (lam
+                                                                      x
+                                                                      [[These (con integer)] (con integer)]
+                                                                      [
+                                                                        [
                                                                           [
-                                                                            [
+                                                                            {
                                                                               [
                                                                                 {
-                                                                                  [
-                                                                                    {
-                                                                                      {
-                                                                                        These_match
-                                                                                        (con integer)
-                                                                                      }
-                                                                                      (con integer)
-                                                                                    }
-                                                                                    x
-                                                                                  ]
-                                                                                  Bool
+                                                                                  {
+                                                                                    These_match
+                                                                                    (con integer)
+                                                                                  }
+                                                                                  (con integer)
                                                                                 }
-                                                                                (lam
-                                                                                  b
-                                                                                  (con integer)
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            Bool_match
-                                                                                            [
-                                                                                              [
-                                                                                                f
-                                                                                                (con
-                                                                                                  0
-                                                                                                )
-                                                                                              ]
-                                                                                              b
-                                                                                            ]
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          [
-                                                                                            go
-                                                                                            xs
-                                                                                          ]
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        False
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
+                                                                                x
                                                                               ]
-                                                                              (lam
-                                                                                a
-                                                                                (con integer)
-                                                                                (lam
-                                                                                  b
-                                                                                  (con integer)
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            Bool_match
-                                                                                            [
-                                                                                              [
-                                                                                                f
-                                                                                                a
-                                                                                              ]
-                                                                                              b
-                                                                                            ]
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          [
-                                                                                            go
-                                                                                            xs
-                                                                                          ]
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        False
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            ]
+                                                                              Bool
+                                                                            }
                                                                             (lam
-                                                                              a
+                                                                              b
                                                                               (con integer)
                                                                               [
                                                                                 [
@@ -4685,11 +4589,11 @@
                                                                                         [
                                                                                           [
                                                                                             f
-                                                                                            a
+                                                                                            (con
+                                                                                              0
+                                                                                            )
                                                                                           ]
-                                                                                          (con
-                                                                                            0
-                                                                                          )
+                                                                                          b
                                                                                         ]
                                                                                       ]
                                                                                       (fun Unit Bool)
@@ -4713,27 +4617,106 @@
                                                                               ]
                                                                             )
                                                                           ]
+                                                                          (lam
+                                                                            a
+                                                                            (con integer)
+                                                                            (lam
+                                                                              b
+                                                                              (con integer)
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        Bool_match
+                                                                                        [
+                                                                                          [
+                                                                                            f
+                                                                                            a
+                                                                                          ]
+                                                                                          b
+                                                                                        ]
+                                                                                      ]
+                                                                                      (fun Unit Bool)
+                                                                                    }
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      [
+                                                                                        go
+                                                                                        xs
+                                                                                      ]
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    False
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
+                                                                          )
+                                                                        ]
+                                                                        (lam
+                                                                          a
+                                                                          (con integer)
+                                                                          [
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    Bool_match
+                                                                                    [
+                                                                                      [
+                                                                                        f
+                                                                                        a
+                                                                                      ]
+                                                                                      (con
+                                                                                        0
+                                                                                      )
+                                                                                    ]
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  [
+                                                                                    go
+                                                                                    xs
+                                                                                  ]
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                False
+                                                                              )
+                                                                            ]
+                                                                            Unit
+                                                                          ]
                                                                         )
-                                                                      )
-                                                                    ]
+                                                                      ]
+                                                                    )
                                                                   )
-                                                                )
+                                                                ]
                                                               )
-                                                            ]
-                                                            Unit
-                                                          ]
-                                                        )
-                                                      )
-                                                      [ go x ]
+                                                            )
+                                                          )
+                                                        ]
+                                                        Unit
+                                                      ]
                                                     )
                                                   )
+                                                  [ go x ]
                                                 )
-                                              ]
+                                              )
                                             )
-                                          )
+                                          ]
                                         )
-                                      ]
-                                      Unit
+                                      )
                                     ]
                                   )
                                 )
@@ -4765,163 +4748,151 @@
                                 [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
                                 [
                                   [
-                                    [
-                                      {
-                                        [
-                                          {
-                                            Nil_match
-                                            [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                          }
-                                          xs
-                                        ]
-                                        (fun Unit Bool)
-                                      }
-                                      (lam thunk Unit True)
-                                    ]
-                                    (lam
-                                      ds
-                                      [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                      (lam
+                                    {
+                                      [
+                                        {
+                                          Nil_match
+                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                        }
                                         xs
-                                        [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                                        (lam
-                                          thunk
-                                          Unit
+                                      ]
+                                      Bool
+                                    }
+                                    True
+                                  ]
+                                  (lam
+                                    ds
+                                    [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                    (lam
+                                      xs
+                                      [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                      [
+                                        {
                                           [
                                             {
-                                              [
-                                                {
-                                                  {
-                                                    Tuple2_match
-                                                    (con bytestring)
-                                                  }
-                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                }
-                                                ds
-                                              ]
-                                              Bool
+                                              { Tuple2_match (con bytestring) }
+                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
                                             }
-                                            (lam
-                                              ds
-                                              (con bytestring)
-                                              (lam
-                                                x
-                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                (let
-                                                  (rec)
-                                                  (termbind
-                                                    (strict)
-                                                    (vardecl
-                                                      go
-                                                      (fun [List [[Tuple2 (con bytestring)] (con integer)]] Bool)
-                                                    )
-                                                    (lam
-                                                      xs
-                                                      [List [[Tuple2 (con bytestring)] (con integer)]]
+                                            ds
+                                          ]
+                                          Bool
+                                        }
+                                        (lam
+                                          ds
+                                          (con bytestring)
+                                          (lam
+                                            x
+                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                            (let
+                                              (rec)
+                                              (termbind
+                                                (strict)
+                                                (vardecl
+                                                  go
+                                                  (fun [List [[Tuple2 (con bytestring)] (con integer)]] Bool)
+                                                )
+                                                (lam
+                                                  xs
+                                                  [List [[Tuple2 (con bytestring)] (con integer)]]
+                                                  [
+                                                    [
                                                       [
-                                                        [
+                                                        {
                                                           [
                                                             {
-                                                              [
-                                                                {
-                                                                  Nil_match
-                                                                  [[Tuple2 (con bytestring)] (con integer)]
-                                                                }
-                                                                xs
-                                                              ]
-                                                              (fun Unit Bool)
+                                                              Nil_match
+                                                              [[Tuple2 (con bytestring)] (con integer)]
                                                             }
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              [ go xs ]
-                                                            )
+                                                            xs
                                                           ]
+                                                          (fun Unit Bool)
+                                                        }
+                                                        (lam
+                                                          thunk Unit [ go xs ]
+                                                        )
+                                                      ]
+                                                      (lam
+                                                        ds
+                                                        [[Tuple2 (con bytestring)] (con integer)]
+                                                        (lam
+                                                          xs
+                                                          [List [[Tuple2 (con bytestring)] (con integer)]]
                                                           (lam
-                                                            ds
-                                                            [[Tuple2 (con bytestring)] (con integer)]
-                                                            (lam
-                                                              xs
-                                                              [List [[Tuple2 (con bytestring)] (con integer)]]
-                                                              (lam
-                                                                thunk
-                                                                Unit
+                                                            thunk
+                                                            Unit
+                                                            [
+                                                              {
                                                                 [
                                                                   {
-                                                                    [
-                                                                      {
-                                                                        {
-                                                                          Tuple2_match
-                                                                          (con bytestring)
-                                                                        }
-                                                                        (con integer)
-                                                                      }
-                                                                      ds
-                                                                    ]
-                                                                    Bool
+                                                                    {
+                                                                      Tuple2_match
+                                                                      (con bytestring)
+                                                                    }
+                                                                    (con integer)
                                                                   }
-                                                                  (lam
-                                                                    ds
-                                                                    (con bytestring)
-                                                                    (lam
-                                                                      x
-                                                                      (con integer)
-                                                                      [
-                                                                        [
-                                                                          [
-                                                                            {
-                                                                              [
-                                                                                Bool_match
-                                                                                [
-                                                                                  [
-                                                                                    equalsInteger
-                                                                                    (con
-                                                                                      0
-                                                                                    )
-                                                                                  ]
-                                                                                  x
-                                                                                ]
-                                                                              ]
-                                                                              (fun Unit Bool)
-                                                                            }
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              [
-                                                                                go
-                                                                                xs
-                                                                              ]
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            False
-                                                                          )
-                                                                        ]
-                                                                        Unit
-                                                                      ]
-                                                                    )
-                                                                  )
+                                                                  ds
                                                                 ]
+                                                                Bool
+                                                              }
+                                                              (lam
+                                                                ds
+                                                                (con bytestring)
+                                                                (lam
+                                                                  x
+                                                                  (con integer)
+                                                                  [
+                                                                    [
+                                                                      [
+                                                                        {
+                                                                          [
+                                                                            Bool_match
+                                                                            [
+                                                                              [
+                                                                                equalsInteger
+                                                                                (con
+                                                                                  0
+                                                                                )
+                                                                              ]
+                                                                              x
+                                                                            ]
+                                                                          ]
+                                                                          (fun Unit Bool)
+                                                                        }
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          [
+                                                                            go
+                                                                            xs
+                                                                          ]
+                                                                        )
+                                                                      ]
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        False
+                                                                      )
+                                                                    ]
+                                                                    Unit
+                                                                  ]
+                                                                )
                                                               )
-                                                            )
+                                                            ]
                                                           )
-                                                        ]
-                                                        Unit
-                                                      ]
-                                                    )
-                                                  )
-                                                  [ go x ]
+                                                        )
+                                                      )
+                                                    ]
+                                                    Unit
+                                                  ]
                                                 )
                                               )
+                                              [ go x ]
                                             )
-                                          ]
+                                          )
                                         )
-                                      )
+                                      ]
                                     )
-                                  ]
-                                  Unit
+                                  )
                                 ]
                               )
                             )
@@ -6237,17 +6208,8 @@
                                   ds
                                   FutureState
                                   [
-                                    [
-                                      [
-                                        {
-                                          [ FutureState_match ds ]
-                                          (fun Unit Bool)
-                                        }
-                                        (lam thunk Unit True)
-                                      ]
-                                      (lam ipv Margins (lam thunk Unit False))
-                                    ]
-                                    Unit
+                                    [ { [ FutureState_match ds ] Bool } True ]
+                                    (lam ipv Margins False)
                                   ]
                                 )
                               ]

--- a/plutus-use-cases/test/Spec/gameStateMachine.pir
+++ b/plutus-use-cases/test/Spec/gameStateMachine.pir
@@ -70,18 +70,8 @@
                             thunk
                             Unit
                             [
-                              [
-                                [
-                                  { [ { Nil_match a } ds ] (fun Unit Bool) }
-                                  (lam thunk Unit True)
-                                ]
-                                (lam
-                                  ipv
-                                  a
-                                  (lam ipv [List a] (lam thunk Unit False))
-                                )
-                              ]
-                              Unit
+                              [ { [ { Nil_match a } ds ] Bool } True ]
+                              (lam ipv a (lam ipv [List a] False))
                             ]
                           )
                         ]
@@ -95,45 +85,34 @@
                               thunk
                               Unit
                               [
-                                [
-                                  [
-                                    { [ { Nil_match a } ds ] (fun Unit Bool) }
-                                    (lam thunk Unit False)
-                                  ]
+                                [ { [ { Nil_match a } ds ] Bool } False ]
+                                (lam
+                                  y
+                                  a
                                   (lam
-                                    y
-                                    a
-                                    (lam
-                                      ys
-                                      [List a]
-                                      (lam
-                                        thunk
-                                        Unit
+                                    ys
+                                    [List a]
+                                    [
+                                      [
                                         [
-                                          [
+                                          {
+                                            [ Bool_match [ [ dEq x ] y ] ]
+                                            (fun Unit Bool)
+                                          }
+                                          (lam
+                                            thunk
+                                            Unit
                                             [
-                                              {
-                                                [ Bool_match [ [ dEq x ] y ] ]
-                                                (fun Unit Bool)
-                                              }
-                                              (lam
-                                                thunk
-                                                Unit
-                                                [
-                                                  [ [ { fEqData_c a } dEq ] xs ]
-                                                  ys
-                                                ]
-                                              )
+                                              [ [ { fEqData_c a } dEq ] xs ] ys
                                             ]
-                                            (lam thunk Unit False)
-                                          ]
-                                          Unit
+                                          )
                                         ]
-                                      )
-                                    )
+                                        (lam thunk Unit False)
+                                      ]
+                                      Unit
+                                    ]
                                   )
-                                ]
-                                Unit
+                                )
                               ]
                             )
                           )
@@ -232,50 +211,28 @@
                                       [
                                         [
                                           [
-                                            [
-                                              {
-                                                [ Data_match ds ]
-                                                (fun Unit Bool)
-                                              }
-                                              (lam
-                                                b
-                                                (con bytestring)
-                                                (lam
-                                                  thunk
-                                                  Unit
-                                                  [ [ equalsByteString b ] b ]
-                                                )
-                                              )
-                                            ]
+                                            { [ Data_match ds ] Bool }
                                             (lam
-                                              default_arg0
-                                              (con integer)
-                                              (lam
-                                                default_arg1
-                                                [List Data]
-                                                (lam thunk Unit False)
-                                              )
+                                              b
+                                              (con bytestring)
+                                              [ [ equalsByteString b ] b ]
                                             )
                                           ]
                                           (lam
                                             default_arg0
                                             (con integer)
-                                            (lam thunk Unit False)
+                                            (lam default_arg1 [List Data] False)
                                           )
                                         ]
-                                        (lam
-                                          default_arg0
-                                          [List Data]
-                                          (lam thunk Unit False)
-                                        )
+                                        (lam default_arg0 (con integer) False)
                                       ]
-                                      (lam
-                                        default_arg0
-                                        [List [[Tuple2 Data] Data]]
-                                        (lam thunk Unit False)
-                                      )
+                                      (lam default_arg0 [List Data] False)
                                     ]
-                                    Unit
+                                    (lam
+                                      default_arg0
+                                      [List [[Tuple2 Data] Data]]
+                                      False
+                                    )
                                   ]
                                 )
                               ]
@@ -290,85 +247,62 @@
                                       [
                                         [
                                           [
-                                            [
-                                              {
-                                                [ Data_match ds ]
-                                                (fun Unit Bool)
-                                              }
-                                              (lam
-                                                default_arg0
-                                                (con bytestring)
-                                                (lam thunk Unit False)
-                                              )
-                                            ]
+                                            { [ Data_match ds ] Bool }
                                             (lam
-                                              i
-                                              (con integer)
-                                              (lam
-                                                ds
-                                                [List Data]
-                                                (lam
-                                                  thunk
-                                                  Unit
-                                                  [
-                                                    [
-                                                      [
-                                                        {
-                                                          [
-                                                            Bool_match
-                                                            [
-                                                              [
-                                                                equalsInteger i
-                                                              ]
-                                                              i
-                                                            ]
-                                                          ]
-                                                          (fun Unit Bool)
-                                                        }
-                                                        (lam
-                                                          thunk
-                                                          Unit
-                                                          [
-                                                            [
-                                                              [
-                                                                {
-                                                                  fEqData_c Data
-                                                                }
-                                                                fEqData_c
-                                                              ]
-                                                              ds
-                                                            ]
-                                                            ds
-                                                          ]
-                                                        )
-                                                      ]
-                                                      (lam thunk Unit False)
-                                                    ]
-                                                    Unit
-                                                  ]
-                                                )
-                                              )
+                                              default_arg0
+                                              (con bytestring)
+                                              False
                                             )
                                           ]
                                           (lam
-                                            default_arg0
+                                            i
                                             (con integer)
-                                            (lam thunk Unit False)
+                                            (lam
+                                              ds
+                                              [List Data]
+                                              [
+                                                [
+                                                  [
+                                                    {
+                                                      [
+                                                        Bool_match
+                                                        [
+                                                          [ equalsInteger i ] i
+                                                        ]
+                                                      ]
+                                                      (fun Unit Bool)
+                                                    }
+                                                    (lam
+                                                      thunk
+                                                      Unit
+                                                      [
+                                                        [
+                                                          [
+                                                            { fEqData_c Data }
+                                                            fEqData_c
+                                                          ]
+                                                          ds
+                                                        ]
+                                                        ds
+                                                      ]
+                                                    )
+                                                  ]
+                                                  (lam thunk Unit False)
+                                                ]
+                                                Unit
+                                              ]
+                                            )
                                           )
                                         ]
-                                        (lam
-                                          default_arg0
-                                          [List Data]
-                                          (lam thunk Unit False)
-                                        )
+                                        (lam default_arg0 (con integer) False)
                                       ]
-                                      (lam
-                                        default_arg0
-                                        [List [[Tuple2 Data] Data]]
-                                        (lam thunk Unit False)
-                                      )
+                                      (lam default_arg0 [List Data] False)
                                     ]
-                                    Unit
+                                    (lam
+                                      default_arg0
+                                      [List [[Tuple2 Data] Data]]
+                                      False
+                                    )
                                   ]
                                 )
                               )
@@ -381,45 +315,25 @@
                                   [
                                     [
                                       [
-                                        [
-                                          { [ Data_match ds ] (fun Unit Bool) }
-                                          (lam
-                                            default_arg0
-                                            (con bytestring)
-                                            (lam thunk Unit False)
-                                          )
-                                        ]
-                                        (lam
-                                          default_arg0
-                                          (con integer)
-                                          (lam
-                                            default_arg1
-                                            [List Data]
-                                            (lam thunk Unit False)
-                                          )
+                                        { [ Data_match ds ] Bool }
+                                        (lam default_arg0 (con bytestring) False
                                         )
                                       ]
                                       (lam
-                                        i
+                                        default_arg0
                                         (con integer)
-                                        (lam
-                                          thunk Unit [ [ equalsInteger i ] i ]
-                                        )
+                                        (lam default_arg1 [List Data] False)
                                       )
                                     ]
                                     (lam
-                                      default_arg0
-                                      [List Data]
-                                      (lam thunk Unit False)
+                                      i (con integer) [ [ equalsInteger i ] i ]
                                     )
                                   ]
-                                  (lam
-                                    default_arg0
-                                    [List [[Tuple2 Data] Data]]
-                                    (lam thunk Unit False)
-                                  )
+                                  (lam default_arg0 [List Data] False)
                                 ]
-                                Unit
+                                (lam
+                                  default_arg0 [List [[Tuple2 Data] Data]] False
+                                )
                               ]
                             )
                           ]
@@ -431,50 +345,26 @@
                                 [
                                   [
                                     [
-                                      [
-                                        { [ Data_match ds ] (fun Unit Bool) }
-                                        (lam
-                                          default_arg0
-                                          (con bytestring)
-                                          (lam thunk Unit False)
-                                        )
-                                      ]
-                                      (lam
-                                        default_arg0
-                                        (con integer)
-                                        (lam
-                                          default_arg1
-                                          [List Data]
-                                          (lam thunk Unit False)
-                                        )
-                                      )
+                                      { [ Data_match ds ] Bool }
+                                      (lam default_arg0 (con bytestring) False)
                                     ]
                                     (lam
                                       default_arg0
                                       (con integer)
-                                      (lam thunk Unit False)
+                                      (lam default_arg1 [List Data] False)
                                     )
                                   ]
-                                  (lam
-                                    ls
-                                    [List Data]
-                                    (lam
-                                      thunk
-                                      Unit
-                                      [
-                                        [ [ { fEqData_c Data } fEqData_c ] ls ]
-                                        ls
-                                      ]
-                                    )
-                                  )
+                                  (lam default_arg0 (con integer) False)
                                 ]
                                 (lam
-                                  default_arg0
-                                  [List [[Tuple2 Data] Data]]
-                                  (lam thunk Unit False)
+                                  ls
+                                  [List Data]
+                                  [ [ [ { fEqData_c Data } fEqData_c ] ls ] ls ]
                                 )
                               ]
-                              Unit
+                              (lam
+                                default_arg0 [List [[Tuple2 Data] Data]] False
+                              )
                             ]
                           )
                         ]
@@ -486,53 +376,29 @@
                               [
                                 [
                                   [
-                                    [
-                                      { [ Data_match ds ] (fun Unit Bool) }
-                                      (lam
-                                        default_arg0
-                                        (con bytestring)
-                                        (lam thunk Unit False)
-                                      )
-                                    ]
-                                    (lam
-                                      default_arg0
-                                      (con integer)
-                                      (lam
-                                        default_arg1
-                                        [List Data]
-                                        (lam thunk Unit False)
-                                      )
-                                    )
+                                    { [ Data_match ds ] Bool }
+                                    (lam default_arg0 (con bytestring) False)
                                   ]
                                   (lam
                                     default_arg0
                                     (con integer)
-                                    (lam thunk Unit False)
+                                    (lam default_arg1 [List Data] False)
                                   )
                                 ]
-                                (lam
-                                  default_arg0
-                                  [List Data]
-                                  (lam thunk Unit False)
-                                )
+                                (lam default_arg0 (con integer) False)
                               ]
-                              (lam
-                                ds
-                                [List [[Tuple2 Data] Data]]
-                                (lam
-                                  thunk
-                                  Unit
-                                  [
-                                    [
-                                      [ { fEqData_c [[Tuple2 Data] Data] } dEq ]
-                                      ds
-                                    ]
-                                    ds
-                                  ]
-                                )
-                              )
+                              (lam default_arg0 [List Data] False)
                             ]
-                            Unit
+                            (lam
+                              ds
+                              [List [[Tuple2 Data] Data]]
+                              [
+                                [
+                                  [ { fEqData_c [[Tuple2 Data] Data] } dEq ] ds
+                                ]
+                                ds
+                              ]
+                            )
                           ]
                         )
                       ]
@@ -2069,32 +1935,19 @@
                                   l
                                   [List a]
                                   [
-                                    [
-                                      [
-                                        { [ { Nil_match a } l ] (fun Unit b) }
-                                        (lam thunk Unit acc)
-                                      ]
+                                    [ { [ { Nil_match a } l ] b } acc ]
+                                    (lam
+                                      x
+                                      a
                                       (lam
-                                        x
-                                        a
-                                        (lam
-                                          xs
-                                          [List a]
-                                          (lam
-                                            thunk
-                                            Unit
-                                            [
-                                              [ f x ]
-                                              [
-                                                [ [ { { foldr a } b } f ] acc ]
-                                                xs
-                                              ]
-                                            ]
-                                          )
-                                        )
+                                        xs
+                                        [List a]
+                                        [
+                                          [ f x ]
+                                          [ [ [ { { foldr a } b } f ] acc ] xs ]
+                                        ]
                                       )
-                                    ]
-                                    Unit
+                                    )
                                   ]
                                 )
                               )
@@ -4270,89 +4123,78 @@
                                                                                                         TxOutType
                                                                                                         [
                                                                                                           [
+                                                                                                            {
+                                                                                                              [
+                                                                                                                TxOutType_match
+                                                                                                                ds
+                                                                                                              ]
+                                                                                                              [List TxOut]
+                                                                                                            }
+                                                                                                            xs
+                                                                                                          ]
+                                                                                                          (lam
+                                                                                                            ds
+                                                                                                            (con bytestring)
                                                                                                             [
-                                                                                                              {
-                                                                                                                [
-                                                                                                                  TxOutType_match
-                                                                                                                  ds
-                                                                                                                ]
-                                                                                                                (fun Unit [List TxOut])
-                                                                                                              }
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  [
+                                                                                                                    Address_match
+                                                                                                                    ds
+                                                                                                                  ]
+                                                                                                                  [List TxOut]
+                                                                                                                }
+                                                                                                                (lam
+                                                                                                                  pkh
+                                                                                                                  (con bytestring)
+                                                                                                                  xs
+                                                                                                                )
+                                                                                                              ]
                                                                                                               (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                xs
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            (lam
-                                                                                                              ds
-                                                                                                              (con bytestring)
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
+                                                                                                                vh
+                                                                                                                (con bytestring)
                                                                                                                 [
                                                                                                                   [
-                                                                                                                    {
-                                                                                                                      [
-                                                                                                                        Address_match
-                                                                                                                        ds
-                                                                                                                      ]
-                                                                                                                      [List TxOut]
-                                                                                                                    }
+                                                                                                                    [
+                                                                                                                      {
+                                                                                                                        [
+                                                                                                                          Bool_match
+                                                                                                                          [
+                                                                                                                            [
+                                                                                                                              equalsByteString
+                                                                                                                              vh
+                                                                                                                            ]
+                                                                                                                            inpHsh
+                                                                                                                          ]
+                                                                                                                        ]
+                                                                                                                        (fun Unit [List TxOut])
+                                                                                                                      }
+                                                                                                                      (lam
+                                                                                                                        thunk
+                                                                                                                        Unit
+                                                                                                                        [
+                                                                                                                          [
+                                                                                                                            {
+                                                                                                                              Cons
+                                                                                                                              TxOut
+                                                                                                                            }
+                                                                                                                            wild
+                                                                                                                          ]
+                                                                                                                          xs
+                                                                                                                        ]
+                                                                                                                      )
+                                                                                                                    ]
                                                                                                                     (lam
-                                                                                                                      pkh
-                                                                                                                      (con bytestring)
+                                                                                                                      thunk
+                                                                                                                      Unit
                                                                                                                       xs
                                                                                                                     )
                                                                                                                   ]
-                                                                                                                  (lam
-                                                                                                                    vh
-                                                                                                                    (con bytestring)
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            [
-                                                                                                                              Bool_match
-                                                                                                                              [
-                                                                                                                                [
-                                                                                                                                  equalsByteString
-                                                                                                                                  vh
-                                                                                                                                ]
-                                                                                                                                inpHsh
-                                                                                                                              ]
-                                                                                                                            ]
-                                                                                                                            (fun Unit [List TxOut])
-                                                                                                                          }
-                                                                                                                          (lam
-                                                                                                                            thunk
-                                                                                                                            Unit
-                                                                                                                            [
-                                                                                                                              [
-                                                                                                                                {
-                                                                                                                                  Cons
-                                                                                                                                  TxOut
-                                                                                                                                }
-                                                                                                                                wild
-                                                                                                                              ]
-                                                                                                                              xs
-                                                                                                                            ]
-                                                                                                                          )
-                                                                                                                        ]
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          xs
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      Unit
-                                                                                                                    ]
-                                                                                                                  )
+                                                                                                                  Unit
                                                                                                                 ]
                                                                                                               )
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          Unit
+                                                                                                            ]
+                                                                                                          )
                                                                                                         ]
                                                                                                       )
                                                                                                     )
@@ -4437,209 +4279,121 @@
                                           [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
                                           [
                                             [
-                                              [
-                                                {
-                                                  [
-                                                    {
-                                                      Nil_match
-                                                      [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                                    }
-                                                    xs
-                                                  ]
-                                                  (fun Unit Bool)
-                                                }
-                                                (lam thunk Unit True)
-                                              ]
-                                              (lam
-                                                ds
-                                                [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                                (lam
+                                              {
+                                                [
+                                                  {
+                                                    Nil_match
+                                                    [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                  }
                                                   xs
-                                                  [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
-                                                  (lam
-                                                    thunk
-                                                    Unit
+                                                ]
+                                                Bool
+                                              }
+                                              True
+                                            ]
+                                            (lam
+                                              ds
+                                              [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                              (lam
+                                                xs
+                                                [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
+                                                [
+                                                  {
                                                     [
                                                       {
-                                                        [
-                                                          {
-                                                            {
-                                                              Tuple2_match
-                                                              (con bytestring)
-                                                            }
-                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                          }
-                                                          ds
-                                                        ]
-                                                        Bool
+                                                        {
+                                                          Tuple2_match
+                                                          (con bytestring)
+                                                        }
+                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
                                                       }
-                                                      (lam
-                                                        ds
-                                                        (con bytestring)
-                                                        (lam
-                                                          x
-                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                          (let
-                                                            (rec)
-                                                            (termbind
-                                                              (strict)
-                                                              (vardecl
-                                                                go
-                                                                (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] Bool)
-                                                              )
-                                                              (lam
-                                                                xs
-                                                                [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                      ds
+                                                    ]
+                                                    Bool
+                                                  }
+                                                  (lam
+                                                    ds
+                                                    (con bytestring)
+                                                    (lam
+                                                      x
+                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
+                                                      (let
+                                                        (rec)
+                                                        (termbind
+                                                          (strict)
+                                                          (vardecl
+                                                            go
+                                                            (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] Bool)
+                                                          )
+                                                          (lam
+                                                            xs
+                                                            [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                            [
+                                                              [
                                                                 [
-                                                                  [
+                                                                  {
                                                                     [
                                                                       {
-                                                                        [
-                                                                          {
-                                                                            Nil_match
-                                                                            [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                          }
-                                                                          xs
-                                                                        ]
-                                                                        (fun Unit Bool)
+                                                                        Nil_match
+                                                                        [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
                                                                       }
-                                                                      (lam
-                                                                        thunk
-                                                                        Unit
-                                                                        [
-                                                                          go xs
-                                                                        ]
-                                                                      )
+                                                                      xs
                                                                     ]
+                                                                    (fun Unit Bool)
+                                                                  }
+                                                                  (lam
+                                                                    thunk
+                                                                    Unit
+                                                                    [ go xs ]
+                                                                  )
+                                                                ]
+                                                                (lam
+                                                                  ds
+                                                                  [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
+                                                                  (lam
+                                                                    xs
+                                                                    [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
                                                                     (lam
-                                                                      ds
-                                                                      [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                      (lam
-                                                                        xs
-                                                                        [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
+                                                                      thunk
+                                                                      Unit
+                                                                      [
+                                                                        {
                                                                           [
                                                                             {
-                                                                              [
-                                                                                {
-                                                                                  {
-                                                                                    Tuple2_match
-                                                                                    (con bytestring)
-                                                                                  }
-                                                                                  [[These (con integer)] (con integer)]
-                                                                                }
-                                                                                ds
-                                                                              ]
-                                                                              Bool
+                                                                              {
+                                                                                Tuple2_match
+                                                                                (con bytestring)
+                                                                              }
+                                                                              [[These (con integer)] (con integer)]
                                                                             }
-                                                                            (lam
-                                                                              ds
-                                                                              (con bytestring)
-                                                                              (lam
-                                                                                x
-                                                                                [[These (con integer)] (con integer)]
+                                                                            ds
+                                                                          ]
+                                                                          Bool
+                                                                        }
+                                                                        (lam
+                                                                          ds
+                                                                          (con bytestring)
+                                                                          (lam
+                                                                            x
+                                                                            [[These (con integer)] (con integer)]
+                                                                            [
+                                                                              [
                                                                                 [
-                                                                                  [
+                                                                                  {
                                                                                     [
                                                                                       {
-                                                                                        [
-                                                                                          {
-                                                                                            {
-                                                                                              These_match
-                                                                                              (con integer)
-                                                                                            }
-                                                                                            (con integer)
-                                                                                          }
-                                                                                          x
-                                                                                        ]
-                                                                                        Bool
+                                                                                        {
+                                                                                          These_match
+                                                                                          (con integer)
+                                                                                        }
+                                                                                        (con integer)
                                                                                       }
-                                                                                      (lam
-                                                                                        b
-                                                                                        (con integer)
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  Bool_match
-                                                                                                  [
-                                                                                                    [
-                                                                                                      f
-                                                                                                      (con
-                                                                                                        0
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    b
-                                                                                                  ]
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                [
-                                                                                                  go
-                                                                                                  xs
-                                                                                                ]
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              False
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
+                                                                                      x
                                                                                     ]
-                                                                                    (lam
-                                                                                      a
-                                                                                      (con integer)
-                                                                                      (lam
-                                                                                        b
-                                                                                        (con integer)
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  Bool_match
-                                                                                                  [
-                                                                                                    [
-                                                                                                      f
-                                                                                                      a
-                                                                                                    ]
-                                                                                                    b
-                                                                                                  ]
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                [
-                                                                                                  go
-                                                                                                  xs
-                                                                                                ]
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              False
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
+                                                                                    Bool
+                                                                                  }
                                                                                   (lam
-                                                                                    a
+                                                                                    b
                                                                                     (con integer)
                                                                                     [
                                                                                       [
@@ -4650,11 +4404,11 @@
                                                                                               [
                                                                                                 [
                                                                                                   f
-                                                                                                  a
+                                                                                                  (con
+                                                                                                    0
+                                                                                                  )
                                                                                                 ]
-                                                                                                (con
-                                                                                                  0
-                                                                                                )
+                                                                                                b
                                                                                               ]
                                                                                             ]
                                                                                             (fun Unit Bool)
@@ -4678,27 +4432,106 @@
                                                                                     ]
                                                                                   )
                                                                                 ]
+                                                                                (lam
+                                                                                  a
+                                                                                  (con integer)
+                                                                                  (lam
+                                                                                    b
+                                                                                    (con integer)
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              Bool_match
+                                                                                              [
+                                                                                                [
+                                                                                                  f
+                                                                                                  a
+                                                                                                ]
+                                                                                                b
+                                                                                              ]
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            [
+                                                                                              go
+                                                                                              xs
+                                                                                            ]
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          False
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                a
+                                                                                (con integer)
+                                                                                [
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        [
+                                                                                          Bool_match
+                                                                                          [
+                                                                                            [
+                                                                                              f
+                                                                                              a
+                                                                                            ]
+                                                                                            (con
+                                                                                              0
+                                                                                            )
+                                                                                          ]
+                                                                                        ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        [
+                                                                                          go
+                                                                                          xs
+                                                                                        ]
+                                                                                      )
+                                                                                    ]
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      False
+                                                                                    )
+                                                                                  ]
+                                                                                  Unit
+                                                                                ]
                                                                               )
-                                                                            )
-                                                                          ]
+                                                                            ]
+                                                                          )
                                                                         )
-                                                                      )
+                                                                      ]
                                                                     )
-                                                                  ]
-                                                                  Unit
-                                                                ]
-                                                              )
-                                                            )
-                                                            [ go x ]
+                                                                  )
+                                                                )
+                                                              ]
+                                                              Unit
+                                                            ]
                                                           )
                                                         )
+                                                        [ go x ]
                                                       )
-                                                    ]
+                                                    )
                                                   )
-                                                )
+                                                ]
                                               )
-                                            ]
-                                            Unit
+                                            )
                                           ]
                                         )
                                       )
@@ -4793,99 +4626,77 @@
                                                                           TxOutType
                                                                           [
                                                                             [
-                                                                              [
-                                                                                {
-                                                                                  [
-                                                                                    TxOutType_match
-                                                                                    ds
-                                                                                  ]
-                                                                                  (fun Unit Bool)
-                                                                                }
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  False
-                                                                                )
-                                                                              ]
-                                                                              (lam
-                                                                                svh
-                                                                                (con bytestring)
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            Bool_match
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  checkBinRel
-                                                                                                  equalsInteger
-                                                                                                ]
-                                                                                                ds
-                                                                                              ]
-                                                                                              ww
-                                                                                            ]
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          [
-                                                                                            [
-                                                                                              [
-                                                                                                {
-                                                                                                  [
-                                                                                                    {
-                                                                                                      Maybe_match
-                                                                                                      (con bytestring)
-                                                                                                    }
-                                                                                                    hsh
-                                                                                                  ]
-                                                                                                  (fun Unit Bool)
-                                                                                                }
-                                                                                                (lam
-                                                                                                  a
-                                                                                                  (con bytestring)
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    [
-                                                                                                      [
-                                                                                                        equalsByteString
-                                                                                                        a
-                                                                                                      ]
-                                                                                                      svh
-                                                                                                    ]
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                False
-                                                                                              )
-                                                                                            ]
-                                                                                            Unit
-                                                                                          ]
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        False
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              )
+                                                                              {
+                                                                                [
+                                                                                  TxOutType_match
+                                                                                  ds
+                                                                                ]
+                                                                                Bool
+                                                                              }
+                                                                              False
                                                                             ]
-                                                                            Unit
+                                                                            (lam
+                                                                              svh
+                                                                              (con bytestring)
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        Bool_match
+                                                                                        [
+                                                                                          [
+                                                                                            [
+                                                                                              checkBinRel
+                                                                                              equalsInteger
+                                                                                            ]
+                                                                                            ds
+                                                                                          ]
+                                                                                          ww
+                                                                                        ]
+                                                                                      ]
+                                                                                      (fun Unit Bool)
+                                                                                    }
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              {
+                                                                                                Maybe_match
+                                                                                                (con bytestring)
+                                                                                              }
+                                                                                              hsh
+                                                                                            ]
+                                                                                            Bool
+                                                                                          }
+                                                                                          (lam
+                                                                                            a
+                                                                                            (con bytestring)
+                                                                                            [
+                                                                                              [
+                                                                                                equalsByteString
+                                                                                                a
+                                                                                              ]
+                                                                                              svh
+                                                                                            ]
+                                                                                          )
+                                                                                        ]
+                                                                                        False
+                                                                                      ]
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    False
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
                                                                           ]
                                                                         )
                                                                       )
@@ -4914,17 +4725,14 @@
                                               thunk
                                               Unit
                                               [
-                                                [
-                                                  {
-                                                    [
-                                                      Unit_match
-                                                      scheckOwnOutputConstraint
-                                                    ]
-                                                    (fun Unit Bool)
-                                                  }
-                                                  (lam thunk Unit False)
-                                                ]
-                                                Unit
+                                                {
+                                                  [
+                                                    Unit_match
+                                                    scheckOwnOutputConstraint
+                                                  ]
+                                                  Bool
+                                                }
+                                                False
                                               ]
                                             )
                                           ]
@@ -5000,14 +4808,11 @@
                               (nonstrict)
                               (vardecl scheckValidatorCtx_j Bool)
                               [
-                                [
-                                  {
-                                    [ Unit_match [ trace scheckValidatorCtx ] ]
-                                    (fun Unit Bool)
-                                  }
-                                  (lam thunk Unit False)
-                                ]
-                                Unit
+                                {
+                                  [ Unit_match [ trace scheckValidatorCtx ] ]
+                                  Bool
+                                }
+                                False
                               ]
                             )
                             (termbind
@@ -5252,26 +5057,19 @@
                                                                           thunk
                                                                           Unit
                                                                           [
-                                                                            [
-                                                                              {
+                                                                            {
+                                                                              [
+                                                                                Unit_match
                                                                                 [
-                                                                                  Unit_match
-                                                                                  [
-                                                                                    trace
-                                                                                    (con
-                                                                                      "Input constraint"
-                                                                                    )
-                                                                                  ]
+                                                                                  trace
+                                                                                  (con
+                                                                                    "Input constraint"
+                                                                                  )
                                                                                 ]
-                                                                                (fun Unit Bool)
-                                                                              }
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                False
-                                                                              )
-                                                                            ]
-                                                                            Unit
+                                                                              ]
+                                                                              Bool
+                                                                            }
+                                                                            False
                                                                           ]
                                                                         )
                                                                       ]
@@ -5367,19 +5165,16 @@
                                         Unit
                                         [
                                           [
-                                            [
-                                              {
-                                                [
-                                                  Bool_match
-                                                  [ [ lessThanEqInteger x ] y ]
-                                                ]
-                                                (fun Unit Ordering)
-                                              }
-                                              (lam thunk Unit LT)
-                                            ]
-                                            (lam thunk Unit GT)
+                                            {
+                                              [
+                                                Bool_match
+                                                [ [ lessThanEqInteger x ] y ]
+                                              ]
+                                              Ordering
+                                            }
+                                            LT
                                           ]
-                                          Unit
+                                          GT
                                         ]
                                       )
                                     ]
@@ -5402,19 +5197,16 @@
                                   (con integer)
                                   [
                                     [
-                                      [
-                                        {
-                                          [
-                                            Bool_match
-                                            [ [ lessThanEqInteger x ] y ]
-                                          ]
-                                          (fun Unit (con integer))
-                                        }
-                                        (lam thunk Unit y)
-                                      ]
-                                      (lam thunk Unit x)
+                                      {
+                                        [
+                                          Bool_match
+                                          [ [ lessThanEqInteger x ] y ]
+                                        ]
+                                        (con integer)
+                                      }
+                                      y
                                     ]
-                                    Unit
+                                    x
                                   ]
                                 )
                               )
@@ -5433,19 +5225,16 @@
                                   (con integer)
                                   [
                                     [
-                                      [
-                                        {
-                                          [
-                                            Bool_match
-                                            [ [ lessThanEqInteger x ] y ]
-                                          ]
-                                          (fun Unit (con integer))
-                                        }
-                                        (lam thunk Unit x)
-                                      ]
-                                      (lam thunk Unit y)
+                                      {
+                                        [
+                                          Bool_match
+                                          [ [ lessThanEqInteger x ] y ]
+                                        ]
+                                        (con integer)
+                                      }
+                                      x
                                     ]
-                                    Unit
+                                    y
                                   ]
                                 )
                               )
@@ -5602,53 +5391,45 @@
                                         [List a]
                                         [
                                           [
-                                            [
-                                              {
-                                                [ { Nil_match a } haystack ]
-                                                (fun Unit Bool)
-                                              }
-                                              (lam thunk Unit False)
-                                            ]
+                                            {
+                                              [ { Nil_match a } haystack ] Bool
+                                            }
+                                            False
+                                          ]
+                                          (lam
+                                            x
+                                            a
                                             (lam
-                                              x
-                                              a
-                                              (lam
-                                                xs
-                                                [List a]
-                                                (lam
-                                                  thunk
-                                                  Unit
+                                              xs
+                                              [List a]
+                                              [
+                                                [
                                                   [
+                                                    {
+                                                      [
+                                                        Bool_match
+                                                        [ [ dEq x ] needle ]
+                                                      ]
+                                                      (fun Unit Bool)
+                                                    }
+                                                    (lam thunk Unit True)
+                                                  ]
+                                                  (lam
+                                                    thunk
+                                                    Unit
                                                     [
                                                       [
-                                                        {
-                                                          [
-                                                            Bool_match
-                                                            [ [ dEq x ] needle ]
-                                                          ]
-                                                          (fun Unit Bool)
-                                                        }
-                                                        (lam thunk Unit True)
+                                                        [ { elem a } dEq ]
+                                                        needle
                                                       ]
-                                                      (lam
-                                                        thunk
-                                                        Unit
-                                                        [
-                                                          [
-                                                            [ { elem a } dEq ]
-                                                            needle
-                                                          ]
-                                                          xs
-                                                        ]
-                                                      )
+                                                      xs
                                                     ]
-                                                    Unit
-                                                  ]
-                                                )
-                                              )
+                                                  )
+                                                ]
+                                                Unit
+                                              ]
                                             )
-                                          ]
-                                          Unit
+                                          )
                                         ]
                                       )
                                     )
@@ -6403,20 +6184,7 @@
                                                                                                                         (lam
                                                                                                                           thunk
                                                                                                                           Unit
-                                                                                                                          (let
-                                                                                                                            (nonrec
-                                                                                                                            )
-                                                                                                                            (termbind
-                                                                                                                              (strict
-                                                                                                                              )
-                                                                                                                              (vardecl
-                                                                                                                                wild
-                                                                                                                                Bool
-                                                                                                                              )
-                                                                                                                              in
-                                                                                                                            )
-                                                                                                                            True
-                                                                                                                          )
+                                                                                                                          True
                                                                                                                         )
                                                                                                                       ]
                                                                                                                       Unit
@@ -6545,20 +6313,7 @@
                                                                                                   (lam
                                                                                                     thunk
                                                                                                     Unit
-                                                                                                    (let
-                                                                                                      (nonrec
-                                                                                                      )
-                                                                                                      (termbind
-                                                                                                        (strict
-                                                                                                        )
-                                                                                                        (vardecl
-                                                                                                          wild
-                                                                                                          Bool
-                                                                                                        )
-                                                                                                        in
-                                                                                                      )
-                                                                                                      True
-                                                                                                    )
+                                                                                                    True
                                                                                                   )
                                                                                                 ]
                                                                                                 Unit
@@ -6668,20 +6423,7 @@
                                                                                                                   (lam
                                                                                                                     thunk
                                                                                                                     Unit
-                                                                                                                    (let
-                                                                                                                      (nonrec
-                                                                                                                      )
-                                                                                                                      (termbind
-                                                                                                                        (strict
-                                                                                                                        )
-                                                                                                                        (vardecl
-                                                                                                                          wild
-                                                                                                                          Bool
-                                                                                                                        )
-                                                                                                                        in
-                                                                                                                      )
-                                                                                                                      True
-                                                                                                                    )
+                                                                                                                    True
                                                                                                                   )
                                                                                                                 ]
                                                                                                                 Unit
@@ -6810,20 +6552,7 @@
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              (let
-                                                                                                (nonrec
-                                                                                                )
-                                                                                                (termbind
-                                                                                                  (strict
-                                                                                                  )
-                                                                                                  (vardecl
-                                                                                                    wild
-                                                                                                    Bool
-                                                                                                  )
-                                                                                                  in
-                                                                                                )
-                                                                                                True
-                                                                                              )
+                                                                                              True
                                                                                             )
                                                                                           ]
                                                                                           Unit
@@ -6893,20 +6622,7 @@
                                                                             (lam
                                                                               thunk
                                                                               Unit
-                                                                              (let
-                                                                                (nonrec
-                                                                                )
-                                                                                (termbind
-                                                                                  (strict
-                                                                                  )
-                                                                                  (vardecl
-                                                                                    wild
-                                                                                    Bool
-                                                                                  )
-                                                                                  in
-                                                                                )
-                                                                                True
-                                                                              )
+                                                                              True
                                                                             )
                                                                           ]
                                                                           Unit
@@ -7041,20 +6757,7 @@
                                                                                                                   (lam
                                                                                                                     thunk
                                                                                                                     Unit
-                                                                                                                    (let
-                                                                                                                      (nonrec
-                                                                                                                      )
-                                                                                                                      (termbind
-                                                                                                                        (strict
-                                                                                                                        )
-                                                                                                                        (vardecl
-                                                                                                                          wild
-                                                                                                                          Bool
-                                                                                                                        )
-                                                                                                                        in
-                                                                                                                      )
-                                                                                                                      True
-                                                                                                                    )
+                                                                                                                    True
                                                                                                                   )
                                                                                                                 ]
                                                                                                                 Unit
@@ -7183,20 +6886,7 @@
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              (let
-                                                                                                (nonrec
-                                                                                                )
-                                                                                                (termbind
-                                                                                                  (strict
-                                                                                                  )
-                                                                                                  (vardecl
-                                                                                                    wild
-                                                                                                    Bool
-                                                                                                  )
-                                                                                                  in
-                                                                                                )
-                                                                                                True
-                                                                                              )
+                                                                                              True
                                                                                             )
                                                                                           ]
                                                                                           Unit
@@ -7306,20 +6996,7 @@
                                                                                                             (lam
                                                                                                               thunk
                                                                                                               Unit
-                                                                                                              (let
-                                                                                                                (nonrec
-                                                                                                                )
-                                                                                                                (termbind
-                                                                                                                  (strict
-                                                                                                                  )
-                                                                                                                  (vardecl
-                                                                                                                    wild
-                                                                                                                    Bool
-                                                                                                                  )
-                                                                                                                  in
-                                                                                                                )
-                                                                                                                True
-                                                                                                              )
+                                                                                                              True
                                                                                                             )
                                                                                                           ]
                                                                                                           Unit
@@ -7448,20 +7125,7 @@
                                                                                       (lam
                                                                                         thunk
                                                                                         Unit
-                                                                                        (let
-                                                                                          (nonrec
-                                                                                          )
-                                                                                          (termbind
-                                                                                            (strict
-                                                                                            )
-                                                                                            (vardecl
-                                                                                              wild
-                                                                                              Bool
-                                                                                            )
-                                                                                            in
-                                                                                          )
-                                                                                          True
-                                                                                        )
+                                                                                        True
                                                                                       )
                                                                                     ]
                                                                                     Unit
@@ -7679,20 +7343,7 @@
                                                                                                                         (lam
                                                                                                                           thunk
                                                                                                                           Unit
-                                                                                                                          (let
-                                                                                                                            (nonrec
-                                                                                                                            )
-                                                                                                                            (termbind
-                                                                                                                              (strict
-                                                                                                                              )
-                                                                                                                              (vardecl
-                                                                                                                                wild
-                                                                                                                                Bool
-                                                                                                                              )
-                                                                                                                              in
-                                                                                                                            )
-                                                                                                                            True
-                                                                                                                          )
+                                                                                                                          True
                                                                                                                         )
                                                                                                                       ]
                                                                                                                       Unit
@@ -7821,20 +7472,7 @@
                                                                                                   (lam
                                                                                                     thunk
                                                                                                     Unit
-                                                                                                    (let
-                                                                                                      (nonrec
-                                                                                                      )
-                                                                                                      (termbind
-                                                                                                        (strict
-                                                                                                        )
-                                                                                                        (vardecl
-                                                                                                          wild
-                                                                                                          Bool
-                                                                                                        )
-                                                                                                        in
-                                                                                                      )
-                                                                                                      True
-                                                                                                    )
+                                                                                                    True
                                                                                                   )
                                                                                                 ]
                                                                                                 Unit
@@ -7944,20 +7582,7 @@
                                                                                                                   (lam
                                                                                                                     thunk
                                                                                                                     Unit
-                                                                                                                    (let
-                                                                                                                      (nonrec
-                                                                                                                      )
-                                                                                                                      (termbind
-                                                                                                                        (strict
-                                                                                                                        )
-                                                                                                                        (vardecl
-                                                                                                                          wild
-                                                                                                                          Bool
-                                                                                                                        )
-                                                                                                                        in
-                                                                                                                      )
-                                                                                                                      True
-                                                                                                                    )
+                                                                                                                    True
                                                                                                                   )
                                                                                                                 ]
                                                                                                                 Unit
@@ -8086,20 +7711,7 @@
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              (let
-                                                                                                (nonrec
-                                                                                                )
-                                                                                                (termbind
-                                                                                                  (strict
-                                                                                                  )
-                                                                                                  (vardecl
-                                                                                                    wild
-                                                                                                    Bool
-                                                                                                  )
-                                                                                                  in
-                                                                                                )
-                                                                                                True
-                                                                                              )
+                                                                                              True
                                                                                             )
                                                                                           ]
                                                                                           Unit
@@ -8169,20 +7781,7 @@
                                                                             (lam
                                                                               thunk
                                                                               Unit
-                                                                              (let
-                                                                                (nonrec
-                                                                                )
-                                                                                (termbind
-                                                                                  (strict
-                                                                                  )
-                                                                                  (vardecl
-                                                                                    wild
-                                                                                    Bool
-                                                                                  )
-                                                                                  in
-                                                                                )
-                                                                                True
-                                                                              )
+                                                                              True
                                                                             )
                                                                           ]
                                                                           Unit
@@ -8317,20 +7916,7 @@
                                                                                                                   (lam
                                                                                                                     thunk
                                                                                                                     Unit
-                                                                                                                    (let
-                                                                                                                      (nonrec
-                                                                                                                      )
-                                                                                                                      (termbind
-                                                                                                                        (strict
-                                                                                                                        )
-                                                                                                                        (vardecl
-                                                                                                                          wild
-                                                                                                                          Bool
-                                                                                                                        )
-                                                                                                                        in
-                                                                                                                      )
-                                                                                                                      True
-                                                                                                                    )
+                                                                                                                    True
                                                                                                                   )
                                                                                                                 ]
                                                                                                                 Unit
@@ -8459,20 +8045,7 @@
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              (let
-                                                                                                (nonrec
-                                                                                                )
-                                                                                                (termbind
-                                                                                                  (strict
-                                                                                                  )
-                                                                                                  (vardecl
-                                                                                                    wild
-                                                                                                    Bool
-                                                                                                  )
-                                                                                                  in
-                                                                                                )
-                                                                                                True
-                                                                                              )
+                                                                                              True
                                                                                             )
                                                                                           ]
                                                                                           Unit
@@ -8582,20 +8155,7 @@
                                                                                                             (lam
                                                                                                               thunk
                                                                                                               Unit
-                                                                                                              (let
-                                                                                                                (nonrec
-                                                                                                                )
-                                                                                                                (termbind
-                                                                                                                  (strict
-                                                                                                                  )
-                                                                                                                  (vardecl
-                                                                                                                    wild
-                                                                                                                    Bool
-                                                                                                                  )
-                                                                                                                  in
-                                                                                                                )
-                                                                                                                True
-                                                                                                              )
+                                                                                                              True
                                                                                                             )
                                                                                                           ]
                                                                                                           Unit
@@ -8724,20 +8284,7 @@
                                                                                       (lam
                                                                                         thunk
                                                                                         Unit
-                                                                                        (let
-                                                                                          (nonrec
-                                                                                          )
-                                                                                          (termbind
-                                                                                            (strict
-                                                                                            )
-                                                                                            (vardecl
-                                                                                              wild
-                                                                                              Bool
-                                                                                            )
-                                                                                            in
-                                                                                          )
-                                                                                          True
-                                                                                        )
+                                                                                        True
                                                                                       )
                                                                                     ]
                                                                                     Unit
@@ -9207,28 +8754,18 @@
                                                 [List a]
                                                 [
                                                   [
-                                                    [
-                                                      {
-                                                        [ { Nil_match a } ds ]
-                                                        (fun Unit b)
-                                                      }
-                                                      (lam thunk Unit z)
-                                                    ]
-                                                    (lam
-                                                      y
-                                                      a
-                                                      (lam
-                                                        ys
-                                                        [List a]
-                                                        (lam
-                                                          thunk
-                                                          Unit
-                                                          [ [ k y ] [ go ys ] ]
-                                                        )
-                                                      )
-                                                    )
+                                                    { [ { Nil_match a } ds ] b }
+                                                    z
                                                   ]
-                                                  Unit
+                                                  (lam
+                                                    y
+                                                    a
+                                                    (lam
+                                                      ys
+                                                      [List a]
+                                                      [ [ k y ] [ go ys ] ]
+                                                    )
+                                                  )
                                                 ]
                                               )
                                             )
@@ -9562,26 +9099,19 @@
                                                                                                 thunk
                                                                                                 Unit
                                                                                                 [
-                                                                                                  [
-                                                                                                    {
+                                                                                                  {
+                                                                                                    [
+                                                                                                      Unit_match
                                                                                                       [
-                                                                                                        Unit_match
-                                                                                                        [
-                                                                                                          trace
-                                                                                                          (con
-                                                                                                            "Missing signature"
-                                                                                                          )
-                                                                                                        ]
+                                                                                                        trace
+                                                                                                        (con
+                                                                                                          "Missing signature"
+                                                                                                        )
                                                                                                       ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      False
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  Unit
+                                                                                                    ]
+                                                                                                    Bool
+                                                                                                  }
+                                                                                                  False
                                                                                                 ]
                                                                                               )
                                                                                             ]
@@ -9688,26 +9218,19 @@
                                                                               thunk
                                                                               Unit
                                                                               [
-                                                                                [
-                                                                                  {
+                                                                                {
+                                                                                  [
+                                                                                    Unit_match
                                                                                     [
-                                                                                      Unit_match
-                                                                                      [
-                                                                                        trace
-                                                                                        (con
-                                                                                          "Value forged not OK"
-                                                                                        )
-                                                                                      ]
+                                                                                      trace
+                                                                                      (con
+                                                                                        "Value forged not OK"
+                                                                                      )
                                                                                     ]
-                                                                                    (fun Unit Bool)
-                                                                                  }
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    False
-                                                                                  )
-                                                                                ]
-                                                                                Unit
+                                                                                  ]
+                                                                                  Bool
+                                                                                }
+                                                                                False
                                                                               ]
                                                                             )
                                                                           ]
@@ -9732,93 +9255,64 @@
                                                                           j Bool
                                                                         )
                                                                         [
-                                                                          [
-                                                                            {
+                                                                          {
+                                                                            [
+                                                                              Unit_match
                                                                               [
-                                                                                Unit_match
-                                                                                [
-                                                                                  trace
-                                                                                  (con
-                                                                                    "MustHashDatum"
-                                                                                  )
-                                                                                ]
+                                                                                trace
+                                                                                (con
+                                                                                  "MustHashDatum"
+                                                                                )
                                                                               ]
-                                                                              (fun Unit Bool)
-                                                                            }
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              False
-                                                                            )
-                                                                          ]
-                                                                          Unit
+                                                                            ]
+                                                                            Bool
+                                                                          }
+                                                                          False
                                                                         ]
                                                                       )
                                                                       [
                                                                         [
-                                                                          [
-                                                                            {
+                                                                          {
+                                                                            [
+                                                                              {
+                                                                                Maybe_match
+                                                                                Data
+                                                                              }
+                                                                              [
+                                                                                [
+                                                                                  findDatum
+                                                                                  dvh
+                                                                                ]
+                                                                                ds
+                                                                              ]
+                                                                            ]
+                                                                            Bool
+                                                                          }
+                                                                          (lam
+                                                                            a
+                                                                            Data
+                                                                            [
                                                                               [
                                                                                 {
-                                                                                  Maybe_match
-                                                                                  Data
-                                                                                }
-                                                                                [
                                                                                   [
-                                                                                    findDatum
-                                                                                    dvh
-                                                                                  ]
-                                                                                  ds
-                                                                                ]
-                                                                              ]
-                                                                              (fun Unit Bool)
-                                                                            }
-                                                                            (lam
-                                                                              a
-                                                                              Data
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                [
-                                                                                  [
+                                                                                    Bool_match
                                                                                     [
-                                                                                      {
-                                                                                        [
-                                                                                          Bool_match
-                                                                                          [
-                                                                                            [
-                                                                                              fEqData_c
-                                                                                              a
-                                                                                            ]
-                                                                                            dv
-                                                                                          ]
-                                                                                        ]
-                                                                                        (fun Unit Bool)
-                                                                                      }
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        True
-                                                                                      )
+                                                                                      [
+                                                                                        fEqData_c
+                                                                                        a
+                                                                                      ]
+                                                                                      dv
                                                                                     ]
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      j
-                                                                                    )
                                                                                   ]
-                                                                                  Unit
-                                                                                ]
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            j
+                                                                                  Bool
+                                                                                }
+                                                                                True
+                                                                              ]
+                                                                              j
+                                                                            ]
                                                                           )
                                                                         ]
-                                                                        Unit
+                                                                        j
                                                                       ]
                                                                     )
                                                                   )
@@ -9912,26 +9406,19 @@
                                                                                           thunk
                                                                                           Unit
                                                                                           [
-                                                                                            [
-                                                                                              {
+                                                                                            {
+                                                                                              [
+                                                                                                Unit_match
                                                                                                 [
-                                                                                                  Unit_match
-                                                                                                  [
-                                                                                                    trace
-                                                                                                    (con
-                                                                                                      "Missing datum"
-                                                                                                    )
-                                                                                                  ]
+                                                                                                  trace
+                                                                                                  (con
+                                                                                                    "Missing datum"
+                                                                                                  )
                                                                                                 ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                False
-                                                                                              )
-                                                                                            ]
-                                                                                            Unit
+                                                                                              ]
+                                                                                              Bool
+                                                                                            }
+                                                                                            False
                                                                                           ]
                                                                                         )
                                                                                       ]
@@ -10070,148 +9557,126 @@
                                                                                                                           TxOutType
                                                                                                                           [
                                                                                                                             [
+                                                                                                                              {
+                                                                                                                                [
+                                                                                                                                  TxOutType_match
+                                                                                                                                  ds
+                                                                                                                                ]
+                                                                                                                                Bool
+                                                                                                                              }
+                                                                                                                              False
+                                                                                                                            ]
+                                                                                                                            (lam
+                                                                                                                              svh
+                                                                                                                              (con bytestring)
                                                                                                                               [
-                                                                                                                                {
+                                                                                                                                [
                                                                                                                                   [
-                                                                                                                                    TxOutType_match
-                                                                                                                                    ds
-                                                                                                                                  ]
-                                                                                                                                  (fun Unit Bool)
-                                                                                                                                }
-                                                                                                                                (lam
-                                                                                                                                  thunk
-                                                                                                                                  Unit
-                                                                                                                                  False
-                                                                                                                                )
-                                                                                                                              ]
-                                                                                                                              (lam
-                                                                                                                                svh
-                                                                                                                                (con bytestring)
-                                                                                                                                (lam
-                                                                                                                                  thunk
-                                                                                                                                  Unit
-                                                                                                                                  [
-                                                                                                                                    [
+                                                                                                                                    {
                                                                                                                                       [
-                                                                                                                                        {
+                                                                                                                                        Bool_match
+                                                                                                                                        [
                                                                                                                                           [
-                                                                                                                                            Bool_match
+                                                                                                                                            [
+                                                                                                                                              checkBinRel
+                                                                                                                                              equalsInteger
+                                                                                                                                            ]
+                                                                                                                                            ds
+                                                                                                                                          ]
+                                                                                                                                          vl
+                                                                                                                                        ]
+                                                                                                                                      ]
+                                                                                                                                      (fun Unit Bool)
+                                                                                                                                    }
+                                                                                                                                    (lam
+                                                                                                                                      thunk
+                                                                                                                                      Unit
+                                                                                                                                      [
+                                                                                                                                        [
+                                                                                                                                          {
+                                                                                                                                            [
+                                                                                                                                              {
+                                                                                                                                                Maybe_match
+                                                                                                                                                (con bytestring)
+                                                                                                                                              }
+                                                                                                                                              hsh
+                                                                                                                                            ]
+                                                                                                                                            Bool
+                                                                                                                                          }
+                                                                                                                                          (lam
+                                                                                                                                            a
+                                                                                                                                            (con bytestring)
                                                                                                                                             [
                                                                                                                                               [
                                                                                                                                                 [
-                                                                                                                                                  checkBinRel
-                                                                                                                                                  equalsInteger
-                                                                                                                                                ]
-                                                                                                                                                ds
-                                                                                                                                              ]
-                                                                                                                                              vl
-                                                                                                                                            ]
-                                                                                                                                          ]
-                                                                                                                                          (fun Unit Bool)
-                                                                                                                                        }
-                                                                                                                                        (lam
-                                                                                                                                          thunk
-                                                                                                                                          Unit
-                                                                                                                                          [
-                                                                                                                                            [
-                                                                                                                                              [
-                                                                                                                                                {
-                                                                                                                                                  [
-                                                                                                                                                    {
-                                                                                                                                                      Maybe_match
-                                                                                                                                                      (con bytestring)
-                                                                                                                                                    }
-                                                                                                                                                    hsh
-                                                                                                                                                  ]
-                                                                                                                                                  (fun Unit Bool)
-                                                                                                                                                }
-                                                                                                                                                (lam
-                                                                                                                                                  a
-                                                                                                                                                  (con bytestring)
+                                                                                                                                                  {
+                                                                                                                                                    [
+                                                                                                                                                      Bool_match
+                                                                                                                                                      [
+                                                                                                                                                        [
+                                                                                                                                                          equalsByteString
+                                                                                                                                                          a
+                                                                                                                                                        ]
+                                                                                                                                                        svh
+                                                                                                                                                      ]
+                                                                                                                                                    ]
+                                                                                                                                                    (fun Unit Bool)
+                                                                                                                                                  }
                                                                                                                                                   (lam
                                                                                                                                                     thunk
                                                                                                                                                     Unit
                                                                                                                                                     [
                                                                                                                                                       [
-                                                                                                                                                        [
-                                                                                                                                                          {
-                                                                                                                                                            [
-                                                                                                                                                              Bool_match
-                                                                                                                                                              [
-                                                                                                                                                                [
-                                                                                                                                                                  equalsByteString
-                                                                                                                                                                  a
-                                                                                                                                                                ]
-                                                                                                                                                                svh
-                                                                                                                                                              ]
-                                                                                                                                                            ]
-                                                                                                                                                            (fun Unit Bool)
-                                                                                                                                                          }
-                                                                                                                                                          (lam
-                                                                                                                                                            thunk
-                                                                                                                                                            Unit
-                                                                                                                                                            [
-                                                                                                                                                              [
-                                                                                                                                                                {
-                                                                                                                                                                  [
-                                                                                                                                                                    Address_match
-                                                                                                                                                                    ds
-                                                                                                                                                                  ]
-                                                                                                                                                                  Bool
-                                                                                                                                                                }
-                                                                                                                                                                (lam
-                                                                                                                                                                  pkh
-                                                                                                                                                                  (con bytestring)
-                                                                                                                                                                  False
-                                                                                                                                                                )
-                                                                                                                                                              ]
-                                                                                                                                                              (lam
-                                                                                                                                                                vh
-                                                                                                                                                                (con bytestring)
-                                                                                                                                                                [
-                                                                                                                                                                  [
-                                                                                                                                                                    equalsByteString
-                                                                                                                                                                    vh
-                                                                                                                                                                  ]
-                                                                                                                                                                  vlh
-                                                                                                                                                                ]
-                                                                                                                                                              )
-                                                                                                                                                            ]
-                                                                                                                                                          )
-                                                                                                                                                        ]
+                                                                                                                                                        {
+                                                                                                                                                          [
+                                                                                                                                                            Address_match
+                                                                                                                                                            ds
+                                                                                                                                                          ]
+                                                                                                                                                          Bool
+                                                                                                                                                        }
                                                                                                                                                         (lam
-                                                                                                                                                          thunk
-                                                                                                                                                          Unit
+                                                                                                                                                          pkh
+                                                                                                                                                          (con bytestring)
                                                                                                                                                           False
                                                                                                                                                         )
                                                                                                                                                       ]
-                                                                                                                                                      Unit
+                                                                                                                                                      (lam
+                                                                                                                                                        vh
+                                                                                                                                                        (con bytestring)
+                                                                                                                                                        [
+                                                                                                                                                          [
+                                                                                                                                                            equalsByteString
+                                                                                                                                                            vh
+                                                                                                                                                          ]
+                                                                                                                                                          vlh
+                                                                                                                                                        ]
+                                                                                                                                                      )
                                                                                                                                                     ]
                                                                                                                                                   )
+                                                                                                                                                ]
+                                                                                                                                                (lam
+                                                                                                                                                  thunk
+                                                                                                                                                  Unit
+                                                                                                                                                  False
                                                                                                                                                 )
                                                                                                                                               ]
-                                                                                                                                              (lam
-                                                                                                                                                thunk
-                                                                                                                                                Unit
-                                                                                                                                                False
-                                                                                                                                              )
+                                                                                                                                              Unit
                                                                                                                                             ]
-                                                                                                                                            Unit
-                                                                                                                                          ]
-                                                                                                                                        )
-                                                                                                                                      ]
-                                                                                                                                      (lam
-                                                                                                                                        thunk
-                                                                                                                                        Unit
+                                                                                                                                          )
+                                                                                                                                        ]
                                                                                                                                         False
-                                                                                                                                      )
-                                                                                                                                    ]
-                                                                                                                                    Unit
+                                                                                                                                      ]
+                                                                                                                                    )
                                                                                                                                   ]
-                                                                                                                                )
-                                                                                                                              )
-                                                                                                                            ]
-                                                                                                                            Unit
+                                                                                                                                  (lam
+                                                                                                                                    thunk
+                                                                                                                                    Unit
+                                                                                                                                    False
+                                                                                                                                  )
+                                                                                                                                ]
+                                                                                                                                Unit
+                                                                                                                              ]
+                                                                                                                            )
                                                                                                                           ]
                                                                                                                         )
                                                                                                                       )
@@ -10241,26 +9706,19 @@
                                                                                               thunk
                                                                                               Unit
                                                                                               [
-                                                                                                [
-                                                                                                  {
+                                                                                                {
+                                                                                                  [
+                                                                                                    Unit_match
                                                                                                     [
-                                                                                                      Unit_match
-                                                                                                      [
-                                                                                                        trace
-                                                                                                        (con
-                                                                                                          "MustPayToOtherScript"
-                                                                                                        )
-                                                                                                      ]
+                                                                                                      trace
+                                                                                                      (con
+                                                                                                        "MustPayToOtherScript"
+                                                                                                      )
                                                                                                     ]
-                                                                                                    (fun Unit Bool)
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    False
-                                                                                                  )
-                                                                                                ]
-                                                                                                Unit
+                                                                                                  ]
+                                                                                                  Bool
+                                                                                                }
+                                                                                                False
                                                                                               ]
                                                                                             )
                                                                                           ]
@@ -10322,26 +9780,19 @@
                                                                     thunk
                                                                     Unit
                                                                     [
-                                                                      [
-                                                                        {
+                                                                      {
+                                                                        [
+                                                                          Unit_match
                                                                           [
-                                                                            Unit_match
-                                                                            [
-                                                                              trace
-                                                                              (con
-                                                                                "MustPayToPubKey"
-                                                                              )
-                                                                            ]
+                                                                            trace
+                                                                            (con
+                                                                              "MustPayToPubKey"
+                                                                            )
                                                                           ]
-                                                                          (fun Unit Bool)
-                                                                        }
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          False
-                                                                        )
-                                                                      ]
-                                                                      Unit
+                                                                        ]
+                                                                        Bool
+                                                                      }
+                                                                      False
                                                                     ]
                                                                   )
                                                                 ]
@@ -10359,113 +9810,86 @@
                                                               (nonstrict)
                                                               (vardecl j Bool)
                                                               [
-                                                                [
-                                                                  {
+                                                                {
+                                                                  [
+                                                                    Unit_match
                                                                     [
-                                                                      Unit_match
-                                                                      [
-                                                                        trace
-                                                                        (con
-                                                                          "Public key output not spent"
-                                                                        )
-                                                                      ]
+                                                                      trace
+                                                                      (con
+                                                                        "Public key output not spent"
+                                                                      )
                                                                     ]
-                                                                    (fun Unit Bool)
-                                                                  }
-                                                                  (lam
-                                                                    thunk
-                                                                    Unit
-                                                                    False
-                                                                  )
-                                                                ]
-                                                                Unit
+                                                                  ]
+                                                                  Bool
+                                                                }
+                                                                False
                                                               ]
                                                             )
                                                             [
                                                               [
-                                                                [
-                                                                  {
+                                                                {
+                                                                  [
+                                                                    {
+                                                                      Maybe_match
+                                                                      TxInInfo
+                                                                    }
                                                                     [
-                                                                      {
-                                                                        Maybe_match
-                                                                        TxInInfo
-                                                                      }
                                                                       [
-                                                                        [
-                                                                          findTxInByTxOutRef
-                                                                          txOutRef
-                                                                        ]
-                                                                        ds
+                                                                        findTxInByTxOutRef
+                                                                        txOutRef
                                                                       ]
+                                                                      ds
                                                                     ]
-                                                                    (fun Unit Bool)
-                                                                  }
-                                                                  (lam
-                                                                    a
-                                                                    TxInInfo
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
+                                                                  ]
+                                                                  Bool
+                                                                }
+                                                                (lam
+                                                                  a
+                                                                  TxInInfo
+                                                                  [
+                                                                    {
                                                                       [
-                                                                        {
-                                                                          [
-                                                                            TxInInfo_match
-                                                                            a
-                                                                          ]
-                                                                          Bool
-                                                                        }
+                                                                        TxInInfo_match
+                                                                        a
+                                                                      ]
+                                                                      Bool
+                                                                    }
+                                                                    (lam
+                                                                      ds
+                                                                      TxOutRef
+                                                                      (lam
+                                                                        ds
+                                                                        [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
                                                                         (lam
                                                                           ds
-                                                                          TxOutRef
-                                                                          (lam
-                                                                            ds
-                                                                            [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
-                                                                            (lam
-                                                                              ds
-                                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                              [
+                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                          [
+                                                                            [
+                                                                              {
                                                                                 [
-                                                                                  [
-                                                                                    {
-                                                                                      [
-                                                                                        {
-                                                                                          Maybe_match
-                                                                                          [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
-                                                                                        }
-                                                                                        ds
-                                                                                      ]
-                                                                                      (fun Unit Bool)
-                                                                                    }
-                                                                                    (lam
-                                                                                      ds
-                                                                                      [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        j
-                                                                                      )
-                                                                                    )
-                                                                                  ]
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    True
-                                                                                  )
+                                                                                  {
+                                                                                    Maybe_match
+                                                                                    [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
+                                                                                  }
+                                                                                  ds
                                                                                 ]
-                                                                                Unit
-                                                                              ]
-                                                                            )
-                                                                          )
+                                                                                Bool
+                                                                              }
+                                                                              (lam
+                                                                                ds
+                                                                                [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
+                                                                                j
+                                                                              )
+                                                                            ]
+                                                                            True
+                                                                          ]
                                                                         )
-                                                                      ]
+                                                                      )
                                                                     )
-                                                                  )
-                                                                ]
-                                                                (lam
-                                                                  thunk Unit j
+                                                                  ]
                                                                 )
                                                               ]
-                                                              Unit
+                                                              j
                                                             ]
                                                           )
                                                         )
@@ -10509,26 +9933,19 @@
                                                                 thunk
                                                                 Unit
                                                                 [
-                                                                  [
-                                                                    {
+                                                                  {
+                                                                    [
+                                                                      Unit_match
                                                                       [
-                                                                        Unit_match
-                                                                        [
-                                                                          trace
-                                                                          (con
-                                                                            "Script output not spent"
-                                                                          )
-                                                                        ]
+                                                                        trace
+                                                                        (con
+                                                                          "Script output not spent"
+                                                                        )
                                                                       ]
-                                                                      (fun Unit Bool)
-                                                                    }
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      False
-                                                                    )
-                                                                  ]
-                                                                  Unit
+                                                                    ]
+                                                                    Bool
+                                                                  }
+                                                                  False
                                                                 ]
                                                               )
                                                             ]
@@ -10569,26 +9986,19 @@
                                                             thunk
                                                             Unit
                                                             [
-                                                              [
-                                                                {
+                                                              {
+                                                                [
+                                                                  Unit_match
                                                                   [
-                                                                    Unit_match
-                                                                    [
-                                                                      trace
-                                                                      (con
-                                                                        "Spent value not OK"
-                                                                      )
-                                                                    ]
+                                                                    trace
+                                                                    (con
+                                                                      "Spent value not OK"
+                                                                    )
                                                                   ]
-                                                                  (fun Unit Bool)
-                                                                }
-                                                                (lam
-                                                                  thunk
-                                                                  Unit
-                                                                  False
-                                                                )
-                                                              ]
-                                                              Unit
+                                                                ]
+                                                                Bool
+                                                              }
+                                                              False
                                                             ]
                                                           )
                                                         ]
@@ -10678,26 +10088,19 @@
                                                                                           Bool
                                                                                         )
                                                                                         [
-                                                                                          [
-                                                                                            {
+                                                                                          {
+                                                                                            [
+                                                                                              Unit_match
                                                                                               [
-                                                                                                Unit_match
-                                                                                                [
-                                                                                                  trace
-                                                                                                  (con
-                                                                                                    "Wrong validation interval"
-                                                                                                  )
-                                                                                                ]
+                                                                                                trace
+                                                                                                (con
+                                                                                                  "Wrong validation interval"
+                                                                                                )
                                                                                               ]
-                                                                                              (fun Unit Bool)
-                                                                                            }
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              False
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
+                                                                                            ]
+                                                                                            Bool
+                                                                                          }
+                                                                                          False
                                                                                         ]
                                                                                       )
                                                                                       [
@@ -10727,39 +10130,28 @@
                                                                                               Unit
                                                                                               [
                                                                                                 [
-                                                                                                  [
-                                                                                                    {
+                                                                                                  {
+                                                                                                    [
+                                                                                                      Bool_match
                                                                                                       [
-                                                                                                        Bool_match
                                                                                                         [
                                                                                                           [
-                                                                                                            [
-                                                                                                              {
-                                                                                                                hull_c
-                                                                                                                (con integer)
-                                                                                                              }
-                                                                                                              fOrdSlot
-                                                                                                            ]
-                                                                                                            h
+                                                                                                            {
+                                                                                                              hull_c
+                                                                                                              (con integer)
+                                                                                                            }
+                                                                                                            fOrdSlot
                                                                                                           ]
                                                                                                           h
                                                                                                         ]
+                                                                                                        h
                                                                                                       ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      True
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    j
-                                                                                                  )
+                                                                                                    ]
+                                                                                                    Bool
+                                                                                                  }
+                                                                                                  True
                                                                                                 ]
-                                                                                                Unit
+                                                                                                j
                                                                                               ]
                                                                                             )
                                                                                           ]
@@ -10952,79 +10344,68 @@
                                                                 Unit
                                                                 [
                                                                   [
-                                                                    [
-                                                                      {
+                                                                    {
+                                                                      [
+                                                                        Bool_match
                                                                         [
-                                                                          Bool_match
                                                                           [
                                                                             [
-                                                                              [
+                                                                              {
                                                                                 {
-                                                                                  {
-                                                                                    foldr
-                                                                                    [OutputConstraint Void]
-                                                                                  }
-                                                                                  Bool
-                                                                                }
-                                                                                (lam
-                                                                                  a
+                                                                                  foldr
                                                                                   [OutputConstraint Void]
-                                                                                  (lam
-                                                                                    acc
-                                                                                    Bool
+                                                                                }
+                                                                                Bool
+                                                                              }
+                                                                              (lam
+                                                                                a
+                                                                                [OutputConstraint Void]
+                                                                                (lam
+                                                                                  acc
+                                                                                  Bool
+                                                                                  [
                                                                                     [
                                                                                       [
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              Bool_match
-                                                                                              acc
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
-                                                                                              [
-                                                                                                scheckOwnOutputConstraint
-                                                                                                w
-                                                                                              ]
-                                                                                              a
-                                                                                            ]
-                                                                                          )
-                                                                                        ]
+                                                                                        {
+                                                                                          [
+                                                                                            Bool_match
+                                                                                            acc
+                                                                                          ]
+                                                                                          (fun Unit Bool)
+                                                                                        }
                                                                                         (lam
                                                                                           thunk
                                                                                           Unit
-                                                                                          False
+                                                                                          [
+                                                                                            [
+                                                                                              scheckOwnOutputConstraint
+                                                                                              w
+                                                                                            ]
+                                                                                            a
+                                                                                          ]
                                                                                         )
                                                                                       ]
-                                                                                      Unit
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        False
+                                                                                      )
                                                                                     ]
-                                                                                  )
+                                                                                    Unit
+                                                                                  ]
                                                                                 )
-                                                                              ]
-                                                                              True
+                                                                              )
                                                                             ]
-                                                                            ww
+                                                                            True
                                                                           ]
+                                                                          ww
                                                                         ]
-                                                                        (fun Unit Bool)
-                                                                      }
-                                                                      (lam
-                                                                        thunk
-                                                                        Unit
-                                                                        True
-                                                                      )
-                                                                    ]
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      scheckValidatorCtx_j
-                                                                    )
+                                                                      ]
+                                                                      Bool
+                                                                    }
+                                                                    True
                                                                   ]
-                                                                  Unit
+                                                                  scheckValidatorCtx_j
                                                                 ]
                                                               )
                                                             ]
@@ -11216,99 +10597,77 @@
                                                                                                 TxOutType
                                                                                                 [
                                                                                                   [
-                                                                                                    [
-                                                                                                      {
-                                                                                                        [
-                                                                                                          TxOutType_match
-                                                                                                          ds
-                                                                                                        ]
-                                                                                                        (fun Unit Bool)
-                                                                                                      }
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        False
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    (lam
-                                                                                                      svh
-                                                                                                      (con bytestring)
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        [
-                                                                                                          [
-                                                                                                            [
-                                                                                                              {
-                                                                                                                [
-                                                                                                                  Bool_match
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        checkBinRel
-                                                                                                                        equalsInteger
-                                                                                                                      ]
-                                                                                                                      ds
-                                                                                                                    ]
-                                                                                                                    ds
-                                                                                                                  ]
-                                                                                                                ]
-                                                                                                                (fun Unit Bool)
-                                                                                                              }
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            Maybe_match
-                                                                                                                            (con bytestring)
-                                                                                                                          }
-                                                                                                                          hsh
-                                                                                                                        ]
-                                                                                                                        (fun Unit Bool)
-                                                                                                                      }
-                                                                                                                      (lam
-                                                                                                                        a
-                                                                                                                        (con bytestring)
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          [
-                                                                                                                            [
-                                                                                                                              equalsByteString
-                                                                                                                              a
-                                                                                                                            ]
-                                                                                                                            svh
-                                                                                                                          ]
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    (lam
-                                                                                                                      thunk
-                                                                                                                      Unit
-                                                                                                                      False
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  Unit
-                                                                                                                ]
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              False
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          Unit
-                                                                                                        ]
-                                                                                                      )
-                                                                                                    )
+                                                                                                    {
+                                                                                                      [
+                                                                                                        TxOutType_match
+                                                                                                        ds
+                                                                                                      ]
+                                                                                                      Bool
+                                                                                                    }
+                                                                                                    False
                                                                                                   ]
-                                                                                                  Unit
+                                                                                                  (lam
+                                                                                                    svh
+                                                                                                    (con bytestring)
+                                                                                                    [
+                                                                                                      [
+                                                                                                        [
+                                                                                                          {
+                                                                                                            [
+                                                                                                              Bool_match
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    checkBinRel
+                                                                                                                    equalsInteger
+                                                                                                                  ]
+                                                                                                                  ds
+                                                                                                                ]
+                                                                                                                ds
+                                                                                                              ]
+                                                                                                            ]
+                                                                                                            (fun Unit Bool)
+                                                                                                          }
+                                                                                                          (lam
+                                                                                                            thunk
+                                                                                                            Unit
+                                                                                                            [
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  [
+                                                                                                                    {
+                                                                                                                      Maybe_match
+                                                                                                                      (con bytestring)
+                                                                                                                    }
+                                                                                                                    hsh
+                                                                                                                  ]
+                                                                                                                  Bool
+                                                                                                                }
+                                                                                                                (lam
+                                                                                                                  a
+                                                                                                                  (con bytestring)
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      equalsByteString
+                                                                                                                      a
+                                                                                                                    ]
+                                                                                                                    svh
+                                                                                                                  ]
+                                                                                                                )
+                                                                                                              ]
+                                                                                                              False
+                                                                                                            ]
+                                                                                                          )
+                                                                                                        ]
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          False
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      Unit
+                                                                                                    ]
+                                                                                                  )
                                                                                                 ]
                                                                                               )
                                                                                             )
@@ -11341,26 +10700,19 @@
                                                                     thunk
                                                                     Unit
                                                                     [
-                                                                      [
-                                                                        {
+                                                                      {
+                                                                        [
+                                                                          Unit_match
                                                                           [
-                                                                            Unit_match
-                                                                            [
-                                                                              trace
-                                                                              (con
-                                                                                "Output constraint"
-                                                                              )
-                                                                            ]
+                                                                            trace
+                                                                            (con
+                                                                              "Output constraint"
+                                                                            )
                                                                           ]
-                                                                          (fun Unit Bool)
-                                                                        }
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          False
-                                                                        )
-                                                                      ]
-                                                                      Unit
+                                                                        ]
+                                                                        Bool
+                                                                      }
+                                                                      False
                                                                     ]
                                                                   )
                                                                 ]
@@ -11428,26 +10780,19 @@
                                                             (nonstrict)
                                                             (vardecl j Bool)
                                                             [
-                                                              [
-                                                                {
+                                                              {
+                                                                [
+                                                                  Unit_match
                                                                   [
-                                                                    Unit_match
-                                                                    [
-                                                                      trace
-                                                                      (con
-                                                                        "checkValidatorCtx failed"
-                                                                      )
-                                                                    ]
+                                                                    trace
+                                                                    (con
+                                                                      "checkValidatorCtx failed"
+                                                                    )
                                                                   ]
-                                                                  (fun Unit Bool)
-                                                                }
-                                                                (lam
-                                                                  thunk
-                                                                  Unit
-                                                                  False
-                                                                )
-                                                              ]
-                                                              Unit
+                                                                ]
+                                                                Bool
+                                                              }
+                                                              False
                                                             ]
                                                           )
                                                           [
@@ -11585,85 +10930,74 @@
                                                                           Unit
                                                                           [
                                                                             [
-                                                                              [
-                                                                                {
+                                                                              {
+                                                                                [
+                                                                                  Bool_match
                                                                                   [
-                                                                                    Bool_match
                                                                                     [
                                                                                       [
-                                                                                        [
+                                                                                        {
                                                                                           {
-                                                                                            {
-                                                                                              foldr
-                                                                                              [OutputConstraint o]
-                                                                                            }
-                                                                                            Bool
-                                                                                          }
-                                                                                          (lam
-                                                                                            a
+                                                                                            foldr
                                                                                             [OutputConstraint o]
-                                                                                            (lam
-                                                                                              acc
-                                                                                              Bool
+                                                                                          }
+                                                                                          Bool
+                                                                                        }
+                                                                                        (lam
+                                                                                          a
+                                                                                          [OutputConstraint o]
+                                                                                          (lam
+                                                                                            acc
+                                                                                            Bool
+                                                                                            [
                                                                                               [
                                                                                                 [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        Bool_match
-                                                                                                        acc
-                                                                                                      ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      [
-                                                                                                        [
-                                                                                                          [
-                                                                                                            {
-                                                                                                              checkOwnOutputConstraint
-                                                                                                              o
-                                                                                                            }
-                                                                                                            dIsData
-                                                                                                          ]
-                                                                                                          ptx
-                                                                                                        ]
-                                                                                                        a
-                                                                                                      ]
-                                                                                                    )
-                                                                                                  ]
+                                                                                                  {
+                                                                                                    [
+                                                                                                      Bool_match
+                                                                                                      acc
+                                                                                                    ]
+                                                                                                    (fun Unit Bool)
+                                                                                                  }
                                                                                                   (lam
                                                                                                     thunk
                                                                                                     Unit
-                                                                                                    False
+                                                                                                    [
+                                                                                                      [
+                                                                                                        [
+                                                                                                          {
+                                                                                                            checkOwnOutputConstraint
+                                                                                                            o
+                                                                                                          }
+                                                                                                          dIsData
+                                                                                                        ]
+                                                                                                        ptx
+                                                                                                      ]
+                                                                                                      a
+                                                                                                    ]
                                                                                                   )
                                                                                                 ]
-                                                                                                Unit
+                                                                                                (lam
+                                                                                                  thunk
+                                                                                                  Unit
+                                                                                                  False
+                                                                                                )
                                                                                               ]
-                                                                                            )
+                                                                                              Unit
+                                                                                            ]
                                                                                           )
-                                                                                        ]
-                                                                                        True
+                                                                                        )
                                                                                       ]
-                                                                                      ds
+                                                                                      True
                                                                                     ]
+                                                                                    ds
                                                                                   ]
-                                                                                  (fun Unit Bool)
-                                                                                }
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  True
-                                                                                )
-                                                                              ]
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                j
-                                                                              )
+                                                                                ]
+                                                                                Bool
+                                                                              }
+                                                                              True
                                                                             ]
-                                                                            Unit
+                                                                            j
                                                                           ]
                                                                         )
                                                                       ]
@@ -11714,166 +11048,158 @@
                                               [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
                                               [
                                                 [
-                                                  [
-                                                    {
-                                                      [
-                                                        {
-                                                          Nil_match
-                                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                        }
-                                                        xs
-                                                      ]
-                                                      (fun Unit Bool)
-                                                    }
-                                                    (lam thunk Unit True)
-                                                  ]
-                                                  (lam
-                                                    ds
-                                                    [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                    (lam
+                                                  {
+                                                    [
+                                                      {
+                                                        Nil_match
+                                                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                      }
                                                       xs
-                                                      [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                                                      (lam
-                                                        thunk
-                                                        Unit
+                                                    ]
+                                                    Bool
+                                                  }
+                                                  True
+                                                ]
+                                                (lam
+                                                  ds
+                                                  [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                  (lam
+                                                    xs
+                                                    [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                                    [
+                                                      {
                                                         [
                                                           {
-                                                            [
-                                                              {
-                                                                {
-                                                                  Tuple2_match
-                                                                  (con bytestring)
-                                                                }
-                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                              }
-                                                              ds
-                                                            ]
-                                                            Bool
+                                                            {
+                                                              Tuple2_match
+                                                              (con bytestring)
+                                                            }
+                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
                                                           }
-                                                          (lam
-                                                            ds
-                                                            (con bytestring)
-                                                            (lam
-                                                              x
-                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                              (let
-                                                                (rec)
-                                                                (termbind
-                                                                  (strict)
-                                                                  (vardecl
-                                                                    go
-                                                                    (fun [List [[Tuple2 (con bytestring)] (con integer)]] Bool)
-                                                                  )
-                                                                  (lam
-                                                                    xs
-                                                                    [List [[Tuple2 (con bytestring)] (con integer)]]
+                                                          ds
+                                                        ]
+                                                        Bool
+                                                      }
+                                                      (lam
+                                                        ds
+                                                        (con bytestring)
+                                                        (lam
+                                                          x
+                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                                          (let
+                                                            (rec)
+                                                            (termbind
+                                                              (strict)
+                                                              (vardecl
+                                                                go
+                                                                (fun [List [[Tuple2 (con bytestring)] (con integer)]] Bool)
+                                                              )
+                                                              (lam
+                                                                xs
+                                                                [List [[Tuple2 (con bytestring)] (con integer)]]
+                                                                [
+                                                                  [
                                                                     [
-                                                                      [
+                                                                      {
                                                                         [
                                                                           {
-                                                                            [
-                                                                              {
-                                                                                Nil_match
-                                                                                [[Tuple2 (con bytestring)] (con integer)]
-                                                                              }
-                                                                              xs
-                                                                            ]
-                                                                            (fun Unit Bool)
+                                                                            Nil_match
+                                                                            [[Tuple2 (con bytestring)] (con integer)]
                                                                           }
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            [
-                                                                              go
-                                                                              xs
-                                                                            ]
-                                                                          )
+                                                                          xs
                                                                         ]
+                                                                        (fun Unit Bool)
+                                                                      }
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        [
+                                                                          go xs
+                                                                        ]
+                                                                      )
+                                                                    ]
+                                                                    (lam
+                                                                      ds
+                                                                      [[Tuple2 (con bytestring)] (con integer)]
+                                                                      (lam
+                                                                        xs
+                                                                        [List [[Tuple2 (con bytestring)] (con integer)]]
                                                                         (lam
-                                                                          ds
-                                                                          [[Tuple2 (con bytestring)] (con integer)]
-                                                                          (lam
-                                                                            xs
-                                                                            [List [[Tuple2 (con bytestring)] (con integer)]]
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
+                                                                          thunk
+                                                                          Unit
+                                                                          [
+                                                                            {
                                                                               [
                                                                                 {
-                                                                                  [
-                                                                                    {
-                                                                                      {
-                                                                                        Tuple2_match
-                                                                                        (con bytestring)
-                                                                                      }
-                                                                                      (con integer)
-                                                                                    }
-                                                                                    ds
-                                                                                  ]
-                                                                                  Bool
+                                                                                  {
+                                                                                    Tuple2_match
+                                                                                    (con bytestring)
+                                                                                  }
+                                                                                  (con integer)
                                                                                 }
-                                                                                (lam
-                                                                                  ds
-                                                                                  (con bytestring)
-                                                                                  (lam
-                                                                                    x
-                                                                                    (con integer)
-                                                                                    [
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              Bool_match
-                                                                                              [
-                                                                                                [
-                                                                                                  equalsInteger
-                                                                                                  (con
-                                                                                                    0
-                                                                                                  )
-                                                                                                ]
-                                                                                                x
-                                                                                              ]
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
-                                                                                              go
-                                                                                              xs
-                                                                                            ]
-                                                                                          )
-                                                                                        ]
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          False
-                                                                                        )
-                                                                                      ]
-                                                                                      Unit
-                                                                                    ]
-                                                                                  )
-                                                                                )
+                                                                                ds
                                                                               ]
+                                                                              Bool
+                                                                            }
+                                                                            (lam
+                                                                              ds
+                                                                              (con bytestring)
+                                                                              (lam
+                                                                                x
+                                                                                (con integer)
+                                                                                [
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        [
+                                                                                          Bool_match
+                                                                                          [
+                                                                                            [
+                                                                                              equalsInteger
+                                                                                              (con
+                                                                                                0
+                                                                                              )
+                                                                                            ]
+                                                                                            x
+                                                                                          ]
+                                                                                        ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        [
+                                                                                          go
+                                                                                          xs
+                                                                                        ]
+                                                                                      )
+                                                                                    ]
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      False
+                                                                                    )
+                                                                                  ]
+                                                                                  Unit
+                                                                                ]
+                                                                              )
                                                                             )
-                                                                          )
+                                                                          ]
                                                                         )
-                                                                      ]
-                                                                      Unit
-                                                                    ]
-                                                                  )
-                                                                )
-                                                                [ go x ]
+                                                                      )
+                                                                    )
+                                                                  ]
+                                                                  Unit
+                                                                ]
                                                               )
                                                             )
+                                                            [ go x ]
                                                           )
-                                                        ]
+                                                        )
                                                       )
-                                                    )
+                                                    ]
                                                   )
-                                                ]
-                                                Unit
+                                                )
                                               ]
                                             )
                                           )
@@ -12185,26 +11511,19 @@
                                                                                                                     thunk
                                                                                                                     Unit
                                                                                                                     [
-                                                                                                                      [
-                                                                                                                        {
+                                                                                                                      {
+                                                                                                                        [
+                                                                                                                          Unit_match
                                                                                                                           [
-                                                                                                                            Unit_match
-                                                                                                                            [
-                                                                                                                              trace
-                                                                                                                              (con
-                                                                                                                                "State transition invalid - constraints not satisfied by ValidatorCtx"
-                                                                                                                              )
-                                                                                                                            ]
+                                                                                                                            trace
+                                                                                                                            (con
+                                                                                                                              "State transition invalid - constraints not satisfied by ValidatorCtx"
+                                                                                                                            )
                                                                                                                           ]
-                                                                                                                          (fun Unit Bool)
-                                                                                                                        }
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          False
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      Unit
+                                                                                                                        ]
+                                                                                                                        Bool
+                                                                                                                      }
+                                                                                                                      False
                                                                                                                     ]
                                                                                                                   )
                                                                                                                 ]
@@ -12220,26 +11539,19 @@
                                                                                                     thunk
                                                                                                     Unit
                                                                                                     [
-                                                                                                      [
-                                                                                                        {
+                                                                                                      {
+                                                                                                        [
+                                                                                                          Unit_match
                                                                                                           [
-                                                                                                            Unit_match
-                                                                                                            [
-                                                                                                              trace
-                                                                                                              (con
-                                                                                                                "Non-zero value allocated in final state"
-                                                                                                              )
-                                                                                                            ]
+                                                                                                            trace
+                                                                                                            (con
+                                                                                                              "Non-zero value allocated in final state"
+                                                                                                            )
                                                                                                           ]
-                                                                                                          (fun Unit Bool)
-                                                                                                        }
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          False
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      Unit
+                                                                                                        ]
+                                                                                                        Bool
+                                                                                                      }
+                                                                                                      False
                                                                                                     ]
                                                                                                   )
                                                                                                 ]
@@ -12360,26 +11672,19 @@
                                                                                                   thunk
                                                                                                   Unit
                                                                                                   [
-                                                                                                    [
-                                                                                                      {
+                                                                                                    {
+                                                                                                      [
+                                                                                                        Unit_match
                                                                                                         [
-                                                                                                          Unit_match
-                                                                                                          [
-                                                                                                            trace
-                                                                                                            (con
-                                                                                                              "State transition invalid - constraints not satisfied by ValidatorCtx"
-                                                                                                            )
-                                                                                                          ]
+                                                                                                          trace
+                                                                                                          (con
+                                                                                                            "State transition invalid - constraints not satisfied by ValidatorCtx"
+                                                                                                          )
                                                                                                         ]
-                                                                                                        (fun Unit Bool)
-                                                                                                      }
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        False
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    Unit
+                                                                                                      ]
+                                                                                                      Bool
+                                                                                                    }
+                                                                                                    False
                                                                                                   ]
                                                                                                 )
                                                                                               ]
@@ -12402,26 +11707,19 @@
                                                                       thunk
                                                                       Unit
                                                                       [
-                                                                        [
-                                                                          {
+                                                                        {
+                                                                          [
+                                                                            Unit_match
                                                                             [
-                                                                              Unit_match
-                                                                              [
-                                                                                trace
-                                                                                (con
-                                                                                  "State transition invalid - input is not a valid transition at the current state"
-                                                                                )
-                                                                              ]
+                                                                              trace
+                                                                              (con
+                                                                                "State transition invalid - input is not a valid transition at the current state"
+                                                                              )
                                                                             ]
-                                                                            (fun Unit Bool)
-                                                                          }
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            False
-                                                                          )
-                                                                        ]
-                                                                        Unit
+                                                                          ]
+                                                                          Bool
+                                                                        }
+                                                                        False
                                                                       ]
                                                                     )
                                                                   ]
@@ -12433,26 +11731,19 @@
                                                               thunk
                                                               Unit
                                                               [
-                                                                [
-                                                                  {
+                                                                {
+                                                                  [
+                                                                    Unit_match
                                                                     [
-                                                                      Unit_match
-                                                                      [
-                                                                        trace
-                                                                        (con
-                                                                          "State transition invalid - checks failed"
-                                                                        )
-                                                                      ]
+                                                                      trace
+                                                                      (con
+                                                                        "State transition invalid - checks failed"
+                                                                      )
                                                                     ]
-                                                                    (fun Unit Bool)
-                                                                  }
-                                                                  (lam
-                                                                    thunk
-                                                                    Unit
-                                                                    False
-                                                                  )
-                                                                ]
-                                                                Unit
+                                                                  ]
+                                                                  Bool
+                                                                }
+                                                                False
                                                               ]
                                                             )
                                                           ]

--- a/plutus-use-cases/test/Spec/multisig.pir
+++ b/plutus-use-cases/test/Spec/multisig.pir
@@ -171,28 +171,16 @@
                       l
                       [List a]
                       [
-                        [
-                          [
-                            { [ { Nil_match a } l ] (fun Unit b) }
-                            (lam thunk Unit acc)
-                          ]
+                        [ { [ { Nil_match a } l ] b } acc ]
+                        (lam
+                          x
+                          a
                           (lam
-                            x
-                            a
-                            (lam
-                              xs
-                              [List a]
-                              (lam
-                                thunk
-                                Unit
-                                [
-                                  [ f x ] [ [ [ { { foldr a } b } f ] acc ] xs ]
-                                ]
-                              )
-                            )
+                            xs
+                            [List a]
+                            [ [ f x ] [ [ [ { { foldr a } b } f ] acc ] xs ] ]
                           )
-                        ]
-                        Unit
+                        )
                       ]
                     )
                   )
@@ -463,55 +451,44 @@
                                                                             (con bytestring)
                                                                             [
                                                                               [
-                                                                                [
-                                                                                  {
+                                                                                {
+                                                                                  [
+                                                                                    {
+                                                                                      Maybe_match
+                                                                                      (con bytestring)
+                                                                                    }
                                                                                     [
-                                                                                      {
-                                                                                        Maybe_match
-                                                                                        (con bytestring)
-                                                                                      }
                                                                                       [
+                                                                                        {
+                                                                                          find
+                                                                                          (con bytestring)
+                                                                                        }
                                                                                         [
-                                                                                          {
-                                                                                            find
-                                                                                            (con bytestring)
-                                                                                          }
-                                                                                          [
-                                                                                            equalsByteString
-                                                                                            e
-                                                                                          ]
-                                                                                        ]
-                                                                                        ds
-                                                                                      ]
-                                                                                    ]
-                                                                                    (fun Unit [List (con bytestring)])
-                                                                                  }
-                                                                                  (lam
-                                                                                    ds
-                                                                                    (con bytestring)
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            Cons
-                                                                                            (con bytestring)
-                                                                                          }
+                                                                                          equalsByteString
                                                                                           e
                                                                                         ]
-                                                                                        xs
                                                                                       ]
-                                                                                    )
-                                                                                  )
-                                                                                ]
+                                                                                      ds
+                                                                                    ]
+                                                                                  ]
+                                                                                  [List (con bytestring)]
+                                                                                }
                                                                                 (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  xs
+                                                                                  ds
+                                                                                  (con bytestring)
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        Cons
+                                                                                        (con bytestring)
+                                                                                      }
+                                                                                      e
+                                                                                    ]
+                                                                                    xs
+                                                                                  ]
                                                                                 )
                                                                               ]
-                                                                              Unit
+                                                                              xs
                                                                             ]
                                                                           )
                                                                         )
@@ -546,17 +523,14 @@
                               thunk
                               Unit
                               [
-                                [
-                                  {
-                                    [
-                                      Unit_match
-                                      [ trace (con "not enough signatures") ]
-                                    ]
-                                    (fun Unit Bool)
-                                  }
-                                  (lam thunk Unit False)
-                                ]
-                                Unit
+                                {
+                                  [
+                                    Unit_match
+                                    [ trace (con "not enough signatures") ]
+                                  ]
+                                  Bool
+                                }
+                                False
                               ]
                             )
                           ]

--- a/plutus-use-cases/test/Spec/multisigStateMachine.pir
+++ b/plutus-use-cases/test/Spec/multisigStateMachine.pir
@@ -52,18 +52,8 @@
                             thunk
                             Unit
                             [
-                              [
-                                [
-                                  { [ { Nil_match a } ds ] (fun Unit Bool) }
-                                  (lam thunk Unit True)
-                                ]
-                                (lam
-                                  ipv
-                                  a
-                                  (lam ipv [List a] (lam thunk Unit False))
-                                )
-                              ]
-                              Unit
+                              [ { [ { Nil_match a } ds ] Bool } True ]
+                              (lam ipv a (lam ipv [List a] False))
                             ]
                           )
                         ]
@@ -77,45 +67,34 @@
                               thunk
                               Unit
                               [
-                                [
-                                  [
-                                    { [ { Nil_match a } ds ] (fun Unit Bool) }
-                                    (lam thunk Unit False)
-                                  ]
+                                [ { [ { Nil_match a } ds ] Bool } False ]
+                                (lam
+                                  y
+                                  a
                                   (lam
-                                    y
-                                    a
-                                    (lam
-                                      ys
-                                      [List a]
-                                      (lam
-                                        thunk
-                                        Unit
+                                    ys
+                                    [List a]
+                                    [
+                                      [
                                         [
-                                          [
+                                          {
+                                            [ Bool_match [ [ dEq x ] y ] ]
+                                            (fun Unit Bool)
+                                          }
+                                          (lam
+                                            thunk
+                                            Unit
                                             [
-                                              {
-                                                [ Bool_match [ [ dEq x ] y ] ]
-                                                (fun Unit Bool)
-                                              }
-                                              (lam
-                                                thunk
-                                                Unit
-                                                [
-                                                  [ [ { fEqData_c a } dEq ] xs ]
-                                                  ys
-                                                ]
-                                              )
+                                              [ [ { fEqData_c a } dEq ] xs ] ys
                                             ]
-                                            (lam thunk Unit False)
-                                          ]
-                                          Unit
+                                          )
                                         ]
-                                      )
-                                    )
+                                        (lam thunk Unit False)
+                                      ]
+                                      Unit
+                                    ]
                                   )
-                                ]
-                                Unit
+                                )
                               ]
                             )
                           )
@@ -222,50 +201,28 @@
                                       [
                                         [
                                           [
-                                            [
-                                              {
-                                                [ Data_match ds ]
-                                                (fun Unit Bool)
-                                              }
-                                              (lam
-                                                b
-                                                (con bytestring)
-                                                (lam
-                                                  thunk
-                                                  Unit
-                                                  [ [ equalsByteString b ] b ]
-                                                )
-                                              )
-                                            ]
+                                            { [ Data_match ds ] Bool }
                                             (lam
-                                              default_arg0
-                                              (con integer)
-                                              (lam
-                                                default_arg1
-                                                [List Data]
-                                                (lam thunk Unit False)
-                                              )
+                                              b
+                                              (con bytestring)
+                                              [ [ equalsByteString b ] b ]
                                             )
                                           ]
                                           (lam
                                             default_arg0
                                             (con integer)
-                                            (lam thunk Unit False)
+                                            (lam default_arg1 [List Data] False)
                                           )
                                         ]
-                                        (lam
-                                          default_arg0
-                                          [List Data]
-                                          (lam thunk Unit False)
-                                        )
+                                        (lam default_arg0 (con integer) False)
                                       ]
-                                      (lam
-                                        default_arg0
-                                        [List [[Tuple2 Data] Data]]
-                                        (lam thunk Unit False)
-                                      )
+                                      (lam default_arg0 [List Data] False)
                                     ]
-                                    Unit
+                                    (lam
+                                      default_arg0
+                                      [List [[Tuple2 Data] Data]]
+                                      False
+                                    )
                                   ]
                                 )
                               ]
@@ -280,85 +237,62 @@
                                       [
                                         [
                                           [
-                                            [
-                                              {
-                                                [ Data_match ds ]
-                                                (fun Unit Bool)
-                                              }
-                                              (lam
-                                                default_arg0
-                                                (con bytestring)
-                                                (lam thunk Unit False)
-                                              )
-                                            ]
+                                            { [ Data_match ds ] Bool }
                                             (lam
-                                              i
-                                              (con integer)
-                                              (lam
-                                                ds
-                                                [List Data]
-                                                (lam
-                                                  thunk
-                                                  Unit
-                                                  [
-                                                    [
-                                                      [
-                                                        {
-                                                          [
-                                                            Bool_match
-                                                            [
-                                                              [
-                                                                equalsInteger i
-                                                              ]
-                                                              i
-                                                            ]
-                                                          ]
-                                                          (fun Unit Bool)
-                                                        }
-                                                        (lam
-                                                          thunk
-                                                          Unit
-                                                          [
-                                                            [
-                                                              [
-                                                                {
-                                                                  fEqData_c Data
-                                                                }
-                                                                fEqData_c
-                                                              ]
-                                                              ds
-                                                            ]
-                                                            ds
-                                                          ]
-                                                        )
-                                                      ]
-                                                      (lam thunk Unit False)
-                                                    ]
-                                                    Unit
-                                                  ]
-                                                )
-                                              )
+                                              default_arg0
+                                              (con bytestring)
+                                              False
                                             )
                                           ]
                                           (lam
-                                            default_arg0
+                                            i
                                             (con integer)
-                                            (lam thunk Unit False)
+                                            (lam
+                                              ds
+                                              [List Data]
+                                              [
+                                                [
+                                                  [
+                                                    {
+                                                      [
+                                                        Bool_match
+                                                        [
+                                                          [ equalsInteger i ] i
+                                                        ]
+                                                      ]
+                                                      (fun Unit Bool)
+                                                    }
+                                                    (lam
+                                                      thunk
+                                                      Unit
+                                                      [
+                                                        [
+                                                          [
+                                                            { fEqData_c Data }
+                                                            fEqData_c
+                                                          ]
+                                                          ds
+                                                        ]
+                                                        ds
+                                                      ]
+                                                    )
+                                                  ]
+                                                  (lam thunk Unit False)
+                                                ]
+                                                Unit
+                                              ]
+                                            )
                                           )
                                         ]
-                                        (lam
-                                          default_arg0
-                                          [List Data]
-                                          (lam thunk Unit False)
-                                        )
+                                        (lam default_arg0 (con integer) False)
                                       ]
-                                      (lam
-                                        default_arg0
-                                        [List [[Tuple2 Data] Data]]
-                                        (lam thunk Unit False)
-                                      )
+                                      (lam default_arg0 [List Data] False)
                                     ]
-                                    Unit
+                                    (lam
+                                      default_arg0
+                                      [List [[Tuple2 Data] Data]]
+                                      False
+                                    )
                                   ]
                                 )
                               )
@@ -371,45 +305,25 @@
                                   [
                                     [
                                       [
-                                        [
-                                          { [ Data_match ds ] (fun Unit Bool) }
-                                          (lam
-                                            default_arg0
-                                            (con bytestring)
-                                            (lam thunk Unit False)
-                                          )
-                                        ]
-                                        (lam
-                                          default_arg0
-                                          (con integer)
-                                          (lam
-                                            default_arg1
-                                            [List Data]
-                                            (lam thunk Unit False)
-                                          )
+                                        { [ Data_match ds ] Bool }
+                                        (lam default_arg0 (con bytestring) False
                                         )
                                       ]
                                       (lam
-                                        i
+                                        default_arg0
                                         (con integer)
-                                        (lam
-                                          thunk Unit [ [ equalsInteger i ] i ]
-                                        )
+                                        (lam default_arg1 [List Data] False)
                                       )
                                     ]
                                     (lam
-                                      default_arg0
-                                      [List Data]
-                                      (lam thunk Unit False)
+                                      i (con integer) [ [ equalsInteger i ] i ]
                                     )
                                   ]
-                                  (lam
-                                    default_arg0
-                                    [List [[Tuple2 Data] Data]]
-                                    (lam thunk Unit False)
-                                  )
+                                  (lam default_arg0 [List Data] False)
                                 ]
-                                Unit
+                                (lam
+                                  default_arg0 [List [[Tuple2 Data] Data]] False
+                                )
                               ]
                             )
                           ]
@@ -421,50 +335,26 @@
                                 [
                                   [
                                     [
-                                      [
-                                        { [ Data_match ds ] (fun Unit Bool) }
-                                        (lam
-                                          default_arg0
-                                          (con bytestring)
-                                          (lam thunk Unit False)
-                                        )
-                                      ]
-                                      (lam
-                                        default_arg0
-                                        (con integer)
-                                        (lam
-                                          default_arg1
-                                          [List Data]
-                                          (lam thunk Unit False)
-                                        )
-                                      )
+                                      { [ Data_match ds ] Bool }
+                                      (lam default_arg0 (con bytestring) False)
                                     ]
                                     (lam
                                       default_arg0
                                       (con integer)
-                                      (lam thunk Unit False)
+                                      (lam default_arg1 [List Data] False)
                                     )
                                   ]
-                                  (lam
-                                    ls
-                                    [List Data]
-                                    (lam
-                                      thunk
-                                      Unit
-                                      [
-                                        [ [ { fEqData_c Data } fEqData_c ] ls ]
-                                        ls
-                                      ]
-                                    )
-                                  )
+                                  (lam default_arg0 (con integer) False)
                                 ]
                                 (lam
-                                  default_arg0
-                                  [List [[Tuple2 Data] Data]]
-                                  (lam thunk Unit False)
+                                  ls
+                                  [List Data]
+                                  [ [ [ { fEqData_c Data } fEqData_c ] ls ] ls ]
                                 )
                               ]
-                              Unit
+                              (lam
+                                default_arg0 [List [[Tuple2 Data] Data]] False
+                              )
                             ]
                           )
                         ]
@@ -476,53 +366,29 @@
                               [
                                 [
                                   [
-                                    [
-                                      { [ Data_match ds ] (fun Unit Bool) }
-                                      (lam
-                                        default_arg0
-                                        (con bytestring)
-                                        (lam thunk Unit False)
-                                      )
-                                    ]
-                                    (lam
-                                      default_arg0
-                                      (con integer)
-                                      (lam
-                                        default_arg1
-                                        [List Data]
-                                        (lam thunk Unit False)
-                                      )
-                                    )
+                                    { [ Data_match ds ] Bool }
+                                    (lam default_arg0 (con bytestring) False)
                                   ]
                                   (lam
                                     default_arg0
                                     (con integer)
-                                    (lam thunk Unit False)
+                                    (lam default_arg1 [List Data] False)
                                   )
                                 ]
-                                (lam
-                                  default_arg0
-                                  [List Data]
-                                  (lam thunk Unit False)
-                                )
+                                (lam default_arg0 (con integer) False)
                               ]
-                              (lam
-                                ds
-                                [List [[Tuple2 Data] Data]]
-                                (lam
-                                  thunk
-                                  Unit
-                                  [
-                                    [
-                                      [ { fEqData_c [[Tuple2 Data] Data] } dEq ]
-                                      ds
-                                    ]
-                                    ds
-                                  ]
-                                )
-                              )
+                              (lam default_arg0 [List Data] False)
                             ]
-                            Unit
+                            (lam
+                              ds
+                              [List [[Tuple2 Data] Data]]
+                              [
+                                [
+                                  [ { fEqData_c [[Tuple2 Data] Data] } dEq ] ds
+                                ]
+                                ds
+                              ]
+                            )
                           ]
                         )
                       ]
@@ -3535,40 +3401,25 @@
                                           l
                                           [List a]
                                           [
-                                            [
-                                              [
-                                                {
-                                                  [ { Nil_match a } l ]
-                                                  (fun Unit b)
-                                                }
-                                                (lam thunk Unit acc)
-                                              ]
+                                            [ { [ { Nil_match a } l ] b } acc ]
+                                            (lam
+                                              x
+                                              a
                                               (lam
-                                                x
-                                                a
-                                                (lam
-                                                  xs
-                                                  [List a]
-                                                  (lam
-                                                    thunk
-                                                    Unit
+                                                xs
+                                                [List a]
+                                                [
+                                                  [ f x ]
+                                                  [
                                                     [
-                                                      [ f x ]
-                                                      [
-                                                        [
-                                                          [
-                                                            { { foldr a } b } f
-                                                          ]
-                                                          acc
-                                                        ]
-                                                        xs
-                                                      ]
+                                                      [ { { foldr a } b } f ]
+                                                      acc
                                                     ]
-                                                  )
-                                                )
+                                                    xs
+                                                  ]
+                                                ]
                                               )
-                                            ]
-                                            Unit
+                                            )
                                           ]
                                         )
                                       )
@@ -3744,89 +3595,78 @@
                                                                                                             TxOutType
                                                                                                             [
                                                                                                               [
+                                                                                                                {
+                                                                                                                  [
+                                                                                                                    TxOutType_match
+                                                                                                                    ds
+                                                                                                                  ]
+                                                                                                                  [List TxOut]
+                                                                                                                }
+                                                                                                                xs
+                                                                                                              ]
+                                                                                                              (lam
+                                                                                                                ds
+                                                                                                                (con bytestring)
                                                                                                                 [
-                                                                                                                  {
-                                                                                                                    [
-                                                                                                                      TxOutType_match
-                                                                                                                      ds
-                                                                                                                    ]
-                                                                                                                    (fun Unit [List TxOut])
-                                                                                                                  }
+                                                                                                                  [
+                                                                                                                    {
+                                                                                                                      [
+                                                                                                                        Address_match
+                                                                                                                        ds
+                                                                                                                      ]
+                                                                                                                      [List TxOut]
+                                                                                                                    }
+                                                                                                                    (lam
+                                                                                                                      pkh
+                                                                                                                      (con bytestring)
+                                                                                                                      xs
+                                                                                                                    )
+                                                                                                                  ]
                                                                                                                   (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    xs
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                                (lam
-                                                                                                                  ds
-                                                                                                                  (con bytestring)
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
+                                                                                                                    vh
+                                                                                                                    (con bytestring)
                                                                                                                     [
                                                                                                                       [
-                                                                                                                        {
-                                                                                                                          [
-                                                                                                                            Address_match
-                                                                                                                            ds
-                                                                                                                          ]
-                                                                                                                          [List TxOut]
-                                                                                                                        }
+                                                                                                                        [
+                                                                                                                          {
+                                                                                                                            [
+                                                                                                                              Bool_match
+                                                                                                                              [
+                                                                                                                                [
+                                                                                                                                  equalsByteString
+                                                                                                                                  vh
+                                                                                                                                ]
+                                                                                                                                inpHsh
+                                                                                                                              ]
+                                                                                                                            ]
+                                                                                                                            (fun Unit [List TxOut])
+                                                                                                                          }
+                                                                                                                          (lam
+                                                                                                                            thunk
+                                                                                                                            Unit
+                                                                                                                            [
+                                                                                                                              [
+                                                                                                                                {
+                                                                                                                                  Cons
+                                                                                                                                  TxOut
+                                                                                                                                }
+                                                                                                                                wild
+                                                                                                                              ]
+                                                                                                                              xs
+                                                                                                                            ]
+                                                                                                                          )
+                                                                                                                        ]
                                                                                                                         (lam
-                                                                                                                          pkh
-                                                                                                                          (con bytestring)
+                                                                                                                          thunk
+                                                                                                                          Unit
                                                                                                                           xs
                                                                                                                         )
                                                                                                                       ]
-                                                                                                                      (lam
-                                                                                                                        vh
-                                                                                                                        (con bytestring)
-                                                                                                                        [
-                                                                                                                          [
-                                                                                                                            [
-                                                                                                                              {
-                                                                                                                                [
-                                                                                                                                  Bool_match
-                                                                                                                                  [
-                                                                                                                                    [
-                                                                                                                                      equalsByteString
-                                                                                                                                      vh
-                                                                                                                                    ]
-                                                                                                                                    inpHsh
-                                                                                                                                  ]
-                                                                                                                                ]
-                                                                                                                                (fun Unit [List TxOut])
-                                                                                                                              }
-                                                                                                                              (lam
-                                                                                                                                thunk
-                                                                                                                                Unit
-                                                                                                                                [
-                                                                                                                                  [
-                                                                                                                                    {
-                                                                                                                                      Cons
-                                                                                                                                      TxOut
-                                                                                                                                    }
-                                                                                                                                    wild
-                                                                                                                                  ]
-                                                                                                                                  xs
-                                                                                                                                ]
-                                                                                                                              )
-                                                                                                                            ]
-                                                                                                                            (lam
-                                                                                                                              thunk
-                                                                                                                              Unit
-                                                                                                                              xs
-                                                                                                                            )
-                                                                                                                          ]
-                                                                                                                          Unit
-                                                                                                                        ]
-                                                                                                                      )
+                                                                                                                      Unit
                                                                                                                     ]
                                                                                                                   )
-                                                                                                                )
-                                                                                                              ]
-                                                                                                              Unit
+                                                                                                                ]
+                                                                                                              )
                                                                                                             ]
                                                                                                           )
                                                                                                         )
@@ -4754,210 +4594,123 @@
                                               [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
                                               [
                                                 [
-                                                  [
-                                                    {
-                                                      [
-                                                        {
-                                                          Nil_match
-                                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                                        }
-                                                        xs
-                                                      ]
-                                                      (fun Unit Bool)
-                                                    }
-                                                    (lam thunk Unit True)
-                                                  ]
-                                                  (lam
-                                                    ds
-                                                    [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                                    (lam
+                                                  {
+                                                    [
+                                                      {
+                                                        Nil_match
+                                                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                      }
                                                       xs
-                                                      [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
-                                                      (lam
-                                                        thunk
-                                                        Unit
+                                                    ]
+                                                    Bool
+                                                  }
+                                                  True
+                                                ]
+                                                (lam
+                                                  ds
+                                                  [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                  (lam
+                                                    xs
+                                                    [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
+                                                    [
+                                                      {
                                                         [
                                                           {
-                                                            [
-                                                              {
-                                                                {
-                                                                  Tuple2_match
-                                                                  (con bytestring)
-                                                                }
-                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                              }
-                                                              ds
-                                                            ]
-                                                            Bool
+                                                            {
+                                                              Tuple2_match
+                                                              (con bytestring)
+                                                            }
+                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
                                                           }
-                                                          (lam
-                                                            ds
-                                                            (con bytestring)
-                                                            (lam
-                                                              x
-                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                              (let
-                                                                (rec)
-                                                                (termbind
-                                                                  (strict)
-                                                                  (vardecl
-                                                                    go
-                                                                    (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] Bool)
-                                                                  )
-                                                                  (lam
-                                                                    xs
-                                                                    [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                          ds
+                                                        ]
+                                                        Bool
+                                                      }
+                                                      (lam
+                                                        ds
+                                                        (con bytestring)
+                                                        (lam
+                                                          x
+                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
+                                                          (let
+                                                            (rec)
+                                                            (termbind
+                                                              (strict)
+                                                              (vardecl
+                                                                go
+                                                                (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] Bool)
+                                                              )
+                                                              (lam
+                                                                xs
+                                                                [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                                [
+                                                                  [
                                                                     [
-                                                                      [
+                                                                      {
                                                                         [
                                                                           {
-                                                                            [
-                                                                              {
-                                                                                Nil_match
-                                                                                [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                              }
-                                                                              xs
-                                                                            ]
-                                                                            (fun Unit Bool)
+                                                                            Nil_match
+                                                                            [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
                                                                           }
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            [
-                                                                              go
-                                                                              xs
-                                                                            ]
-                                                                          )
+                                                                          xs
                                                                         ]
+                                                                        (fun Unit Bool)
+                                                                      }
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        [
+                                                                          go xs
+                                                                        ]
+                                                                      )
+                                                                    ]
+                                                                    (lam
+                                                                      ds
+                                                                      [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
+                                                                      (lam
+                                                                        xs
+                                                                        [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
                                                                         (lam
-                                                                          ds
-                                                                          [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                          (lam
-                                                                            xs
-                                                                            [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
+                                                                          thunk
+                                                                          Unit
+                                                                          [
+                                                                            {
                                                                               [
                                                                                 {
-                                                                                  [
-                                                                                    {
-                                                                                      {
-                                                                                        Tuple2_match
-                                                                                        (con bytestring)
-                                                                                      }
-                                                                                      [[These (con integer)] (con integer)]
-                                                                                    }
-                                                                                    ds
-                                                                                  ]
-                                                                                  Bool
+                                                                                  {
+                                                                                    Tuple2_match
+                                                                                    (con bytestring)
+                                                                                  }
+                                                                                  [[These (con integer)] (con integer)]
                                                                                 }
-                                                                                (lam
-                                                                                  ds
-                                                                                  (con bytestring)
-                                                                                  (lam
-                                                                                    x
-                                                                                    [[These (con integer)] (con integer)]
+                                                                                ds
+                                                                              ]
+                                                                              Bool
+                                                                            }
+                                                                            (lam
+                                                                              ds
+                                                                              (con bytestring)
+                                                                              (lam
+                                                                                x
+                                                                                [[These (con integer)] (con integer)]
+                                                                                [
+                                                                                  [
                                                                                     [
-                                                                                      [
+                                                                                      {
                                                                                         [
                                                                                           {
-                                                                                            [
-                                                                                              {
-                                                                                                {
-                                                                                                  These_match
-                                                                                                  (con integer)
-                                                                                                }
-                                                                                                (con integer)
-                                                                                              }
-                                                                                              x
-                                                                                            ]
-                                                                                            Bool
+                                                                                            {
+                                                                                              These_match
+                                                                                              (con integer)
+                                                                                            }
+                                                                                            (con integer)
                                                                                           }
-                                                                                          (lam
-                                                                                            b
-                                                                                            (con integer)
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      Bool_match
-                                                                                                      [
-                                                                                                        [
-                                                                                                          f
-                                                                                                          (con
-                                                                                                            0
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        b
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                    (fun Unit Bool)
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    [
-                                                                                                      go
-                                                                                                      xs
-                                                                                                    ]
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  False
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
+                                                                                          x
                                                                                         ]
-                                                                                        (lam
-                                                                                          a
-                                                                                          (con integer)
-                                                                                          (lam
-                                                                                            b
-                                                                                            (con integer)
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      Bool_match
-                                                                                                      [
-                                                                                                        [
-                                                                                                          f
-                                                                                                          a
-                                                                                                        ]
-                                                                                                        b
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                    (fun Unit Bool)
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    [
-                                                                                                      go
-                                                                                                      xs
-                                                                                                    ]
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  False
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        )
-                                                                                      ]
+                                                                                        Bool
+                                                                                      }
                                                                                       (lam
-                                                                                        a
+                                                                                        b
                                                                                         (con integer)
                                                                                         [
                                                                                           [
@@ -4968,11 +4721,11 @@
                                                                                                   [
                                                                                                     [
                                                                                                       f
-                                                                                                      a
+                                                                                                      (con
+                                                                                                        0
+                                                                                                      )
                                                                                                     ]
-                                                                                                    (con
-                                                                                                      0
-                                                                                                    )
+                                                                                                    b
                                                                                                   ]
                                                                                                 ]
                                                                                                 (fun Unit Bool)
@@ -4996,27 +4749,106 @@
                                                                                         ]
                                                                                       )
                                                                                     ]
+                                                                                    (lam
+                                                                                      a
+                                                                                      (con integer)
+                                                                                      (lam
+                                                                                        b
+                                                                                        (con integer)
+                                                                                        [
+                                                                                          [
+                                                                                            [
+                                                                                              {
+                                                                                                [
+                                                                                                  Bool_match
+                                                                                                  [
+                                                                                                    [
+                                                                                                      f
+                                                                                                      a
+                                                                                                    ]
+                                                                                                    b
+                                                                                                  ]
+                                                                                                ]
+                                                                                                (fun Unit Bool)
+                                                                                              }
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                [
+                                                                                                  go
+                                                                                                  xs
+                                                                                                ]
+                                                                                              )
+                                                                                            ]
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              False
+                                                                                            )
+                                                                                          ]
+                                                                                          Unit
+                                                                                        ]
+                                                                                      )
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    a
+                                                                                    (con integer)
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              Bool_match
+                                                                                              [
+                                                                                                [
+                                                                                                  f
+                                                                                                  a
+                                                                                                ]
+                                                                                                (con
+                                                                                                  0
+                                                                                                )
+                                                                                              ]
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            [
+                                                                                              go
+                                                                                              xs
+                                                                                            ]
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          False
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
                                                                                   )
-                                                                                )
-                                                                              ]
+                                                                                ]
+                                                                              )
                                                                             )
-                                                                          )
+                                                                          ]
                                                                         )
-                                                                      ]
-                                                                      Unit
-                                                                    ]
-                                                                  )
-                                                                )
-                                                                [ go x ]
+                                                                      )
+                                                                    )
+                                                                  ]
+                                                                  Unit
+                                                                ]
                                                               )
                                                             )
+                                                            [ go x ]
                                                           )
-                                                        ]
+                                                        )
                                                       )
-                                                    )
+                                                    ]
                                                   )
-                                                ]
-                                                Unit
+                                                )
                                               ]
                                             )
                                           )
@@ -5116,99 +4948,77 @@
                                                                               TxOutType
                                                                               [
                                                                                 [
-                                                                                  [
-                                                                                    {
-                                                                                      [
-                                                                                        TxOutType_match
-                                                                                        ds
-                                                                                      ]
-                                                                                      (fun Unit Bool)
-                                                                                    }
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      False
-                                                                                    )
-                                                                                  ]
-                                                                                  (lam
-                                                                                    svh
-                                                                                    (con bytestring)
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        [
-                                                                                          [
-                                                                                            {
-                                                                                              [
-                                                                                                Bool_match
-                                                                                                [
-                                                                                                  [
-                                                                                                    [
-                                                                                                      checkBinRel
-                                                                                                      equalsInteger
-                                                                                                    ]
-                                                                                                    ds
-                                                                                                  ]
-                                                                                                  ww
-                                                                                                ]
-                                                                                              ]
-                                                                                              (fun Unit Bool)
-                                                                                            }
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        {
-                                                                                                          Maybe_match
-                                                                                                          (con bytestring)
-                                                                                                        }
-                                                                                                        hsh
-                                                                                                      ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      a
-                                                                                                      (con bytestring)
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        [
-                                                                                                          [
-                                                                                                            equalsByteString
-                                                                                                            a
-                                                                                                          ]
-                                                                                                          svh
-                                                                                                        ]
-                                                                                                      )
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    False
-                                                                                                  )
-                                                                                                ]
-                                                                                                Unit
-                                                                                              ]
-                                                                                            )
-                                                                                          ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            False
-                                                                                          )
-                                                                                        ]
-                                                                                        Unit
-                                                                                      ]
-                                                                                    )
-                                                                                  )
+                                                                                  {
+                                                                                    [
+                                                                                      TxOutType_match
+                                                                                      ds
+                                                                                    ]
+                                                                                    Bool
+                                                                                  }
+                                                                                  False
                                                                                 ]
-                                                                                Unit
+                                                                                (lam
+                                                                                  svh
+                                                                                  (con bytestring)
+                                                                                  [
+                                                                                    [
+                                                                                      [
+                                                                                        {
+                                                                                          [
+                                                                                            Bool_match
+                                                                                            [
+                                                                                              [
+                                                                                                [
+                                                                                                  checkBinRel
+                                                                                                  equalsInteger
+                                                                                                ]
+                                                                                                ds
+                                                                                              ]
+                                                                                              ww
+                                                                                            ]
+                                                                                          ]
+                                                                                          (fun Unit Bool)
+                                                                                        }
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          [
+                                                                                            [
+                                                                                              {
+                                                                                                [
+                                                                                                  {
+                                                                                                    Maybe_match
+                                                                                                    (con bytestring)
+                                                                                                  }
+                                                                                                  hsh
+                                                                                                ]
+                                                                                                Bool
+                                                                                              }
+                                                                                              (lam
+                                                                                                a
+                                                                                                (con bytestring)
+                                                                                                [
+                                                                                                  [
+                                                                                                    equalsByteString
+                                                                                                    a
+                                                                                                  ]
+                                                                                                  svh
+                                                                                                ]
+                                                                                              )
+                                                                                            ]
+                                                                                            False
+                                                                                          ]
+                                                                                        )
+                                                                                      ]
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        False
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
+                                                                                  ]
+                                                                                )
                                                                               ]
                                                                             )
                                                                           )
@@ -5240,17 +5050,14 @@
                                                   thunk
                                                   Unit
                                                   [
-                                                    [
-                                                      {
-                                                        [
-                                                          Unit_match
-                                                          scheckOwnOutputConstraint
-                                                        ]
-                                                        (fun Unit Bool)
-                                                      }
-                                                      (lam thunk Unit False)
-                                                    ]
-                                                    Unit
+                                                    {
+                                                      [
+                                                        Unit_match
+                                                        scheckOwnOutputConstraint
+                                                      ]
+                                                      Bool
+                                                    }
+                                                    False
                                                   ]
                                                 )
                                               ]
@@ -5342,17 +5149,13 @@
                                   (nonstrict)
                                   (vardecl scheckValidatorCtx_j Bool)
                                   [
-                                    [
-                                      {
-                                        [
-                                          Unit_match
-                                          [ trace scheckValidatorCtx ]
-                                        ]
-                                        (fun Unit Bool)
-                                      }
-                                      (lam thunk Unit False)
-                                    ]
-                                    Unit
+                                    {
+                                      [
+                                        Unit_match [ trace scheckValidatorCtx ]
+                                      ]
+                                      Bool
+                                    }
+                                    False
                                   ]
                                 )
                                 (termbind
@@ -5617,26 +5420,19 @@
                                                                               thunk
                                                                               Unit
                                                                               [
-                                                                                [
-                                                                                  {
+                                                                                {
+                                                                                  [
+                                                                                    Unit_match
                                                                                     [
-                                                                                      Unit_match
-                                                                                      [
-                                                                                        trace
-                                                                                        (con
-                                                                                          "Input constraint"
-                                                                                        )
-                                                                                      ]
+                                                                                      trace
+                                                                                      (con
+                                                                                        "Input constraint"
+                                                                                      )
                                                                                     ]
-                                                                                    (fun Unit Bool)
-                                                                                  }
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    False
-                                                                                  )
-                                                                                ]
-                                                                                Unit
+                                                                                  ]
+                                                                                  Bool
+                                                                                }
+                                                                                False
                                                                               ]
                                                                             )
                                                                           ]
@@ -5737,22 +5533,18 @@
                                             Unit
                                             [
                                               [
-                                                [
-                                                  {
+                                                {
+                                                  [
+                                                    Bool_match
                                                     [
-                                                      Bool_match
-                                                      [
-                                                        [ lessThanEqInteger x ]
-                                                        y
-                                                      ]
+                                                      [ lessThanEqInteger x ] y
                                                     ]
-                                                    (fun Unit Ordering)
-                                                  }
-                                                  (lam thunk Unit LT)
-                                                ]
-                                                (lam thunk Unit GT)
+                                                  ]
+                                                  Ordering
+                                                }
+                                                LT
                                               ]
-                                              Unit
+                                              GT
                                             ]
                                           )
                                         ]
@@ -5775,19 +5567,16 @@
                                       (con integer)
                                       [
                                         [
-                                          [
-                                            {
-                                              [
-                                                Bool_match
-                                                [ [ lessThanEqInteger x ] y ]
-                                              ]
-                                              (fun Unit (con integer))
-                                            }
-                                            (lam thunk Unit y)
-                                          ]
-                                          (lam thunk Unit x)
+                                          {
+                                            [
+                                              Bool_match
+                                              [ [ lessThanEqInteger x ] y ]
+                                            ]
+                                            (con integer)
+                                          }
+                                          y
                                         ]
-                                        Unit
+                                        x
                                       ]
                                     )
                                   )
@@ -5806,19 +5595,16 @@
                                       (con integer)
                                       [
                                         [
-                                          [
-                                            {
-                                              [
-                                                Bool_match
-                                                [ [ lessThanEqInteger x ] y ]
-                                              ]
-                                              (fun Unit (con integer))
-                                            }
-                                            (lam thunk Unit x)
-                                          ]
-                                          (lam thunk Unit y)
+                                          {
+                                            [
+                                              Bool_match
+                                              [ [ lessThanEqInteger x ] y ]
+                                            ]
+                                            (con integer)
+                                          }
+                                          x
                                         ]
-                                        Unit
+                                        y
                                       ]
                                     )
                                   )
@@ -5989,59 +5775,46 @@
                                             [List a]
                                             [
                                               [
-                                                [
-                                                  {
-                                                    [ { Nil_match a } haystack ]
-                                                    (fun Unit Bool)
-                                                  }
-                                                  (lam thunk Unit False)
-                                                ]
+                                                {
+                                                  [ { Nil_match a } haystack ]
+                                                  Bool
+                                                }
+                                                False
+                                              ]
+                                              (lam
+                                                x
+                                                a
                                                 (lam
-                                                  x
-                                                  a
-                                                  (lam
-                                                    xs
-                                                    [List a]
-                                                    (lam
-                                                      thunk
-                                                      Unit
+                                                  xs
+                                                  [List a]
+                                                  [
+                                                    [
                                                       [
+                                                        {
+                                                          [
+                                                            Bool_match
+                                                            [ [ dEq x ] needle ]
+                                                          ]
+                                                          (fun Unit Bool)
+                                                        }
+                                                        (lam thunk Unit True)
+                                                      ]
+                                                      (lam
+                                                        thunk
+                                                        Unit
                                                         [
                                                           [
-                                                            {
-                                                              [
-                                                                Bool_match
-                                                                [
-                                                                  [ dEq x ]
-                                                                  needle
-                                                                ]
-                                                              ]
-                                                              (fun Unit Bool)
-                                                            }
-                                                            (lam thunk Unit True
-                                                            )
+                                                            [ { elem a } dEq ]
+                                                            needle
                                                           ]
-                                                          (lam
-                                                            thunk
-                                                            Unit
-                                                            [
-                                                              [
-                                                                [
-                                                                  { elem a } dEq
-                                                                ]
-                                                                needle
-                                                              ]
-                                                              xs
-                                                            ]
-                                                          )
+                                                          xs
                                                         ]
-                                                        Unit
-                                                      ]
-                                                    )
-                                                  )
+                                                      )
+                                                    ]
+                                                    Unit
+                                                  ]
                                                 )
-                                              ]
-                                              Unit
+                                              )
                                             ]
                                           )
                                         )
@@ -6820,20 +6593,7 @@
                                                                                                                             (lam
                                                                                                                               thunk
                                                                                                                               Unit
-                                                                                                                              (let
-                                                                                                                                (nonrec
-                                                                                                                                )
-                                                                                                                                (termbind
-                                                                                                                                  (strict
-                                                                                                                                  )
-                                                                                                                                  (vardecl
-                                                                                                                                    wild
-                                                                                                                                    Bool
-                                                                                                                                  )
-                                                                                                                                  in
-                                                                                                                                )
-                                                                                                                                True
-                                                                                                                              )
+                                                                                                                              True
                                                                                                                             )
                                                                                                                           ]
                                                                                                                           Unit
@@ -6962,20 +6722,7 @@
                                                                                                       (lam
                                                                                                         thunk
                                                                                                         Unit
-                                                                                                        (let
-                                                                                                          (nonrec
-                                                                                                          )
-                                                                                                          (termbind
-                                                                                                            (strict
-                                                                                                            )
-                                                                                                            (vardecl
-                                                                                                              wild
-                                                                                                              Bool
-                                                                                                            )
-                                                                                                            in
-                                                                                                          )
-                                                                                                          True
-                                                                                                        )
+                                                                                                        True
                                                                                                       )
                                                                                                     ]
                                                                                                     Unit
@@ -7085,20 +6832,7 @@
                                                                                                                       (lam
                                                                                                                         thunk
                                                                                                                         Unit
-                                                                                                                        (let
-                                                                                                                          (nonrec
-                                                                                                                          )
-                                                                                                                          (termbind
-                                                                                                                            (strict
-                                                                                                                            )
-                                                                                                                            (vardecl
-                                                                                                                              wild
-                                                                                                                              Bool
-                                                                                                                            )
-                                                                                                                            in
-                                                                                                                          )
-                                                                                                                          True
-                                                                                                                        )
+                                                                                                                        True
                                                                                                                       )
                                                                                                                     ]
                                                                                                                     Unit
@@ -7227,20 +6961,7 @@
                                                                                                 (lam
                                                                                                   thunk
                                                                                                   Unit
-                                                                                                  (let
-                                                                                                    (nonrec
-                                                                                                    )
-                                                                                                    (termbind
-                                                                                                      (strict
-                                                                                                      )
-                                                                                                      (vardecl
-                                                                                                        wild
-                                                                                                        Bool
-                                                                                                      )
-                                                                                                      in
-                                                                                                    )
-                                                                                                    True
-                                                                                                  )
+                                                                                                  True
                                                                                                 )
                                                                                               ]
                                                                                               Unit
@@ -7310,20 +7031,7 @@
                                                                                 (lam
                                                                                   thunk
                                                                                   Unit
-                                                                                  (let
-                                                                                    (nonrec
-                                                                                    )
-                                                                                    (termbind
-                                                                                      (strict
-                                                                                      )
-                                                                                      (vardecl
-                                                                                        wild
-                                                                                        Bool
-                                                                                      )
-                                                                                      in
-                                                                                    )
-                                                                                    True
-                                                                                  )
+                                                                                  True
                                                                                 )
                                                                               ]
                                                                               Unit
@@ -7459,20 +7167,7 @@
                                                                                                                       (lam
                                                                                                                         thunk
                                                                                                                         Unit
-                                                                                                                        (let
-                                                                                                                          (nonrec
-                                                                                                                          )
-                                                                                                                          (termbind
-                                                                                                                            (strict
-                                                                                                                            )
-                                                                                                                            (vardecl
-                                                                                                                              wild
-                                                                                                                              Bool
-                                                                                                                            )
-                                                                                                                            in
-                                                                                                                          )
-                                                                                                                          True
-                                                                                                                        )
+                                                                                                                        True
                                                                                                                       )
                                                                                                                     ]
                                                                                                                     Unit
@@ -7601,20 +7296,7 @@
                                                                                                 (lam
                                                                                                   thunk
                                                                                                   Unit
-                                                                                                  (let
-                                                                                                    (nonrec
-                                                                                                    )
-                                                                                                    (termbind
-                                                                                                      (strict
-                                                                                                      )
-                                                                                                      (vardecl
-                                                                                                        wild
-                                                                                                        Bool
-                                                                                                      )
-                                                                                                      in
-                                                                                                    )
-                                                                                                    True
-                                                                                                  )
+                                                                                                  True
                                                                                                 )
                                                                                               ]
                                                                                               Unit
@@ -7724,20 +7406,7 @@
                                                                                                                 (lam
                                                                                                                   thunk
                                                                                                                   Unit
-                                                                                                                  (let
-                                                                                                                    (nonrec
-                                                                                                                    )
-                                                                                                                    (termbind
-                                                                                                                      (strict
-                                                                                                                      )
-                                                                                                                      (vardecl
-                                                                                                                        wild
-                                                                                                                        Bool
-                                                                                                                      )
-                                                                                                                      in
-                                                                                                                    )
-                                                                                                                    True
-                                                                                                                  )
+                                                                                                                  True
                                                                                                                 )
                                                                                                               ]
                                                                                                               Unit
@@ -7866,20 +7535,7 @@
                                                                                           (lam
                                                                                             thunk
                                                                                             Unit
-                                                                                            (let
-                                                                                              (nonrec
-                                                                                              )
-                                                                                              (termbind
-                                                                                                (strict
-                                                                                                )
-                                                                                                (vardecl
-                                                                                                  wild
-                                                                                                  Bool
-                                                                                                )
-                                                                                                in
-                                                                                              )
-                                                                                              True
-                                                                                            )
+                                                                                            True
                                                                                           )
                                                                                         ]
                                                                                         Unit
@@ -8103,20 +7759,7 @@
                                                                                                                             (lam
                                                                                                                               thunk
                                                                                                                               Unit
-                                                                                                                              (let
-                                                                                                                                (nonrec
-                                                                                                                                )
-                                                                                                                                (termbind
-                                                                                                                                  (strict
-                                                                                                                                  )
-                                                                                                                                  (vardecl
-                                                                                                                                    wild
-                                                                                                                                    Bool
-                                                                                                                                  )
-                                                                                                                                  in
-                                                                                                                                )
-                                                                                                                                True
-                                                                                                                              )
+                                                                                                                              True
                                                                                                                             )
                                                                                                                           ]
                                                                                                                           Unit
@@ -8245,20 +7888,7 @@
                                                                                                       (lam
                                                                                                         thunk
                                                                                                         Unit
-                                                                                                        (let
-                                                                                                          (nonrec
-                                                                                                          )
-                                                                                                          (termbind
-                                                                                                            (strict
-                                                                                                            )
-                                                                                                            (vardecl
-                                                                                                              wild
-                                                                                                              Bool
-                                                                                                            )
-                                                                                                            in
-                                                                                                          )
-                                                                                                          True
-                                                                                                        )
+                                                                                                        True
                                                                                                       )
                                                                                                     ]
                                                                                                     Unit
@@ -8368,20 +7998,7 @@
                                                                                                                       (lam
                                                                                                                         thunk
                                                                                                                         Unit
-                                                                                                                        (let
-                                                                                                                          (nonrec
-                                                                                                                          )
-                                                                                                                          (termbind
-                                                                                                                            (strict
-                                                                                                                            )
-                                                                                                                            (vardecl
-                                                                                                                              wild
-                                                                                                                              Bool
-                                                                                                                            )
-                                                                                                                            in
-                                                                                                                          )
-                                                                                                                          True
-                                                                                                                        )
+                                                                                                                        True
                                                                                                                       )
                                                                                                                     ]
                                                                                                                     Unit
@@ -8510,20 +8127,7 @@
                                                                                                 (lam
                                                                                                   thunk
                                                                                                   Unit
-                                                                                                  (let
-                                                                                                    (nonrec
-                                                                                                    )
-                                                                                                    (termbind
-                                                                                                      (strict
-                                                                                                      )
-                                                                                                      (vardecl
-                                                                                                        wild
-                                                                                                        Bool
-                                                                                                      )
-                                                                                                      in
-                                                                                                    )
-                                                                                                    True
-                                                                                                  )
+                                                                                                  True
                                                                                                 )
                                                                                               ]
                                                                                               Unit
@@ -8593,20 +8197,7 @@
                                                                                 (lam
                                                                                   thunk
                                                                                   Unit
-                                                                                  (let
-                                                                                    (nonrec
-                                                                                    )
-                                                                                    (termbind
-                                                                                      (strict
-                                                                                      )
-                                                                                      (vardecl
-                                                                                        wild
-                                                                                        Bool
-                                                                                      )
-                                                                                      in
-                                                                                    )
-                                                                                    True
-                                                                                  )
+                                                                                  True
                                                                                 )
                                                                               ]
                                                                               Unit
@@ -8742,20 +8333,7 @@
                                                                                                                       (lam
                                                                                                                         thunk
                                                                                                                         Unit
-                                                                                                                        (let
-                                                                                                                          (nonrec
-                                                                                                                          )
-                                                                                                                          (termbind
-                                                                                                                            (strict
-                                                                                                                            )
-                                                                                                                            (vardecl
-                                                                                                                              wild
-                                                                                                                              Bool
-                                                                                                                            )
-                                                                                                                            in
-                                                                                                                          )
-                                                                                                                          True
-                                                                                                                        )
+                                                                                                                        True
                                                                                                                       )
                                                                                                                     ]
                                                                                                                     Unit
@@ -8884,20 +8462,7 @@
                                                                                                 (lam
                                                                                                   thunk
                                                                                                   Unit
-                                                                                                  (let
-                                                                                                    (nonrec
-                                                                                                    )
-                                                                                                    (termbind
-                                                                                                      (strict
-                                                                                                      )
-                                                                                                      (vardecl
-                                                                                                        wild
-                                                                                                        Bool
-                                                                                                      )
-                                                                                                      in
-                                                                                                    )
-                                                                                                    True
-                                                                                                  )
+                                                                                                  True
                                                                                                 )
                                                                                               ]
                                                                                               Unit
@@ -9007,20 +8572,7 @@
                                                                                                                 (lam
                                                                                                                   thunk
                                                                                                                   Unit
-                                                                                                                  (let
-                                                                                                                    (nonrec
-                                                                                                                    )
-                                                                                                                    (termbind
-                                                                                                                      (strict
-                                                                                                                      )
-                                                                                                                      (vardecl
-                                                                                                                        wild
-                                                                                                                        Bool
-                                                                                                                      )
-                                                                                                                      in
-                                                                                                                    )
-                                                                                                                    True
-                                                                                                                  )
+                                                                                                                  True
                                                                                                                 )
                                                                                                               ]
                                                                                                               Unit
@@ -9149,20 +8701,7 @@
                                                                                           (lam
                                                                                             thunk
                                                                                             Unit
-                                                                                            (let
-                                                                                              (nonrec
-                                                                                              )
-                                                                                              (termbind
-                                                                                                (strict
-                                                                                                )
-                                                                                                (vardecl
-                                                                                                  wild
-                                                                                                  Bool
-                                                                                                )
-                                                                                                in
-                                                                                              )
-                                                                                              True
-                                                                                            )
+                                                                                            True
                                                                                           )
                                                                                         ]
                                                                                         Unit
@@ -9978,33 +9517,21 @@
                                                     [List a]
                                                     [
                                                       [
-                                                        [
-                                                          {
-                                                            [
-                                                              { Nil_match a } ds
-                                                            ]
-                                                            (fun Unit b)
-                                                          }
-                                                          (lam thunk Unit z)
-                                                        ]
-                                                        (lam
-                                                          y
-                                                          a
-                                                          (lam
-                                                            ys
-                                                            [List a]
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              [
-                                                                [ k y ]
-                                                                [ go ys ]
-                                                              ]
-                                                            )
-                                                          )
-                                                        )
+                                                        {
+                                                          [ { Nil_match a } ds ]
+                                                          b
+                                                        }
+                                                        z
                                                       ]
-                                                      Unit
+                                                      (lam
+                                                        y
+                                                        a
+                                                        (lam
+                                                          ys
+                                                          [List a]
+                                                          [ [ k y ] [ go ys ] ]
+                                                        )
+                                                      )
                                                     ]
                                                   )
                                                 )
@@ -10343,26 +9870,19 @@
                                                                                                     thunk
                                                                                                     Unit
                                                                                                     [
-                                                                                                      [
-                                                                                                        {
+                                                                                                      {
+                                                                                                        [
+                                                                                                          Unit_match
                                                                                                           [
-                                                                                                            Unit_match
-                                                                                                            [
-                                                                                                              trace
-                                                                                                              (con
-                                                                                                                "Missing signature"
-                                                                                                              )
-                                                                                                            ]
+                                                                                                            trace
+                                                                                                            (con
+                                                                                                              "Missing signature"
+                                                                                                            )
                                                                                                           ]
-                                                                                                          (fun Unit Bool)
-                                                                                                        }
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          False
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      Unit
+                                                                                                        ]
+                                                                                                        Bool
+                                                                                                      }
+                                                                                                      False
                                                                                                     ]
                                                                                                   )
                                                                                                 ]
@@ -10469,26 +9989,19 @@
                                                                                   thunk
                                                                                   Unit
                                                                                   [
-                                                                                    [
-                                                                                      {
+                                                                                    {
+                                                                                      [
+                                                                                        Unit_match
                                                                                         [
-                                                                                          Unit_match
-                                                                                          [
-                                                                                            trace
-                                                                                            (con
-                                                                                              "Value forged not OK"
-                                                                                            )
-                                                                                          ]
+                                                                                          trace
+                                                                                          (con
+                                                                                            "Value forged not OK"
+                                                                                          )
                                                                                         ]
-                                                                                        (fun Unit Bool)
-                                                                                      }
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        False
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
+                                                                                      ]
+                                                                                      Bool
+                                                                                    }
+                                                                                    False
                                                                                   ]
                                                                                 )
                                                                               ]
@@ -10515,93 +10028,64 @@
                                                                               Bool
                                                                             )
                                                                             [
-                                                                              [
-                                                                                {
+                                                                              {
+                                                                                [
+                                                                                  Unit_match
                                                                                   [
-                                                                                    Unit_match
-                                                                                    [
-                                                                                      trace
-                                                                                      (con
-                                                                                        "MustHashDatum"
-                                                                                      )
-                                                                                    ]
+                                                                                    trace
+                                                                                    (con
+                                                                                      "MustHashDatum"
+                                                                                    )
                                                                                   ]
-                                                                                  (fun Unit Bool)
-                                                                                }
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  False
-                                                                                )
-                                                                              ]
-                                                                              Unit
+                                                                                ]
+                                                                                Bool
+                                                                              }
+                                                                              False
                                                                             ]
                                                                           )
                                                                           [
                                                                             [
-                                                                              [
-                                                                                {
+                                                                              {
+                                                                                [
+                                                                                  {
+                                                                                    Maybe_match
+                                                                                    Data
+                                                                                  }
+                                                                                  [
+                                                                                    [
+                                                                                      findDatum
+                                                                                      dvh
+                                                                                    ]
+                                                                                    ds
+                                                                                  ]
+                                                                                ]
+                                                                                Bool
+                                                                              }
+                                                                              (lam
+                                                                                a
+                                                                                Data
+                                                                                [
                                                                                   [
                                                                                     {
-                                                                                      Maybe_match
-                                                                                      Data
-                                                                                    }
-                                                                                    [
                                                                                       [
-                                                                                        findDatum
-                                                                                        dvh
-                                                                                      ]
-                                                                                      ds
-                                                                                    ]
-                                                                                  ]
-                                                                                  (fun Unit Bool)
-                                                                                }
-                                                                                (lam
-                                                                                  a
-                                                                                  Data
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    [
-                                                                                      [
+                                                                                        Bool_match
                                                                                         [
-                                                                                          {
-                                                                                            [
-                                                                                              Bool_match
-                                                                                              [
-                                                                                                [
-                                                                                                  fEqData_c
-                                                                                                  a
-                                                                                                ]
-                                                                                                dv
-                                                                                              ]
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            True
-                                                                                          )
+                                                                                          [
+                                                                                            fEqData_c
+                                                                                            a
+                                                                                          ]
+                                                                                          dv
                                                                                         ]
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          j
-                                                                                        )
                                                                                       ]
-                                                                                      Unit
-                                                                                    ]
-                                                                                  )
-                                                                                )
-                                                                              ]
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                j
+                                                                                      Bool
+                                                                                    }
+                                                                                    True
+                                                                                  ]
+                                                                                  j
+                                                                                ]
                                                                               )
                                                                             ]
-                                                                            Unit
+                                                                            j
                                                                           ]
                                                                         )
                                                                       )
@@ -10695,26 +10179,19 @@
                                                                                               thunk
                                                                                               Unit
                                                                                               [
-                                                                                                [
-                                                                                                  {
+                                                                                                {
+                                                                                                  [
+                                                                                                    Unit_match
                                                                                                     [
-                                                                                                      Unit_match
-                                                                                                      [
-                                                                                                        trace
-                                                                                                        (con
-                                                                                                          "Missing datum"
-                                                                                                        )
-                                                                                                      ]
+                                                                                                      trace
+                                                                                                      (con
+                                                                                                        "Missing datum"
+                                                                                                      )
                                                                                                     ]
-                                                                                                    (fun Unit Bool)
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    False
-                                                                                                  )
-                                                                                                ]
-                                                                                                Unit
+                                                                                                  ]
+                                                                                                  Bool
+                                                                                                }
+                                                                                                False
                                                                                               ]
                                                                                             )
                                                                                           ]
@@ -10853,148 +10330,126 @@
                                                                                                                               TxOutType
                                                                                                                               [
                                                                                                                                 [
+                                                                                                                                  {
+                                                                                                                                    [
+                                                                                                                                      TxOutType_match
+                                                                                                                                      ds
+                                                                                                                                    ]
+                                                                                                                                    Bool
+                                                                                                                                  }
+                                                                                                                                  False
+                                                                                                                                ]
+                                                                                                                                (lam
+                                                                                                                                  svh
+                                                                                                                                  (con bytestring)
                                                                                                                                   [
-                                                                                                                                    {
+                                                                                                                                    [
                                                                                                                                       [
-                                                                                                                                        TxOutType_match
-                                                                                                                                        ds
-                                                                                                                                      ]
-                                                                                                                                      (fun Unit Bool)
-                                                                                                                                    }
-                                                                                                                                    (lam
-                                                                                                                                      thunk
-                                                                                                                                      Unit
-                                                                                                                                      False
-                                                                                                                                    )
-                                                                                                                                  ]
-                                                                                                                                  (lam
-                                                                                                                                    svh
-                                                                                                                                    (con bytestring)
-                                                                                                                                    (lam
-                                                                                                                                      thunk
-                                                                                                                                      Unit
-                                                                                                                                      [
-                                                                                                                                        [
+                                                                                                                                        {
                                                                                                                                           [
-                                                                                                                                            {
+                                                                                                                                            Bool_match
+                                                                                                                                            [
                                                                                                                                               [
-                                                                                                                                                Bool_match
+                                                                                                                                                [
+                                                                                                                                                  checkBinRel
+                                                                                                                                                  equalsInteger
+                                                                                                                                                ]
+                                                                                                                                                ds
+                                                                                                                                              ]
+                                                                                                                                              vl
+                                                                                                                                            ]
+                                                                                                                                          ]
+                                                                                                                                          (fun Unit Bool)
+                                                                                                                                        }
+                                                                                                                                        (lam
+                                                                                                                                          thunk
+                                                                                                                                          Unit
+                                                                                                                                          [
+                                                                                                                                            [
+                                                                                                                                              {
+                                                                                                                                                [
+                                                                                                                                                  {
+                                                                                                                                                    Maybe_match
+                                                                                                                                                    (con bytestring)
+                                                                                                                                                  }
+                                                                                                                                                  hsh
+                                                                                                                                                ]
+                                                                                                                                                Bool
+                                                                                                                                              }
+                                                                                                                                              (lam
+                                                                                                                                                a
+                                                                                                                                                (con bytestring)
                                                                                                                                                 [
                                                                                                                                                   [
                                                                                                                                                     [
-                                                                                                                                                      checkBinRel
-                                                                                                                                                      equalsInteger
-                                                                                                                                                    ]
-                                                                                                                                                    ds
-                                                                                                                                                  ]
-                                                                                                                                                  vl
-                                                                                                                                                ]
-                                                                                                                                              ]
-                                                                                                                                              (fun Unit Bool)
-                                                                                                                                            }
-                                                                                                                                            (lam
-                                                                                                                                              thunk
-                                                                                                                                              Unit
-                                                                                                                                              [
-                                                                                                                                                [
-                                                                                                                                                  [
-                                                                                                                                                    {
-                                                                                                                                                      [
-                                                                                                                                                        {
-                                                                                                                                                          Maybe_match
-                                                                                                                                                          (con bytestring)
-                                                                                                                                                        }
-                                                                                                                                                        hsh
-                                                                                                                                                      ]
-                                                                                                                                                      (fun Unit Bool)
-                                                                                                                                                    }
-                                                                                                                                                    (lam
-                                                                                                                                                      a
-                                                                                                                                                      (con bytestring)
+                                                                                                                                                      {
+                                                                                                                                                        [
+                                                                                                                                                          Bool_match
+                                                                                                                                                          [
+                                                                                                                                                            [
+                                                                                                                                                              equalsByteString
+                                                                                                                                                              a
+                                                                                                                                                            ]
+                                                                                                                                                            svh
+                                                                                                                                                          ]
+                                                                                                                                                        ]
+                                                                                                                                                        (fun Unit Bool)
+                                                                                                                                                      }
                                                                                                                                                       (lam
                                                                                                                                                         thunk
                                                                                                                                                         Unit
                                                                                                                                                         [
                                                                                                                                                           [
-                                                                                                                                                            [
-                                                                                                                                                              {
-                                                                                                                                                                [
-                                                                                                                                                                  Bool_match
-                                                                                                                                                                  [
-                                                                                                                                                                    [
-                                                                                                                                                                      equalsByteString
-                                                                                                                                                                      a
-                                                                                                                                                                    ]
-                                                                                                                                                                    svh
-                                                                                                                                                                  ]
-                                                                                                                                                                ]
-                                                                                                                                                                (fun Unit Bool)
-                                                                                                                                                              }
-                                                                                                                                                              (lam
-                                                                                                                                                                thunk
-                                                                                                                                                                Unit
-                                                                                                                                                                [
-                                                                                                                                                                  [
-                                                                                                                                                                    {
-                                                                                                                                                                      [
-                                                                                                                                                                        Address_match
-                                                                                                                                                                        ds
-                                                                                                                                                                      ]
-                                                                                                                                                                      Bool
-                                                                                                                                                                    }
-                                                                                                                                                                    (lam
-                                                                                                                                                                      pkh
-                                                                                                                                                                      (con bytestring)
-                                                                                                                                                                      False
-                                                                                                                                                                    )
-                                                                                                                                                                  ]
-                                                                                                                                                                  (lam
-                                                                                                                                                                    vh
-                                                                                                                                                                    (con bytestring)
-                                                                                                                                                                    [
-                                                                                                                                                                      [
-                                                                                                                                                                        equalsByteString
-                                                                                                                                                                        vh
-                                                                                                                                                                      ]
-                                                                                                                                                                      vlh
-                                                                                                                                                                    ]
-                                                                                                                                                                  )
-                                                                                                                                                                ]
-                                                                                                                                                              )
-                                                                                                                                                            ]
+                                                                                                                                                            {
+                                                                                                                                                              [
+                                                                                                                                                                Address_match
+                                                                                                                                                                ds
+                                                                                                                                                              ]
+                                                                                                                                                              Bool
+                                                                                                                                                            }
                                                                                                                                                             (lam
-                                                                                                                                                              thunk
-                                                                                                                                                              Unit
+                                                                                                                                                              pkh
+                                                                                                                                                              (con bytestring)
                                                                                                                                                               False
                                                                                                                                                             )
                                                                                                                                                           ]
-                                                                                                                                                          Unit
+                                                                                                                                                          (lam
+                                                                                                                                                            vh
+                                                                                                                                                            (con bytestring)
+                                                                                                                                                            [
+                                                                                                                                                              [
+                                                                                                                                                                equalsByteString
+                                                                                                                                                                vh
+                                                                                                                                                              ]
+                                                                                                                                                              vlh
+                                                                                                                                                            ]
+                                                                                                                                                          )
                                                                                                                                                         ]
                                                                                                                                                       )
+                                                                                                                                                    ]
+                                                                                                                                                    (lam
+                                                                                                                                                      thunk
+                                                                                                                                                      Unit
+                                                                                                                                                      False
                                                                                                                                                     )
                                                                                                                                                   ]
-                                                                                                                                                  (lam
-                                                                                                                                                    thunk
-                                                                                                                                                    Unit
-                                                                                                                                                    False
-                                                                                                                                                  )
+                                                                                                                                                  Unit
                                                                                                                                                 ]
-                                                                                                                                                Unit
-                                                                                                                                              ]
-                                                                                                                                            )
-                                                                                                                                          ]
-                                                                                                                                          (lam
-                                                                                                                                            thunk
-                                                                                                                                            Unit
+                                                                                                                                              )
+                                                                                                                                            ]
                                                                                                                                             False
-                                                                                                                                          )
-                                                                                                                                        ]
-                                                                                                                                        Unit
+                                                                                                                                          ]
+                                                                                                                                        )
                                                                                                                                       ]
-                                                                                                                                    )
-                                                                                                                                  )
-                                                                                                                                ]
-                                                                                                                                Unit
+                                                                                                                                      (lam
+                                                                                                                                        thunk
+                                                                                                                                        Unit
+                                                                                                                                        False
+                                                                                                                                      )
+                                                                                                                                    ]
+                                                                                                                                    Unit
+                                                                                                                                  ]
+                                                                                                                                )
                                                                                                                               ]
                                                                                                                             )
                                                                                                                           )
@@ -11024,26 +10479,19 @@
                                                                                                   thunk
                                                                                                   Unit
                                                                                                   [
-                                                                                                    [
-                                                                                                      {
+                                                                                                    {
+                                                                                                      [
+                                                                                                        Unit_match
                                                                                                         [
-                                                                                                          Unit_match
-                                                                                                          [
-                                                                                                            trace
-                                                                                                            (con
-                                                                                                              "MustPayToOtherScript"
-                                                                                                            )
-                                                                                                          ]
+                                                                                                          trace
+                                                                                                          (con
+                                                                                                            "MustPayToOtherScript"
+                                                                                                          )
                                                                                                         ]
-                                                                                                        (fun Unit Bool)
-                                                                                                      }
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        False
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    Unit
+                                                                                                      ]
+                                                                                                      Bool
+                                                                                                    }
+                                                                                                    False
                                                                                                   ]
                                                                                                 )
                                                                                               ]
@@ -11105,26 +10553,19 @@
                                                                         thunk
                                                                         Unit
                                                                         [
-                                                                          [
-                                                                            {
+                                                                          {
+                                                                            [
+                                                                              Unit_match
                                                                               [
-                                                                                Unit_match
-                                                                                [
-                                                                                  trace
-                                                                                  (con
-                                                                                    "MustPayToPubKey"
-                                                                                  )
-                                                                                ]
+                                                                                trace
+                                                                                (con
+                                                                                  "MustPayToPubKey"
+                                                                                )
                                                                               ]
-                                                                              (fun Unit Bool)
-                                                                            }
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              False
-                                                                            )
-                                                                          ]
-                                                                          Unit
+                                                                            ]
+                                                                            Bool
+                                                                          }
+                                                                          False
                                                                         ]
                                                                       )
                                                                     ]
@@ -11144,115 +10585,86 @@
                                                                     j Bool
                                                                   )
                                                                   [
-                                                                    [
-                                                                      {
+                                                                    {
+                                                                      [
+                                                                        Unit_match
                                                                         [
-                                                                          Unit_match
-                                                                          [
-                                                                            trace
-                                                                            (con
-                                                                              "Public key output not spent"
-                                                                            )
-                                                                          ]
+                                                                          trace
+                                                                          (con
+                                                                            "Public key output not spent"
+                                                                          )
                                                                         ]
-                                                                        (fun Unit Bool)
-                                                                      }
-                                                                      (lam
-                                                                        thunk
-                                                                        Unit
-                                                                        False
-                                                                      )
-                                                                    ]
-                                                                    Unit
+                                                                      ]
+                                                                      Bool
+                                                                    }
+                                                                    False
                                                                   ]
                                                                 )
                                                                 [
                                                                   [
-                                                                    [
-                                                                      {
+                                                                    {
+                                                                      [
+                                                                        {
+                                                                          Maybe_match
+                                                                          TxInInfo
+                                                                        }
                                                                         [
-                                                                          {
-                                                                            Maybe_match
-                                                                            TxInInfo
-                                                                          }
                                                                           [
-                                                                            [
-                                                                              findTxInByTxOutRef
-                                                                              txOutRef
-                                                                            ]
-                                                                            ds
+                                                                            findTxInByTxOutRef
+                                                                            txOutRef
                                                                           ]
+                                                                          ds
                                                                         ]
-                                                                        (fun Unit Bool)
-                                                                      }
-                                                                      (lam
-                                                                        a
-                                                                        TxInInfo
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
+                                                                      ]
+                                                                      Bool
+                                                                    }
+                                                                    (lam
+                                                                      a
+                                                                      TxInInfo
+                                                                      [
+                                                                        {
                                                                           [
-                                                                            {
-                                                                              [
-                                                                                TxInInfo_match
-                                                                                a
-                                                                              ]
-                                                                              Bool
-                                                                            }
+                                                                            TxInInfo_match
+                                                                            a
+                                                                          ]
+                                                                          Bool
+                                                                        }
+                                                                        (lam
+                                                                          ds
+                                                                          TxOutRef
+                                                                          (lam
+                                                                            ds
+                                                                            [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
                                                                             (lam
                                                                               ds
-                                                                              TxOutRef
-                                                                              (lam
-                                                                                ds
-                                                                                [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
-                                                                                (lam
-                                                                                  ds
-                                                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                  [
+                                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                              [
+                                                                                [
+                                                                                  {
                                                                                     [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            {
-                                                                                              Maybe_match
-                                                                                              [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
-                                                                                            }
-                                                                                            ds
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          ds
-                                                                                          [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            j
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        True
-                                                                                      )
+                                                                                      {
+                                                                                        Maybe_match
+                                                                                        [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
+                                                                                      }
+                                                                                      ds
                                                                                     ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              )
+                                                                                    Bool
+                                                                                  }
+                                                                                  (lam
+                                                                                    ds
+                                                                                    [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
+                                                                                    j
+                                                                                  )
+                                                                                ]
+                                                                                True
+                                                                              ]
                                                                             )
-                                                                          ]
+                                                                          )
                                                                         )
-                                                                      )
-                                                                    ]
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      j
+                                                                      ]
                                                                     )
                                                                   ]
-                                                                  Unit
+                                                                  j
                                                                 ]
                                                               )
                                                             )
@@ -11296,26 +10708,19 @@
                                                                     thunk
                                                                     Unit
                                                                     [
-                                                                      [
-                                                                        {
+                                                                      {
+                                                                        [
+                                                                          Unit_match
                                                                           [
-                                                                            Unit_match
-                                                                            [
-                                                                              trace
-                                                                              (con
-                                                                                "Script output not spent"
-                                                                              )
-                                                                            ]
+                                                                            trace
+                                                                            (con
+                                                                              "Script output not spent"
+                                                                            )
                                                                           ]
-                                                                          (fun Unit Bool)
-                                                                        }
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          False
-                                                                        )
-                                                                      ]
-                                                                      Unit
+                                                                        ]
+                                                                        Bool
+                                                                      }
+                                                                      False
                                                                     ]
                                                                   )
                                                                 ]
@@ -11359,26 +10764,19 @@
                                                                 thunk
                                                                 Unit
                                                                 [
-                                                                  [
-                                                                    {
+                                                                  {
+                                                                    [
+                                                                      Unit_match
                                                                       [
-                                                                        Unit_match
-                                                                        [
-                                                                          trace
-                                                                          (con
-                                                                            "Spent value not OK"
-                                                                          )
-                                                                        ]
+                                                                        trace
+                                                                        (con
+                                                                          "Spent value not OK"
+                                                                        )
                                                                       ]
-                                                                      (fun Unit Bool)
-                                                                    }
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      False
-                                                                    )
-                                                                  ]
-                                                                  Unit
+                                                                    ]
+                                                                    Bool
+                                                                  }
+                                                                  False
                                                                 ]
                                                               )
                                                             ]
@@ -11469,26 +10867,19 @@
                                                                                               Bool
                                                                                             )
                                                                                             [
-                                                                                              [
-                                                                                                {
+                                                                                              {
+                                                                                                [
+                                                                                                  Unit_match
                                                                                                   [
-                                                                                                    Unit_match
-                                                                                                    [
-                                                                                                      trace
-                                                                                                      (con
-                                                                                                        "Wrong validation interval"
-                                                                                                      )
-                                                                                                    ]
+                                                                                                    trace
+                                                                                                    (con
+                                                                                                      "Wrong validation interval"
+                                                                                                    )
                                                                                                   ]
-                                                                                                  (fun Unit Bool)
-                                                                                                }
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  False
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
+                                                                                                ]
+                                                                                                Bool
+                                                                                              }
+                                                                                              False
                                                                                             ]
                                                                                           )
                                                                                           [
@@ -11518,39 +10909,28 @@
                                                                                                   Unit
                                                                                                   [
                                                                                                     [
-                                                                                                      [
-                                                                                                        {
+                                                                                                      {
+                                                                                                        [
+                                                                                                          Bool_match
                                                                                                           [
-                                                                                                            Bool_match
                                                                                                             [
                                                                                                               [
-                                                                                                                [
-                                                                                                                  {
-                                                                                                                    hull_c
-                                                                                                                    (con integer)
-                                                                                                                  }
-                                                                                                                  fOrdSlot
-                                                                                                                ]
-                                                                                                                h
+                                                                                                                {
+                                                                                                                  hull_c
+                                                                                                                  (con integer)
+                                                                                                                }
+                                                                                                                fOrdSlot
                                                                                                               ]
                                                                                                               h
                                                                                                             ]
+                                                                                                            h
                                                                                                           ]
-                                                                                                          (fun Unit Bool)
-                                                                                                        }
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          True
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        j
-                                                                                                      )
+                                                                                                        ]
+                                                                                                        Bool
+                                                                                                      }
+                                                                                                      True
                                                                                                     ]
-                                                                                                    Unit
+                                                                                                    j
                                                                                                   ]
                                                                                                 )
                                                                                               ]
@@ -11743,79 +11123,68 @@
                                                                     Unit
                                                                     [
                                                                       [
-                                                                        [
-                                                                          {
+                                                                        {
+                                                                          [
+                                                                            Bool_match
                                                                             [
-                                                                              Bool_match
                                                                               [
                                                                                 [
-                                                                                  [
+                                                                                  {
                                                                                     {
-                                                                                      {
-                                                                                        foldr
-                                                                                        [OutputConstraint Void]
-                                                                                      }
-                                                                                      Bool
-                                                                                    }
-                                                                                    (lam
-                                                                                      a
+                                                                                      foldr
                                                                                       [OutputConstraint Void]
-                                                                                      (lam
-                                                                                        acc
-                                                                                        Bool
+                                                                                    }
+                                                                                    Bool
+                                                                                  }
+                                                                                  (lam
+                                                                                    a
+                                                                                    [OutputConstraint Void]
+                                                                                    (lam
+                                                                                      acc
+                                                                                      Bool
+                                                                                      [
                                                                                         [
                                                                                           [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  Bool_match
-                                                                                                  acc
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                [
-                                                                                                  [
-                                                                                                    scheckOwnOutputConstraint
-                                                                                                    w
-                                                                                                  ]
-                                                                                                  a
-                                                                                                ]
-                                                                                              )
-                                                                                            ]
+                                                                                            {
+                                                                                              [
+                                                                                                Bool_match
+                                                                                                acc
+                                                                                              ]
+                                                                                              (fun Unit Bool)
+                                                                                            }
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              False
+                                                                                              [
+                                                                                                [
+                                                                                                  scheckOwnOutputConstraint
+                                                                                                  w
+                                                                                                ]
+                                                                                                a
+                                                                                              ]
                                                                                             )
                                                                                           ]
-                                                                                          Unit
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            False
+                                                                                          )
                                                                                         ]
-                                                                                      )
+                                                                                        Unit
+                                                                                      ]
                                                                                     )
-                                                                                  ]
-                                                                                  True
+                                                                                  )
                                                                                 ]
-                                                                                ww
+                                                                                True
                                                                               ]
+                                                                              ww
                                                                             ]
-                                                                            (fun Unit Bool)
-                                                                          }
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            True
-                                                                          )
-                                                                        ]
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          scheckValidatorCtx_j
-                                                                        )
+                                                                          ]
+                                                                          Bool
+                                                                        }
+                                                                        True
                                                                       ]
-                                                                      Unit
+                                                                      scheckValidatorCtx_j
                                                                     ]
                                                                   )
                                                                 ]
@@ -11984,99 +11353,77 @@
                                                                                                     TxOutType
                                                                                                     [
                                                                                                       [
-                                                                                                        [
-                                                                                                          {
-                                                                                                            [
-                                                                                                              TxOutType_match
-                                                                                                              ds
-                                                                                                            ]
-                                                                                                            (fun Unit Bool)
-                                                                                                          }
-                                                                                                          (lam
-                                                                                                            thunk
-                                                                                                            Unit
-                                                                                                            False
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        (lam
-                                                                                                          svh
-                                                                                                          (con bytestring)
-                                                                                                          (lam
-                                                                                                            thunk
-                                                                                                            Unit
-                                                                                                            [
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  {
-                                                                                                                    [
-                                                                                                                      Bool_match
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          [
-                                                                                                                            checkBinRel
-                                                                                                                            equalsInteger
-                                                                                                                          ]
-                                                                                                                          ds
-                                                                                                                        ]
-                                                                                                                        ds
-                                                                                                                      ]
-                                                                                                                    ]
-                                                                                                                    (fun Unit Bool)
-                                                                                                                  }
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            [
-                                                                                                                              {
-                                                                                                                                Maybe_match
-                                                                                                                                (con bytestring)
-                                                                                                                              }
-                                                                                                                              hsh
-                                                                                                                            ]
-                                                                                                                            (fun Unit Bool)
-                                                                                                                          }
-                                                                                                                          (lam
-                                                                                                                            a
-                                                                                                                            (con bytestring)
-                                                                                                                            (lam
-                                                                                                                              thunk
-                                                                                                                              Unit
-                                                                                                                              [
-                                                                                                                                [
-                                                                                                                                  equalsByteString
-                                                                                                                                  a
-                                                                                                                                ]
-                                                                                                                                svh
-                                                                                                                              ]
-                                                                                                                            )
-                                                                                                                          )
-                                                                                                                        ]
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          False
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      Unit
-                                                                                                                    ]
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                                (lam
-                                                                                                                  thunk
-                                                                                                                  Unit
-                                                                                                                  False
-                                                                                                                )
-                                                                                                              ]
-                                                                                                              Unit
-                                                                                                            ]
-                                                                                                          )
-                                                                                                        )
+                                                                                                        {
+                                                                                                          [
+                                                                                                            TxOutType_match
+                                                                                                            ds
+                                                                                                          ]
+                                                                                                          Bool
+                                                                                                        }
+                                                                                                        False
                                                                                                       ]
-                                                                                                      Unit
+                                                                                                      (lam
+                                                                                                        svh
+                                                                                                        (con bytestring)
+                                                                                                        [
+                                                                                                          [
+                                                                                                            [
+                                                                                                              {
+                                                                                                                [
+                                                                                                                  Bool_match
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      [
+                                                                                                                        checkBinRel
+                                                                                                                        equalsInteger
+                                                                                                                      ]
+                                                                                                                      ds
+                                                                                                                    ]
+                                                                                                                    ds
+                                                                                                                  ]
+                                                                                                                ]
+                                                                                                                (fun Unit Bool)
+                                                                                                              }
+                                                                                                              (lam
+                                                                                                                thunk
+                                                                                                                Unit
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    {
+                                                                                                                      [
+                                                                                                                        {
+                                                                                                                          Maybe_match
+                                                                                                                          (con bytestring)
+                                                                                                                        }
+                                                                                                                        hsh
+                                                                                                                      ]
+                                                                                                                      Bool
+                                                                                                                    }
+                                                                                                                    (lam
+                                                                                                                      a
+                                                                                                                      (con bytestring)
+                                                                                                                      [
+                                                                                                                        [
+                                                                                                                          equalsByteString
+                                                                                                                          a
+                                                                                                                        ]
+                                                                                                                        svh
+                                                                                                                      ]
+                                                                                                                    )
+                                                                                                                  ]
+                                                                                                                  False
+                                                                                                                ]
+                                                                                                              )
+                                                                                                            ]
+                                                                                                            (lam
+                                                                                                              thunk
+                                                                                                              Unit
+                                                                                                              False
+                                                                                                            )
+                                                                                                          ]
+                                                                                                          Unit
+                                                                                                        ]
+                                                                                                      )
                                                                                                     ]
                                                                                                   )
                                                                                                 )
@@ -12109,26 +11456,19 @@
                                                                         thunk
                                                                         Unit
                                                                         [
-                                                                          [
-                                                                            {
+                                                                          {
+                                                                            [
+                                                                              Unit_match
                                                                               [
-                                                                                Unit_match
-                                                                                [
-                                                                                  trace
-                                                                                  (con
-                                                                                    "Output constraint"
-                                                                                  )
-                                                                                ]
+                                                                                trace
+                                                                                (con
+                                                                                  "Output constraint"
+                                                                                )
                                                                               ]
-                                                                              (fun Unit Bool)
-                                                                            }
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              False
-                                                                            )
-                                                                          ]
-                                                                          Unit
+                                                                            ]
+                                                                            Bool
+                                                                          }
+                                                                          False
                                                                         ]
                                                                       )
                                                                     ]
@@ -12212,26 +11552,19 @@
                                                                 (nonstrict)
                                                                 (vardecl j Bool)
                                                                 [
-                                                                  [
-                                                                    {
+                                                                  {
+                                                                    [
+                                                                      Unit_match
                                                                       [
-                                                                        Unit_match
-                                                                        [
-                                                                          trace
-                                                                          (con
-                                                                            "checkValidatorCtx failed"
-                                                                          )
-                                                                        ]
+                                                                        trace
+                                                                        (con
+                                                                          "checkValidatorCtx failed"
+                                                                        )
                                                                       ]
-                                                                      (fun Unit Bool)
-                                                                    }
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      False
-                                                                    )
-                                                                  ]
-                                                                  Unit
+                                                                    ]
+                                                                    Bool
+                                                                  }
+                                                                  False
                                                                 ]
                                                               )
                                                               [
@@ -12369,85 +11702,74 @@
                                                                               Unit
                                                                               [
                                                                                 [
-                                                                                  [
-                                                                                    {
+                                                                                  {
+                                                                                    [
+                                                                                      Bool_match
                                                                                       [
-                                                                                        Bool_match
                                                                                         [
                                                                                           [
-                                                                                            [
+                                                                                            {
                                                                                               {
-                                                                                                {
-                                                                                                  foldr
-                                                                                                  [OutputConstraint o]
-                                                                                                }
-                                                                                                Bool
-                                                                                              }
-                                                                                              (lam
-                                                                                                a
+                                                                                                foldr
                                                                                                 [OutputConstraint o]
-                                                                                                (lam
-                                                                                                  acc
-                                                                                                  Bool
+                                                                                              }
+                                                                                              Bool
+                                                                                            }
+                                                                                            (lam
+                                                                                              a
+                                                                                              [OutputConstraint o]
+                                                                                              (lam
+                                                                                                acc
+                                                                                                Bool
+                                                                                                [
                                                                                                   [
                                                                                                     [
-                                                                                                      [
-                                                                                                        {
-                                                                                                          [
-                                                                                                            Bool_match
-                                                                                                            acc
-                                                                                                          ]
-                                                                                                          (fun Unit Bool)
-                                                                                                        }
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          [
-                                                                                                            [
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  checkOwnOutputConstraint
-                                                                                                                  o
-                                                                                                                }
-                                                                                                                dIsData
-                                                                                                              ]
-                                                                                                              ptx
-                                                                                                            ]
-                                                                                                            a
-                                                                                                          ]
-                                                                                                        )
-                                                                                                      ]
+                                                                                                      {
+                                                                                                        [
+                                                                                                          Bool_match
+                                                                                                          acc
+                                                                                                        ]
+                                                                                                        (fun Unit Bool)
+                                                                                                      }
                                                                                                       (lam
                                                                                                         thunk
                                                                                                         Unit
-                                                                                                        False
+                                                                                                        [
+                                                                                                          [
+                                                                                                            [
+                                                                                                              {
+                                                                                                                checkOwnOutputConstraint
+                                                                                                                o
+                                                                                                              }
+                                                                                                              dIsData
+                                                                                                            ]
+                                                                                                            ptx
+                                                                                                          ]
+                                                                                                          a
+                                                                                                        ]
                                                                                                       )
                                                                                                     ]
-                                                                                                    Unit
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      False
+                                                                                                    )
                                                                                                   ]
-                                                                                                )
+                                                                                                  Unit
+                                                                                                ]
                                                                                               )
-                                                                                            ]
-                                                                                            True
+                                                                                            )
                                                                                           ]
-                                                                                          ds
+                                                                                          True
                                                                                         ]
+                                                                                        ds
                                                                                       ]
-                                                                                      (fun Unit Bool)
-                                                                                    }
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      True
-                                                                                    )
-                                                                                  ]
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    j
-                                                                                  )
+                                                                                    ]
+                                                                                    Bool
+                                                                                  }
+                                                                                  True
                                                                                 ]
-                                                                                Unit
+                                                                                j
                                                                               ]
                                                                             )
                                                                           ]
@@ -12500,166 +11822,159 @@
                                                   [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
                                                   [
                                                     [
-                                                      [
-                                                        {
-                                                          [
-                                                            {
-                                                              Nil_match
-                                                              [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                            }
-                                                            xs
-                                                          ]
-                                                          (fun Unit Bool)
-                                                        }
-                                                        (lam thunk Unit True)
-                                                      ]
-                                                      (lam
-                                                        ds
-                                                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                        (lam
+                                                      {
+                                                        [
+                                                          {
+                                                            Nil_match
+                                                            [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                          }
                                                           xs
-                                                          [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                                                          (lam
-                                                            thunk
-                                                            Unit
+                                                        ]
+                                                        Bool
+                                                      }
+                                                      True
+                                                    ]
+                                                    (lam
+                                                      ds
+                                                      [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                      (lam
+                                                        xs
+                                                        [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                                        [
+                                                          {
                                                             [
                                                               {
-                                                                [
-                                                                  {
-                                                                    {
-                                                                      Tuple2_match
-                                                                      (con bytestring)
-                                                                    }
-                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                                  }
-                                                                  ds
-                                                                ]
-                                                                Bool
+                                                                {
+                                                                  Tuple2_match
+                                                                  (con bytestring)
+                                                                }
+                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
                                                               }
-                                                              (lam
-                                                                ds
-                                                                (con bytestring)
-                                                                (lam
-                                                                  x
-                                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                                  (let
-                                                                    (rec)
-                                                                    (termbind
-                                                                      (strict)
-                                                                      (vardecl
-                                                                        go
-                                                                        (fun [List [[Tuple2 (con bytestring)] (con integer)]] Bool)
-                                                                      )
-                                                                      (lam
-                                                                        xs
-                                                                        [List [[Tuple2 (con bytestring)] (con integer)]]
+                                                              ds
+                                                            ]
+                                                            Bool
+                                                          }
+                                                          (lam
+                                                            ds
+                                                            (con bytestring)
+                                                            (lam
+                                                              x
+                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                                              (let
+                                                                (rec)
+                                                                (termbind
+                                                                  (strict)
+                                                                  (vardecl
+                                                                    go
+                                                                    (fun [List [[Tuple2 (con bytestring)] (con integer)]] Bool)
+                                                                  )
+                                                                  (lam
+                                                                    xs
+                                                                    [List [[Tuple2 (con bytestring)] (con integer)]]
+                                                                    [
+                                                                      [
                                                                         [
-                                                                          [
+                                                                          {
                                                                             [
                                                                               {
-                                                                                [
-                                                                                  {
-                                                                                    Nil_match
-                                                                                    [[Tuple2 (con bytestring)] (con integer)]
-                                                                                  }
-                                                                                  xs
-                                                                                ]
-                                                                                (fun Unit Bool)
+                                                                                Nil_match
+                                                                                [[Tuple2 (con bytestring)] (con integer)]
                                                                               }
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                [
-                                                                                  go
-                                                                                  xs
-                                                                                ]
-                                                                              )
+                                                                              xs
                                                                             ]
+                                                                            (fun Unit Bool)
+                                                                          }
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            [
+                                                                              go
+                                                                              xs
+                                                                            ]
+                                                                          )
+                                                                        ]
+                                                                        (lam
+                                                                          ds
+                                                                          [[Tuple2 (con bytestring)] (con integer)]
+                                                                          (lam
+                                                                            xs
+                                                                            [List [[Tuple2 (con bytestring)] (con integer)]]
                                                                             (lam
-                                                                              ds
-                                                                              [[Tuple2 (con bytestring)] (con integer)]
-                                                                              (lam
-                                                                                xs
-                                                                                [List [[Tuple2 (con bytestring)] (con integer)]]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
+                                                                              thunk
+                                                                              Unit
+                                                                              [
+                                                                                {
                                                                                   [
                                                                                     {
-                                                                                      [
-                                                                                        {
-                                                                                          {
-                                                                                            Tuple2_match
-                                                                                            (con bytestring)
-                                                                                          }
-                                                                                          (con integer)
-                                                                                        }
-                                                                                        ds
-                                                                                      ]
-                                                                                      Bool
+                                                                                      {
+                                                                                        Tuple2_match
+                                                                                        (con bytestring)
+                                                                                      }
+                                                                                      (con integer)
                                                                                     }
-                                                                                    (lam
-                                                                                      ds
-                                                                                      (con bytestring)
-                                                                                      (lam
-                                                                                        x
-                                                                                        (con integer)
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  Bool_match
-                                                                                                  [
-                                                                                                    [
-                                                                                                      equalsInteger
-                                                                                                      (con
-                                                                                                        0
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    x
-                                                                                                  ]
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                [
-                                                                                                  go
-                                                                                                  xs
-                                                                                                ]
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              False
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    )
+                                                                                    ds
                                                                                   ]
+                                                                                  Bool
+                                                                                }
+                                                                                (lam
+                                                                                  ds
+                                                                                  (con bytestring)
+                                                                                  (lam
+                                                                                    x
+                                                                                    (con integer)
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              Bool_match
+                                                                                              [
+                                                                                                [
+                                                                                                  equalsInteger
+                                                                                                  (con
+                                                                                                    0
+                                                                                                  )
+                                                                                                ]
+                                                                                                x
+                                                                                              ]
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            [
+                                                                                              go
+                                                                                              xs
+                                                                                            ]
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          False
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
                                                                                 )
-                                                                              )
+                                                                              ]
                                                                             )
-                                                                          ]
-                                                                          Unit
-                                                                        ]
-                                                                      )
-                                                                    )
-                                                                    [ go x ]
+                                                                          )
+                                                                        )
+                                                                      ]
+                                                                      Unit
+                                                                    ]
                                                                   )
                                                                 )
+                                                                [ go x ]
                                                               )
-                                                            ]
+                                                            )
                                                           )
-                                                        )
+                                                        ]
                                                       )
-                                                    ]
-                                                    Unit
+                                                    )
                                                   ]
                                                 )
                                               )
@@ -12986,26 +12301,19 @@
                                                                                                                         thunk
                                                                                                                         Unit
                                                                                                                         [
-                                                                                                                          [
-                                                                                                                            {
+                                                                                                                          {
+                                                                                                                            [
+                                                                                                                              Unit_match
                                                                                                                               [
-                                                                                                                                Unit_match
-                                                                                                                                [
-                                                                                                                                  trace
-                                                                                                                                  (con
-                                                                                                                                    "State transition invalid - constraints not satisfied by ValidatorCtx"
-                                                                                                                                  )
-                                                                                                                                ]
+                                                                                                                                trace
+                                                                                                                                (con
+                                                                                                                                  "State transition invalid - constraints not satisfied by ValidatorCtx"
+                                                                                                                                )
                                                                                                                               ]
-                                                                                                                              (fun Unit Bool)
-                                                                                                                            }
-                                                                                                                            (lam
-                                                                                                                              thunk
-                                                                                                                              Unit
-                                                                                                                              False
-                                                                                                                            )
-                                                                                                                          ]
-                                                                                                                          Unit
+                                                                                                                            ]
+                                                                                                                            Bool
+                                                                                                                          }
+                                                                                                                          False
                                                                                                                         ]
                                                                                                                       )
                                                                                                                     ]
@@ -13021,26 +12329,19 @@
                                                                                                         thunk
                                                                                                         Unit
                                                                                                         [
-                                                                                                          [
-                                                                                                            {
+                                                                                                          {
+                                                                                                            [
+                                                                                                              Unit_match
                                                                                                               [
-                                                                                                                Unit_match
-                                                                                                                [
-                                                                                                                  trace
-                                                                                                                  (con
-                                                                                                                    "Non-zero value allocated in final state"
-                                                                                                                  )
-                                                                                                                ]
+                                                                                                                trace
+                                                                                                                (con
+                                                                                                                  "Non-zero value allocated in final state"
+                                                                                                                )
                                                                                                               ]
-                                                                                                              (fun Unit Bool)
-                                                                                                            }
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              False
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          Unit
+                                                                                                            ]
+                                                                                                            Bool
+                                                                                                          }
+                                                                                                          False
                                                                                                         ]
                                                                                                       )
                                                                                                     ]
@@ -13161,26 +12462,19 @@
                                                                                                       thunk
                                                                                                       Unit
                                                                                                       [
-                                                                                                        [
-                                                                                                          {
+                                                                                                        {
+                                                                                                          [
+                                                                                                            Unit_match
                                                                                                             [
-                                                                                                              Unit_match
-                                                                                                              [
-                                                                                                                trace
-                                                                                                                (con
-                                                                                                                  "State transition invalid - constraints not satisfied by ValidatorCtx"
-                                                                                                                )
-                                                                                                              ]
+                                                                                                              trace
+                                                                                                              (con
+                                                                                                                "State transition invalid - constraints not satisfied by ValidatorCtx"
+                                                                                                              )
                                                                                                             ]
-                                                                                                            (fun Unit Bool)
-                                                                                                          }
-                                                                                                          (lam
-                                                                                                            thunk
-                                                                                                            Unit
-                                                                                                            False
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        Unit
+                                                                                                          ]
+                                                                                                          Bool
+                                                                                                        }
+                                                                                                        False
                                                                                                       ]
                                                                                                     )
                                                                                                   ]
@@ -13203,26 +12497,19 @@
                                                                           thunk
                                                                           Unit
                                                                           [
-                                                                            [
-                                                                              {
+                                                                            {
+                                                                              [
+                                                                                Unit_match
                                                                                 [
-                                                                                  Unit_match
-                                                                                  [
-                                                                                    trace
-                                                                                    (con
-                                                                                      "State transition invalid - input is not a valid transition at the current state"
-                                                                                    )
-                                                                                  ]
+                                                                                  trace
+                                                                                  (con
+                                                                                    "State transition invalid - input is not a valid transition at the current state"
+                                                                                  )
                                                                                 ]
-                                                                                (fun Unit Bool)
-                                                                              }
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                False
-                                                                              )
-                                                                            ]
-                                                                            Unit
+                                                                              ]
+                                                                              Bool
+                                                                            }
+                                                                            False
                                                                           ]
                                                                         )
                                                                       ]
@@ -13234,26 +12521,19 @@
                                                                   thunk
                                                                   Unit
                                                                   [
-                                                                    [
-                                                                      {
+                                                                    {
+                                                                      [
+                                                                        Unit_match
                                                                         [
-                                                                          Unit_match
-                                                                          [
-                                                                            trace
-                                                                            (con
-                                                                              "State transition invalid - checks failed"
-                                                                            )
-                                                                          ]
+                                                                          trace
+                                                                          (con
+                                                                            "State transition invalid - checks failed"
+                                                                          )
                                                                         ]
-                                                                        (fun Unit Bool)
-                                                                      }
-                                                                      (lam
-                                                                        thunk
-                                                                        Unit
-                                                                        False
-                                                                      )
-                                                                    ]
-                                                                    Unit
+                                                                      ]
+                                                                      Bool
+                                                                    }
+                                                                    False
                                                                   ]
                                                                 )
                                                               ]

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       27b285df0f32a6b17d0af0ae6331953c87466d71ff316864dca84a6de6e6812d
+TxId:       9253d436cea207978e86b84b751f0bb1ebff9c01025d28fd7171586f1a00ae4a
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f58200fdc59b5592129748aab7ee8fd8e1ed65c...
+              Signature: 5f582064be48e61e6f01fc82c6210e2754132093...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 03d200a81ee0feace8fb845e5ec950a6f9add837... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+  Destination:  Script: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
   Value:
     Ada:      Lovelace:  10
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+  Script: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       22037c4240c09d86f7617323d1b41ab8e8f2d3f6cbb04db1e446d3b0c616cbed
+TxId:       81803ed7ab4212645ba302c7ed06a921b06c4f41d81a4a00d97be34315d28a5a
 Fee:        -
 Forge:      -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 5f5820aa3793234e05ff5f8a138419bdb17da134...
+              Signature: 5f58201cfe1a974235babc86731e7ec96514ea0e...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: feb345e86b9c2a7add2bfc695fa8aecd4ac5b0df... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+  Destination:  Script: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
   Value:
     Ada:      Lovelace:  10
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+  Script: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
   Value:
     Ada:      Lovelace:  20
 
 ==== Slot #3, Tx #0 ====
-TxId:       ec7d2e1d35bb8b99594d3641531209d1c891d84b5fa7525886e3aa4965bdc98c
+TxId:       d5c424d255c7d92327084fee7e06c6ea86bbb10ce28c20dc0b1154c6aa14fb09
 Fee:        -
 Forge:      -
 Signatures  PubKey: f81fb54a825fced95eb033afcd64314075abfb0a...
-              Signature: 5f582038799fb756ea45a2baf2d6cdeedac8a573...
+              Signature: 5f58200fb7ec1a5435bba5c3ddafb9af07f2c8da...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 5aebc31421e7af1bdb47326709c27f3fd9381b00... (Wallet 4)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  9999
   
   ---- Output 1 ----
-  Destination:  Script: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+  Destination:  Script: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
   Value:
     Ada:      Lovelace:  1
 
@@ -318,41 +318,41 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+  Script: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
   Value:
     Ada:      Lovelace:  21
 
 ==== Slot #20, Tx #0 ====
-TxId:       2d83b74095a10e377641e5a06c975340283702c6697cc9fea9d1d78aead15207
+TxId:       73e8e250c29d3ba19491bcffa45af2e9608e8a9e65dd94e22a3edce818f66266
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f5820e15e2472e079194bf72342b9918f7a5835...
+              Signature: 5f58206e88f54fab27fb51d8cde3a03eee0d6116...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+  Destination:  Script: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     22037c4240c09d86f7617323d1b41ab8e8f2d3f6cbb04db1e446d3b0c616cbed
+    Tx:     81803ed7ab4212645ba302c7ed06a921b06c4f41d81a4a00d97be34315d28a5a
     Output #1
     Script: 01000003030264666978311829036161182a0003...
   
   ---- Input 1 ----
-  Destination:  Script: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+  Destination:  Script: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     27b285df0f32a6b17d0af0ae6331953c87466d71ff316864dca84a6de6e6812d
+    Tx:     9253d436cea207978e86b84b751f0bb1ebff9c01025d28fd7171586f1a00ae4a
     Output #1
     Script: 01000003030264666978311829036161182a0003...
   
   ---- Input 2 ----
-  Destination:  Script: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+  Destination:  Script: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
   Value:
     Ada:      Lovelace:  1
   Source:
-    Tx:     ec7d2e1d35bb8b99594d3641531209d1c891d84b5fa7525886e3aa4965bdc98c
+    Tx:     d5c424d255c7d92327084fee7e06c6ea86bbb10ce28c20dc0b1154c6aa14fb09
     Output #1
     Script: 01000003030264666978311829036161182a0003...
 
@@ -405,6 +405,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: 72b54f02ca265dfbd7cf97ff8cea62502f54543a74e810c879da2ed703dfaad5
+  Script: 5781a62a44f953bc7d989c79e9a94f12bcf8a59eecc90d731416bdc176df7d87
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       6e4d69682bd94ef06adf5045f4c4e921737f2f36b4947db4dac7745092d0ee7a
+TxId:       a7e3889dea47b643db155d5681cf37219aa4e5b3f0e9915dabadcffc7dc9c4a3
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f5820ee810fc6a8c4ef24d85e4a812aeb0cf6d8...
+              Signature: 5f58200356456585e05fa0aa4a5f254fa9e281ec...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 2721f657e9ed91d2fc2a282f7ff5ed81ae48f48b... (Wallet 1)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 72a2578bf059d7708383c45a972f9a56a62aee4ad6380f018504d76d7207f905
+  Destination:  Script: e304d11ed9bf022f69f476d7f2a665ba83b8aaf579fc00137a928cb88934677c
   Value:
     Ada:      Lovelace:  10
 
@@ -170,23 +170,23 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 72a2578bf059d7708383c45a972f9a56a62aee4ad6380f018504d76d7207f905
+  Script: e304d11ed9bf022f69f476d7f2a665ba83b8aaf579fc00137a928cb88934677c
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       c7a5041f96722e4d3f5da5c20102e05bdfb38af2a5dee3516949a7c3d31a4b53
+TxId:       ec8279ac124dad6d0066b5bbd9f731f3e8c868cdc89ccf8379e8468ee8c3ef87
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f5820cfdf17d78d5d73fcc689b5a3943dc64351...
+              Signature: 5f58200a3bba07500b5141aab3261485bf80f40a...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 72a2578bf059d7708383c45a972f9a56a62aee4ad6380f018504d76d7207f905
+  Destination:  Script: e304d11ed9bf022f69f476d7f2a665ba83b8aaf579fc00137a928cb88934677c
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     6e4d69682bd94ef06adf5045f4c4e921737f2f36b4947db4dac7745092d0ee7a
+    Tx:     a7e3889dea47b643db155d5681cf37219aa4e5b3f0e9915dabadcffc7dc9c4a3
     Output #1
     Script: 01000003030264666978311829036161182a0003...
 
@@ -239,6 +239,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 72a2578bf059d7708383c45a972f9a56a62aee4ad6380f018504d76d7207f905
+  Script: e304d11ed9bf022f69f476d7f2a665ba83b8aaf579fc00137a928cb88934677c
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       0eefe99eba8d885e75985a91c4783bf743472980f28295c10d4b5be3628d641b
+TxId:       142bef2038b3d75deb56fb45fcaf7fdae49e57d3cbdd1a209e69e7a25dbb0cb9
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f58207776c7de7d5658f485c82d147292b6f359...
+              Signature: 5f5820aa4723961ac3f350cd6b7b7ef1e3de10e6...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 03d200a81ee0feace8fb845e5ec950a6f9add837... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9940
   
   ---- Output 1 ----
-  Destination:  Script: 3ff33d646187e16c4c33ec50faefafe666049af48ba887a1650066eb62bd04fa
+  Destination:  Script: 84425e329ef03021ba5e792e93374baf1384bde92a3d0407a502e21df5c62bad
   Value:
     Ada:      Lovelace:  60
 
@@ -170,23 +170,23 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 3ff33d646187e16c4c33ec50faefafe666049af48ba887a1650066eb62bd04fa
+  Script: 84425e329ef03021ba5e792e93374baf1384bde92a3d0407a502e21df5c62bad
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #12, Tx #0 ====
-TxId:       6488fa82402a1cab0650972c47ed5f79312ac56968ec54c7f88054d56fc58247
+TxId:       3e99b0ced40af381f7eac2fdf5166f58a4a0220bf27c103829bc26b5eca035f5
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f5820d846a80f8b22e75254814d74257990f26b...
+              Signature: 5f582083c0ab9a86471f8029c503e0eca9d49002...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 3ff33d646187e16c4c33ec50faefafe666049af48ba887a1650066eb62bd04fa
+  Destination:  Script: 84425e329ef03021ba5e792e93374baf1384bde92a3d0407a502e21df5c62bad
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     0eefe99eba8d885e75985a91c4783bf743472980f28295c10d4b5be3628d641b
+    Tx:     142bef2038b3d75deb56fb45fcaf7fdae49e57d3cbdd1a209e69e7a25dbb0cb9
     Output #1
     Script: 01000003030264666978311829036161182a0003...
 
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  10
   
   ---- Output 1 ----
-  Destination:  Script: 3ff33d646187e16c4c33ec50faefafe666049af48ba887a1650066eb62bd04fa
+  Destination:  Script: 84425e329ef03021ba5e792e93374baf1384bde92a3d0407a502e21df5c62bad
   Value:
     Ada:      Lovelace:  50
 
@@ -244,6 +244,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 3ff33d646187e16c4c33ec50faefafe666049af48ba887a1650066eb62bd04fa
+  Script: 84425e329ef03021ba5e792e93374baf1384bde92a3d0407a502e21df5c62bad
   Value:
     Ada:      Lovelace:  50

--- a/plutus-use-cases/test/Spec/vesting.pir
+++ b/plutus-use-cases/test/Spec/vesting.pir
@@ -391,31 +391,19 @@
                                 l
                                 [List a]
                                 [
-                                  [
-                                    [
-                                      { [ { Nil_match a } l ] (fun Unit b) }
-                                      (lam thunk Unit acc)
-                                    ]
+                                  [ { [ { Nil_match a } l ] b } acc ]
+                                  (lam
+                                    x
+                                    a
                                     (lam
-                                      x
-                                      a
-                                      (lam
-                                        xs
-                                        [List a]
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            [ f x ]
-                                            [
-                                              [ [ { { foldr a } b } f ] acc ] xs
-                                            ]
-                                          ]
-                                        )
-                                      )
+                                      xs
+                                      [List a]
+                                      [
+                                        [ f x ]
+                                        [ [ [ { { foldr a } b } f ] acc ] xs ]
+                                      ]
                                     )
-                                  ]
-                                  Unit
+                                  )
                                 ]
                               )
                             )
@@ -1567,207 +1555,121 @@
                                     [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
                                     [
                                       [
-                                        [
-                                          {
-                                            [
-                                              {
-                                                Nil_match
-                                                [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                              }
-                                              xs
-                                            ]
-                                            (fun Unit Bool)
-                                          }
-                                          (lam thunk Unit True)
-                                        ]
-                                        (lam
-                                          ds
-                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                          (lam
+                                        {
+                                          [
+                                            {
+                                              Nil_match
+                                              [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                            }
                                             xs
-                                            [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
-                                            (lam
-                                              thunk
-                                              Unit
+                                          ]
+                                          Bool
+                                        }
+                                        True
+                                      ]
+                                      (lam
+                                        ds
+                                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                        (lam
+                                          xs
+                                          [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
+                                          [
+                                            {
                                               [
                                                 {
-                                                  [
-                                                    {
-                                                      {
-                                                        Tuple2_match
-                                                        (con bytestring)
-                                                      }
-                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                    }
-                                                    ds
-                                                  ]
-                                                  Bool
+                                                  {
+                                                    Tuple2_match
+                                                    (con bytestring)
+                                                  }
+                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
                                                 }
-                                                (lam
-                                                  ds
-                                                  (con bytestring)
-                                                  (lam
-                                                    x
-                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                    (let
-                                                      (rec)
-                                                      (termbind
-                                                        (strict)
-                                                        (vardecl
-                                                          go
-                                                          (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] Bool)
-                                                        )
-                                                        (lam
-                                                          xs
-                                                          [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                ds
+                                              ]
+                                              Bool
+                                            }
+                                            (lam
+                                              ds
+                                              (con bytestring)
+                                              (lam
+                                                x
+                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
+                                                (let
+                                                  (rec)
+                                                  (termbind
+                                                    (strict)
+                                                    (vardecl
+                                                      go
+                                                      (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] Bool)
+                                                    )
+                                                    (lam
+                                                      xs
+                                                      [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                      [
+                                                        [
                                                           [
-                                                            [
+                                                            {
                                                               [
                                                                 {
-                                                                  [
-                                                                    {
-                                                                      Nil_match
-                                                                      [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                    }
-                                                                    xs
-                                                                  ]
-                                                                  (fun Unit Bool)
+                                                                  Nil_match
+                                                                  [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
                                                                 }
-                                                                (lam
-                                                                  thunk
-                                                                  Unit
-                                                                  [ go xs ]
-                                                                )
+                                                                xs
                                                               ]
+                                                              (fun Unit Bool)
+                                                            }
+                                                            (lam
+                                                              thunk
+                                                              Unit
+                                                              [ go xs ]
+                                                            )
+                                                          ]
+                                                          (lam
+                                                            ds
+                                                            [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
+                                                            (lam
+                                                              xs
+                                                              [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
                                                               (lam
-                                                                ds
-                                                                [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                (lam
-                                                                  xs
-                                                                  [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
-                                                                  (lam
-                                                                    thunk
-                                                                    Unit
+                                                                thunk
+                                                                Unit
+                                                                [
+                                                                  {
                                                                     [
                                                                       {
-                                                                        [
-                                                                          {
-                                                                            {
-                                                                              Tuple2_match
-                                                                              (con bytestring)
-                                                                            }
-                                                                            [[These (con integer)] (con integer)]
-                                                                          }
-                                                                          ds
-                                                                        ]
-                                                                        Bool
+                                                                        {
+                                                                          Tuple2_match
+                                                                          (con bytestring)
+                                                                        }
+                                                                        [[These (con integer)] (con integer)]
                                                                       }
-                                                                      (lam
-                                                                        ds
-                                                                        (con bytestring)
-                                                                        (lam
-                                                                          x
-                                                                          [[These (con integer)] (con integer)]
+                                                                      ds
+                                                                    ]
+                                                                    Bool
+                                                                  }
+                                                                  (lam
+                                                                    ds
+                                                                    (con bytestring)
+                                                                    (lam
+                                                                      x
+                                                                      [[These (con integer)] (con integer)]
+                                                                      [
+                                                                        [
                                                                           [
-                                                                            [
+                                                                            {
                                                                               [
                                                                                 {
-                                                                                  [
-                                                                                    {
-                                                                                      {
-                                                                                        These_match
-                                                                                        (con integer)
-                                                                                      }
-                                                                                      (con integer)
-                                                                                    }
-                                                                                    x
-                                                                                  ]
-                                                                                  Bool
+                                                                                  {
+                                                                                    These_match
+                                                                                    (con integer)
+                                                                                  }
+                                                                                  (con integer)
                                                                                 }
-                                                                                (lam
-                                                                                  b
-                                                                                  (con integer)
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            Bool_match
-                                                                                            [
-                                                                                              [
-                                                                                                f
-                                                                                                (con
-                                                                                                  0
-                                                                                                )
-                                                                                              ]
-                                                                                              b
-                                                                                            ]
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          [
-                                                                                            go
-                                                                                            xs
-                                                                                          ]
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        False
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
+                                                                                x
                                                                               ]
-                                                                              (lam
-                                                                                a
-                                                                                (con integer)
-                                                                                (lam
-                                                                                  b
-                                                                                  (con integer)
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            Bool_match
-                                                                                            [
-                                                                                              [
-                                                                                                f
-                                                                                                a
-                                                                                              ]
-                                                                                              b
-                                                                                            ]
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          [
-                                                                                            go
-                                                                                            xs
-                                                                                          ]
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        False
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            ]
+                                                                              Bool
+                                                                            }
                                                                             (lam
-                                                                              a
+                                                                              b
                                                                               (con integer)
                                                                               [
                                                                                 [
@@ -1778,11 +1680,11 @@
                                                                                         [
                                                                                           [
                                                                                             f
-                                                                                            a
+                                                                                            (con
+                                                                                              0
+                                                                                            )
                                                                                           ]
-                                                                                          (con
-                                                                                            0
-                                                                                          )
+                                                                                          b
                                                                                         ]
                                                                                       ]
                                                                                       (fun Unit Bool)
@@ -1806,27 +1708,106 @@
                                                                               ]
                                                                             )
                                                                           ]
+                                                                          (lam
+                                                                            a
+                                                                            (con integer)
+                                                                            (lam
+                                                                              b
+                                                                              (con integer)
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        Bool_match
+                                                                                        [
+                                                                                          [
+                                                                                            f
+                                                                                            a
+                                                                                          ]
+                                                                                          b
+                                                                                        ]
+                                                                                      ]
+                                                                                      (fun Unit Bool)
+                                                                                    }
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      [
+                                                                                        go
+                                                                                        xs
+                                                                                      ]
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    False
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
+                                                                          )
+                                                                        ]
+                                                                        (lam
+                                                                          a
+                                                                          (con integer)
+                                                                          [
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    Bool_match
+                                                                                    [
+                                                                                      [
+                                                                                        f
+                                                                                        a
+                                                                                      ]
+                                                                                      (con
+                                                                                        0
+                                                                                      )
+                                                                                    ]
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  [
+                                                                                    go
+                                                                                    xs
+                                                                                  ]
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                False
+                                                                              )
+                                                                            ]
+                                                                            Unit
+                                                                          ]
                                                                         )
-                                                                      )
-                                                                    ]
+                                                                      ]
+                                                                    )
                                                                   )
-                                                                )
+                                                                ]
                                                               )
-                                                            ]
-                                                            Unit
-                                                          ]
-                                                        )
-                                                      )
-                                                      [ go x ]
+                                                            )
+                                                          )
+                                                        ]
+                                                        Unit
+                                                      ]
                                                     )
                                                   )
+                                                  [ go x ]
                                                 )
-                                              ]
+                                              )
                                             )
-                                          )
+                                          ]
                                         )
-                                      ]
-                                      Unit
+                                      )
                                     ]
                                   )
                                 )
@@ -1929,27 +1910,13 @@
                                       ds
                                       [List a]
                                       [
-                                        [
-                                          [
-                                            {
-                                              [ { Nil_match a } ds ]
-                                              (fun Unit b)
-                                            }
-                                            (lam thunk Unit z)
-                                          ]
-                                          (lam
-                                            y
-                                            a
-                                            (lam
-                                              ys
-                                              [List a]
-                                              (lam
-                                                thunk Unit [ [ k y ] [ go ys ] ]
-                                              )
-                                            )
+                                        [ { [ { Nil_match a } ds ] b } z ]
+                                        (lam
+                                          y
+                                          a
+                                          (lam ys [List a] [ [ k y ] [ go ys ] ]
                                           )
-                                        ]
-                                        Unit
+                                        )
                                       ]
                                     )
                                   )
@@ -2398,89 +2365,64 @@
                                                                     (lam
                                                                       thunk
                                                                       Unit
-                                                                      (let
-                                                                        (nonrec)
-                                                                        (termbind
-                                                                          (strict
-                                                                          )
-                                                                          (vardecl
-                                                                            wild
-                                                                            Bool
-                                                                          )
-                                                                          in
-                                                                        )
-                                                                        [
-                                                                          {
-                                                                            [
-                                                                              {
-                                                                                UpperBound_match
-                                                                                (con integer)
-                                                                              }
-                                                                              h
-                                                                            ]
-                                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                          }
+                                                                      [
+                                                                        {
+                                                                          [
+                                                                            {
+                                                                              UpperBound_match
+                                                                              (con integer)
+                                                                            }
+                                                                            h
+                                                                          ]
+                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                        }
+                                                                        (lam
+                                                                          v
+                                                                          [Extended (con integer)]
                                                                           (lam
-                                                                            v
-                                                                            [Extended (con integer)]
-                                                                            (lam
-                                                                              in
-                                                                              Bool
+                                                                            in
+                                                                            Bool
+                                                                            [
                                                                               [
                                                                                 [
                                                                                   [
-                                                                                    [
-                                                                                      {
-                                                                                        [
-                                                                                          {
-                                                                                            Extended_match
-                                                                                            (con integer)
-                                                                                          }
-                                                                                          v
-                                                                                        ]
-                                                                                        (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
-                                                                                      }
-                                                                                      (lam
-                                                                                        default_arg0
-                                                                                        (con integer)
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          ww
-                                                                                        )
-                                                                                      )
-                                                                                    ]
+                                                                                    {
+                                                                                      [
+                                                                                        {
+                                                                                          Extended_match
+                                                                                          (con integer)
+                                                                                        }
+                                                                                        v
+                                                                                      ]
+                                                                                      (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
+                                                                                    }
                                                                                     (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      ww
+                                                                                      default_arg0
+                                                                                      (con integer)
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        ww
+                                                                                      )
                                                                                     )
                                                                                   ]
                                                                                   (lam
                                                                                     thunk
                                                                                     Unit
-                                                                                    (let
-                                                                                      (nonrec
-                                                                                      )
-                                                                                      (termbind
-                                                                                        (strict
-                                                                                        )
-                                                                                        (vardecl
-                                                                                          wild
-                                                                                          Bool
-                                                                                        )
-                                                                                        in
-                                                                                      )
-                                                                                      ww
-                                                                                    )
+                                                                                    ww
                                                                                   )
                                                                                 ]
-                                                                                Unit
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  ww
+                                                                                )
                                                                               ]
-                                                                            )
+                                                                              Unit
+                                                                            ]
                                                                           )
-                                                                        ]
-                                                                      )
+                                                                        )
+                                                                      ]
                                                                     )
                                                                   ]
                                                                   (lam
@@ -2555,20 +2497,7 @@
                                                                                       (lam
                                                                                         thunk
                                                                                         Unit
-                                                                                        (let
-                                                                                          (nonrec
-                                                                                          )
-                                                                                          (termbind
-                                                                                            (strict
-                                                                                            )
-                                                                                            (vardecl
-                                                                                              wild
-                                                                                              Bool
-                                                                                            )
-                                                                                            in
-                                                                                          )
-                                                                                          ww
-                                                                                        )
+                                                                                        ww
                                                                                       )
                                                                                     ]
                                                                                     Unit
@@ -2658,18 +2587,7 @@
                                                                   (lam
                                                                     thunk
                                                                     Unit
-                                                                    (let
-                                                                      (nonrec)
-                                                                      (termbind
-                                                                        (strict)
-                                                                        (vardecl
-                                                                          wild
-                                                                          Bool
-                                                                        )
-                                                                        in
-                                                                      )
-                                                                      ww
-                                                                    )
+                                                                    ww
                                                                   )
                                                                 ]
                                                                 Unit
@@ -2799,101 +2717,90 @@
                                                                       TxOutType
                                                                       [
                                                                         [
+                                                                          {
+                                                                            [
+                                                                              TxOutType_match
+                                                                              ds
+                                                                            ]
+                                                                            [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]]
+                                                                          }
+                                                                          xs
+                                                                        ]
+                                                                        (lam
+                                                                          ds
+                                                                          (con bytestring)
                                                                           [
-                                                                            {
-                                                                              [
-                                                                                TxOutType_match
-                                                                                ds
-                                                                              ]
-                                                                              (fun Unit [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]])
-                                                                            }
+                                                                            [
+                                                                              {
+                                                                                [
+                                                                                  Address_match
+                                                                                  ds
+                                                                                ]
+                                                                                [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]]
+                                                                              }
+                                                                              (lam
+                                                                                ipv
+                                                                                (con bytestring)
+                                                                                xs
+                                                                              )
+                                                                            ]
                                                                             (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              xs
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            ds
-                                                                            (con bytestring)
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
+                                                                              vh
+                                                                              (con bytestring)
                                                                               [
                                                                                 [
-                                                                                  {
-                                                                                    [
-                                                                                      Address_match
-                                                                                      ds
-                                                                                    ]
-                                                                                    [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]]
-                                                                                  }
-                                                                                  (lam
-                                                                                    ipv
-                                                                                    (con bytestring)
-                                                                                    xs
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  vh
-                                                                                  (con bytestring)
                                                                                   [
-                                                                                    [
+                                                                                    {
                                                                                       [
-                                                                                        {
+                                                                                        Bool_match
+                                                                                        [
                                                                                           [
-                                                                                            Bool_match
-                                                                                            [
-                                                                                              [
-                                                                                                equalsByteString
-                                                                                                h
-                                                                                              ]
-                                                                                              vh
-                                                                                            ]
+                                                                                            equalsByteString
+                                                                                            h
                                                                                           ]
-                                                                                          (fun Unit [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]])
-                                                                                        }
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
+                                                                                          vh
+                                                                                        ]
+                                                                                      ]
+                                                                                      (fun Unit [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]])
+                                                                                    }
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            Cons
+                                                                                            [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                                                                          }
                                                                                           [
                                                                                             [
                                                                                               {
-                                                                                                Cons
-                                                                                                [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                                                                                {
+                                                                                                  Tuple2
+                                                                                                  (con bytestring)
+                                                                                                }
+                                                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                                               }
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    {
-                                                                                                      Tuple2
-                                                                                                      (con bytestring)
-                                                                                                    }
-                                                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                  }
-                                                                                                  ds
-                                                                                                ]
-                                                                                                ds
-                                                                                              ]
+                                                                                              ds
                                                                                             ]
-                                                                                            xs
+                                                                                            ds
                                                                                           ]
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
+                                                                                        ]
                                                                                         xs
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
+                                                                                      ]
+                                                                                    )
                                                                                   ]
-                                                                                )
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    xs
+                                                                                  )
+                                                                                ]
+                                                                                Unit
                                                                               ]
                                                                             )
-                                                                          )
-                                                                        ]
-                                                                        Unit
+                                                                          ]
+                                                                        )
                                                                       ]
                                                                     )
                                                                   )
@@ -3263,46 +3170,35 @@
                                                                                             Unit
                                                                                             [
                                                                                               [
-                                                                                                [
-                                                                                                  {
+                                                                                                {
+                                                                                                  [
+                                                                                                    {
+                                                                                                      Maybe_match
+                                                                                                      (con bytestring)
+                                                                                                    }
                                                                                                     [
-                                                                                                      {
-                                                                                                        Maybe_match
-                                                                                                        (con bytestring)
-                                                                                                      }
                                                                                                       [
+                                                                                                        {
+                                                                                                          find
+                                                                                                          (con bytestring)
+                                                                                                        }
                                                                                                         [
-                                                                                                          {
-                                                                                                            find
-                                                                                                            (con bytestring)
-                                                                                                          }
-                                                                                                          [
-                                                                                                            equalsByteString
-                                                                                                            ds
-                                                                                                          ]
+                                                                                                          equalsByteString
+                                                                                                          ds
                                                                                                         ]
-                                                                                                        ds
                                                                                                       ]
+                                                                                                      ds
                                                                                                     ]
-                                                                                                    (fun Unit Bool)
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    ds
-                                                                                                    (con bytestring)
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      True
-                                                                                                    )
-                                                                                                  )
-                                                                                                ]
+                                                                                                  ]
+                                                                                                  Bool
+                                                                                                }
                                                                                                 (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  False
+                                                                                                  ds
+                                                                                                  (con bytestring)
+                                                                                                  True
                                                                                                 )
                                                                                               ]
-                                                                                              Unit
+                                                                                              False
                                                                                             ]
                                                                                           )
                                                                                         ]


### PR DESCRIPTION
For some reason we were not including variables here. I think I was
confused about this: variables can be substituted with other terms
during evaluation, but those terms must themselves all be values, since
arguments to lambdas are evaluated before substitution.

This is somewhat consequential: we care about whether a term is a value
in a few places in the compiler. Mostly if we believe a term is not a
value we have to be careful with it, since it might have side-effects.
So this means we can be a bit more aggressive with some optimizations
and code generation.