### PR TITLE
Work around cabal issue 7006

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -170,9 +170,9 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
   tag: bd7eb69d27bfaee46d435bc1d2720520b1446426
-  subdir: 
-    . 
-    test
+  -- Because they includes `.` subdirs need to be on the same line
+  -- See https://github.com/haskell/cabal/issues/7006
+  subdir: . test
 
 source-repository-package
   type: git


### PR DESCRIPTION
See https://github.com/haskell/cabal/issues/7006 for details

To reproduce this issue in this repo:

```
nix-shell
cabal build lib:cardano-prelude
```