### PR TITLE
SCB: Adding the scaffolding for better frontend tests.

### DIFF
--- a/plutus-scb-client/src/MonadApp.purs
+++ b/plutus-scb-client/src/MonadApp.purs
@@ -1,0 +1,84 @@
+module MonadApp where
+
+import Prelude
+import Animation (class MonadAnimate, animate)
+import Clipboard (class MonadClipboard, copy)
+import Control.Monad.Except (ExceptT, runExceptT)
+import Control.Monad.Reader.Class (class MonadAsk)
+import Control.Monad.State.Class (class MonadState)
+import Control.Monad.Trans.Class (class MonadTrans)
+import Data.Lens (view)
+import Data.Newtype (class Newtype, unwrap)
+import Data.RawJson (RawJson)
+import Effect.Aff.Class (class MonadAff)
+import Effect.Class (class MonadEffect)
+import Effect.Console as Console
+import Halogen (HalogenM, liftEffect)
+import Language.Plutus.Contract.Effects.ExposeEndpoint (EndpointDescription)
+import Network.RemoteData as RemoteData
+import Playground.Lenses (_getEndpointDescription)
+import Plutus.SCB.Events.Contract (ContractInstanceId, ContractInstanceState)
+import Plutus.SCB.Types (ContractExe)
+import Plutus.SCB.Webserver (SPParams_, getApiContractByContractinstanceidSchema, getApiFullreport, postApiContractActivate, postApiContractByContractinstanceidEndpointByEndpointname)
+import Plutus.SCB.Webserver.Types (ContractSignatureResponse, FullReport)
+import Servant.PureScript.Ajax (AjaxError)
+import Servant.PureScript.Settings (SPSettings_)
+import Types (HAction, State, WebData, _contractInstanceIdString)
+
+class
+  Monad m <= MonadApp m where
+  getFullReport :: m (WebData (FullReport ContractExe))
+  getContractSignature :: ContractInstanceId -> m (WebData (ContractSignatureResponse ContractExe))
+  invokeEndpoint :: RawJson -> ContractInstanceId -> EndpointDescription -> m (WebData (ContractInstanceState ContractExe))
+  activateContract :: ContractExe -> m Unit
+  log :: String -> m Unit
+
+newtype HalogenApp m a
+  = HalogenApp (HalogenM State HAction () Void m a)
+
+derive instance newtypeHalogenApp :: Newtype (HalogenApp m a) _
+
+derive newtype instance functorHalogenApp :: Functor (HalogenApp m)
+
+derive newtype instance applicativeHalogenApp :: Applicative (HalogenApp m)
+
+derive newtype instance applyHalogenApp :: Apply (HalogenApp m)
+
+derive newtype instance bindHalogenApp :: Bind (HalogenApp m)
+
+derive newtype instance monadHalogenApp :: Monad (HalogenApp m)
+
+derive newtype instance monadTransHalogenApp :: MonadTrans HalogenApp
+
+derive newtype instance monadStateHalogenApp :: MonadState State (HalogenApp m)
+
+derive newtype instance monadAskHalogenApp :: MonadAsk env m => MonadAsk env (HalogenApp m)
+
+derive newtype instance monadEffectHalogenApp :: MonadEffect m => MonadEffect (HalogenApp m)
+
+derive newtype instance monadAffHalogenApp :: MonadAff m => MonadAff (HalogenApp m)
+
+instance monadAnimateHalogenApp :: MonadAff m => MonadAnimate (HalogenApp m) State where
+  animate toggle action = HalogenApp $ animate toggle (unwrap action)
+
+instance monadClipboardHalogenApp :: MonadEffect m => MonadClipboard (HalogenApp m) where
+  copy = liftEffect <<< copy
+
+------------------------------------------------------------
+runHalogenApp :: forall m a. HalogenApp m a -> HalogenM State HAction () Void m a
+runHalogenApp = unwrap
+
+instance monadAppHalogenApp :: (MonadAff m, MonadAsk (SPSettings_ SPParams_) m) => MonadApp (HalogenApp m) where
+  getFullReport = runAjax getApiFullreport
+  getContractSignature csContract = runAjax $ getApiContractByContractinstanceidSchema $ view _contractInstanceIdString csContract
+  invokeEndpoint payload contractInstanceId endpointDescription =
+    runAjax
+      $ postApiContractByContractinstanceidEndpointByEndpointname
+          payload
+          (view _contractInstanceIdString contractInstanceId)
+          (view _getEndpointDescription endpointDescription)
+  activateContract contract = void $ runAjax $ postApiContractActivate contract
+  log str = liftEffect $ Console.log str
+
+runAjax :: forall m a. Functor m => ExceptT AjaxError m a -> m (WebData a)
+runAjax action = RemoteData.fromEither <$> runExceptT action

