### PR TITLE
mp refactor - get rid of simulation component

### DIFF
--- a/marlowe-playground-client/src/HaskellEditor.purs
+++ b/marlowe-playground-client/src/HaskellEditor.purs
@@ -32,18 +32,15 @@ import Language.Haskell.Monaco as HM
 import LocalStorage as LocalStorage
 import Marlowe (SPParams_)
 import Marlowe as Server
-import Marlowe.Parser (parseContract)
 import Monaco (IMarkerData, markerSeverity)
 import Monaco (getModel, setValue) as Monaco
 import Network.RemoteData (RemoteData(..), isLoading, isSuccess)
 import Network.RemoteData as RemoteData
 import Servant.PureScript.Settings (SPSettings_)
 import Simulation.State (_result)
-import Simulation.Types as ST
 import StaticData (bufferLocalStorageKey)
 import StaticData as StaticData
-import Text.Pretty (pretty)
-import Types (ChildSlots, Message, _blocklySlot, _haskellEditorSlot, _simulationSlot, bottomPanelHeight)
+import Types (ChildSlots, Message, _blocklySlot, _haskellEditorSlot, bottomPanelHeight)
 
 handleAction ::
   forall m.
@@ -86,20 +83,7 @@ handleAction _ (ShowBottomPanel val) = do
   void $ query _haskellEditorSlot unit (Monaco.Resize unit)
   pure unit
 
-handleAction _ SendResultToSimulator = do
-  mContract <- use _compilationResult
-  let
-    contract = case mContract of
-      Success (JsonEither (Right result)) ->
-        let
-          unformatted = view (_InterpreterResult <<< _result <<< _RunResult) result
-        in
-          case parseContract unformatted of
-            Right pcon -> show $ pretty pcon
-            Left _ -> unformatted
-      _ -> ""
-  void $ query _simulationSlot unit (ST.SetEditorText contract unit)
-  void $ query _simulationSlot unit (ST.ResetContract unit)
+handleAction _ SendResultToSimulator = pure unit
 
 handleAction _ SendResultToBlockly = do
   mContract <- use _compilationResult

--- a/marlowe-playground-client/src/Reachability.purs
+++ b/marlowe-playground-client/src/Reachability.purs
@@ -12,7 +12,8 @@ import Marlowe.Semantics as S
 import Marlowe.Symbolic.Types.Response (Result(..))
 import Network.RemoteData (RemoteData(..))
 import Prelude (Unit, bind, discard, map, pure, unit, ($), (<<<), (+), (/=))
-import Simulation.Types (Action, ChildSlots, ContractPathStep(..), ContractPath, Message(..), ReachabilityAnalysisData(..), State)
+import Simulation.Types (Action, ContractPathStep(..), ContractPath, ReachabilityAnalysisData(..), State)
+import Types (ChildSlots, Message(..))
 import WebSocket (WebSocketRequestMessage(..))
 
 data ContractZipper

--- a/marlowe-playground-client/src/Simulation.purs
+++ b/marlowe-playground-client/src/Simulation.purs
@@ -37,7 +37,6 @@ import Gists as Gists
 import Global.Unsafe (unsafeStringify)
 import Halogen (HalogenM, query)
 import Halogen as H
-import Halogen.Analytics (handleActionWithAnalyticsTracking)
 import Halogen.Classes (aHorizontal, active, activeClasses, blocklyIcon, bold, closeDrawerIcon, codeEditor, expanded, infoIcon, jFlexStart, minusBtn, noMargins, panelSubHeader, panelSubHeaderMain, panelSubHeaderSide, plusBtn, pointer, sidebarComposer, smallBtn, spaceLeft, spanText, textSecondaryColor, uppercase)
 import Halogen.Classes as Classes
 import Halogen.HTML (ClassName(..), ComponentHTML, HTML, a, article, aside, b_, br_, button, div, em_, h2, h6, h6_, img, input, label, li, li_, option, p, p_, section, select, slot, small, span, strong_, text, ul, ul_)
@@ -64,16 +63,17 @@ import Monaco (IMarker, isError, isWarning)
 import Monaco (getModel, getMonaco, setTheme, setValue) as Monaco
 import Network.RemoteData (RemoteData(..), _Success)
 import Network.RemoteData as RemoteData
