### PR TITLE
SCP-855: Add logging to contracts

### DIFF
--- a/plutus-contract/src/Language/Plutus/Contract.hs
+++ b/plutus-contract/src/Language/Plutus/Contract.hs
@@ -63,6 +63,11 @@ module Language.Plutus.Contract(
     , checkpoint
     , AsCheckpointError(..)
     , CheckpointError(..)
+    -- * Logging
+    , logDebug
+    , logInfo
+    , logWarn
+    , logError
     -- * Row-related things
     , HasType
     , ContractRow
@@ -70,6 +75,7 @@ module Language.Plutus.Contract(
     , type Empty
     ) where
 
+import           Data.Aeson                                        (ToJSON (toJSON))
 import           Data.Row
 
 import           Language.Plutus.Contract.Effects.AwaitSlot        as AwaitSlot
@@ -87,6 +93,7 @@ import           Language.Plutus.Contract.Types                    (AsCheckpoint
                                                                     ContractError (..), checkpoint, mapError, select,
                                                                     selectEither, throwError)
 
+import qualified Control.Monad.Freer.Log                           as L
 import           Prelude                                           hiding (until)
 import           Wallet.API                                        (WalletAPIError)
 
@@ -114,3 +121,19 @@ both :: Contract s e a -> Contract s e b -> Contract s e (a, b)
 both a b =
   let swap (b_, a_) = (a_, b_) in
   ((,) <$> a <*> b) `select` (fmap swap ((,) <$> b <*> a))
+
+-- | Log a message at the 'Debug' level
+logDebug :: ToJSON a => a -> Contract s e ()
+logDebug = Contract . L.logDebug . toJSON
+
+-- | Log a message at the 'Info' level
+logInfo :: ToJSON a => a -> Contract s e ()
+logInfo = Contract . L.logInfo . toJSON
+
+-- | Log a message at the 'Warning' level
+logWarn :: ToJSON a => a -> Contract s e ()
+logWarn = Contract . L.logWarn . toJSON
+
+-- | Log a message at the 'Error' level
+logError :: ToJSON a => a -> Contract s e ()
+logError = Contract . L.logError . toJSON

--- a/plutus-contract/src/Language/Plutus/Contract/App.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/App.hs
@@ -49,7 +49,7 @@ type AppSchema s =
 -- | Run the contract as an HTTP server with servant/warp
 run
     :: forall s e.
-       ( AppSchema s, Show e )
+       ( AppSchema s, ToJSON e, Show e )
     => Contract s e () -> IO ()
 run st = runWithTraces @s st []
 
@@ -57,7 +57,7 @@ run st = runWithTraces @s st []
 --   print the 'Request' values for the given traces.
 runWithTraces
     :: forall s e.
-       ( AppSchema s, Show e )
+       ( AppSchema s, ToJSON e, Show e )
     => Contract s e ()
     -> [(String, (Wallet, ContractTrace s e (EmulatorAction (TraceError e)) () ()))]
     -> IO ()
@@ -87,7 +87,6 @@ printTracesAndExit mp = do
 printTrace
     :: forall s e.
        ( Forall (Input s) ToJSON
-       , Show e
        )
     => Contract s e ()
     -> Wallet
@@ -99,7 +98,7 @@ printTrace con wllt ctr = do
             let st = newState previous
                 newRequest = ContractRequest { oldState = st, event = evt }
             BSL.putStrLn (Aeson.encode newRequest)
-            either (error . show) pure (insertAndUpdateContract con newRequest)
+            pure (insertAndUpdateContract con newRequest)
 
-    initial <- either (error . show) pure (initialiseContract @s con)
+    initial <- pure (initialiseContract @s con)
     foldM_ go initial events

--- a/plutus-contract/src/Language/Plutus/Contract/Types.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Types.hs
@@ -50,12 +50,15 @@ import           Control.Monad.Freer
 import           Control.Monad.Freer.Coroutine
 import           Control.Monad.Freer.Error           (Error)
 import qualified Control.Monad.Freer.Error           as E
-import           Control.Monad.Freer.Extras          (raiseEnd3, raiseUnderN)
-import           Control.Monad.Freer.Log             (LogMsg, handleLogIgnore)
+import           Control.Monad.Freer.Extras          (raiseEnd4, raiseUnderN)
+import           Control.Monad.Freer.Log             (LogMessage, LogMsg, handleLogIgnore, handleLogWriter)
 import           Control.Monad.Freer.NonDet
 import           Control.Monad.Freer.Reader
 import           Control.Monad.Freer.State
+import qualified Control.Monad.Freer.Writer          as W
+import           Data.Aeson                          (Value)
 import qualified Data.Aeson                          as Aeson
+import           Data.Sequence                       (Seq)
 import           Data.String                         (IsString (..))
 import           Data.Text                           (Text)
 import qualified Data.Text                           as T
@@ -123,6 +126,7 @@ instance AsCheckpointError ContractError where
 -- | Effects that are available to contracts.
 type ContractEffs s e =
     '[ Error e
+    ,  LogMsg Value
     ,  Checkpoint
     ,  Resumable (Event s) (Handlers s)
     ]
