### PR TITLE
Kwxm/remove staged builtins

### DIFF
--- a/language-plutus-core/budgeting-bench/Bench.hs
+++ b/language-plutus-core/budgeting-bench/Bench.hs
@@ -48,14 +48,14 @@ createTwoTermBuiltinBench name as bs =
     bgroup (show name) $
         as <&> (\(x, xMem) ->
             bgroup (show xMem) $ bs <&> (\(y, yMem) ->
-                runTermBench (show yMem) $ mkIterApp () (builtin () $ StaticBuiltinName () name) [(mkConstant () x), (mkConstant () y)]
+                runTermBench (show yMem) $ mkIterApp () (staticBuiltinNameAsTerm name) [(mkConstant () x), (mkConstant () y)]
             ))
 
 benchHashOperations :: StaticBuiltinName -> Benchmark
 benchHashOperations name =
     bgroup (show name) $
         byteStringsToBench seedA <&> (\(x, xMem) ->
-            runTermBench (show xMem) $ mkIterApp () (builtin () $ StaticBuiltinName () name) [(mkConstant () x)]
+            runTermBench (show xMem) $ mkIterApp () (staticBuiltinNameAsTerm name) [(mkConstant () x)]
         )
 
 -- for VerifySignature, for speed purposes, it shouldn't matter if the sig / pubkey are correct
@@ -67,7 +67,7 @@ benchVerifySignature :: Benchmark
 benchVerifySignature =
     bgroup (show name) $
         bs <&> (\(x, xMem) ->
-            runTermBench (show xMem) $ mkIterApp () (builtin () $ StaticBuiltinName () name) [(mkConstant () pubKey), (mkConstant () x), (mkConstant () sig)]
+            runTermBench (show xMem) $ mkIterApp () (staticBuiltinNameAsTerm name) [(mkConstant () pubKey), (mkConstant () x), (mkConstant () sig)]
         )
     where
         name = VerifySignature

--- a/language-plutus-core/budgeting-bench/Bench.hs
+++ b/language-plutus-core/budgeting-bench/Bench.hs
@@ -32,30 +32,30 @@ runTermBench name term = env
         )
     (\_ -> bench name $ nf (unsafeEvaluateCek mempty defaultCostModel) term)
 
-benchSameTwoByteStrings :: BuiltinName -> Benchmark
+benchSameTwoByteStrings :: StaticBuiltinName -> Benchmark
 benchSameTwoByteStrings name = createTwoTermBuiltinBench name (byteStringsToBench seedA) (byteStringsToBench seedA)
 
-benchTwoByteStrings :: BuiltinName -> Benchmark
+benchTwoByteStrings :: StaticBuiltinName -> Benchmark
 benchTwoByteStrings name = createTwoTermBuiltinBench name (byteStringsToBench seedA) (byteStringsToBench seedB)
 
-benchBytestringOperations :: BuiltinName -> Benchmark -- TODO the numbers are a bit too big here
+benchBytestringOperations :: StaticBuiltinName -> Benchmark -- TODO the numbers are a bit too big here
 benchBytestringOperations name = createTwoTermBuiltinBench @Integer @BSL.ByteString name numbers (byteStringsToBench seedA)
     where
         numbers = expToBenchingInteger <$> expsToBench
 
-createTwoTermBuiltinBench :: (DefaultUni `Includes` a, DefaultUni `Includes` b) => BuiltinName -> [(a, ExMemory)] -> [(b, ExMemory)] -> Benchmark
+createTwoTermBuiltinBench :: (DefaultUni `Includes` a, DefaultUni `Includes` b) => StaticBuiltinName -> [(a, ExMemory)] -> [(b, ExMemory)] -> Benchmark
 createTwoTermBuiltinBench name as bs =
     bgroup (show name) $
         as <&> (\(x, xMem) ->
             bgroup (show xMem) $ bs <&> (\(y, yMem) ->
-                runTermBench (show yMem) $ mkIterApp () (builtin () $ BuiltinName () name) [(mkConstant () x), (mkConstant () y)]
+                runTermBench (show yMem) $ mkIterApp () (builtin () $ StaticBuiltinName () name) [(mkConstant () x), (mkConstant () y)]
             ))
 
-benchHashOperations :: BuiltinName -> Benchmark
+benchHashOperations :: StaticBuiltinName -> Benchmark
 benchHashOperations name =
     bgroup (show name) $
         byteStringsToBench seedA <&> (\(x, xMem) ->
-            runTermBench (show xMem) $ mkIterApp () (builtin () $ BuiltinName () name) [(mkConstant () x)]
+            runTermBench (show xMem) $ mkIterApp () (builtin () $ StaticBuiltinName () name) [(mkConstant () x)]
         )
 
 -- for VerifySignature, for speed purposes, it shouldn't matter if the sig / pubkey are correct
@@ -67,7 +67,7 @@ benchVerifySignature :: Benchmark
 benchVerifySignature =
     bgroup (show name) $
         bs <&> (\(x, xMem) ->
-            runTermBench (show xMem) $ mkIterApp () (builtin () $ BuiltinName () name) [(mkConstant () pubKey), (mkConstant () x), (mkConstant () sig)]
+            runTermBench (show xMem) $ mkIterApp () (builtin () $ StaticBuiltinName () name) [(mkConstant () pubKey), (mkConstant () x), (mkConstant () sig)]
         )
     where
         name = VerifySignature
@@ -101,7 +101,7 @@ expToBenchingInteger e =
                 x = ((3 :: Integer) ^ e)
             in (x, memoryUsage x)
 
-benchTwoInt :: BuiltinName -> Benchmark
+benchTwoInt :: StaticBuiltinName -> Benchmark
 benchTwoInt builtinName =
     createTwoTermBuiltinBench builtinName numbers numbers
     where

--- a/language-plutus-core/examples/Language/PlutusCore/Examples/Data/Vec.hs
+++ b/language-plutus-core/examples/Language/PlutusCore/Examples/Data/Vec.hs
@@ -383,7 +383,7 @@ scottSumHeadsOr0 = runQuote $ do
               . LamAbs () xs' (vecInteger $ TyVar () p)
               . LamAbs () coe
                   (TyFun () (vecInteger $ TyVar () n) $ vecInteger (TyApp () succT $ TyVar () p))
