### PR TITLE
remove input composer in simulation

### DIFF
--- a/marlowe-playground-client/src/Simulation.purs
+++ b/marlowe-playground-client/src/Simulation.purs
@@ -519,33 +519,33 @@ transactionComposer state =
         [ ul [ classes [ ClassName "demo-list", aHorizontal ] ]
             [ li [ classes [ bold, pointer ] ]
                 [ a
-                    [ onClick
+                    [ onClick $ const
                         $ if hasHistory state then
-                            Just <<< const Undo
+                            Just Undo
                           else
-                            const Nothing
+                            Nothing
                     , class_ (Classes.disabled $ not isEnabled)
                     ]
                     [ text "Undo" ]
                 ]
             , li [ classes [ bold, pointer ] ]
                 [ a
-                    [ onClick
+                    [ onClick $ const
                         $ if hasHistory state then
-                            Just <<< const ResetSimulator
+                            Just ResetSimulator
                           else
-                            const Nothing
+                            Nothing
                     , class_ (Classes.disabled $ not isEnabled)
                     ]
                     [ text "Reset" ]
                 ]
             , li [ classes [ bold, pointer ] ]
                 [ a
-                    [ onClick
+                    [ onClick $ const
                         $ if isEnabled then
-                            Just <<< const NextSlot
+                            Just NextSlot
                           else
-                            const Nothing
+                            Nothing
                     , class_ (Classes.disabled $ not isEnabled)
                     ]
                     [ text $ "Next Slot (" <> show currentBlock <> ")" ]

--- a/marlowe-playground-client/src/Simulation/BottomPanel.purs
+++ b/marlowe-playground-client/src/Simulation/BottomPanel.purs
@@ -24,7 +24,7 @@ import Halogen.HTML (ClassName(..), HTML, a, a_, b_, button, code_, div, h2, h3,
 import Halogen.HTML.Events (onClick)
 import Halogen.HTML.Properties (alt, class_, classes, enabled, src)
 import Marlowe.Parser (transactionInputList, transactionWarningList)
-import Marlowe.Semantics (AccountId(..), Assets(..), ChoiceId(..), Input(..), Party, Payee(..), Payment(..), Slot(..), SlotInterval(..), Token(..), TransactionInput(..), TransactionWarning(..), ValueId(..), _accounts, _boundValues, _choices, maxTime, showPrettyToken)
+import Marlowe.Semantics (AccountId(..), Assets(..), ChoiceId(..), Input(..), Party, Payee(..), Payment(..), Slot(..), SlotInterval(..), Token(..), TransactionInput(..), TransactionWarning(..), ValueId(..), _accounts, _boundValues, _choices, showPrettyToken, timeouts)
 import Marlowe.Symbolic.Types.Response as R
 import Network.RemoteData (RemoteData(..), isLoading)
 import Prelude (bind, const, mempty, pure, show, zero, ($), (&&), (<$>), (<<<), (<>))
@@ -133,7 +133,7 @@ panelContents state CurrentStateView =
   where
   contractMaxTime Nothing = "Closed"
 
-  contractMaxTime (Just contract) = let t = maxTime contract in if t == zero then "Closed" else show t
+  contractMaxTime (Just contract) = let t = (_.maxTime <<< timeouts) contract in if t == zero then "Closed" else show t
 
   warnings = state ^. (_marloweState <<< _Head <<< _transactionWarnings)
 

--- a/marlowe-playground-client/src/Simulation/BottomPanel.purs
+++ b/marlowe-playground-client/src/Simulation/BottomPanel.purs
@@ -14,6 +14,7 @@ import Data.List (List, toUnfoldable)
 import Data.List as List
 import Data.Map as Map
 import Data.Maybe (Maybe(..), isJust, isNothing)
+import Data.Newtype (unwrap)
 import Data.String (take)
 import Data.String.Extra (unlines)
 import Data.Tuple (Tuple(..))
@@ -133,7 +134,11 @@ panelContents state CurrentStateView =
   where
   contractMaxTime Nothing = "Closed"
 
-  contractMaxTime (Just contract) = let t = (_.maxTime <<< timeouts) contract in if t == zero then "Closed" else show t
+  contractMaxTime (Just contract) =
+    let
+      t = (_.maxTime <<< unwrap <<< timeouts) contract
+    in
+      if t == zero then "Closed" else show t
 
   warnings = state ^. (_marloweState <<< _Head <<< _transactionWarnings)
 

--- a/marlowe-playground-client/src/Simulation/Types.purs
+++ b/marlowe-playground-client/src/Simulation/Types.purs
@@ -180,10 +180,9 @@ data Action
   | CheckAuthStatus
   | GistAction GistAction
   -- marlowe actions
-  | ApplyTransaction
   | NextSlot
-  | AddInput (Maybe PubKey) Input (Array Bound)
-  | RemoveInput (Maybe PubKey) Input
+  | AddInput Input (Array Bound)
+  | RemoveInput Input
   | SetChoice ChoiceId ChosenNum
   | ResetContract
   | ResetSimulator
@@ -214,10 +213,9 @@ instance isEventAction :: IsEvent Action where
   toEvent CheckAuthStatus = Just $ defaultEvent "CheckAuthStatus"
   toEvent (LoadScript script) = Just $ (defaultEvent "LoadScript") { label = Just script }
   toEvent (SetEditorText _) = Just $ (defaultEvent "SetEditorText")
-  toEvent ApplyTransaction = Just $ defaultEvent "ApplyTransaction"
   toEvent NextSlot = Just $ defaultEvent "NextBlock"
-  toEvent (AddInput _ _ _) = Just $ defaultEvent "AddInput"
-  toEvent (RemoveInput _ _) = Just $ defaultEvent "RemoveInput"
+  toEvent (AddInput _ _) = Just $ defaultEvent "AddInput"
+  toEvent (RemoveInput _) = Just $ defaultEvent "RemoveInput"
   toEvent (SetChoice _ _) = Just $ defaultEvent "SetChoice"
   toEvent ResetSimulator = Just $ defaultEvent "ResetSimulator"
   toEvent ResetContract = Just $ defaultEvent "ResetContract"

--- a/marlowe-playground-client/src/Wallet.purs
+++ b/marlowe-playground-client/src/Wallet.purs
@@ -826,7 +826,11 @@ renderCurrentState state =
   where
   contractMaxTime Nothing = "Closed"
 
-  contractMaxTime (Just contract) = let t = (_.maxTime <<< timeouts) contract in if t == zero then "Closed" else show t
+  contractMaxTime (Just contract) =
+    let
+      t = (_.maxTime <<< unwrap <<< timeouts) contract
+    in
+      if t == zero then "Closed" else show t
 
   warnings = state ^. (_currentLoadedMarloweState <<< _transactionWarnings)
 

--- a/marlowe-playground-client/static/css/panels.css
+++ b/marlowe-playground-client/static/css/panels.css
@@ -166,12 +166,7 @@
   padding: 0 0.1rem;
 }
 
-.transaction-composer .participants {
-  display: flex;
-  flex-flow: wrap;
-}
-
-.input-composer ul li ul {
+.transaction-composer ul li ul {
   display: flex;
 }
 

--- a/marlowe-playground-client/test/Marlowe/ContractTests.purs
+++ b/marlowe-playground-client/test/Marlowe/ContractTests.purs
@@ -38,10 +38,10 @@ all =
         (Tuple _ finalState) =
           (flip runState mkState) do
             updateContractInState Contracts.escrow
-            updateMarloweState (over _pendingInputs ((flip snoc) (Tuple deposit (Just alice))))
+            updateMarloweState (over _pendingInputs ((flip snoc) deposit))
             applyTransactions
-            updateMarloweState (over _pendingInputs ((flip snoc) (Tuple choice1 (Just alice))))
-            updateMarloweState (over _pendingInputs ((flip snoc) (Tuple choice2 (Just bob))))
+            updateMarloweState (over _pendingInputs ((flip snoc) choice1))
+            updateMarloweState (over _pendingInputs ((flip snoc) choice2))
             applyTransactions
 
         finalContract = finalState ^. _marloweState <<< _Head <<< _contract


### PR DESCRIPTION
* If a contract is inside a When that has a Notify and that Notify evaluates to true then an input button "Notify" should be displayed.
* If we pass over a timeout by progressing the slot number, an empty transaction should be submitted automatically
* It should not possible to submit a transaction that causes an error

Note that this is for the simulation tab only and the wallets simulation remains unchanged

Deployed to https://david.marlowe.iohkdev.io/#/simulation