### PR TITLE
improve error message

### DIFF
--- a/marlowe-playground-client/src/Halogen/Blockly.purs
+++ b/marlowe-playground-client/src/Halogen/Blockly.purs
@@ -136,7 +136,7 @@ handleAction GetCode = do
 
         rootBlockName = blocklyState.rootBlockName
       block <- except <<< (note $ unexpected ("Can't find root block" <> rootBlockName)) $ getBlockById workspace rootBlockName
-      code <- except <<< lmap (const "This workspace cannot be converted to code") $ blockToCode block generator
+      code <- except <<< lmap unexpected $ blockToCode block generator
       except <<< lmap (unexpected <<< show) $ Parser.parseContract (Text.stripParens code)
   case res of
     Left e -> assign _errorMessage $ Just e
@@ -144,7 +144,7 @@ handleAction GetCode = do
       assign _errorMessage Nothing
       raise <<< CurrentCode <<< show <<< pretty $ contract
   where
-  unexpected s = "An unexpected error has occurred, please raise a support issue: " <> s
+  unexpected s = "An unexpected error has occurred, please raise a support issue at https://github.com/input-output-hk/plutus/issues/new: " <> s
 
 blocklyRef :: RefLabel
 blocklyRef = RefLabel "blockly"


### PR DESCRIPTION
It turns out that it is no longer possible to get blockly to return an error because we have holes and blockly won't let you put bad values in. I don't think it's useful to a user to have any additional information because if something breaks it is a bug, not a user error however I have changed the error to be an 'unexpected' error and improved the message to include details of how to raise an issue on github.