-              $ mkIterApp () (builtin () $ BuiltinName () AddInteger)
+              $ mkIterApp () (staticBuiltinNameAsTerm AddInteger)
                   [ Var () x
                   ,   Apply () (mkIterInst () scottHead [integer, TyVar () p])
                     . Apply () (Var () coe)

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/AST.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/AST.hs
@@ -9,8 +9,8 @@ module Language.PlutusCore.Generators.AST
     , genName
     , genTyName
     , genKind
+    , genStaticBuiltinName
     , genBuiltinName
-    , genBuiltin
     , genConstant
     , genType
     , genTerm
@@ -61,7 +61,7 @@ genNames = do
     let genUniq = Unique <$> Gen.int (Range.linear 0 100)
     uniqs <- Set.toList <$> Gen.set (Range.linear 1 20) genUniq
     let isKeyword n = n `elem` fmap display allKeywords
-        isBuiltin n = n `elem` fmap display allBuiltinNames
+        isBuiltin n = n `elem` fmap display allStaticBuiltinNames
         isReserved t = isKeyword t || isBuiltin t
         genText = Gen.filterT (not . isReserved) $ Gen.text (Range.linear 1 4) Gen.lower
     for uniqs $ \uniq -> do
@@ -79,11 +79,11 @@ genKind = simpleRecursive nonRecursive recursive where
     nonRecursive = pure <$> sequence [Type] ()
     recursive = [KindArrow () <$> genKind <*> genKind]
 
-genBuiltinName :: AstGen BuiltinName
-genBuiltinName = Gen.element allBuiltinNames
+genStaticBuiltinName :: AstGen StaticBuiltinName
+genStaticBuiltinName = Gen.element allStaticBuiltinNames
 
-genBuiltin :: AstGen (Builtin ())
-genBuiltin = BuiltinName () <$> genBuiltinName
+genBuiltinName :: AstGen (BuiltinName ())
+genBuiltinName = StaticBuiltinName () <$> genStaticBuiltinName
 
 genConstant :: AstGen (Some (ValueOf DefaultUni))
 genConstant = Gen.choice
@@ -112,7 +112,7 @@ genTerm = simpleRecursive nonRecursive recursive where
     wrapGen = IWrap () <$> genType <*> genType <*> genTerm
     errorGen = Error () <$> genType
     recursive = [absGen, instGen, lamGen, applyGen, unwrapGen, wrapGen]
-    nonRecursive = [varGen, Constant () <$> genConstant, Builtin () <$> genBuiltin, errorGen]
+    nonRecursive = [varGen, Constant () <$> genConstant, Builtin () <$> genBuiltinName, errorGen]
 
 genProgram :: AstGen (Program TyName Name DefaultUni ())
 genProgram = Program () <$> genVersion <*> genTerm

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/AST.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/AST.hs
@@ -82,8 +82,8 @@ genKind = simpleRecursive nonRecursive recursive where
 genStaticBuiltinName :: AstGen StaticBuiltinName
 genStaticBuiltinName = Gen.element allStaticBuiltinNames
 
-genBuiltinName :: AstGen (BuiltinName ())
-genBuiltinName = StaticBuiltinName () <$> genStaticBuiltinName
+genBuiltinName :: AstGen BuiltinName
+genBuiltinName = StaticBuiltinName <$> genStaticBuiltinName
 
 genConstant :: AstGen (Some (ValueOf DefaultUni))
 genConstant = Gen.choice

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Interesting.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Interesting.hs
@@ -59,10 +59,10 @@ genOverapplication = do
     TermOf tj j <- genTypedBuiltinDef typedInteger
     let term =
             mkIterApp ()
-                (TyInst () (builtinNameAsTerm IfThenElse) . TyFun () integer $ TyFun () integer integer)
-                [ mkIterApp () (builtinNameAsTerm LessThanInteger) [ti, tj]
-                , builtinNameAsTerm AddInteger
-                , builtinNameAsTerm SubtractInteger
+                (TyInst () (staticBuiltinNameAsTerm IfThenElse) . TyFun () integer $ TyFun () integer integer)
+                [ mkIterApp () (staticBuiltinNameAsTerm LessThanInteger) [ti, tj]
+                , staticBuiltinNameAsTerm AddInteger
+                , staticBuiltinNameAsTerm SubtractInteger
                 , ti
                 , tj
                 ]
@@ -105,13 +105,13 @@ naiveFib iv = runQuote $ do
             [   LamAbs () rec (TyFun () intS intS)
               . LamAbs () i intS
               $ mkIterApp () (TyInst () ifThenElse intS)
-                  [ mkIterApp () (builtinNameAsTerm LessThanEqInteger)
+                  [ mkIterApp () (staticBuiltinNameAsTerm LessThanEqInteger)
                       [Var () i, mkConstant @Integer () 1]
                   , LamAbs () u unit $ Var () i
-                  , LamAbs () u unit $ mkIterApp () (builtinNameAsTerm AddInteger)
-                      [ Apply () (Var () rec) $ mkIterApp () (builtinNameAsTerm SubtractInteger)
+                  , LamAbs () u unit $ mkIterApp () (staticBuiltinNameAsTerm AddInteger)
+                      [ Apply () (Var () rec) $ mkIterApp () (staticBuiltinNameAsTerm SubtractInteger)
                           [Var () i, mkConstant @Integer () 1]
-                      , Apply () (Var () rec) $ mkIterApp () (builtinNameAsTerm SubtractInteger)
+                      , Apply () (Var () rec) $ mkIterApp () (staticBuiltinNameAsTerm SubtractInteger)
                           [Var () i, mkConstant @Integer () 2]
                       ]
                   ]
@@ -154,7 +154,7 @@ natSum :: uni `Includes` Integer => Term TyName Name uni ()
 natSum = runQuote $ do
     let int = mkTyBuiltin @Integer ()
         nat = _recursiveType natData
-        add = Builtin () (BuiltinName () AddInteger)
+        add = staticBuiltinNameAsTerm AddInteger
     acc <- freshName "acc"
     n <- freshName "n"
     return
@@ -206,7 +206,7 @@ genApplyAdd1 = do
     TermOf j jv <- genTermLoose typedInt
     let term =
             mkIterApp () (mkIterInst () applyFun [int, int])
-                [ Apply () (builtinNameAsTerm AddInteger) i
+                [ Apply () (staticBuiltinNameAsTerm AddInteger) i
                 , j
                 ]
     return . TermOf term $ iv + jv
@@ -220,7 +220,7 @@ genApplyAdd2 = do
     TermOf j jv <- genTermLoose typedInt
     let term =
             mkIterApp () (mkIterInst () applyFun [int, TyFun () int int])
-                [ builtinNameAsTerm AddInteger
+                [ staticBuiltinNameAsTerm AddInteger
                 , i
                 , j
                 ]
@@ -231,7 +231,7 @@ genDivideByZero :: Generatable uni => TermGen uni (EvaluationResult Integer)
 genDivideByZero = do
     op <- Gen.element [DivideInteger, QuotientInteger, ModInteger, RemainderInteger]
     TermOf i _ <- genTermLoose $ AsKnownType @_ @Integer
-    let term = mkIterApp () (builtinNameAsTerm op) [i, mkConstant @Integer () 0]
+    let term = mkIterApp () (staticBuiltinNameAsTerm op) [i, mkConstant @Integer () 0]
     return $ TermOf term EvaluationFailure
 
 -- | Check that division by zero results in 'Error' even if a function doesn't use that argument.
@@ -243,7 +243,7 @@ genDivideByZeroDrop = do
     TermOf i iv <- genTermLoose typedInt
     let term =
             mkIterApp () (mkIterInst () Function.const [int, int])
-                [ mkIterApp () (builtinNameAsTerm op) [i, mkConstant @Integer () 0]
+                [ mkIterApp () (staticBuiltinNameAsTerm op) [i, mkConstant @Integer () 0]
                 , mkConstant @Integer () iv
                 ]
     return $ TermOf term EvaluationFailure

--- a/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Denotation.hs
+++ b/language-plutus-core/generators/Language/PlutusCore/Generators/Internal/Denotation.hs
@@ -10,9 +10,9 @@ module Language.PlutusCore.Generators.Internal.Denotation
     , DenotationContextMember(..)
     , DenotationContext(..)
     , denoteVariable
-    , denoteTypedBuiltinName
+    , denoteTypedStaticBuiltinName
     , insertVariable
-    , insertTypedBuiltinName
+    , insertTypedStaticBuiltinName
     , typedBuiltinNames
     ) where
 
@@ -20,6 +20,7 @@ import           Language.PlutusCore.Generators.Internal.Dependent
 
 import           Language.PlutusCore.Constant
 import           Language.PlutusCore.Core
+import           Language.PlutusCore.MkPlc                         (staticBuiltinNameAsTerm)
 import           Language.PlutusCore.Name
 import           Language.PlutusCore.Universe
 
@@ -74,13 +75,13 @@ typeSchemeResult (TypeSchemeAllType _ schK) = typeSchemeResult $ schK Proxy
 denoteVariable :: KnownType (Term TyName Name uni ()) res => Name -> res -> Denotation uni Name res
 denoteVariable name meta = Denotation name (Var ()) meta (TypeSchemeResult Proxy)
 
--- | Get the 'Denotation' of a 'TypedBuiltinName'.
-denoteTypedBuiltinName
-    :: TypedBuiltinName (Term TyName Name uni ()) args res
+-- | Get the 'Denotation' of a 'TypedStaticBuiltinName'.
+denoteTypedStaticBuiltinName
+    :: TypedStaticBuiltinName (Term TyName Name uni ()) args res
     -> FoldArgs args res
-    -> Denotation uni BuiltinName res
-denoteTypedBuiltinName (TypedBuiltinName name scheme) meta =
-    Denotation name (Builtin () . BuiltinName ()) meta scheme
+    -> Denotation uni StaticBuiltinName res
+denoteTypedStaticBuiltinName (TypedStaticBuiltinName name scheme) meta =
+    Denotation name staticBuiltinNameAsTerm meta scheme
 
 -- | Insert the 'Denotation' of an object into a 'DenotationContext'.
 insertDenotation
@@ -100,40 +101,40 @@ insertVariable
 insertVariable name = insertDenotation . denoteVariable name
 
 -- | Insert a 'TypedBuiltinName' into a 'DenotationContext'.
-insertTypedBuiltinName
+insertTypedStaticBuiltinName
     :: GShow uni
-    => TypedBuiltinName (Term TyName Name uni ()) args res
+    => TypedStaticBuiltinName (Term TyName Name uni ()) args res
     -> FoldArgs args res
     -> DenotationContext uni
     -> DenotationContext uni
-insertTypedBuiltinName tbn@(TypedBuiltinName _ scheme) meta =
+insertTypedStaticBuiltinName tbn@(TypedStaticBuiltinName _ scheme) meta =
     case typeSchemeResult scheme of
-        AsKnownType -> insertDenotation (denoteTypedBuiltinName tbn meta)
+        AsKnownType -> insertDenotation (denoteTypedStaticBuiltinName tbn meta)
 
 -- Builtins that may fail are commented out, because we cannot handle them right now.
 -- Look for "UNDEFINED BEHAVIOR" in "Language.PlutusCore.Generators.Internal.Dependent".
--- | A 'DenotationContext' that consists of 'TypedBuiltinName's.
+-- | A 'DenotationContext' that consists of 'TypedStaticBuiltinName's.
 typedBuiltinNames
     :: (GShow uni, GEq uni, DefaultUni <: uni)
     => DenotationContext uni
 typedBuiltinNames
-    = insertTypedBuiltinName typedAddInteger           (+)
-    . insertTypedBuiltinName typedSubtractInteger      (-)
-    . insertTypedBuiltinName typedMultiplyInteger      (*)
---     . insertTypedBuiltinName typedDivideInteger        (nonZeroArg div)
---     . insertTypedBuiltinName typedRemainderInteger     (nonZeroArg rem)
---     . insertTypedBuiltinName typedQuotientInteger      (nonZeroArg quot)
---     . insertTypedBuiltinName typedModInteger           (nonZeroArg mod)
-    . insertTypedBuiltinName typedLessThanInteger      (<)
-    . insertTypedBuiltinName typedLessThanEqInteger    (<=)
-    . insertTypedBuiltinName typedGreaterThanInteger   (>)
-    . insertTypedBuiltinName typedGreaterThanEqInteger (>=)
-    . insertTypedBuiltinName typedEqInteger            (==)
-    . insertTypedBuiltinName typedConcatenate          (coerce BSL.append)
-    . insertTypedBuiltinName typedTakeByteString       (coerce BSL.take . integerToInt64)
-    . insertTypedBuiltinName typedDropByteString       (coerce BSL.drop . integerToInt64)
-    . insertTypedBuiltinName typedSHA2                 (coerce Hash.sha2)
-    . insertTypedBuiltinName typedSHA3                 (coerce Hash.sha3)
---     . insertTypedBuiltinName typedVerifySignature      verifySignature
-    . insertTypedBuiltinName typedEqByteString         (==)
+    = insertTypedStaticBuiltinName typedAddInteger           (+)
+    . insertTypedStaticBuiltinName typedSubtractInteger      (-)
+    . insertTypedStaticBuiltinName typedMultiplyInteger      (*)
+--     . insertTypedStaticBuiltinName typedDivideInteger        (nonZeroArg div)
+--     . insertTypedStaticBuiltinName typedRemainderInteger     (nonZeroArg rem)
+--     . insertTypedStaticBuiltinName typedQuotientInteger      (nonZeroArg quot)
+--     . insertTypedStaticBuiltinName typedModInteger           (nonZeroArg mod)
+    . insertTypedStaticBuiltinName typedLessThanInteger      (<)
+    . insertTypedStaticBuiltinName typedLessThanEqInteger    (<=)
+    . insertTypedStaticBuiltinName typedGreaterThanInteger   (>)
+    . insertTypedStaticBuiltinName typedGreaterThanEqInteger (>=)
+    . insertTypedStaticBuiltinName typedEqInteger            (==)
+    . insertTypedStaticBuiltinName typedConcatenate          (coerce BSL.append)
+    . insertTypedStaticBuiltinName typedTakeByteString       (coerce BSL.take . integerToInt64)
+    . insertTypedStaticBuiltinName typedDropByteString       (coerce BSL.drop . integerToInt64)
+    . insertTypedStaticBuiltinName typedSHA2                 (coerce Hash.sha2)
+    . insertTypedStaticBuiltinName typedSHA3                 (coerce Hash.sha3)
+--     . insertTypedStaticBuiltinName typedVerifySignature      verifySignature
+    . insertTypedStaticBuiltinName typedEqByteString         (==)
     $ DenotationContext mempty

--- a/language-plutus-core/plutus-ir/Language/PlutusIR.hs
+++ b/language-plutus-core/plutus-ir/Language/PlutusIR.hs
@@ -197,7 +197,7 @@ data Term tyname name uni a =
                         | LamAbs a name (Type tyname uni a) (Term tyname name uni a)
                         | Apply a (Term tyname name uni a) (Term tyname name uni a)
                         | Constant a (PLC.Some (PLC.ValueOf uni))
-                        | Builtin a (PLC.BuiltinName a)
+                        | Builtin a PLC.BuiltinName
                         | TyInst a (Term tyname name uni a) (Type tyname uni a)
                         | Error a (Type tyname uni a)
                         | IWrap a (Type tyname uni a) (Type tyname uni a) (Term tyname name uni a)

--- a/language-plutus-core/plutus-ir/Language/PlutusIR.hs
+++ b/language-plutus-core/plutus-ir/Language/PlutusIR.hs
@@ -197,7 +197,7 @@ data Term tyname name uni a =
                         | LamAbs a name (Type tyname uni a) (Term tyname name uni a)
                         | Apply a (Term tyname name uni a) (Term tyname name uni a)
                         | Constant a (PLC.Some (PLC.ValueOf uni))
-                        | Builtin a (PLC.Builtin a)
+                        | Builtin a (PLC.BuiltinName a)
                         | TyInst a (Term tyname name uni a) (Type tyname uni a)
                         | Error a (Type tyname uni a)
                         | IWrap a (Type tyname uni a) (Type tyname uni a) (Term tyname name uni a)

--- a/language-plutus-core/plutus-ir/Language/PlutusIR/Generators/AST.hs
+++ b/language-plutus-core/plutus-ir/Language/PlutusIR/Generators/AST.hs
@@ -15,8 +15,9 @@ module Language.PlutusIR.Generators.AST
 
 import           Language.PlutusIR
 
-import           Language.PlutusCore.Generators.AST as Export (AstGen, genBuiltin, genBuiltinName, genConstant, genKind,
-                                                               genVersion, runAstGen, simpleRecursive)
+import           Language.PlutusCore.Generators.AST as Export (AstGen, genBuiltinName, genConstant, genKind,
+                                                               genStaticBuiltinName, genVersion, runAstGen,
+                                                               simpleRecursive)
 import qualified Language.PlutusCore.Generators.AST as PLC
 import qualified Language.PlutusCore.Universe       as PLC
 
@@ -82,7 +83,7 @@ genTerm = simpleRecursive nonRecursive recursive where
     errorGen = Error () <$> genType
     letGen = Let () <$> genRecursivity <*> Gen.nonEmpty (Range.linear 1 10) genBinding <*> genTerm
     recursive = [absGen, instGen, lamGen, applyGen, unwrapGen, wrapGen, letGen]
-    nonRecursive = [varGen, Constant () <$> genConstant, Builtin () <$> genBuiltin, errorGen]
+    nonRecursive = [varGen, Constant () <$> genConstant, Builtin () <$> genBuiltinName, errorGen]
 
 genProgram :: PLC.AstGen (Program TyName Name PLC.DefaultUni ())
 genProgram = Program () <$> genTerm

--- a/language-plutus-core/plutus-ir/Language/PlutusIR/Parser.hs
+++ b/language-plutus-core/plutus-ir/Language/PlutusIR/Parser.hs
@@ -120,7 +120,7 @@ inBraces = between lbrace rbrace
 
 reservedWords :: [T.Text]
 reservedWords =
-    map display PLC.allBuiltinNames ++
+    map display PLC.allStaticBuiltinNames ++
     [ "abs"
     , "lam"
     , "ifix"
@@ -159,9 +159,10 @@ reservedWord w = lexeme $ try $ do
     notFollowedBy (satisfy isIdentifierChar)
     return p
 
-builtinName :: Parser PLC.BuiltinName
-builtinName = lexeme $ choice $ map parseBuiltinName PLC.allBuiltinNames
-    where parseBuiltinName :: PLC.BuiltinName -> Parser PLC.BuiltinName
+-- FIXME: can't parse dynamic names
+staticBuiltinName :: Parser PLC.StaticBuiltinName
+staticBuiltinName = lexeme $ choice $ map parseBuiltinName PLC.allStaticBuiltinNames
+    where parseBuiltinName :: PLC.StaticBuiltinName -> Parser PLC.StaticBuiltinName
           parseBuiltinName builtin = try $ string (display builtin) >> pure builtin
 
 name :: Parser Name
@@ -178,8 +179,8 @@ var = name
 tyVar :: Parser TyName
 tyVar = TyName <$> name
 
-builtinVar :: Parser (PLC.Builtin SourcePos)
-builtinVar = PLC.BuiltinName <$> getSourcePos <*> builtinName
+builtinVar :: Parser (PLC.BuiltinName SourcePos)
+builtinVar = PLC.StaticBuiltinName <$> getSourcePos <*> staticBuiltinName
 
 -- This should not accept spaces after the sign, hence the `return ()`
 integer :: Parser Integer

--- a/language-plutus-core/plutus-ir/Language/PlutusIR/Parser.hs
+++ b/language-plutus-core/plutus-ir/Language/PlutusIR/Parser.hs
@@ -179,8 +179,8 @@ var = name
 tyVar :: Parser TyName
 tyVar = TyName <$> name
 
-builtinVar :: Parser (PLC.BuiltinName SourcePos)
-builtinVar = PLC.StaticBuiltinName <$> getSourcePos <*> staticBuiltinName
+builtinVar :: Parser PLC.BuiltinName
+builtinVar = PLC.StaticBuiltinName <$> staticBuiltinName
 
 -- This should not accept spaces after the sign, hence the `return ()`
 integer :: Parser Integer

--- a/language-plutus-core/plutus-ir/Language/PlutusIR/Purity.hs
+++ b/language-plutus-core/plutus-ir/Language/PlutusIR/Purity.hs
@@ -25,13 +25,13 @@ saturatesScheme ::  [Arg tyname name uni a] -> TypeScheme term args res -> Maybe
 saturatesScheme _ TypeSchemeResult{} = Just True
 -- Consume one argument
 saturatesScheme (TermArg _ : args) (TypeSchemeArrow _ sch) = saturatesScheme args sch
-saturatesScheme (TypeArg _ : args) (TypeSchemeAllType _ k) = saturatesScheme args (k Proxy)
+saturatesScheme (TypeArg _ : args) (TypeSchemeAll _ _ k)   = saturatesScheme args (k Proxy)
 -- Under-applied, not saturated
 saturatesScheme [] TypeSchemeArrow{} = Just False
-saturatesScheme [] TypeSchemeAllType{} = Just False
+saturatesScheme [] TypeSchemeAll{}   = Just False
 -- These cases are only possible in case we have an ill-typed builtin application, so we can't give an answer.
 saturatesScheme (TypeArg _ : _) TypeSchemeArrow{} = Nothing
-saturatesScheme (TermArg _ : _) TypeSchemeAllType{} = Nothing
+saturatesScheme (TermArg _ : _) TypeSchemeAll{}   = Nothing
 
 -- | Is the given 'BuiltinApp' saturated? Returns 'Nothing' if something is badly wrong and we can't tell.
 isSaturated

--- a/language-plutus-core/plutus-ir/Language/PlutusIR/Purity.hs
+++ b/language-plutus-core/plutus-ir/Language/PlutusIR/Purity.hs
@@ -18,7 +18,7 @@ import qualified Data.Map as Map
 data Arg tyname name uni a = TypeArg (Type tyname uni a) | TermArg (Term tyname name uni a)
 
 -- | A (not necessarily saturated) builtin application, consisting of the builtin and the arguments it has been applied to.
-data BuiltinApp tyname name uni a = BuiltinApp (PLC.Builtin a) [Arg tyname name uni a]
+data BuiltinApp tyname name uni a = BuiltinApp (PLC.BuiltinName a) [Arg tyname name uni a]
 
 saturatesScheme ::  [Arg tyname name uni a] -> TypeScheme term args res -> Maybe Bool
 -- We've passed enough arguments that the builtin will reduce. Note that this also accepts over-applied builtins.
@@ -41,7 +41,7 @@ isSaturated
     -> BuiltinApp tyname name uni a
     -> Maybe Bool
 isSaturated (DynamicBuiltinNameMeanings means) (BuiltinApp b args) = case b of
-    PLC.BuiltinName _ bn -> withTypedBuiltinName @uni @term bn $ \(TypedBuiltinName _ sch) -> saturatesScheme args sch
+    PLC.StaticBuiltinName _ bn -> withTypedStaticBuiltinName @uni @term bn $ \(TypedStaticBuiltinName _ sch) -> saturatesScheme args sch
     PLC.DynBuiltinName _ bn -> case Map.lookup bn means of
         Just (DynamicBuiltinNameMeaning sch _ _) -> saturatesScheme args sch
         Nothing -> Nothing

--- a/language-plutus-core/plutus-ir/Language/PlutusIR/Purity.hs
+++ b/language-plutus-core/plutus-ir/Language/PlutusIR/Purity.hs
@@ -18,7 +18,7 @@ import qualified Data.Map as Map
 data Arg tyname name uni a = TypeArg (Type tyname uni a) | TermArg (Term tyname name uni a)
 
 -- | A (not necessarily saturated) builtin application, consisting of the builtin and the arguments it has been applied to.
-data BuiltinApp tyname name uni a = BuiltinApp (PLC.BuiltinName a) [Arg tyname name uni a]
+data BuiltinApp tyname name uni a = BuiltinApp PLC.BuiltinName [Arg tyname name uni a]
 
 saturatesScheme ::  [Arg tyname name uni a] -> TypeScheme term args res -> Maybe Bool
 -- We've passed enough arguments that the builtin will reduce. Note that this also accepts over-applied builtins.
@@ -41,8 +41,8 @@ isSaturated
     -> BuiltinApp tyname name uni a
     -> Maybe Bool
 isSaturated (DynamicBuiltinNameMeanings means) (BuiltinApp b args) = case b of
-    PLC.StaticBuiltinName _ bn -> withTypedStaticBuiltinName @uni @term bn $ \(TypedStaticBuiltinName _ sch) -> saturatesScheme args sch
-    PLC.DynBuiltinName _ bn -> case Map.lookup bn means of
+    PLC.StaticBuiltinName bn -> withTypedStaticBuiltinName @uni @term bn $ \(TypedStaticBuiltinName _ sch) -> saturatesScheme args sch
+    PLC.DynBuiltinName bn -> case Map.lookup bn means of
         Just (DynamicBuiltinNameMeaning sch _ _) -> saturatesScheme args sch
         Nothing -> Nothing
 

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -38,7 +38,7 @@ module Language.PlutusCore
     , termSubtypes
     , Type (..)
     , typeSubtypes
-    , Builtin (..)
+    , BuiltinName (..)
     , Kind (..)
     , ParseError (..)
     , Version (..)
@@ -48,12 +48,12 @@ module Language.PlutusCore
     , Unique (..)
     , UniqueMap (..)
     , Value
-    , BuiltinName (..)
+    , StaticBuiltinName (..)
     , DynamicBuiltinName (..)
     , StagedBuiltinName (..)
     , Normalized (..)
     , defaultVersion
-    , allBuiltinNames
+    , allStaticBuiltinNames
     , allKeywords
     , toTerm
     , termAnn

--- a/language-plutus-core/src/Language/PlutusCore.hs
+++ b/language-plutus-core/src/Language/PlutusCore.hs
@@ -50,7 +50,6 @@ module Language.PlutusCore
     , Value
     , StaticBuiltinName (..)
     , DynamicBuiltinName (..)
-    , StagedBuiltinName (..)
     , Normalized (..)
     , defaultVersion
     , allStaticBuiltinNames

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -107,7 +107,7 @@ instance (Closed uni, uni `Everywhere` Serialise) => Serialise (Some (ValueOf un
     decode = go =<< decode where
         go (Some (TypeIn uni)) = Some . ValueOf uni <$> bring (Proxy @Serialise) uni decode
 
-instance Serialise BuiltinName where
+instance Serialise StaticBuiltinName where
     encode = encodeConstructorTag . \case
               AddInteger           -> 0
               SubtractInteger      -> 1
@@ -208,13 +208,13 @@ instance Serialise DynamicBuiltinName where
     encode (DynamicBuiltinName name) = encode name
     decode = DynamicBuiltinName <$> decode
 
-instance Serialise ann => Serialise (Builtin ann) where
-    encode (BuiltinName ann bn)     = encodeConstructorTag 0 <> encode ann <> encode bn
-    encode (DynBuiltinName ann dbn) = encodeConstructorTag 1 <> encode ann <> encode dbn
+instance Serialise ann => Serialise (BuiltinName ann) where
+    encode (StaticBuiltinName ann bn) = encodeConstructorTag 0 <> encode ann <> encode bn
+    encode (DynBuiltinName ann dbn)   = encodeConstructorTag 1 <> encode ann <> encode dbn
 
     decode = go =<< decodeConstructorTag
-        where go 0 = BuiltinName    <$> decode <*> decode
-              go 1 = DynBuiltinName <$> decode <*> decode
+        where go 0 = StaticBuiltinName <$> decode <*> decode
+              go 1 = DynBuiltinName    <$> decode <*> decode
               go _ = fail "Failed to decode Builtin ()"
 
 instance ( Closed uni

--- a/language-plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/language-plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -208,13 +208,13 @@ instance Serialise DynamicBuiltinName where
     encode (DynamicBuiltinName name) = encode name
     decode = DynamicBuiltinName <$> decode
 
-instance Serialise ann => Serialise (BuiltinName ann) where
-    encode (StaticBuiltinName ann bn) = encodeConstructorTag 0 <> encode ann <> encode bn
-    encode (DynBuiltinName ann dbn)   = encodeConstructorTag 1 <> encode ann <> encode dbn
+instance Serialise BuiltinName where
+    encode (StaticBuiltinName bn) = encodeConstructorTag 0 <> encode bn
+    encode (DynBuiltinName   dbn) = encodeConstructorTag 1 <> encode dbn
 
     decode = go =<< decodeConstructorTag
-        where go 0 = StaticBuiltinName <$> decode <*> decode
-              go 1 = DynBuiltinName    <$> decode <*> decode
+        where go 0 = StaticBuiltinName <$> decode
+              go 1 = DynBuiltinName    <$> decode
               go _ = fail "Failed to decode Builtin ()"
 
 instance ( Closed uni

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
@@ -17,7 +17,7 @@ module Language.PlutusCore.Constant.Apply
     , nonZeroArg
     , integerToInt64
     , applyTypeSchemed
-    , applyBuiltinName
+    , applyStaticBuiltinName
     ) where
 
 import           Language.PlutusCore.Constant.Name
@@ -111,159 +111,159 @@ applyTypeSchemed name = go where
                     go schB (f x) exF' args'
                 _ -> go schB (f x) exF' args'
 
--- | Apply a 'TypedBuiltinName' to a list of 'Constant's (unwrapped from 'Value's)
+-- | Apply a 'TypedStaticBuiltinName' to a list of 'Constant's (unwrapped from 'Value's)
 -- Checks that the constants are of expected types.
-applyTypedBuiltinName
+applyTypedStaticBuiltinName
     :: ( MonadError (ErrorWithCause err term) m, AsUnliftingError err, AsConstAppError err term
        , SpendBudget m term
        )
-    => TypedBuiltinName term args res
+    => TypedStaticBuiltinName term args res
     -> FoldArgs args res
     -> FoldArgsEx args
     -> [term]
     -> m (ConstAppResult term)
-applyTypedBuiltinName (TypedBuiltinName name schema) =
+applyTypedStaticBuiltinName (TypedStaticBuiltinName name schema) =
     applyTypeSchemed (StaticStagedBuiltinName name) schema
 
 -- | Apply a 'TypedBuiltinName' to a list of 'Value's.
 -- Checks that the values are of expected types.
-applyBuiltinName
+applyStaticBuiltinName
     :: forall m err uni term
     .  ( MonadError (ErrorWithCause err term) m, AsUnliftingError err, AsConstAppError err term
        , SpendBudget m term, HasConstantIn uni term, GShow uni, GEq uni, DefaultUni <: uni
        )
-    => BuiltinName -> [term] -> m (ConstAppResult term)
-applyBuiltinName name args = do
+    => StaticBuiltinName -> [term] -> m (ConstAppResult term)
+applyStaticBuiltinName name args = do
     params <- builtinCostParams
     case name of
         AddInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedAddInteger
                 (+)
                 (runCostingFunTwoArguments $ paramAddInteger params)
                 args
         SubtractInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedSubtractInteger
                 (-)
                 (runCostingFunTwoArguments $ paramSubtractInteger params)
                 args
         MultiplyInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedMultiplyInteger
                 (*)
                 (runCostingFunTwoArguments $ paramMultiplyInteger params)
                 args
         DivideInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedDivideInteger
                 (nonZeroArg div)
                 (runCostingFunTwoArguments $ paramDivideInteger params)
                 args
         QuotientInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedQuotientInteger
                 (nonZeroArg quot)
                 (runCostingFunTwoArguments $ paramQuotientInteger params)
                 args
         RemainderInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedRemainderInteger
                 (nonZeroArg rem)
                 (runCostingFunTwoArguments $ paramRemainderInteger params)
                 args
         ModInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedModInteger
                 (nonZeroArg mod)
                 (runCostingFunTwoArguments $ paramModInteger params)
                 args
         LessThanInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedLessThanInteger
                 (<)
                 (runCostingFunTwoArguments $ paramLessThanInteger params)
                 args
         LessThanEqInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedLessThanEqInteger
                 (<=)
                 (runCostingFunTwoArguments $ paramLessThanEqInteger params)
                 args
         GreaterThanInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedGreaterThanInteger
                 (>)
                 (runCostingFunTwoArguments $ paramGreaterThanInteger params)
                 args
         GreaterThanEqInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedGreaterThanInteger
                 (>=)
                 (runCostingFunTwoArguments $ paramGreaterThanEqInteger params)
                 args
         EqInteger ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedEqInteger
                 (==)
                 (runCostingFunTwoArguments $ paramEqInteger params)
                 args
         Concatenate ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedConcatenate
                 (<>)
                 (runCostingFunTwoArguments $ paramConcatenate params)
                 args
         TakeByteString ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedTakeByteString
                 (coerce BSL.take . integerToInt64)
                 (runCostingFunTwoArguments $ paramTakeByteString params)
                 args
         DropByteString ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedDropByteString
                 (coerce BSL.drop . integerToInt64)
                 (runCostingFunTwoArguments $ paramDropByteString params)
                 args
         SHA2 ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedSHA2
                 (coerce Hash.sha2)
                 (runCostingFunOneArgument $ paramSHA2 params)
                 args
         SHA3 ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedSHA3
                 (coerce Hash.sha3)
                 (runCostingFunOneArgument $ paramSHA3 params)
                 args
         VerifySignature ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedVerifySignature
                 (coerce $ verifySignature @EvaluationResult)
                 (runCostingFunThreeArguments $ paramVerifySignature params)
                 args
         EqByteString ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedEqByteString
                 (==)
                 (runCostingFunTwoArguments $ paramEqByteString params)
                 args
         LtByteString ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedLtByteString
                 (<)
                 (runCostingFunTwoArguments $ paramLtByteString params)
                 args
         GtByteString ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedGtByteString
                 (>)
                 (runCostingFunTwoArguments $ paramGtByteString params)
                 args
         IfThenElse ->
-            applyTypedBuiltinName
+            applyTypedStaticBuiltinName
                 typedIfThenElse
                 (\b x y -> if b then x else y)
                 (runCostingFunThreeArguments $ paramIfThenElse params)

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Apply.hs
@@ -69,7 +69,7 @@ applyTypeSchemed
        ( MonadError (ErrorWithCause err term) m, AsUnliftingError err, AsConstAppError err term
        , SpendBudget m term
        )
-    => StagedBuiltinName
+    => BuiltinName
     -> TypeScheme term args res
     -> FoldArgs args res
     -> FoldArgsEx args
@@ -123,7 +123,7 @@ applyTypedStaticBuiltinName
     -> [term]
     -> m (ConstAppResult term)
 applyTypedStaticBuiltinName (TypedStaticBuiltinName name schema) =
-    applyTypeSchemed (StaticStagedBuiltinName name) schema
+    applyTypeSchemed (StaticBuiltinName name) schema
 
 -- | Apply a 'TypedBuiltinName' to a list of 'Value's.
 -- Checks that the values are of expected types.

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Function.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Function.hs
@@ -7,7 +7,7 @@ module Language.PlutusCore.Constant.Function
     ( typeSchemeToType
     , dynamicBuiltinNameMeaningToType
     , insertDynamicBuiltinNameDefinition
-    , typeOfTypedBuiltinName
+    , typeOfTypedStaticBuiltinName
     ) where
 
 import           Language.PlutusCore.Constant.Typed
@@ -47,6 +47,6 @@ insertDynamicBuiltinNameDefinition
         DynamicBuiltinNameMeanings $ Map.insert name mean nameMeans
 
 -- | Return the 'Type' of a 'TypedBuiltinName'.
-typeOfTypedBuiltinName
-    :: UniOf term ~ uni => TypedBuiltinName term as r -> Type TyName uni ()
-typeOfTypedBuiltinName (TypedBuiltinName _ scheme) = typeSchemeToType scheme
+typeOfTypedStaticBuiltinName
+    :: UniOf term ~ uni => TypedStaticBuiltinName term as r -> Type TyName uni ()
+typeOfTypedStaticBuiltinName (TypedStaticBuiltinName _ scheme) = typeSchemeToType scheme

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Name.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Name.hs
@@ -10,8 +10,8 @@
 {-# LANGUAGE UndecidableInstances   #-}
 
 module Language.PlutusCore.Constant.Name
-    ( makeTypedBuiltinName
-    , withTypedBuiltinName
+    ( makeTypedStaticBuiltinName
+    , withTypedStaticBuiltinName
     , typedAddInteger
     , typedSubtractInteger
     , typedMultiplyInteger
@@ -56,166 +56,166 @@ instance (KnownType term arg, KnownTypeScheme term args res) =>
     knownTypeScheme = Proxy `TypeSchemeArrow` knownTypeScheme
 
 -- | Automatically typify a 'BuiltinName'.
-makeTypedBuiltinName :: KnownTypeScheme term args res => BuiltinName -> TypedBuiltinName term args res
-makeTypedBuiltinName name = TypedBuiltinName name knownTypeScheme
+makeTypedStaticBuiltinName :: KnownTypeScheme term args res => StaticBuiltinName -> TypedStaticBuiltinName term args res
+makeTypedStaticBuiltinName name = TypedStaticBuiltinName name knownTypeScheme
 
 -- | Apply a continuation to the typed version of a 'BuiltinName'.
-withTypedBuiltinName
+withTypedStaticBuiltinName
     :: (HasConstantIn uni term, GShow uni, GEq uni, DefaultUni <: uni)
-    => BuiltinName -> (forall args res. TypedBuiltinName term args res -> c) -> c
-withTypedBuiltinName AddInteger           k = k typedAddInteger
-withTypedBuiltinName SubtractInteger      k = k typedSubtractInteger
-withTypedBuiltinName MultiplyInteger      k = k typedMultiplyInteger
-withTypedBuiltinName DivideInteger        k = k typedDivideInteger
-withTypedBuiltinName QuotientInteger      k = k typedQuotientInteger
-withTypedBuiltinName RemainderInteger     k = k typedRemainderInteger
-withTypedBuiltinName ModInteger           k = k typedModInteger
-withTypedBuiltinName LessThanInteger      k = k typedLessThanInteger
-withTypedBuiltinName LessThanEqInteger    k = k typedLessThanEqInteger
-withTypedBuiltinName GreaterThanInteger   k = k typedGreaterThanInteger
-withTypedBuiltinName GreaterThanEqInteger k = k typedGreaterThanEqInteger
-withTypedBuiltinName EqInteger            k = k typedEqInteger
-withTypedBuiltinName Concatenate          k = k typedConcatenate
-withTypedBuiltinName TakeByteString       k = k typedTakeByteString
-withTypedBuiltinName DropByteString       k = k typedDropByteString
-withTypedBuiltinName SHA2                 k = k typedSHA2
-withTypedBuiltinName SHA3                 k = k typedSHA3
-withTypedBuiltinName VerifySignature      k = k typedVerifySignature
-withTypedBuiltinName EqByteString         k = k typedEqByteString
-withTypedBuiltinName LtByteString         k = k typedLtByteString
-withTypedBuiltinName GtByteString         k = k typedGtByteString
-withTypedBuiltinName IfThenElse           k = k typedIfThenElse
+    => StaticBuiltinName -> (forall args res. TypedStaticBuiltinName term args res -> c) -> c
+withTypedStaticBuiltinName AddInteger           k = k typedAddInteger
+withTypedStaticBuiltinName SubtractInteger      k = k typedSubtractInteger
+withTypedStaticBuiltinName MultiplyInteger      k = k typedMultiplyInteger
+withTypedStaticBuiltinName DivideInteger        k = k typedDivideInteger
+withTypedStaticBuiltinName QuotientInteger      k = k typedQuotientInteger
+withTypedStaticBuiltinName RemainderInteger     k = k typedRemainderInteger
+withTypedStaticBuiltinName ModInteger           k = k typedModInteger
+withTypedStaticBuiltinName LessThanInteger      k = k typedLessThanInteger
+withTypedStaticBuiltinName LessThanEqInteger    k = k typedLessThanEqInteger
+withTypedStaticBuiltinName GreaterThanInteger   k = k typedGreaterThanInteger
+withTypedStaticBuiltinName GreaterThanEqInteger k = k typedGreaterThanEqInteger
+withTypedStaticBuiltinName EqInteger            k = k typedEqInteger
+withTypedStaticBuiltinName Concatenate          k = k typedConcatenate
+withTypedStaticBuiltinName TakeByteString       k = k typedTakeByteString
+withTypedStaticBuiltinName DropByteString       k = k typedDropByteString
+withTypedStaticBuiltinName SHA2                 k = k typedSHA2
+withTypedStaticBuiltinName SHA3                 k = k typedSHA3
+withTypedStaticBuiltinName VerifySignature      k = k typedVerifySignature
+withTypedStaticBuiltinName EqByteString         k = k typedEqByteString
+withTypedStaticBuiltinName LtByteString         k = k typedLtByteString
+withTypedStaticBuiltinName GtByteString         k = k typedGtByteString
+withTypedStaticBuiltinName IfThenElse           k = k typedIfThenElse
 
 -- | Typed 'AddInteger'.
 typedAddInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `Includes` Integer)
-    => TypedBuiltinName term '[Integer, Integer] Integer
-typedAddInteger = makeTypedBuiltinName AddInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] Integer
+typedAddInteger = makeTypedStaticBuiltinName AddInteger
 
 -- | Typed 'SubtractInteger'.
 typedSubtractInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `Includes` Integer)
-    => TypedBuiltinName term '[Integer, Integer] Integer
-typedSubtractInteger = makeTypedBuiltinName SubtractInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] Integer
+typedSubtractInteger = makeTypedStaticBuiltinName SubtractInteger
 
 -- | Typed 'MultiplyInteger'.
 typedMultiplyInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `Includes` Integer)
-    => TypedBuiltinName term '[Integer, Integer] Integer
-typedMultiplyInteger = makeTypedBuiltinName MultiplyInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] Integer
+typedMultiplyInteger = makeTypedStaticBuiltinName MultiplyInteger
 
 -- | Typed 'DivideInteger'.
 typedDivideInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `Includes` Integer)
-    => TypedBuiltinName term '[Integer, Integer] (EvaluationResult Integer)
-typedDivideInteger = makeTypedBuiltinName DivideInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] (EvaluationResult Integer)
+typedDivideInteger = makeTypedStaticBuiltinName DivideInteger
 
 -- | Typed 'QuotientInteger'
 typedQuotientInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `Includes` Integer)
-    => TypedBuiltinName term '[Integer, Integer] (EvaluationResult Integer)
-typedQuotientInteger = makeTypedBuiltinName QuotientInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] (EvaluationResult Integer)
+typedQuotientInteger = makeTypedStaticBuiltinName QuotientInteger
 
 -- | Typed 'RemainderInteger'.
 typedRemainderInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `Includes` Integer)
-    => TypedBuiltinName term '[Integer, Integer] (EvaluationResult Integer)
-typedRemainderInteger = makeTypedBuiltinName RemainderInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] (EvaluationResult Integer)
+typedRemainderInteger = makeTypedStaticBuiltinName RemainderInteger
 
 -- | Typed 'ModInteger'
 typedModInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `Includes` Integer)
-    => TypedBuiltinName term '[Integer, Integer] (EvaluationResult Integer)
-typedModInteger = makeTypedBuiltinName ModInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] (EvaluationResult Integer)
+typedModInteger = makeTypedStaticBuiltinName ModInteger
 
 -- | Typed 'LessThanInteger'.
 typedLessThanInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[Integer, Bool])
