### PR TITLE
add web-ghc to playgrounds infra

### DIFF
--- a/deployment/nixops/default.nix
+++ b/deployment/nixops/default.nix
@@ -2,6 +2,7 @@ let
   plutus = import ../../. {};
   serverTemplate = import ./server.nix;
   prometheusTemplate = import ./prometheus.nix;
+  webghc = import ./webghc.nix;
   machines = (plutus.pkgs.lib.importJSON ./machines.json);
   overlays = import ./overlays.nix;
   secrets = (plutus.pkgs.lib.importJSON ./secrets.json);
@@ -54,10 +55,12 @@ let
   playgroundB = serverTemplate.mkInstance playgroundOptions machines.playgroundB;
   marlowePlaygroundA = serverTemplate.mkInstance (marlowePlaygroundOptions (marloweUrl + "/machine-a/api")) machines.marlowePlaygroundA;
   marlowePlaygroundB = serverTemplate.mkInstance (marlowePlaygroundOptions (marloweUrl + "/machine-b/api")) machines.marlowePlaygroundB;
+  webGhcA = webghc.mkInstance (options // {web-ghc = plutus.web-ghc; }) machines.webGhcA;
+  webGhcB = webghc.mkInstance (options // {web-ghc = plutus.web-ghc; }) machines.webGhcA;
   nixops = prometheusTemplate.mkInstance 
             (options // {configDir = deploymentConfigDir; inherit deploymentServer enableGithubHooks;}) 
             {dns = "nixops.internal.${machines.environment}.${machines.plutusTld}";
              ip = "127.0.0.1";
              name = "nixops"; };
 in
-  { inherit playgroundA playgroundB marlowePlaygroundA marlowePlaygroundB nixops; }
+  { inherit playgroundA playgroundB marlowePlaygroundA marlowePlaygroundB nixops webGhcA webGhcB; }

--- a/deployment/nixops/network.nix
+++ b/deployment/nixops/network.nix
@@ -10,9 +10,11 @@ let
   playgroundB = mkInstance machines.playgroundB;
   marlowePlaygroundA = mkInstance machines.marlowePlaygroundA;
   marlowePlaygroundB = mkInstance machines.marlowePlaygroundB;
+  webGhcA = mkInstance machines.webghcA;
+  webGhcB = mkInstance machines.webghcB;
   nixops = { deployment.targetHost = "localhost"; };
 in
-  { inherit playgroundA playgroundB marlowePlaygroundA marlowePlaygroundB nixops;
+  { inherit playgroundA playgroundB marlowePlaygroundA marlowePlaygroundB webGhcA webGhcB nixops;
     network.description = "Plutus Playground";
     network.enableRollback = true;
   }

--- a/deployment/nixops/prometheus.nix
+++ b/deployment/nixops/prometheus.nix
@@ -12,7 +12,7 @@
                , ... }: node: { config, pkgs, lib, ... }:
 
 let
-    servers = [machines.marlowePlaygroundA machines.marlowePlaygroundB machines.playgroundA machines.playgroundB];
+    servers = [machines.marlowePlaygroundA machines.marlowePlaygroundB machines.playgroundA machines.playgroundB machines.webghcA machines.webghcB];
     nginxPort = 80;
     deploymentServerPort = 8080;
     target = port: node:

--- a/deployment/nixops/webghc.nix
+++ b/deployment/nixops/webghc.nix
@@ -1,0 +1,81 @@
+{
+  mkInstance = { defaultMachine, machines, web-ghc, ... }:
+    node:
+    { config, pkgs, lib, ... }:
+    let
+      serviceSystemctl = pkgs.writeScriptBin "web-ghc-systemctl" ''
+        COMMAND="$1"
+        if [[ $COMMAND =~ ^(stop|start|restart|status)$ ]]
+        then
+        systemctl "$COMMAND" "web-ghc.service"
+        else
+        echo "usage: $0 (stop|start|restart|status) <instance>"
+        fi
+      '';
+      promNodeTextfileDir = pkgs.writeTextDir "roles.prom"
+                            ''
+                            machine_role{role="webghc"} 1
+                            '';
+    in {
+      imports = [ (defaultMachine node pkgs) ];
+
+      security.sudo = {
+        enable = true;
+        extraRules = [{
+          users = [ "monitor" ];
+          commands = [{
+            command = "${serviceSystemctl}/bin/web-ghc-systemctl";
+            options = [ "NOPASSWD" ];
+          }];
+        }];
+      };
+
+      networking.firewall = {
+        enable = true;
+        allowedTCPPorts = [ 80 9100 9091 9113 ];
+      };
+
+      services.prometheus.exporters = {
+        node = {
+          enable = true;
+          enabledCollectors = [ "systemd" ];
+          extraFlags =
+            [ "--collector.textfile.directory ${promNodeTextfileDir}" ];
+        };
+        nginx = { enable = true; };
+      };
+
+      # a user for people who want to ssh in and fiddle with webghc service only
+      users.users.monitor = {
+        isNormalUser = true;
+        home = "/home/monitor";
+        description = "a user for administering web-ghc";
+        extraGroups = [ "systemd-journal" ];
+        openssh.authorizedKeys.keys = machines.playgroundSshKeys;
+        packages = [ serviceSystemctl ];
+      };
+
+      systemd.services.web-ghc = {
+        wantedBy = [ ];
+        before = [ ];
+        enable = true;
+        path = [ "${web-ghc}" ];
+
+        serviceConfig = {
+          TimeoutStartSec = "0";
+          Restart = "always";
+          DynamicUser = true;
+          ProtectKernelTunables = true;
+          ProtectControlGroups = true;
+          ProtectKernelModules = true;
+          PrivateDevices = true;
+          SystemCallArchitectures = "native";
+          CapabilityBoundingSet = "~CAP_SYS_ADMIN";
+          AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        };
+
+        script = "web-ghc-server webserver -b 0.0.0.0 -p 80";
+      };
+    };
+}
+

--- a/deployment/terraform/machines.tf
+++ b/deployment/terraform/machines.tf
@@ -30,6 +30,17 @@ locals {
     ip   = "${element(concat(aws_instance.marlowe_b.*.private_ip, list("")), 0)}"
     dns  = "marlowe-b.${element(concat(aws_route53_zone.plutus_private_zone.*.name, list("")), 0)}"
   }
+  webghcA = {
+    name = "webghcA"
+    ip   = "${element(concat(aws_instance.webghc_a.*.private_ip, list("")), 0)}"
+    dns  = "webghc-a.${element(concat(aws_route53_zone.plutus_private_zone.*.name, list("")), 0)}"
+  }
+
+  webghcB = {
+    name = "webghcB"
+    ip   = "${element(concat(aws_instance.webghc_b.*.private_ip, list("")), 0)}"
+    dns  = "webghc-b.${element(concat(aws_route53_zone.plutus_private_zone.*.name, list("")), 0)}"
+  }
 
   nixops = {
     name = "nixops"
@@ -49,6 +60,8 @@ locals {
     playgroundB       = "${local.playgroundB}"
     marlowePlaygroundA       = "${local.marlowePlaygroundA}"
     marlowePlaygroundB       = "${local.marlowePlaygroundB}"
+    webghcA       = "${local.webghcA}"
+    webghcB       = "${local.webghcB}"
     nixops         = "${local.nixops}"
     playgroundSshKeys = "${data.template_file.playground_ssh_keys.*.rendered}"
     rootSshKeys = "${data.template_file.nixops_ssh_keys.*.rendered}"

--- a/deployment/terraform/ssh_config.tf
+++ b/deployment/terraform/ssh_config.tf
@@ -57,8 +57,33 @@ data "template_file" "ssh_config_section_marlowe_b" {
     user_name        = "plutus"
   }
 }
+
+data "template_file" "ssh_config_section_webghc_a" {
+  template = "${file("${path.module}/templates/ssh-config")}"
+
+  vars {
+    full_hostname    = "webghc-a.${aws_route53_zone.plutus_private_zone.name}"
+    short_hostname   = "webghc-a.${var.project}"
+    ip               = "${aws_instance.webghc_a.private_ip}"
+    bastion_hostname = "${aws_instance.bastion.*.public_ip[0]}"
+    user_name        = "monitoring"
+  }
+}
+
+data "template_file" "ssh_config_section_webghc_b" {
+  template = "${file("${path.module}/templates/ssh-config")}"
+
+  vars {
+    full_hostname    = "webghc-b.${aws_route53_zone.plutus_private_zone.name}"
+    short_hostname   = "webghc-b.${var.project}"
+    ip               = "${aws_instance.webghc_b.private_ip}"
+    bastion_hostname = "${aws_instance.bastion.*.public_ip[0]}"
+    user_name        = "monitoring"
+  }
+}
+
 data "template_file" "ssh_config" {
-  template = "\n$${nixops_node}\n$${playground_a}\n$${playground_b}\n$${marlowe_a}\n$${marlowe_b}"
+  template = "\n$${nixops_node}\n$${playground_a}\n$${playground_b}\n$${marlowe_a}\n$${marlowe_b}\n$${webghc_a}\n$${webghc_b}"
 
   vars {
     nixops_node      = "${data.template_file.ssh_config_section_nixops.rendered}"
@@ -66,6 +91,8 @@ data "template_file" "ssh_config" {
     playground_b     = "${data.template_file.ssh_config_section_playground_b.rendered}"
     marlowe_a         = "${data.template_file.ssh_config_section_marlowe_a.rendered}"
     marlowe_b         = "${data.template_file.ssh_config_section_marlowe_b.rendered}"
+    webghc_a         = "${data.template_file.ssh_config_section_webghc_a.rendered}"
+    webghc_b         = "${data.template_file.ssh_config_section_webghc_b.rendered}"
   }
 }
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -47,6 +47,11 @@ variable "monitoring_full_domain" {
 variable "monitoring_public_zone" {
   default = "Z2Y3TWJMJ0Q6Z7"
 }
+
+variable "webghc_instance_type" {
+  default = "t3.large"
+}
+
 variable "marlowe_instance_type" {
   default = "t3.small"
 }
@@ -136,6 +141,28 @@ variable "aws_amis" {
     "ap-northeast-2" = "ami-a1248bcf"
     "sa-east-1"      = "ami-b090c6dc"
     "ap-south-1"     = "ami-32c9ec5d"
+  }
+}
+
+variable "20_03_amis" {
+  default = {
+    "ap-east-1" = "ami-0d18fdd309cdefa86"
+    "ap-northeast-1" = "ami-093d9cc49c191eb6c"
+    "ap-northeast-2" = "ami-0087df91a7b6ebd45"
+    "ap-south-1" = "ami-0a1a6b569af04af9d"
+    "ap-southeast-1" = "ami-0dbf353e168d155f7"
+    "ap-southeast-2" = "ami-04c0f3a75f63daddd"
+    "ca-central-1" = "ami-02365684a173255c7"
+    "eu-central-1" = "ami-0a1a94722dcbff94c"
+    "eu-north-1" = "ami-02699abfacbb6464b"
+    "eu-west-1" = "ami-02c34db5766cc7013"
+    "eu-west-2" = "ami-0e32bd8c7853883f1"
+    "eu-west-3" = "ami-061edb1356c1d69fd"
+    "sa-east-1" = "ami-09859378158ae971d"
+    "us-east-1" = "ami-0c5e7760748b74e85"
+    "us-east-2" = "ami-030296bb256764655"
+    "us-west-1" = "ami-050be818e0266b741"
+    "us-west-2" = "ami-06562f78dca68eda2"
   }
 }
 

--- a/deployment/terraform/webghc.tf
+++ b/deployment/terraform/webghc.tf
@@ -1,0 +1,124 @@
+# Security Group
+resource "aws_security_group" "webghc" {
+  vpc_id = "${aws_vpc.plutus.id}"
+  name   = "${var.project}_${var.env}_webghc"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "TCP"
+    cidr_blocks = ["${var.public_subnet_cidrs}", "${var.private_subnet_cidrs}"]
+  }
+
+  ## inbound (world): http
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "TCP"
+    cidr_blocks = ["${var.public_subnet_cidrs}", "${var.private_subnet_cidrs}"]
+  }
+
+  ingress {
+    from_port   = 9100
+    to_port     = 9100
+    protocol    = "TCP"
+    cidr_blocks = ["${var.private_subnet_cidrs}"]
+  }
+
+  ingress {
+    from_port   = 9091
+    to_port     = 9091
+    protocol    = "TCP"
+    cidr_blocks = ["${var.private_subnet_cidrs}"]
+  }
+
+  ingress {
+    from_port   = 9113
+    to_port     = 9113
+    protocol    = "TCP"
+    cidr_blocks = ["${var.private_subnet_cidrs}"]
+  }
+
+  ## outgoing: all
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "${var.project}_${var.env}_webghc"
+    Project     = "${var.project}"
+    Environment = "${var.env}"
+  }
+}
+
+data "template_file" "webghc_user_data" {
+  template = "${file("${path.module}/templates/default_configuration.nix")}"
+
+  vars {
+    root_ssh_keys      = "${join(" ", formatlist("\"%s\"", data.template_file.nixops_ssh_keys.*.rendered))}"
+  }
+}
+
+resource "aws_instance" "webghc_a" {
+  ami = "${lookup(var.20_03_amis, var.aws_region)}"
+
+  instance_type        = "${var.webghc_instance_type}"
+  subnet_id            = "${aws_subnet.private.*.id[0]}"
+  user_data            = "${data.template_file.webghc_user_data.rendered}"
+
+  vpc_security_group_ids = [
+    "${aws_security_group.webghc.id}",
+  ]
+
+  root_block_device = {
+    volume_size = "20"
+  }
+
+  tags {
+    Name        = "${var.project}_${var.env}_webghc_a"
+    Project     = "${var.project}"
+    Environment = "${var.env}"
+  }
+}
+
+resource "aws_route53_record" "webghc_internal_a" {
+  zone_id = "${aws_route53_zone.plutus_private_zone.zone_id}"
+  type    = "A"
+  name    = "webghc-a.${aws_route53_zone.plutus_private_zone.name}"
+  ttl     = 300
+  records = ["${aws_instance.webghc_a.private_ip}"]
+}
+
+resource "aws_instance" "webghc_b" {
+  ami = "${lookup(var.20_03_amis, var.aws_region)}"
+
+  instance_type        = "${var.webghc_instance_type}"
+  subnet_id            = "${aws_subnet.private.*.id[1]}"
+  user_data            = "${data.template_file.webghc_user_data.rendered}"
+
+  vpc_security_group_ids = [
+    "${aws_security_group.webghc.id}",
+  ]
+
+  root_block_device = {
+    volume_size = "20"
+  }
+
+  tags {
+    Name        = "${var.project}_${var.env}_webghc_b"
+    Project     = "${var.project}"
+    Environment = "${var.env}"
+  }
+}
+
+resource "aws_route53_record" "webghc_internal_b" {
+  zone_id = "${aws_route53_zone.plutus_private_zone.zone_id}"
+  type    = "A"
+  name    = "webghc-b.${aws_route53_zone.plutus_private_zone.name}"
+  ttl     = 300
+  records = ["${aws_instance.webghc_b.private_ip}"]
+}


### PR DESCRIPTION
currently can be accessed by the marlowe ALB only but in the future we will be moving this to a nomad cluster. 

For now we intend to convert the marlowe playground to use this ALB endpoint and possibly the same with the plutus playground (although we will need to add the service to the plutus playground ALB also then).