-import Prelude (class Show, Unit, add, bind, bottom, const, discard, eq, flip, identity, mempty, one, pure, show, unit, zero, ($), (/=), (<$>), (<<<), (<>), (=<<), (==), (>), (-), (<))
+import Prelude (class Show, Unit, add, bind, bottom, const, discard, eq, flip, identity, mempty, one, pure, show, unit, zero, ($), (/=), (<$>), (<<<), (<>), (=<<), (==), (-), (<))
 import Reachability (startReachabilityAnalysis, updateWithResponse)
 import Servant.PureScript.Ajax (AjaxError, errorToString)
 import Servant.PureScript.Settings (SPSettings_)
 import Simulation.BottomPanel (bottomPanel)
 import Simulation.State (ActionInput(..), ActionInputId, _editorErrors, _editorWarnings, _pendingInputs, _possibleActions, _slot, _state, applyTransactions, emptyMarloweState, hasHistory, updateContractInState, updateMarloweState)
-import Simulation.Types (Action(..), AnalysisState(..), ChildSlots, Message(..), Query(..), State, WebData, _activeDemo, _analysisState, _authStatus, _bottomPanelView, _createGistResult, _currentContract, _currentMarloweState, _editorKeybindings, _editorSlot, _gistUrl, _helpContext, _loadGistResult, _marloweState, _oldContract, _selectedHole, _showBottomPanel, _showErrorDetail, _showRightPanel, isContractValid, mkState)
+import Simulation.Types (Action(..), AnalysisState(..), Query(..), State, WebData, _activeDemo, _analysisState, _authStatus, _bottomPanelView, _createGistResult, _currentContract, _currentMarloweState, _editorKeybindings, _gistUrl, _helpContext, _loadGistResult, _marloweState, _oldContract, _selectedHole, _showBottomPanel, _showErrorDetail, _showRightPanel, isContractValid)
 import StaticData (marloweBufferLocalStorageKey)
 import StaticData as StaticData
 import Text.Pretty (genericPretty, pretty)
+import Types (ChildSlots, Message(..), _marloweEditorSlot)
 import Web.DOM.Document as D
 import Web.DOM.Element (setScrollTop)
 import Web.DOM.Element as E
@@ -83,36 +83,7 @@ import Web.HTML.HTMLDocument (toDocument)
 import Web.HTML.Window as W
 import WebSocket (WebSocketRequestMessage(..))
 
-mkComponent :: forall m. MonadEffect m => MonadAff m => SPSettings_ SPParams_ -> H.Component HTML Query Unit Message m
-mkComponent settings =
-  H.mkComponent
-    { initialState: const mkState
-    , render
-    , eval:
-      H.mkEval
-        { handleAction: handleActionWithAnalyticsTracking (handleAction settings)
-        , handleQuery
-        , initialize: Just Init
-        , receive: const Nothing
-        , finalize: Nothing
-        }
-    }
-
 handleQuery :: forall a m. Query a -> HalogenM State Action ChildSlots Message m (Maybe a)
-handleQuery (SetEditorText contents next) = do
-  editorSetValue contents
-  updateContractInState contents
-  pure (Just next)
-
-handleQuery (ResizeEditor next) = do
-  void $ query _editorSlot unit (Monaco.Resize unit)
-  void $ query _editorSlot unit (Monaco.SetTheme MM.daylightTheme.name unit)
-  pure (Just next)
-
-handleQuery (ResetContract next) = do
-  resetContract
-  pure (Just next)
-
 handleQuery (WebsocketResponse response next) = do
   analysisState <- use _analysisState
   case analysisState of
@@ -125,17 +96,6 @@ handleQuery (WebsocketResponse response next) = do
       assign _analysisState (ReachabilityAnalysis newReachabilityAnalysisState)
       pure (Just next)
 
-handleQuery (HasStarted f) = do
-  state <- use _marloweState
-  pure $ Just $ f (NEL.length state > 1)
-
-handleQuery (GetCurrentContract next) = do
-  oldContract <- use _oldContract
-  currContract <- editorGetValue
-  let
-    newContract = fromMaybe mempty $ oldContract <|> currContract
-  pure $ Just $ next newContract
-
 handleAction ::
   forall m.
   MonadEffect m =>
@@ -143,7 +103,7 @@ handleAction ::
   SPSettings_ SPParams_ -> Action -> HalogenM State Action ChildSlots Message m Unit
 handleAction settings Init = do
   checkAuthStatus settings
-  void $ query _editorSlot unit (Monaco.SetTheme MM.daylightTheme.name unit)
+  void $ query _marloweEditorSlot unit (Monaco.SetTheme MM.daylightTheme.name unit)
 
 handleAction _ (HandleEditorMessage (Monaco.TextChanged text)) = do
   assign _selectedHole Nothing