-    => TypedBuiltinName term '[Integer, Integer] Bool
-typedLessThanInteger = makeTypedBuiltinName LessThanInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] Bool
+typedLessThanInteger = makeTypedStaticBuiltinName LessThanInteger
 
 -- | Typed 'LessThanEqInteger'.
 typedLessThanEqInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[Integer, Bool])
-    => TypedBuiltinName term '[Integer, Integer] Bool
-typedLessThanEqInteger = makeTypedBuiltinName LessThanEqInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] Bool
+typedLessThanEqInteger = makeTypedStaticBuiltinName LessThanEqInteger
 
 -- | Typed 'GreaterThanInteger'.
 typedGreaterThanInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[Integer, Bool])
-    => TypedBuiltinName term '[Integer, Integer] Bool
-typedGreaterThanInteger = makeTypedBuiltinName GreaterThanInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] Bool
+typedGreaterThanInteger = makeTypedStaticBuiltinName GreaterThanInteger
 
 -- | Typed 'GreaterThanEqInteger'.
 typedGreaterThanEqInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[Integer, Bool])
-    => TypedBuiltinName term '[Integer, Integer] Bool
-typedGreaterThanEqInteger = makeTypedBuiltinName GreaterThanEqInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] Bool
+typedGreaterThanEqInteger = makeTypedStaticBuiltinName GreaterThanEqInteger
 
 -- | Typed 'EqInteger'.
 typedEqInteger
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[Integer, Bool])
-    => TypedBuiltinName term '[Integer, Integer] Bool
-typedEqInteger = makeTypedBuiltinName EqInteger
+    => TypedStaticBuiltinName term '[Integer, Integer] Bool
+typedEqInteger = makeTypedStaticBuiltinName EqInteger
 
 -- | Typed 'Concatenate'.
 typedConcatenate
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `Includes` BSL.ByteString)
-    => TypedBuiltinName term '[BSL.ByteString, BSL.ByteString] BSL.ByteString
-typedConcatenate = makeTypedBuiltinName Concatenate
+    => TypedStaticBuiltinName term '[BSL.ByteString, BSL.ByteString] BSL.ByteString
+typedConcatenate = makeTypedStaticBuiltinName Concatenate
 
 -- | Typed 'TakeByteString'.
 typedTakeByteString
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[Integer, BSL.ByteString])
-    => TypedBuiltinName term '[Integer, BSL.ByteString] BSL.ByteString
-typedTakeByteString = makeTypedBuiltinName TakeByteString
+    => TypedStaticBuiltinName term '[Integer, BSL.ByteString] BSL.ByteString
+typedTakeByteString = makeTypedStaticBuiltinName TakeByteString
 
 -- | Typed 'DropByteString'.
 typedDropByteString
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[Integer, BSL.ByteString])
-    => TypedBuiltinName term '[Integer, BSL.ByteString] BSL.ByteString
-typedDropByteString = makeTypedBuiltinName DropByteString
+    => TypedStaticBuiltinName term '[Integer, BSL.ByteString] BSL.ByteString
+typedDropByteString = makeTypedStaticBuiltinName DropByteString
 
 -- | Typed 'SHA2'.
 typedSHA2
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `Includes` BSL.ByteString)
-    => TypedBuiltinName term '[BSL.ByteString] BSL.ByteString
-typedSHA2 = makeTypedBuiltinName SHA2
+    => TypedStaticBuiltinName term '[BSL.ByteString] BSL.ByteString
+typedSHA2 = makeTypedStaticBuiltinName SHA2
 
 -- | Typed 'SHA3'.
 typedSHA3
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `Includes` BSL.ByteString)
-    => TypedBuiltinName term '[BSL.ByteString] BSL.ByteString
-typedSHA3 = makeTypedBuiltinName SHA3
+    => TypedStaticBuiltinName term '[BSL.ByteString] BSL.ByteString
+typedSHA3 = makeTypedStaticBuiltinName SHA3
 
 -- | Typed 'VerifySignature'.
 typedVerifySignature
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[BSL.ByteString, Bool])
-    => TypedBuiltinName term '[BSL.ByteString, BSL.ByteString, BSL.ByteString] (EvaluationResult Bool)
-typedVerifySignature = makeTypedBuiltinName VerifySignature
+    => TypedStaticBuiltinName term '[BSL.ByteString, BSL.ByteString, BSL.ByteString] (EvaluationResult Bool)
+typedVerifySignature = makeTypedStaticBuiltinName VerifySignature
 
 -- | Typed 'EqByteString'.
 typedEqByteString
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[BSL.ByteString, Bool])
-    => TypedBuiltinName term '[BSL.ByteString, BSL.ByteString] Bool
-typedEqByteString = makeTypedBuiltinName EqByteString
+    => TypedStaticBuiltinName term '[BSL.ByteString, BSL.ByteString] Bool
+typedEqByteString = makeTypedStaticBuiltinName EqByteString
 
 -- | Typed 'LtByteString'.
 typedLtByteString
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[BSL.ByteString, Bool])
-    => TypedBuiltinName term '[BSL.ByteString, BSL.ByteString] Bool
-typedLtByteString = makeTypedBuiltinName LtByteString
+    => TypedStaticBuiltinName term '[BSL.ByteString, BSL.ByteString] Bool
+typedLtByteString = makeTypedStaticBuiltinName LtByteString
 
 -- | Typed 'GtByteString'.
 typedGtByteString
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[BSL.ByteString, Bool])
-    => TypedBuiltinName term '[BSL.ByteString, BSL.ByteString] Bool
-typedGtByteString = makeTypedBuiltinName GtByteString
+    => TypedStaticBuiltinName term '[BSL.ByteString, BSL.ByteString] Bool
+typedGtByteString = makeTypedStaticBuiltinName GtByteString
 
 -- | Typed 'IfThenElse'.
 typedIfThenElse
     :: (HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[BSL.ByteString, Bool])
