### PR TITLE
[PLC] [Costing] Generalized 'ExBudgetCategory'

### DIFF
--- a/plutus-core/src/Language/PlutusCore/Evaluation/Machine/Cek.hs
+++ b/plutus-core/src/Language/PlutusCore/Evaluation/Machine/Cek.hs
@@ -11,6 +11,7 @@
 -- (wrapped in 'OtherMachineError').
 
 {-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -29,9 +30,12 @@ module Language.PlutusCore.Evaluation.Machine.Cek
     , ErrorWithCause(..)
     , EvaluationError(..)
     , ExBudget(..)
+    , ExBudgetCategory(..)
     , ExBudgetMode(..)
     , ExRestrictingBudget(..)
     , ExTally(..)
+    , CekExBudgetState
+    , CekExTally
     , exBudgetStateTally
     , extractEvaluationResult
     , runCek
@@ -64,6 +68,7 @@ import           Control.Monad.Morph
 import           Control.Monad.Reader
 import           Control.Monad.State.Strict
 import           Data.Array
+import           Data.Hashable
 import           Data.HashMap.Monoidal
 import qualified Data.Map                                           as Map
 import           Data.Text.Prettyprint.Doc
@@ -153,13 +158,31 @@ type CekEvaluationExceptionCarrying term =
 -- | A generalized version of 'CekM' carrying a @term@.
 -- 'State' is inside the 'ExceptT', so we can get it back in case of error.
 type CekCarryingM term uni =
-    ReaderT (CekEnv uni) (ExceptT (CekEvaluationExceptionCarrying term) (State ExBudgetState))
+    ReaderT (CekEnv uni)
+        (ExceptT (CekEvaluationExceptionCarrying term)
+            (State CekExBudgetState))
 
 -- | The CEK machine-specific 'EvaluationException'.
 type CekEvaluationException uni = CekEvaluationExceptionCarrying (Plain Term uni)
 
 -- | The monad the CEK machine runs in.
 type CekM uni = CekCarryingM (Plain Term uni) uni
+data ExBudgetCategory
+    = BTyInst
+    | BApply
+    | BIWrap
+    | BUnwrap
+    | BVar
+    | BBuiltin BuiltinName
+    | BAST
+    deriving stock (Show, Eq, Generic)
+    deriving anyclass NFData
+instance Hashable ExBudgetCategory
+instance (PrettyBy config) ExBudgetCategory where
+    prettyBy _ = viaShow
+
+type CekExBudgetState = ExBudgetState ExBudgetCategory
+type CekExTally       = ExTally       ExBudgetCategory
 
 instance Pretty CekUserError where
     pretty (CekOutOfExError (ExRestrictingBudget res) b) =
@@ -248,7 +271,10 @@ instance ToExMemory (CekValue uni) where
         VIWrap ex _ _ _ -> ex
         VBuiltin ex _ _ _ _ _ _ -> ex
 
-instance ToExMemory term => SpendBudget (CekCarryingM term uni) term where
+instance ExBudgetBuiltin ExBudgetCategory where
+    exBudgetBuiltin = BBuiltin
+
+instance ToExMemory term => SpendBudget (CekCarryingM term uni) ExBudgetCategory term where
     builtinCostParams = asks cekEnvBuiltinCostParams
     spendBudget key budget = do
         modifying exBudgetStateTally
@@ -276,9 +302,9 @@ type Context uni = [Frame uni]
 runCekM
     :: forall a uni
      . CekEnv uni
-    -> ExBudgetState
+    -> CekExBudgetState
     -> CekM uni a
-    -> (Either (CekEvaluationException uni) a, ExBudgetState)
+    -> (Either (CekEvaluationException uni) a, CekExBudgetState)
 runCekM env s a = runState (runExceptT $ runReaderT a env) s
 
 -- | Extend an environment with a variable name, the value the variable stands for
@@ -512,7 +538,7 @@ runCek
     -> ExBudgetMode
     -> CostModel
     -> Plain Term uni
-    -> (Either (CekEvaluationException uni) (Plain Term uni), ExBudgetState)
+    -> (Either (CekEvaluationException uni) (Plain Term uni), CekExBudgetState)
 runCek means mode params term =
     runCekM (CekEnv means mode params)
             (ExBudgetState mempty mempty)
@@ -528,7 +554,7 @@ runCekCounting
     => DynamicBuiltinNameMeanings (CekValue uni)
     -> CostModel
     -> Plain Term uni
-    -> (Either (CekEvaluationException uni) (Plain Term uni), ExBudgetState)
+    -> (Either (CekEvaluationException uni) (Plain Term uni), CekExBudgetState)
 runCekCounting means = runCek means Counting
 
 -- | Evaluate a term using the CEK machine.

--- a/plutus-core/src/Language/PlutusCore/Evaluation/Machine/Ck.hs
+++ b/plutus-core/src/Language/PlutusCore/Evaluation/Machine/Ck.hs
@@ -120,7 +120,7 @@ to look up a free variable in an environment: there's no CkValue for
 Var, so we can't report which variable caused the error.
 -}
 
