### PR TITLE
Plumbing in the Swagger API for the SCB server.

### DIFF
--- a/nix/stack.materialized/plutus-scb.nix
+++ b/nix/stack.materialized/plutus-scb.nix
@@ -83,6 +83,8 @@
           (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
           (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
           (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
+          (hsPkgs."servant-swagger" or (errorHandler.buildDepError "servant-swagger"))
+          (hsPkgs."swagger2" or (errorHandler.buildDepError "swagger2"))
           (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
           (hsPkgs."typed-protocols-examples" or (errorHandler.buildDepError "typed-protocols-examples"))
           (hsPkgs."servant-websockets" or (errorHandler.buildDepError "servant-websockets"))
@@ -161,6 +163,7 @@
           "Plutus/SCB/Instances"
           "Plutus/SCB/MonadLoggerBridge"
           "Plutus/SCB/Monitoring"
+          "Plutus/SCB/Swagger"
           "Plutus/SCB/Webserver/API"
           "Plutus/SCB/Webserver/Handler"
           "Plutus/SCB/Webserver/Server"

--- a/plutus-scb/plutus-scb.cabal
+++ b/plutus-scb/plutus-scb.cabal
@@ -98,6 +98,7 @@ library
         Plutus.SCB.Instances
         Plutus.SCB.MonadLoggerBridge
         Plutus.SCB.Monitoring
+        Plutus.SCB.Swagger
         Plutus.SCB.Webserver.API
         Plutus.SCB.Webserver.Handler
         Plutus.SCB.Webserver.Server
@@ -170,6 +171,8 @@ library
         servant -any,
         servant-client -any,
         servant-server -any,
+        servant-swagger -any,
+        swagger2 -any,
         typed-protocols -any,
         typed-protocols-examples -any,
         servant-websockets -any,

--- a/plutus-scb/src/Plutus/SCB/Swagger.hs
+++ b/plutus-scb/src/Plutus/SCB/Swagger.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Plutus.SCB.Swagger
+    ( SwaggerAPI
+    , module X
+    , handler
+    ) where
+
+import           Data.Proxy      (Proxy)
+import           Data.Swagger    (Swagger, ToSchema, declareNamedSchema)
+import qualified Data.Swagger    as X
+import           Servant         (Handler)
+import           Servant.API     ((:>), Get, JSON)
+import           Servant.Swagger (HasSwagger, toSwagger)
+
+type SwaggerAPI = "swagger.json" :> Get '[ JSON] Swagger
+
+handler :: HasSwagger api => Proxy api -> Handler Swagger
+handler = pure . toSwagger

--- a/plutus-scb/src/Plutus/SCB/Webserver/API.hs
+++ b/plutus-scb/src/Plutus/SCB/Webserver/API.hs
@@ -4,6 +4,7 @@
 module Plutus.SCB.Webserver.API
     ( API
     , WSAPI
+    , DocumentationAPI
     ) where
 
 import qualified Data.Aeson                 as JSON
@@ -21,3 +22,6 @@ type API t
                                                                                   :<|> "endpoint" :> Capture "endpoint-name" String :> ReqBody '[ JSON] JSON.Value :> Post '[ JSON] (ContractInstanceState t))))
 
 type WSAPI = "ws" :> WebSocketPending
+
+type DocumentationAPI t
+     = "api" :> "healthcheck" :> Get '[ JSON] ()


### PR DESCRIPTION
Adding swagger to the webservers is a two part affair - figure out how to plumb it in, then add a gajillion instances of `Data.Swagger.ToSchema` everywhere. (Most of those instances can be derived with generics, but plenty cannot.) This is a classic "brainwork / legwork" split.

There was a discussion in last week's planning meeting as to whether this was worth the effort, given that the API is still changing and the team(s) that want us to support swagger won't actually need it for several months.

As a balance, I propose this change. It merges the plumbing I've already figured out, so the brainwork is kept. And we can save the legwork of adding instances for when we actually have a consumer.