### PR TITLE
Remove catamorphisms from CBOR encoder (SCP-1033)

### DIFF
--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeOperators        #-}
@@ -34,7 +35,6 @@ import           Codec.CBOR.Decoding
 import           Codec.CBOR.Encoding
 import           Codec.Serialise
 import qualified Data.ByteString.Lazy           as BSL
-import           Data.Functor.Foldable          hiding (fold)
 import           Data.Proxy
 
 {- Note [Stable encoding of PLC]
@@ -70,6 +70,22 @@ tags with predefined meanings which we shouldn't interfere with.
 See http://hackage.haskell.org/package/serialise.
 -}
 
+{- [Note: Don't use catamorphims!]  
+We use Codec.Serialise for encoding.  This uses an itermediate type
+`Encoding` to encode things. `Encoding` is a monoid, which allows
+subobjects to be encoded and then efficiently concatenated when a
+larger object is being encoded to CBOR.  The monoid structure makes it
+tempting to use catamoprhisms to encode things, but this is
+*dangerous*. When a list is encoded to CBOR, the start and end of the
+list is marked by a special token; this is then followed by the
+encodings of the individual list elements, then another token to mark
+the end of the list.  If we use a catamorphism to encode a list `l` it
+just encodes the elements and concatenates the encoded versions
+together without the markers, which is wrong: instead we should call
+`encode l` directly.  At present we aren't encoding any lists, but we 
+should take care to avoid this trap just in case.
+-}
+
 encodeConstructorTag :: Word -> Encoding
 encodeConstructorTag = encodeWord
 
@@ -92,31 +108,29 @@ instance (Closed uni, uni `Everywhere` Serialise) => Serialise (Some (ValueOf un
         go (Some (TypeIn uni)) = Some . ValueOf uni <$> bring (Proxy @Serialise) uni decode
 
 instance Serialise BuiltinName where
-    encode bi =
-        let i = case bi of
-                AddInteger           -> 0
-                SubtractInteger      -> 1
-                MultiplyInteger      -> 2
-                DivideInteger        -> 3
-                RemainderInteger     -> 4
-                LessThanInteger      -> 5
-                LessThanEqInteger    -> 6
-                GreaterThanInteger   -> 7
-                GreaterThanEqInteger -> 8
-                EqInteger            -> 9
-                Concatenate          -> 10
-                TakeByteString       -> 11
-                DropByteString       -> 12
-                SHA2                 -> 13
-                SHA3                 -> 14
-                VerifySignature      -> 15
-                EqByteString         -> 16
-                QuotientInteger      -> 17
-                ModInteger           -> 18
-                LtByteString         -> 19
-                GtByteString         -> 20
-                IfThenElse           -> 21
-        in encodeConstructorTag i
+    encode = encodeConstructorTag . \case 
+              AddInteger           -> 0
+              SubtractInteger      -> 1
+              MultiplyInteger      -> 2
+              DivideInteger        -> 3
+              RemainderInteger     -> 4
+              LessThanInteger      -> 5
+              LessThanEqInteger    -> 6
+              GreaterThanInteger   -> 7
+              GreaterThanEqInteger -> 8
+              EqInteger            -> 9
+              Concatenate          -> 10
+              TakeByteString       -> 11
+              DropByteString       -> 12
+              SHA2                 -> 13
+              SHA3                 -> 14
+              VerifySignature      -> 15
+              EqByteString         -> 16
+              QuotientInteger      -> 17
+              ModInteger           -> 18
+              LtByteString         -> 19
+              GtByteString         -> 20
+              IfThenElse           -> 21
 
     decode = go =<< decodeConstructorTag
         where go 0  = pure AddInteger
@@ -157,37 +171,37 @@ instance Serialise TyName where
     decode = TyName <$> decode
 
 instance Serialise ann => Serialise (Version ann) where
-    encode (Version ann n n' n'') = fold [ encode ann, encode n, encode n', encode n'' ]
+    encode (Version ann n n' n'') = encode ann <> encode n <> encode n' <> encode n''
     decode = Version <$> decode <*> decode <*> decode <*> decode
 
 instance Serialise ann => Serialise (Kind ann) where
-    encode = cata a where
-        a (TypeF ann)           = encodeConstructorTag 0 <> encode ann
-        a (KindArrowF ann k k') = fold [ encodeConstructorTag 1, encode ann, k , k' ]
+    encode = \case
+        Type ann           -> encodeConstructorTag 0 <> encode ann
+        KindArrow ann k k' -> encodeConstructorTag 1 <> encode ann <> encode k  <> encode k'
 
     decode = go =<< decodeConstructorTag
-        where go 0 = Type <$> decode
+        where go 0 = Type      <$> decode
               go 1 = KindArrow <$> decode <*> decode <*> decode
               go _ = fail "Failed to decode Kind ()"
 
 instance (Closed uni, Serialise ann, Serialise tyname) => Serialise (Type tyname uni ann) where
-    encode = cata a where
-        a (TyVarF ann tn)        = encodeConstructorTag 0 <> encode ann <> encode tn
-        a (TyFunF ann t t')      = encodeConstructorTag 1 <> encode ann <> t <> t'
-        a (TyIFixF ann pat arg)  = encodeConstructorTag 2 <> encode ann <> pat <> arg
-        a (TyForallF ann tn k t) = encodeConstructorTag 3 <> encode ann <> encode tn <> encode k <> t
-        a (TyBuiltinF ann con)   = encodeConstructorTag 4 <> encode ann <> encode con
-        a (TyLamF ann n k t)     = encodeConstructorTag 5 <> encode ann <> encode n <> encode k <> t
-        a (TyAppF ann t t')      = encodeConstructorTag 6 <> encode ann <> t <> t'
+    encode = \case
+        TyVar     ann tn      -> encodeConstructorTag 0 <> encode ann <> encode tn
+        TyFun     ann t t'    -> encodeConstructorTag 1 <> encode ann <> encode t   <> encode t'
+        TyIFix    ann pat arg -> encodeConstructorTag 2 <> encode ann <> encode pat <> encode arg
+        TyForall  ann tn k t  -> encodeConstructorTag 3 <> encode ann <> encode tn  <> encode k <> encode t
+        TyBuiltin ann con     -> encodeConstructorTag 4 <> encode ann <> encode con
+        TyLam     ann n k t   -> encodeConstructorTag 5 <> encode ann <> encode n   <> encode k <> encode t
+        TyApp     ann t t'    -> encodeConstructorTag 6 <> encode ann <> encode t   <> encode t'
 
     decode = go =<< decodeConstructorTag
-        where go 0 = TyVar <$> decode <*> decode
-              go 1 = TyFun <$> decode <*> decode <*> decode
-              go 2 = TyIFix <$> decode <*> decode <*> decode
-              go 3 = TyForall <$> decode <*> decode <*> decode <*> decode
+        where go 0 = TyVar     <$> decode <*> decode
+              go 1 = TyFun     <$> decode <*> decode <*> decode
+              go 2 = TyIFix    <$> decode <*> decode <*> decode
+              go 3 = TyForall  <$> decode <*> decode <*> decode <*> decode
               go 4 = TyBuiltin <$> decode <*> decode
-              go 5 = TyLam <$> decode <*> decode <*> decode <*> decode
-              go 6 = TyApp <$> decode <*> decode <*> decode
+              go 5 = TyLam     <$> decode <*> decode <*> decode <*> decode
+              go 6 = TyApp     <$> decode <*> decode <*> decode
               go _ = fail "Failed to decode Type TyName ()"
 
 instance Serialise DynamicBuiltinName where
@@ -199,7 +213,7 @@ instance Serialise ann => Serialise (Builtin ann) where
     encode (DynBuiltinName ann dbn) = encodeConstructorTag 1 <> encode ann <> encode dbn
 
     decode = go =<< decodeConstructorTag
-        where go 0 = BuiltinName <$> decode <*> decode
+        where go 0 = BuiltinName    <$> decode <*> decode
               go 1 = DynBuiltinName <$> decode <*> decode
               go _ = fail "Failed to decode Builtin ()"
 
@@ -209,29 +223,29 @@ instance ( Closed uni
          , Serialise tyname
          , Serialise name
          ) => Serialise (Term tyname name uni ann) where
-    encode = cata a where
-        a (VarF ann n)           = encodeConstructorTag 0 <> encode ann <> encode n
-        a (TyAbsF ann tn k t)    = encodeConstructorTag 1 <> encode ann <> encode tn <> encode k <> t
-        a (LamAbsF ann n ty t)   = encodeConstructorTag 2 <> encode ann <> encode n <> encode ty <> t
-        a (ApplyF ann t t')      = encodeConstructorTag 3 <> encode ann <> t <> t'
-        a (ConstantF ann c)      = encodeConstructorTag 4 <> encode ann <> encode c
-        a (TyInstF ann t ty)     = encodeConstructorTag 5 <> encode ann <> t <> encode ty
-        a (UnwrapF ann t)        = encodeConstructorTag 6 <> encode ann <> t
-        a (IWrapF ann pat arg t) = encodeConstructorTag 7 <> encode ann <> encode pat <> encode arg <> t
-        a (ErrorF ann ty)        = encodeConstructorTag 8 <> encode ann <> encode ty
-        a (BuiltinF ann bi)      = encodeConstructorTag 9 <> encode ann <> encode bi
+    encode = \case
+        Var      ann n         -> encodeConstructorTag 0 <> encode ann <> encode n
+        TyAbs    ann tn k t    -> encodeConstructorTag 1 <> encode ann <> encode tn  <> encode k   <> encode t
+        LamAbs   ann n ty t    -> encodeConstructorTag 2 <> encode ann <> encode n   <> encode ty  <> encode t
+        Apply    ann t t'      -> encodeConstructorTag 3 <> encode ann <> encode t   <> encode t'
+        Constant ann c         -> encodeConstructorTag 4 <> encode ann <> encode c
+        TyInst   ann t ty      -> encodeConstructorTag 5 <> encode ann <> encode t   <> encode ty
+        Unwrap   ann t         -> encodeConstructorTag 6 <> encode ann <> encode t
+        IWrap    ann pat arg t -> encodeConstructorTag 7 <> encode ann <> encode pat <> encode arg <> encode t
+        Error    ann ty        -> encodeConstructorTag 8 <> encode ann <> encode ty
+        Builtin  ann bn        -> encodeConstructorTag 9 <> encode ann <> encode bn
 
     decode = go =<< decodeConstructorTag
-        where go 0 = Var <$> decode <*> decode
-              go 1 = TyAbs <$> decode <*> decode <*> decode <*> decode
-              go 2 = LamAbs <$> decode <*> decode <*> decode <*> decode
-              go 3 = Apply <$> decode <*> decode <*> decode
+        where go 0 = Var      <$> decode <*> decode
+              go 1 = TyAbs    <$> decode <*> decode <*> decode <*> decode
+              go 2 = LamAbs   <$> decode <*> decode <*> decode <*> decode
+              go 3 = Apply    <$> decode <*> decode <*> decode
               go 4 = Constant <$> decode <*> decode
-              go 5 = TyInst <$> decode <*> decode <*> decode
-              go 6 = Unwrap <$> decode <*> decode
-              go 7 = IWrap <$> decode <*> decode <*> decode <*> decode
-              go 8 = Error <$> decode <*> decode
-              go 9 = Builtin <$> decode <*> decode
+              go 5 = TyInst   <$> decode <*> decode <*> decode
+              go 6 = Unwrap   <$> decode <*> decode
+              go 7 = IWrap    <$> decode <*> decode <*> decode <*> decode
+              go 8 = Error    <$> decode <*> decode
+              go 9 = Builtin  <$> decode <*> decode
               go _ = fail "Failed to decode Term TyName Name ()"
 
 instance ( Closed uni

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -70,7 +70,7 @@ tags with predefined meanings which we shouldn't interfere with.
 See http://hackage.haskell.org/package/serialise.
 -}
 
-{- [Note: Don't use catamorphims!]  
+{- [Note: Don't use catamorphims!]
 We use Codec.Serialise for encoding.  This uses an itermediate type
 `Encoding` to encode things. `Encoding` is a monoid, which allows
 subobjects to be encoded and then efficiently concatenated when a
@@ -108,7 +108,7 @@ instance (Closed uni, uni `Everywhere` Serialise) => Serialise (Some (ValueOf un
         go (Some (TypeIn uni)) = Some . ValueOf uni <$> bring (Proxy @Serialise) uni decode
 
 instance Serialise BuiltinName where
-    encode = encodeConstructorTag . \case 
+    encode = encodeConstructorTag . \case
               AddInteger           -> 0
               SubtractInteger      -> 1
               MultiplyInteger      -> 2

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -76,14 +76,14 @@ We use Codec.Serialise for encoding.  This uses an itermediate type
 subobjects to be encoded and then efficiently concatenated when a
 larger object is being encoded to CBOR.  The monoid structure makes it
 tempting to use catamoprhisms to encode things, but this is
-*dangerous*. When a list is encoded to CBOR, the start and end of the
-list is marked by a special token; this is then followed by the
-encodings of the individual list elements, then another token to mark
-the end of the list.  If we use a catamorphism to encode a list `l` it
-just encodes the elements and concatenates the encoded versions
-together without the markers, which is wrong: instead we should call
-`encode l` directly.  At present we aren't encoding any lists, but we 
-should take care to avoid this trap just in case.
+*dangerous*. When a list is encoded to CBOR, the start of the list is
+marked by a special token; this is then followed by the encodings of
+the individual list elements, then another token to mark the end of
+the list.  If we use a catamorphism to encode a list `l` it just
+encodes the elements and concatenates the encoded versions together
+without the markers, which is wrong: instead we should call `encode l`
+directly.  At present we aren't encoding any lists, but we should take
+care to avoid this trap just in case.
 -}
 
 encodeConstructorTag :: Word -> Encoding


### PR DESCRIPTION
A small update to CBOR.hs.  See [Note: Don't use catamorphisms!] for an explanation.