@@ -134,6 +138,7 @@ handleContractEffs ::
   , Member (State (Requests (Handlers s))) effs
   , Member (State CheckpointStore) effs
   , Member (LogMsg CheckpointLogMsg) effs
+  , Member (LogMsg Value) effs
   )
   => Eff (ContractEffs s e) a
   -> Eff effs (Maybe a)
@@ -143,8 +148,9 @@ handleContractEffs =
   . handleResumable
   . handleCheckpoint
   . addEnvToCheckpoint
-  . subsume @(Error e) @(Checkpoint ': Resumable (Event s) (Handlers s) ': Yield (Handlers s) (Event s) ': State IterationID ': NonDet ': State RequestID ': State CheckpointKey ': effs)
-  . raiseEnd3 @(Yield (Handlers s) (Event s) ': State IterationID ': NonDet ': State RequestID ': State CheckpointKey ': effs)
+  . subsume @(LogMsg Value)
+  . subsume @(Error e) @(LogMsg Value ': Checkpoint ': Resumable (Event s) (Handlers s) ': Yield (Handlers s) (Event s) ': State IterationID ': NonDet ': State RequestID ': State CheckpointKey ': effs)
+  . raiseEnd4 @(Yield (Handlers s) (Event s) ': State IterationID ': NonDet ': State RequestID ': State CheckpointKey ': effs)
 
 type ContractEnv = (IterationID, RequestID)
 
@@ -237,7 +243,7 @@ runResumable ::
   [Response (Event s)]
   -> CheckpointStore
   -> Eff (ContractEffs s e) a
-  -> Either e (ResumableResult (Event s) (Handlers s) a)
+  -> ResumableResult e (Event s) (Handlers s) a
 runResumable events store action =
   let record = foldr insertResponse mempty events in
   runWithRecord action store record
@@ -247,16 +253,17 @@ runWithRecord ::
   Eff (ContractEffs s e) a
   -> CheckpointStore
   -> Responses (Event s)
-  -> Either e (ResumableResult (Event s) (Handlers s) a)
-runWithRecord action store rc =
-  let mkResult ((rs, reqState), newStore) = ResumableResult{wcsResponses = rc, wcsRequests = reqState, wcsFinalState = rs, wcsCheckpointStore = newStore}
-  in fmap mkResult
+  -> ResumableResult e (Event s) (Handlers s) a
+runWithRecord action store responses =
+  mkResult responses
       $ run
-      $ E.runError  @e @_
-      $ runReader @(Responses (Event s)) @_ rc
+      $ W.runWriter @(Seq (LogMessage Value))
+      $ interpret (handleLogWriter @Value @(Seq (LogMessage Value)) $ unto return)
+      $ runReader @(Responses (Event s)) @_ responses
       $ handleLogIgnore @CheckpointLogMsg
       $ runState @CheckpointStore store
-      $ runState  @(Requests (Handlers s)) mempty
+      $ runState @(Requests (Handlers s)) mempty
+      $ E.runError  @e @_
       $ handleContractEffs @s @e @_ @a action
 
 insertAndUpdate ::
@@ -265,15 +272,29 @@ insertAndUpdate ::
   -> CheckpointStore
   -> Responses (Event s)
   -> Response (Event s)
-  -> Either e (ResumableResult (Event s) (Handlers s) a)
+  -> ResumableResult e (Event s) (Handlers s) a
 insertAndUpdate action store record newResponse =
   runWithRecord action store (insertResponse newResponse record)
 
+mkResult ::
+    Responses (Event s)
+    -> (((Either e (Maybe a), Requests (Handlers s)), CheckpointStore), Seq (LogMessage Value))
+    -> ResumableResult e (Event s) (Handlers s) a
+mkResult responses (((result, reqState), newStore), logs) =
+    ResumableResult
+        { wcsResponses = responses
+        , wcsRequests = reqState
+        , wcsFinalState = result
+        , wcsCheckpointStore = newStore
+        , wcsLogs = logs
+        }
+
 -- | The result of running a 'Resumable'
-data ResumableResult i o a =
+data ResumableResult e i o a =
     ResumableResult
         { wcsResponses       :: Responses i -- The record with the resumable's execution history
         , wcsRequests        :: Requests o -- Handlers that the 'Resumable' has registered
-        , wcsFinalState      :: Maybe a -- Final state of the 'Resumable'
+        , wcsFinalState      :: Either e (Maybe a) -- Error or final state of the 'Resumable' (if it has finished)
+        , wcsLogs            :: Seq (LogMessage Value) -- Log messages
         , wcsCheckpointStore :: CheckpointStore
         }

--- a/plutus-scb/app/PSGenerator.hs
+++ b/plutus-scb/app/PSGenerator.hs
@@ -16,6 +16,7 @@ module PSGenerator
 import           Control.Applicative                               ((<|>))
 import           Control.Lens                                      (set, (&))
 import           Control.Monad                                     (void)
+import           Control.Monad.Freer.Log                           (LogLevel, LogMessage)
 import qualified Data.Aeson.Encode.Pretty                          as JSON
 import qualified Data.ByteString.Lazy                              as BSL
 import           Data.Proxy                                        (Proxy (Proxy))
@@ -127,6 +128,10 @@ myTypes =
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @(Responses A))
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @AddressChangeRequest)
     , (equal <*> (genericShow <*> mkSumType)) (Proxy @AddressChangeResponse)
+
+    -- Logging types
+    , (equal <*> (genericShow <*> mkSumType)) (Proxy @(LogMessage A))
+    , (equal <*> (genericShow <*> mkSumType)) (Proxy @LogLevel)
     ]
 
 mySettings :: Settings

