### PR TITLE
get rid of nearley hack

### DIFF
--- a/marlowe-playground-client/grammar.ne
+++ b/marlowe-playground-client/grammar.ne
@@ -1,4 +1,8 @@
 @{%
+const marlowe = require('./src/Marlowe/Holes')
+const semantics = require('./src/Marlowe/Semantics')
+const bigInteger = require('./src/Data/BigInteger');
+
 const moo = require("moo");
 
 const lexer = moo.compile({
@@ -80,27 +84,27 @@ lsquare -> %lsquare manyWS
 
 rsquare ->  manyWS %rsquare
 
-hole -> %hole {% ([hole]) => opts.mkHole(hole.value.substring(1))({startLineNumber: hole.line, startColumn: hole.col, endLineNumber: hole.line, endColumn: hole.col + hole.value.length}) %}
+hole -> %hole {% ([hole]) => marlowe.mkHole(hole.value.substring(1))({startLineNumber: hole.line, startColumn: hole.col, endLineNumber: hole.line, endColumn: hole.col + hole.value.length}) %}
 
 number
-   -> %number {% ([n]) => opts.mkBigInteger(n.value) %}
-    | lparen %number rparen {% ([,n,]) => opts.mkBigInteger(n.value) %}
+   -> %number {% ([n]) => bigInteger.fromInt(n.value) %}
+    | lparen %number rparen {% ([,n,]) => bigInteger.fromInt(n.value) %}
 
 timeout
-   -> %number {% ([n]) => opts.mkTimeout(n.value)({startLineNumber: n.line, startColumn: n.col, endLineNumber: n.line, endColumn: n.col + n.value.toString().length}) %}
-    | lparen %number rparen {% ([start,n,end]) => opts.mkTimeout(n.value)({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+   -> %number {% ([n]) => marlowe.mkTimeout(n.value)({startLineNumber: n.line, startColumn: n.col, endLineNumber: n.line, endColumn: n.col + n.value.toString().length}) %}
+    | lparen %number rparen {% ([start,n,end]) => marlowe.mkTimeout(n.value)({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 string
    -> %string {% ([s]) => s.value %}
 
 topContract
    -> hole {% ([hole]) => hole %}
-    | "Close" {% ([{line, col}]) => opts.mkTerm(opts.mkClose)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 5}) %}
-    | "Pay" someWS accountId someWS payee someWS token someWS value someWS contract {% ([{line, col},,accountId,,payee,,token,,value,,contract]) => opts.mkTerm(opts.mkPay(accountId)(payee)(token)(value)(contract))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract).endLineNumber, endColumn: opts.getRange(contract).endColumn}) %}
-    | "If" someWS observation someWS contract someWS contract {% ([{line, col},,observation,,contract1,,contract2]) => opts.mkTerm(opts.mkIf(observation)(contract1)(contract2))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract2).endLineNumber, endColumn: opts.getRange(contract2).endColumn}) %}
-    | "When" someWS lsquare cases:* rsquare someWS timeout someWS contract {% ([{line, col},,,cases,,,timeout,,contract]) => opts.mkTerm(opts.mkWhen(cases)(timeout)(contract))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract).endLineNumber, endColumn: opts.getRange(contract).endColumn}) %}
-    | "Let" someWS valueId someWS value someWS contract {% ([{line, col},,valueId,,value,,contract]) => opts.mkTerm(opts.mkLet(valueId)(value)(contract))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract).endLineNumber, endColumn: opts.getRange(contract).endColumn}) %}
-    | "Assert" someWS observation someWS contract {% ([{line, col},,observation,,contract]) => opts.mkTerm(opts.mkAssert(observation)(contract))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract).endLineNumber, endColumn: opts.getRange(contract).endColumn}) %}
+    | "Close" {% ([{line, col}]) => marlowe.Term.create(marlowe.Close.value)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 5}) %}
+    | "Pay" someWS accountId someWS payee someWS token someWS value someWS contract {% ([{line, col},,accountId,,payee,,token,,value,,contract]) => marlowe.Term.create(marlowe.Pay.create(accountId)(payee)(token)(value)(contract))({startLineNumber: line, startColumn: col, endLineNumber: marlowe.getRange(contract).endLineNumber, endColumn: marlowe.getRange(contract).endColumn}) %}
+    | "If" someWS observation someWS contract someWS contract {% ([{line, col},,observation,,contract1,,contract2]) => marlowe.Term.create(marlowe.If.create(observation)(contract1)(contract2))({startLineNumber: line, startColumn: col, endLineNumber: marlowe.getRange(contract2).endLineNumber, endColumn: marlowe.getRange(contract2).endColumn}) %}
+    | "When" someWS lsquare cases:* rsquare someWS timeout someWS contract {% ([{line, col},,,cases,,,timeout,,contract]) => marlowe.Term.create(marlowe.When.create(cases)(timeout)(contract))({startLineNumber: line, startColumn: col, endLineNumber: marlowe.getRange(contract).endLineNumber, endColumn: marlowe.getRange(contract).endColumn}) %}
+    | "Let" someWS valueId someWS value someWS contract {% ([{line, col},,valueId,,value,,contract]) => marlowe.Term.create(marlowe.Let.create(valueId)(value)(contract))({startLineNumber: line, startColumn: col, endLineNumber: marlowe.getRange(contract).endLineNumber, endColumn: marlowe.getRange(contract).endColumn}) %}
+    | "Assert" someWS observation someWS contract {% ([{line, col},,observation,,contract]) => marlowe.Term.create(marlowe.Assert.create(observation)(contract))({startLineNumber: line, startColumn: col, endLineNumber: marlowe.getRange(contract).endLineNumber, endColumn: marlowe.getRange(contract).endColumn}) %}
 
 cases
    -> hole {% ([hole]) => hole %}
@@ -109,8 +113,8 @@ cases
 
 case
    -> hole {% ([hole]) => hole %}