-    => TypedBuiltinName term '[Bool, Opaque term "a" 0, Opaque term "a" 0] (Opaque term "a" 0)
+    => TypedStaticBuiltinName term '[Bool, Opaque term "a" 0, Opaque term "a" 0] (Opaque term "a" 0)
 typedIfThenElse =
-    TypedBuiltinName IfThenElse $
+    TypedStaticBuiltinName IfThenElse $
         TypeSchemeAllType @"a" @0 Proxy $ \_ -> knownTypeScheme

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Name.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Name.hs
@@ -217,7 +217,7 @@ typedIfThenElse
     :: ( HasConstantIn uni term, GShow uni, GEq uni, uni `IncludesAll` '[BSL.ByteString, Bool]
        , a ~ Opaque term (TyVarRep "a" 0)
        )
-    => TypedBuiltinName term '[Bool, a, a] a
+    => TypedStaticBuiltinName term '[Bool, a, a] a
 typedIfThenElse =
-    TypedBuiltinName IfThenElse $
+    TypedStaticBuiltinName IfThenElse $
         TypeSchemeAll @"a" @0 Proxy (Type ()) $ \_ -> knownTypeScheme

--- a/language-plutus-core/src/Language/PlutusCore/Constant/Typed.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Constant/Typed.hs
@@ -19,7 +19,7 @@
 
 module Language.PlutusCore.Constant.Typed
     ( TypeScheme (..)
-    , TypedBuiltinName (..)
+    , TypedStaticBuiltinName (..)
     , FoldArgs
     , FoldArgsEx
     , DynamicBuiltinNameMeaning (..)
@@ -93,8 +93,8 @@ data TypeScheme term (args :: [GHC.Type]) res where
         -> (forall ot. ot ~ Opaque term text uniq => Proxy ot -> TypeScheme term args res)
         -> TypeScheme term args res
 
--- | A 'BuiltinName' with an associated 'TypeScheme'.
-data TypedBuiltinName term args res = TypedBuiltinName BuiltinName (TypeScheme term args res)
+-- | A 'StaticBuiltinName' with an associated 'TypeScheme'.
+data TypedStaticBuiltinName term args res = TypedStaticBuiltinName StaticBuiltinName (TypeScheme term args res)
 
 -- | Turn a list of Haskell types @as@ into a functional type ending in @r@.
 --

--- a/language-plutus-core/src/Language/PlutusCore/Core/Instance/Eq.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Core/Instance/Eq.hs
@@ -30,9 +30,9 @@ instance Eq (Kind ann) where
     Type{}      == _ = False
     KindArrow{} == _ = False
 
-instance Eq (BuiltinName ann) where
-    StaticBuiltinName _ name1 == StaticBuiltinName _ name2 = name1 == name2
-    DynBuiltinName    _ name1 == DynBuiltinName    _ name2 = name1 == name2
+instance Eq BuiltinName where
+    StaticBuiltinName name1 == StaticBuiltinName name2 = name1 == name2
+    DynBuiltinName    name1 == DynBuiltinName    name2 = name1 == name2
     StaticBuiltinName{}       == _ = False
     DynBuiltinName{}          == _ = False
 

--- a/language-plutus-core/src/Language/PlutusCore/Core/Instance/Eq.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Core/Instance/Eq.hs
@@ -30,11 +30,11 @@ instance Eq (Kind ann) where
     Type{}      == _ = False
     KindArrow{} == _ = False
 
-instance Eq (Builtin ann) where
-    BuiltinName    _ name1 == BuiltinName    _ name2 = name1 == name2
-    DynBuiltinName _ name1 == DynBuiltinName _ name2 = name1 == name2
-    BuiltinName{}    == _ = False
-    DynBuiltinName{} == _ = False
+instance Eq (BuiltinName ann) where
+    StaticBuiltinName _ name1 == StaticBuiltinName _ name2 = name1 == name2
+    DynBuiltinName    _ name1 == DynBuiltinName    _ name2 = name1 == name2
+    StaticBuiltinName{}       == _ = False
+    DynBuiltinName{}          == _ = False
 
 instance Eq (Version ann) where
     Version _ n1 m1 p1 == Version _ n2 m2 p2 = [n1, m1, p1] == [n2, m2, p2]

--- a/language-plutus-core/src/Language/PlutusCore/Core/Instance/Pretty/Common.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Core/Instance/Pretty/Common.hs
@@ -35,13 +35,9 @@ instance Pretty StaticBuiltinName where
 instance Pretty DynamicBuiltinName where
     pretty (DynamicBuiltinName n) = pretty n
 
-instance Pretty StagedBuiltinName where
-    pretty (StaticStagedBuiltinName  n) = pretty n
-    pretty (DynamicStagedBuiltinName n) = pretty n
-
-instance Pretty (BuiltinName ann) where
-    pretty (StaticBuiltinName    _ n) = pretty n
-    pretty (DynBuiltinName _ n)       = pretty n
+instance Pretty BuiltinName where
+    pretty (StaticBuiltinName n) = pretty n
+    pretty (DynBuiltinName n)    = pretty n
 
 instance Pretty (Version ann) where
     pretty (Version _ i j k) = pretty i <> "." <> pretty j <> "." <> pretty k

--- a/language-plutus-core/src/Language/PlutusCore/Core/Instance/Pretty/Common.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Core/Instance/Pretty/Common.hs
@@ -8,7 +8,7 @@ import           PlutusPrelude
 
 import           Language.PlutusCore.Core.Type
 
-instance Pretty BuiltinName where
+instance Pretty StaticBuiltinName where
     pretty AddInteger           = "addInteger"
     pretty SubtractInteger      = "subtractInteger"
     pretty MultiplyInteger      = "multiplyInteger"
@@ -39,9 +39,9 @@ instance Pretty StagedBuiltinName where
     pretty (StaticStagedBuiltinName  n) = pretty n
     pretty (DynamicStagedBuiltinName n) = pretty n
 
-instance Pretty (Builtin ann) where
-    pretty (BuiltinName    _ n) = pretty n
-    pretty (DynBuiltinName _ n) = pretty n
+instance Pretty (BuiltinName ann) where
+    pretty (StaticBuiltinName    _ n) = pretty n
+    pretty (DynBuiltinName _ n)       = pretty n
 
 instance Pretty (Version ann) where
     pretty (Version _ i j k) = pretty i <> "." <> pretty j <> "." <> pretty k

--- a/language-plutus-core/src/Language/PlutusCore/Core/Instance/Pretty/Plc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Core/Instance/Pretty/Plc.hs
@@ -29,5 +29,5 @@ deriving via PrettyAny (Program tyname name uni ann)
     instance DefaultPrettyPlcStrategy (Program tyname name uni ann) =>
         PrettyBy PrettyConfigPlc (Program tyname name uni ann)
 
-instance PrettyBy PrettyConfigPlc BuiltinName
-instance PrettyBy PrettyConfigPlc (Builtin ann)
+instance PrettyBy PrettyConfigPlc StaticBuiltinName
+instance PrettyBy PrettyConfigPlc (BuiltinName ann)

--- a/language-plutus-core/src/Language/PlutusCore/Core/Instance/Pretty/Plc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Core/Instance/Pretty/Plc.hs
@@ -30,4 +30,4 @@ deriving via PrettyAny (Program tyname name uni ann)
         PrettyBy PrettyConfigPlc (Program tyname name uni ann)
 
 instance PrettyBy PrettyConfigPlc StaticBuiltinName
-instance PrettyBy PrettyConfigPlc (BuiltinName ann)
+instance PrettyBy PrettyConfigPlc BuiltinName

--- a/language-plutus-core/src/Language/PlutusCore/Core/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Core/Type.hs
@@ -11,9 +11,9 @@ module Language.PlutusCore.Core.Type
     ( Kind(..)
     , Type(..)
     , BuiltinName(..)
+    , StaticBuiltinName(..)
     , DynamicBuiltinName(..)
     , StagedBuiltinName(..)
-    , Builtin(..)
     , Term(..)
     , Value
     , Version(..)
@@ -22,7 +22,7 @@ module Language.PlutusCore.Core.Type
     , Normalized(..)
     , HasUniques
     , defaultVersion
-    , allBuiltinNames
+    , allStaticBuiltinNames
     -- * Helper functions
     , toTerm
     , termAnn
@@ -65,7 +65,7 @@ data Type tyname uni ann
     deriving (Show, Functor, Generic, NFData, Lift, Hashable)
 
 -- | Builtin functions
-data BuiltinName
+data StaticBuiltinName
     = AddInteger
     | SubtractInteger
     | MultiplyInteger
@@ -100,12 +100,12 @@ newtype DynamicBuiltinName = DynamicBuiltinName
 
 -- | Either a 'BuiltinName' (known statically) or a 'DynamicBuiltinName' (known dynamically).
 data StagedBuiltinName
-    = StaticStagedBuiltinName  BuiltinName
+    = StaticStagedBuiltinName  StaticBuiltinName
     | DynamicStagedBuiltinName DynamicBuiltinName
     deriving (Show, Eq, Generic, NFData, Lift, Hashable)
 
-data Builtin ann
-    = BuiltinName ann BuiltinName
+data BuiltinName ann
+    = StaticBuiltinName ann StaticBuiltinName
     | DynBuiltinName ann DynamicBuiltinName
     deriving (Show, Functor, Generic, NFData, Lift, Hashable)
 
@@ -115,7 +115,7 @@ data Term tyname name uni ann
     | LamAbs ann name (Type tyname uni ann) (Term tyname name uni ann)
     | Apply ann (Term tyname name uni ann) (Term tyname name uni ann)
     | Constant ann (Some (ValueOf uni)) -- ^ a constant term
-    | Builtin ann (Builtin ann)
+    | Builtin ann (BuiltinName ann)
     | TyInst ann (Term tyname name uni ann) (Type tyname uni ann)
     | Unwrap ann (Term tyname name uni ann)
     | IWrap ann (Type tyname uni ann) (Type tyname uni ann) (Term tyname name uni ann)
@@ -158,8 +158,8 @@ defaultVersion :: ann -> Version ann
 defaultVersion ann = Version ann 1 0 0
 
 -- | The list of all 'BuiltinName's.
-allBuiltinNames :: [BuiltinName]
-allBuiltinNames = [minBound .. maxBound]
+allStaticBuiltinNames :: [StaticBuiltinName]
+allStaticBuiltinNames = [minBound .. maxBound]
 -- The way it's defined ensures that it's enough to add a new built-in to 'BuiltinName' and it'll be
 -- automatically handled by tests and other stuff that deals with all built-in names at once.
 

--- a/language-plutus-core/src/Language/PlutusCore/Core/Type.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Core/Type.hs
@@ -13,7 +13,6 @@ module Language.PlutusCore.Core.Type
     , BuiltinName(..)
     , StaticBuiltinName(..)
     , DynamicBuiltinName(..)
-    , StagedBuiltinName(..)
     , Term(..)
     , Value
     , Version(..)
@@ -98,16 +97,10 @@ newtype DynamicBuiltinName = DynamicBuiltinName
     } deriving (Show, Eq, Ord, Generic)
       deriving newtype (NFData, Lift, Hashable)
 
--- | Either a 'BuiltinName' (known statically) or a 'DynamicBuiltinName' (known dynamically).
-data StagedBuiltinName
-    = StaticStagedBuiltinName  StaticBuiltinName
-    | DynamicStagedBuiltinName DynamicBuiltinName
-    deriving (Show, Eq, Generic, NFData, Lift, Hashable)
-
-data BuiltinName ann
-    = StaticBuiltinName ann StaticBuiltinName
-    | DynBuiltinName ann DynamicBuiltinName
-    deriving (Show, Functor, Generic, NFData, Lift, Hashable)
+data BuiltinName
+    = StaticBuiltinName StaticBuiltinName
+    | DynBuiltinName DynamicBuiltinName
+    deriving (Show, Generic, NFData, Lift, Hashable)
 
 data Term tyname name uni ann
     = Var ann name -- ^ a named variable
@@ -115,7 +108,7 @@ data Term tyname name uni ann
     | LamAbs ann name (Type tyname uni ann) (Term tyname name uni ann)
     | Apply ann (Term tyname name uni ann) (Term tyname name uni ann)
     | Constant ann (Some (ValueOf uni)) -- ^ a constant term
-    | Builtin ann (BuiltinName ann)
+    | Builtin ann BuiltinName
     | TyInst ann (Term tyname name uni ann) (Type tyname uni ann)
     | Unwrap ann (Term tyname name uni ann)
     | IWrap ann (Type tyname uni ann) (Type tyname uni ann) (Term tyname name uni ann)

--- a/language-plutus-core/src/Language/PlutusCore/Error.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Error.hs
@@ -91,7 +91,7 @@ makeClassyPrisms ''UnknownDynamicBuiltinNameError
 
 -- | An internal error occurred during type checking.
 data InternalTypeError uni ann
-    = OpenTypeOfBuiltin (Type TyName uni ()) (Builtin ())
+    = OpenTypeOfBuiltin (Type TyName uni ()) (BuiltinName ())
     deriving (Show, Eq, Generic, NFData)
 makeClassyPrisms ''InternalTypeError
 

--- a/language-plutus-core/src/Language/PlutusCore/Error.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Error.hs
@@ -91,7 +91,7 @@ makeClassyPrisms ''UnknownDynamicBuiltinNameError
 
 -- | An internal error occurred during type checking.
 data InternalTypeError uni ann
-    = OpenTypeOfBuiltin (Type TyName uni ()) (BuiltinName ())
+    = OpenTypeOfBuiltin (Type TyName uni ()) BuiltinName
     deriving (Show, Eq, Generic, NFData)
 makeClassyPrisms ''InternalTypeError
 

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/Cek.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/Cek.hs
@@ -191,7 +191,7 @@ lookupDynamicBuiltinName dynName = do
     case Map.lookup dynName means of
         Nothing   -> throwingWithCause _MachineError err $ Just term where
             err  = OtherMachineError $ UnknownDynamicBuiltinNameErrorE dynName
-            term = Builtin (memoryUsage ()) $ DynBuiltinName (memoryUsage ()) dynName
+            term = Builtin (memoryUsage ()) $ DynBuiltinName dynName
         Just mean -> pure mean
 
 -- See Note [Scoping].
@@ -390,7 +390,7 @@ applyEvaluate funVarEnv argVarEnv con fun arg = do
             Nothing                       ->
                 throwingWithCause _MachineError NonPrimitiveApplicationMachineError $ Just term
             Just (IterApp headName spine) -> do
-                constAppResult <- applyStagedBuiltinName headName spine
+                constAppResult <- applyBuiltinName headName spine
                 case constAppResult of
                     ConstAppFailure     ->
                         throwingWithCause
@@ -400,16 +400,16 @@ applyEvaluate funVarEnv argVarEnv con fun arg = do
                     ConstAppSuccess res -> computeCek con res
                     ConstAppStuck       -> returnCek con term
 
--- | Apply a 'StagedBuiltinName' to a list of 'Value's.
-applyStagedBuiltinName
+-- | Apply a 'BuiltinName' to a list of 'Value's.
+applyBuiltinName
     :: (GShow uni, GEq uni, DefaultUni <: uni, Closed uni, uni `Everywhere` ExMemoryUsage)
-    => StagedBuiltinName
+    => BuiltinName
     -> [WithMemory Value uni]
     -> CekM uni (ConstAppResult (WithMemory Term uni))
-applyStagedBuiltinName n@(DynamicStagedBuiltinName name) args = do
+applyBuiltinName n@(DynBuiltinName name) args = do
     DynamicBuiltinNameMeaning sch x exX <- lookupDynamicBuiltinName name
     applyTypeSchemed n sch x exX args
-applyStagedBuiltinName (StaticStagedBuiltinName name) args =
+applyBuiltinName (StaticBuiltinName name) args =
     applyStaticBuiltinName name args
 
 -- | Evaluate a term using the CEK machine and keep track of costing.

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/Cek.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/Cek.hs
@@ -410,7 +410,7 @@ applyStagedBuiltinName n@(DynamicStagedBuiltinName name) args = do
     DynamicBuiltinNameMeaning sch x exX <- lookupDynamicBuiltinName name
     applyTypeSchemed n sch x exX args
 applyStagedBuiltinName (StaticStagedBuiltinName name) args =
-    applyBuiltinName name args
+    applyStaticBuiltinName name args
 
 -- | Evaluate a term using the CEK machine and keep track of costing.
 runCek

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/Ck.hs
@@ -163,7 +163,7 @@ applyEvaluate stack fun                    arg =
                     (OtherMachineError NoDynamicBuiltinNamesMachineError)
                     (Just term)
             Just (IterApp (StaticStagedBuiltinName name) spine) -> do
-                constAppResult <- applyBuiltinName name spine
+                constAppResult <- applyStaticBuiltinName name spine
                 case constAppResult of
                     ConstAppFailure     ->
                         throwingWithCause _EvaluationError (UserEvaluationError ()) $ Just term

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/Ck.hs
@@ -158,11 +158,11 @@ applyEvaluate stack fun                    arg =
         case termAsPrimIterApp term of
             Nothing ->
                 throwingWithCause _MachineError NonPrimitiveApplicationMachineError $ Just term
-            Just (IterApp DynamicStagedBuiltinName{} _) ->
+            Just (IterApp (DynBuiltinName{}) _) ->
                 throwingWithCause _MachineError
                     (OtherMachineError NoDynamicBuiltinNamesMachineError)
                     (Just term)
-            Just (IterApp (StaticStagedBuiltinName name) spine) -> do
+            Just (IterApp (StaticBuiltinName name) spine) -> do
                 constAppResult <- applyStaticBuiltinName name spine
                 case constAppResult of
                     ConstAppFailure     ->

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/ExBudgeting.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/ExBudgeting.hs
@@ -202,7 +202,7 @@ instance PrettyDefaultBy config Integer => PrettyBy config ExTally where
 
 -- TODO See language-plutus-core/docs/Constant application.md for how to properly implement this
 estimateStaticStagedCost
-    :: BuiltinName -> [WithMemory Value uni] -> (ExCPU, ExMemory)
+    :: StaticBuiltinName -> [WithMemory Value uni] -> (ExCPU, ExMemory)
 estimateStaticStagedCost _ _ = (1, 1)
 
 type CostModel = CostModelBase CostingFun

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/ExBudgeting.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/ExBudgeting.hs
@@ -91,7 +91,6 @@ module Language.PlutusCore.Evaluation.Machine.ExBudgeting
     , ModelOneArgument(..)
     , ModelTwoArguments(..)
     , ModelThreeArguments(..)
-    , estimateStaticStagedCost
     , exBudgetCPU
     , exBudgetMemory
     , exBudgetStateBudget
@@ -159,7 +158,7 @@ data ExBudgetCategory
     | BIWrap
     | BUnwrap
     | BVar
-    | BBuiltin StagedBuiltinName
+    | BBuiltin BuiltinName
     | BAST
     deriving stock (Show, Eq, Generic)
     deriving anyclass NFData
@@ -199,11 +198,6 @@ instance PrettyDefaultBy config Integer => PrettyBy config ExTally where
     prettyBy config (ExTally m) =
         parens $ fold (["{ "] <> (intersperse (line <> "| ") $ fmap group $
           ifoldMap (\k v -> [(prettyBy config k <+> "causes" <+> prettyBy config v)]) m) <> ["}"])
-
--- TODO See language-plutus-core/docs/Constant application.md for how to properly implement this
-estimateStaticStagedCost
-    :: StaticBuiltinName -> [WithMemory Value uni] -> (ExCPU, ExMemory)
-estimateStaticStagedCost _ _ = (1, 1)
 
 type CostModel = CostModelBase CostingFun
 

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -104,9 +104,9 @@ class ExMemoryUsage a where
 
 deriving via (GenericExMemoryUsage Name) instance ExMemoryUsage Name
 deriving via (GenericExMemoryUsage (Type TyName uni ann)) instance ExMemoryUsage ann => ExMemoryUsage (Type TyName uni ann)
-deriving via (GenericExMemoryUsage (Builtin ann)) instance ExMemoryUsage ann => ExMemoryUsage (Builtin ann)
+deriving via (GenericExMemoryUsage (BuiltinName ann)) instance ExMemoryUsage ann => ExMemoryUsage (BuiltinName ann)
 deriving via (GenericExMemoryUsage (Kind ann)) instance ExMemoryUsage ann => ExMemoryUsage (Kind ann)
-deriving via (GenericExMemoryUsage BuiltinName) instance ExMemoryUsage BuiltinName
+deriving via (GenericExMemoryUsage StaticBuiltinName) instance ExMemoryUsage StaticBuiltinName
 deriving via (GenericExMemoryUsage DynamicBuiltinName) instance ExMemoryUsage DynamicBuiltinName
 deriving via (GenericExMemoryUsage (Term TyName Name uni ann))
   instance (ExMemoryUsage ann, Closed uni, uni `Everywhere` ExMemoryUsage) =>

--- a/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/ExMemory.hs
+++ b/language-plutus-core/src/Language/PlutusCore/Evaluation/Machine/ExMemory.hs
@@ -104,7 +104,7 @@ class ExMemoryUsage a where
 
 deriving via (GenericExMemoryUsage Name) instance ExMemoryUsage Name
 deriving via (GenericExMemoryUsage (Type TyName uni ann)) instance ExMemoryUsage ann => ExMemoryUsage (Type TyName uni ann)
-deriving via (GenericExMemoryUsage (BuiltinName ann)) instance ExMemoryUsage ann => ExMemoryUsage (BuiltinName ann)
+deriving via (GenericExMemoryUsage BuiltinName) instance ExMemoryUsage BuiltinName
 deriving via (GenericExMemoryUsage (Kind ann)) instance ExMemoryUsage ann => ExMemoryUsage (Kind ann)
 deriving via (GenericExMemoryUsage StaticBuiltinName) instance ExMemoryUsage StaticBuiltinName
 deriving via (GenericExMemoryUsage DynamicBuiltinName) instance ExMemoryUsage DynamicBuiltinName

--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -60,7 +60,7 @@ class TermLike term tyname name uni | term -> tyname, term -> name, term -> uni 
     lamAbs   :: ann -> name -> Type tyname uni ann -> term ann -> term ann
     apply    :: ann -> term ann -> term ann -> term ann
     constant :: ann -> Some (ValueOf uni) -> term ann
-    builtin  :: ann -> BuiltinName ann -> term ann
+    builtin  :: ann -> BuiltinName -> term ann
     tyInst   :: ann -> term ann -> Type tyname uni ann -> term ann
     unwrap   :: ann -> term ann -> term ann
     iWrap    :: ann -> Type tyname uni ann -> Type tyname uni ann -> term ann -> term ann
@@ -70,11 +70,11 @@ class TermLike term tyname name uni | term -> tyname, term -> name, term -> uni 
 
 -- | Lift a 'BuiltinName' to 'Term'.
 staticBuiltinNameAsTerm :: TermLike term tyname name uni => StaticBuiltinName -> term ()
-staticBuiltinNameAsTerm = builtin () . StaticBuiltinName ()
+staticBuiltinNameAsTerm = builtin () . StaticBuiltinName 
 
 -- | Lift a 'DynamicBuiltinName' to 'Term'.
 dynamicBuiltinNameAsTerm :: TermLike term tyname name uni => DynamicBuiltinName -> term ()
-dynamicBuiltinNameAsTerm = builtin () . DynBuiltinName ()
+dynamicBuiltinNameAsTerm = builtin () . DynBuiltinName
 
 -- | Embed a type from a universe into a PLC type.
 mkTyBuiltin

--- a/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
+++ b/language-plutus-core/src/Language/PlutusCore/MkPlc.hs
@@ -12,7 +12,7 @@
 module Language.PlutusCore.MkPlc
     ( TermLike (..)
     , UniOf
-    , builtinNameAsTerm
+    , staticBuiltinNameAsTerm
     , dynamicBuiltinNameAsTerm
     , mkTyBuiltin
     , mkConstant
@@ -60,7 +60,7 @@ class TermLike term tyname name uni | term -> tyname, term -> name, term -> uni 
     lamAbs   :: ann -> name -> Type tyname uni ann -> term ann -> term ann
     apply    :: ann -> term ann -> term ann -> term ann
     constant :: ann -> Some (ValueOf uni) -> term ann
-    builtin  :: ann -> Builtin ann -> term ann
+    builtin  :: ann -> BuiltinName ann -> term ann
     tyInst   :: ann -> term ann -> Type tyname uni ann -> term ann
     unwrap   :: ann -> term ann -> term ann
     iWrap    :: ann -> Type tyname uni ann -> Type tyname uni ann -> term ann -> term ann
@@ -69,8 +69,8 @@ class TermLike term tyname name uni | term -> tyname, term -> name, term -> uni 
     typeLet  :: ann -> TypeDef tyname uni ann -> term ann -> term ann
 
 -- | Lift a 'BuiltinName' to 'Term'.
-builtinNameAsTerm :: TermLike term tyname name uni => BuiltinName -> term ()
-builtinNameAsTerm = builtin () . BuiltinName ()
+staticBuiltinNameAsTerm :: TermLike term tyname name uni => StaticBuiltinName -> term ()
+staticBuiltinNameAsTerm = builtin () . StaticBuiltinName ()
 
 -- | Lift a 'DynamicBuiltinName' to 'Term'.
 dynamicBuiltinNameAsTerm :: TermLike term tyname name uni => DynamicBuiltinName -> term ()

--- a/language-plutus-core/src/Language/PlutusCore/Parser.y
+++ b/language-plutus-core/src/Language/PlutusCore/Parser.y
@@ -137,7 +137,7 @@ Term : Var                                        { $1 }
      | openBracket Term some(Term) closeBracket   { app $1 $2 (NE.reverse $3) }
      | openParen con Constant closeParen          { Constant $2 $3 }
      | openParen iwrap Type Type Term closeParen  { IWrap $2 $3 $4 $5 }
-     | openParen builtin builtinid closeParen     { mkBuiltin $2 (tkLoc $3) (tkBuiltinId $3) }
+     | openParen builtin builtinid closeParen     { mkBuiltin $2 (tkBuiltinId $3) }
      | openParen unwrap Term closeParen           { Unwrap $2 $3 }
      | openParen errorTerm Type closeParen        { Error $2 $3 }
 
@@ -190,11 +190,11 @@ getStaticBuiltinName = \case
     "ifThenElse"               -> Just IfThenElse
     _                          -> Nothing
 
-mkBuiltin :: a -> a -> T.Text -> Term TyName Name uni a
-mkBuiltin loc loc' ident = 
+mkBuiltin :: a -> T.Text -> Term TyName Name uni a
+mkBuiltin loc ident = 
    case getStaticBuiltinName ident of 
-      Just b  -> Builtin loc $ StaticBuiltinName loc' b
-      Nothing -> Builtin loc (DynBuiltinName loc' (DynamicBuiltinName ident))
+      Just b  -> Builtin loc $ StaticBuiltinName b
+      Nothing -> Builtin loc (DynBuiltinName (DynamicBuiltinName ident))
 
 -- FIXME: at this point it would be good to have access to the current
 -- dynamic builtin names to check if a builtin with that name exists

--- a/language-plutus-core/src/Language/PlutusCore/Parser.y
+++ b/language-plutus-core/src/Language/PlutusCore/Parser.y
@@ -164,8 +164,8 @@ fixStr :: Token ann -> Token ann
 fixStr (TkString ann s) = TkString ann (read s)   
 fixStr t = t
   
-getBuiltinName :: T.Text -> Maybe BuiltinName
-getBuiltinName = \case
+getStaticBuiltinName :: T.Text -> Maybe StaticBuiltinName
+getStaticBuiltinName = \case
     "addInteger"               -> Just AddInteger
     "subtractInteger"          -> Just SubtractInteger
     "multiplyInteger"          -> Just MultiplyInteger
@@ -192,8 +192,8 @@ getBuiltinName = \case
 
 mkBuiltin :: a -> a -> T.Text -> Term TyName Name uni a
 mkBuiltin loc loc' ident = 
-   case getBuiltinName ident of 
-      Just b  -> Builtin loc $ BuiltinName loc' b
+   case getStaticBuiltinName ident of 
+      Just b  -> Builtin loc $ StaticBuiltinName loc' b
       Nothing -> Builtin loc (DynBuiltinName loc' (DynamicBuiltinName ident))
 
 -- FIXME: at this point it would be good to have access to the current

--- a/language-plutus-core/src/Language/PlutusCore/TypeCheck.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeCheck.hs
@@ -14,7 +14,7 @@ module Language.PlutusCore.TypeCheck
     -- * Kind/type inference/checking.
     , inferKind
     , checkKind
-    , typeOfBuiltinName
+    , typeOfStaticBuiltinName
     , inferType
     , checkType
     , inferTypeOfProgram

--- a/language-plutus-core/src/Language/PlutusCore/TypeCheck/Internal.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeCheck/Internal.hs
@@ -303,18 +303,18 @@ unfoldFixOf pat arg k = do
             , vArg
             ]
 
--- | Infer the type of a 'Builtin'.
+-- | Infer the type of a 'Builtin'.  The annotation is required for the error message if the name isn't found.
 inferTypeOfBuiltinNameM
     :: (GShow uni, GEq uni, DefaultUni <: uni)
-    => BuiltinName ann -> TypeCheckM uni ann (Normalized (Type TyName uni ()))
+    => ann -> BuiltinName -> TypeCheckM uni ann (Normalized (Type TyName uni ()))
 -- We have a weird corner case here: the type of a 'BuiltinName' can contain 'TypedBuiltinDyn', i.e.
 -- a static built-in name is allowed to depend on a dynamic built-in type which are not required
 -- to be normalized. For dynamic built-in names we store a map from them to their *normalized types*,
 -- with the normalization happening in this module, but what should we do for static built-in names?
 -- Right now we just renormalize the type of a static built-in name each time we encounter that name.
-inferTypeOfBuiltinNameM (StaticBuiltinName _   name) = normalizeType $ typeOfStaticBuiltinName name
+inferTypeOfBuiltinNameM _ (StaticBuiltinName name) = normalizeType $ typeOfStaticBuiltinName name
 -- TODO: inline this definition once we have only dynamic built-in names.
-inferTypeOfBuiltinNameM (DynBuiltinName ann name)    = lookupDynamicBuiltinNameM ann name
+inferTypeOfBuiltinNameM ann (DynBuiltinName name)  = lookupDynamicBuiltinNameM ann name
 
 -- See the [Global uniqueness] and [Type rules] notes.
 -- | Synthesize the type of a term, returning a normalized type.
@@ -332,8 +332,8 @@ inferTypeM (Constant _ (Some (ValueOf uni _))) =
 -- [infer| G !- bi : vTy]
 -- ------------------------------
 -- [infer| G !- builtin bi : vTy]
-inferTypeM (Builtin _ bn)           =
-    inferTypeOfBuiltinNameM bn
+inferTypeM (Builtin ann bn)         =
+    inferTypeOfBuiltinNameM ann bn
 
 -- [infer| G !- v : ty]    ty ~>? vTy
 -- ----------------------------------

--- a/language-plutus-core/src/Language/PlutusCore/TypeCheck/Internal.hs
+++ b/language-plutus-core/src/Language/PlutusCore/TypeCheck/Internal.hs
@@ -20,7 +20,7 @@ module Language.PlutusCore.TypeCheck.Internal
     , inferKindM
     , checkKindM
     , checkKindOfPatternFunctorM
-    , typeOfBuiltinName
+    , typeOfStaticBuiltinName
     , inferTypeM
     , checkTypeM
     ) where
@@ -282,10 +282,10 @@ checkKindOfPatternFunctorM ann pat k =
 -- ###################
 
 -- | Return the 'Type' of a 'BuiltinName'.
-typeOfBuiltinName
+typeOfStaticBuiltinName
     :: (GShow uni, GEq uni, DefaultUni <: uni)
-    => BuiltinName -> Type TyName uni ()
-typeOfBuiltinName bn = withTypedBuiltinName bn $ typeOfTypedBuiltinName @(Term TyName Name _ ())
+    => StaticBuiltinName -> Type TyName uni ()
+typeOfStaticBuiltinName bn = withTypedStaticBuiltinName bn $ typeOfTypedStaticBuiltinName @(Term TyName Name _ ())
 
 -- | @unfoldFixOf pat arg k = NORM (vPat (\(a :: k) -> ifix vPat a) arg)@
 unfoldFixOf
@@ -304,17 +304,17 @@ unfoldFixOf pat arg k = do
             ]
 
 -- | Infer the type of a 'Builtin'.
-inferTypeOfBuiltinM
+inferTypeOfBuiltinNameM
     :: (GShow uni, GEq uni, DefaultUni <: uni)
-    => Builtin ann -> TypeCheckM uni ann (Normalized (Type TyName uni ()))
+    => BuiltinName ann -> TypeCheckM uni ann (Normalized (Type TyName uni ()))
 -- We have a weird corner case here: the type of a 'BuiltinName' can contain 'TypedBuiltinDyn', i.e.
 -- a static built-in name is allowed to depend on a dynamic built-in type which are not required
 -- to be normalized. For dynamic built-in names we store a map from them to their *normalized types*,
 -- with the normalization happening in this module, but what should we do for static built-in names?
 -- Right now we just renormalize the type of a static built-in name each time we encounter that name.
-inferTypeOfBuiltinM (BuiltinName    _   name) = normalizeType $ typeOfBuiltinName name
+inferTypeOfBuiltinNameM (StaticBuiltinName _   name) = normalizeType $ typeOfStaticBuiltinName name
 -- TODO: inline this definition once we have only dynamic built-in names.
-inferTypeOfBuiltinM (DynBuiltinName ann name) = lookupDynamicBuiltinNameM ann name
+inferTypeOfBuiltinNameM (DynBuiltinName ann name)    = lookupDynamicBuiltinNameM ann name
 
 -- See the [Global uniqueness] and [Type rules] notes.
 -- | Synthesize the type of a term, returning a normalized type.
@@ -332,8 +332,8 @@ inferTypeM (Constant _ (Some (ValueOf uni _))) =
 -- [infer| G !- bi : vTy]
 -- ------------------------------
 -- [infer| G !- builtin bi : vTy]
-inferTypeM (Builtin _ bi)           =
-    inferTypeOfBuiltinM bi
+inferTypeM (Builtin _ bn)           =
+    inferTypeOfBuiltinNameM bn
 
 -- [infer| G !- v : ty]    ty ~>? vTy
 -- ----------------------------------

--- a/language-plutus-core/src/Language/PlutusCore/View.hs
+++ b/language-plutus-core/src/Language/PlutusCore/View.hs
@@ -7,7 +7,6 @@ module Language.PlutusCore.View
     ( IterApp(..)
     , TermIterApp
     , PrimIterApp
-    , constantAsStagedBuiltinName
     , termAsBuiltin
     , termAsTermIterApp
     , termAsPrimIterApp
@@ -31,19 +30,14 @@ type TermIterApp tyname name uni a =
 
 -- | An iterated application of a 'BuiltinName' to a list of 'Value's.
 type PrimIterApp tyname name uni a =
-    IterApp StagedBuiltinName (Value tyname name uni a)
+    IterApp BuiltinName (Value tyname name uni a)
 
 instance (PrettyBy config head, PrettyBy config arg) => PrettyBy config (IterApp head arg) where
     prettyBy config (IterApp appHead appSpine) =
         parens $ foldl' (\fun arg -> fun <+> prettyBy config arg) (prettyBy config appHead) appSpine
 
--- | View a 'Constant' as a 'StagedBuiltinName'.
-constantAsStagedBuiltinName :: BuiltinName a -> StagedBuiltinName
-constantAsStagedBuiltinName (StaticBuiltinName    _ name) = StaticStagedBuiltinName  name
-constantAsStagedBuiltinName (DynBuiltinName _ name)       = DynamicStagedBuiltinName name
-
 -- | View a 'Term' as a 'Constant'.
-termAsBuiltin :: Term tyname name uni a -> Maybe (BuiltinName a)
+termAsBuiltin :: Term tyname name uni a -> Maybe BuiltinName
 termAsBuiltin (Builtin _ bn) = Just bn
 termAsBuiltin _              = Nothing
 
@@ -58,7 +52,7 @@ termAsTermIterApp = go [] where
 termAsPrimIterApp :: Term tyname name uni a -> Maybe (PrimIterApp tyname name uni a)
 termAsPrimIterApp term = do
     let IterApp termHead spine = termAsTermIterApp term
-    headName <- constantAsStagedBuiltinName <$> termAsBuiltin termHead
+    headName <- termAsBuiltin termHead
     -- This is commented out for two reasons:
     -- 1. we use 'termAsPrimIterApp' in abstract machines and we may not want to have this overhead
     -- 2. 'Error' is not a value, but we can return 'Error' from a failed constant application

--- a/language-plutus-core/src/Language/PlutusCore/View.hs
+++ b/language-plutus-core/src/Language/PlutusCore/View.hs
@@ -38,13 +38,13 @@ instance (PrettyBy config head, PrettyBy config arg) => PrettyBy config (IterApp
         parens $ foldl' (\fun arg -> fun <+> prettyBy config arg) (prettyBy config appHead) appSpine
 
 -- | View a 'Constant' as a 'StagedBuiltinName'.
-constantAsStagedBuiltinName :: Builtin a -> StagedBuiltinName
-constantAsStagedBuiltinName (BuiltinName    _ name) = StaticStagedBuiltinName  name
-constantAsStagedBuiltinName (DynBuiltinName _ name) = DynamicStagedBuiltinName name
+constantAsStagedBuiltinName :: BuiltinName a -> StagedBuiltinName
+constantAsStagedBuiltinName (StaticBuiltinName    _ name) = StaticStagedBuiltinName  name
+constantAsStagedBuiltinName (DynBuiltinName _ name)       = DynamicStagedBuiltinName name
 
 -- | View a 'Term' as a 'Constant'.
-termAsBuiltin :: Term tyname name uni a -> Maybe (Builtin a)
-termAsBuiltin (Builtin _ bi) = Just bi
+termAsBuiltin :: Term tyname name uni a -> Maybe (BuiltinName a)
+termAsBuiltin (Builtin _ bn) = Just bn
 termAsBuiltin _              = Nothing
 
 -- | An iterated application of a 'Term' to a list of 'Term's.

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Bool.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Bool.hs
@@ -50,5 +50,5 @@ ifThenElse = runQuote $ do
           VarDecl () y unitFunA
           ]
       $ mkIterApp ()
-          (tyInst () (builtinNameAsTerm IfThenElse) unitFunA)
+          (tyInst () (staticBuiltinNameAsTerm IfThenElse) unitFunA)
           [var () b, var () x, var () y, unitval]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Integer.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Integer.hs
@@ -26,7 +26,7 @@ succInteger = runQuote $ do
     i  <- freshName "i"
     return
         . lamAbs () i integer
-        . mkIterApp () (builtin () $ BuiltinName () AddInteger)
+        . mkIterApp () (staticBuiltinNameAsTerm AddInteger)
         $ [ var () i
           , mkConstant @Integer () 1
           ]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/List.hs
@@ -224,7 +224,7 @@ enumFromTo = runQuote $ do
     rec <- freshName "rec"
     n'  <- freshName "n'"
     u   <- freshName "u"
-    let gtInteger  = builtin () $ BuiltinName () GreaterThanInteger
+    let gtInteger  = staticBuiltinNameAsTerm GreaterThanInteger
         int = mkTyBuiltin @Integer ()
         listInt = TyApp () list int
     return
@@ -252,7 +252,7 @@ enumFromTo = runQuote $ do
 sum :: (TermLike term TyName Name uni, uni `Includes` Integer) => term ()
 sum = runQuote $ do
     let int = mkTyBuiltin @Integer ()
-        add = builtin () (BuiltinName () AddInteger)
+        add = staticBuiltinNameAsTerm AddInteger
     return
         . mkIterApp () (mkIterInst () foldList [int, int])
         $ [ add , mkConstant @Integer () 0]
@@ -263,7 +263,7 @@ sum = runQuote $ do
 product :: (TermLike term TyName Name uni, uni `Includes` Integer) => term ()
 product = runQuote $ do
     let int = mkTyBuiltin @Integer ()
-        mul = builtin () (BuiltinName () MultiplyInteger)
+        mul = staticBuiltinNameAsTerm MultiplyInteger
     return
         . mkIterApp () (mkIterInst () foldList [int, int])
         $ [ mul , mkConstant @Integer () 1]

--- a/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
+++ b/language-plutus-core/stdlib/Language/PlutusCore/StdLib/Data/Nat.hs
@@ -132,7 +132,7 @@ foldNat = runQuote $ do
 -- > foldNat {integer} (addInteger 1) 1
 natToInteger :: (TermLike term TyName Name uni, uni `Includes` Integer) => term ()
 natToInteger = runQuote $ do
-    let addInteger = builtin () $ BuiltinName () AddInteger
+    let addInteger = staticBuiltinNameAsTerm AddInteger
     return $
         mkIterApp () (tyInst () foldNat $ mkTyBuiltin @Integer ())
           [ apply () addInteger (mkConstant @Integer () 1)

--- a/language-plutus-core/test/Check/Spec.hs
+++ b/language-plutus-core/test/Check/Spec.hs
@@ -111,7 +111,7 @@ values = runQuote $ do
         , testCase "unwrap" $ VR.isTermValue (Unwrap () val) @?= False
         , testCase "inst" $ VR.isTermValue (TyInst () val aV) @?= False
         , testCase "constant" $ VR.isTermValue (mkConstant @Integer @DefaultUni () 1) @?= True
-        , testCase "builtin" $ VR.isTermValue (builtinNameAsTerm AddInteger) @?= False
+        , testCase "builtin" $ VR.isTermValue (staticBuiltinNameAsTerm AddInteger) @?= False
       ]
 
 normalTypes :: TestTree
@@ -168,7 +168,7 @@ normalTypesCheck = runQuote $ do
         , testCase "errorNonNormal" $ isLeft (checkNormal (Error () nonNormal)) @? "Normalization"
 
         , testCase "constant" $ isRight (checkNormal (mkConstant @Integer () 2)) @? "Normalization"
-        , testCase "builtin" $ isRight (checkNormal (builtinNameAsTerm AddInteger)) @? "Normalization"
+        , testCase "builtin" $ isRight (checkNormal (staticBuiltinNameAsTerm AddInteger)) @? "Normalization"
       ]
         where
             checkNormal :: Term TyName Name DefaultUni () -> Either (Normal.NormCheckError TyName Name DefaultUni ()) ()

--- a/language-plutus-core/test/Evaluation/ApplyBuiltinName.hs
+++ b/language-plutus-core/test/Evaluation/ApplyBuiltinName.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeApplications      #-}
 
 module Evaluation.ApplyBuiltinName
-    ( test_applyBuiltinName
+    ( test_applyStaticBuiltinName
     ) where
 
 import           Language.PlutusCore
@@ -37,9 +37,9 @@ import           Test.Tasty.Hedgehog
 -- and supply them to a function on the Haskell side. When all appropriate arguments are generated,
 -- we check that the results of the two computations match. We also check that each
 -- underapplication on the PLC side is a stuck application.
-prop_applyBuiltinName
+prop_applyStaticBuiltinName
     :: (uni ~ DefaultUni, KnownType (Plain Term uni) r, PrettyConst r)
-    => TypedBuiltinName (Plain Term uni) as r
+    => TypedStaticBuiltinName (Plain Term uni) as r
        -- ^ A (typed) builtin name to apply.
     -> FoldArgs as r
        -- ^ The semantics of the builtin name. E.g. the semantics of
@@ -47,125 +47,125 @@ prop_applyBuiltinName
     -> TypedBuiltinGenT uni IO
        -- ^ How to generate values of builtin types.
     -> Property
-prop_applyBuiltinName tbn op allTbs = property $ do
-    let getIterAppValue = runPlcT allTbs . genIterAppValue $ denoteTypedBuiltinName tbn op
+prop_applyStaticBuiltinName tbn op allTbs = property $ do
+    let getIterAppValue = runPlcT allTbs . genIterAppValue $ denoteTypedStaticBuiltinName tbn op
     IterAppValue _ iterApp y <- forAllPrettyPlcT getIterAppValue
     let IterApp name spine = iterApp
-        app = applyBuiltinName @(CkM DefaultUni) name
+        app = applyStaticBuiltinName @(CkM DefaultUni) name
     traverse_ (\prefix -> app prefix === Right ConstAppStuck) . init $ inits spine
     app spine === Right (evaluationConstAppResult $ makeKnown y)
 
 test_typedAddInteger :: TestTree
 test_typedAddInteger
     = testProperty "typedAddInteger"
-    $ prop_applyBuiltinName typedAddInteger (+)
+    $ prop_applyStaticBuiltinName typedAddInteger (+)
     $ genTypedBuiltinDef
 
 test_typedSubtractInteger :: TestTree
 test_typedSubtractInteger
     = testProperty "typedSubtractInteger"
-    $ prop_applyBuiltinName typedSubtractInteger (-)
+    $ prop_applyStaticBuiltinName typedSubtractInteger (-)
     $ genTypedBuiltinDef
 
 test_typedMultiplyInteger :: TestTree
 test_typedMultiplyInteger
     = testProperty "typedMultiplyInteger"
-    $ prop_applyBuiltinName typedMultiplyInteger (*)
+    $ prop_applyStaticBuiltinName typedMultiplyInteger (*)
     $ genTypedBuiltinDef
 
 test_typedDivideInteger :: TestTree
 test_typedDivideInteger
     = testProperty "typedDivideInteger"
-    $ prop_applyBuiltinName typedDivideInteger (nonZeroArg div)
+    $ prop_applyStaticBuiltinName typedDivideInteger (nonZeroArg div)
     $ genTypedBuiltinDivide
 
 test_typedQuotientInteger :: TestTree
 test_typedQuotientInteger
     = testProperty "typedQuotientInteger"
-    $ prop_applyBuiltinName typedQuotientInteger (nonZeroArg quot)
+    $ prop_applyStaticBuiltinName typedQuotientInteger (nonZeroArg quot)
     $ genTypedBuiltinDivide
 
 test_typedModInteger :: TestTree
 test_typedModInteger
     = testProperty "typedModInteger"
-    $ prop_applyBuiltinName typedModInteger (nonZeroArg mod)
+    $ prop_applyStaticBuiltinName typedModInteger (nonZeroArg mod)
     $ genTypedBuiltinDivide
 
 test_typedRemainderInteger :: TestTree
 test_typedRemainderInteger
     = testProperty "typedRemainderInteger"
-    $ prop_applyBuiltinName typedRemainderInteger (nonZeroArg rem)
+    $ prop_applyStaticBuiltinName typedRemainderInteger (nonZeroArg rem)
     $ genTypedBuiltinDivide
 
 test_typedLessThanInteger :: TestTree
 test_typedLessThanInteger
     = testProperty "typedLessThanInteger"
-    $ prop_applyBuiltinName typedLessThanInteger (<)
+    $ prop_applyStaticBuiltinName typedLessThanInteger (<)
     $ genTypedBuiltinDef
 
 test_typedLessThanEqInteger :: TestTree
 test_typedLessThanEqInteger
     = testProperty "typedLessThanEqInteger"
-    $ prop_applyBuiltinName typedLessThanEqInteger (<=)
+    $ prop_applyStaticBuiltinName typedLessThanEqInteger (<=)
     $ genTypedBuiltinDef
 
 test_typedGreaterThanInteger :: TestTree
 test_typedGreaterThanInteger
     = testProperty "typedGreaterThanInteger"
-    $ prop_applyBuiltinName typedGreaterThanInteger (>)
+    $ prop_applyStaticBuiltinName typedGreaterThanInteger (>)
     $ genTypedBuiltinDef
 
 test_typedGreaterThanEqInteger :: TestTree
 test_typedGreaterThanEqInteger
     = testProperty "typedGreaterThanEqInteger"
-    $ prop_applyBuiltinName typedGreaterThanEqInteger (>=)
+    $ prop_applyStaticBuiltinName typedGreaterThanEqInteger (>=)
     $ genTypedBuiltinDef
 
 test_typedEqInteger :: TestTree
 test_typedEqInteger
     = testProperty "typedEqInteger"
-    $ prop_applyBuiltinName typedEqInteger (==)
+    $ prop_applyStaticBuiltinName typedEqInteger (==)
     $ genTypedBuiltinDef
 
 test_typedConcatenate :: TestTree
 test_typedConcatenate
     = testProperty "typedConcatenate"
-    $ prop_applyBuiltinName typedConcatenate (<>)
+    $ prop_applyStaticBuiltinName typedConcatenate (<>)
     $ genTypedBuiltinDef
 
 test_typedTakeByteString :: TestTree
 test_typedTakeByteString
     = testProperty "typedTakeByteString"
-    $ prop_applyBuiltinName typedTakeByteString (coerce BSL.take . integerToInt64)
+    $ prop_applyStaticBuiltinName typedTakeByteString (coerce BSL.take . integerToInt64)
     $ genTypedBuiltinDef
 
 test_typedSHA2 :: TestTree
 test_typedSHA2
     = testProperty "typedSHA2"
-    $ prop_applyBuiltinName typedSHA2 (coerce Hash.sha2)
+    $ prop_applyStaticBuiltinName typedSHA2 (coerce Hash.sha2)
     $ genTypedBuiltinDef
 
 test_typedSHA3 :: TestTree
 test_typedSHA3
     = testProperty "typedSHA3"
-    $ prop_applyBuiltinName typedSHA3 (coerce Hash.sha3)
+    $ prop_applyStaticBuiltinName typedSHA3 (coerce Hash.sha3)
     $ genTypedBuiltinDef
 
 test_typedDropByteString :: TestTree
 test_typedDropByteString
     = testProperty "typedDropByteString"
-    $ prop_applyBuiltinName typedDropByteString (coerce BSL.drop . integerToInt64)
+    $ prop_applyStaticBuiltinName typedDropByteString (coerce BSL.drop . integerToInt64)
     $ genTypedBuiltinDef
 
 test_typedEqByteString :: TestTree
 test_typedEqByteString
     = testProperty "typedEqByteString"
-    $ prop_applyBuiltinName typedEqByteString (==)
+    $ prop_applyStaticBuiltinName typedEqByteString (==)
     $ genTypedBuiltinDef
 
-test_applyBuiltinName :: TestTree
-test_applyBuiltinName =
-    testGroup "applyBuiltinName"
+test_applyStaticBuiltinName :: TestTree
+test_applyStaticBuiltinName =
+    testGroup "applyStaticBuiltinName"
         [ test_typedAddInteger
         , test_typedSubtractInteger
         , test_typedMultiplyInteger

--- a/language-plutus-core/test/Evaluation/Machines/Budget/Fib/1.plc.golden
+++ b/language-plutus-core/test/Evaluation/Machines/Budget/Fib/1.plc.golden
@@ -11,10 +11,10 @@
 | BIWrap causes ({ cpu: 1
 | mem: 1
 })
-| BBuiltin (StaticStagedBuiltinName LessThanEqInteger) causes ({ cpu: 13
+| BBuiltin (StaticBuiltinName LessThanEqInteger) causes ({ cpu: 13
 | mem: 1
 })
-| BBuiltin (StaticStagedBuiltinName IfThenElse) causes ({ cpu: 1
+| BBuiltin (StaticBuiltinName IfThenElse) causes ({ cpu: 1
 | mem: 1
 })
 | BUnwrap causes ({ cpu: 2

--- a/language-plutus-core/test/Evaluation/Machines/Budget/Fib/2.plc.golden
+++ b/language-plutus-core/test/Evaluation/Machines/Budget/Fib/2.plc.golden
@@ -1,8 +1,8 @@
 ( (Right (1))
-, ({ tally: ({ BBuiltin (StaticStagedBuiltinName SubtractInteger) causes ({ cpu: 96
+, ({ tally: ({ BBuiltin (StaticBuiltinName SubtractInteger) causes ({ cpu: 96
 | mem: 2
 })
-| BBuiltin (StaticStagedBuiltinName AddInteger) causes ({ cpu: 44
+| BBuiltin (StaticBuiltinName AddInteger) causes ({ cpu: 44
 | mem: 1
 })
 | BTyInst causes ({ cpu: 12
@@ -17,10 +17,10 @@
 | BIWrap causes ({ cpu: 1
 | mem: 1
 })
-| BBuiltin (StaticStagedBuiltinName LessThanEqInteger) causes ({ cpu: 39
+| BBuiltin (StaticBuiltinName LessThanEqInteger) causes ({ cpu: 39
 | mem: 3
 })
-| BBuiltin (StaticStagedBuiltinName IfThenElse) causes ({ cpu: 3
+| BBuiltin (StaticBuiltinName IfThenElse) causes ({ cpu: 3
 | mem: 3
 })
 | BUnwrap causes ({ cpu: 4

--- a/language-plutus-core/test/Evaluation/Machines/Budget/Fib/3.plc.golden
+++ b/language-plutus-core/test/Evaluation/Machines/Budget/Fib/3.plc.golden
@@ -1,8 +1,8 @@
 ( (Right (2))
-, ({ tally: ({ BBuiltin (StaticStagedBuiltinName SubtractInteger) causes ({ cpu: 190
+, ({ tally: ({ BBuiltin (StaticBuiltinName SubtractInteger) causes ({ cpu: 190
 | mem: 4
 })
-| BBuiltin (StaticStagedBuiltinName AddInteger) causes ({ cpu: 88
+| BBuiltin (StaticBuiltinName AddInteger) causes ({ cpu: 88
 | mem: 2
 })
 | BTyInst causes ({ cpu: 18
@@ -17,10 +17,10 @@
 | BIWrap causes ({ cpu: 1
 | mem: 1
 })
-| BBuiltin (StaticStagedBuiltinName LessThanEqInteger) causes ({ cpu: 65
+| BBuiltin (StaticBuiltinName LessThanEqInteger) causes ({ cpu: 65
 | mem: 5
 })
-| BBuiltin (StaticStagedBuiltinName IfThenElse) causes ({ cpu: 5
+| BBuiltin (StaticBuiltinName IfThenElse) causes ({ cpu: 5
 | mem: 5
 })
 | BUnwrap causes ({ cpu: 6

--- a/language-plutus-core/test/Evaluation/Machines/Counting/Fib/1.plc.golden
+++ b/language-plutus-core/test/Evaluation/Machines/Counting/Fib/1.plc.golden
@@ -11,10 +11,10 @@
 | BIWrap causes ({ cpu: 1
 | mem: 1
 })
-| BBuiltin (StaticStagedBuiltinName LessThanEqInteger) causes ({ cpu: 13
+| BBuiltin (StaticBuiltinName LessThanEqInteger) causes ({ cpu: 13
 | mem: 1
 })
-| BBuiltin (StaticStagedBuiltinName IfThenElse) causes ({ cpu: 1
+| BBuiltin (StaticBuiltinName IfThenElse) causes ({ cpu: 1
 | mem: 1
 })
 | BUnwrap causes ({ cpu: 2

--- a/language-plutus-core/test/Evaluation/Machines/Counting/Fib/2.plc.golden
+++ b/language-plutus-core/test/Evaluation/Machines/Counting/Fib/2.plc.golden
@@ -1,8 +1,8 @@
 ( (Right (1))
-, ({ tally: ({ BBuiltin (StaticStagedBuiltinName SubtractInteger) causes ({ cpu: 96
+, ({ tally: ({ BBuiltin (StaticBuiltinName SubtractInteger) causes ({ cpu: 96
 | mem: 2
 })
-| BBuiltin (StaticStagedBuiltinName AddInteger) causes ({ cpu: 44
+| BBuiltin (StaticBuiltinName AddInteger) causes ({ cpu: 44
 | mem: 1
 })
 | BTyInst causes ({ cpu: 12
@@ -17,10 +17,10 @@
 | BIWrap causes ({ cpu: 1
 | mem: 1
 })
-| BBuiltin (StaticStagedBuiltinName LessThanEqInteger) causes ({ cpu: 39
+| BBuiltin (StaticBuiltinName LessThanEqInteger) causes ({ cpu: 39
 | mem: 3
 })
-| BBuiltin (StaticStagedBuiltinName IfThenElse) causes ({ cpu: 3
+| BBuiltin (StaticBuiltinName IfThenElse) causes ({ cpu: 3
 | mem: 3
 })
 | BUnwrap causes ({ cpu: 4

--- a/language-plutus-core/test/Evaluation/Machines/Counting/Fib/3.plc.golden
+++ b/language-plutus-core/test/Evaluation/Machines/Counting/Fib/3.plc.golden
@@ -1,8 +1,8 @@
 ( (Right (2))
-, ({ tally: ({ BBuiltin (StaticStagedBuiltinName SubtractInteger) causes ({ cpu: 190
+, ({ tally: ({ BBuiltin (StaticBuiltinName SubtractInteger) causes ({ cpu: 190
 | mem: 4
 })
-| BBuiltin (StaticStagedBuiltinName AddInteger) causes ({ cpu: 88
+| BBuiltin (StaticBuiltinName AddInteger) causes ({ cpu: 88
 | mem: 2
 })
 | BTyInst causes ({ cpu: 18
@@ -17,10 +17,10 @@
 | BIWrap causes ({ cpu: 1
 | mem: 1
 })
-| BBuiltin (StaticStagedBuiltinName LessThanEqInteger) causes ({ cpu: 65
+| BBuiltin (StaticBuiltinName LessThanEqInteger) causes ({ cpu: 65
 | mem: 5
 })
-| BBuiltin (StaticStagedBuiltinName IfThenElse) causes ({ cpu: 5
+| BBuiltin (StaticBuiltinName IfThenElse) causes ({ cpu: 5
 | mem: 5
 })
 | BUnwrap causes ({ cpu: 6

--- a/language-plutus-core/test/Evaluation/Spec.hs
+++ b/language-plutus-core/test/Evaluation/Spec.hs
@@ -1,6 +1,6 @@
 module Evaluation.Spec where
 
-import           Evaluation.ApplyBuiltinName (test_applyBuiltinName)
+import           Evaluation.ApplyBuiltinName (test_applyStaticBuiltinName)
 import           Evaluation.DynamicBuiltins  (test_dynamicBuiltins)
 import           Evaluation.Golden           (test_golden)
 import           Evaluation.Machines         (test_budget, test_counting, test_machines, test_memory)
@@ -10,7 +10,7 @@ import           Test.Tasty
 test_evaluation :: TestTree
 test_evaluation =
     testGroup "evaluation"
-        [ test_applyBuiltinName
+        [ test_applyStaticBuiltinName
         , test_dynamicBuiltins
         , test_golden
         , test_machines

--- a/language-plutus-core/test/TypeSynthesis/Spec.hs
+++ b/language-plutus-core/test/TypeSynthesis/Spec.hs
@@ -77,20 +77,20 @@ test_typecheckIllTyped =
             [ selfApply
             ]
 
-test_typecheckBuiltinName :: BuiltinName -> TestTree
-test_typecheckBuiltinName name = goldenVsDoc testName path doc where
+test_typecheckStaticBuiltinName :: StaticBuiltinName -> TestTree
+test_typecheckStaticBuiltinName name = goldenVsDoc testName path doc where
     testName = show name
     path     = "test" </> "TypeSynthesis" </> "Golden" </> (testName ++ ".plc.golden")
-    doc      = prettyPlcDef $ typeOfBuiltinName @DefaultUni name
+    doc      = prettyPlcDef $ typeOfStaticBuiltinName @DefaultUni name
 
-test_typecheckBuiltinNames :: TestTree
-test_typecheckBuiltinNames =
-    testGroup "built-in name" $ map test_typecheckBuiltinName allBuiltinNames
+test_typecheckStaticBuiltinNames :: TestTree
+test_typecheckStaticBuiltinNames =
+    testGroup "built-in name" $ map test_typecheckStaticBuiltinName allStaticBuiltinNames
 
 test_typecheck :: TestTree
 test_typecheck =
     testGroup "typecheck"
-        [ test_typecheckBuiltinNames
+        [ test_typecheckStaticBuiltinNames
         , test_typecheckAvailable
         , test_typecheckIllTyped
         ]

--- a/metatheory/Builtin.lagda
+++ b/metatheory/Builtin.lagda
@@ -24,5 +24,5 @@ data Builtin : Set where
   ifThenElse               : Builtin
 
 {-# FOREIGN GHC import Language.PlutusCore #-}
-{-# COMPILE GHC Builtin = data BuiltinName (AddInteger | SubtractInteger | MultiplyInteger | DivideInteger | QuotientInteger | RemainderInteger | ModInteger | LessThanInteger | LessThanEqInteger | GreaterThanInteger | GreaterThanEqInteger | EqInteger | Concatenate | TakeByteString | DropByteString | SHA2 | SHA3 | VerifySignature | EqByteString | IfThenElse) #-}
+{-# COMPILE GHC Builtin = data StaticBuiltinName (AddInteger | SubtractInteger | MultiplyInteger | DivideInteger | QuotientInteger | RemainderInteger | ModInteger | LessThanInteger | LessThanEqInteger | GreaterThanInteger | GreaterThanEqInteger | EqInteger | Concatenate | TakeByteString | DropByteString | SHA2 | SHA3 | VerifySignature | EqByteString | IfThenElse) #-}
 \end{code}

--- a/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Builtins.hs
@@ -156,8 +156,8 @@ Fortunately, we have a more sophisticated purity check that also detects unsatur
 which handles these cases too.
 -}
 
-mkBuiltin :: PLC.BuiltinName -> PIR.Term tyname name uni ()
-mkBuiltin n = PIR.Builtin () $ PLC.BuiltinName () n
+mkStaticBuiltin :: PLC.StaticBuiltinName -> PIR.Term tyname name uni ()
+mkStaticBuiltin n = PIR.Builtin () $ PLC.StaticBuiltinName () n
 
 mkDynBuiltin :: PLC.DynamicBuiltinName -> PIR.Term tyname name uni ()
 mkDynBuiltin n = PIR.Builtin () $ PLC.DynBuiltinName () n
@@ -251,28 +251,28 @@ defineBuiltinTerms = do
 
     -- Bytestring builtins
     do
-        let term = mkBuiltin PLC.Concatenate
+        let term = mkStaticBuiltin PLC.Concatenate
         defineBuiltinTerm 'Builtins.concatenate term [bs]
     do
-        let term = mkBuiltin PLC.TakeByteString
+        let term = mkStaticBuiltin PLC.TakeByteString
         defineBuiltinTerm 'Builtins.takeByteString term [int, bs]
     do
-        let term = mkBuiltin PLC.DropByteString
+        let term = mkStaticBuiltin PLC.DropByteString
         defineBuiltinTerm 'Builtins.dropByteString term [int, bs]
     do
-        let term = mkBuiltin PLC.SHA2
+        let term = mkStaticBuiltin PLC.SHA2
         defineBuiltinTerm 'Builtins.sha2_256 term [bs]
     do
-        let term = mkBuiltin PLC.SHA3
+        let term = mkStaticBuiltin PLC.SHA3
         defineBuiltinTerm 'Builtins.sha3_256 term [bs]
     do
-        term <- wrapRel bsTy 2 $ mkBuiltin PLC.EqByteString
+        term <- wrapRel bsTy 2 $ mkStaticBuiltin PLC.EqByteString
         defineBuiltinTerm 'Builtins.equalsByteString term [bs, bool]
     do
-        term <- wrapRel bsTy 2 $ mkBuiltin PLC.LtByteString
+        term <- wrapRel bsTy 2 $ mkStaticBuiltin PLC.LtByteString
         defineBuiltinTerm 'Builtins.lessThanByteString term [bs, bool]
     do
-        term <- wrapRel bsTy 2 $ mkBuiltin PLC.GtByteString
+        term <- wrapRel bsTy 2 $ mkStaticBuiltin PLC.GtByteString
         defineBuiltinTerm 'Builtins.greaterThanByteString term [bs, bool]
 
     do
@@ -281,39 +281,39 @@ defineBuiltinTerms = do
 
     -- Integer builtins
     do
-        let term = mkBuiltin PLC.AddInteger
+        let term = mkStaticBuiltin PLC.AddInteger
         defineBuiltinTerm 'Builtins.addInteger term [int]
     do
-        let term = mkBuiltin PLC.SubtractInteger
+        let term = mkStaticBuiltin PLC.SubtractInteger
         defineBuiltinTerm 'Builtins.subtractInteger term [int]
     do
-        let term = mkBuiltin PLC.MultiplyInteger
+        let term = mkStaticBuiltin PLC.MultiplyInteger
         defineBuiltinTerm 'Builtins.multiplyInteger term [int]
     do
-        let term = mkBuiltin PLC.DivideInteger
+        let term = mkStaticBuiltin PLC.DivideInteger
         defineBuiltinTerm 'Builtins.divideInteger term [int]
     do
-        let term = mkBuiltin PLC.RemainderInteger
+        let term = mkStaticBuiltin PLC.RemainderInteger
         defineBuiltinTerm 'Builtins.remainderInteger term [int]
     do
-        term <- wrapRel intTy 2 $ mkBuiltin PLC.GreaterThanInteger
+        term <- wrapRel intTy 2 $ mkStaticBuiltin PLC.GreaterThanInteger
         defineBuiltinTerm 'Builtins.greaterThanInteger term [int, bool]
     do
-        term <- wrapRel intTy 2 $ mkBuiltin PLC.GreaterThanEqInteger
+        term <- wrapRel intTy 2 $ mkStaticBuiltin PLC.GreaterThanEqInteger
         defineBuiltinTerm 'Builtins.greaterThanEqInteger term [int, bool]
     do
-        term <- wrapRel intTy 2 $ mkBuiltin PLC.LessThanInteger
+        term <- wrapRel intTy 2 $ mkStaticBuiltin PLC.LessThanInteger
         defineBuiltinTerm 'Builtins.lessThanInteger term [int, bool]
     do
-        term <- wrapRel intTy 2 $ mkBuiltin PLC.LessThanEqInteger
+        term <- wrapRel intTy 2 $ mkStaticBuiltin PLC.LessThanEqInteger
         defineBuiltinTerm 'Builtins.lessThanEqInteger term [int, bool]
     do
-        term <- wrapRel intTy 2 $ mkBuiltin PLC.EqInteger
+        term <- wrapRel intTy 2 $ mkStaticBuiltin PLC.EqInteger
         defineBuiltinTerm 'Builtins.equalsInteger term [int, bool]
 
     -- Blockchain builtins
     do
-        term <- wrapRel bsTy 3 $ mkBuiltin PLC.VerifySignature
+        term <- wrapRel bsTy 3 $ mkStaticBuiltin PLC.VerifySignature
         defineBuiltinTerm 'Builtins.verifySignature term [bs, bool]
 
     -- Error
@@ -402,7 +402,7 @@ scottBoolToHaskellBool = do
     haskellBoolTy <- compileType GHC.boolTy
 
     arg <- liftQuote $ freshName "b"
-    let instantiatedMatch = PIR.TyInst () (PIR.builtinNameAsTerm PLC.IfThenElse) haskellBoolTy
+    let instantiatedMatch = PIR.TyInst () (PIR.staticBuiltinNameAsTerm PLC.IfThenElse) haskellBoolTy
 
     haskellTrue <- compileDataConRef GHC.trueDataCon
     haskellFalse <- compileDataConRef GHC.falseDataCon

--- a/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Builtins.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Compiler/Builtins.hs
@@ -157,10 +157,10 @@ which handles these cases too.
 -}
 
 mkStaticBuiltin :: PLC.StaticBuiltinName -> PIR.Term tyname name uni ()
-mkStaticBuiltin n = PIR.Builtin () $ PLC.StaticBuiltinName () n
+mkStaticBuiltin n = PIR.Builtin () $ PLC.StaticBuiltinName n
 
 mkDynBuiltin :: PLC.DynamicBuiltinName -> PIR.Term tyname name uni ()
-mkDynBuiltin n = PIR.Builtin () $ PLC.DynBuiltinName () n
+mkDynBuiltin n = PIR.Builtin () $ PLC.DynBuiltinName n
 
 -- | The 'TH.Name's for which 'BuiltinNameInfo' needs to be provided.
 builtinNames :: [TH.Name]


### PR DESCRIPTION
Like it says, this removes `StagedBuiltinName`s, which were pretty much the same as ordinary built-in names.  This will simplify the alternative CEK machine a bit (might rebase that branch later).

I also took the opportunity to rationalise the type names a bit. We formerly had 

```
data Builtin ann
    = BuiltinName ann BuiltinName
    | DynBuiltinName ann DynamicBuiltinName
```

and I've changed this to 

```
data BuiltinName
    = StaticBuiltinName StaticBuiltinName
    | DynBuiltinName DynamicBuiltinName
```
This makes it a bit easier to work out which things are dealing with static names and which are dealing with dynamic names.  This might help when we get round to getting rid of static builtins.

@reactormonk I made a few minor changes to the budgeting code (mostly deleting stuff) which you might want to check.