@@ -153,9 +113,9 @@ handleAction _ (HandleEditorMessage (Monaco.TextChanged text)) = do
   state <- use (_currentMarloweState <<< _state)
   let
     (Tuple markerData additionalContext) = Linter.markers state text
-  markers <- query _editorSlot unit (Monaco.SetModelMarkers markerData identity)
+  markers <- query _marloweEditorSlot unit (Monaco.SetModelMarkers markerData identity)
   void $ traverse editorSetMarkers markers
-  objects <- query _editorSlot unit (Monaco.GetObjects identity)
+  objects <- query _marloweEditorSlot unit (Monaco.GetObjects identity)
   case objects of
     Just { codeActionProvider: Just caProvider, completionItemProvider: Just ciProvider } -> pure $ updateAdditionalContext caProvider ciProvider additionalContext
     _ -> pure unit
@@ -169,11 +129,11 @@ handleAction _ (HandleDropEvent event) = do
   updateContractInState contents
 
 handleAction _ (MoveToPosition lineNumber column) = do
-  void $ query _editorSlot unit (Monaco.SetPosition { column, lineNumber } unit)
+  void $ query _marloweEditorSlot unit (Monaco.SetPosition { column, lineNumber } unit)
 
 handleAction _ (SelectEditorKeyBindings bindings) = do
   assign _editorKeybindings bindings
-  void $ query _editorSlot unit (Monaco.SetKeyBindings bindings unit)
+  void $ query _marloweEditorSlot unit (Monaco.SetKeyBindings bindings unit)
 
 handleAction _ (LoadScript key) = do
   case preview (ix key) (Map.fromFoldable StaticData.marloweContracts) of
@@ -188,6 +148,10 @@ handleAction _ (LoadScript key) = do
       updateContractInState prettyContents
       resetContract
       assign _activeDemo key
+
+handleAction _ (SetEditorText contents) = do
+  editorSetValue contents
+  updateContractInState contents
 
 handleAction _ ApplyTransaction = do
   saveInitialState
@@ -236,6 +200,8 @@ handleAction _ ResetSimulator = do
   editorSetValue newContract
   resetContract
 
+handleAction _ ResetContract = resetContract
+
 handleAction _ Undo = do
   modifying _marloweState tailIfNotEmpty
   mCurrContract <- use _currentContract
@@ -248,7 +214,7 @@ handleAction _ (SelectHole hole) = assign _selectedHole hole
 handleAction _ (ChangeSimulationView view) = do
   assign _bottomPanelView view
   assign _showBottomPanel true
-  void $ query _editorSlot unit (Monaco.Resize unit)
+  void $ query _marloweEditorSlot unit (Monaco.Resize unit)
 
 handleAction _ (ChangeHelpContext help) = do
   assign _helpContext help
@@ -263,15 +229,11 @@ handleAction _ (ShowRightPanel val) = assign _showRightPanel val
 
 handleAction _ (ShowBottomPanel val) = do
   assign _showBottomPanel val
-  void $ query _editorSlot unit (Monaco.Resize unit)
+  void $ query _marloweEditorSlot unit (Monaco.Resize unit)
 
 handleAction _ (ShowErrorDetail val) = assign _showErrorDetail val
 
-handleAction _ SetBlocklyCode = do
-  source <- editorGetValue
-  case source of
-    Just source' -> H.raise (BlocklyCodeSet source')
-    Nothing -> pure unit
+handleAction _ SetBlocklyCode = pure unit
 
 handleAction _ AnalyseContract = do
   currContract <- use _currentContract
@@ -295,6 +257,12 @@ handleAction _ AnalyseReachabilityContract = do
     Just contract -> do
       newReachabilityAnalysisState <- startReachabilityAnalysis contract currState
       assign _analysisState (ReachabilityAnalysis newReachabilityAnalysisState)
+
+getCurrentContract :: forall m. HalogenM State Action ChildSlots Message m String
+getCurrentContract = do
+  oldContract <- use _oldContract
+  currContract <- editorGetValue
+  pure $ fromMaybe mempty $ oldContract <|> currContract
 
 checkAuthStatus :: forall m. MonadAff m => SPSettings_ SPParams_ -> HalogenM State Action ChildSlots Message m Unit
 checkAuthStatus settings = do
@@ -385,10 +353,10 @@ scrollHelpPanel =
       _, _ -> pure unit
 
 editorSetValue :: forall m. String -> HalogenM State Action ChildSlots Message m Unit
