### PR TITLE
plutus-contract: Scrap MonadEmulator MTL effects

### DIFF
--- a/nix/stack.materialized/playground-common.nix
+++ b/nix/stack.materialized/playground-common.nix
@@ -83,6 +83,7 @@
           (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
           (hsPkgs."wai" or (errorHandler.buildDepError "wai"))
           (hsPkgs."wl-pprint-text" or (errorHandler.buildDepError "wl-pprint-text"))
+          (hsPkgs."freer-simple" or (errorHandler.buildDepError "freer-simple"))
           ];
         buildable = true;
         modules = [

--- a/playground-common/playground-common.cabal
+++ b/playground-common/playground-common.cabal
@@ -90,7 +90,8 @@ library
         transformers -any,
         unordered-containers -any,
         wai -any,
-        wl-pprint-text -any
+        wl-pprint-text -any,
+        freer-simple -any
 
 test-suite playground-common-test
     type: exitcode-stdio-1.0

--- a/plutus-contract/src/Language/Plutus/Contract/App.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/App.hs
@@ -25,7 +25,7 @@ import           Language.Plutus.Contract.Schema  (Input, Output)
 import           Language.Plutus.Contract.Servant (contractApp)
 import           Language.Plutus.Contract.State   (ContractRequest (..), ContractResponse (..), initialiseContract,
                                                    insertAndUpdateContract)
-import           Language.Plutus.Contract.Trace   (ContractTrace, EmulatorAction, TraceError, execTrace)
+import           Language.Plutus.Contract.Trace   (ContractTrace, execTrace)
 import qualified Network.Wai.Handler.Warp         as Warp
 import           System.Environment               (getArgs)
 import           Wallet.Emulator                  (Wallet (..))
@@ -59,7 +59,7 @@ runWithTraces
     :: forall s e.
        ( AppSchema s, ToJSON e, Show e )
     => Contract s e ()
-    -> [(String, (Wallet, ContractTrace s e (EmulatorAction (TraceError e)) () ()))]
+    -> [(String, (Wallet, ContractTrace s e () ()))]
     -> IO ()
 runWithTraces con traces = do
     let mp = Map.fromList traces
@@ -90,7 +90,7 @@ printTrace
        )
     => Contract s e ()
     -> Wallet
-    -> ContractTrace s e (EmulatorAction (TraceError e)) () ()
+    -> ContractTrace s e () ()
     -> IO ()
 printTrace con wllt ctr = do
     let events = Map.findWithDefault [] wllt $ execTrace con ctr

--- a/plutus-contract/src/Language/Plutus/Contract/Test.hs
+++ b/plutus-contract/src/Language/Plutus/Contract/Test.hs
@@ -150,13 +150,13 @@ checkPredicate
     => String
     -> Contract s e a
     -> TracePredicate s (TraceError e) a
-    -> ContractTrace s e (EmulatorAction (TraceError e)) a ()
+    -> ContractTrace s e a ()
     -> TestTree
 checkPredicate nm con predicate action =
     HUnit.testCaseSteps nm $ \step ->
         case runTrace con action of
             (Left err, _) ->
-                HUnit.assertFailure $ "EmulatorAction failed. " ++ show err
+                HUnit.assertFailure $ "ContractTrace failed. " ++ show err
             (Right ((), st), ms) -> do
                 let dt = ContractTraceResult ms st
                     (result, testOutputs) = runWriter $ unPredF predicate (defaultDist, dt)

