### PR TITLE
SCP-944 Use UTF-8 for TokenName.

### DIFF
--- a/plutus-ledger/src/Ledger/Generators.hs
+++ b/plutus-ledger/src/Ledger/Generators.hs
@@ -26,6 +26,7 @@ module Ledger.Generators(
     genValueNonNegative,
     genSizedByteString,
     genSizedByteStringExact,
+    genTokenName,
     splitVal,
     validateMockchain,
     signAll
@@ -201,6 +202,9 @@ genSizedByteStringExact s =
     let range = Range.singleton s in
     BSL.fromStrict <$> Gen.bytes range
 
+genTokenName :: MonadGen m => m TokenName
+genTokenName = (Value.TokenName . BSL.fromStrict) <$> Gen.utf8 (Range.linear 0 32) Gen.unicode
+
 genValue' :: MonadGen m => Range Integer -> m Value
 genValue' valueRange = do
     let
@@ -213,7 +217,7 @@ genValue' valueRange = do
 
         -- token is either an arbitrary bytestring or the ada token name
         token   = Gen.choice
-                    [ Value.tokenName <$> genSizedByteString 32
+                    [ genTokenName
                     , pure Ada.adaToken
                     ]
         sngl      = Value.singleton <$> currency <*> token <*> Gen.integral valueRange

--- a/plutus-ledger/test/Spec.hs
+++ b/plutus-ledger/test/Spec.hs
@@ -69,7 +69,7 @@ tests = testGroup "all tests" [
     testGroup "Value" ([
         testProperty "Value ToJSON/FromJSON" (jsonRoundTrip Gen.genValue),
         testProperty "CurrencySymbol ToJSON/FromJSON" (jsonRoundTrip $ Value.currencySymbol <$> Gen.genSizedByteStringExact 32),
-        testProperty "TokenName ToJSON/FromJSON" (jsonRoundTrip $ fromString @Value.TokenName <$> Gen.string (Range.linear 0 32) Gen.latin1),
+        testProperty "TokenName ToJSON/FromJSON" (jsonRoundTrip Gen.genTokenName),
         testProperty "CurrencySymbol IsString/Show" currencySymbolIsStringShow
         ] ++ (let   vlJson :: BSL.ByteString
                     vlJson = "{\"getValue\":[[{\"unCurrencySymbol\":\"ab01ff\"},[[{\"unTokenName\":\"myToken\"},50]]]]}"


### PR DESCRIPTION
Most people would expect TokenName to be UTF-8 encoded. 
Allows to use Unicode for tokens! ₳₿