-instance SpendBudget (CkM uni) (CkValue uni) where
+instance SpendBudget (CkM uni) () (CkValue uni) where
     builtinCostParams = pure defaultCostModel
     spendBudget _key _budget = pure ()
 

--- a/plutus-core/test/Evaluation/ApplyBuiltinName.hs
+++ b/plutus-core/test/Evaluation/ApplyBuiltinName.hs
@@ -38,7 +38,7 @@ type TestEvaluationException uni =
 
 type TestM uni = Either (TestEvaluationException uni)
 
-instance SpendBudget (TestM uni) (Term TyName Name uni ()) where
+instance SpendBudget (TestM uni) () (Term TyName Name uni ()) where
     builtinCostParams = pure defaultCostModel
     spendBudget _key _budget = pure ()
 

--- a/plutus-core/untyped-plutus-core-test/Evaluation/ApplyBuiltinName.hs
+++ b/plutus-core/untyped-plutus-core-test/Evaluation/ApplyBuiltinName.hs
@@ -45,7 +45,7 @@ newtype AppM a = AppM
     { unAppM :: Either AppErr a
     } deriving newtype (Functor, Applicative, Monad, MonadError AppErr)
 
-instance SpendBudget AppM (Term Name DefaultUni ()) where
+instance SpendBudget AppM () (Term Name DefaultUni ()) where
     spendBudget _ _ = pure ()
     builtinCostParams = pure defaultCostModel
 

--- a/plutus-tx-plugin/test/TH/Spec.hs
+++ b/plutus-tx-plugin/test/TH/Spec.hs
@@ -54,7 +54,7 @@ runPlcCek values = do
      let p = foldl1 applyProgram ps
      either (throwError . SomeException) Haskell.pure $ evaluateCek p
 
-runPlcCekTrace :: GetProgram a PLC.DefaultUni => [a] -> ExceptT SomeException IO ([String], ExTally, (Plain Term PLC.DefaultUni))
+runPlcCekTrace :: GetProgram a PLC.DefaultUni => [a] -> ExceptT SomeException IO ([String], CekExTally, (Plain Term PLC.DefaultUni))
 runPlcCekTrace values = do
      ps <- Haskell.traverse getProgram values
      let p = foldl1 applyProgram ps

--- a/plutus-tx/src/Language/PlutusTx/Evaluation.hs
+++ b/plutus-tx/src/Language/PlutusTx/Evaluation.hs
@@ -8,7 +8,7 @@ module Language.PlutusTx.Evaluation
     , evaluateCekTrace
     , ErrorWithCause(..)
     , EvaluationError(..)
-    , ExTally
+    , CekExTally
     , CekEvaluationException
     , Plain
     )
@@ -58,7 +58,7 @@ unsafeEvaluateCek = PLC.unsafeEvaluateCek stringBuiltins PLC.defaultCostModel . 
 evaluateCekTrace
     :: (GShow uni, GEq uni, DefaultUni <: uni, Closed uni, uni `Everywhere` ExMemoryUsage)
     => Program TyName Name uni ()
-    -> ([String], ExTally, Either (CekEvaluationException uni) (Plain Term uni))
+    -> ([String], CekExTally, Either (CekEvaluationException uni) (Plain Term uni))
 evaluateCekTrace p =
     let
         (lg, (res, state)) = unsafePerformIO $ withEmit $ \emit -> do


### PR DESCRIPTION
Now instead of having a hardcoded `ExBudgetCategory` we parameterize `SpendBudget` by an `exBudgetCategory` as per discussion in slack.