--- a/plutus-contract/src/Wallet/Emulator/Types.hs
+++ b/plutus-contract/src/Wallet/Emulator/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes   #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DerivingStrategies    #-}
@@ -7,6 +8,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Rank2Types            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# OPTIONS_GHC -Wno-overlapping-patterns #-}
 module Wallet.Emulator.Types(
@@ -28,7 +30,7 @@ module Wallet.Emulator.Types(
     EmulatorEvent,
     EmulatorEvent',
     EmulatorTimeEvent(..),
-    EmulatorAction(..),
+    EmulatorBackend,
     -- ** Wallet state
     WalletState(..),
     emptyWalletState,
@@ -64,7 +66,6 @@ module Wallet.Emulator.Types(
     index,
     chainState,
     currentSlot,
-    MonadEmulator,
     processEmulated,
     runWalletActionAndProcessPending,
     runWalletControlActionAndProcessPending,
@@ -75,11 +76,13 @@ module Wallet.Emulator.Types(
 
 import           Control.Lens               hiding (index)
 import           Control.Monad.Except
-import qualified Control.Monad.Freer        as Eff
+import           Control.Monad.Freer
+import           Control.Monad.Freer.Error  (Error)
 import qualified Control.Monad.Freer.Error  as Eff
 import qualified Control.Monad.Freer.Extras as Eff
 import           Control.Monad.Freer.Log    (LogLevel (..), LogMessage, logMessage)
-import           Control.Monad.State
+import           Control.Monad.Freer.State  (State)
+import qualified Control.Monad.Freer.State  as Eff
 import           Data.Foldable              (traverse_)
 import qualified Data.Text                  as T
 import           Prelude                    as P
@@ -96,46 +99,52 @@ import           Wallet.Emulator.Wallet
 type EmulatorEffs = '[MultiAgentEffect, ChainEffect, ChainControlEffect]
 
 -- | Notify the given 'Wallet' of some blockchain events.
-walletRecvBlocks :: Eff.Members EmulatorEffs effs => Wallet -> [ChainClientNotification] -> Eff.Eff effs ()
+walletRecvBlocks :: Members EmulatorEffs effs => Wallet -> [ChainClientNotification] -> Eff effs ()
 walletRecvBlocks w nots = void $ walletControlAction w (traverse_ go nots) where
     go noti = clientNotify noti >> chainIndexNotify noti
 
 -- | Notify the given 'Wallet' that a block has been validated.
-walletNotifyBlock :: Eff.Members EmulatorEffs effs => Wallet -> Block -> Eff.Eff effs ()
+walletNotifyBlock :: Members EmulatorEffs effs => Wallet -> Block -> Eff effs ()
 walletNotifyBlock w block = do
     sl <- Chain.getCurrentSlot
     walletRecvBlocks w [BlockValidated block, SlotChanged sl]
 
 -- | Notify a list of 'Wallet's that a block has been validated.
-walletsNotifyBlock :: forall effs . Eff.Members EmulatorEffs effs => [Wallet] -> Block -> Eff.Eff effs ()
+walletsNotifyBlock :: forall effs . Members EmulatorEffs effs => [Wallet] -> Block -> Eff effs ()
 walletsNotifyBlock wls b = mapM_ (\w -> walletNotifyBlock w b) wls
 
 -- | Validate all pending transactions.
-processPending :: forall effs . Eff.Members EmulatorEffs effs => Eff.Eff effs Block
+processPending :: forall effs . Members EmulatorEffs effs => Eff effs Block
 processPending = processBlock
 
 -- | Add a number of empty blocks to the blockchain, by performing
 --   'processPending' @n@ times.
-addBlocks :: Eff.Members EmulatorEffs effs => Integer -> Eff.Eff effs [Block]
+addBlocks :: Members EmulatorEffs effs => Integer -> Eff effs [Block]
 addBlocks i = traverse (const processPending) [1..i]
 
 -- | Add a number of blocks, notifying all the given 'Wallet's after each block.
-addBlocksAndNotify :: Eff.Members EmulatorEffs effs => [Wallet] -> Integer -> Eff.Eff effs [Block]
+addBlocksAndNotify :: Members EmulatorEffs effs => [Wallet] -> Integer -> Eff effs [Block]
 addBlocksAndNotify wallets i =
-    let run = do
+    let go = do
             block <- processPending
             walletsNotifyBlock wallets block
             pure block
-    in traverse (const run) [1..i]
+    in traverse (const go) [1..i]
 
-type MonadEmulator e m = (MonadError e m, AsAssertionError e, MonadState EmulatorState m)
+type EmulatorBackend e =
+    '[ Error e
+    , State EmulatorState
+    ]
 
-newtype EmulatorAction e a = EmulatorAction { unEmulatorAction :: ExceptT e (State EmulatorState) a }
-    deriving newtype (Functor, Applicative, Monad, MonadState EmulatorState, MonadError e)
-
-processEmulated :: forall m e a . (MonadEmulator e m) => Eff.Eff EmulatorEffs a -> m a
+processEmulated :: forall e effs.
+    ( AsAssertionError e
+    , Member (Error e) effs
+    , Member (State EmulatorState) effs
+    )
+    => Eff EmulatorEffs
+    ~> Eff effs
 processEmulated act = do
-    emulatorTime <- use (chainState . currentSlot)
+    emulatorTime <- Eff.gets (view $ chainState . currentSlot)
     let
         p1 :: Prism' [LogMessage EmulatorEvent] [ChainEvent]
         p1 =  below (logMessage Info . emulatorTimeEvent emulatorTime . chainEvent)
@@ -146,52 +155,49 @@ processEmulated act = do
         & handleMultiAgent
         & handleChain
         & handleControlChain
-        & Eff.interpret (Eff.handleZoomedWriter p1)
-        & Eff.interpret (Eff.handleZoomedState chainState)
-        & Eff.interpret (Eff.writeIntoState emulatorLog)
+        & interpret (Eff.handleZoomedWriter p1)
+        & interpret (Eff.handleZoomedState chainState)
+        & interpret (Eff.writeIntoState emulatorLog)
         -- HACK
         & flip Eff.handleError (\(e :: WalletAPIError) -> Eff.throwError $ GenericAssertion $ T.pack $ show e)
-        & Eff.interpret (Eff.handleZoomedError p2)
-        & Eff.interpretM Eff.stateToMonadState
-        & Eff.interpretM Eff.errorToMonadError
-        & Eff.runM
+        & interpret (Eff.handleZoomedError p2)
 
 
--- | Run a 'MonadEmulator' action on an 'EmulatorState', returning the final
---   state and either the result or an 'AssertionError'.
-runEmulator :: forall e a . EmulatorState -> EmulatorAction e a -> (Either e a, EmulatorState)
-runEmulator e a = runState (runExceptT $ unEmulatorAction a) e
+-- | Run a 'Eff (EmulatorBackend e)' action on an 'EmulatorState', returning
+--   the final state and either the result or an error.
+runEmulator :: forall e a . EmulatorState -> Eff (EmulatorBackend e) a -> (Either e a, EmulatorState)
+runEmulator state = run . Eff.runState state . Eff.runError
 
 -- | Run an 'Trace' on a blockchain.
-runTraceChain :: Blockchain -> Eff.Eff EmulatorEffs a -> (Either AssertionError a, EmulatorState)
-runTraceChain ch t = runState (runExceptT $ processEmulated t) emState where
-    emState = emulatorState ch
+runTraceChain :: Blockchain -> Eff EmulatorEffs a -> (Either AssertionError a, EmulatorState)
+runTraceChain chain = run . Eff.runState emState . Eff.runError . processEmulated @AssertionError where
+    emState = emulatorState chain
 
 -- | Run a 'Trace' on an empty blockchain with a pool of pending transactions.
-runTraceTxPool :: TxPool -> Eff.Eff EmulatorEffs a -> (Either AssertionError a, EmulatorState)
-runTraceTxPool tp t = runState (runExceptT $ processEmulated t) emState where
+runTraceTxPool :: TxPool -> Eff EmulatorEffs a -> (Either AssertionError a, EmulatorState)
+runTraceTxPool tp = run . Eff.runState emState . Eff.runError . processEmulated @AssertionError where
     emState = emulatorStatePool tp
 
 -- | Evaluate a 'Trace' on an empty blockchain with a pool of pending
 --   transactions and return the final value, discarding the final
 --   'EmulatorState'.
-evalTraceTxPool :: TxPool -> Eff.Eff EmulatorEffs a -> Either AssertionError a
+evalTraceTxPool :: TxPool -> Eff EmulatorEffs a -> Either AssertionError a
 evalTraceTxPool pl t = fst $ runTraceTxPool pl t
 
 -- | Evaluate a 'Trace' on an empty blockchain with a pool of pending
 --   transactions and return the final 'EmulatorState', discarding the final
 --   value.
-execTraceTxPool :: TxPool -> Eff.Eff EmulatorEffs a -> EmulatorState
+execTraceTxPool :: TxPool -> Eff EmulatorEffs a -> EmulatorState
 execTraceTxPool pl t = snd $ runTraceTxPool pl t
 
 -- | Run an action as a wallet, subsequently process any pending transactions
 --   and notify wallets. Returns the new block
 runWalletActionAndProcessPending
-    :: Eff.Members EmulatorEffs effs
+    :: Members EmulatorEffs effs
     => [Wallet]
     -> Wallet
-    -> Eff.Eff EmulatedWalletEffects a
-    -> Eff.Eff effs ([Tx], a)
+    -> Eff EmulatedWalletEffects a
+    -> Eff effs ([Tx], a)
 runWalletActionAndProcessPending wallets wallet action = do
     result <- walletAction wallet action
     block <- addBlocksAndNotify wallets 1
@@ -200,11 +206,11 @@ runWalletActionAndProcessPending wallets wallet action = do
 -- | Run a control action as a wallet, subsequently process any pending
 --   transactions and notify wallets. Returns the new block.
 runWalletControlActionAndProcessPending
-    :: Eff.Members EmulatorEffs effs
+    :: Members EmulatorEffs effs
     => [Wallet]
     -> Wallet
-    -> Eff.Eff EmulatedWalletControlEffects a
-    -> Eff.Eff effs ([Tx], a)
+    -> Eff EmulatedWalletControlEffects a
+    -> Eff effs ([Tx], a)
 runWalletControlActionAndProcessPending wallets wallet action = do
     result <- walletControlAction wallet action
     block <- addBlocksAndNotify wallets 1

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Crowdfunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Crowdfunding.hs
@@ -54,7 +54,7 @@ import           GHC.Generics                      (Generic)
 import           IOTS                              (IotsType)
 
 import           Language.Plutus.Contract
-import           Language.Plutus.Contract.Trace    (ContractTrace, MonadEmulator, TraceError)
+import           Language.Plutus.Contract.Trace    (ContractTrace)
 import qualified Language.Plutus.Contract.Trace    as Trace
 import qualified Language.Plutus.Contract.Typed.Tx as Typed
 import qualified Language.PlutusTx                 as PlutusTx
@@ -255,19 +255,16 @@ scheduleCollection cmp = do
 
 -- | Call the "schedule collection" endpoint and instruct the campaign owner's
 --   wallet (wallet 1) to start watching the campaign address.
-startCampaign
-    :: ( MonadEmulator (TraceError ContractError) m  )
-    => ContractTrace CrowdfundingSchema ContractError m () ()
+startCampaign :: ContractTrace CrowdfundingSchema ContractError () ()
 startCampaign =
     Trace.callEndpoint @"schedule collection" (Trace.Wallet 1)  ()
         >> Trace.notifyInterestingAddresses (Trace.Wallet 1)
 
 -- | Call the "contribute" endpoint, contributing the amount from the wallet
 makeContribution
-    :: ( MonadEmulator (TraceError ContractError) m )
-    => Wallet
+    :: Wallet
     -> Value
-    -> ContractTrace CrowdfundingSchema ContractError m () ()
+    -> ContractTrace CrowdfundingSchema ContractError () ()
 makeContribution w v =
     Trace.callEndpoint @"contribute" w Contribution{contribValue=v}
         >> Trace.handleBlockchainEvents w
@@ -275,8 +272,7 @@ makeContribution w v =
 
 -- | Run a successful campaign with contributions from wallets 2, 3 and 4.
 successfulCampaign
-    :: ( MonadEmulator (TraceError ContractError) m )
-    => ContractTrace CrowdfundingSchema ContractError m () ()
+    :: ContractTrace CrowdfundingSchema ContractError () ()
 successfulCampaign =
     startCampaign
         >> makeContribution (Trace.Wallet 2) (Ada.lovelaceValueOf 10)

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Game.hs
@@ -46,7 +46,7 @@ import GHC.Generics (Generic)
 import IOTS (IotsType)
 import Language.Plutus.Contract
 import Language.Plutus.Contract.Schema ()
-import Language.Plutus.Contract.Trace (ContractTrace, MonadEmulator, TraceError)
+import Language.Plutus.Contract.Trace (ContractTrace)
 import qualified Language.Plutus.Contract.Trace as Trace
 import qualified Language.PlutusTx as PlutusTx
 import Language.PlutusTx.Prelude
@@ -145,8 +145,7 @@ game :: AsContractError e => Contract GameSchema e ()
 game = lock `select` guess
 
 lockTrace
-    :: ( MonadEmulator (TraceError e) m )
-    => ContractTrace GameSchema e m () ()
+    :: ContractTrace GameSchema e () ()
 lockTrace =
     let w1 = Trace.Wallet 1 in
     Trace.callEndpoint @"lock" w1 (LockParams "secret" (Ada.lovelaceValueOf 10))
@@ -154,8 +153,7 @@ lockTrace =
         >> Trace.addBlocks 1
 
 guessTrace
-    :: ( MonadEmulator (TraceError e) m )
-    => ContractTrace GameSchema e m () ()
+    :: ContractTrace GameSchema e () ()
 guessTrace =
     let w2 = Trace.Wallet 2 in
     lockTrace
@@ -164,8 +162,7 @@ guessTrace =
         >> Trace.addBlocks 1
 
 guessWrongTrace
-    :: ( MonadEmulator (TraceError e) m )
-    => ContractTrace GameSchema e m () ()
+    :: ContractTrace GameSchema e () ()
 guessWrongTrace =
     let w2 = Trace.Wallet 2 in
     lockTrace

--- a/plutus-use-cases/test/Spec/Crowdfunding.hs
+++ b/plutus-use-cases/test/Spec/Crowdfunding.hs
@@ -145,11 +145,11 @@ tests = testGroup "crowdfunding"
 
 renderPredicate
     :: Contract CrowdfundingSchema ContractError ()
-    -> ContractTrace CrowdfundingSchema ContractError (EmulatorAction (TraceError ContractError)) () ()
+    -> ContractTrace CrowdfundingSchema ContractError () ()
     -> IO ByteString
 renderPredicate contract trace = do
     case runTrace contract trace of
         (Left err, _) ->
-            HUnit.assertFailure $ "EmulatorAction failed. " ++ show err
+            HUnit.assertFailure $ "ContractTrace failed. " ++ show err
         (Right (_, st), _) -> do
             pure $ BSL.fromStrict $ T.encodeUtf8 $ renderTraceContext mempty st

--- a/plutus-use-cases/test/Spec/Future.hs
+++ b/plutus-use-cases/test/Spec/Future.hs
@@ -109,7 +109,7 @@ theFuture = Future {
 
 -- | After this trace, the initial margin of wallet 1, and the two tokens,
 --   are locked by the contract.
-initContract :: MonadEmulator (TraceError FutureError) m => ContractTrace FutureSchema FutureError m a ()
+initContract :: ContractTrace FutureSchema FutureError a ()
 initContract = do
     callEndpoint @"initialise-future" (Wallet 1) (setup, Short)
     handleBlockchainEvents (Wallet 1)
@@ -122,7 +122,7 @@ initContract = do
 
 -- | Calls the "join-future" endpoint for wallet 2 and processes
 --   all resulting transactions.
-joinFuture :: MonadEmulator (TraceError FutureError) m => ContractTrace FutureSchema FutureError m a ()
+joinFuture :: ContractTrace FutureSchema FutureError a ()
 joinFuture = do
     callEndpoint @"join-future" (Wallet 2) (accounts, setup)
     handleBlockchainEvents (Wallet 2)
@@ -135,7 +135,7 @@ joinFuture = do
 
 -- | Calls the "settle-future" endpoint for wallet 2 and processes
 --   all resulting transactions.
-payOut :: MonadEmulator (TraceError FutureError) m => ContractTrace FutureSchema FutureError m a ()
+payOut :: ContractTrace FutureSchema FutureError a ()
 payOut = do
     let
         spotPrice = Ada.lovelaceValueOf 1124
@@ -169,7 +169,7 @@ accounts =
             F.setupTokens
             (handleBlockchainEvents w1 >> addBlocks 1 >> handleBlockchainEvents w1 >> addBlocks 1 >> handleBlockchainEvents w1 ) w1
 
-increaseMargin :: MonadEmulator (TraceError FutureError) m => ContractTrace FutureSchema FutureError m a ()
+increaseMargin :: ContractTrace FutureSchema FutureError a ()
 increaseMargin = do
     callEndpoint @"increase-margin" (Wallet 2) (Ada.lovelaceValueOf 100, Long)
     addBlocks 1
@@ -177,7 +177,7 @@ increaseMargin = do
     addBlocks 1
     handleBlockchainEvents (Wallet 2)
 
-settleEarly :: MonadEmulator (TraceError FutureError) m => ContractTrace FutureSchema FutureError m a ()
+settleEarly :: ContractTrace FutureSchema FutureError a ()
 settleEarly = do
     let
         spotPrice = Ada.lovelaceValueOf 11240

--- a/plutus-use-cases/test/Spec/GameStateMachine.hs
+++ b/plutus-use-cases/test/Spec/GameStateMachine.hs
@@ -81,7 +81,7 @@ w2 = EM.Wallet 2
 w3 :: EM.Wallet
 w3 = EM.Wallet 3
 
-successTrace :: MonadEmulator (TraceError e) m => ContractTrace GameStateMachineSchema e m a ()
+successTrace :: ContractTrace GameStateMachineSchema e a ()
 successTrace = do
     callEndpoint @"lock" w1 LockArgs{lockArgsSecret="hello", lockArgsValue= Ada.lovelaceValueOf 8}
     handleBlockchainEvents w1

--- a/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
+++ b/plutus-use-cases/test/Spec/MultiSigStateMachine.hs
@@ -86,10 +86,9 @@ payment =
 --   'payment', then call @"add-signature"@ a number of times and
 --   finally call @"pay"@ a number of times.
 lockProposeSignPay
-    :: MonadEmulator (TraceError MultiSigError) m
-    => Integer
+    :: Integer
     -> Integer
-    -> ContractTrace MultiSigSchema MultiSigError m a ()
+    -> ContractTrace MultiSigSchema MultiSigError a ()
 lockProposeSignPay signatures rounds = do
 
     let

--- a/plutus-use-cases/test/Spec/Rollup.hs
+++ b/plutus-use-cases/test/Spec/Rollup.hs
@@ -45,7 +45,7 @@ tests = testGroup "showBlockchain"
 render
     :: forall s e a. ( Show e )
     => Contract s e a
-    -> ContractTrace s e (EmulatorAction (TraceError e)) a ()
+    -> ContractTrace s e a ()
     -> IO ByteString
 render con trace = do
     let (result, EmulatorState{ _chainState = cs, _walletClientStates = wallets}) = runTrace con trace

--- a/plutus-use-cases/test/Spec/Vesting.hs
+++ b/plutus-use-cases/test/Spec/Vesting.hs
@@ -88,8 +88,7 @@ vesting =
         , vestingOwner    = Ledger.pubKeyHash $ walletPubKey wallet1 }
 
 retrieveFundsTrace
-    :: ( MonadEmulator (TraceError e) m )
-    => ContractTrace VestingSchema e m () ()
+    :: ContractTrace VestingSchema e () ()
 retrieveFundsTrace = do
     callEndpoint @"vest funds" wallet2 ()
     handleBlockchainEvents wallet2


### PR DESCRIPTION
* Replace 'MonadEmulator' and 'EmulatorAction' types with their
equivalents from `freer-simple`
* Get rid of a couple of constraints at call-sites