-editorSetValue contents = void $ query _editorSlot unit (Monaco.SetText contents unit)
+editorSetValue contents = void $ query _marloweEditorSlot unit (Monaco.SetText contents unit)
 
 editorGetValue :: forall m. HalogenM State Action ChildSlots Message m (Maybe String)
-editorGetValue = query _editorSlot unit (Monaco.GetText identity)
+editorGetValue = query _marloweEditorSlot unit (Monaco.GetText identity)
 
 saveInitialState :: forall m. MonadEffect m => HalogenM State Action ChildSlots Message m Unit
 saveInitialState = do
@@ -500,7 +468,7 @@ marloweEditor ::
   MonadAff m =>
   State ->
   ComponentHTML Action ChildSlots m
-marloweEditor state = slot _editorSlot unit component unit (Just <<< HandleEditorMessage)
+marloweEditor state = slot _marloweEditorSlot unit component unit (Just <<< HandleEditorMessage)
   where
   setup editor = do
     mContents <- liftEffect $ LocalStorage.getItem StaticData.marloweBufferLocalStorageKey

--- a/marlowe-playground-client/src/Simulation/Types.purs
+++ b/marlowe-playground-client/src/Simulation/Types.purs
@@ -20,7 +20,6 @@ import Data.Symbol (SProxy(..))
 import Data.Tuple.Nested (type (/\))
 import Gist (Gist)
 import Gists (GistAction)
-import Halogen as H
 import Halogen.Monaco (KeyBindings(..))
 import Halogen.Monaco as Monaco
 import Help (HelpContext(..))
@@ -176,6 +175,7 @@ data Action
   | MoveToPosition Pos Pos
   | SelectEditorKeyBindings KeyBindings
   | LoadScript String
+  | SetEditorText String
   -- Gist support.
   | CheckAuthStatus
   | GistAction GistAction
@@ -185,6 +185,7 @@ data Action
   | AddInput (Maybe PubKey) Input (Array Bound)
   | RemoveInput (Maybe PubKey) Input
   | SetChoice ChoiceId ChosenNum
+  | ResetContract
   | ResetSimulator
   | Undo
   | SelectHole (Maybe String)
@@ -212,12 +213,14 @@ instance isEventAction :: IsEvent Action where
   toEvent (SelectEditorKeyBindings _) = Just $ defaultEvent "SelectEditorKeyBindings"
   toEvent CheckAuthStatus = Just $ defaultEvent "CheckAuthStatus"
   toEvent (LoadScript script) = Just $ (defaultEvent "LoadScript") { label = Just script }
+  toEvent (SetEditorText _) = Just $ (defaultEvent "SetEditorText")
   toEvent ApplyTransaction = Just $ defaultEvent "ApplyTransaction"
   toEvent NextSlot = Just $ defaultEvent "NextBlock"
   toEvent (AddInput _ _ _) = Just $ defaultEvent "AddInput"
   toEvent (RemoveInput _ _) = Just $ defaultEvent "RemoveInput"
   toEvent (SetChoice _ _) = Just $ defaultEvent "SetChoice"
   toEvent ResetSimulator = Just $ defaultEvent "ResetSimulator"
+  toEvent ResetContract = Just $ defaultEvent "ResetContract"
   toEvent Undo = Just $ defaultEvent "Undo"
   toEvent (SelectHole _) = Just $ defaultEvent "SelectHole"
   toEvent (ChangeSimulationView view) = Just $ (defaultEvent "ChangeSimulationView") { label = Just $ show view }
@@ -231,23 +234,7 @@ instance isEventAction :: IsEvent Action where
   toEvent AnalyseReachabilityContract = Just $ defaultEvent "AnalyseReachabilityContract"
 
 data Query a
-  = SetEditorText String a
-  | ResizeEditor a
-  | ResetContract a
-  | WebsocketResponse (RemoteData String Result) a
-  | HasStarted (Boolean -> a)
-  | GetCurrentContract (String -> a)
-
-data Message
-  = BlocklyCodeSet String
-  | WebsocketMessage String
-
-type ChildSlots
-  = ( editorSlot :: H.Slot Monaco.Query Monaco.Message Unit
-    )
-
-_editorSlot :: SProxy "editorSlot"
-_editorSlot = SProxy
+  = WebsocketResponse (RemoteData String Result) a
 
 data BottomPanelView
   = CurrentStateView


### PR DESCRIPTION
part of an ongoing effort to get rid of halogen components for all purescript code, use components only for javascript things that need to be wrapped up. Functions like `toSimulation` can enable you to split the concerns in a very similar way without the 'component' needing to be stateful in itself.