--- a/plutus-scb/src/Plutus/SCB/ContractCLI.hs
+++ b/plutus-scb/src/Plutus/SCB/ContractCLI.hs
@@ -92,7 +92,7 @@ runCliCommand :: forall s m.
     => Contract s Text ()
     -> Command
     -> m (Either BS8.ByteString BS8.ByteString)
-runCliCommand schema Initialise = pure $ bimap JSON.encodePretty JSON.encodePretty $ ContractState.initialiseContract schema
+runCliCommand schema Initialise = pure $ Right $ JSON.encodePretty $ ContractState.initialiseContract schema
 runCliCommand schema Update = do
     arg <- liftIO BSL.getContents
     pure $ runUpdate schema arg
@@ -110,10 +110,10 @@ runUpdate :: forall s.
     -> BSL.ByteString
     -> Either BS8.ByteString BS8.ByteString
 runUpdate contract arg =
-    bimap JSON.encodePretty JSON.encodePretty $
-        case JSON.eitherDecode arg of
-            Left err      -> Left $ Text.pack err
-            Right request -> ContractState.insertAndUpdateContract contract request
+    bimap
+        (JSON.encodePretty . Text.pack)
+        (JSON.encodePretty . ContractState.insertAndUpdateContract contract)
+        (JSON.eitherDecode arg)
 
 commandLineApp ::
        ( AllUniqueLabels (Input s)

--- a/plutus-scb/src/Plutus/SCB/Events/Contract.hs
+++ b/plutus-scb/src/Plutus/SCB/Events/Contract.hs
@@ -40,6 +40,7 @@ module Plutus.SCB.Events.Contract(
   ) where
 
 import           Control.Lens.TH                                   (makePrisms)
+import           Control.Monad.Freer.Log                           (LogMessage)
 import           Data.Aeson                                        (FromJSON, FromJSONKey, ToJSON, ToJSONKey, Value,
                                                                     (.:))
 import qualified Data.Aeson                                        as JSON
@@ -195,6 +196,7 @@ data PartiallyDecodedResponse v =
     PartiallyDecodedResponse
         { newState :: Contract.State Value
         , hooks    :: [Contract.Request v]
+        , logs     :: [LogMessage Value]
         }
     deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
     deriving anyclass (ToJSON, FromJSON)

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -182,23 +182,32 @@ Events by wallet:
 Contract result by wallet:
     Wallet: W1
       Done
+      Logs:
+        [INFO] String "Campaign started. Waiting for campaign deadline to collect funds."
+        [INFO] String "Collecting funds"
     Wallet: W2
       Running, waiting for input:
           Requests:
             Iteration 4 request ID 4
             Request: {slot:
                       WaitingForSlot: Slot: 30}
+      Logs:
+        [INFO] String "Contributing Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}"
     Wallet: W3
       Running, waiting for input:
           Requests:
             Iteration 4 request ID 4
             Request: {slot:
                       WaitingForSlot: Slot: 30}
+      Logs:
+        [INFO] String "Contributing Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}"
     Wallet: W4
       Running, waiting for input:
           Requests:
             Iteration 4 request ID 4
             Request: {slot:
                       WaitingForSlot: Slot: 30}
+      Logs:
+        [INFO] String "Contributing Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}"
 Checkpoint state by wallet
     


### PR DESCRIPTION
We can now use 'Control.Monad.Freer.Log' inside of contracts. The type
of log messages is 'Data.Aeson.Value', because all contract outputs are
serialised to JSON when they cross the process boundary anyway.

I also changed the `ResumableResult` type to include possible errors that happened during contract execution. So we went from
`Either e (ResumableResult i o a)` to `ResumableResult e i o a`, which is a bit nicer because it lets you look at the log outputs and the contract state even if there is an error.