### PR TITLE
make haskell result pretty

### DIFF
--- a/marlowe-playground-client/src/HaskellEditor.purs
+++ b/marlowe-playground-client/src/HaskellEditor.purs
@@ -8,6 +8,7 @@ import Data.Lens (to, view, (^.))
 import Data.Map as Map
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (unwrap)
+import Data.String (Pattern(..), split)
 import Data.String as String
 import Effect.Aff.Class (class MonadAff)
 import Examples.Haskell.Contracts as HE
@@ -89,7 +90,7 @@ bottomPanel state =
     [ div
         [ classes [ footerPanelBg, ClassName "flip-x" ] ]
         [ section [ classes [ ClassName "panel-header", aHorizontal ] ]
-            [ div [ classes [ ClassName "panel-sub-header-main", aHorizontal, accentBorderBottom ] ]
+            [ div [ classes [ ClassName "panel-sub-header-main", aHorizontal ] ]
                 [ div [ class_ (ClassName "minimize-icon-container") ]
                     [ a [ onClick $ const $ Just $ ShowBottomPanel (state ^. _showBottomPanel <<< to not) ]
                         [ img [ classes (minimizeIcon $ state ^. _showBottomPanel), src closeDrawerArrowIcon, alt "close drawer icon" ] ]
@@ -128,10 +129,15 @@ resultPane :: forall p. FrontendState -> Array (HTML p HAction)
 resultPane state =
   if state ^. _showBottomPanel then case view _compilationResult state of
     Success (JsonEither (Right (InterpreterResult result))) ->
-      [ code_
-          [ pre [ class_ $ ClassName "success-code" ] [ text (unwrap result.result) ]
-          ]
+      [ div [ classes [ ClassName "code-editor", ClassName "expanded", ClassName "code" ] ]
+          numberedText
       ]
+      -- [ code_
+      --     [ pre [ class_ $ ClassName "success-code" ] [ text (unwrap result.result) ]
+      --     ]
+      -- ]
+      where
+      numberedText = (code_ <<< Array.singleton <<< text) <$> split (Pattern "\n") (unwrap result.result)
     Success (JsonEither (Left (TimeoutError error))) -> [ text error ]
     Success (JsonEither (Left (CompilationErrors errors))) -> map compilationErrorPane errors
     _ -> [ text "" ]

--- a/marlowe-playground-client/static/css/panels.css
+++ b/marlowe-playground-client/static/css/panels.css
@@ -476,7 +476,7 @@ button.minus-btn:hover {
   transform: rotateX(180deg);
 }
 
-.wallet-contents .code {
+.code {
   height: auto;
   min-height: 100px;
   white-space: pre;
@@ -484,19 +484,19 @@ button.minus-btn:hover {
   padding-bottom: 3rem;
 }
 
-.wallet-contents .code code {
+.code code {
   display: block;
 }
 
-.wallet-contents .code:before {
+.code:before {
   counter-reset: listing;
 }
 
-.wallet-contents .code code {
+.code code {
   counter-increment: listing;
 }
 
-.wallet-contents .code code::before {
+.code code::before {
   content: counter(listing);
   display: inline-block;
   margin-right: 1rem;


### PR DESCRIPTION
Deployed to https://david.marlowe.iohkdev.io/
When you compile code successfully, it will be displayed with line numbers in a way that looks similar to the marlowe editor.
When you have a compile error it will be displayed in a `pre` as it was previously.

![captured](https://user-images.githubusercontent.com/934267/88953209-f234bf00-d26e-11ea-9a45-863e06780e17.png)
![captured (1)](https://user-images.githubusercontent.com/934267/88953216-f52faf80-d26e-11ea-9283-9238d8c83bd5.png)
![captured (2)](https://user-images.githubusercontent.com/934267/88953219-f660dc80-d26e-11ea-82b6-b63b9e808890.png)