-    | "Case" someWS action someWS contract {% ([{line, col},,action,,contract]) => opts.mkTerm(opts.mkCase(action)(contract))({startLineNumber: line, startColumn: col, endLineNumber: opts.getRange(contract).endLineNumber, endColumn: opts.getRange(contract).endColumn}) %}
-    | lparen "Case" someWS action someWS contract rparen {% ([start,,,action,,contract,end]) => opts.mkTerm(opts.mkCase(action)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | "Case" someWS action someWS contract {% ([{line, col},,action,,contract]) => marlowe.Term.create(marlowe.Case.create(action)(contract))({startLineNumber: line, startColumn: col, endLineNumber: marlowe.getRange(contract).endLineNumber, endColumn: marlowe.getRange(contract).endColumn}) %}
+    | lparen "Case" someWS action someWS contract rparen {% ([start,,,action,,contract,end]) => marlowe.Term.create(marlowe.Case.create(action)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 bounds
    -> hole {% ([hole]) => hole %}
@@ -119,79 +123,79 @@ bounds
 
 bound
    -> hole {% ([hole]) => hole %}
-    | "Bound" someWS number someWS number {% ([{line, col},,bottom,,top]) => opts.mkTerm(opts.mkBound(bottom)(top))({startLineNumber: line, startColumn: col, endLineNumber: top.line, endColumn: top.col + top.value.toString().length}) %}
+    | "Bound" someWS number someWS number {% ([{line, col},,bottom,,top]) => marlowe.Term.create(marlowe.Bound.create(bottom)(top))({startLineNumber: line, startColumn: col, endLineNumber: top.line, endColumn: top.col + top.value.toString().length}) %}
     | lparen bound rparen {% ([,bound,]) => bound %}
 
 action
    -> hole {% ([hole]) => hole %}
-    | lparen "Deposit" someWS accountId someWS party someWS token someWS value rparen {% ([start,{line, col},,accountId,,party,,token,,value,end]) => opts.mkTerm(opts.mkDeposit(accountId)(party)(token)(value))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "Choice" someWS choiceId someWS lsquare bounds:* rsquare rparen {% ([start,{line, col},,choiceId,,,bounds,,end]) => opts.mkTerm(opts.mkChoice(choiceId)(bounds))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "Notify" someWS observation rparen {% ([start,{line, col},,observation,end]) => opts.mkTerm(opts.mkNotify(observation))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Deposit" someWS accountId someWS party someWS token someWS value rparen {% ([start,{line, col},,accountId,,party,,token,,value,end]) => marlowe.Term.create(marlowe.Deposit.create(accountId)(party)(token)(value))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Choice" someWS choiceId someWS lsquare bounds:* rsquare rparen {% ([start,{line, col},,choiceId,,,bounds,,end]) => marlowe.Term.create(marlowe.Choice.create(choiceId)(bounds))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Notify" someWS observation rparen {% ([start,{line, col},,observation,end]) => marlowe.Term.create(marlowe.Notify.create(observation))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 # Beacause top level contracts don't have parenthesis we need to duplicate the lower-level contracts in order to get the start and end positions
 contract
    -> hole {% ([hole]) => hole %}
-    | "Close" {% ([{line,col}]) => opts.mkTerm(opts.mkClose)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 5}) %}
-    | lparen "Pay" someWS accountId someWS payee someWS token someWS value someWS contract rparen {% ([start,{line, col},,accountId,,payee,,token,,value,,contract,end]) => opts.mkTerm(opts.mkPay(accountId)(payee)(token)(value)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "If" someWS observation someWS contract someWS contract rparen {% ([start,{line, col},,observation,,contract1,,contract2,end]) => opts.mkTerm(opts.mkIf(observation)(contract1)(contract2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "When" someWS lsquare cases:* rsquare someWS timeout someWS contract rparen {% ([start,{line, col},,,cases,,,timeout,,contract,end]) => opts.mkTerm(opts.mkWhen(cases)(timeout)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "Let" someWS valueId someWS value someWS contract rparen {% ([start,{line, col},,valueId,,value,,contract,end]) => opts.mkTerm(opts.mkLet(valueId)(value)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "Assert" someWS observation someWS contract rparen {% ([start,{line, col},,observation,,contract,end]) => opts.mkTerm(opts.mkAssert(observation)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | "Close" {% ([{line,col}]) => marlowe.Term.create(marlowe.Close.value)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 5}) %}
+    | lparen "Pay" someWS accountId someWS payee someWS token someWS value someWS contract rparen {% ([start,{line, col},,accountId,,payee,,token,,value,,contract,end]) => marlowe.Term.create(marlowe.Pay.create(accountId)(payee)(token)(value)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "If" someWS observation someWS contract someWS contract rparen {% ([start,{line, col},,observation,,contract1,,contract2,end]) => marlowe.Term.create(marlowe.If.create(observation)(contract1)(contract2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "When" someWS lsquare cases:* rsquare someWS timeout someWS contract rparen {% ([start,{line, col},,,cases,,,timeout,,contract,end]) => marlowe.Term.create(marlowe.When.create(cases)(timeout)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Let" someWS valueId someWS value someWS contract rparen {% ([start,{line, col},,valueId,,value,,contract,end]) => marlowe.Term.create(marlowe.Let.create(valueId)(value)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Assert" someWS observation someWS contract rparen {% ([start,{line, col},,observation,,contract,end]) => marlowe.Term.create(marlowe.Assert.create(observation)(contract))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 choiceId
-   -> lparen %CHOICE_ID someWS string someWS party rparen {% ([,{line,col},,cid,,party,]) => opts.mkChoiceId(cid)(party) %}
+   -> lparen %CHOICE_ID someWS string someWS party rparen {% ([,{line,col},,cid,,party,]) => marlowe.ChoiceId.create(cid)(party) %}
 
 # FIXME: There is a difference between the Haskell pretty printer and the purescript parser
 valueId
-   -> %string {% ([{value,line,col}]) => opts.mkTermWrapper(opts.mkValueId(value))({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + value.length}) %}
+   -> %string {% ([{value,line,col}]) => marlowe.TermWrapper.create(marlowe.ValueId(value))({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + value.length}) %}
 # valueId -> lparen %VALUE_ID someWS string rparen
 
 accountId
-   -> lparen %ACCOUNT_ID someWS number someWS party rparen {% ([,{line,col},,aid,,party,]) => opts.mkAccountId(aid)(party) %}
+   -> lparen %ACCOUNT_ID someWS number someWS party rparen {% ([,{line,col},,aid,,party,]) => marlowe.AccountId.create(aid)(party) %}
 
 token
    -> hole {% ([hole]) => hole %}
-    | lparen %TOKEN someWS string someWS string rparen {% ([start,{line,col},,a,,b,end]) => opts.mkTerm(opts.mkToken(a)(b))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen %TOKEN someWS string someWS string rparen {% ([start,{line,col},,a,,b,end]) => marlowe.Term.create(marlowe.Token.create(a)(b))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 party
    -> hole {% ([hole]) => hole %}
-    | lparen "PK" someWS string rparen {% ([start,{line,col},,k,end]) => opts.mkTerm(opts.mkPK(k))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "Role" someWS string rparen {% ([start,{line,col},,k,end]) => opts.mkTerm(opts.mkRole(k))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "PK" someWS string rparen {% ([start,{line,col},,k,end]) => marlowe.Term.create(marlowe.PK.create(k))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Role" someWS string rparen {% ([start,{line,col},,k,end]) => marlowe.Term.create(marlowe.Role.create(k))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 payee
    -> hole {% ([hole]) => hole %}
-    | lparen "Account" someWS accountId rparen {% ([start,{line,col},,accountId,end]) => opts.mkTerm(opts.mkAccount(accountId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "Party" someWS party rparen {% ([start,{line,col},,party,end]) => opts.mkTerm(opts.mkParty(party))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Account" someWS accountId rparen {% ([start,{line,col},,accountId,end]) => marlowe.Term.create(marlowe.Account.create(accountId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "Party" someWS party rparen {% ([start,{line,col},,party,end]) => marlowe.Term.create(marlowe.Party.create(party))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
 
 observation
    -> hole {% ([hole]) => hole %}
-    | lparen "AndObs" someWS observation someWS observation rparen {% ([start,{line,col},,o1,,o2,end]) => opts.mkTerm(opts.mkAndObs(o1)(o2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "OrObs" someWS observation someWS observation rparen {% ([start,{line,col},,o1,,o2,end]) => opts.mkTerm(opts.mkOrObs(o1)(o2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "NotObs" someWS observation rparen {% ([start,{line,col},,o1,end]) => opts.mkTerm(opts.mkNotObs(o1))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "ChoseSomething" someWS choiceId rparen {% ([start,{line,col},,choiceId,end]) => opts.mkTerm(opts.mkChoseSomething(choiceId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "ValueGE" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkValueGE(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "ValueGT" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkValueGT(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "ValueLT" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkValueLT(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "ValueLE" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkValueLE(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | lparen "ValueEQ" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkValueEQ(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
-    | "TrueObs" {% ([{line,col}]) => opts.mkTerm(opts.mkTrueObs)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 7}) %}
-    | "FalseObs" {% ([{line,col}]) => opts.mkTerm(opts.mkFalseObs)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 8}) %}
+    | lparen "AndObs" someWS observation someWS observation rparen {% ([start,{line,col},,o1,,o2,end]) => marlowe.Term.create(marlowe.AndObs.create(o1)(o2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "OrObs" someWS observation someWS observation rparen {% ([start,{line,col},,o1,,o2,end]) => marlowe.Term.create(marlowe.OrObs.create(o1)(o2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "NotObs" someWS observation rparen {% ([start,{line,col},,o1,end]) => marlowe.Term.create(marlowe.NotObs.create(o1))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ChoseSomething" someWS choiceId rparen {% ([start,{line,col},,choiceId,end]) => marlowe.Term.create(marlowe.ChoseSomething.create(choiceId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ValueGE" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => marlowe.Term.create(marlowe.ValueGE.create(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ValueGT" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => marlowe.Term.create(marlowe.ValueGT.create(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ValueLT" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => marlowe.Term.create(marlowe.ValueLT.create(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ValueLE" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => marlowe.Term.create(marlowe.ValueLE.create(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | lparen "ValueEQ" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => marlowe.Term.create(marlowe.ValueEQ.create(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col}) %}
+    | "TrueObs" {% ([{line,col}]) => marlowe.Term.create(marlowe.TrueObs.value)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 7}) %}
+    | "FalseObs" {% ([{line,col}]) => marlowe.Term.create(marlowe.FalseObs.value)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 8}) %}
 
 rational
     -> hole {% ([hole]) => hole %}
-    | number manyWS %ratio manyWS number {%([num,,,,denom]) => opts.mkTerm(opts.mkRational(num)(denom))({startLineNumber: num.line, startColumn: num.col, endLineNumber: denom.line, endColumn: denom.col + denom.value.toString().length}) %}
+    | number manyWS %ratio manyWS number {%([num,,,,denom]) => marlowe.Term.create(semantics.Rational.create(num)(denom))({startLineNumber: num.line, startColumn: num.col, endLineNumber: denom.line, endColumn: denom.col + denom.value.toString().length}) %}
 
 value
    -> hole {% ([hole]) => hole %}
-    | lparen "AvailableMoney" someWS accountId someWS token rparen {% ([start,{line,col},,accountId,,token,end]) => opts.mkTerm(opts.mkAvailableMoney(accountId)(token))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
-    | lparen "Constant" someWS number rparen {% ([start,{line,col},,number,end]) => opts.mkTerm(opts.mkConstant(number))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
-    | lparen "NegValue" someWS value rparen {% ([start,{line,col},,value,end]) => opts.mkTerm(opts.mkNegValue(value))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
-    | lparen "AddValue" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkAddValue(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
-    | lparen "SubValue" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkSubValue(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
-    | lparen "MulValue" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => opts.mkTerm(opts.mkMulValue(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
-    | lparen "Scale" someWS lparen rational rparen someWS value rparen {% ([start,{line,col},,,ratio,,,v,end]) => opts.mkTerm(opts.mkScale(ratio)(v))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
-    | lparen "ChoiceValue" someWS choiceId rparen {% ([start,{line,col},,choiceId,end]) => opts.mkTerm(opts.mkChoiceValue(choiceId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
-    | "SlotIntervalStart" {% ([{line,col}]) => opts.mkTerm(opts.mkSlotIntervalStart)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 17}) %}
-    | "SlotIntervalEnd" {% ([{line,col}]) => opts.mkTerm(opts.mkSlotIntervalEnd)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 15}) %}
-    | lparen "UseValue" someWS valueId rparen {% ([start,{line,col},,valueId,end]) => opts.mkTerm(opts.mkUseValue(valueId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
-    | lparen "Cond" someWS observation someWS value someWS value rparen {% ([start,{line,col},,oo,,v1,,v2,end]) => opts.mkTerm(opts.mkCond(oo)(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
+    | lparen "AvailableMoney" someWS accountId someWS token rparen {% ([start,{line,col},,accountId,,token,end]) => marlowe.Term.create(marlowe.AvailableMoney.create(accountId)(token))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
+    | lparen "Constant" someWS number rparen {% ([start,{line,col},,number,end]) => marlowe.Term.create(marlowe.Constant.create(number))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
+    | lparen "NegValue" someWS value rparen {% ([start,{line,col},,value,end]) => marlowe.Term.create(marlowe.NegValue.create(value))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
+    | lparen "AddValue" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => marlowe.Term.create(marlowe.AddValue.create(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
+    | lparen "SubValue" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => marlowe.Term.create(marlowe.SubValue.create(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
+    | lparen "MulValue" someWS value someWS value rparen {% ([start,{line,col},,v1,,v2,end]) => marlowe.Term.create(marlowe.MulValue.create(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
+    | lparen "Scale" someWS lparen rational rparen someWS value rparen {% ([start,{line,col},,,ratio,,,v,end]) => marlowe.Term.create(marlowe.Scale.create(ratio)(v))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
+    | lparen "ChoiceValue" someWS choiceId rparen {% ([start,{line,col},,choiceId,end]) => marlowe.Term.create(marlowe.ChoiceValue.create(choiceId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
+    | "SlotIntervalStart" {% ([{line,col}]) => marlowe.Term.create(marlowe.SlotIntervalStart.value)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 17}) %}
+    | "SlotIntervalEnd" {% ([{line,col}]) => marlowe.Term.create(marlowe.SlotIntervalEnd.value)({startLineNumber: line, startColumn: col, endLineNumber: line, endColumn: col + 15}) %}
+    | lparen "UseValue" someWS valueId rparen {% ([start,{line,col},,valueId,end]) => marlowe.Term.create(marlowe.UseValue.create(valueId))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}
+    | lparen "Cond" someWS observation someWS value someWS value rparen {% ([start,{line,col},,oo,,v1,,v2,end]) => marlowe.Term.create(marlowe.Cond.create(oo)(v1)(v2))({startLineNumber: start.line, startColumn: start.col, endLineNumber: end.line, endColumn: end.col + 1}) %}

--- a/marlowe-playground-client/package.json
+++ b/marlowe-playground-client/package.json
@@ -32,7 +32,7 @@
     "file-loader": "^2.0.0",
     "html-webpack-plugin": "^3.2.0",
     "monaco-editor-webpack-plugin": "^1.9.0",
-    "nearley-webpack-loader": "https://github.com/shmish111/nearley-webpack-loader/archive/master.tar.gz",
+    "nearley-webpack-loader": "^0.0.2",
     "node-sass": "^4.12.0",
     "purs-loader": "^3.6.0",
     "sass-loader": "^7.1.0",

--- a/marlowe-playground-client/src/HaskellEditor.purs
+++ b/marlowe-playground-client/src/HaskellEditor.purs
@@ -13,8 +13,8 @@ import Data.String as String
 import Effect.Aff.Class (class MonadAff)
 import Examples.Haskell.Contracts as HE
 import Halogen (ClassName(..), ComponentHTML, liftEffect)
-import Halogen.Classes (aHorizontal, accentBorderBottom, activeClasses, analysisPanel, closeDrawerArrowIcon, codeEditor, footerPanelBg, jFlexStart, minimizeIcon, panelSubHeader, panelSubHeaderMain, spaceLeft)
-import Halogen.HTML (HTML, a, button, code_, div, div_, img, li, option, pre, pre_, section, select, slot, small_, text, ul)
+import Halogen.Classes (aHorizontal, activeClasses, analysisPanel, closeDrawerArrowIcon, codeEditor, footerPanelBg, jFlexStart, minimizeIcon, panelSubHeader, panelSubHeaderMain, spaceLeft)
+import Halogen.HTML (HTML, a, button, code_, div, div_, img, li, option, pre_, section, select, slot, small_, text, ul)
 import Halogen.HTML.Events (onClick, onSelectedIndexChange)
 import Halogen.HTML.Properties (alt, class_, classes, disabled, src)
 import Halogen.HTML.Properties as HTML

--- a/marlowe-playground-client/src/Marlowe/Holes.purs
+++ b/marlowe-playground-client/src/Marlowe/Holes.purs
@@ -4,6 +4,7 @@ import Prelude
 import Data.Array (foldMap)
 import Data.Array as Array
 import Data.BigInteger (BigInteger)
+import Data.BigInteger as BigInteger
 import Data.Enum (class BoundedEnum, class Enum, upFromIncluding)
 import Data.Foldable (intercalate)
 import Data.Function (on)
@@ -24,7 +25,7 @@ import Data.String.CodeUnits (dropRight)
 import Data.Symbol (SProxy(..))
 import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
-import Marlowe.Semantics (PubKey, Rational(..), Slot, TokenName)
+import Marlowe.Semantics (PubKey, Rational(..), Slot(..), TokenName)
 import Marlowe.Semantics as S
 import Monaco (CompletionItem, IRange, completionItemKind)
 import Text.Extra as Text
@@ -373,6 +374,9 @@ instance termWrapperHasContractData :: HasContractData a => HasContractData (Ter
 
 mkDefaultTermWrapper :: forall a. a -> TermWrapper a
 mkDefaultTermWrapper a = TermWrapper a zero
+
+mkTimeout :: Int -> Range -> TermWrapper Slot
+mkTimeout v pos = TermWrapper (Slot (BigInteger.fromInt v)) pos
 
 -- special case
 instance fromTermRational :: FromTerm Rational Rational where

--- a/marlowe-playground-client/src/Marlowe/Parser.js
+++ b/marlowe-playground-client/src/Marlowe/Parser.js
@@ -3,11 +3,12 @@
 
 const nearley = require("nearley");
 const grammar = require("grammar");
-exports.parse_ = function (emptyInputError, parserError, success, fs, input) {
+
+exports.parse_ = function (emptyInputError, parserError, success, input) {
     if (!input) {
         return emptyInputError;
     }
-    const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar(fs)));
+    const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
     try {
         parser.feed(input);
         return success(parser.results[0]);

--- a/marlowe-playground-client/src/Marlowe/Parser.purs
+++ b/marlowe-playground-client/src/Marlowe/Parser.purs
@@ -8,7 +8,7 @@ import Data.Bifunctor (lmap)
 import Data.BigInteger (BigInteger)
 import Data.BigInteger as BigInteger
 import Data.Either (Either(..))
-import Data.Function.Uncurried (Fn5, runFn5)
+import Data.Function.Uncurried (Fn4, runFn4)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.List (List)
@@ -16,7 +16,7 @@ import Data.Maybe (Maybe(..))
 import Data.String (length)
 import Data.String.CodeUnits (fromCharArray)
 import Data.Unit (Unit, unit)
-import Marlowe.Holes (class FromTerm, AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Range, Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), fromTerm, getRange, mkHole)
+import Marlowe.Holes (class FromTerm, AccountId(..), Action(..), Bound(..), Case(..), ChoiceId(..), Contract(..), Observation(..), Party(..), Payee(..), Term(..), TermWrapper(..), Token(..), Value(..), ValueId(..), fromTerm)
 import Marlowe.Semantics (CurrencySymbol, Rational(..), PubKey, Slot(..), SlotInterval(..), TransactionInput(..), TransactionWarning(..), TokenName)
 import Marlowe.Semantics as S
 import Prelude (class Show, bind, const, discard, pure, show, void, zero, ($), (*>), (-), (<$), (<$>), (<*), (<*>), (<<<))
@@ -25,111 +25,6 @@ import Text.Parsing.StringParser.Basic (integral, parens, someWhiteSpace, whiteS
 import Text.Parsing.StringParser.CodeUnits (alphaNum, char, skipSpaces, string)
 import Text.Parsing.StringParser.Combinators (between, choice, sepBy)
 import Type.Proxy (Proxy(..))
-
-type HelperFunctions a
-  = { mkHole :: String -> Range -> Term a
-    , mkTerm :: a -> Range -> Term a
-    , mkTermWrapper :: a -> Range -> TermWrapper a
-    , getRange :: Term a -> Range
-    , mkBigInteger :: Int -> BigInteger
-    , mkTimeout :: Int -> Range -> TermWrapper Slot
-    , mkClose :: Contract
-    , mkPay :: AccountId -> Term Payee -> Term Token -> Term Value -> Term Contract -> Contract
-    , mkWhen :: Array (Term Case) -> (TermWrapper Slot) -> Term Contract -> Contract
-    , mkIf :: Term Observation -> Term Contract -> Term Contract -> Contract
-    , mkLet :: TermWrapper ValueId -> Term Value -> Term Contract -> Contract
-    , mkAssert :: Term Observation -> Term Contract -> Contract
-    , mkCase :: Term Action -> Term Contract -> Case
-    , mkBound :: BigInteger -> BigInteger -> Bound
-    , mkDeposit :: AccountId -> Term Party -> Term Token -> Term Value -> Action
-    , mkChoice :: ChoiceId -> Array (Term Bound) -> Action
-    , mkNotify :: Term Observation -> Action
-    , mkChoiceId :: String -> Term Party -> ChoiceId
-    , mkValueId :: String -> ValueId
-    , mkAccountId :: BigInteger -> Term Party -> AccountId
-    , mkToken :: String -> String -> Token
-    , mkPK :: String -> Party
-    , mkRole :: String -> Party
-    , mkAccount :: AccountId -> Payee
-    , mkParty :: Term Party -> Payee
-    , mkAndObs :: Term Observation -> Term Observation -> Observation
-    , mkOrObs :: Term Observation -> Term Observation -> Observation
-    , mkNotObs :: Term Observation -> Observation
-    , mkChoseSomething :: ChoiceId -> Observation
-    , mkValueGE :: Term Value -> Term Value -> Observation
-    , mkValueGT :: Term Value -> Term Value -> Observation
-    , mkValueLT :: Term Value -> Term Value -> Observation
-    , mkValueLE :: Term Value -> Term Value -> Observation
-    , mkValueEQ :: Term Value -> Term Value -> Observation
-    , mkTrueObs :: Observation
-    , mkFalseObs :: Observation
-    , mkAvailableMoney :: AccountId -> Term Token -> Value
-    , mkConstant :: BigInteger -> Value
-    , mkNegValue :: Term Value -> Value
-    , mkAddValue :: Term Value -> Term Value -> Value
-    , mkSubValue :: Term Value -> Term Value -> Value
-    , mkMulValue :: Term Value -> Term Value -> Value
-    , mkRational :: BigInteger -> BigInteger -> Rational
-    , mkScale :: TermWrapper Rational -> Term Value -> Value
-    , mkChoiceValue :: ChoiceId -> Value
-    , mkSlotIntervalStart :: Value
-    , mkSlotIntervalEnd :: Value
-    , mkUseValue :: TermWrapper ValueId -> Value
-    , mkCond :: Term Observation -> Term Value -> Term Value -> Value
-    }
-
-helperFunctions :: forall a. HelperFunctions a
-helperFunctions =
-  { mkHole: mkHole
-  , mkTerm: Term
-  , mkTermWrapper: TermWrapper
-  , getRange: getRange
-  , mkBigInteger: BigInteger.fromInt
-  , mkTimeout: \v pos -> TermWrapper (Slot (BigInteger.fromInt v)) pos
-  , mkClose: Close
-  , mkPay: Pay
-  , mkWhen: When
-  , mkIf: If
-  , mkAssert: Assert
-  , mkLet: Let
-  , mkCase: Case
-  , mkBound: Bound
-  , mkDeposit: Deposit
-  , mkChoice: Choice
-  , mkNotify: Notify
-  , mkChoiceId: ChoiceId
-  , mkValueId: ValueId
-  , mkAccountId: AccountId
-  , mkToken: Token
-  , mkPK: PK
-  , mkRole: Role
-  , mkAccount: Account
-  , mkParty: Party
-  , mkAndObs: AndObs
-  , mkOrObs: OrObs
-  , mkNotObs: NotObs
-  , mkChoseSomething: ChoseSomething
-  , mkValueGE: ValueGE
-  , mkValueGT: ValueGT
-  , mkValueLT: ValueLT
-  , mkValueLE: ValueLE
-  , mkValueEQ: ValueEQ
-  , mkTrueObs: TrueObs
-  , mkFalseObs: FalseObs
-  , mkAvailableMoney: AvailableMoney
-  , mkConstant: Constant
-  , mkNegValue: NegValue
-  , mkAddValue: AddValue
-  , mkSubValue: SubValue
-  , mkMulValue: MulValue
-  , mkRational: Rational
-  , mkScale: Scale
-  , mkChoiceValue: ChoiceValue
-  , mkSlotIntervalStart: SlotIntervalStart
-  , mkSlotIntervalEnd: SlotIntervalEnd
-  , mkUseValue: UseValue
-  , mkCond: Cond
-  }
 
 data ContractParseError
   = EmptyInput
@@ -141,17 +36,15 @@ instance showContractParseError :: Show ContractParseError where
   show e = genericShow e
 
 foreign import parse_ ::
-  forall a.
-  Fn5
+  Fn4
     (Either ContractParseError (Term Contract))
     ({ message :: String, row :: Int, column :: Int, token :: String } -> Either ContractParseError (Term Contract))
     (Term Contract -> Either ContractParseError (Term Contract))
-    (HelperFunctions a)
     String
     (Either ContractParseError (Term Contract))
 
 parseContract :: String -> Either ContractParseError (Term Contract)
-parseContract = runFn5 parse_ (Left EmptyInput) (Left <<< ContractParseError) Right helperFunctions
+parseContract = runFn4 parse_ (Left EmptyInput) (Left <<< ContractParseError) Right
 
 parse :: forall a. Parser a -> String -> Either String a
 parse p = lmap show <<< runParser (parens p <|> p)

--- a/marlowe-playground-client/yarn.lock
+++ b/marlowe-playground-client/yarn.lock
@@ -3024,9 +3024,10 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-"nearley-webpack-loader@https://github.com/shmish111/nearley-webpack-loader/archive/master.tar.gz":
+nearley-webpack-loader@^0.0.2:
   version "0.0.2"
-  resolved "https://github.com/shmish111/nearley-webpack-loader/archive/master.tar.gz#f7e80853852229971ae0ded75cdae2a078908529"
+  resolved "https://registry.yarnpkg.com/nearley-webpack-loader/-/nearley-webpack-loader-0.0.2.tgz#7d7f2f758e6f3d510a5c3f7a0980514263770c83"
+  integrity sha512-N0dE+lUS88hJJrTi7kobtKgwudagdGFhlM5cK431UvQouBQaT32OJztPhYEH90dZQAQtrIO/BFh+paetwMMsCQ==
   dependencies:
     loader-utils "^1.1.0"
     nearley "^2.11.0"

--- a/marlowe-playground-client/yarn.nix
+++ b/marlowe-playground-client/yarn.nix
@@ -1,7 +1,6 @@
-{fetchurl, linkFarm}: rec {
+{ fetchurl, fetchgit, linkFarm, runCommandNoCC, gnutar }: rec {
   offline_cache = linkFarm "offline" packages;
   packages = [
-
     {
       name = "_fortawesome_fontawesome_free___fontawesome_free_5.10.2.tgz";
       path = fetchurl {
@@ -10,7 +9,6 @@
         sha1 = "27e02da1e34b50c9869179d364fb46627b521130";
       };
     }
-
     {
       name = "_webassemblyjs_ast___ast_1.8.5.tgz";
       path = fetchurl {
@@ -19,7 +17,6 @@
         sha1 = "51b1c5fe6576a34953bf4b253df9f0d490d9e359";
       };
     }
-
     {
       name = "_webassemblyjs_floating_point_hex_parser___floating_point_hex_parser_1.8.5.tgz";
       path = fetchurl {
@@ -28,7 +25,6 @@
         sha1 = "1ba926a2923613edce496fd5b02e8ce8a5f49721";
       };
     }
-
     {
       name = "_webassemblyjs_helper_api_error___helper_api_error_1.8.5.tgz";
       path = fetchurl {
@@ -37,7 +33,6 @@
         sha1 = "c49dad22f645227c5edb610bdb9697f1aab721f7";
       };
     }
-
     {
       name = "_webassemblyjs_helper_buffer___helper_buffer_1.8.5.tgz";
       path = fetchurl {
@@ -46,7 +41,6 @@
         sha1 = "fea93e429863dd5e4338555f42292385a653f204";
       };
     }
-
     {
       name = "_webassemblyjs_helper_code_frame___helper_code_frame_1.8.5.tgz";
       path = fetchurl {
@@ -55,7 +49,6 @@
         sha1 = "9a740ff48e3faa3022b1dff54423df9aa293c25e";
       };
     }
-
     {
       name = "_webassemblyjs_helper_fsm___helper_fsm_1.8.5.tgz";
       path = fetchurl {
@@ -64,7 +57,6 @@
         sha1 = "ba0b7d3b3f7e4733da6059c9332275d860702452";
       };
     }
-
     {
       name = "_webassemblyjs_helper_module_context___helper_module_context_1.8.5.tgz";
       path = fetchurl {
@@ -73,7 +65,6 @@
         sha1 = "def4b9927b0101dc8cbbd8d1edb5b7b9c82eb245";
       };
     }
-
     {
       name = "_webassemblyjs_helper_wasm_bytecode___helper_wasm_bytecode_1.8.5.tgz";
       path = fetchurl {
@@ -82,7 +73,6 @@
         sha1 = "537a750eddf5c1e932f3744206551c91c1b93e61";
       };
     }
-
     {
       name = "_webassemblyjs_helper_wasm_section___helper_wasm_section_1.8.5.tgz";
       path = fetchurl {
@@ -91,7 +81,6 @@
         sha1 = "74ca6a6bcbe19e50a3b6b462847e69503e6bfcbf";
       };
     }
-
     {
       name = "_webassemblyjs_ieee754___ieee754_1.8.5.tgz";
       path = fetchurl {
@@ -100,7 +89,6 @@
         sha1 = "712329dbef240f36bf57bd2f7b8fb9bf4154421e";
       };
     }
-
     {
       name = "_webassemblyjs_leb128___leb128_1.8.5.tgz";
       path = fetchurl {
@@ -109,7 +97,6 @@
         sha1 = "044edeb34ea679f3e04cd4fd9824d5e35767ae10";
       };
     }
-
     {
       name = "_webassemblyjs_utf8___utf8_1.8.5.tgz";
       path = fetchurl {
@@ -118,7 +105,6 @@
         sha1 = "a8bf3b5d8ffe986c7c1e373ccbdc2a0915f0cedc";
       };
     }
-
     {
       name = "_webassemblyjs_wasm_edit___wasm_edit_1.8.5.tgz";
       path = fetchurl {
@@ -127,7 +113,6 @@
         sha1 = "962da12aa5acc1c131c81c4232991c82ce56e01a";
       };
     }
-
     {
       name = "_webassemblyjs_wasm_gen___wasm_gen_1.8.5.tgz";
       path = fetchurl {
@@ -136,7 +121,6 @@
         sha1 = "54840766c2c1002eb64ed1abe720aded714f98bc";
       };
     }
-
     {
       name = "_webassemblyjs_wasm_opt___wasm_opt_1.8.5.tgz";
       path = fetchurl {
@@ -145,7 +129,6 @@
         sha1 = "b24d9f6ba50394af1349f510afa8ffcb8a63d264";
       };
     }
-
     {
       name = "_webassemblyjs_wasm_parser___wasm_parser_1.8.5.tgz";
       path = fetchurl {
@@ -154,7 +137,6 @@
         sha1 = "21576f0ec88b91427357b8536383668ef7c66b8d";
       };
     }
-
     {
       name = "_webassemblyjs_wast_parser___wast_parser_1.8.5.tgz";
       path = fetchurl {
@@ -163,7 +145,6 @@
         sha1 = "e10eecd542d0e7bd394f6827c49f3df6d4eefb8c";
       };
     }
-
     {
       name = "_webassemblyjs_wast_printer___wast_printer_1.8.5.tgz";
       path = fetchurl {
@@ -172,7 +153,6 @@
         sha1 = "114bbc481fd10ca0e23b3560fa812748b0bae5bc";
       };
     }
-
     {
       name = "_xtuc_ieee754___ieee754_1.2.0.tgz";
       path = fetchurl {
@@ -181,7 +161,6 @@
         sha1 = "eef014a3145ae477a1cbc00cd1e552336dceb790";
       };
     }
-
     {
       name = "_xtuc_long___long_4.2.2.tgz";
       path = fetchurl {
@@ -190,7 +169,6 @@
         sha1 = "d291c6a4e97989b5c61d9acf396ae4fe133a718d";
       };
     }
-
     {
       name = "abab___abab_2.0.3.tgz";
       path = fetchurl {
@@ -199,7 +177,6 @@
         sha1 = "623e2075e02eb2d3f2475e49f99c91846467907a";
       };
     }
-
     {
       name = "abbrev___abbrev_1.1.1.tgz";
       path = fetchurl {
@@ -208,7 +185,6 @@
         sha1 = "f8f2c887ad10bf67f634f005b6987fed3179aac8";
       };
     }
-
     {
       name = "accepts___accepts_1.3.5.tgz";
       path = fetchurl {
@@ -217,7 +193,6 @@
         sha1 = "eb777df6011723a3b14e8a72c0805c8e86746bd2";
       };
     }
-
     {
       name = "acorn_globals___acorn_globals_1.0.9.tgz";
       path = fetchurl {
@@ -226,7 +201,6 @@
         sha1 = "55bb5e98691507b74579d0513413217c380c54cf";
       };
     }
-
     {
       name = "acorn_globals___acorn_globals_4.3.4.tgz";
       path = fetchurl {
@@ -235,7 +209,6 @@
         sha1 = "9fa1926addc11c97308c4e66d7add0d40c3272e7";
       };
     }
-
     {
       name = "acorn_walk___acorn_walk_6.2.0.tgz";
       path = fetchurl {
@@ -244,7 +217,6 @@
         sha1 = "123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c";
       };
     }
-
     {
       name = "acorn___acorn_2.7.0.tgz";
       path = fetchurl {
@@ -253,7 +225,6 @@
         sha1 = "ab6e7d9d886aaca8b085bc3312b79a198433f0e7";
       };
     }
-
     {
       name = "acorn___acorn_6.4.1.tgz";
       path = fetchurl {
@@ -262,7 +233,6 @@
         sha1 = "531e58ba3f51b9dacb9a6646ca4debf5b14ca474";
       };
     }
-
     {
       name = "acorn___acorn_6.3.0.tgz";
       path = fetchurl {
@@ -271,7 +241,6 @@
         sha1 = "0087509119ffa4fc0a0041d1e93a417e68cb856e";
       };
     }
-
     {
       name = "acorn___acorn_7.3.1.tgz";
       path = fetchurl {
@@ -280,7 +249,6 @@
         sha1 = "85010754db53c3fbaf3b9ea3e083aa5c5d147ffd";
       };
     }
-
     {
       name = "ajv_errors___ajv_errors_1.0.1.tgz";
       path = fetchurl {
@@ -289,7 +257,6 @@
         sha1 = "f35986aceb91afadec4102fbd85014950cefa64d";
       };
     }
-
     {
       name = "ajv_keywords___ajv_keywords_3.4.0.tgz";
       path = fetchurl {
@@ -298,7 +265,6 @@
         sha1 = "4b831e7b531415a7cc518cd404e73f6193c6349d";
       };
     }
-
     {
       name = "ajv_keywords___ajv_keywords_3.4.1.tgz";
       path = fetchurl {
@@ -307,7 +273,6 @@
         sha1 = "ef916e271c64ac12171fd8384eaae6b2345854da";
       };
     }
-
     {
       name = "ajv___ajv_6.10.0.tgz";
       path = fetchurl {
@@ -316,7 +281,6 @@
         sha1 = "90d0d54439da587cd7e843bfb7045f50bd22bdf1";
       };
     }
-
     {
       name = "ajv___ajv_6.10.2.tgz";
       path = fetchurl {
@@ -325,7 +289,6 @@
         sha1 = "d3cea04d6b017b2894ad69040fec8b623eb4bd52";
       };
     }
-
     {
       name = "ajv___ajv_6.12.2.tgz";
       path = fetchurl {
@@ -334,7 +297,6 @@
         sha1 = "c629c5eced17baf314437918d2da88c99d5958cd";
       };
     }
-
     {
       name = "amdefine___amdefine_1.0.1.tgz";
       path = fetchurl {
@@ -343,7 +305,6 @@
         sha1 = "4a5282ac164729e93619bcfd3ad151f817ce91f5";
       };
     }
-
     {
       name = "ansi_colors___ansi_colors_3.2.4.tgz";
       path = fetchurl {
@@ -352,7 +313,6 @@
         sha1 = "e3a3da4bfbae6c86a9c285625de124a234026fbf";
       };
     }
-
     {
       name = "ansi_html___ansi_html_0.0.7.tgz";
       path = fetchurl {
@@ -361,7 +321,6 @@
         sha1 = "813584021962a9e9e6fd039f940d12f56ca7859e";
       };
     }
-
     {
       name = "ansi_regex___ansi_regex_2.1.1.tgz";
       path = fetchurl {
@@ -370,7 +329,6 @@
         sha1 = "c3b33ab5ee360d86e0e628f0468ae7ef27d654df";
       };
     }
-
     {
       name = "ansi_regex___ansi_regex_3.0.0.tgz";
       path = fetchurl {
@@ -379,7 +337,6 @@
         sha1 = "ed0317c322064f79466c02966bddb605ab37d998";
       };
     }
-
     {
       name = "ansi_styles___ansi_styles_2.2.1.tgz";
       path = fetchurl {
@@ -388,7 +345,6 @@
         sha1 = "b432dd3358b634cf75e1e4664368240533c1ddbe";
       };
     }
-
     {
       name = "ansi_styles___ansi_styles_3.2.1.tgz";
       path = fetchurl {
@@ -397,7 +353,6 @@
         sha1 = "41fbb20243e50b12be0f04b8dedbf07520ce841d";
       };
     }
-
     {
       name = "anymatch___anymatch_2.0.0.tgz";
       path = fetchurl {
@@ -406,7 +361,6 @@
         sha1 = "bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb";
       };
     }
-
     {
       name = "aproba___aproba_1.2.0.tgz";
       path = fetchurl {
@@ -415,7 +369,6 @@
         sha1 = "6802e6264efd18c790a1b0d517f0f2627bf2c94a";
       };
     }
-
     {
       name = "are_we_there_yet___are_we_there_yet_1.1.5.tgz";
       path = fetchurl {
@@ -424,7 +377,6 @@
         sha1 = "4b35c2944f062a8bfcda66410760350fe9ddfc21";
       };
     }
-
     {
       name = "arr_diff___arr_diff_4.0.0.tgz";
       path = fetchurl {
@@ -433,7 +385,6 @@
         sha1 = "d6461074febfec71e7e15235761a329a5dc7c520";
       };
     }
-
     {
       name = "arr_flatten___arr_flatten_1.1.0.tgz";
       path = fetchurl {
@@ -442,7 +393,6 @@
         sha1 = "36048bbff4e7b47e136644316c99669ea5ae91f1";
       };
     }
-
     {
       name = "arr_union___arr_union_3.1.0.tgz";
       path = fetchurl {
@@ -451,7 +401,6 @@
         sha1 = "e39b09aea9def866a8f206e288af63919bae39c4";
       };
     }
-
     {
       name = "array_equal___array_equal_1.0.0.tgz";
       path = fetchurl {
@@ -460,7 +409,6 @@
         sha1 = "8c2a5ef2472fd9ea742b04c77a75093ba2757c93";
       };
     }
-
     {
       name = "array_find_index___array_find_index_1.0.2.tgz";
       path = fetchurl {
@@ -469,7 +417,6 @@
         sha1 = "df010aa1287e164bbda6f9723b0a96a1ec4187a1";
       };
     }
-
     {
       name = "array_flatten___array_flatten_1.1.1.tgz";
       path = fetchurl {
@@ -478,7 +425,6 @@
         sha1 = "9a5f699051b1e7073328f2a008968b64ea2955d2";
       };
     }
-
     {
       name = "array_flatten___array_flatten_2.1.2.tgz";
       path = fetchurl {
@@ -487,7 +433,6 @@
         sha1 = "24ef80a28c1a893617e2149b0c6d0d788293b099";
       };
     }
-
     {
       name = "array_union___array_union_1.0.2.tgz";
       path = fetchurl {
@@ -496,7 +441,6 @@
         sha1 = "9a34410e4f4e3da23dea375be5be70f24778ec39";
       };
     }
-
     {
       name = "array_uniq___array_uniq_1.0.3.tgz";
       path = fetchurl {
@@ -505,7 +449,6 @@
         sha1 = "af6ac877a25cc7f74e058894753858dfdb24fdb6";
       };
     }
-
     {
       name = "array_unique___array_unique_0.3.2.tgz";
       path = fetchurl {
@@ -514,7 +457,6 @@
         sha1 = "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428";
       };
     }
-
     {
       name = "arrify___arrify_1.0.1.tgz";
       path = fetchurl {
@@ -523,7 +465,6 @@
         sha1 = "898508da2226f380df904728456849c1501a4b0d";
       };
     }
-
     {
       name = "asn1.js___asn1.js_4.10.1.tgz";
       path = fetchurl {
@@ -532,7 +473,6 @@
         sha1 = "b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0";
       };
     }
-
     {
       name = "asn1___asn1_0.2.4.tgz";
       path = fetchurl {
@@ -541,7 +481,6 @@
         sha1 = "8d2475dfab553bb33e77b54e59e880bb8ce23136";
       };
     }
-
     {
       name = "assert_plus___assert_plus_1.0.0.tgz";
       path = fetchurl {
@@ -550,7 +489,6 @@
         sha1 = "f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525";
       };
     }
-
     {
       name = "assert___assert_1.4.1.tgz";
       path = fetchurl {
@@ -559,7 +497,6 @@
         sha1 = "99912d591836b5a6f5b345c0f07eefc08fc65d91";
       };
     }
-
     {
       name = "assign_symbols___assign_symbols_1.0.0.tgz";
       path = fetchurl {
@@ -568,7 +505,6 @@
         sha1 = "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367";
       };
     }
-
     {
       name = "async_each___async_each_1.0.1.tgz";
       path = fetchurl {
@@ -577,7 +513,6 @@
         sha1 = "19d386a1d9edc6e7c1c85d388aedbcc56d33602d";
       };
     }
-
     {
       name = "async_foreach___async_foreach_0.1.3.tgz";
       path = fetchurl {
@@ -586,7 +521,6 @@
         sha1 = "36121f845c0578172de419a97dbeb1d16ec34542";
       };
     }
-
     {
       name = "async___async_1.5.2.tgz";
       path = fetchurl {
@@ -595,7 +529,6 @@
         sha1 = "ec6a61ae56480c0c3cb241c95618e20892f9672a";
       };
     }
-
     {
       name = "asynckit___asynckit_0.4.0.tgz";
       path = fetchurl {
@@ -604,7 +537,6 @@
         sha1 = "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79";
       };
     }
-
     {
       name = "atob___atob_2.1.2.tgz";
       path = fetchurl {
@@ -613,7 +545,6 @@
         sha1 = "6d9517eb9e030d2436666651e86bd9f6f13533c9";
       };
     }
-
     {
       name = "aws_sign2___aws_sign2_0.7.0.tgz";
       path = fetchurl {
@@ -622,7 +553,6 @@
         sha1 = "b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8";
       };
     }
-
     {
       name = "aws4___aws4_1.10.0.tgz";
       path = fetchurl {
@@ -631,7 +561,6 @@
         sha1 = "a17b3a8ea811060e74d47d306122400ad4497ae2";
       };
     }
-
     {
       name = "babel_code_frame___babel_code_frame_6.26.0.tgz";
       path = fetchurl {
@@ -640,7 +569,6 @@
         sha1 = "63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b";
       };
     }
-
     {
       name = "balanced_match___balanced_match_1.0.0.tgz";
       path = fetchurl {
@@ -649,7 +577,6 @@
         sha1 = "89b4d199ab2bee49de164ea02b89ce462d71b767";
       };
     }
-
     {
       name = "base64_js___base64_js_1.3.0.tgz";
       path = fetchurl {
@@ -658,7 +585,6 @@
         sha1 = "cab1e6118f051095e58b5281aea8c1cd22bfc0e3";
       };
     }
-
     {
       name = "base___base_0.11.2.tgz";
       path = fetchurl {
@@ -667,7 +593,6 @@
         sha1 = "7bde5ced145b6d551a90db87f83c558b4eb48a8f";
       };
     }
-
     {
       name = "batch___batch_0.6.1.tgz";
       path = fetchurl {
@@ -676,7 +601,6 @@
         sha1 = "dc34314f4e679318093fc760272525f94bf25c16";
       };
     }
-
     {
       name = "bcrypt_pbkdf___bcrypt_pbkdf_1.0.2.tgz";
       path = fetchurl {
@@ -685,7 +609,6 @@
         sha1 = "a4301d389b6a43f9b67ff3ca11a3f6637e360e9e";
       };
     }
-
     {
       name = "big_integer___big_integer_1.6.42.tgz";
       path = fetchurl {
@@ -694,7 +617,6 @@
         sha1 = "91623ae5ceeff9a47416c56c9440a66f12f534f1";
       };
     }
-
     {
       name = "big.js___big.js_3.2.0.tgz";
       path = fetchurl {
@@ -703,7 +625,6 @@
         sha1 = "a5fc298b81b9e0dca2e458824784b65c52ba588e";
       };
     }
-
     {
       name = "big.js___big.js_5.2.2.tgz";
       path = fetchurl {
@@ -712,7 +633,6 @@
         sha1 = "65f0af382f578bcdc742bd9c281e9cb2d7768328";
       };
     }
-
     {
       name = "binary_extensions___binary_extensions_1.13.0.tgz";
       path = fetchurl {
@@ -721,7 +641,6 @@
         sha1 = "9523e001306a32444b907423f1de2164222f6ab1";
       };
     }
-
     {
       name = "bindings___bindings_1.3.1.tgz";
       path = fetchurl {
@@ -730,7 +649,6 @@
         sha1 = "21fc7c6d67c18516ec5aaa2815b145ff77b26ea5";
       };
     }
-
     {
       name = "block_stream___block_stream_0.0.9.tgz";
       path = fetchurl {
@@ -739,7 +657,6 @@
         sha1 = "13ebfe778a03205cfe03751481ebb4b3300c126a";
       };
     }
-
     {
       name = "bluebird___bluebird_3.5.3.tgz";
       path = fetchurl {
@@ -748,7 +665,6 @@
         sha1 = "7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7";
       };
     }
-
     {
       name = "bluebird___bluebird_3.7.0.tgz";
       path = fetchurl {
@@ -757,7 +673,6 @@
         sha1 = "56a6a886e03f6ae577cffedeb524f8f2450293cf";
       };
     }
-
     {
       name = "bn.js___bn.js_4.11.8.tgz";
       path = fetchurl {
@@ -766,7 +681,6 @@
         sha1 = "2cde09eb5ee341f484746bb0309b3253b1b1442f";
       };
     }
-
     {
       name = "body_parser___body_parser_1.18.3.tgz";
       path = fetchurl {
@@ -775,7 +689,6 @@
         sha1 = "5b292198ffdd553b3a0f20ded0592b956955c8b4";
       };
     }
-
     {
       name = "bonjour___bonjour_3.5.0.tgz";
       path = fetchurl {
@@ -784,7 +697,6 @@
         sha1 = "8e890a183d8ee9a2393b3844c691a42bcf7bc9f5";
       };
     }
-
     {
       name = "boolbase___boolbase_1.0.0.tgz";
       path = fetchurl {
@@ -793,7 +705,6 @@
         sha1 = "68dff5fbe60c51eb37725ea9e3ed310dcc1e776e";
       };
     }
-
     {
       name = "bootstrap___bootstrap_4.3.1.tgz";
       path = fetchurl {
@@ -802,7 +713,6 @@
         sha1 = "280ca8f610504d99d7b6b4bfc4b68cec601704ac";
       };
     }
-
     {
       name = "brace_expansion___brace_expansion_1.1.11.tgz";
       path = fetchurl {
@@ -811,7 +721,6 @@
         sha1 = "3c7fcbf529d87226f3d2f52b966ff5271eb441dd";
       };
     }
-
     {
       name = "braces___braces_2.3.2.tgz";
       path = fetchurl {
@@ -820,7 +729,6 @@
         sha1 = "5979fd3f14cd531565e5fa2df1abfff1dfaee729";
       };
     }
-
     {
       name = "braces___braces_3.0.2.tgz";
       path = fetchurl {
@@ -829,7 +737,6 @@
         sha1 = "3454e1a462ee8d599e236df336cd9ea4f8afe107";
       };
     }
-
     {
       name = "brorand___brorand_1.1.0.tgz";
       path = fetchurl {
@@ -838,7 +745,6 @@
         sha1 = "12c25efe40a45e3c323eb8675a0a0ce57b22371f";
       };
     }
-
     {
       name = "browser_process_hrtime___browser_process_hrtime_1.0.0.tgz";
       path = fetchurl {
@@ -847,7 +753,6 @@
         sha1 = "3c9b4b7d782c8121e56f10106d84c0d0ffc94626";
       };
     }
-
     {
       name = "browser_request___browser_request_0.3.3.tgz";
       path = fetchurl {
@@ -856,7 +761,6 @@
         sha1 = "9ece5b5aca89a29932242e18bf933def9876cc17";
       };
     }
-
     {
       name = "browserify_aes___browserify_aes_1.2.0.tgz";
       path = fetchurl {
@@ -865,7 +769,6 @@
         sha1 = "326734642f403dabc3003209853bb70ad428ef48";
       };
     }
-
     {
       name = "browserify_cipher___browserify_cipher_1.0.1.tgz";
       path = fetchurl {
@@ -874,7 +777,6 @@
         sha1 = "8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0";
       };
     }
-
     {
       name = "browserify_des___browserify_des_1.0.2.tgz";
       path = fetchurl {
@@ -883,7 +785,6 @@
         sha1 = "3af4f1f59839403572f1c66204375f7a7f703e9c";
       };
     }
-
     {
       name = "browserify_rsa___browserify_rsa_4.0.1.tgz";
       path = fetchurl {
@@ -892,7 +793,6 @@
         sha1 = "21e0abfaf6f2029cf2fafb133567a701d4135524";
       };
     }
-
     {
       name = "browserify_sign___browserify_sign_4.0.4.tgz";
       path = fetchurl {
@@ -901,7 +801,6 @@
         sha1 = "aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298";
       };
     }
-
     {
       name = "browserify_zlib___browserify_zlib_0.2.0.tgz";
       path = fetchurl {
@@ -910,7 +809,6 @@
         sha1 = "2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f";
       };
     }
-
     {
       name = "buffer_from___buffer_from_1.1.1.tgz";
       path = fetchurl {
@@ -919,7 +817,6 @@
         sha1 = "32713bc028f75c02fdb710d7c7bcec1f2c6070ef";
       };
     }
-
     {
       name = "buffer_indexof___buffer_indexof_1.1.1.tgz";
       path = fetchurl {
@@ -928,7 +825,6 @@
         sha1 = "52fabcc6a606d1a00302802648ef68f639da268c";
       };
     }
-
     {
       name = "buffer_xor___buffer_xor_1.0.3.tgz";
       path = fetchurl {
@@ -937,7 +833,6 @@
         sha1 = "26e61ed1422fb70dd42e6e36729ed51d855fe8d9";
       };
     }
-
     {
       name = "buffer___buffer_4.9.1.tgz";
       path = fetchurl {
@@ -946,7 +841,6 @@
         sha1 = "6d1bb601b07a4efced97094132093027c95bc298";
       };
     }
-
     {
       name = "builtin_status_codes___builtin_status_codes_3.0.0.tgz";
       path = fetchurl {
@@ -955,7 +849,6 @@
         sha1 = "85982878e21b98e1c66425e03d0174788f569ee8";
       };
     }
-
     {
       name = "bytes___bytes_3.0.0.tgz";
       path = fetchurl {
@@ -964,7 +857,6 @@
         sha1 = "d32815404d689699f85a4ea4fa8755dd13a96048";
       };
     }
-
     {
       name = "cacache___cacache_12.0.3.tgz";
       path = fetchurl {
@@ -973,7 +865,6 @@
         sha1 = "be99abba4e1bf5df461cd5a2c1071fc432573390";
       };
     }
-
     {
       name = "cache_base___cache_base_1.0.1.tgz";
       path = fetchurl {
@@ -982,7 +873,6 @@
         sha1 = "0a7f46416831c8b662ee36fe4e7c59d76f666ab2";
       };
     }
-
     {
       name = "camel_case___camel_case_3.0.0.tgz";
       path = fetchurl {
@@ -991,7 +881,6 @@
         sha1 = "ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73";
       };
     }
-
     {
       name = "camelcase_keys___camelcase_keys_2.1.0.tgz";
       path = fetchurl {
@@ -1000,7 +889,6 @@
         sha1 = "308beeaffdf28119051efa1d932213c91b8f92e7";
       };
     }
-
     {
       name = "camelcase___camelcase_2.1.1.tgz";
       path = fetchurl {
@@ -1009,7 +897,6 @@
         sha1 = "7c1d16d679a1bbe59ca02cacecfb011e201f5a1f";
       };
     }
-
     {
       name = "camelcase___camelcase_3.0.0.tgz";
       path = fetchurl {
@@ -1018,7 +905,6 @@
         sha1 = "32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a";
       };
     }
-
     {
       name = "camelcase___camelcase_4.1.0.tgz";
       path = fetchurl {
@@ -1027,7 +913,6 @@
         sha1 = "d545635be1e33c542649c69173e5de6acfae34dd";
       };
     }
-
     {
       name = "camelcase___camelcase_5.2.0.tgz";
       path = fetchurl {
@@ -1036,7 +921,6 @@
         sha1 = "e7522abda5ed94cc0489e1b8466610e88404cf45";
       };
     }
-
     {
       name = "caseless___caseless_0.12.0.tgz";
       path = fetchurl {
@@ -1045,7 +929,6 @@
         sha1 = "1b681c21ff84033c826543090689420d187151dc";
       };
     }
-
     {
       name = "chalk___chalk_1.1.3.tgz";
       path = fetchurl {
@@ -1054,7 +937,6 @@
         sha1 = "a8115c55e4a702fe4d150abd3872822a7e09fc98";
       };
     }
-
     {
       name = "chalk___chalk_2.4.2.tgz";
       path = fetchurl {
@@ -1063,7 +945,6 @@
         sha1 = "cd42541677a54333cf541a49108c1432b44c9424";
       };
     }
-
     {
       name = "chokidar___chokidar_2.1.2.tgz";
       path = fetchurl {
@@ -1072,7 +953,6 @@
         sha1 = "9c23ea40b01638439e0513864d362aeacc5ad058";
       };
     }
-
     {
       name = "chownr___chownr_1.1.1.tgz";
       path = fetchurl {
@@ -1081,7 +961,6 @@
         sha1 = "54726b8b8fff4df053c42187e801fb4412df1494";
       };
     }
-
     {
       name = "chrome_trace_event___chrome_trace_event_1.0.2.tgz";
       path = fetchurl {
@@ -1090,7 +969,6 @@
         sha1 = "234090ee97c7d4ad1a2c4beae27505deffc608a4";
       };
     }
-
     {
       name = "cipher_base___cipher_base_1.0.4.tgz";
       path = fetchurl {
@@ -1099,7 +977,6 @@
         sha1 = "8760e4ecc272f4c363532f926d874aae2c1397de";
       };
     }
-
     {
       name = "class_utils___class_utils_0.3.6.tgz";
       path = fetchurl {
@@ -1108,7 +985,6 @@
         sha1 = "f93369ae8b9a7ce02fd41faad0ca83033190c463";
       };
     }
-
     {
       name = "clean_css___clean_css_4.2.1.tgz";
       path = fetchurl {
@@ -1117,7 +993,6 @@
         sha1 = "2d411ef76b8569b6d0c84068dabe85b0aa5e5c17";
       };
     }
-
     {
       name = "cliui___cliui_3.2.0.tgz";
       path = fetchurl {
@@ -1126,7 +1001,6 @@
         sha1 = "120601537a916d29940f934da3b48d585a39213d";
       };
     }
-
     {
       name = "cliui___cliui_4.1.0.tgz";
       path = fetchurl {
@@ -1135,7 +1009,6 @@
         sha1 = "348422dbe82d800b3022eef4f6ac10bf2e4d1b49";
       };
     }
-
     {
       name = "clone_deep___clone_deep_2.0.2.tgz";
       path = fetchurl {
@@ -1144,7 +1017,6 @@
         sha1 = "00db3a1e173656730d1188c3d6aced6d7ea97713";
       };
     }
-
     {
       name = "code_point_at___code_point_at_1.1.0.tgz";
       path = fetchurl {
@@ -1153,7 +1025,6 @@
         sha1 = "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77";
       };
     }
-
     {
       name = "collection_visit___collection_visit_1.0.0.tgz";
       path = fetchurl {
@@ -1162,7 +1033,6 @@
         sha1 = "4bc0373c164bc3291b4d368c829cf1a80a59dca0";
       };
     }
-
     {
       name = "color_convert___color_convert_1.9.3.tgz";
       path = fetchurl {
@@ -1171,7 +1041,6 @@
         sha1 = "bb71850690e1f136567de629d2d5471deda4c1e8";
       };
     }
-
     {
       name = "color_name___color_name_1.1.3.tgz";
       path = fetchurl {
@@ -1180,7 +1049,6 @@
         sha1 = "a7d0558bd89c42f795dd42328f740831ca53bc25";
       };
     }
-
     {
       name = "combined_stream___combined_stream_1.0.8.tgz";
       path = fetchurl {
@@ -1189,7 +1057,6 @@
         sha1 = "c3d45a8b34fd730631a110a8a2520682b31d5a7f";
       };
     }
-
     {
       name = "commander___commander_2.17.1.tgz";
       path = fetchurl {
@@ -1198,7 +1065,6 @@
         sha1 = "bd77ab7de6de94205ceacc72f1716d29f20a77bf";
       };
     }
-
     {
       name = "commander___commander_2.20.3.tgz";
       path = fetchurl {
@@ -1207,7 +1073,6 @@
         sha1 = "fd485e84c03eb4881c20722ba48035e8531aeb33";
       };
     }
-
     {
       name = "commondir___commondir_1.0.1.tgz";
       path = fetchurl {
@@ -1216,7 +1081,6 @@
         sha1 = "ddd800da0c66127393cca5950ea968a3aaf1253b";
       };
     }
-
     {
       name = "component_emitter___component_emitter_1.2.1.tgz";
       path = fetchurl {
@@ -1225,7 +1089,6 @@
         sha1 = "137918d6d78283f7df7a6b7c5a63e140e69425e6";
       };
     }
-
     {
       name = "compressible___compressible_2.0.16.tgz";
       path = fetchurl {
@@ -1234,7 +1097,6 @@
         sha1 = "a49bf9858f3821b64ce1be0296afc7380466a77f";
       };
     }
-
     {
       name = "compression___compression_1.7.3.tgz";
       path = fetchurl {
@@ -1243,7 +1105,6 @@
         sha1 = "27e0e176aaf260f7f2c2813c3e440adb9f1993db";
       };
     }
-
     {
       name = "concat_map___concat_map_0.0.1.tgz";
       path = fetchurl {
@@ -1252,7 +1113,6 @@
         sha1 = "d8a96bd77fd68df7793a73036a3ba0d5405d477b";
       };
     }
-
     {
       name = "concat_stream___concat_stream_1.6.2.tgz";
       path = fetchurl {
@@ -1261,7 +1121,6 @@
         sha1 = "904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34";
       };
     }
-
     {
       name = "connect_history_api_fallback___connect_history_api_fallback_1.6.0.tgz";
       path = fetchurl {
@@ -1270,7 +1129,6 @@
         sha1 = "8b32089359308d111115d81cad3fceab888f97bc";
       };
     }
-
     {
       name = "console_browserify___console_browserify_1.1.0.tgz";
       path = fetchurl {
@@ -1279,7 +1137,6 @@
         sha1 = "f0241c45730a9fc6323b206dbf38edc741d0bb10";
       };
     }
-
     {
       name = "console_control_strings___console_control_strings_1.1.0.tgz";
       path = fetchurl {
@@ -1288,7 +1145,6 @@
         sha1 = "3d7cf4464db6446ea644bf4b39507f9851008e8e";
       };
     }
-
     {
       name = "constants_browserify___constants_browserify_1.0.0.tgz";
       path = fetchurl {
@@ -1297,7 +1153,6 @@
         sha1 = "c20b96d8c617748aaf1c16021760cd27fcb8cb75";
       };
     }
-
     {
       name = "content_disposition___content_disposition_0.5.2.tgz";
       path = fetchurl {
@@ -1306,7 +1161,6 @@
         sha1 = "0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4";
       };
     }
-
     {
       name = "content_type___content_type_1.0.4.tgz";
       path = fetchurl {
@@ -1315,7 +1169,6 @@
         sha1 = "e138cc75e040c727b1966fe5e5f8c9aee256fe3b";
       };
     }
-
     {
       name = "cookie_signature___cookie_signature_1.0.6.tgz";
       path = fetchurl {
@@ -1324,7 +1177,6 @@
         sha1 = "e303a882b342cc3ee8ca513a79999734dab3ae2c";
       };
     }
-
     {
       name = "cookie___cookie_0.3.1.tgz";
       path = fetchurl {
@@ -1333,7 +1185,6 @@
         sha1 = "e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb";
       };
     }
-
     {
       name = "copy_concurrently___copy_concurrently_1.0.5.tgz";
       path = fetchurl {
@@ -1342,7 +1193,6 @@
         sha1 = "92297398cae34937fcafd6ec8139c18051f0b5e0";
       };
     }
-
     {
       name = "copy_descriptor___copy_descriptor_0.1.1.tgz";
       path = fetchurl {
@@ -1351,7 +1201,6 @@
         sha1 = "676f6eb3c39997c2ee1ac3a924fd6124748f578d";
       };
     }
-
     {
       name = "core_util_is___core_util_is_1.0.2.tgz";
       path = fetchurl {
@@ -1360,7 +1209,6 @@
         sha1 = "b5fd54220aa2bc5ab57aab7140c940754503c1a7";
       };
     }
-
     {
       name = "create_ecdh___create_ecdh_4.0.3.tgz";
       path = fetchurl {
@@ -1369,7 +1217,6 @@
         sha1 = "c9111b6f33045c4697f144787f9254cdc77c45ff";
       };
     }
-
     {
       name = "create_hash___create_hash_1.2.0.tgz";
       path = fetchurl {
@@ -1378,7 +1225,6 @@
         sha1 = "889078af11a63756bcfb59bd221996be3a9ef196";
       };
     }
-
     {
       name = "create_hmac___create_hmac_1.1.7.tgz";
       path = fetchurl {
@@ -1387,7 +1233,6 @@
         sha1 = "69170c78b3ab957147b2b8b04572e47ead2243ff";
       };
     }
-
     {
       name = "cross_spawn___cross_spawn_3.0.1.tgz";
       path = fetchurl {
@@ -1396,7 +1241,6 @@
         sha1 = "1256037ecb9f0c5f79e3d6ef135e30770184b982";
       };
     }
-
     {
       name = "cross_spawn___cross_spawn_6.0.5.tgz";
       path = fetchurl {
@@ -1405,7 +1249,6 @@
         sha1 = "4a5ec7c64dfae22c3a14124dbacdee846d80cbc4";
       };
     }
-
     {
       name = "crypto_browserify___crypto_browserify_3.12.0.tgz";
       path = fetchurl {
@@ -1414,7 +1257,6 @@
         sha1 = "396cf9f3137f03e4b8e532c58f698254e00f80ec";
       };
     }
-
     {
       name = "css_loader___css_loader_1.0.1.tgz";
       path = fetchurl {
@@ -1423,7 +1265,6 @@
         sha1 = "6885bb5233b35ec47b006057da01cc640b6b79fe";
       };
     }
-
     {
       name = "css_select___css_select_1.2.0.tgz";
       path = fetchurl {
@@ -1432,7 +1273,6 @@
         sha1 = "2b3a110539c5355f1cd8d314623e870b121ec858";
       };
     }
-
     {
       name = "css_selector_tokenizer___css_selector_tokenizer_0.7.1.tgz";
       path = fetchurl {
@@ -1441,7 +1281,6 @@
         sha1 = "a177271a8bca5019172f4f891fc6eed9cbf68d5d";
       };
     }
-
     {
       name = "css_what___css_what_2.1.3.tgz";
       path = fetchurl {
@@ -1450,7 +1289,6 @@
         sha1 = "a6d7604573365fe74686c3f311c56513d88285f2";
       };
     }
-
     {
       name = "cssesc___cssesc_0.1.0.tgz";
       path = fetchurl {
@@ -1459,7 +1297,6 @@
         sha1 = "c814903e45623371a0477b40109aaafbeeaddbb4";
       };
     }
-
     {
       name = "cssom___cssom_0.3.8.tgz";
       path = fetchurl {
@@ -1468,7 +1305,6 @@
         sha1 = "9f1276f5b2b463f2114d3f2c75250af8c1a36f4a";
       };
     }
-
     {
       name = "cssom___cssom_0.4.4.tgz";
       path = fetchurl {
@@ -1477,7 +1313,6 @@
         sha1 = "5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10";
       };
     }
-
     {
       name = "cssstyle___cssstyle_0.2.37.tgz";
       path = fetchurl {
@@ -1486,7 +1321,6 @@
         sha1 = "541097234cb2513c83ceed3acddc27ff27987d54";
       };
     }
-
     {
       name = "cssstyle___cssstyle_2.3.0.tgz";
       path = fetchurl {
@@ -1495,7 +1329,6 @@
         sha1 = "ff665a0ddbdc31864b09647f34163443d90b0852";
       };
     }
-
     {
       name = "currently_unhandled___currently_unhandled_0.4.1.tgz";
       path = fetchurl {
@@ -1504,7 +1337,6 @@
         sha1 = "988df33feab191ef799a61369dd76c17adf957ea";
       };
     }
-
     {
       name = "cyclist___cyclist_0.2.2.tgz";
       path = fetchurl {
@@ -1513,7 +1345,6 @@
         sha1 = "1b33792e11e914a2fd6d6ed6447464444e5fa640";
       };
     }
-
     {
       name = "dargs___dargs_5.1.0.tgz";
       path = fetchurl {
@@ -1522,7 +1353,6 @@
         sha1 = "ec7ea50c78564cd36c9d5ec18f66329fade27829";
       };
     }
-
     {
       name = "dashdash___dashdash_1.14.1.tgz";
       path = fetchurl {
@@ -1531,7 +1361,6 @@
         sha1 = "853cfa0f7cbe2fed5de20326b8dd581035f6e2f0";
       };
     }
-
     {
       name = "data_urls___data_urls_1.1.0.tgz";
       path = fetchurl {
@@ -1540,7 +1369,6 @@
         sha1 = "15ee0582baa5e22bb59c77140da8f9c76963bbfe";
       };
     }
-
     {
       name = "date_now___date_now_0.1.4.tgz";
       path = fetchurl {
@@ -1549,7 +1377,6 @@
         sha1 = "eaf439fd4d4848ad74e5cc7dbef200672b9e345b";
       };
     }
-
     {
       name = "debug___debug_2.6.9.tgz";
       path = fetchurl {
@@ -1558,7 +1385,6 @@
         sha1 = "5d128515df134ff327e90a4c93f4e077a536341f";
       };
     }
-
     {
       name = "debug___debug_3.2.6.tgz";
       path = fetchurl {
@@ -1567,7 +1393,6 @@
         sha1 = "e83d17de16d8a7efb7717edbe5fb10135eee629b";
       };
     }
-
     {
       name = "debug___debug_4.1.1.tgz";
       path = fetchurl {
@@ -1576,7 +1401,6 @@
         sha1 = "3b72260255109c6b589cee050f1d516139664791";
       };
     }
-
     {
       name = "decamelize___decamelize_1.2.0.tgz";
       path = fetchurl {
@@ -1585,7 +1409,6 @@
         sha1 = "f6534d15148269b20352e7bee26f501f9a191290";
       };
     }
-
     {
       name = "decamelize___decamelize_2.0.0.tgz";
       path = fetchurl {
@@ -1594,7 +1417,6 @@
         sha1 = "656d7bbc8094c4c788ea53c5840908c9c7d063c7";
       };
     }
-
     {
       name = "decode_uri_component___decode_uri_component_0.2.0.tgz";
       path = fetchurl {
@@ -1603,7 +1425,6 @@
         sha1 = "eb3913333458775cb84cd1a1fae062106bb87545";
       };
     }
-
     {
       name = "deep_equal___deep_equal_1.0.1.tgz";
       path = fetchurl {
@@ -1612,7 +1433,6 @@
         sha1 = "f5d260292b660e084eff4cdbc9f08ad3247448b5";
       };
     }
-
     {
       name = "deep_extend___deep_extend_0.6.0.tgz";
       path = fetchurl {
@@ -1621,7 +1441,6 @@
         sha1 = "c4fa7c95404a17a9c3e8ca7e1537312b736330ac";
       };
     }
-
     {
       name = "deep_is___deep_is_0.1.3.tgz";
       path = fetchurl {
@@ -1630,7 +1449,6 @@
         sha1 = "b369d6fb5dbc13eecf524f91b070feedc357cf34";
       };
     }
-
     {
       name = "default_gateway___default_gateway_4.2.0.tgz";
       path = fetchurl {
@@ -1639,7 +1457,6 @@
         sha1 = "167104c7500c2115f6dd69b0a536bb8ed720552b";
       };
     }
-
     {
       name = "define_properties___define_properties_1.1.3.tgz";
       path = fetchurl {
@@ -1648,7 +1465,6 @@
         sha1 = "cf88da6cbee26fe6db7094f61d870cbd84cee9f1";
       };
     }
-
     {
       name = "define_property___define_property_0.2.5.tgz";
       path = fetchurl {
@@ -1657,7 +1473,6 @@
         sha1 = "c35b1ef918ec3c990f9a5bc57be04aacec5c8116";
       };
     }
-
     {
       name = "define_property___define_property_1.0.0.tgz";
       path = fetchurl {
@@ -1666,7 +1481,6 @@
         sha1 = "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6";
       };
     }
-
     {
       name = "define_property___define_property_2.0.2.tgz";
       path = fetchurl {
@@ -1675,7 +1489,6 @@
         sha1 = "d459689e8d654ba77e02a817f8710d702cb16e9d";
       };
     }
-
     {
       name = "del___del_3.0.0.tgz";
       path = fetchurl {
@@ -1684,7 +1497,6 @@
         sha1 = "53ecf699ffcbcb39637691ab13baf160819766e5";
       };
     }
-
     {
       name = "delayed_stream___delayed_stream_1.0.0.tgz";
       path = fetchurl {
@@ -1693,7 +1505,6 @@
         sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
       };
     }
-
     {
       name = "delegates___delegates_1.0.0.tgz";
       path = fetchurl {
@@ -1702,7 +1513,6 @@
         sha1 = "84c6e159b81904fdca59a0ef44cd870d31250f9a";
       };
     }
-
     {
       name = "depd___depd_1.1.2.tgz";
       path = fetchurl {
@@ -1711,7 +1521,6 @@
         sha1 = "9bcd52e14c097763e749b274c4346ed2e560b5a9";
       };
     }
-
     {
       name = "des.js___des.js_1.0.0.tgz";
       path = fetchurl {
@@ -1720,7 +1529,6 @@
         sha1 = "c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc";
       };
     }
-
     {
       name = "destroy___destroy_1.0.4.tgz";
       path = fetchurl {
@@ -1729,7 +1537,6 @@
         sha1 = "978857442c44749e4206613e37946205826abd80";
       };
     }
-
     {
       name = "detect_file___detect_file_1.0.0.tgz";
       path = fetchurl {
@@ -1738,7 +1545,6 @@
         sha1 = "f0d66d03672a825cb1b73bdb3fe62310c8e552b7";
       };
     }
-
     {
       name = "detect_libc___detect_libc_1.0.3.tgz";
       path = fetchurl {
@@ -1747,7 +1553,6 @@
         sha1 = "fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b";
       };
     }
-
     {
       name = "detect_node___detect_node_2.0.4.tgz";
       path = fetchurl {
@@ -1756,7 +1561,6 @@
         sha1 = "014ee8f8f669c5c58023da64b8179c083a28c46c";
       };
     }
-
     {
       name = "diffie_hellman___diffie_hellman_5.0.3.tgz";
       path = fetchurl {
@@ -1765,7 +1569,6 @@
         sha1 = "40e8ee98f55a2149607146921c63e1ae5f3d2875";
       };
     }
-
     {
       name = "discontinuous_range___discontinuous_range_1.0.0.tgz";
       path = fetchurl {
@@ -1774,7 +1577,6 @@
         sha1 = "e38331f0844bba49b9a9cb71c771585aab1bc65a";
       };
     }
-
     {
       name = "dns_equal___dns_equal_1.0.0.tgz";
       path = fetchurl {
@@ -1783,7 +1585,6 @@
         sha1 = "b39e7f1da6eb0a75ba9c17324b34753c47e0654d";
       };
     }
-
     {
       name = "dns_packet___dns_packet_1.3.1.tgz";
       path = fetchurl {
@@ -1792,7 +1593,6 @@
         sha1 = "12aa426981075be500b910eedcd0b47dd7deda5a";
       };
     }
-
     {
       name = "dns_txt___dns_txt_2.0.2.tgz";
       path = fetchurl {
@@ -1801,7 +1601,6 @@
         sha1 = "b91d806f5d27188e4ab3e7d107d881a1cc4642b6";
       };
     }
-
     {
       name = "dom_converter___dom_converter_0.2.0.tgz";
       path = fetchurl {
@@ -1810,7 +1609,6 @@
         sha1 = "6721a9daee2e293682955b6afe416771627bb768";
       };
     }
-
     {
       name = "dom_serializer___dom_serializer_0.1.1.tgz";
       path = fetchurl {
@@ -1819,7 +1617,6 @@
         sha1 = "1ec4059e284babed36eec2941d4a970a189ce7c0";
       };
     }
-
     {
       name = "domain_browser___domain_browser_1.2.0.tgz";
       path = fetchurl {
@@ -1828,7 +1625,6 @@
         sha1 = "3d31f50191a6749dd1375a7f522e823d42e54eda";
       };
     }
-
     {
       name = "domelementtype___domelementtype_1.3.1.tgz";
       path = fetchurl {
@@ -1837,7 +1633,6 @@
         sha1 = "d048c44b37b0d10a7f2a3d5fee3f4333d790481f";
       };
     }
-
     {
       name = "domexception___domexception_1.0.1.tgz";
       path = fetchurl {
@@ -1846,7 +1641,6 @@
         sha1 = "937442644ca6a31261ef36e3ec677fe805582c90";
       };
     }
-
     {
       name = "domhandler___domhandler_2.4.2.tgz";
       path = fetchurl {
@@ -1855,7 +1649,6 @@
         sha1 = "8805097e933d65e85546f726d60f5eb88b44f803";
       };
     }
-
     {
       name = "domutils___domutils_1.5.1.tgz";
       path = fetchurl {
@@ -1864,7 +1657,6 @@
         sha1 = "dcd8488a26f563d61079e48c9f7b7e32373682cf";
       };
     }
-
     {
       name = "domutils___domutils_1.7.0.tgz";
       path = fetchurl {
@@ -1873,7 +1665,6 @@
         sha1 = "56ea341e834e06e6748af7a1cb25da67ea9f8c2a";
       };
     }
-
     {
       name = "duplexify___duplexify_3.7.1.tgz";
       path = fetchurl {
@@ -1882,7 +1673,6 @@
         sha1 = "2a4df5317f6ccfd91f86d6fd25d8d8a103b88309";
       };
     }
-
     {
       name = "ecc_jsbn___ecc_jsbn_0.1.2.tgz";
       path = fetchurl {
@@ -1891,7 +1681,6 @@
         sha1 = "3a83a904e54353287874c564b7549386849a98c9";
       };
     }
-
     {
       name = "ee_first___ee_first_1.1.1.tgz";
       path = fetchurl {
@@ -1900,7 +1689,6 @@
         sha1 = "590c61156b0ae2f4f0255732a158b266bc56b21d";
       };
     }
-
     {
       name = "elliptic___elliptic_6.4.1.tgz";
       path = fetchurl {
@@ -1909,7 +1697,6 @@
         sha1 = "c2d0b7776911b86722c632c3c06c60f2f819939a";
       };
     }
-
     {
       name = "emojis_list___emojis_list_2.1.0.tgz";
       path = fetchurl {
@@ -1918,7 +1705,6 @@
         sha1 = "4daa4d9db00f9819880c79fa457ae5b09a1fd389";
       };
     }
-
     {
       name = "emojis_list___emojis_list_3.0.0.tgz";
       path = fetchurl {
@@ -1927,7 +1713,6 @@
         sha1 = "5570662046ad29e2e916e71aae260abdff4f6a78";
       };
     }
-
     {
       name = "encodeurl___encodeurl_1.0.2.tgz";
       path = fetchurl {
@@ -1936,7 +1721,6 @@
         sha1 = "ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59";
       };
     }
-
     {
       name = "end_of_stream___end_of_stream_1.4.1.tgz";
       path = fetchurl {
@@ -1945,7 +1729,6 @@
         sha1 = "ed29634d19baba463b6ce6b80a37213eab71ec43";
       };
     }
-
     {
       name = "enhanced_resolve___enhanced_resolve_4.1.1.tgz";
       path = fetchurl {
@@ -1954,7 +1737,6 @@
         sha1 = "2937e2b8066cd0fe7ce0990a98f0d71a35189f66";
       };
     }
-
     {
       name = "enhanced_resolve___enhanced_resolve_4.1.0.tgz";
       path = fetchurl {
@@ -1963,7 +1745,6 @@
         sha1 = "41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f";
       };
     }
-
     {
       name = "entities___entities_1.1.2.tgz";
       path = fetchurl {
@@ -1972,7 +1753,6 @@
         sha1 = "bdfa735299664dfafd34529ed4f8522a275fea56";
       };
     }
-
     {
       name = "err_code___err_code_1.1.2.tgz";
       path = fetchurl {
@@ -1981,7 +1761,6 @@
         sha1 = "06e0116d3028f6aef4806849eb0ea6a748ae6960";
       };
     }
-
     {
       name = "errno___errno_0.1.7.tgz";
       path = fetchurl {
@@ -1990,7 +1769,6 @@
         sha1 = "4684d71779ad39af177e3f007996f7c67c852618";
       };
     }
-
     {
       name = "error_ex___error_ex_1.3.2.tgz";
       path = fetchurl {
@@ -1999,7 +1777,6 @@
         sha1 = "b4ac40648107fdcdcfae242f428bea8a14d4f1bf";
       };
     }
-
     {
       name = "es_abstract___es_abstract_1.13.0.tgz";
       path = fetchurl {
@@ -2008,7 +1785,6 @@
         sha1 = "ac86145fdd5099d8dd49558ccba2eaf9b88e24e9";
       };
     }
-
     {
       name = "es_to_primitive___es_to_primitive_1.2.0.tgz";
       path = fetchurl {
@@ -2017,7 +1793,6 @@
         sha1 = "edf72478033456e8dda8ef09e00ad9650707f377";
       };
     }
-
     {
       name = "escape_html___escape_html_1.0.3.tgz";
       path = fetchurl {
@@ -2026,7 +1801,6 @@
         sha1 = "0258eae4d3d0c0974de1c169188ef0051d1d1988";
       };
     }
-
     {
       name = "escape_string_regexp___escape_string_regexp_1.0.5.tgz";
       path = fetchurl {
@@ -2035,7 +1809,6 @@
         sha1 = "1b61c0562190a8dff6ae3bb2cf0200ca130b86d4";
       };
     }
-
     {
       name = "escodegen___escodegen_1.14.3.tgz";
       path = fetchurl {
@@ -2044,7 +1817,6 @@
         sha1 = "4e7b81fba61581dc97582ed78cab7f0e8d63f503";
       };
     }
-
     {
       name = "eslint_scope___eslint_scope_4.0.3.tgz";
       path = fetchurl {
@@ -2053,7 +1825,6 @@
         sha1 = "ca03833310f6889a3264781aa82e63eb9cfe7848";
       };
     }
-
     {
       name = "esprima___esprima_4.0.1.tgz";
       path = fetchurl {
@@ -2062,7 +1833,6 @@
         sha1 = "13b04cdb3e6c5d19df91ab6987a8695619b0aa71";
       };
     }
-
     {
       name = "esrecurse___esrecurse_4.2.1.tgz";
       path = fetchurl {
@@ -2071,7 +1841,6 @@
         sha1 = "007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf";
       };
     }
-
     {
       name = "estraverse___estraverse_4.2.0.tgz";
       path = fetchurl {
@@ -2080,7 +1849,6 @@
         sha1 = "0dee3fed31fcd469618ce7342099fc1afa0bdb13";
       };
     }
-
     {
       name = "estraverse___estraverse_4.3.0.tgz";
       path = fetchurl {
@@ -2089,7 +1857,6 @@
         sha1 = "398ad3f3c5a24948be7725e83d11a7de28cdbd1d";
       };
     }
-
     {
       name = "esutils___esutils_2.0.3.tgz";
       path = fetchurl {
@@ -2098,7 +1865,6 @@
         sha1 = "74d2eb4de0b8da1293711910d50775b9b710ef64";
       };
     }
-
     {
       name = "etag___etag_1.8.1.tgz";
       path = fetchurl {
@@ -2107,7 +1873,6 @@
         sha1 = "41ae2eeb65efa62268aebfea83ac7d79299b0887";
       };
     }
-
     {
       name = "eventemitter3___eventemitter3_3.1.0.tgz";
       path = fetchurl {
@@ -2116,7 +1881,6 @@
         sha1 = "090b4d6cdbd645ed10bf750d4b5407942d7ba163";
       };
     }
-
     {
       name = "events___events_3.0.0.tgz";
       path = fetchurl {
@@ -2125,7 +1889,6 @@
         sha1 = "9a0a0dfaf62893d92b875b8f2698ca4114973e88";
       };
     }
-
     {
       name = "eventsource___eventsource_1.0.7.tgz";
       path = fetchurl {
@@ -2134,7 +1897,6 @@
         sha1 = "8fbc72c93fcd34088090bc0a4e64f4b5cee6d8d0";
       };
     }
-
     {
       name = "evp_bytestokey___evp_bytestokey_1.0.3.tgz";
       path = fetchurl {
@@ -2143,7 +1905,6 @@
         sha1 = "7fcbdb198dc71959432efe13842684e0525acb02";
       };
     }
-
     {
       name = "execa___execa_1.0.0.tgz";
       path = fetchurl {
@@ -2152,7 +1913,6 @@
         sha1 = "c6236a5bb4df6d6f15e88e7f017798216749ddd8";
       };
     }
-
     {
       name = "expand_brackets___expand_brackets_2.1.4.tgz";
       path = fetchurl {
@@ -2161,7 +1921,6 @@
         sha1 = "b77735e315ce30f6b6eff0f83b04151a22449622";
       };
     }
-
     {
       name = "expand_tilde___expand_tilde_2.0.2.tgz";
       path = fetchurl {
@@ -2170,7 +1929,6 @@
         sha1 = "97e801aa052df02454de46b02bf621642cdc8502";
       };
     }
-
     {
       name = "express___express_4.16.4.tgz";
       path = fetchurl {
@@ -2179,7 +1937,6 @@
         sha1 = "fddef61926109e24c515ea97fd2f1bdbf62df12e";
       };
     }
-
     {
       name = "extend_shallow___extend_shallow_2.0.1.tgz";
       path = fetchurl {
@@ -2188,7 +1945,6 @@
         sha1 = "51af7d614ad9a9f610ea1bafbb989d6b1c56890f";
       };
     }
-
     {
       name = "extend_shallow___extend_shallow_3.0.2.tgz";
       path = fetchurl {
@@ -2197,7 +1953,6 @@
         sha1 = "26a71aaf073b39fb2127172746131c2704028db8";
       };
     }
-
     {
       name = "extend___extend_3.0.2.tgz";
       path = fetchurl {
@@ -2206,7 +1961,6 @@
         sha1 = "f8b1136b4071fbd8eb140aff858b1019ec2915fa";
       };
     }
-
     {
       name = "extglob___extglob_2.0.4.tgz";
       path = fetchurl {
@@ -2215,7 +1969,6 @@
         sha1 = "ad00fe4dc612a9232e8718711dc5cb5ab0285543";
       };
     }
-
     {
       name = "extsprintf___extsprintf_1.3.0.tgz";
       path = fetchurl {
@@ -2224,7 +1977,6 @@
         sha1 = "96918440e3041a7a414f8c52e3c574eb3c3e1e05";
       };
     }
-
     {
       name = "extsprintf___extsprintf_1.4.0.tgz";
       path = fetchurl {
@@ -2233,7 +1985,6 @@
         sha1 = "e2689f8f356fad62cca65a3a91c5df5f9551692f";
       };
     }
-
     {
       name = "fast_deep_equal___fast_deep_equal_2.0.1.tgz";
       path = fetchurl {
@@ -2242,7 +1993,6 @@
         sha1 = "7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49";
       };
     }
-
     {
       name = "fast_deep_equal___fast_deep_equal_3.1.3.tgz";
       path = fetchurl {
@@ -2251,7 +2001,6 @@
         sha1 = "3a7d56b559d6cbc3eb512325244e619a65c6c525";
       };
     }
-
     {
       name = "fast_json_stable_stringify___fast_json_stable_stringify_2.1.0.tgz";
       path = fetchurl {
@@ -2260,7 +2009,6 @@
         sha1 = "874bf69c6f404c2b5d99c481341399fd55892633";
       };
     }
-
     {
       name = "fast_levenshtein___fast_levenshtein_2.0.6.tgz";
       path = fetchurl {
@@ -2269,7 +2017,6 @@
         sha1 = "3d8a5c66883a16a30ca8643e851f19baa7797917";
       };
     }
-
     {
       name = "fastparse___fastparse_1.1.2.tgz";
       path = fetchurl {
@@ -2278,7 +2025,6 @@
         sha1 = "91728c5a5942eced8531283c79441ee4122c35a9";
       };
     }
-
     {
       name = "faye_websocket___faye_websocket_0.10.0.tgz";
       path = fetchurl {
@@ -2287,7 +2033,6 @@
         sha1 = "4e492f8d04dfb6f89003507f6edbf2d501e7c6f4";
       };
     }
-
     {
       name = "faye_websocket___faye_websocket_0.11.1.tgz";
       path = fetchurl {
@@ -2296,7 +2041,6 @@
         sha1 = "f0efe18c4f56e4f40afc7e06c719fd5ee6188f38";
       };
     }
-
     {
       name = "figgy_pudding___figgy_pudding_3.5.1.tgz";
       path = fetchurl {
@@ -2305,7 +2049,6 @@
         sha1 = "862470112901c727a0e495a80744bd5baa1d6790";
       };
     }
-
     {
       name = "file_loader___file_loader_2.0.0.tgz";
       path = fetchurl {
@@ -2314,7 +2057,6 @@
         sha1 = "39749c82f020b9e85901dcff98e8004e6401cfde";
       };
     }
-
     {
       name = "fill_range___fill_range_4.0.0.tgz";
       path = fetchurl {
@@ -2323,7 +2065,6 @@
         sha1 = "d544811d428f98eb06a63dc402d2403c328c38f7";
       };
     }
-
     {
       name = "fill_range___fill_range_7.0.1.tgz";
       path = fetchurl {
@@ -2332,7 +2073,6 @@
         sha1 = "1919a6a7c75fe38b2c7c77e5198535da9acdda40";
       };
     }
-
     {
       name = "finalhandler___finalhandler_1.1.1.tgz";
       path = fetchurl {
@@ -2341,7 +2081,6 @@
         sha1 = "eebf4ed840079c83f4249038c9d703008301b105";
       };
     }
-
     {
       name = "find_cache_dir___find_cache_dir_2.1.0.tgz";
       path = fetchurl {
@@ -2350,7 +2089,6 @@
         sha1 = "8d0f94cd13fe43c6c7c261a0d86115ca918c05f7";
       };
     }
-
     {
       name = "find_up___find_up_1.1.2.tgz";
       path = fetchurl {
@@ -2359,7 +2097,6 @@
         sha1 = "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f";
       };
     }
-
     {
       name = "find_up___find_up_3.0.0.tgz";
       path = fetchurl {
@@ -2368,7 +2105,6 @@
         sha1 = "49169f1d7993430646da61ecc5ae355c21c97b73";
       };
     }
-
     {
       name = "findup_sync___findup_sync_2.0.0.tgz";
       path = fetchurl {
@@ -2377,7 +2113,6 @@
         sha1 = "9326b1488c22d1a6088650a86901b2d9a90a2cbc";
       };
     }
-
     {
       name = "flush_write_stream___flush_write_stream_1.1.1.tgz";
       path = fetchurl {
@@ -2386,7 +2121,6 @@
         sha1 = "8dd7d873a1babc207d94ead0c2e0e44276ebf2e8";
       };
     }
-
     {
       name = "follow_redirects___follow_redirects_1.7.0.tgz";
       path = fetchurl {
@@ -2395,7 +2129,6 @@
         sha1 = "489ebc198dc0e7f64167bd23b03c4c19b5784c76";
       };
     }
-
     {
       name = "for_in___for_in_0.1.8.tgz";
       path = fetchurl {
@@ -2404,7 +2137,6 @@
         sha1 = "d8773908e31256109952b1fdb9b3fa867d2775e1";
       };
     }
-
     {
       name = "for_in___for_in_1.0.2.tgz";
       path = fetchurl {
@@ -2413,7 +2145,6 @@
         sha1 = "81068d295a8142ec0ac726c6e2200c30fb6d5e80";
       };
     }
-
     {
       name = "for_own___for_own_1.0.0.tgz";
       path = fetchurl {
@@ -2422,7 +2153,6 @@
         sha1 = "c63332f415cedc4b04dbfe70cf836494c53cb44b";
       };
     }
-
     {
       name = "forever_agent___forever_agent_0.6.1.tgz";
       path = fetchurl {
@@ -2431,7 +2161,6 @@
         sha1 = "fbc71f0c41adeb37f96c577ad1ed42d8fdacca91";
       };
     }
-
     {
       name = "form_data___form_data_2.3.3.tgz";
       path = fetchurl {
@@ -2440,7 +2169,6 @@
         sha1 = "dcce52c05f644f298c6a7ab936bd724ceffbf3a6";
       };
     }
-
     {
       name = "forwarded___forwarded_0.1.2.tgz";
       path = fetchurl {
@@ -2449,7 +2177,6 @@
         sha1 = "98c23dab1175657b8c0573e8ceccd91b0ff18c84";
       };
     }
-
     {
       name = "fragment_cache___fragment_cache_0.2.1.tgz";
       path = fetchurl {
@@ -2458,7 +2185,6 @@
         sha1 = "4290fad27f13e89be7f33799c6bc5a0abfff0d19";
       };
     }
-
     {
       name = "fresh___fresh_0.5.2.tgz";
       path = fetchurl {
@@ -2467,7 +2193,6 @@
         sha1 = "3d8cadd90d976569fa835ab1f8e4b23a105605a7";
       };
     }
-
     {
       name = "from2___from2_2.3.0.tgz";
       path = fetchurl {
@@ -2476,7 +2201,6 @@
         sha1 = "8bfb5502bde4a4d36cfdeea007fcca21d7e382af";
       };
     }
-
     {
       name = "fs_minipass___fs_minipass_1.2.5.tgz";
       path = fetchurl {
@@ -2485,7 +2209,6 @@
         sha1 = "06c277218454ec288df77ada54a03b8702aacb9d";
       };
     }
-
     {
       name = "fs_write_stream_atomic___fs_write_stream_atomic_1.0.10.tgz";
       path = fetchurl {
@@ -2494,7 +2217,6 @@
         sha1 = "b47df53493ef911df75731e70a9ded0189db40c9";
       };
     }
-
     {
       name = "fs.realpath___fs.realpath_1.0.0.tgz";
       path = fetchurl {
@@ -2503,7 +2225,6 @@
         sha1 = "1504ad2523158caa40db4a2787cb01411994ea4f";
       };
     }
-
     {
       name = "fsevents___fsevents_1.2.7.tgz";
       path = fetchurl {
@@ -2512,7 +2233,6 @@
         sha1 = "4851b664a3783e52003b3c66eb0eee1074933aa4";
       };
     }
-
     {
       name = "fstream___fstream_1.0.11.tgz";
       path = fetchurl {
@@ -2521,7 +2241,6 @@
         sha1 = "5c1fb1f117477114f0632a0eb4b71b3cb0fd3171";
       };
     }
-
     {
       name = "function_bind___function_bind_1.1.1.tgz";
       path = fetchurl {
@@ -2530,7 +2249,6 @@
         sha1 = "a56899d3ea3c9bab874bb9773b7c5ede92f4895d";
       };
     }
-
     {
       name = "gauge___gauge_2.7.4.tgz";
       path = fetchurl {
@@ -2539,7 +2257,6 @@
         sha1 = "2c03405c7538c39d7eb37b317022e325fb018bf7";
       };
     }
-
     {
       name = "gaze___gaze_1.1.3.tgz";
       path = fetchurl {
@@ -2548,7 +2265,6 @@
         sha1 = "c441733e13b927ac8c0ff0b4c3b033f28812924a";
       };
     }
-
     {
       name = "get_caller_file___get_caller_file_1.0.3.tgz";
       path = fetchurl {
@@ -2557,7 +2273,6 @@
         sha1 = "f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a";
       };
     }
-
     {
       name = "get_stdin___get_stdin_4.0.1.tgz";
       path = fetchurl {
@@ -2566,7 +2281,6 @@
         sha1 = "b968c6b0a04384324902e8bf1a5df32579a450fe";
       };
     }
-
     {
       name = "get_stream___get_stream_4.1.0.tgz";
       path = fetchurl {
@@ -2575,7 +2289,6 @@
         sha1 = "c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5";
       };
     }
-
     {
       name = "get_value___get_value_2.0.6.tgz";
       path = fetchurl {
@@ -2584,7 +2297,6 @@
         sha1 = "dc15ca1c672387ca76bd37ac0a395ba2042a2c28";
       };
     }
-
     {
       name = "getpass___getpass_0.1.7.tgz";
       path = fetchurl {
@@ -2593,7 +2305,6 @@
         sha1 = "5eff8e3e684d569ae4cb2b1282604e8ba62149fa";
       };
     }
-
     {
       name = "glob_parent___glob_parent_3.1.0.tgz";
       path = fetchurl {
@@ -2602,7 +2313,6 @@
         sha1 = "9e6af6299d8d3bd2bd40430832bd113df906c5ae";
       };
     }
-
     {
       name = "glob___glob_6.0.4.tgz";
       path = fetchurl {
@@ -2611,7 +2321,6 @@
         sha1 = "0f08860f6a155127b2fadd4f9ce24b1aab6e4d22";
       };
     }
-
     {
       name = "glob___glob_7.1.3.tgz";
       path = fetchurl {
@@ -2620,7 +2329,6 @@
         sha1 = "3960832d3f1574108342dafd3a67b332c0969df1";
       };
     }
-
     {
       name = "glob___glob_7.1.4.tgz";
       path = fetchurl {
@@ -2629,7 +2337,6 @@
         sha1 = "aa608a2f6c577ad357e1ae5a5c26d9a8d1969255";
       };
     }
-
     {
       name = "global_modules___global_modules_1.0.0.tgz";
       path = fetchurl {
@@ -2638,7 +2345,6 @@
         sha1 = "6d770f0eb523ac78164d72b5e71a8877265cc3ea";
       };
     }
-
     {
       name = "global_prefix___global_prefix_1.0.2.tgz";
       path = fetchurl {
@@ -2647,7 +2353,6 @@
         sha1 = "dbf743c6c14992593c655568cb66ed32c0122ebe";
       };
     }
-
     {
       name = "globby___globby_4.1.0.tgz";
       path = fetchurl {
@@ -2656,7 +2361,6 @@
         sha1 = "080f54549ec1b82a6c60e631fc82e1211dbe95f8";
       };
     }
-
     {
       name = "globby___globby_6.1.0.tgz";
       path = fetchurl {
@@ -2665,7 +2369,6 @@
         sha1 = "f5a6d70e8395e21c858fb0489d64df02424d506c";
       };
     }
-
     {
       name = "globule___globule_1.2.1.tgz";
       path = fetchurl {
@@ -2674,7 +2377,6 @@
         sha1 = "5dffb1b191f22d20797a9369b49eab4e9839696d";
       };
     }
-
     {
       name = "graceful_fs___graceful_fs_4.1.15.tgz";
       path = fetchurl {
@@ -2683,7 +2385,6 @@
         sha1 = "ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00";
       };
     }
-
     {
       name = "handle_thing___handle_thing_2.0.0.tgz";
       path = fetchurl {
@@ -2692,7 +2393,6 @@
         sha1 = "0e039695ff50c93fc288557d696f3c1dc6776754";
       };
     }
-
     {
       name = "har_schema___har_schema_2.0.0.tgz";
       path = fetchurl {
@@ -2701,7 +2401,6 @@
         sha1 = "a94c2224ebcac04782a0d9035521f24735b7ec92";
       };
     }
-
     {
       name = "har_validator___har_validator_5.1.3.tgz";
       path = fetchurl {
@@ -2710,7 +2409,6 @@
         sha1 = "1ef89ebd3e4996557675eed9893110dc350fa080";
       };
     }
-
     {
       name = "has_ansi___has_ansi_2.0.0.tgz";
       path = fetchurl {
@@ -2719,7 +2417,6 @@
         sha1 = "34f5049ce1ecdf2b0649af3ef24e45ed35416d91";
       };
     }
-
     {
       name = "has_flag___has_flag_3.0.0.tgz";
       path = fetchurl {
@@ -2728,7 +2425,6 @@
         sha1 = "b5d454dc2199ae225699f3467e5a07f3b955bafd";
       };
     }
-
     {
       name = "has_symbols___has_symbols_1.0.0.tgz";
       path = fetchurl {
@@ -2737,7 +2433,6 @@
         sha1 = "ba1a8f1af2a0fc39650f5c850367704122063b44";
       };
     }
-
     {
       name = "has_unicode___has_unicode_2.0.1.tgz";
       path = fetchurl {
@@ -2746,7 +2441,6 @@
         sha1 = "e0e6fe6a28cf51138855e086d1691e771de2a8b9";
       };
     }
-
     {
       name = "has_value___has_value_0.3.1.tgz";
       path = fetchurl {
@@ -2755,7 +2449,6 @@
         sha1 = "7b1f58bada62ca827ec0a2078025654845995e1f";
       };
     }
-
     {
       name = "has_value___has_value_1.0.0.tgz";
       path = fetchurl {
@@ -2764,7 +2457,6 @@
         sha1 = "18b281da585b1c5c51def24c930ed29a0be6b177";
       };
     }
-
     {
       name = "has_values___has_values_0.1.4.tgz";
       path = fetchurl {
@@ -2773,7 +2465,6 @@
         sha1 = "6d61de95d91dfca9b9a02089ad384bff8f62b771";
       };
     }
-
     {
       name = "has_values___has_values_1.0.0.tgz";
       path = fetchurl {
@@ -2782,7 +2473,6 @@
         sha1 = "95b0b63fec2146619a6fe57fe75628d5a39efe4f";
       };
     }
-
     {
       name = "has___has_1.0.3.tgz";
       path = fetchurl {
@@ -2791,7 +2481,6 @@
         sha1 = "722d7cbfc1f6aa8241f16dd814e011e1f41e8796";
       };
     }
-
     {
       name = "hash_base___hash_base_3.0.4.tgz";
       path = fetchurl {
@@ -2800,7 +2489,6 @@
         sha1 = "5fc8686847ecd73499403319a6b0a3f3f6ae4918";
       };
     }
-
     {
       name = "hash.js___hash.js_1.1.7.tgz";
       path = fetchurl {
@@ -2809,7 +2497,6 @@
         sha1 = "0babca538e8d4ee4a0f8988d68866537a003cf42";
       };
     }
-
     {
       name = "he___he_1.2.0.tgz";
       path = fetchurl {
@@ -2818,7 +2505,6 @@
         sha1 = "84ae65fa7eafb165fddb61566ae14baf05664f0f";
       };
     }
-
     {
       name = "hmac_drbg___hmac_drbg_1.0.1.tgz";
       path = fetchurl {
@@ -2827,7 +2513,6 @@
         sha1 = "d2745701025a6c775a6c545793ed502fc0c649a1";
       };
     }
-
     {
       name = "homedir_polyfill___homedir_polyfill_1.0.3.tgz";
       path = fetchurl {
@@ -2836,7 +2521,6 @@
         sha1 = "743298cef4e5af3e194161fbadcc2151d3a058e8";
       };
     }
-
     {
       name = "hosted_git_info___hosted_git_info_2.7.1.tgz";
       path = fetchurl {
@@ -2845,7 +2529,6 @@
         sha1 = "97f236977bd6e125408930ff6de3eec6281ec047";
       };
     }
-
     {
       name = "hpack.js___hpack.js_2.1.6.tgz";
       path = fetchurl {
@@ -2854,7 +2537,6 @@
         sha1 = "87774c0949e513f42e84575b3c45681fade2a0b2";
       };
     }
-
     {
       name = "html_encoding_sniffer___html_encoding_sniffer_1.0.2.tgz";
       path = fetchurl {
@@ -2863,7 +2545,6 @@
         sha1 = "e70d84b94da53aa375e11fe3a351be6642ca46f8";
       };
     }
-
     {
       name = "html_entities___html_entities_1.2.1.tgz";
       path = fetchurl {
@@ -2872,7 +2553,6 @@
         sha1 = "0df29351f0721163515dfb9e5543e5f6eed5162f";
       };
     }
-
     {
       name = "html_minifier___html_minifier_3.5.21.tgz";
       path = fetchurl {
@@ -2881,7 +2561,6 @@
         sha1 = "d0040e054730e354db008463593194015212d20c";
       };
     }
-
     {
       name = "html_webpack_plugin___html_webpack_plugin_3.2.0.tgz";
       path = fetchurl {
@@ -2890,7 +2569,6 @@
         sha1 = "b01abbd723acaaa7b37b6af4492ebda03d9dd37b";
       };
     }
-
     {
       name = "htmlparser2___htmlparser2_3.10.1.tgz";
       path = fetchurl {
@@ -2899,7 +2577,6 @@
         sha1 = "bd679dc3f59897b6a34bb10749c855bb53a9392f";
       };
     }
-
     {
       name = "http_deceiver___http_deceiver_1.2.7.tgz";
       path = fetchurl {
@@ -2908,7 +2585,6 @@
         sha1 = "fa7168944ab9a519d337cb0bec7284dc3e723d87";
       };
     }
-
     {
       name = "http_errors___http_errors_1.6.3.tgz";
       path = fetchurl {
@@ -2917,7 +2593,6 @@
         sha1 = "8b55680bb4be283a0b5bf4ea2e38580be1d9320d";
       };
     }
-
     {
       name = "http_parser_js___http_parser_js_0.5.0.tgz";
       path = fetchurl {
@@ -2926,7 +2601,6 @@
         sha1 = "d65edbede84349d0dc30320815a15d39cc3cbbd8";
       };
     }
-
     {
       name = "http_proxy_middleware___http_proxy_middleware_0.19.1.tgz";
       path = fetchurl {
@@ -2935,7 +2609,6 @@
         sha1 = "183c7dc4aa1479150306498c210cdaf96080a43a";
       };
     }
-
     {
       name = "http_proxy___http_proxy_1.17.0.tgz";
       path = fetchurl {
@@ -2944,7 +2617,6 @@
         sha1 = "7ad38494658f84605e2f6db4436df410f4e5be9a";
       };
     }
-
     {
       name = "http_signature___http_signature_1.2.0.tgz";
       path = fetchurl {
@@ -2953,7 +2625,6 @@
         sha1 = "9aecd925114772f3d95b65a60abb8f7c18fbace1";
       };
     }
-
     {
       name = "https_browserify___https_browserify_1.0.0.tgz";
       path = fetchurl {
@@ -2962,7 +2633,6 @@
         sha1 = "ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73";
       };
     }
-
     {
       name = "iconv_lite___iconv_lite_0.4.23.tgz";
       path = fetchurl {
@@ -2971,7 +2641,6 @@
         sha1 = "297871f63be507adcfbfca715d0cd0eed84e9a63";
       };
     }
-
     {
       name = "iconv_lite___iconv_lite_0.4.24.tgz";
       path = fetchurl {
@@ -2980,7 +2649,6 @@
         sha1 = "2022b4b25fbddc21d2f524974a474aafe733908b";
       };
     }
-
     {
       name = "icss_replace_symbols___icss_replace_symbols_1.1.0.tgz";
       path = fetchurl {
@@ -2989,7 +2657,6 @@
         sha1 = "06ea6f83679a7749e386cfe1fe812ae5db223ded";
       };
     }
-
     {
       name = "icss_utils___icss_utils_2.1.0.tgz";
       path = fetchurl {
@@ -2998,7 +2665,6 @@
         sha1 = "83f0a0ec378bf3246178b6c2ad9136f135b1c962";
       };
     }
-
     {
       name = "ieee754___ieee754_1.1.12.tgz";
       path = fetchurl {
@@ -3007,7 +2673,6 @@
         sha1 = "50bf24e5b9c8bb98af4964c941cdb0918da7b60b";
       };
     }
-
     {
       name = "iferr___iferr_0.1.5.tgz";
       path = fetchurl {
@@ -3016,7 +2681,6 @@
         sha1 = "c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501";
       };
     }
-
     {
       name = "ignore_walk___ignore_walk_3.0.1.tgz";
       path = fetchurl {
@@ -3025,7 +2689,6 @@
         sha1 = "a83e62e7d272ac0e3b551aaa82831a19b69f82f8";
       };
     }
-
     {
       name = "import_local___import_local_2.0.0.tgz";
       path = fetchurl {
@@ -3034,7 +2697,6 @@
         sha1 = "55070be38a5993cf18ef6db7e961f5bee5c5a09d";
       };
     }
-
     {
       name = "imurmurhash___imurmurhash_0.1.4.tgz";
       path = fetchurl {
@@ -3043,7 +2705,6 @@
         sha1 = "9218b9b2b928a238b13dc4fb6b6d576f231453ea";
       };
     }
-
     {
       name = "in_publish___in_publish_2.0.0.tgz";
       path = fetchurl {
@@ -3052,7 +2713,6 @@
         sha1 = "e20ff5e3a2afc2690320b6dc552682a9c7fadf51";
       };
     }
-
     {
       name = "indent_string___indent_string_2.1.0.tgz";
       path = fetchurl {
@@ -3061,7 +2721,6 @@
         sha1 = "8e2d48348742121b4a8218b7a137e9a52049dc80";
       };
     }
-
     {
       name = "infer_owner___infer_owner_1.0.4.tgz";
       path = fetchurl {
@@ -3070,7 +2729,6 @@
         sha1 = "c4cefcaa8e51051c2a40ba2ce8a3d27295af9467";
       };
     }
-
     {
       name = "inflight___inflight_1.0.6.tgz";
       path = fetchurl {
@@ -3079,7 +2737,6 @@
         sha1 = "49bd6331d7d02d0c09bc910a1075ba8165b56df9";
       };
     }
-
     {
       name = "inherits___inherits_2.0.3.tgz";
       path = fetchurl {
@@ -3088,7 +2745,6 @@
         sha1 = "633c2c83e3da42a502f52466022480f4208261de";
       };
     }
-
     {
       name = "inherits___inherits_2.0.1.tgz";
       path = fetchurl {
@@ -3097,7 +2753,6 @@
         sha1 = "b17d08d326b4423e568eff719f91b0b1cbdf69f1";
       };
     }
-
     {
       name = "ini___ini_1.3.5.tgz";
       path = fetchurl {
@@ -3106,7 +2761,6 @@
         sha1 = "eee25f56db1c9ec6085e0c22778083f596abf927";
       };
     }
-
     {
       name = "internal_ip___internal_ip_4.2.0.tgz";
       path = fetchurl {
@@ -3115,7 +2769,6 @@
         sha1 = "46e81b638d84c338e5c67e42b1a17db67d0814fa";
       };
     }
-
     {
       name = "interpret___interpret_1.2.0.tgz";
       path = fetchurl {
@@ -3124,7 +2777,6 @@
         sha1 = "d5061a6224be58e8083985f5014d844359576296";
       };
     }
-
     {
       name = "invert_kv___invert_kv_1.0.0.tgz";
       path = fetchurl {
@@ -3133,7 +2785,6 @@
         sha1 = "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6";
       };
     }
-
     {
       name = "invert_kv___invert_kv_2.0.0.tgz";
       path = fetchurl {
@@ -3142,7 +2793,6 @@
         sha1 = "7393f5afa59ec9ff5f67a27620d11c226e3eec02";
       };
     }
-
     {
       name = "ip_regex___ip_regex_2.1.0.tgz";
       path = fetchurl {
@@ -3151,7 +2801,6 @@
         sha1 = "fa78bf5d2e6913c911ce9f819ee5146bb6d844e9";
       };
     }
-
     {
       name = "ip___ip_1.1.5.tgz";
       path = fetchurl {
@@ -3160,7 +2809,6 @@
         sha1 = "bdded70114290828c0a039e72ef25f5aaec4354a";
       };
     }
-
     {
       name = "ipaddr.js___ipaddr.js_1.8.0.tgz";
       path = fetchurl {
@@ -3169,7 +2817,6 @@
         sha1 = "eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e";
       };
     }
-
     {
       name = "ipaddr.js___ipaddr.js_1.9.0.tgz";
       path = fetchurl {
@@ -3178,7 +2825,6 @@
         sha1 = "37df74e430a0e47550fe54a2defe30d8acd95f65";
       };
     }
-
     {
       name = "is_accessor_descriptor___is_accessor_descriptor_0.1.6.tgz";
       path = fetchurl {
@@ -3187,7 +2833,6 @@
         sha1 = "a9e12cb3ae8d876727eeef3843f8a0897b5c98d6";
       };
     }
-
     {
       name = "is_accessor_descriptor___is_accessor_descriptor_1.0.0.tgz";
       path = fetchurl {
@@ -3196,7 +2841,6 @@
         sha1 = "169c2f6d3df1f992618072365c9b0ea1f6878656";
       };
     }
-
     {
       name = "is_arrayish___is_arrayish_0.2.1.tgz";
       path = fetchurl {
@@ -3205,7 +2849,6 @@
         sha1 = "77c99840527aa8ecb1a8ba697b80645a7a926a9d";
       };
     }
-
     {
       name = "is_binary_path___is_binary_path_1.0.1.tgz";
       path = fetchurl {
@@ -3214,7 +2857,6 @@
         sha1 = "75f16642b480f187a711c814161fd3a4a7655898";
       };
     }
-
     {
       name = "is_buffer___is_buffer_1.1.6.tgz";
       path = fetchurl {
@@ -3223,7 +2865,6 @@
         sha1 = "efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be";
       };
     }
-
     {
       name = "is_callable___is_callable_1.1.4.tgz";
       path = fetchurl {
@@ -3232,7 +2873,6 @@
         sha1 = "1e1adf219e1eeb684d691f9d6a05ff0d30a24d75";
       };
     }
-
     {
       name = "is_data_descriptor___is_data_descriptor_0.1.4.tgz";
       path = fetchurl {
@@ -3241,7 +2881,6 @@
         sha1 = "0b5ee648388e2c860282e793f1856fec3f301b56";
       };
     }
-
     {
       name = "is_data_descriptor___is_data_descriptor_1.0.0.tgz";
       path = fetchurl {
@@ -3250,7 +2889,6 @@
         sha1 = "d84876321d0e7add03990406abbbbd36ba9268c7";
       };
     }
-
     {
       name = "is_date_object___is_date_object_1.0.1.tgz";
       path = fetchurl {
@@ -3259,7 +2897,6 @@
         sha1 = "9aa20eb6aeebbff77fbd33e74ca01b33581d3a16";
       };
     }
-
     {
       name = "is_descriptor___is_descriptor_0.1.6.tgz";
       path = fetchurl {
@@ -3268,7 +2905,6 @@
         sha1 = "366d8240dde487ca51823b1ab9f07a10a78251ca";
       };
     }
-
     {
       name = "is_descriptor___is_descriptor_1.0.2.tgz";
       path = fetchurl {
@@ -3277,7 +2913,6 @@
         sha1 = "3b159746a66604b04f8c81524ba365c5f14d86ec";
       };
     }
-
     {
       name = "is_extendable___is_extendable_0.1.1.tgz";
       path = fetchurl {
@@ -3286,7 +2921,6 @@
         sha1 = "62b110e289a471418e3ec36a617d472e301dfc89";
       };
     }
-
     {
       name = "is_extendable___is_extendable_1.0.1.tgz";
       path = fetchurl {
@@ -3295,7 +2929,6 @@
         sha1 = "a7470f9e426733d81bd81e1155264e3a3507cab4";
       };
     }
-
     {
       name = "is_extglob___is_extglob_2.1.1.tgz";
       path = fetchurl {
@@ -3304,7 +2937,6 @@
         sha1 = "a88c02535791f02ed37c76a1b9ea9773c833f8c2";
       };
     }
-
     {
       name = "is_finite___is_finite_1.0.2.tgz";
       path = fetchurl {
@@ -3313,7 +2945,6 @@
         sha1 = "cc6677695602be550ef11e8b4aa6305342b6d0aa";
       };
     }
-
     {
       name = "is_fullwidth_code_point___is_fullwidth_code_point_1.0.0.tgz";
       path = fetchurl {
@@ -3322,7 +2953,6 @@
         sha1 = "ef9e31386f031a7f0d643af82fde50c457ef00cb";
       };
     }
-
     {
       name = "is_fullwidth_code_point___is_fullwidth_code_point_2.0.0.tgz";
       path = fetchurl {
@@ -3331,7 +2961,6 @@
         sha1 = "a3b30a5c4f199183167aaab93beefae3ddfb654f";
       };
     }
-
     {
       name = "is_glob___is_glob_3.1.0.tgz";
       path = fetchurl {
@@ -3340,7 +2969,6 @@
         sha1 = "7ba5ae24217804ac70707b96922567486cc3e84a";
       };
     }
-
     {
       name = "is_glob___is_glob_4.0.0.tgz";
       path = fetchurl {
@@ -3349,7 +2977,6 @@
         sha1 = "9521c76845cc2610a85203ddf080a958c2ffabc0";
       };
     }
-
     {
       name = "is_number___is_number_3.0.0.tgz";
       path = fetchurl {
@@ -3358,7 +2985,6 @@
         sha1 = "24fd6201a4782cf50561c810276afc7d12d71195";
       };
     }
-
     {
       name = "is_number___is_number_7.0.0.tgz";
       path = fetchurl {
@@ -3367,7 +2993,6 @@
         sha1 = "7535345b896734d5f80c4d06c50955527a14f12b";
       };
     }
-
     {
       name = "is_path_cwd___is_path_cwd_1.0.0.tgz";
       path = fetchurl {
@@ -3376,7 +3001,6 @@
         sha1 = "d225ec23132e89edd38fda767472e62e65f1106d";
       };
     }
-
     {
       name = "is_path_in_cwd___is_path_in_cwd_1.0.1.tgz";
       path = fetchurl {
@@ -3385,7 +3009,6 @@
         sha1 = "5ac48b345ef675339bd6c7a48a912110b241cf52";
       };
     }
-
     {
       name = "is_path_inside___is_path_inside_1.0.1.tgz";
       path = fetchurl {
@@ -3394,7 +3017,6 @@
         sha1 = "8ef5b7de50437a3fdca6b4e865ef7aa55cb48036";
       };
     }
-
     {
       name = "is_plain_object___is_plain_object_2.0.4.tgz";
       path = fetchurl {
@@ -3403,7 +3025,6 @@
         sha1 = "2c163b3fafb1b606d9d17928f05c2a1c38e07677";
       };
     }
-
     {
       name = "is_regex___is_regex_1.0.4.tgz";
       path = fetchurl {
@@ -3412,7 +3033,6 @@
         sha1 = "5517489b547091b0930e095654ced25ee97e9491";
       };
     }
-
     {
       name = "is_stream___is_stream_1.1.0.tgz";
       path = fetchurl {
@@ -3421,7 +3041,6 @@
         sha1 = "12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44";
       };
     }
-
     {
       name = "is_symbol___is_symbol_1.0.2.tgz";
       path = fetchurl {
@@ -3430,7 +3049,6 @@
         sha1 = "a055f6ae57192caee329e7a860118b497a950f38";
       };
     }
-
     {
       name = "is_typedarray___is_typedarray_1.0.0.tgz";
       path = fetchurl {
@@ -3439,7 +3057,6 @@
         sha1 = "e479c80858df0c1b11ddda6940f96011fcda4a9a";
       };
     }
-
     {
       name = "is_utf8___is_utf8_0.2.1.tgz";
       path = fetchurl {
@@ -3448,7 +3065,6 @@
         sha1 = "4b0da1442104d1b336340e80797e865cf39f7d72";
       };
     }
-
     {
       name = "is_windows___is_windows_1.0.2.tgz";
       path = fetchurl {
@@ -3457,7 +3073,6 @@
         sha1 = "d1850eb9791ecd18e6182ce12a30f396634bb19d";
       };
     }
-
     {
       name = "is_wsl___is_wsl_1.1.0.tgz";
       path = fetchurl {
@@ -3466,7 +3081,6 @@
         sha1 = "1f16e4aa22b04d1336b66188a66af3c600c3a66d";
       };
     }
-
     {
       name = "isarray___isarray_1.0.0.tgz";
       path = fetchurl {
@@ -3475,7 +3089,6 @@
         sha1 = "bb935d48582cba168c06834957a54a3e07124f11";
       };
     }
-
     {
       name = "isexe___isexe_2.0.0.tgz";
       path = fetchurl {
@@ -3484,7 +3097,6 @@
         sha1 = "e8fbf374dc556ff8947a10dcb0572d633f2cfa10";
       };
     }
-
     {
       name = "isobject___isobject_2.1.0.tgz";
       path = fetchurl {
@@ -3493,7 +3105,6 @@
         sha1 = "f065561096a3f1da2ef46272f815c840d87e0c89";
       };
     }
-
     {
       name = "isobject___isobject_3.0.1.tgz";
       path = fetchurl {
@@ -3502,7 +3113,6 @@
         sha1 = "4e431e92b11a9731636aa1f9c8d1ccbcfdab78df";
       };
     }
-
     {
       name = "isstream___isstream_0.1.2.tgz";
       path = fetchurl {
@@ -3511,7 +3121,6 @@
         sha1 = "47e63f7af55afa6f92e1500e690eb8b8529c099a";
       };
     }
-
     {
       name = "js_base64___js_base64_2.5.1.tgz";
       path = fetchurl {
@@ -3520,7 +3129,6 @@
         sha1 = "1efa39ef2c5f7980bb1784ade4a8af2de3291121";
       };
     }
-
     {
       name = "js_string_escape___js_string_escape_1.0.1.tgz";
       path = fetchurl {
@@ -3529,7 +3137,6 @@
         sha1 = "e2625badbc0d67c7533e9edc1068c587ae4137ef";
       };
     }
-
     {
       name = "js_tokens___js_tokens_3.0.2.tgz";
       path = fetchurl {
@@ -3538,7 +3145,6 @@
         sha1 = "9866df395102130e38f7f996bceb65443209c25b";
       };
     }
-
     {
       name = "jsbn___jsbn_0.1.1.tgz";
       path = fetchurl {
@@ -3547,7 +3153,6 @@
         sha1 = "a5e654c2e5a2deb5f201d96cefbca80c0ef2f513";
       };
     }
-
     {
       name = "jsdom___jsdom_15.2.1.tgz";
       path = fetchurl {
@@ -3556,7 +3161,6 @@
         sha1 = "d2feb1aef7183f86be521b8c6833ff5296d07ec5";
       };
     }
-
     {
       name = "jsdom___jsdom_6.5.1.tgz";
       path = fetchurl {
@@ -3565,7 +3169,6 @@
         sha1 = "b6064d6a7651081af41d576edc56bc51e00122c0";
       };
     }
-
     {
       name = "jsesc___jsesc_0.5.0.tgz";
       path = fetchurl {
@@ -3574,7 +3177,6 @@
         sha1 = "e7dee66e35d6fc16f710fe91d5cf69f70f08911d";
       };
     }
-
     {
       name = "json_parse_better_errors___json_parse_better_errors_1.0.2.tgz";
       path = fetchurl {
@@ -3583,7 +3185,6 @@
         sha1 = "bb867cfb3450e69107c131d1c514bab3dc8bcaa9";
       };
     }
-
     {
       name = "json_schema_traverse___json_schema_traverse_0.4.1.tgz";
       path = fetchurl {
@@ -3592,7 +3193,6 @@
         sha1 = "69f6a87d9513ab8bb8fe63bdb0979c448e684660";
       };
     }
-
     {
       name = "json_schema___json_schema_0.2.3.tgz";
       path = fetchurl {
@@ -3601,7 +3201,6 @@
         sha1 = "b480c892e59a2f05954ce727bd3f2a4e882f9e13";
       };
     }
-
     {
       name = "json_stringify_safe___json_stringify_safe_5.0.1.tgz";
       path = fetchurl {
@@ -3610,7 +3209,6 @@
         sha1 = "1296a2d58fd45f19a0f6ce01d65701e2c735b6eb";
       };
     }
-
     {
       name = "json3___json3_3.3.2.tgz";
       path = fetchurl {
@@ -3619,7 +3217,6 @@
         sha1 = "3c0434743df93e2f5c42aee7b19bcb483575f4e1";
       };
     }
-
     {
       name = "json5___json5_0.5.1.tgz";
       path = fetchurl {
@@ -3628,7 +3225,6 @@
         sha1 = "1eade7acc012034ad84e2396767ead9fa5495821";
       };
     }
-
     {
       name = "json5___json5_1.0.1.tgz";
       path = fetchurl {
@@ -3637,7 +3233,6 @@
         sha1 = "779fb0018604fa854eacbf6252180d83543e3dbe";
       };
     }
-
     {
       name = "jsprim___jsprim_1.4.1.tgz";
       path = fetchurl {
@@ -3646,7 +3241,6 @@
         sha1 = "313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2";
       };
     }
-
     {
       name = "killable___killable_1.0.1.tgz";
       path = fetchurl {
@@ -3655,7 +3249,6 @@
         sha1 = "4c8ce441187a061c7474fb87ca08e2a638194892";
       };
     }
-
     {
       name = "kind_of___kind_of_3.2.2.tgz";
       path = fetchurl {
@@ -3664,7 +3257,6 @@
         sha1 = "31ea21a734bab9bbb0f32466d893aea51e4a3c64";
       };
     }
-
     {
       name = "kind_of___kind_of_4.0.0.tgz";
       path = fetchurl {
@@ -3673,7 +3265,6 @@
         sha1 = "20813df3d712928b207378691a45066fae72dd57";
       };
     }
-
     {
       name = "kind_of___kind_of_5.1.0.tgz";
       path = fetchurl {
@@ -3682,7 +3273,6 @@
         sha1 = "729c91e2d857b7a419a1f9aa65685c4c33f5845d";
       };
     }
-
     {
       name = "kind_of___kind_of_6.0.2.tgz";
       path = fetchurl {
@@ -3691,7 +3281,6 @@
         sha1 = "01146b36a6218e64e58f3a8d66de5d7fc6f6d051";
       };
     }
-
     {
       name = "lcid___lcid_1.0.0.tgz";
       path = fetchurl {
@@ -3700,7 +3289,6 @@
         sha1 = "308accafa0bc483a3867b4b6f2b9506251d1b835";
       };
     }
-
     {
       name = "lcid___lcid_2.0.0.tgz";
       path = fetchurl {
@@ -3709,7 +3297,6 @@
         sha1 = "6ef5d2df60e52f82eb228a4c373e8d1f397253cf";
       };
     }
-
     {
       name = "levn___levn_0.3.0.tgz";
       path = fetchurl {
@@ -3718,7 +3305,6 @@
         sha1 = "3b09924edf9f083c0490fdd4c0bc4421e04764ee";
       };
     }
-
     {
       name = "https___codeload.github.com_znerol_libxmljs_tar.gz_0517e063347ea2532c9fdf38dc47878c628bf0ae";
       path = fetchurl {
@@ -3727,7 +3313,6 @@
         sha1 = "4e4f370d14a3478786e60e693fe05376c36c4f54";
       };
     }
-
     {
       name = "load_json_file___load_json_file_1.1.0.tgz";
       path = fetchurl {
@@ -3736,7 +3321,6 @@
         sha1 = "956905708d58b4bab4c2261b04f59f31c99374c0";
       };
     }
-
     {
       name = "loader_runner___loader_runner_2.4.0.tgz";
       path = fetchurl {
@@ -3745,7 +3329,6 @@
         sha1 = "ed47066bfe534d7e84c4c7b9998c2a75607d9357";
       };
     }
-
     {
       name = "loader_utils___loader_utils_0.2.17.tgz";
       path = fetchurl {
@@ -3754,7 +3337,6 @@
         sha1 = "f86e6374d43205a6e6c60e9196f17c0299bfb348";
       };
     }
-
     {
       name = "loader_utils___loader_utils_1.2.3.tgz";
       path = fetchurl {
@@ -3763,7 +3345,6 @@
         sha1 = "1ff5dc6911c9f0a062531a4c04b609406108c2c7";
       };
     }
-
     {
       name = "loader_utils___loader_utils_1.4.0.tgz";
       path = fetchurl {
@@ -3772,7 +3353,6 @@
         sha1 = "c579b5e34cb34b1a74edc6c1fb36bfa371d5a613";
       };
     }
-
     {
       name = "locate_path___locate_path_3.0.0.tgz";
       path = fetchurl {
@@ -3781,7 +3361,6 @@
         sha1 = "dbec3b3ab759758071b58fe59fc41871af21400e";
       };
     }
-
     {
       name = "lodash.difference___lodash.difference_4.5.0.tgz";
       path = fetchurl {
@@ -3790,7 +3369,6 @@
         sha1 = "9ccb4e505d486b91651345772885a2df27fd017c";
       };
     }
-
     {
       name = "lodash.kebabcase___lodash.kebabcase_4.1.1.tgz";
       path = fetchurl {
@@ -3799,7 +3377,6 @@
         sha1 = "8489b1cb0d29ff88195cceca448ff6d6cc295c36";
       };
     }
-
     {
       name = "lodash.sortby___lodash.sortby_4.7.0.tgz";
       path = fetchurl {
@@ -3808,7 +3385,6 @@
         sha1 = "edd14c824e2cc9c1e0b0a1b42bb5210516a42438";
       };
     }
-
     {
       name = "lodash.tail___lodash.tail_4.1.1.tgz";
       path = fetchurl {
@@ -3817,7 +3393,6 @@
         sha1 = "d2333a36d9e7717c8ad2f7cacafec7c32b444664";
       };
     }
-
     {
       name = "lodash.throttle___lodash.throttle_4.1.1.tgz";
       path = fetchurl {
@@ -3826,7 +3401,6 @@
         sha1 = "c23e91b710242ac70c37f1e1cda9274cc39bf2f4";
       };
     }
-
     {
       name = "lodash___lodash_4.17.11.tgz";
       path = fetchurl {
@@ -3835,7 +3409,6 @@
         sha1 = "b39ea6229ef607ecd89e2c8df12536891cac9b8d";
       };
     }
-
     {
       name = "lodash___lodash_4.17.15.tgz";
       path = fetchurl {
@@ -3844,7 +3417,6 @@
         sha1 = "b447f6670a0455bbfeedd11392eff330ea097548";
       };
     }
-
     {
       name = "loglevel___loglevel_1.6.1.tgz";
       path = fetchurl {
@@ -3853,7 +3425,6 @@
         sha1 = "e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa";
       };
     }
-
     {
       name = "loud_rejection___loud_rejection_1.6.0.tgz";
       path = fetchurl {
@@ -3862,7 +3433,6 @@
         sha1 = "5b46f80147edee578870f086d04821cf998e551f";
       };
     }
-
     {
       name = "lower_case___lower_case_1.1.4.tgz";
       path = fetchurl {
@@ -3871,7 +3441,6 @@
         sha1 = "9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac";
       };
     }
-
     {
       name = "lru_cache___lru_cache_4.1.5.tgz";
       path = fetchurl {
@@ -3880,7 +3449,6 @@
         sha1 = "8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd";
       };
     }
-
     {
       name = "lru_cache___lru_cache_5.1.1.tgz";
       path = fetchurl {
@@ -3889,7 +3457,6 @@
         sha1 = "1da27e6710271947695daf6848e847f01d84b920";
       };
     }
-
     {
       name = "make_dir___make_dir_2.1.0.tgz";
       path = fetchurl {
@@ -3898,7 +3465,6 @@
         sha1 = "5f0310e18b8be898cc07009295a30ae41e91e6f5";
       };
     }
-
     {
       name = "mamacro___mamacro_0.0.3.tgz";
       path = fetchurl {
@@ -3907,7 +3473,6 @@
         sha1 = "ad2c9576197c9f1abf308d0787865bd975a3f3e4";
       };
     }
-
     {
       name = "map_age_cleaner___map_age_cleaner_0.1.3.tgz";
       path = fetchurl {
@@ -3916,7 +3481,6 @@
         sha1 = "7d583a7306434c055fe474b0f45078e6e1b4b92a";
       };
     }
-
     {
       name = "map_cache___map_cache_0.2.2.tgz";
       path = fetchurl {
@@ -3925,7 +3489,6 @@
         sha1 = "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf";
       };
     }
-
     {
       name = "map_obj___map_obj_1.0.1.tgz";
       path = fetchurl {
@@ -3934,7 +3497,6 @@
         sha1 = "d933ceb9205d82bdcf4886f6742bdc2b4dea146d";
       };
     }
-
     {
       name = "map_visit___map_visit_1.0.0.tgz";
       path = fetchurl {
@@ -3943,7 +3505,6 @@
         sha1 = "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f";
       };
     }
-
     {
       name = "md5.js___md5.js_1.3.5.tgz";
       path = fetchurl {
@@ -3952,7 +3513,6 @@
         sha1 = "b5d07b8e3216e3e27cd728d72f70d1e6a342005f";
       };
     }
-
     {
       name = "media_typer___media_typer_0.3.0.tgz";
       path = fetchurl {
@@ -3961,7 +3521,6 @@
         sha1 = "8710d7af0aa626f8fffa1ce00168545263255748";
       };
     }
-
     {
       name = "mem___mem_4.2.0.tgz";
       path = fetchurl {
@@ -3970,7 +3529,6 @@
         sha1 = "5ee057680ed9cb8dad8a78d820f9a8897a102025";
       };
     }
-
     {
       name = "memory_fs___memory_fs_0.4.1.tgz";
       path = fetchurl {
@@ -3979,7 +3537,6 @@
         sha1 = "3a9a20b8462523e447cfbc7e8bb80ed667bfc552";
       };
     }
-
     {
       name = "memory_fs___memory_fs_0.5.0.tgz";
       path = fetchurl {
@@ -3988,7 +3545,6 @@
         sha1 = "324c01288b88652966d161db77838720845a8e3c";
       };
     }
-
     {
       name = "meow___meow_3.7.0.tgz";
       path = fetchurl {
@@ -3997,7 +3553,6 @@
         sha1 = "72cb668b425228290abbfa856892587308a801fb";
       };
     }
-
     {
       name = "merge_descriptors___merge_descriptors_1.0.1.tgz";
       path = fetchurl {
@@ -4006,7 +3561,6 @@
         sha1 = "b00aaa556dd8b44568150ec9d1b953f3f90cbb61";
       };
     }
-
     {
       name = "methods___methods_1.1.2.tgz";
       path = fetchurl {
@@ -4015,7 +3569,6 @@
         sha1 = "5529a4d67654134edcc5266656835b0f851afcee";
       };
     }
-
     {
       name = "micromatch___micromatch_3.1.10.tgz";
       path = fetchurl {
@@ -4024,7 +3577,6 @@
         sha1 = "70859bc95c9840952f359a068a3fc49f9ecfac23";
       };
     }
-
     {
       name = "micromatch___micromatch_4.0.2.tgz";
       path = fetchurl {
@@ -4033,7 +3585,6 @@
         sha1 = "4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259";
       };
     }
-
     {
       name = "miller_rabin___miller_rabin_4.0.1.tgz";
       path = fetchurl {
@@ -4042,7 +3593,6 @@
         sha1 = "f080351c865b0dc562a8462966daa53543c78a4d";
       };
     }
-
     {
       name = "mime_db___mime_db_1.44.0.tgz";
       path = fetchurl {
@@ -4051,7 +3601,6 @@
         sha1 = "fa11c5eb0aca1334b4233cb4d52f10c5a6272f92";
       };
     }
-
     {
       name = "mime_db___mime_db_1.38.0.tgz";
       path = fetchurl {
@@ -4060,7 +3609,6 @@
         sha1 = "1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad";
       };
     }
-
     {
       name = "mime_types___mime_types_2.1.27.tgz";
       path = fetchurl {
@@ -4069,7 +3617,6 @@
         sha1 = "47949f98e279ea53119f5722e0f34e529bec009f";
       };
     }
-
     {
       name = "mime_types___mime_types_2.1.22.tgz";
       path = fetchurl {
@@ -4078,7 +3625,6 @@
         sha1 = "fe6b355a190926ab7698c9a0556a11199b2199bd";
       };
     }
-
     {
       name = "mime___mime_1.4.1.tgz";
       path = fetchurl {
@@ -4087,7 +3633,6 @@
         sha1 = "121f9ebc49e3766f311a76e1fa1c8003c4b03aa6";
       };
     }
-
     {
       name = "mime___mime_2.4.0.tgz";
       path = fetchurl {
@@ -4096,7 +3641,6 @@
         sha1 = "e051fd881358585f3279df333fe694da0bcffdd6";
       };
     }
-
     {
       name = "mimic_fn___mimic_fn_2.0.0.tgz";
       path = fetchurl {
@@ -4105,7 +3649,6 @@
         sha1 = "0913ff0b121db44ef5848242c38bbb35d44cabde";
       };
     }
-
     {
       name = "minimalistic_assert___minimalistic_assert_1.0.1.tgz";
       path = fetchurl {
@@ -4114,7 +3657,6 @@
         sha1 = "2e194de044626d4a10e7f7fbc00ce73e83e4d5c7";
       };
     }
-
     {
       name = "minimalistic_crypto_utils___minimalistic_crypto_utils_1.0.1.tgz";
       path = fetchurl {
@@ -4123,7 +3665,6 @@
         sha1 = "f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a";
       };
     }
-
     {
       name = "minimatch___minimatch_3.0.4.tgz";
       path = fetchurl {
@@ -4132,7 +3673,6 @@
         sha1 = "5166e286457f03306064be5497e8dbb0c3d32083";
       };
     }
-
     {
       name = "minimist___minimist_0.0.8.tgz";
       path = fetchurl {
@@ -4141,7 +3681,6 @@
         sha1 = "857fcabfc3397d2625b8228262e86aa7a011b05d";
       };
     }
-
     {
       name = "minimist___minimist_1.2.0.tgz";
       path = fetchurl {
@@ -4150,7 +3689,6 @@
         sha1 = "a35008b20f41383eec1fb914f4cd5df79a264284";
       };
     }
-
     {
       name = "minimist___minimist_1.2.5.tgz";
       path = fetchurl {
@@ -4159,7 +3697,6 @@
         sha1 = "67d66014b66a6a8aaa0c083c5fd58df4e4e97602";
       };
     }
-
     {
       name = "minipass___minipass_2.3.5.tgz";
       path = fetchurl {
@@ -4168,7 +3705,6 @@
         sha1 = "cacebe492022497f656b0f0f51e2682a9ed2d848";
       };
     }
-
     {
       name = "minizlib___minizlib_1.2.1.tgz";
       path = fetchurl {
@@ -4177,7 +3713,6 @@
         sha1 = "dd27ea6136243c7c880684e8672bb3a45fd9b614";
       };
     }
-
     {
       name = "mississippi___mississippi_3.0.0.tgz";
       path = fetchurl {
@@ -4186,7 +3721,6 @@
         sha1 = "ea0a3291f97e0b5e8776b363d5f0a12d94c67022";
       };
     }
-
     {
       name = "mixin_deep___mixin_deep_1.3.1.tgz";
       path = fetchurl {
@@ -4195,7 +3729,6 @@
         sha1 = "a49e7268dce1a0d9698e45326c5626df3543d0fe";
       };
     }
-
     {
       name = "mixin_object___mixin_object_2.0.1.tgz";
       path = fetchurl {
@@ -4204,7 +3737,6 @@
         sha1 = "4fb949441dab182540f1fe035ba60e1947a5e57e";
       };
     }
-
     {
       name = "mkdirp___mkdirp_0.5.1.tgz";
       path = fetchurl {
@@ -4213,7 +3745,6 @@
         sha1 = "30057438eac6cf7f8c4767f38648d6697d75c903";
       };
     }
-
     {
       name = "monaco_editor_webpack_plugin___monaco_editor_webpack_plugin_1.9.0.tgz";
       path = fetchurl {
@@ -4222,7 +3753,6 @@
         sha1 = "5b547281b9f404057dc5d8c5722390df9ac90be6";
       };
     }
-
     {
       name = "monaco_editor___monaco_editor_0.20.0.tgz";
       path = fetchurl {
@@ -4231,7 +3761,6 @@
         sha1 = "5d5009343a550124426cb4d965a4d27a348b4dea";
       };
     }
-
     {
       name = "monaco_emacs___monaco_emacs_0.2.2.tgz";
       path = fetchurl {
@@ -4240,7 +3769,6 @@
         sha1 = "798cb7a71a26ee7067581e4c8745be5869c82110";
       };
     }
-
     {
       name = "monaco_vim___monaco_vim_0.1.7.tgz";
       path = fetchurl {
@@ -4249,7 +3777,6 @@
         sha1 = "6c0489f2adc59b6663817d98e1e8b59a8577281a";
       };
     }
-
     {
       name = "moo___moo_0.5.1.tgz";
       path = fetchurl {
@@ -4258,7 +3785,6 @@
         sha1 = "7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4";
       };
     }
-
     {
       name = "move_concurrently___move_concurrently_1.0.1.tgz";
       path = fetchurl {
@@ -4267,7 +3793,6 @@
         sha1 = "be2c005fda32e0b29af1f05d7c4b33214c701f92";
       };
     }
-
     {
       name = "ms___ms_2.0.0.tgz";
       path = fetchurl {
@@ -4276,7 +3801,6 @@
         sha1 = "5608aeadfc00be6c2901df5f9861788de0d597c8";
       };
     }
-
     {
       name = "ms___ms_2.1.1.tgz";
       path = fetchurl {
@@ -4285,7 +3809,6 @@
         sha1 = "30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a";
       };
     }
-
     {
       name = "multicast_dns_service_types___multicast_dns_service_types_1.1.0.tgz";
       path = fetchurl {
@@ -4294,7 +3817,6 @@
         sha1 = "899f11d9686e5e05cb91b35d5f0e63b773cfc901";
       };
     }
-
     {
       name = "multicast_dns___multicast_dns_6.2.3.tgz";
       path = fetchurl {
@@ -4303,7 +3825,6 @@
         sha1 = "a0ec7bd9055c4282f790c3c82f4e28db3b31b229";
       };
     }
-
     {
       name = "nan___nan_2.14.0.tgz";
       path = fetchurl {
@@ -4312,7 +3833,6 @@
         sha1 = "7818f722027b2459a86f0295d434d1fc2336c52c";
       };
     }
-
     {
       name = "nan___nan_2.12.1.tgz";
       path = fetchurl {
@@ -4321,7 +3841,6 @@
         sha1 = "7b1aa193e9aa86057e3c7bbd0ac448e770925552";
       };
     }
-
     {
       name = "nan___nan_2.14.1.tgz";
       path = fetchurl {
@@ -4330,7 +3849,6 @@
         sha1 = "d7be34dfa3105b91494c3147089315eff8874b01";
       };
     }
-
     {
       name = "nanomatch___nanomatch_1.2.13.tgz";
       path = fetchurl {
@@ -4339,16 +3857,14 @@
         sha1 = "b87a8aa4fc0de8fe6be88895b38983ff265bd119";
       };
     }
-
     {
-      name = "https___github.com_shmish111_nearley_webpack_loader_archive_master.tar.gz";
+      name = "nearley_webpack_loader___nearley_webpack_loader_0.0.2.tgz";
       path = fetchurl {
-        name = "https___github.com_shmish111_nearley_webpack_loader_archive_master.tar.gz";
-        url  = "https://github.com/shmish111/nearley-webpack-loader/archive/master.tar.gz";
-        sha1 = "f7e80853852229971ae0ded75cdae2a078908529";
+        name = "nearley_webpack_loader___nearley_webpack_loader_0.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/nearley-webpack-loader/-/nearley-webpack-loader-0.0.2.tgz";
+        sha1 = "7d7f2f758e6f3d510a5c3f7a0980514263770c83";
       };
     }
-
     {
       name = "nearley___nearley_2.19.1.tgz";
       path = fetchurl {
@@ -4357,7 +3873,6 @@
         sha1 = "4af4006e16645ff800e9f993c3af039857d9dbdc";
       };
     }
-
     {
       name = "needle___needle_2.2.4.tgz";
       path = fetchurl {
@@ -4366,7 +3881,6 @@
         sha1 = "51931bff82533b1928b7d1d69e01f1b00ffd2a4e";
       };
     }
-
     {
       name = "negotiator___negotiator_0.6.1.tgz";
       path = fetchurl {
@@ -4375,7 +3889,6 @@
         sha1 = "2b327184e8992101177b28563fb5e7102acd0ca9";
       };
     }
-
     {
       name = "neo_async___neo_async_2.6.0.tgz";
       path = fetchurl {
@@ -4384,7 +3897,6 @@
         sha1 = "b9d15e4d71c6762908654b5183ed38b753340835";
       };
     }
-
     {
       name = "neo_async___neo_async_2.6.1.tgz";
       path = fetchurl {
@@ -4393,7 +3905,6 @@
         sha1 = "ac27ada66167fa8849a6addd837f6b189ad2081c";
       };
     }
-
     {
       name = "nice_try___nice_try_1.0.5.tgz";
       path = fetchurl {
@@ -4402,7 +3913,6 @@
         sha1 = "a3378a7696ce7d223e88fc9b764bd7ef1089e366";
       };
     }
-
     {
       name = "no_case___no_case_2.3.2.tgz";
       path = fetchurl {
@@ -4411,7 +3921,6 @@
         sha1 = "60b813396be39b3f1288a4c1ed5d1e7d28b464ac";
       };
     }
-
     {
       name = "node_blockly___node_blockly_1.2.8.tgz";
       path = fetchurl {
@@ -4420,7 +3929,6 @@
         sha1 = "865f2b859058d270eb7259d8b5d1c87435ac1d8c";
       };
     }
-
     {
       name = "node_forge___node_forge_0.7.5.tgz";
       path = fetchurl {
@@ -4429,7 +3937,6 @@
         sha1 = "6c152c345ce11c52f465c2abd957e8639cd674df";
       };
     }
-
     {
       name = "node_gyp___node_gyp_3.8.0.tgz";
       path = fetchurl {
@@ -4438,7 +3945,6 @@
         sha1 = "540304261c330e80d0d5edce253a68cb3964218c";
       };
     }
-
     {
       name = "node_libs_browser___node_libs_browser_2.2.1.tgz";
       path = fetchurl {
@@ -4447,7 +3953,6 @@
         sha1 = "b64f513d18338625f90346d27b0d235e631f6425";
       };
     }
-
     {
       name = "node_pre_gyp___node_pre_gyp_0.10.3.tgz";
       path = fetchurl {
@@ -4456,7 +3961,6 @@
         sha1 = "3070040716afdc778747b61b6887bf78880b80fc";
       };
     }
-
     {
       name = "node_sass___node_sass_4.12.0.tgz";
       path = fetchurl {
@@ -4465,7 +3969,6 @@
         sha1 = "0914f531932380114a30cc5fa4fa63233a25f017";
       };
     }
-
     {
       name = "nopt___nopt_3.0.6.tgz";
       path = fetchurl {
@@ -4474,7 +3977,6 @@
         sha1 = "c6465dbf08abcd4db359317f79ac68a646b28ff9";
       };
     }
-
     {
       name = "nopt___nopt_4.0.1.tgz";
       path = fetchurl {
@@ -4483,7 +3985,6 @@
         sha1 = "d0d4685afd5415193c8c7505602d0d17cd64474d";
       };
     }
-
     {
       name = "normalize_package_data___normalize_package_data_2.5.0.tgz";
       path = fetchurl {
@@ -4492,7 +3993,6 @@
         sha1 = "e66db1838b200c1dfc233225d12cb36520e234a8";
       };
     }
-
     {
       name = "normalize_path___normalize_path_2.1.1.tgz";
       path = fetchurl {
@@ -4501,7 +4001,6 @@
         sha1 = "1ab28b556e198363a8c1a6f7e6fa20137fe6aed9";
       };
     }
-
     {
       name = "normalize_path___normalize_path_3.0.0.tgz";
       path = fetchurl {
@@ -4510,7 +4009,6 @@
         sha1 = "0dcd69ff23a1c9b11fd0978316644a0388216a65";
       };
     }
-
     {
       name = "npm_bundled___npm_bundled_1.0.6.tgz";
       path = fetchurl {
@@ -4519,7 +4017,6 @@
         sha1 = "e7ba9aadcef962bb61248f91721cd932b3fe6bdd";
       };
     }
-
     {
       name = "npm_packlist___npm_packlist_1.4.1.tgz";
       path = fetchurl {
@@ -4528,7 +4025,6 @@
         sha1 = "19064cdf988da80ea3cee45533879d90192bbfbc";
       };
     }
-
     {
       name = "npm_run_path___npm_run_path_2.0.2.tgz";
       path = fetchurl {
@@ -4537,7 +4033,6 @@
         sha1 = "35a9232dfa35d7067b4cb2ddf2357b1871536c5f";
       };
     }
-
     {
       name = "npmlog___npmlog_4.1.2.tgz";
       path = fetchurl {
@@ -4546,7 +4041,6 @@
         sha1 = "08a7f2a8bf734604779a9efa4ad5cc717abb954b";
       };
     }
-
     {
       name = "nth_check___nth_check_1.0.2.tgz";
       path = fetchurl {
@@ -4555,7 +4049,6 @@
         sha1 = "b2bd295c37e3dd58a3bf0700376663ba4d9cf05c";
       };
     }
-
     {
       name = "number_is_nan___number_is_nan_1.0.1.tgz";
       path = fetchurl {
@@ -4564,7 +4057,6 @@
         sha1 = "097b602b53422a522c1afb8790318336941a011d";
       };
     }
-
     {
       name = "nwmatcher___nwmatcher_1.4.4.tgz";
       path = fetchurl {
@@ -4573,7 +4065,6 @@
         sha1 = "2285631f34a95f0d0395cd900c96ed39b58f346e";
       };
     }
-
     {
       name = "nwsapi___nwsapi_2.2.0.tgz";
       path = fetchurl {
@@ -4582,7 +4073,6 @@
         sha1 = "204879a9e3d068ff2a55139c2c772780681a38b7";
       };
     }
-
     {
       name = "oauth_sign___oauth_sign_0.9.0.tgz";
       path = fetchurl {
@@ -4591,7 +4081,6 @@
         sha1 = "47a7b016baa68b5fa0ecf3dee08a85c679ac6455";
       };
     }
-
     {
       name = "object_assign___object_assign_4.1.1.tgz";
       path = fetchurl {
@@ -4600,7 +4089,6 @@
         sha1 = "2109adc7965887cfc05cbbd442cac8bfbb360863";
       };
     }
-
     {
       name = "object_copy___object_copy_0.1.0.tgz";
       path = fetchurl {
@@ -4609,7 +4097,6 @@
         sha1 = "7e7d858b781bd7c991a41ba975ed3812754e998c";
       };
     }
-
     {
       name = "object_keys___object_keys_1.1.0.tgz";
       path = fetchurl {
@@ -4618,7 +4105,6 @@
         sha1 = "11bd22348dd2e096a045ab06f6c85bcc340fa032";
       };
     }
-
     {
       name = "object_visit___object_visit_1.0.1.tgz";
       path = fetchurl {
@@ -4627,7 +4113,6 @@
         sha1 = "f79c4493af0c5377b59fe39d395e41042dd045bb";
       };
     }
-
     {
       name = "object.getownpropertydescriptors___object.getownpropertydescriptors_2.0.3.tgz";
       path = fetchurl {
@@ -4636,7 +4121,6 @@
         sha1 = "8758c846f5b407adab0f236e0986f14b051caa16";
       };
     }
-
     {
       name = "object.pick___object.pick_1.3.0.tgz";
       path = fetchurl {
@@ -4645,7 +4129,6 @@
         sha1 = "87a10ac4c1694bd2e1cbf53591a66141fb5dd747";
       };
     }
-
     {
       name = "obuf___obuf_1.1.2.tgz";
       path = fetchurl {
@@ -4654,7 +4137,6 @@
         sha1 = "09bea3343d41859ebd446292d11c9d4db619084e";
       };
     }
-
     {
       name = "on_finished___on_finished_2.3.0.tgz";
       path = fetchurl {
@@ -4663,7 +4145,6 @@
         sha1 = "20f1336481b083cd75337992a16971aa2d906947";
       };
     }
-
     {
       name = "on_headers___on_headers_1.0.2.tgz";
       path = fetchurl {
@@ -4672,7 +4153,6 @@
         sha1 = "772b0ae6aaa525c399e489adfad90c403eb3c28f";
       };
     }
-
     {
       name = "once___once_1.4.0.tgz";
       path = fetchurl {
@@ -4681,7 +4161,6 @@
         sha1 = "583b1aa775961d4b113ac17d9c50baef9dd76bd1";
       };
     }
-
     {
       name = "opn___opn_5.4.0.tgz";
       path = fetchurl {
@@ -4690,7 +4169,6 @@
         sha1 = "cb545e7aab78562beb11aa3bfabc7042e1761035";
       };
     }
-
     {
       name = "optionator___optionator_0.8.3.tgz";
       path = fetchurl {
@@ -4699,7 +4177,6 @@
         sha1 = "84fa1d036fe9d3c7e21d99884b601167ec8fb495";
       };
     }
-
     {
       name = "original___original_1.0.2.tgz";
       path = fetchurl {
@@ -4708,7 +4185,6 @@
         sha1 = "e442a61cffe1c5fd20a65f3261c26663b303f25f";
       };
     }
-
     {
       name = "os_browserify___os_browserify_0.3.0.tgz";
       path = fetchurl {
@@ -4717,7 +4193,6 @@
         sha1 = "854373c7f5c2315914fc9bfc6bd8238fdda1ec27";
       };
     }
-
     {
       name = "os_homedir___os_homedir_1.0.2.tgz";
       path = fetchurl {
@@ -4726,7 +4201,6 @@
         sha1 = "ffbc4988336e0e833de0c168c7ef152121aa7fb3";
       };
     }
-
     {
       name = "os_locale___os_locale_1.4.0.tgz";
       path = fetchurl {
@@ -4735,7 +4209,6 @@
         sha1 = "20f9f17ae29ed345e8bde583b13d2009803c14d9";
       };
     }
-
     {
       name = "os_locale___os_locale_3.1.0.tgz";
       path = fetchurl {
@@ -4744,7 +4217,6 @@
         sha1 = "a802a6ee17f24c10483ab9935719cef4ed16bf1a";
       };
     }
-
     {
       name = "os_tmpdir___os_tmpdir_1.0.2.tgz";
       path = fetchurl {
@@ -4753,7 +4225,6 @@
         sha1 = "bbe67406c79aa85c5cfec766fe5734555dfa1274";
       };
     }
-
     {
       name = "osenv___osenv_0.1.5.tgz";
       path = fetchurl {
@@ -4762,7 +4233,6 @@
         sha1 = "85cdfafaeb28e8677f416e287592b5f3f49ea410";
       };
     }
-
     {
       name = "p_defer___p_defer_1.0.0.tgz";
       path = fetchurl {
@@ -4771,7 +4241,6 @@
         sha1 = "9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c";
       };
     }
-
     {
       name = "p_finally___p_finally_1.0.0.tgz";
       path = fetchurl {
@@ -4780,7 +4249,6 @@
         sha1 = "3fbcfb15b899a44123b34b6dcc18b724336a2cae";
       };
     }
-
     {
       name = "p_is_promise___p_is_promise_2.0.0.tgz";
       path = fetchurl {
@@ -4789,7 +4257,6 @@
         sha1 = "7554e3d572109a87e1f3f53f6a7d85d1b194f4c5";
       };
     }
-
     {
       name = "p_limit___p_limit_2.2.0.tgz";
       path = fetchurl {
@@ -4798,7 +4265,6 @@
         sha1 = "417c9941e6027a9abcba5092dd2904e255b5fbc2";
       };
     }
-
     {
       name = "p_locate___p_locate_3.0.0.tgz";
       path = fetchurl {
@@ -4807,7 +4273,6 @@
         sha1 = "322d69a05c0264b25997d9f40cd8a891ab0064a4";
       };
     }
-
     {
       name = "p_map___p_map_1.2.0.tgz";
       path = fetchurl {
@@ -4816,7 +4281,6 @@
         sha1 = "e4e94f311eabbc8633a1e79908165fca26241b6b";
       };
     }
-
     {
       name = "p_try___p_try_2.0.0.tgz";
       path = fetchurl {
@@ -4825,7 +4289,6 @@
         sha1 = "85080bb87c64688fa47996fe8f7dfbe8211760b1";
       };
     }
-
     {
       name = "pako___pako_1.0.10.tgz";
       path = fetchurl {
@@ -4834,7 +4297,6 @@
         sha1 = "4328badb5086a426aa90f541977d4955da5c9732";
       };
     }
-
     {
       name = "parallel_transform___parallel_transform_1.1.0.tgz";
       path = fetchurl {
@@ -4843,7 +4305,6 @@
         sha1 = "d410f065b05da23081fcd10f28854c29bda33b06";
       };
     }
-
     {
       name = "param_case___param_case_2.1.1.tgz";
       path = fetchurl {
@@ -4852,7 +4313,6 @@
         sha1 = "df94fd8cf6531ecf75e6bef9a0858fbc72be2247";
       };
     }
-
     {
       name = "parse_asn1___parse_asn1_5.1.4.tgz";
       path = fetchurl {
@@ -4861,7 +4321,6 @@
         sha1 = "37f6628f823fbdeb2273b4d540434a22f3ef1fcc";
       };
     }
-
     {
       name = "parse_json___parse_json_2.2.0.tgz";
       path = fetchurl {
@@ -4870,7 +4329,6 @@
         sha1 = "f480f40434ef80741f8469099f8dea18f55a4dc9";
       };
     }
-
     {
       name = "parse_passwd___parse_passwd_1.0.0.tgz";
       path = fetchurl {
@@ -4879,7 +4337,6 @@
         sha1 = "6d5b934a456993b23d37f40a382d6f1666a8e5c6";
       };
     }
-
     {
       name = "parse5___parse5_5.1.0.tgz";
       path = fetchurl {
@@ -4888,7 +4345,6 @@
         sha1 = "c59341c9723f414c452975564c7c00a68d58acd2";
       };
     }
-
     {
       name = "parse5___parse5_1.5.1.tgz";
       path = fetchurl {
@@ -4897,7 +4353,6 @@
         sha1 = "9b7f3b0de32be78dc2401b17573ccaf0f6f59d94";
       };
     }
-
     {
       name = "parseurl___parseurl_1.3.2.tgz";
       path = fetchurl {
@@ -4906,7 +4361,6 @@
         sha1 = "fc289d4ed8993119460c156253262cdc8de65bf3";
       };
     }
-
     {
       name = "pascalcase___pascalcase_0.1.1.tgz";
       path = fetchurl {
@@ -4915,7 +4369,6 @@
         sha1 = "b363e55e8006ca6fe21784d2db22bd15d7917f14";
       };
     }
-
     {
       name = "path_browserify___path_browserify_0.0.1.tgz";
       path = fetchurl {
@@ -4924,7 +4377,6 @@
         sha1 = "e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a";
       };
     }
-
     {
       name = "path_dirname___path_dirname_1.0.2.tgz";
       path = fetchurl {
@@ -4933,7 +4385,6 @@
         sha1 = "cc33d24d525e099a5388c0336c6e32b9160609e0";
       };
     }
-
     {
       name = "path_exists___path_exists_2.1.0.tgz";
       path = fetchurl {
@@ -4942,7 +4393,6 @@
         sha1 = "0feb6c64f0fc518d9a754dd5efb62c7022761f4b";
       };
     }
-
     {
       name = "path_exists___path_exists_3.0.0.tgz";
       path = fetchurl {
@@ -4951,7 +4401,6 @@
         sha1 = "ce0ebeaa5f78cb18925ea7d810d7b59b010fd515";
       };
     }
-
     {
       name = "path_is_absolute___path_is_absolute_1.0.1.tgz";
       path = fetchurl {
@@ -4960,7 +4409,6 @@
         sha1 = "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f";
       };
     }
-
     {
       name = "path_is_inside___path_is_inside_1.0.2.tgz";
       path = fetchurl {
@@ -4969,7 +4417,6 @@
         sha1 = "365417dede44430d1c11af61027facf074bdfc53";
       };
     }
-
     {
       name = "path_key___path_key_2.0.1.tgz";
       path = fetchurl {
@@ -4978,7 +4425,6 @@
         sha1 = "411cadb574c5a140d3a4b1910d40d80cc9f40b40";
       };
     }
-
     {
       name = "path_parse___path_parse_1.0.6.tgz";
       path = fetchurl {
@@ -4987,7 +4433,6 @@
         sha1 = "d62dbb5679405d72c4737ec58600e9ddcf06d24c";
       };
     }
-
     {
       name = "path_to_regexp___path_to_regexp_0.1.7.tgz";
       path = fetchurl {
@@ -4996,7 +4441,6 @@
         sha1 = "df604178005f522f15eb4490e7247a1bfaa67f8c";
       };
     }
-
     {
       name = "path_type___path_type_1.1.0.tgz";
       path = fetchurl {
@@ -5005,7 +4449,6 @@
         sha1 = "59c44f7ee491da704da415da5a4070ba4f8fe441";
       };
     }
-
     {
       name = "pbkdf2___pbkdf2_3.0.17.tgz";
       path = fetchurl {
@@ -5014,7 +4457,6 @@
         sha1 = "976c206530617b14ebb32114239f7b09336e93a6";
       };
     }
-
     {
       name = "performance_now___performance_now_2.1.0.tgz";
       path = fetchurl {
@@ -5023,7 +4465,6 @@
         sha1 = "6309f4e0e5fa913ec1c69307ae364b4b377c9e7b";
       };
     }
-
     {
       name = "picomatch___picomatch_2.2.1.tgz";
       path = fetchurl {
@@ -5032,7 +4473,6 @@
         sha1 = "21bac888b6ed8601f831ce7816e335bc779f0a4a";
       };
     }
-
     {
       name = "pify___pify_2.3.0.tgz";
       path = fetchurl {
@@ -5041,7 +4481,6 @@
         sha1 = "ed141a6ac043a849ea588498e7dca8b15330e90c";
       };
     }
-
     {
       name = "pify___pify_3.0.0.tgz";
       path = fetchurl {
@@ -5050,7 +4489,6 @@
         sha1 = "e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176";
       };
     }
-
     {
       name = "pify___pify_4.0.1.tgz";
       path = fetchurl {
@@ -5059,7 +4497,6 @@
         sha1 = "4b2cd25c50d598735c50292224fd8c6df41e3231";
       };
     }
-
     {
       name = "pinkie_promise___pinkie_promise_2.0.1.tgz";
       path = fetchurl {
@@ -5068,7 +4505,6 @@
         sha1 = "2135d6dfa7a358c069ac9b178776288228450ffa";
       };
     }
-
     {
       name = "pinkie___pinkie_2.0.4.tgz";
       path = fetchurl {
@@ -5077,7 +4513,6 @@
         sha1 = "72556b80cfa0d48a974e80e77248e80ed4f7f870";
       };
     }
-
     {
       name = "pkg_dir___pkg_dir_3.0.0.tgz";
       path = fetchurl {
@@ -5086,7 +4521,6 @@
         sha1 = "2749020f239ed990881b1f71210d51eb6523bea3";
       };
     }
-
     {
       name = "pn___pn_1.1.0.tgz";
       path = fetchurl {
@@ -5095,7 +4529,6 @@
         sha1 = "e2f4cef0e219f463c179ab37463e4e1ecdccbafb";
       };
     }
-
     {
       name = "popper.js___popper.js_1.14.7.tgz";
       path = fetchurl {
@@ -5104,7 +4537,6 @@
         sha1 = "e31ec06cfac6a97a53280c3e55e4e0c860e7738e";
       };
     }
-
     {
       name = "portfinder___portfinder_1.0.20.tgz";
       path = fetchurl {
@@ -5113,7 +4545,6 @@
         sha1 = "bea68632e54b2e13ab7b0c4775e9b41bf270e44a";
       };
     }
-
     {
       name = "posix_character_classes___posix_character_classes_0.1.1.tgz";
       path = fetchurl {
@@ -5122,7 +4553,6 @@
         sha1 = "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab";
       };
     }
-
     {
       name = "postcss_modules_extract_imports___postcss_modules_extract_imports_1.2.1.tgz";
       path = fetchurl {
@@ -5131,7 +4561,6 @@
         sha1 = "dc87e34148ec7eab5f791f7cd5849833375b741a";
       };
     }
-
     {
       name = "postcss_modules_local_by_default___postcss_modules_local_by_default_1.2.0.tgz";
       path = fetchurl {
@@ -5140,7 +4569,6 @@
         sha1 = "f7d80c398c5a393fa7964466bd19500a7d61c069";
       };
     }
-
     {
       name = "postcss_modules_scope___postcss_modules_scope_1.1.0.tgz";
       path = fetchurl {
@@ -5149,7 +4577,6 @@
         sha1 = "d6ea64994c79f97b62a72b426fbe6056a194bb90";
       };
     }
-
     {
       name = "postcss_modules_values___postcss_modules_values_1.3.0.tgz";
       path = fetchurl {
@@ -5158,7 +4585,6 @@
         sha1 = "ecffa9d7e192518389f42ad0e83f72aec456ea20";
       };
     }
-
     {
       name = "postcss_value_parser___postcss_value_parser_3.3.1.tgz";
       path = fetchurl {
@@ -5167,7 +4593,6 @@
         sha1 = "9ff822547e2893213cf1c30efa51ac5fd1ba8281";
       };
     }
-
     {
       name = "postcss___postcss_6.0.23.tgz";
       path = fetchurl {
@@ -5176,7 +4601,6 @@
         sha1 = "61c82cc328ac60e677645f979054eb98bc0e3324";
       };
     }
-
     {
       name = "prelude_ls___prelude_ls_1.1.2.tgz";
       path = fetchurl {
@@ -5185,7 +4609,6 @@
         sha1 = "21932a549f5e52ffd9a827f570e04be62a97da54";
       };
     }
-
     {
       name = "pretty_error___pretty_error_2.1.1.tgz";
       path = fetchurl {
@@ -5194,7 +4617,6 @@
         sha1 = "5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3";
       };
     }
-
     {
       name = "process_nextick_args___process_nextick_args_2.0.0.tgz";
       path = fetchurl {
@@ -5203,7 +4625,6 @@
         sha1 = "a37d732f4271b4ab1ad070d35508e8290788ffaa";
       };
     }
-
     {
       name = "process___process_0.11.10.tgz";
       path = fetchurl {
@@ -5212,7 +4633,6 @@
         sha1 = "7332300e840161bda3e69a1d1d91a7d4bc16f182";
       };
     }
-
     {
       name = "promise_inflight___promise_inflight_1.0.1.tgz";
       path = fetchurl {
@@ -5221,7 +4641,6 @@
         sha1 = "98472870bf228132fcbdd868129bad12c3c029e3";
       };
     }
-
     {
       name = "promise_retry___promise_retry_1.1.1.tgz";
       path = fetchurl {
@@ -5230,7 +4649,6 @@
         sha1 = "6739e968e3051da20ce6497fb2b50f6911df3d6d";
       };
     }
-
     {
       name = "proxy_addr___proxy_addr_2.0.4.tgz";
       path = fetchurl {
@@ -5239,7 +4657,6 @@
         sha1 = "ecfc733bf22ff8c6f407fa275327b9ab67e48b93";
       };
     }
-
     {
       name = "prr___prr_1.0.1.tgz";
       path = fetchurl {
@@ -5248,7 +4665,6 @@
         sha1 = "d3fc114ba06995a45ec6893f484ceb1d78f5f476";
       };
     }
-
     {
       name = "pseudomap___pseudomap_1.0.2.tgz";
       path = fetchurl {
@@ -5257,7 +4673,6 @@
         sha1 = "f052a28da70e618917ef0a8ac34c1ae5a68286b3";
       };
     }
-
     {
       name = "psl___psl_1.8.0.tgz";
       path = fetchurl {
@@ -5266,7 +4681,6 @@
         sha1 = "9326f8bcfb013adcc005fdff056acce020e51c24";
       };
     }
-
     {
       name = "public_encrypt___public_encrypt_4.0.3.tgz";
       path = fetchurl {
@@ -5275,7 +4689,6 @@
         sha1 = "4fcc9d77a07e48ba7527e7cbe0de33d0701331e0";
       };
     }
-
     {
       name = "pump___pump_2.0.1.tgz";
       path = fetchurl {
@@ -5284,7 +4697,6 @@
         sha1 = "12399add6e4cf7526d973cbc8b5ce2e2908b3909";
       };
     }
-
     {
       name = "pump___pump_3.0.0.tgz";
       path = fetchurl {
@@ -5293,7 +4705,6 @@
         sha1 = "b4a2116815bde2f4e1ea602354e8c75565107a64";
       };
     }
-
     {
       name = "pumpify___pumpify_1.5.1.tgz";
       path = fetchurl {
@@ -5302,7 +4713,6 @@
         sha1 = "36513be246ab27570b1a374a5ce278bfd74370ce";
       };
     }
-
     {
       name = "punycode___punycode_1.3.2.tgz";
       path = fetchurl {
@@ -5311,7 +4721,6 @@
         sha1 = "9653a036fb7c1ee42342f2325cceefea3926c48d";
       };
     }
-
     {
       name = "punycode___punycode_1.4.1.tgz";
       path = fetchurl {
@@ -5320,7 +4729,6 @@
         sha1 = "c0d5a63b2718800ad8e1eb0fa5269c84dd41845e";
       };
     }
-
     {
       name = "punycode___punycode_2.1.1.tgz";
       path = fetchurl {
@@ -5329,7 +4737,6 @@
         sha1 = "b58b010ac40c22c5657616c8d2c2c02c7bf479ec";
       };
     }
-
     {
       name = "purs_loader___purs_loader_3.7.1.tgz";
       path = fetchurl {
@@ -5338,7 +4745,6 @@
         sha1 = "190ae0362f03648bd0200fda436eeb0aeacb2616";
       };
     }
-
     {
       name = "qs___qs_6.5.2.tgz";
       path = fetchurl {
@@ -5347,7 +4753,6 @@
         sha1 = "cb3ae806e8740444584ef154ce8ee98d403f3e36";
       };
     }
-
     {
       name = "querystring_es3___querystring_es3_0.2.1.tgz";
       path = fetchurl {
@@ -5356,7 +4761,6 @@
         sha1 = "9ec61f79049875707d69414596fd907a4d711e73";
       };
     }
-
     {
       name = "querystring___querystring_0.2.0.tgz";
       path = fetchurl {
@@ -5365,7 +4769,6 @@
         sha1 = "b209849203bb25df820da756e747005878521620";
       };
     }
-
     {
       name = "querystringify___querystringify_2.1.0.tgz";
       path = fetchurl {
@@ -5374,7 +4777,6 @@
         sha1 = "7ded8dfbf7879dcc60d0a644ac6754b283ad17ef";
       };
     }
-
     {
       name = "railroad_diagrams___railroad_diagrams_1.0.0.tgz";
       path = fetchurl {
@@ -5383,7 +4785,6 @@
         sha1 = "eb7e6267548ddedfb899c1b90e57374559cddb7e";
       };
     }
-
     {
       name = "randexp___randexp_0.4.6.tgz";
       path = fetchurl {
@@ -5392,7 +4793,6 @@
         sha1 = "e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3";
       };
     }
-
     {
       name = "randombytes___randombytes_2.1.0.tgz";
       path = fetchurl {
@@ -5401,7 +4801,6 @@
         sha1 = "df6f84372f0270dc65cdf6291349ab7a473d4f2a";
       };
     }
-
     {
       name = "randomfill___randomfill_1.0.4.tgz";
       path = fetchurl {
@@ -5410,7 +4809,6 @@
         sha1 = "c92196fc86ab42be983f1bf31778224931d61458";
       };
     }
-
     {
       name = "range_parser___range_parser_1.2.0.tgz";
       path = fetchurl {
@@ -5419,7 +4817,6 @@
         sha1 = "f49be6b487894ddc40dcc94a322f611092e00d5e";
       };
     }
-
     {
       name = "raw_body___raw_body_2.3.3.tgz";
       path = fetchurl {
@@ -5428,7 +4825,6 @@
         sha1 = "1b324ece6b5706e153855bc1148c65bb7f6ea0c3";
       };
     }
-
     {
       name = "rc___rc_1.2.8.tgz";
       path = fetchurl {
@@ -5437,7 +4833,6 @@
         sha1 = "cd924bf5200a075b83c188cd6b9e211b7fc0d3ed";
       };
     }
-
     {
       name = "read_pkg_up___read_pkg_up_1.0.1.tgz";
       path = fetchurl {
@@ -5446,7 +4841,6 @@
         sha1 = "9d63c13276c065918d57f002a57f40a1b643fb02";
       };
     }
-
     {
       name = "read_pkg___read_pkg_1.1.0.tgz";
       path = fetchurl {
@@ -5455,7 +4849,6 @@
         sha1 = "f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28";
       };
     }
-
     {
       name = "readable_stream___readable_stream_2.3.6.tgz";
       path = fetchurl {
@@ -5464,7 +4857,6 @@
         sha1 = "b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf";
       };
     }
-
     {
       name = "readable_stream___readable_stream_3.2.0.tgz";
       path = fetchurl {
@@ -5473,7 +4865,6 @@
         sha1 = "de17f229864c120a9f56945756e4f32c4045245d";
       };
     }
-
     {
       name = "readdirp___readdirp_2.2.1.tgz";
       path = fetchurl {
@@ -5482,7 +4873,6 @@
         sha1 = "0e87622a3325aa33e892285caf8b4e846529a525";
       };
     }
-
     {
       name = "redent___redent_1.0.0.tgz";
       path = fetchurl {
@@ -5491,7 +4881,6 @@
         sha1 = "cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde";
       };
     }
-
     {
       name = "regenerate___regenerate_1.4.0.tgz";
       path = fetchurl {
@@ -5500,7 +4889,6 @@
         sha1 = "4a856ec4b56e4077c557589cae85e7a4c8869a11";
       };
     }
-
     {
       name = "regex_not___regex_not_1.0.2.tgz";
       path = fetchurl {
@@ -5509,7 +4897,6 @@
         sha1 = "1f4ece27e00b0b65e0247a6810e6a85d83a5752c";
       };
     }
-
     {
       name = "regexpu_core___regexpu_core_1.0.0.tgz";
       path = fetchurl {
@@ -5518,7 +4905,6 @@
         sha1 = "86a763f58ee4d7c2f6b102e4764050de7ed90c6b";
       };
     }
-
     {
       name = "regjsgen___regjsgen_0.2.0.tgz";
       path = fetchurl {
@@ -5527,7 +4913,6 @@
         sha1 = "6c016adeac554f75823fe37ac05b92d5a4edb1f7";
       };
     }
-
     {
       name = "regjsparser___regjsparser_0.1.5.tgz";
       path = fetchurl {
@@ -5536,7 +4921,6 @@
         sha1 = "7ee8f84dc6fa792d3fd0ae228d24bd949ead205c";
       };
     }
-
     {
       name = "relateurl___relateurl_0.2.7.tgz";
       path = fetchurl {
@@ -5545,7 +4929,6 @@
         sha1 = "54dbf377e51440aca90a4cd274600d3ff2d888a9";
       };
     }
-
     {
       name = "remove_trailing_separator___remove_trailing_separator_1.1.0.tgz";
       path = fetchurl {
@@ -5554,7 +4937,6 @@
         sha1 = "c24bce2a283adad5bc3f58e0d48249b92379d8ef";
       };
     }
-
     {
       name = "renderkid___renderkid_2.0.3.tgz";
       path = fetchurl {
@@ -5563,7 +4945,6 @@
         sha1 = "380179c2ff5ae1365c522bf2fcfcff01c5b74149";
       };
     }
-
     {
       name = "repeat_element___repeat_element_1.1.3.tgz";
       path = fetchurl {
@@ -5572,7 +4953,6 @@
         sha1 = "782e0d825c0c5a3bb39731f84efee6b742e6b1ce";
       };
     }
-
     {
       name = "repeat_string___repeat_string_1.6.1.tgz";
       path = fetchurl {
@@ -5581,7 +4961,6 @@
         sha1 = "8dcae470e1c88abc2d600fff4a776286da75e637";
       };
     }
-
     {
       name = "repeating___repeating_2.0.1.tgz";
       path = fetchurl {
@@ -5590,7 +4969,6 @@
         sha1 = "5214c53a926d3552707527fbab415dbc08d06dda";
       };
     }
-
     {
       name = "request_promise_core___request_promise_core_1.1.3.tgz";
       path = fetchurl {
@@ -5599,7 +4977,6 @@
         sha1 = "e9a3c081b51380dfea677336061fea879a829ee9";
       };
     }
-
     {
       name = "request_promise_native___request_promise_native_1.0.8.tgz";
       path = fetchurl {
@@ -5608,7 +4985,6 @@
         sha1 = "a455b960b826e44e2bf8999af64dff2bfe58cb36";
       };
     }
-
     {
       name = "request___request_2.88.2.tgz";
       path = fetchurl {
@@ -5617,7 +4993,6 @@
         sha1 = "d73c918731cb5a87da047e207234146f664d12b3";
       };
     }
-
     {
       name = "request___request_2.88.0.tgz";
       path = fetchurl {
@@ -5626,7 +5001,6 @@
         sha1 = "9c2fca4f7d35b592efe57c7f0a55e81052124fef";
       };
     }
-
     {
       name = "require_directory___require_directory_2.1.1.tgz";
       path = fetchurl {
@@ -5635,7 +5009,6 @@
         sha1 = "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42";
       };
     }
-
     {
       name = "require_main_filename___require_main_filename_1.0.1.tgz";
       path = fetchurl {
@@ -5644,7 +5017,6 @@
         sha1 = "97f717b69d48784f5f526a6c5aa8ffdda055a4d1";
       };
     }
-
     {
       name = "requires_port___requires_port_1.0.0.tgz";
       path = fetchurl {
@@ -5653,7 +5025,6 @@
         sha1 = "925d2601d39ac485e091cf0da5c6e694dc3dcaff";
       };
     }
-
     {
       name = "resolve_cwd___resolve_cwd_2.0.0.tgz";
       path = fetchurl {
@@ -5662,7 +5033,6 @@
         sha1 = "00a9f7387556e27038eae232caa372a6a59b665a";
       };
     }
-
     {
       name = "resolve_dir___resolve_dir_1.0.1.tgz";
       path = fetchurl {
@@ -5671,7 +5041,6 @@
         sha1 = "79a40644c362be82f26effe739c9bb5382046f43";
       };
     }
-
     {
       name = "resolve_from___resolve_from_3.0.0.tgz";
       path = fetchurl {
@@ -5680,7 +5049,6 @@
         sha1 = "b22c7af7d9d6881bc8b6e653335eebcb0a188748";
       };
     }
-
     {
       name = "resolve_url___resolve_url_0.2.1.tgz";
       path = fetchurl {
@@ -5689,7 +5057,6 @@
         sha1 = "2c637fe77c893afd2a663fe21aa9080068e2052a";
       };
     }
-
     {
       name = "resolve___resolve_1.10.0.tgz";
       path = fetchurl {
@@ -5698,7 +5065,6 @@
         sha1 = "3bdaaeaf45cc07f375656dfd2e54ed0810b101ba";
       };
     }
-
     {
       name = "ret___ret_0.1.15.tgz";
       path = fetchurl {
@@ -5707,7 +5073,6 @@
         sha1 = "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc";
       };
     }
-
     {
       name = "retry___retry_0.10.1.tgz";
       path = fetchurl {
@@ -5716,7 +5081,6 @@
         sha1 = "e76388d217992c252750241d3d3956fed98d8ff4";
       };
     }
-
     {
       name = "rimraf___rimraf_2.6.3.tgz";
       path = fetchurl {
@@ -5725,7 +5089,6 @@
         sha1 = "b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab";
       };
     }
-
     {
       name = "rimraf___rimraf_2.7.1.tgz";
       path = fetchurl {
@@ -5734,7 +5097,6 @@
         sha1 = "35797f13a7fdadc566142c29d4f07ccad483e3ec";
       };
     }
-
     {
       name = "ripemd160___ripemd160_2.0.2.tgz";
       path = fetchurl {
@@ -5743,7 +5105,6 @@
         sha1 = "a1c1a6f624751577ba5d07914cbc92850585890c";
       };
     }
-
     {
       name = "run_queue___run_queue_1.0.3.tgz";
       path = fetchurl {
@@ -5752,7 +5113,6 @@
         sha1 = "e848396f057d223f24386924618e25694161ec47";
       };
     }
-
     {
       name = "safe_buffer___safe_buffer_5.1.2.tgz";
       path = fetchurl {
@@ -5761,7 +5121,6 @@
         sha1 = "991ec69d296e0313747d59bdfd2b745c35f8828d";
       };
     }
-
     {
       name = "safe_buffer___safe_buffer_5.2.1.tgz";
       path = fetchurl {
@@ -5770,7 +5129,6 @@
         sha1 = "1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6";
       };
     }
-
     {
       name = "safe_regex___safe_regex_1.1.0.tgz";
       path = fetchurl {
@@ -5779,7 +5137,6 @@
         sha1 = "40a3669f3b077d1e943d44629e157dd48023bf2e";
       };
     }
-
     {
       name = "safer_buffer___safer_buffer_2.1.2.tgz";
       path = fetchurl {
@@ -5788,7 +5145,6 @@
         sha1 = "44fa161b0187b9549dd84bb91802f9bd8385cd6a";
       };
     }
-
     {
       name = "sass_graph___sass_graph_2.2.4.tgz";
       path = fetchurl {
@@ -5797,7 +5153,6 @@
         sha1 = "13fbd63cd1caf0908b9fd93476ad43a51d1e0b49";
       };
     }
-
     {
       name = "sass_loader___sass_loader_7.1.0.tgz";
       path = fetchurl {
@@ -5806,7 +5161,6 @@
         sha1 = "16fd5138cb8b424bf8a759528a1972d72aad069d";
       };
     }
-
     {
       name = "sax___sax_1.2.4.tgz";
       path = fetchurl {
@@ -5815,7 +5169,6 @@
         sha1 = "2816234e2378bddc4e5354fab5caa895df7100d9";
       };
     }
-
     {
       name = "saxes___saxes_3.1.11.tgz";
       path = fetchurl {
@@ -5824,7 +5177,6 @@
         sha1 = "d59d1fd332ec92ad98a2e0b2ee644702384b1c5b";
       };
     }
-
     {
       name = "schema_utils___schema_utils_1.0.0.tgz";
       path = fetchurl {
@@ -5833,7 +5185,6 @@
         sha1 = "0b79a93204d7b600d4b2850d1f66c2a34951c770";
       };
     }
-
     {
       name = "scss_tokenizer___scss_tokenizer_0.2.3.tgz";
       path = fetchurl {
@@ -5842,7 +5193,6 @@
         sha1 = "8eb06db9a9723333824d3f5530641149847ce5d1";
       };
     }
-
     {
       name = "select_hose___select_hose_2.0.0.tgz";
       path = fetchurl {
@@ -5851,7 +5201,6 @@
         sha1 = "625d8658f865af43ec962bfc376a37359a4994ca";
       };
     }
-
     {
       name = "selfsigned___selfsigned_1.10.4.tgz";
       path = fetchurl {
@@ -5860,7 +5209,6 @@
         sha1 = "cdd7eccfca4ed7635d47a08bf2d5d3074092e2cd";
       };
     }
-
     {
       name = "semver___semver_5.6.0.tgz";
       path = fetchurl {
@@ -5869,7 +5217,6 @@
         sha1 = "7e74256fbaa49c75aa7c7a205cc22799cac80004";
       };
     }
-
     {
       name = "semver___semver_5.7.1.tgz";
       path = fetchurl {
@@ -5878,7 +5225,6 @@
         sha1 = "a954f931aeba508d307bbf069eff0c01c96116f7";
       };
     }
-
     {
       name = "semver___semver_6.3.0.tgz";
       path = fetchurl {
@@ -5887,7 +5233,6 @@
         sha1 = "ee0a64c8af5e8ceea67687b133761e1becbd1d3d";
       };
     }
-
     {
       name = "semver___semver_5.3.0.tgz";
       path = fetchurl {
@@ -5896,7 +5241,6 @@
         sha1 = "9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f";
       };
     }
-
     {
       name = "send___send_0.16.2.tgz";
       path = fetchurl {
@@ -5905,7 +5249,6 @@
         sha1 = "6ecca1e0f8c156d141597559848df64730a6bbc1";
       };
     }
-
     {
       name = "serialize_javascript___serialize_javascript_1.9.1.tgz";
       path = fetchurl {
@@ -5914,7 +5257,6 @@
         sha1 = "cfc200aef77b600c47da9bb8149c943e798c2fdb";
       };
     }
-
     {
       name = "serve_index___serve_index_1.9.1.tgz";
       path = fetchurl {
@@ -5923,7 +5265,6 @@
         sha1 = "d3768d69b1e7d82e5ce050fff5b453bea12a9239";
       };
     }
-
     {
       name = "serve_static___serve_static_1.13.2.tgz";
       path = fetchurl {
@@ -5932,7 +5273,6 @@
         sha1 = "095e8472fd5b46237db50ce486a43f4b86c6cec1";
       };
     }
-
     {
       name = "set_blocking___set_blocking_2.0.0.tgz";
       path = fetchurl {
@@ -5941,7 +5281,6 @@
         sha1 = "045f9782d011ae9a6803ddd382b24392b3d890f7";
       };
     }
-
     {
       name = "set_value___set_value_0.4.3.tgz";
       path = fetchurl {
@@ -5950,7 +5289,6 @@
         sha1 = "7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1";
       };
     }
-
     {
       name = "set_value___set_value_2.0.0.tgz";
       path = fetchurl {
@@ -5959,7 +5297,6 @@
         sha1 = "71ae4a88f0feefbbf52d1ea604f3fb315ebb6274";
       };
     }
-
     {
       name = "setimmediate___setimmediate_1.0.5.tgz";
       path = fetchurl {
@@ -5968,7 +5305,6 @@
         sha1 = "290cbb232e306942d7d7ea9b83732ab7856f8285";
       };
     }
-
     {
       name = "setprototypeof___setprototypeof_1.1.0.tgz";
       path = fetchurl {
@@ -5977,7 +5313,6 @@
         sha1 = "d0bd85536887b6fe7c0d818cb962d9d91c54e656";
       };
     }
-
     {
       name = "sha.js___sha.js_2.4.11.tgz";
       path = fetchurl {
@@ -5986,7 +5321,6 @@
         sha1 = "37a5cf0b81ecbc6943de109ba2960d1b26584ae7";
       };
     }
-
     {
       name = "shallow_clone___shallow_clone_1.0.0.tgz";
       path = fetchurl {
@@ -5995,7 +5329,6 @@
         sha1 = "4480cd06e882ef68b2ad88a3ea54832e2c48b571";
       };
     }
-
     {
       name = "shebang_command___shebang_command_1.2.0.tgz";
       path = fetchurl {
@@ -6004,7 +5337,6 @@
         sha1 = "44aac65b695b03398968c39f363fee5deafdf1ea";
       };
     }
-
     {
       name = "shebang_regex___shebang_regex_1.0.0.tgz";
       path = fetchurl {
@@ -6013,7 +5345,6 @@
         sha1 = "da42f49740c0b42db2ca9728571cb190c98efea3";
       };
     }
-
     {
       name = "signal_exit___signal_exit_3.0.2.tgz";
       path = fetchurl {
@@ -6022,7 +5353,6 @@
         sha1 = "b5fdc08f1287ea1178628e415e25132b73646c6d";
       };
     }
-
     {
       name = "snapdragon_node___snapdragon_node_2.1.1.tgz";
       path = fetchurl {
@@ -6031,7 +5361,6 @@
         sha1 = "6c175f86ff14bdb0724563e8f3c1b021a286853b";
       };
     }
-
     {
       name = "snapdragon_util___snapdragon_util_3.0.1.tgz";
       path = fetchurl {
@@ -6040,7 +5369,6 @@
         sha1 = "f956479486f2acd79700693f6f7b805e45ab56e2";
       };
     }
-
     {
       name = "snapdragon___snapdragon_0.8.2.tgz";
       path = fetchurl {
@@ -6049,7 +5377,6 @@
         sha1 = "64922e7c565b0e14204ba1aa7d6964278d25182d";
       };
     }
-
     {
       name = "sockjs_client___sockjs_client_1.3.0.tgz";
       path = fetchurl {
@@ -6058,7 +5385,6 @@
         sha1 = "12fc9d6cb663da5739d3dc5fb6e8687da95cb177";
       };
     }
-
     {
       name = "sockjs___sockjs_0.3.19.tgz";
       path = fetchurl {
@@ -6067,7 +5393,6 @@
         sha1 = "d976bbe800af7bd20ae08598d582393508993c0d";
       };
     }
-
     {
       name = "source_list_map___source_list_map_2.0.1.tgz";
       path = fetchurl {
@@ -6076,7 +5401,6 @@
         sha1 = "3993bd873bfc48479cca9ea3a547835c7c154b34";
       };
     }
-
     {
       name = "source_map_resolve___source_map_resolve_0.5.2.tgz";
       path = fetchurl {
@@ -6085,7 +5409,6 @@
         sha1 = "72e2cc34095543e43b2c62b2c4c10d4a9054f259";
       };
     }
-
     {
       name = "source_map_support___source_map_support_0.5.13.tgz";
       path = fetchurl {
@@ -6094,7 +5417,6 @@
         sha1 = "31b24a9c2e73c2de85066c0feb7d44767ed52932";
       };
     }
-
     {
       name = "source_map_url___source_map_url_0.4.0.tgz";
       path = fetchurl {
@@ -6103,7 +5425,6 @@
         sha1 = "3e935d7ddd73631b97659956d55128e87b5084a3";
       };
     }
-
     {
       name = "source_map___source_map_0.4.4.tgz";
       path = fetchurl {
@@ -6112,7 +5433,6 @@
         sha1 = "eba4f5da9c0dc999de68032d8b4f76173652036b";
       };
     }
-
     {
       name = "source_map___source_map_0.5.7.tgz";
       path = fetchurl {
@@ -6121,7 +5441,6 @@
         sha1 = "8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc";
       };
     }
-
     {
       name = "source_map___source_map_0.6.1.tgz";
       path = fetchurl {
@@ -6130,7 +5449,6 @@
         sha1 = "74722af32e9614e9c287a8d0bbde48b5e2f1a263";
       };
     }
-
     {
       name = "spdx_correct___spdx_correct_3.1.0.tgz";
       path = fetchurl {
@@ -6139,7 +5457,6 @@
         sha1 = "fb83e504445268f154b074e218c87c003cd31df4";
       };
     }
-
     {
       name = "spdx_exceptions___spdx_exceptions_2.2.0.tgz";
       path = fetchurl {
@@ -6148,7 +5465,6 @@
         sha1 = "2ea450aee74f2a89bfb94519c07fcd6f41322977";
       };
     }
-
     {
       name = "spdx_expression_parse___spdx_expression_parse_3.0.0.tgz";
       path = fetchurl {
@@ -6157,7 +5473,6 @@
         sha1 = "99e119b7a5da00e05491c9fa338b7904823b41d0";
       };
     }
-
     {
       name = "spdx_license_ids___spdx_license_ids_3.0.3.tgz";
       path = fetchurl {
@@ -6166,7 +5481,6 @@
         sha1 = "81c0ce8f21474756148bbb5f3bfc0f36bf15d76e";
       };
     }
-
     {
       name = "spdy_transport___spdy_transport_3.0.0.tgz";
       path = fetchurl {
@@ -6175,7 +5489,6 @@
         sha1 = "00d4863a6400ad75df93361a1608605e5dcdcf31";
       };
     }
-
     {
       name = "spdy___spdy_4.0.0.tgz";
       path = fetchurl {
@@ -6184,7 +5497,6 @@
         sha1 = "81f222b5a743a329aa12cea6a390e60e9b613c52";
       };
     }
-
     {
       name = "split_string___split_string_3.1.0.tgz";
       path = fetchurl {
@@ -6193,7 +5505,6 @@
         sha1 = "7cb09dda3a86585705c64b39a6466038682e8fe2";
       };
     }
-
     {
       name = "sshpk___sshpk_1.16.1.tgz";
       path = fetchurl {
@@ -6202,7 +5513,6 @@
         sha1 = "fb661c0bef29b39db40769ee39fa70093d6f6877";
       };
     }
-
     {
       name = "ssri___ssri_6.0.1.tgz";
       path = fetchurl {
@@ -6211,7 +5521,6 @@
         sha1 = "2a3c41b28dd45b62b63676ecb74001265ae9edd8";
       };
     }
-
     {
       name = "static_extend___static_extend_0.1.2.tgz";
       path = fetchurl {
@@ -6220,7 +5529,6 @@
         sha1 = "60809c39cbff55337226fd5e0b520f341f1fb5c6";
       };
     }
-
     {
       name = "statuses___statuses_1.5.0.tgz";
       path = fetchurl {
@@ -6229,7 +5537,6 @@
         sha1 = "161c7dac177659fd9811f43771fa99381478628c";
       };
     }
-
     {
       name = "statuses___statuses_1.4.0.tgz";
       path = fetchurl {
@@ -6238,7 +5545,6 @@
         sha1 = "bb73d446da2796106efcc1b601a253d6c46bd087";
       };
     }
-
     {
       name = "stdout_stream___stdout_stream_1.4.1.tgz";
       path = fetchurl {
@@ -6247,7 +5553,6 @@
         sha1 = "5ac174cdd5cd726104aa0c0b2bd83815d8d535de";
       };
     }
-
     {
       name = "stealthy_require___stealthy_require_1.1.1.tgz";
       path = fetchurl {
@@ -6256,7 +5561,6 @@
         sha1 = "35b09875b4ff49f26a777e509b3090a3226bf24b";
       };
     }
-
     {
       name = "stream_browserify___stream_browserify_2.0.2.tgz";
       path = fetchurl {
@@ -6265,7 +5569,6 @@
         sha1 = "87521d38a44aa7ee91ce1cd2a47df0cb49dd660b";
       };
     }
-
     {
       name = "stream_each___stream_each_1.2.3.tgz";
       path = fetchurl {
@@ -6274,7 +5577,6 @@
         sha1 = "ebe27a0c389b04fbcc233642952e10731afa9bae";
       };
     }
-
     {
       name = "stream_http___stream_http_2.8.3.tgz";
       path = fetchurl {
@@ -6283,7 +5585,6 @@
         sha1 = "b2d242469288a5a27ec4fe8933acf623de6514fc";
       };
     }
-
     {
       name = "stream_shift___stream_shift_1.0.0.tgz";
       path = fetchurl {
@@ -6292,7 +5593,6 @@
         sha1 = "d5c752825e5367e786f78e18e445ea223a155952";
       };
     }
-
     {
       name = "string_width___string_width_1.0.2.tgz";
       path = fetchurl {
@@ -6301,7 +5601,6 @@
         sha1 = "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3";
       };
     }
-
     {
       name = "string_width___string_width_2.1.1.tgz";
       path = fetchurl {
@@ -6310,7 +5609,6 @@
         sha1 = "ab93f27a8dc13d28cac815c462143a6d9012ae9e";
       };
     }
-
     {
       name = "string_decoder___string_decoder_1.2.0.tgz";
       path = fetchurl {
@@ -6319,7 +5617,6 @@
         sha1 = "fe86e738b19544afe70469243b2a1ee9240eae8d";
       };
     }
-
     {
       name = "string_decoder___string_decoder_1.1.1.tgz";
       path = fetchurl {
@@ -6328,7 +5625,6 @@
         sha1 = "9cf1611ba62685d7030ae9e4ba34149c3af03fc8";
       };
     }
-
     {
       name = "strip_ansi___strip_ansi_3.0.1.tgz";
       path = fetchurl {
@@ -6337,7 +5633,6 @@
         sha1 = "6a385fb8853d952d5ff05d0e8aaf94278dc63dcf";
       };
     }
-
     {
       name = "strip_ansi___strip_ansi_4.0.0.tgz";
       path = fetchurl {
@@ -6346,7 +5641,6 @@
         sha1 = "a8479022eb1ac368a871389b635262c505ee368f";
       };
     }
-
     {
       name = "strip_bom___strip_bom_2.0.0.tgz";
       path = fetchurl {
@@ -6355,7 +5649,6 @@
         sha1 = "6219a85616520491f35788bdbf1447a99c7e6b0e";
       };
     }
-
     {
       name = "strip_eof___strip_eof_1.0.0.tgz";
       path = fetchurl {
@@ -6364,7 +5657,6 @@
         sha1 = "bb43ff5598a6eb05d89b59fcd129c983313606bf";
       };
     }
-
     {
       name = "strip_indent___strip_indent_1.0.1.tgz";
       path = fetchurl {
@@ -6373,7 +5665,6 @@
         sha1 = "0c7962a6adefa7bbd4ac366460a638552ae1a0a2";
       };
     }
-
     {
       name = "strip_json_comments___strip_json_comments_2.0.1.tgz";
       path = fetchurl {
@@ -6382,7 +5673,6 @@
         sha1 = "3c531942e908c2697c0ec344858c286c7ca0a60a";
       };
     }
-
     {
       name = "style_loader___style_loader_0.23.1.tgz";
       path = fetchurl {
@@ -6391,7 +5681,6 @@
         sha1 = "cb9154606f3e771ab6c4ab637026a1049174d925";
       };
     }
-
     {
       name = "supports_color___supports_color_2.0.0.tgz";
       path = fetchurl {
@@ -6400,7 +5689,6 @@
         sha1 = "535d045ce6b6363fa40117084629995e9df324c7";
       };
     }
-
     {
       name = "supports_color___supports_color_5.5.0.tgz";
       path = fetchurl {
@@ -6409,7 +5697,6 @@
         sha1 = "e2e69a44ac8772f78a1ec0b35b689df6530efc8f";
       };
     }
-
     {
       name = "supports_color___supports_color_6.1.0.tgz";
       path = fetchurl {
@@ -6418,7 +5705,6 @@
         sha1 = "0764abc69c63d5ac842dd4867e8d025e880df8f3";
       };
     }
-
     {
       name = "symbol_tree___symbol_tree_3.2.4.tgz";
       path = fetchurl {
@@ -6427,7 +5713,6 @@
         sha1 = "430637d248ba77e078883951fb9aa0eed7c63fa2";
       };
     }
-
     {
       name = "tapable___tapable_1.1.1.tgz";
       path = fetchurl {
@@ -6436,7 +5721,6 @@
         sha1 = "4d297923c5a72a42360de2ab52dadfaaec00018e";
       };
     }
-
     {
       name = "tapable___tapable_1.1.3.tgz";
       path = fetchurl {
@@ -6445,7 +5729,6 @@
         sha1 = "a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2";
       };
     }
-
     {
       name = "tar___tar_2.2.1.tgz";
       path = fetchurl {
@@ -6454,7 +5737,6 @@
         sha1 = "8e4d2a256c0e2185c6b18ad694aec968b83cb1d1";
       };
     }
-
     {
       name = "tar___tar_4.4.8.tgz";
       path = fetchurl {
@@ -6463,7 +5745,6 @@
         sha1 = "b19eec3fde2a96e64666df9fdb40c5ca1bc3747d";
       };
     }
-
     {
       name = "terser_webpack_plugin___terser_webpack_plugin_1.4.1.tgz";
       path = fetchurl {
@@ -6472,7 +5753,6 @@
         sha1 = "61b18e40eaee5be97e771cdbb10ed1280888c2b4";
       };
     }
-
     {
       name = "terser___terser_4.3.8.tgz";
       path = fetchurl {
@@ -6481,7 +5761,6 @@
         sha1 = "707f05f3f4c1c70c840e626addfdb1c158a17136";
       };
     }
-
     {
       name = "through2___through2_2.0.5.tgz";
       path = fetchurl {
@@ -6490,7 +5769,6 @@
         sha1 = "01c1e39eb31d07cb7d03a96a70823260b23132cd";
       };
     }
-
     {
       name = "thunky___thunky_1.0.3.tgz";
       path = fetchurl {
@@ -6499,7 +5777,6 @@
         sha1 = "f5df732453407b09191dae73e2a8cc73f381a826";
       };
     }
-
     {
       name = "timers_browserify___timers_browserify_2.0.10.tgz";
       path = fetchurl {
@@ -6508,7 +5785,6 @@
         sha1 = "1d28e3d2aadf1d5a5996c4e9f95601cd053480ae";
       };
     }
-
     {
       name = "to_arraybuffer___to_arraybuffer_1.0.1.tgz";
       path = fetchurl {
@@ -6517,7 +5793,6 @@
         sha1 = "7d229b1fcc637e466ca081180836a7aabff83f43";
       };
     }
-
     {
       name = "to_object_path___to_object_path_0.3.0.tgz";
       path = fetchurl {
@@ -6526,7 +5801,6 @@
         sha1 = "297588b7b0e7e0ac08e04e672f85c1f4999e17af";
       };
     }
-
     {
       name = "to_regex_range___to_regex_range_2.1.1.tgz";
       path = fetchurl {
@@ -6535,7 +5809,6 @@
         sha1 = "7c80c17b9dfebe599e27367e0d4dd5590141db38";
       };
     }
-
     {
       name = "to_regex_range___to_regex_range_5.0.1.tgz";
       path = fetchurl {
@@ -6544,7 +5817,6 @@
         sha1 = "1648c44aae7c8d988a326018ed72f5b4dd0392e4";
       };
     }
-
     {
       name = "to_regex___to_regex_3.0.2.tgz";
       path = fetchurl {
@@ -6553,7 +5825,6 @@
         sha1 = "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce";
       };
     }
-
     {
       name = "toposort___toposort_1.0.7.tgz";
       path = fetchurl {
@@ -6562,7 +5833,6 @@
         sha1 = "2e68442d9f64ec720b8cc89e6443ac6caa950029";
       };
     }
-
     {
       name = "tough_cookie___tough_cookie_2.5.0.tgz";
       path = fetchurl {
@@ -6571,7 +5841,6 @@
         sha1 = "cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2";
       };
     }
-
     {
       name = "tough_cookie___tough_cookie_3.0.1.tgz";
       path = fetchurl {
@@ -6580,7 +5849,6 @@
         sha1 = "9df4f57e739c26930a018184887f4adb7dca73b2";
       };
     }
-
     {
       name = "tough_cookie___tough_cookie_2.4.3.tgz";
       path = fetchurl {
@@ -6589,7 +5857,6 @@
         sha1 = "53f36da3f47783b0925afa06ff9f3b165280f781";
       };
     }
-
     {
       name = "tr46___tr46_1.0.1.tgz";
       path = fetchurl {
@@ -6598,7 +5865,6 @@
         sha1 = "a8b13fd6bfd2489519674ccde55ba3693b706d09";
       };
     }
-
     {
       name = "tr46___tr46_0.0.3.tgz";
       path = fetchurl {
@@ -6607,7 +5873,6 @@
         sha1 = "8184fd347dac9cdc185992f3a6622e14b9d9ab6a";
       };
     }
-
     {
       name = "trim_newlines___trim_newlines_1.0.0.tgz";
       path = fetchurl {
@@ -6616,7 +5881,6 @@
         sha1 = "5887966bb582a4503a41eb524f7d35011815a613";
       };
     }
-
     {
       name = "true_case_path___true_case_path_1.0.3.tgz";
       path = fetchurl {
@@ -6625,7 +5889,6 @@
         sha1 = "f813b5a8c86b40da59606722b144e3225799f47d";
       };
     }
-
     {
       name = "ts_loader___ts_loader_6.2.1.tgz";
       path = fetchurl {
@@ -6634,7 +5897,6 @@
         sha1 = "67939d5772e8a8c6bdaf6277ca023a4812da02ef";
       };
     }
-
     {
       name = "tslib___tslib_1.9.3.tgz";
       path = fetchurl {
@@ -6643,7 +5905,6 @@
         sha1 = "d7e4dd79245d85428c4d7e4822a79917954ca286";
       };
     }
-
     {
       name = "tty_browserify___tty_browserify_0.0.0.tgz";
       path = fetchurl {
@@ -6652,7 +5913,6 @@
         sha1 = "a157ba402da24e9bf957f9aa69d524eed42901a6";
       };
     }
-
     {
       name = "tunnel_agent___tunnel_agent_0.6.0.tgz";
       path = fetchurl {
@@ -6661,7 +5921,6 @@
         sha1 = "27a5dea06b36b04a0a9966774b290868f0fc40fd";
       };
     }
-
     {
       name = "tweetnacl___tweetnacl_0.14.5.tgz";
       path = fetchurl {
@@ -6670,7 +5929,6 @@
         sha1 = "5ae68177f192d4456269d108afa93ff8743f4f64";
       };
     }
-
     {
       name = "type_check___type_check_0.3.2.tgz";
       path = fetchurl {
@@ -6679,7 +5937,6 @@
         sha1 = "5884cab512cf1d355e3fb784f30804b2b520db72";
       };
     }
-
     {
       name = "type_is___type_is_1.6.16.tgz";
       path = fetchurl {
@@ -6688,7 +5945,6 @@
         sha1 = "f89ce341541c672b25ee7ae3c73dee3b2be50194";
       };
     }
-
     {
       name = "typedarray___typedarray_0.0.6.tgz";
       path = fetchurl {
@@ -6697,7 +5953,6 @@
         sha1 = "867ac74e3864187b1d3d47d996a78ec5c8830777";
       };
     }
-
     {
       name = "typescript___typescript_3.8.3.tgz";
       path = fetchurl {
@@ -6706,7 +5961,6 @@
         sha1 = "409eb8544ea0335711205869ec458ab109ee1061";
       };
     }
-
     {
       name = "uglify_js___uglify_js_3.4.9.tgz";
       path = fetchurl {
@@ -6715,7 +5969,6 @@
         sha1 = "af02f180c1207d76432e473ed24a28f4a782bae3";
       };
     }
-
     {
       name = "union_value___union_value_1.0.0.tgz";
       path = fetchurl {
@@ -6724,7 +5977,6 @@
         sha1 = "5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4";
       };
     }
-
     {
       name = "unique_filename___unique_filename_1.1.1.tgz";
       path = fetchurl {
@@ -6733,7 +5985,6 @@
         sha1 = "1d69769369ada0583103a1e6ae87681b56573230";
       };
     }
-
     {
       name = "unique_slug___unique_slug_2.0.1.tgz";
       path = fetchurl {
@@ -6742,7 +5993,6 @@
         sha1 = "5e9edc6d1ce8fb264db18a507ef9bd8544451ca6";
       };
     }
-
     {
       name = "unpipe___unpipe_1.0.0.tgz";
       path = fetchurl {
@@ -6751,7 +6001,6 @@
         sha1 = "b2bf4ee8514aae6165b4817829d21b2ef49904ec";
       };
     }
-
     {
       name = "unset_value___unset_value_1.0.0.tgz";
       path = fetchurl {
@@ -6760,7 +6009,6 @@
         sha1 = "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559";
       };
     }
-
     {
       name = "upath___upath_1.1.2.tgz";
       path = fetchurl {
@@ -6769,7 +6017,6 @@
         sha1 = "3db658600edaeeccbe6db5e684d67ee8c2acd068";
       };
     }
-
     {
       name = "upper_case___upper_case_1.1.3.tgz";
       path = fetchurl {
@@ -6778,7 +6025,6 @@
         sha1 = "f6b4501c2ec4cdd26ba78be7222961de77621598";
       };
     }
-
     {
       name = "uri_js___uri_js_4.2.2.tgz";
       path = fetchurl {
@@ -6787,7 +6033,6 @@
         sha1 = "94c540e1ff772956e2299507c010aea6c8838eb0";
       };
     }
-
     {
       name = "urix___urix_0.1.0.tgz";
       path = fetchurl {
@@ -6796,7 +6041,6 @@
         sha1 = "da937f7a62e21fec1fd18d49b35c2935067a6c72";
       };
     }
-
     {
       name = "url_loader___url_loader_1.1.2.tgz";
       path = fetchurl {
@@ -6805,7 +6049,6 @@
         sha1 = "b971d191b83af693c5e3fea4064be9e1f2d7f8d8";
       };
     }
-
     {
       name = "url_parse___url_parse_1.4.4.tgz";
       path = fetchurl {
@@ -6814,7 +6057,6 @@
         sha1 = "cac1556e95faa0303691fec5cf9d5a1bc34648f8";
       };
     }
-
     {
       name = "url___url_0.11.0.tgz";
       path = fetchurl {
@@ -6823,7 +6065,6 @@
         sha1 = "3838e97cfc60521eb73c525a8e55bfdd9e2e28f1";
       };
     }
-
     {
       name = "use___use_3.1.1.tgz";
       path = fetchurl {
@@ -6832,7 +6073,6 @@
         sha1 = "d50c8cac79a19fbc20f2911f56eb973f4e10070f";
       };
     }
-
     {
       name = "util_deprecate___util_deprecate_1.0.2.tgz";
       path = fetchurl {
@@ -6841,7 +6081,6 @@
         sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
       };
     }
-
     {
       name = "util.promisify___util.promisify_1.0.0.tgz";
       path = fetchurl {
@@ -6850,7 +6089,6 @@
         sha1 = "440f7165a459c9a16dc145eb8e72f35687097030";
       };
     }
-
     {
       name = "util___util_0.10.3.tgz";
       path = fetchurl {
@@ -6859,7 +6097,6 @@
         sha1 = "7afb1afe50805246489e3db7fe0ed379336ac0f9";
       };
     }
-
     {
       name = "util___util_0.11.1.tgz";
       path = fetchurl {
@@ -6868,7 +6105,6 @@
         sha1 = "3236733720ec64bb27f6e26f421aaa2e1b588d61";
       };
     }
-
     {
       name = "utila___utila_0.4.0.tgz";
       path = fetchurl {
@@ -6877,7 +6113,6 @@
         sha1 = "8a16a05d445657a3aea5eecc5b12a4fa5379772c";
       };
     }
-
     {
       name = "utils_merge___utils_merge_1.0.1.tgz";
       path = fetchurl {
@@ -6886,7 +6121,6 @@
         sha1 = "9f95710f50a267947b2ccc124741c1028427e713";
       };
     }
-
     {
       name = "uuid___uuid_3.3.2.tgz";
       path = fetchurl {
@@ -6895,7 +6129,6 @@
         sha1 = "1b4af4955eb3077c501c23872fc6513811587131";
       };
     }
-
     {
       name = "uuid___uuid_3.4.0.tgz";
       path = fetchurl {
@@ -6904,7 +6137,6 @@
         sha1 = "b23e4358afa8a202fe7a100af1f5f883f02007ee";
       };
     }
-
     {
       name = "v8_compile_cache___v8_compile_cache_2.0.2.tgz";
       path = fetchurl {
@@ -6913,7 +6145,6 @@
         sha1 = "a428b28bb26790734c4fc8bc9fa106fccebf6a6c";
       };
     }
-
     {
       name = "validate_npm_package_license___validate_npm_package_license_3.0.4.tgz";
       path = fetchurl {
@@ -6922,7 +6153,6 @@
         sha1 = "fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a";
       };
     }
-
     {
       name = "vary___vary_1.1.2.tgz";
       path = fetchurl {
@@ -6931,7 +6161,6 @@
         sha1 = "2299f02c6ded30d4a5961b0b9f74524a18f634fc";
       };
     }
-
     {
       name = "verror___verror_1.10.0.tgz";
       path = fetchurl {
@@ -6940,7 +6169,6 @@
         sha1 = "3a105ca17053af55d6e270c1f8288682e18da400";
       };
     }
-
     {
       name = "vm_browserify___vm_browserify_1.1.0.tgz";
       path = fetchurl {
@@ -6949,7 +6177,6 @@
         sha1 = "bd76d6a23323e2ca8ffa12028dc04559c75f9019";
       };
     }
-
     {
       name = "w3c_hr_time___w3c_hr_time_1.0.2.tgz";
       path = fetchurl {
@@ -6958,7 +6185,6 @@
         sha1 = "0a89cdf5cc15822df9c360543676963e0cc308cd";
       };
     }
-
     {
       name = "w3c_xmlserializer___w3c_xmlserializer_1.1.2.tgz";
       path = fetchurl {
@@ -6967,7 +6193,6 @@
         sha1 = "30485ca7d70a6fd052420a3d12fd90e6339ce794";
       };
     }
-
     {
       name = "watchpack___watchpack_1.6.0.tgz";
       path = fetchurl {
@@ -6976,7 +6201,6 @@
         sha1 = "4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00";
       };
     }
-
     {
       name = "wbuf___wbuf_1.7.3.tgz";
       path = fetchurl {
@@ -6985,7 +6209,6 @@
         sha1 = "c1d8d149316d3ea852848895cb6a0bfe887b87df";
       };
     }
-
     {
       name = "webidl_conversions___webidl_conversions_4.0.2.tgz";
       path = fetchurl {
@@ -6994,7 +6217,6 @@
         sha1 = "a855980b1f0b6b359ba1d5d9fb39ae941faa63ad";
       };
     }
-
     {
       name = "webpack_cli___webpack_cli_3.2.3.tgz";
       path = fetchurl {
@@ -7003,7 +6225,6 @@
         sha1 = "13653549adfd8ccd920ad7be1ef868bacc22e346";
       };
     }
-
     {
       name = "webpack_dev_middleware___webpack_dev_middleware_3.6.1.tgz";
       path = fetchurl {
@@ -7012,7 +6233,6 @@
         sha1 = "91f2531218a633a99189f7de36045a331a4b9cd4";
       };
     }
-
     {
       name = "webpack_dev_server___webpack_dev_server_3.2.1.tgz";
       path = fetchurl {
@@ -7021,7 +6241,6 @@
         sha1 = "1b45ce3ecfc55b6ebe5e36dab2777c02bc508c4e";
       };
     }
-
     {
       name = "webpack_log___webpack_log_2.0.0.tgz";
       path = fetchurl {
@@ -7030,7 +6249,6 @@
         sha1 = "5b7928e0637593f119d32f6227c1e0ac31e1b47f";
       };
     }
-
     {
       name = "webpack_node_externals___webpack_node_externals_1.7.2.tgz";
       path = fetchurl {
@@ -7039,7 +6257,6 @@
         sha1 = "6e1ee79ac67c070402ba700ef033a9b8d52ac4e3";
       };
     }
-
     {
       name = "webpack_sources___webpack_sources_1.4.3.tgz";
       path = fetchurl {
@@ -7048,7 +6265,6 @@
         sha1 = "eedd8ec0b928fbf1cbfe994e22d2d890f330a933";
       };
     }
-
     {
       name = "webpack___webpack_4.41.1.tgz";
       path = fetchurl {
@@ -7057,7 +6273,6 @@
         sha1 = "5388dd3047d680d5d382a84249fd4750e87372fd";
       };
     }
-
     {
       name = "websocket_driver___websocket_driver_0.7.0.tgz";
       path = fetchurl {
@@ -7066,7 +6281,6 @@
         sha1 = "0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb";
       };
     }
-
     {
       name = "websocket_extensions___websocket_extensions_0.1.3.tgz";
       path = fetchurl {
@@ -7075,7 +6289,6 @@
         sha1 = "5d2ff22977003ec687a4b87073dfbbac146ccf29";
       };
     }
-
     {
       name = "whatwg_encoding___whatwg_encoding_1.0.5.tgz";
       path = fetchurl {
@@ -7084,7 +6297,6 @@
         sha1 = "5abacf777c32166a51d085d6b4f3e7d27113ddb0";
       };
     }
-
     {
       name = "whatwg_mimetype___whatwg_mimetype_2.3.0.tgz";
       path = fetchurl {
@@ -7093,7 +6305,6 @@
         sha1 = "3d4b1e0312d2079879f826aff18dbeeca5960fbf";
       };
     }
-
     {
       name = "whatwg_url_compat___whatwg_url_compat_0.6.5.tgz";
       path = fetchurl {
@@ -7102,7 +6313,6 @@
         sha1 = "00898111af689bb097541cd5a45ca6c8798445bf";
       };
     }
-
     {
       name = "whatwg_url___whatwg_url_7.1.0.tgz";
       path = fetchurl {
@@ -7111,7 +6321,6 @@
         sha1 = "c2c492f1eca612988efd3d2266be1b9fc6170d06";
       };
     }
-
     {
       name = "which_module___which_module_1.0.0.tgz";
       path = fetchurl {
@@ -7120,7 +6329,6 @@
         sha1 = "bba63ca861948994ff307736089e3b96026c2a4f";
       };
     }
-
     {
       name = "which_module___which_module_2.0.0.tgz";
       path = fetchurl {
@@ -7129,7 +6337,6 @@
         sha1 = "d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a";
       };
     }
-
     {
       name = "which___which_1.3.1.tgz";
       path = fetchurl {
@@ -7138,7 +6345,6 @@
         sha1 = "a45043d54f5805316da8d62f9f50918d3da70b0a";
       };
     }
-
     {
       name = "wide_align___wide_align_1.1.3.tgz";
       path = fetchurl {
@@ -7147,7 +6353,6 @@
         sha1 = "ae074e6bdc0c14a431e804e624549c633b000457";
       };
     }
-
     {
       name = "word_wrap___word_wrap_1.2.3.tgz";
       path = fetchurl {
@@ -7156,7 +6361,6 @@
         sha1 = "610636f6b1f703891bd34771ccb17fb93b47079c";
       };
     }
-
     {
       name = "worker_farm___worker_farm_1.7.0.tgz";
       path = fetchurl {
@@ -7165,7 +6369,6 @@
         sha1 = "26a94c5391bbca926152002f69b84a4bf772e5a8";
       };
     }
-
     {
       name = "wrap_ansi___wrap_ansi_2.1.0.tgz";
       path = fetchurl {
@@ -7174,7 +6377,6 @@
         sha1 = "d8fc3d284dd05794fe84973caecdd1cf824fdd85";
       };
     }
-
     {
       name = "wrappy___wrappy_1.0.2.tgz";
       path = fetchurl {
@@ -7183,7 +6385,6 @@
         sha1 = "b5243d8f3ec1aa35f1364605bc0d1036e30ab69f";
       };
     }
-
     {
       name = "ws___ws_7.3.0.tgz";
       path = fetchurl {
@@ -7192,7 +6393,6 @@
         sha1 = "4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd";
       };
     }
-
     {
       name = "xhr2___xhr2_0.1.4.tgz";
       path = fetchurl {
@@ -7201,7 +6401,6 @@
         sha1 = "7f87658847716db5026323812f818cadab387a5f";
       };
     }
-
     {
       name = "xml_name_validator___xml_name_validator_2.0.1.tgz";
       path = fetchurl {
@@ -7210,7 +6409,6 @@
         sha1 = "4d8b8f1eccd3419aa362061becef515e1e559635";
       };
     }
-
     {
       name = "xml_name_validator___xml_name_validator_3.0.0.tgz";
       path = fetchurl {
@@ -7219,7 +6417,6 @@
         sha1 = "6ae73e06de4d8c6e47f9fb181f78d648ad457c6a";
       };
     }
-
     {
       name = "xmlchars___xmlchars_2.2.0.tgz";
       path = fetchurl {
@@ -7228,7 +6425,6 @@
         sha1 = "060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb";
       };
     }
-
     {
       name = "xmlhttprequest___xmlhttprequest_1.8.0.tgz";
       path = fetchurl {
@@ -7237,7 +6433,6 @@
         sha1 = "67fe075c5c24fef39f9d65f5f7b7fe75171968fc";
       };
     }
-
     {
       name = "xmlshim___xmlshim_0.2.7.tgz";
       path = fetchurl {
@@ -7246,7 +6441,6 @@
         sha1 = "486558b6c8da0ba5aa2726974604781864e3f15c";
       };
     }
-
     {
       name = "xregexp___xregexp_4.0.0.tgz";
       path = fetchurl {
@@ -7255,7 +6449,6 @@
         sha1 = "e698189de49dd2a18cc5687b05e17c8e43943020";
       };
     }
-
     {
       name = "xtend___xtend_4.0.1.tgz";
       path = fetchurl {
@@ -7264,7 +6457,6 @@
         sha1 = "a5c6d532be656e23db820efb943a1f04998d63af";
       };
     }
-
     {
       name = "y18n___y18n_3.2.1.tgz";
       path = fetchurl {
@@ -7273,7 +6465,6 @@
         sha1 = "6d15fba884c08679c0d77e88e7759e811e07fa41";
       };
     }
-
     {
       name = "y18n___y18n_4.0.0.tgz";
       path = fetchurl {
@@ -7282,7 +6473,6 @@
         sha1 = "95ef94f85ecc81d007c264e190a120f0a3c8566b";
       };
     }
-
     {
       name = "yallist___yallist_2.1.2.tgz";
       path = fetchurl {
@@ -7291,7 +6481,6 @@
         sha1 = "1c11f9218f076089a47dd512f93c6699a6a81d52";
       };
     }
-
     {
       name = "yallist___yallist_3.0.3.tgz";
       path = fetchurl {
@@ -7300,7 +6489,6 @@
         sha1 = "b4b049e314be545e3ce802236d6cd22cd91c3de9";
       };
     }
-
     {
       name = "yargs_parser___yargs_parser_10.1.0.tgz";
       path = fetchurl {
@@ -7309,7 +6497,6 @@
         sha1 = "7202265b89f7e9e9f2e5765e0fe735a905edbaa8";
       };
     }
-
     {
       name = "yargs_parser___yargs_parser_11.1.1.tgz";
       path = fetchurl {
@@ -7318,7 +6505,6 @@
         sha1 = "879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4";
       };
     }
-
     {
       name = "yargs_parser___yargs_parser_5.0.0.tgz";
       path = fetchurl {
@@ -7327,7 +6513,6 @@
         sha1 = "275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a";
       };
     }
-
     {
       name = "yargs___yargs_12.0.2.tgz";
       path = fetchurl {
@@ -7336,7 +6521,6 @@
         sha1 = "fe58234369392af33ecbef53819171eff0f5aadc";
       };
     }
-
     {
       name = "yargs___yargs_12.0.5.tgz";
       path = fetchurl {
@@ -7345,7 +6529,6 @@
         sha1 = "05f5997b609647b64f66b81e3b4b10a368e7ad13";
       };
     }
-
     {
       name = "yargs___yargs_7.1.0.tgz";
       path = fetchurl {


### PR DESCRIPTION
I used to have a fork of the nearley webpack plugin that enabled you to inject something into the generated javascript however I realised this is not necessary as I can simple call compiled purescript directly from the `ne` file.