--- a/plutus-scb-client/test/MainFrameTests.purs
+++ b/plutus-scb-client/test/MainFrameTests.purs
@@ -3,7 +3,93 @@ module MainFrameTests
   ) where
 
 import Prelude
-import Test.Unit (TestSuite, suite)
+import Types (HAction(..), State, _currentView)
+import Animation (class MonadAnimate)
+import Clipboard (class MonadClipboard)
+import Control.Monad.Except.Trans (class MonadThrow)
+import Control.Monad.RWS (RWSResult(..), RWST(..), runRWST)
+import Control.Monad.Reader.Class (class MonadAsk)
+import Control.Monad.State.Class (class MonadState)
+import Control.Monad.Trans.Class (class MonadTrans)
+import Data.Either (Either(..))
+import Data.Lens (_1, appendModifying, view)
+import Data.Lens.Record (prop)
+import Data.Newtype (class Newtype, unwrap, wrap)
+import Data.Symbol (SProxy(..))
+import Data.Traversable (traverse_)
+import Data.Tuple (Tuple(..))
+import Effect.Exception (Error)
+import MainFrame (handleAction)
+import MainFrame as MainFrame
+import MonadApp (class MonadApp)
+import Network.RemoteData (RemoteData(..))
+import Plutus.SCB.Webserver (SPParams_(..))
+import Servant.PureScript.Settings (SPSettings_, defaultSettings)
+import Test.QuickCheck ((<?>))
+import Test.Unit (TestSuite, suite, test)
+import Test.Unit.QuickCheck (quickCheck)
+
+type World
+  = { console :: Array String }
+
+execMockApp :: forall m. MonadThrow Error m => World -> Array HAction -> m (Tuple World State)
+execMockApp world queries = do
+  let
+    initialState = MainFrame.initialState
+  RWSResult state result writer <-
+    runRWST
+      (unwrap (traverse_ handleAction queries :: MockApp m Unit))
+      (defaultSettings (SPParams_ { baseURL: "/" }))
+      (Tuple world initialState)
+  pure state
+
+-- | A dummy implementation of `MonadApp`, for testing the main handleAction loop.
+newtype MockApp m a
+  = MockApp (RWST (SPSettings_ SPParams_) Unit (Tuple World State) m a)
+
+derive instance newtypeMockApp :: Newtype (MockApp m a) _
+
+derive newtype instance functorMockApp :: Functor m => Functor (MockApp m)
+
+derive newtype instance applicativeMockApp :: Monad m => Applicative (MockApp m)
+
+derive newtype instance applyMockApp :: Bind m => Apply (MockApp m)
+
+derive newtype instance bindMockApp :: Bind m => Bind (MockApp m)
+
+derive newtype instance monadMockApp :: Monad m => Monad (MockApp m)
+
+derive newtype instance monadTransMockApp :: MonadTrans MockApp
+
+derive newtype instance monadAskMockApp :: Monad m => MonadAsk (SPSettings_ SPParams_) (MockApp m)
+
+instance monadStateMockApp :: Monad m => MonadState State (MockApp m) where
+  state f =
+    MockApp
+      $ RWST \r (Tuple world appState) -> case f appState of
+          (Tuple a appState') -> pure $ RWSResult (Tuple world appState') a unit
+
+instance monadAppMockApp :: Monad m => MonadApp (MockApp m) where
+  activateContract _ = pure unit
+  invokeEndpoint _ _ _ = pure Loading
+  getContractSignature _ = pure Loading
+  getFullReport = pure Loading
+  log msg =
+    wrap
+      $ appendModifying
+          (_1 <<< prop (SProxy :: SProxy "console"))
+          [ msg ]
+
+-- | The mock app makes no attempt to animate anything, and just calls the embedded `action`.
+instance monadAnimateMockApp :: MonadAnimate (MockApp m) State where
+  animate toggle action = action
+
+instance monadClipboardMockApp :: Monad m => MonadClipboard (MockApp m) where
+  copy _ = pure unit
+
+------------------------------------------------------------
+mockWorld :: World
+mockWorld = { console: [] }
 
 all :: TestSuite
 all =
@@ -13,4 +99,10 @@ all =
 evalTests :: TestSuite
 evalTests =
   suite "handleAction" do
-    pure unit
+    test "ChangeView" do
+      quickCheck \aView -> do
+        let
+          result = execMockApp mockWorld [ ChangeView aView ]
+        case result of
+          Right (Tuple _ finalState) -> (aView == view _currentView finalState) <?> "Unexpected final view."
+          Left err -> false <?> show err


### PR DESCRIPTION
Similar to the other two frontends, we introduce `MonadApp` for all the
side-effecting calls, so we can replace them with mock implementations in a
test environment.