### PR TITLE
Move static files to S3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -259,15 +259,9 @@ in rec {
       };
   });
 
-  terraform-vars = pkgs.writeTextFile {
-    name ="terraform-vars"; 
-    destination = "/generated.tf.json"; 
-    text = (builtins.toJSON {
-      locals = {
-        marlowe_client = ''${marlowe-playground.client}'';
-      };
-    });
-  };
+  marlowe-symbolic-lambda = pkgsMusl.callPackage ./marlowe-symbolic/lambda.nix { haskellPackages = haskell.muslPackages; };
+
+  deployment = pkgs.callPackage ./deployment { inherit marlowe-playground marlowe-symbolic-lambda; };
 
   inherit (haskell.packages.plutus-scb.components.exes) plutus-game plutus-currency;
 
@@ -368,8 +362,6 @@ in rec {
         ];
       }) // { version = haskellNixAgda.identifier.version; };
     in pkgs.callPackage ./nix/agda/default.nix { Agda = frankenAgda; };
-
-  marlowe-symbolic-lambda = pkgsMusl.callPackage ./marlowe-symbolic/lambda.nix { haskellPackages = haskell.muslPackages; };
 
   dev = import ./nix/dev.nix { inherit pkgs haskell easyPS; };
 }

--- a/default.nix
+++ b/default.nix
@@ -259,6 +259,16 @@ in rec {
       };
   });
 
+  terraform-vars = pkgs.writeTextFile {
+    name ="terraform-vars"; 
+    destination = "/generated.tf.json"; 
+    text = (builtins.toJSON {
+      locals = {
+        marlowe_client = ''${marlowe-playground.client}'';
+      };
+    });
+  };
+
   inherit (haskell.packages.plutus-scb.components.exes) plutus-game plutus-currency;
 
   plutus-scb = pkgs.recurseIntoAttrs (rec {

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,6 +1,36 @@
 # Plutus and Marlowe Playgrounds Infrastructure
 
-The infrastructure is comprised of 2 parts, terraform and nixops:
+## New infrastructure
+
+We are currently in the process of migrating to a new infrastructure, at the moment this is just for the marlowe playground but the intention is to move the plutus playground soon after. The new infrastructure aims to do the following:
+
+1. Remove the need for managing servers
+2. Make setup and configuration easy by using nix to generate scripts to do everything
+3. Make scaling easier and quicker
+4. Cut costs
+
+A website is served from AWS API Gateway which will proxy to the following parts:
+
+* static data is stored in S3
+* anything that can be run in a lambda is
+* other things (currently web-ghc) are run elsewhere (currently on the old server infrastructure)
+
+### Getting Started
+
+If you are using OSX then you cannot build the lambdas locally, therefore if you want to update the infrastructure you will need to build the lambdas on a linux machine and then copy them to a location on your machine. Then you can set the env var `export TF_VAR_symbolic_lambda_file=/path/to/marlowe-symbolic.zip`.
+
+If you have not setup AWS authentication but you have enabled MFA then you can run `$(nix-build -A deployment.david.getCreds)` before you run any other command to setup temporary credentials that are valid for 24 hours.
+
+The infrastructure is based around multiple environments, for example `alpha`, `david` etc. Scripts exist for updating a particular environment under the `deployment` attribute, e.g. the main deployment script for the environment `david` can be run with `$(nix-build -A deployment.david.deploy)`. This will run other scripts that will do everything needed. These other scripts can be run individually, which can be useful if you are playing around with the infrastructure.
+
+* `deployment.env.runTerraform` will run only the terraform apply command
+* `deployment.env.syncS3` will sync the marlowe client static code with S3
+* `deployment.env.terraform-locals` will produce `generated.tf.json` which contains locals such as `env`
+* `deployment.env.terraform-vars` will produce `env.tfvars` which contains variables such as `symbolic_lambda_file` if you are not on OSX
+
+## Legacy Infrastructure
+
+The legacy infrastructure is comprised of 2 parts, terraform and nixops:
 
 ## Terraform
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -19,7 +19,7 @@ A website is served from AWS API Gateway which will proxy to the following parts
 
 If you are using OSX then you cannot build the lambdas locally, therefore if you want to update the infrastructure you will need to build the lambdas on a linux machine and then copy them to a location on your machine. Then you can set the env var `export TF_VAR_symbolic_lambda_file=/path/to/marlowe-symbolic.zip`.
 
-If you have not setup AWS authentication but you have enabled MFA then you can run `$(nix-build -A deployment.david.getCreds)` before you run any other command to setup temporary credentials that are valid for 24 hours.
+If you have not setup AWS authentication but you have enabled MFA then you can run `$(nix-build -A deployment.david.getCreds) user.name 123456` (where 123456 is the current MFA code) before you run any other command to setup temporary credentials that are valid for 24 hours.
 
 The scripts produce files for use with nixops (until we get rid of the legacy infra) and so you should provide the location where you want these files to go by setting another terraform variable, e.g. `export TF_VAR_nixops_root=$(pwd)/deployment/nixops`.
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -21,6 +21,8 @@ If you are using OSX then you cannot build the lambdas locally, therefore if you
 
 If you have not setup AWS authentication but you have enabled MFA then you can run `$(nix-build -A deployment.david.getCreds)` before you run any other command to setup temporary credentials that are valid for 24 hours.
 
+The scripts produce files for use with nixops (until we get rid of the legacy infra) and so you should provide the location where you want these files to go by setting another terraform variable, e.g. `export TF_VAR_nixops_root=$(pwd)/deployment/nixops`.
+
 The infrastructure is based around multiple environments, for example `alpha`, `david` etc. Scripts exist for updating a particular environment under the `deployment` attribute, e.g. the main deployment script for the environment `david` can be run with `$(nix-build -A deployment.david.deploy)`. This will run other scripts that will do everything needed. These other scripts can be run individually, which can be useful if you are playing around with the infrastructure.
 
 * `deployment.env.runTerraform` will run only the terraform apply command

--- a/deployment/default.nix
+++ b/deployment/default.nix
@@ -1,0 +1,73 @@
+{ pkgs, marlowe-playground, marlowe-symbolic-lambda }:
+with pkgs;
+let
+  # 20.03 version of terraform is broken on some versions of OSX so I have copied the last 0_12 version from nixpkgs
+  terraform = (callPackage ./terraform.nix { }).terraform_0_12;
+
+  getCreds = pkgs.writeShellScript "getcreds" ''
+    export AWS_PROFILE=dev-mantis
+    unset AWS_SESSION_TOKEN
+    unset AWS_SECRET_ACCESS_KEY
+    unset AWS_ACCESS_KEY_ID
+
+    ${awscli}/bin/aws sts get-session-token --serial-number arn:aws:iam::454236594309:mfa/david.smith --output text --duration-seconds 86400 --token-code $1 \
+            | awk '{printf("export AWS_ACCESS_KEY_ID=\"%s\"\nexport AWS_SECRET_ACCESS_KEY=\"%s\"\nexport AWS_SESSION_TOKEN=\"%s\"\n",$2,$4,$5)}'
+      '';
+
+  terraform-locals = env:
+    writeTextFile {
+      name = "terraform-locals";
+      destination = "/generated.tf.json";
+      text = (builtins.toJSON {
+        locals = {
+          env = "${env}";
+          marlowe_client = "${marlowe-playground.client}";
+        };
+      });
+    };
+
+  terraform-vars = env:
+    writeTextFile {
+      name = "terraform-vars";
+      destination = "/${env}.tfvars";
+      text = if pkgs.stdenv.isDarwin then
+        ""
+      else
+        ''
+          symbolic_lambda_file="${marlowe-symbolic-lambda}/marlowe-symbolic.zip"'';
+    };
+
+  runTerraform = env:
+    writeShellScript "terraform" ''
+      tmp_dir=$(mktemp -d)
+      ln -s ${./terraform}/* $tmp_dir
+      ln -s ${terraform-locals env}/* $tmp_dir
+      ln -s ${terraform-vars env}/* $tmp_dir
+      cd $tmp_dir
+      ${terraform}/bin/terraform init
+      ${terraform}/bin/terraform workspace select ${env}
+      ${terraform}/bin/terraform apply -var-file=${env}.tfvars
+    '';
+
+  syncS3 = env:
+    writeShellScript "syncs3"
+    "${awscli}/bin/aws s3 sync ${marlowe-playground.client} s3://marlowe-playground-website/${env}";
+
+  deploy = env:
+    writeShellScript "deploy" ''
+      echo "apply terraform"
+      ${runTerraform env} -auto-approve
+      echo "sync with S3"
+      ${syncS3 env}
+      echo "done"
+    '';
+
+  mkEnv = env: {
+    inherit getCreds terraform-vars terraform-locals terraform;
+    syncS3 = (syncS3 env);
+    runTerraform = (runTerraform env);
+    deploy = (deploy env);
+  };
+
+  envs = { david = mkEnv "david"; };
+in envs

--- a/deployment/default.nix
+++ b/deployment/default.nix
@@ -5,7 +5,7 @@ let
   terraform = (callPackage ./terraform.nix { }).terraform_0_12;
 
   getCreds = pkgs.writeShellScript "getcreds" ''
-    if [[ $1 == "" || $2 == "" ]]; then
+    if [[ $# -ne 2 ]]; then
       echo "Please call the script with your AWS account username followed by the MFA code"
       exit 1
     fi

--- a/deployment/provider-path.patch
+++ b/deployment/provider-path.patch
@@ -1,0 +1,16 @@
+diff --git a/command/init.go b/command/init.go
+index 403ca245b..05d98329a 100644
+--- a/command/init.go
++++ b/command/init.go
+@@ -64,6 +64,11 @@ func (c *InitCommand) Run(args []string) int {
+ 		return 1
+ 	}
+ 
++	val, ok := os.LookupEnv("NIX_TERRAFORM_PLUGIN_DIR")
++	if ok {
++		flagPluginPath = append(flagPluginPath, val)
++	}
++
+ 	if len(flagPluginPath) > 0 {
+ 		c.pluginPath = flagPluginPath
+ 		c.getPlugins = false

--- a/deployment/terraform.nix
+++ b/deployment/terraform.nix
@@ -1,0 +1,161 @@
+{ stdenv, lib, buildEnv, buildGoPackage, fetchFromGitHub, makeWrapper, coreutils
+, runCommand, writeText, terraform-providers, fetchpatch }:
+
+let
+  goPackagePath = "github.com/hashicorp/terraform";
+
+  generic = { version, sha256, ... }@attrs:
+    let attrs' = builtins.removeAttrs attrs [ "version" "sha256" ];
+    in buildGoPackage ({
+      name = "terraform-${version}";
+
+      inherit goPackagePath;
+
+      src = fetchFromGitHub {
+        owner = "hashicorp";
+        repo = "terraform";
+        rev = "v${version}";
+        inherit sha256;
+      };
+
+      postPatch = ''
+        # speakeasy hardcodes /bin/stty https://github.com/bgentry/speakeasy/issues/22
+        substituteInPlace vendor/github.com/bgentry/speakeasy/speakeasy_unix.go \
+          --replace "/bin/stty" "${coreutils}/bin/stty"
+      '';
+
+      postInstall = ''
+        # remove all plugins, they are part of the main binary now
+        for i in $out/bin/*; do
+          if [[ $(basename $i) != terraform ]]; then
+            rm "$i"
+          fi
+        done
+      '';
+
+      preCheck = ''
+        export HOME=$TMP
+      '';
+
+      meta = with stdenv.lib; {
+        description =
+          "Tool for building, changing, and versioning infrastructure";
+        homepage = "https://www.terraform.io/";
+        license = licenses.mpl20;
+        maintainers = with maintainers; [
+          zimbatm
+          peterhoeg
+          kalbasit
+          marsam
+          babariviere
+          Chili-Man
+        ];
+      };
+    } // attrs');
+
+  pluggable = terraform:
+    let
+      withPlugins = plugins:
+        let
+          actualPlugins = plugins terraform.plugins;
+
+          # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
+          wrapperInputs = lib.unique (lib.flatten
+            (lib.catAttrs "propagatedBuildInputs"
+              (builtins.filter (x: x != null) actualPlugins)));
+
+          passthru = {
+            withPlugins = newplugins:
+              withPlugins (x: newplugins x ++ actualPlugins);
+            full = withPlugins lib.attrValues;
+
+            # Ouch
+            overrideDerivation = f:
+              (pluggable (terraform.overrideDerivation f)).withPlugins plugins;
+            overrideAttrs = f:
+              (pluggable (terraform.overrideAttrs f)).withPlugins plugins;
+            override = x:
+              (pluggable (terraform.override x)).withPlugins plugins;
+          };
+          # Don't bother wrapping unless we actually have plugins, since the wrapper will stop automatic downloading
+          # of plugins, which might be counterintuitive if someone just wants a vanilla Terraform.
+        in if actualPlugins == [ ] then
+          terraform.overrideAttrs
+          (orig: { passthru = orig.passthru // passthru; })
+        else
+          lib.appendToName "with-plugins" (stdenv.mkDerivation {
+            inherit (terraform) name;
+            buildInputs = [ makeWrapper ];
+
+            buildCommand = ''
+              mkdir -p $out/bin/
+              makeWrapper "${terraform}/bin/terraform" "$out/bin/terraform" \
+                --set NIX_TERRAFORM_PLUGIN_DIR "${
+                  buildEnv {
+                    name = "tf-plugin-env";
+                    paths = actualPlugins;
+                  }
+                }/bin" \
+                --prefix PATH : "${lib.makeBinPath wrapperInputs}"
+            '';
+
+            inherit passthru;
+          });
+    in withPlugins (_: [ ]);
+
+  plugins = removeAttrs terraform-providers [
+    "override"
+    "overrideDerivation"
+    "recurseForDerivations"
+  ];
+in rec {
+  terraform_0_11 = pluggable (generic {
+    version = "0.11.14";
+    sha256 = "1bzz5wy13gh8j47mxxp6ij6yh20xmxd9n5lidaln3mf1bil19dmc";
+    patches = [ ./provider-path.patch ];
+    passthru = { inherit plugins; };
+  });
+
+  terraform_0_11-full = terraform_0_11.full;
+
+  terraform_0_12 = pluggable (generic {
+    version = "0.12.29";
+    sha256 = "18i7vkvnvfybwzhww8d84cyh93xfbwswcnwfrgvcny1qwm8rsaj8";
+    patches = [
+        ./provider-path.patch
+        (fetchpatch {
+            name = "fix-mac-mojave-crashes.patch";
+            url = "https://github.com/hashicorp/terraform/commit/cd65b28da051174a13ac76e54b7bb95d3051255c.patch";
+            sha256 = "1k70kk4hli72x8gza6fy3vpckdm3sf881w61fmssrah3hgmfmbrs";
+        }) ];
+    passthru = { inherit plugins; };
+  });
+
+  terraform_0_13 = pluggable (generic {
+    version = "0.13.0-rc1";
+    sha256 = "1lja2s9viz5ja40qmlf49p6hk3rwdz6q0rw3ff1894b464zbsnk2";
+    patches = [ ./provider-path.patch ];
+    passthru = { inherit plugins; };
+  });
+
+  # Tests that the plugins are being used. Terraform looks at the specific
+  # file pattern and if the plugin is not found it will try to download it
+  # from the Internet. With sandboxing enable this test will fail if that is
+  # the case.
+  terraform_plugins_test = let
+    mainTf = writeText "main.tf" ''
+      resource "random_id" "test" {}
+    '';
+    terraform = terraform_0_11.withPlugins (p: [ p.random ]);
+    test =
+      runCommand "terraform-plugin-test" { buildInputs = [ terraform ]; } ''
+        set -e
+        # make it fail outside of sandbox
+        export HTTP_PROXY=http://127.0.0.1:0 HTTPS_PROXY=https://127.0.0.1:0
+        cp ${mainTf} main.tf
+        terraform init
+        touch $out
+      '';
+  in test;
+
+}

--- a/deployment/terraform/gateway.tf
+++ b/deployment/terraform/gateway.tf
@@ -1,0 +1,114 @@
+## API Gateway
+
+resource "aws_api_gateway_rest_api" "marlowe_symbolic_lambda" {
+  name        = "marlowe_symbolic_lambda_${var.env}"
+  description = "API Gateway for the Marlowe Symbolic Lambda"
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
+resource "aws_api_gateway_resource" "marlowe_symbolic_proxy" {
+  rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  parent_id   = aws_api_gateway_rest_api.marlowe_symbolic_lambda.root_resource_id
+  path_part   = "marlowe-analysis"
+}
+
+resource "aws_api_gateway_method" "marlowe_symbolic_proxy" {
+  rest_api_id   = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id   = aws_api_gateway_resource.marlowe_symbolic_proxy.id
+  http_method   = "POST"
+  authorization = "NONE"
+  api_key_required = false
+}
+
+resource "aws_api_gateway_integration" "marlowe_symbolic_lambda" {
+  rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id = aws_api_gateway_method.marlowe_symbolic_proxy.resource_id
+  http_method = aws_api_gateway_method.marlowe_symbolic_proxy.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS"
+  uri                     = aws_lambda_function.marlowe_symbolic.invoke_arn
+
+  request_parameters = {
+  }
+}
+
+resource "aws_api_gateway_method_response" "marlowe_symbolic_lambda" {
+  rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id = aws_api_gateway_resource.marlowe_symbolic_proxy.id
+  http_method = aws_api_gateway_method.marlowe_symbolic_proxy.http_method
+  status_code = "200"
+}
+
+resource "aws_api_gateway_integration_response" "marlowe_symbolic_lambda" {
+  rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id = aws_api_gateway_resource.marlowe_symbolic_proxy.id
+  http_method = aws_api_gateway_method.marlowe_symbolic_proxy.http_method
+  status_code = aws_api_gateway_method_response.marlowe_symbolic_lambda.status_code
+}
+
+resource "aws_api_gateway_deployment" "marlowe_symbolic_lambda" {
+  depends_on = [
+    aws_api_gateway_integration.marlowe_symbolic_lambda,
+  ]
+
+  rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  stage_name  = "${var.env}"
+}
+
+resource "aws_lambda_permission" "marlowe_symbolic_lambda_api_gw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.marlowe_symbolic.function_name
+  principal     = "apigateway.amazonaws.com"
+
+  # The "/*/*" portion grants access from any method on any resource
+  # within the API Gateway REST API.
+  source_arn = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.execution_arn}/*/*"
+}
+
+resource "aws_api_gateway_usage_plan" "marlowe_symbolic_lambda" {
+  name = "marlowe_symbolic_lambda_${var.env}"
+
+  api_stages {
+    api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+    stage  = aws_api_gateway_deployment.marlowe_symbolic_lambda.stage_name
+  }
+
+  quota_settings {
+    limit  = 86400
+    offset = 0
+    period = "DAY"
+  }
+}
+
+resource "aws_api_gateway_domain_name" "marlowe_symbolic_lambda" {
+  # AWS certificate wildcards can only have one level so we cannot use lambda.alpha.marlowe.iohk.io
+  # we must use lambda-alpha.marlowe.iohk.io instead
+  domain_name = "lambda-${local.marlowe_domain_name}"
+
+  regional_certificate_arn   = "${data.aws_acm_certificate.marlowe_private.arn}"
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
+resource "aws_api_gateway_base_path_mapping" "marlowe_symbolic_lambda" {
+  # The path, if not specified, is `/` by default
+  api_id      = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.id}"
+  stage_name  = "${aws_api_gateway_deployment.marlowe_symbolic_lambda.stage_name}"
+  domain_name = "${aws_api_gateway_domain_name.marlowe_symbolic_lambda.domain_name}"
+}
+
+resource "aws_route53_record" "lambda" {
+  name    = "lambda-${local.marlowe_domain_name}"
+  type    = "A"
+  zone_id = "${var.marlowe_public_zone}"
+  alias {
+    name                   = "${aws_api_gateway_domain_name.marlowe_symbolic_lambda.regional_domain_name}"
+    zone_id                = "${aws_api_gateway_domain_name.marlowe_symbolic_lambda.regional_zone_id}"
+    evaluate_target_health = true
+  }
+}

--- a/deployment/terraform/gateway.tf
+++ b/deployment/terraform/gateway.tf
@@ -55,7 +55,7 @@ resource "aws_api_gateway_deployment" "marlowe_symbolic_lambda" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
-  stage_name  = "${var.env}"
+  stage_name  = var.env
 }
 
 resource "aws_lambda_permission" "marlowe_symbolic_lambda_api_gw" {

--- a/deployment/terraform/gateway.tf
+++ b/deployment/terraform/gateway.tf
@@ -6,6 +6,7 @@ resource "aws_api_gateway_rest_api" "marlowe_symbolic_lambda" {
   endpoint_configuration {
     types = ["REGIONAL"]
   }
+  binary_media_types = ["image/x-icon", "font/woff2", "font/ttf"]
 }
 
 resource "aws_api_gateway_resource" "marlowe_symbolic_proxy" {
@@ -111,4 +112,12 @@ resource "aws_route53_record" "lambda" {
     zone_id                = "${aws_api_gateway_domain_name.marlowe_symbolic_lambda.regional_zone_id}"
     evaluate_target_health = true
   }
+}
+
+output "rest_api_id" {
+  value = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.id}"
+}
+
+output "region" {
+  value = "${var.aws_region}"
 }

--- a/deployment/terraform/loadbalancing.tf
+++ b/deployment/terraform/loadbalancing.tf
@@ -32,10 +32,10 @@ resource "aws_security_group" "public_alb" {
     from_port   = "${local.nixops_nginx_port}"
     to_port     = "${local.nixops_nginx_port}"
     protocol    = "TCP"
-    cidr_blocks = ["${var.private_subnet_cidrs}"]
+    cidr_blocks = var.private_subnet_cidrs
   }
 
-  tags {
+  tags = {
     Name        = "${var.project}_${var.env}_public_alb"
     Project     = "${var.project}"
     Environment = "${var.env}"
@@ -61,10 +61,11 @@ data "aws_acm_certificate" "monitoring_private" {
 }
 
 resource "aws_alb" "plutus" {
-  subnets = ["${aws_subnet.public.*.id}"]
+  subnets         = aws_subnet.public.*.id
   security_groups = ["${aws_security_group.public_alb.id}"]
   internal        = false
-  tags {
+
+  tags = {
     Name        = "${var.project}_${var.env}_public_alb"
     Project     = "${var.project}"
     Environment = "${var.env}"
@@ -92,6 +93,7 @@ resource "aws_alb_listener" "playground" {
   port              = "443"
   protocol          = "HTTPS"
   certificate_arn   = "${data.aws_acm_certificate.plutus_private.arn}"
+
   default_action {
     target_group_arn = "${aws_alb_target_group.playground.arn}"
     type             = "forward"
@@ -114,27 +116,33 @@ resource "aws_alb_target_group" "playground" {
   port     = "80"
   protocol = "HTTP"
   vpc_id   = "${aws_vpc.plutus.id}"
-  health_check = {
+
+  health_check {
     path = "/api/health"
+
     # The playground health check is currently a bit slow since it compiles some contracts
     timeout = 20
   }
-  stickiness = {
+
+  stickiness {
     type = "lb_cookie"
   }
 }
 
 resource "aws_alb_listener_rule" "playground" {
-  depends_on   = ["aws_alb_target_group.playground"]
+  depends_on   = [aws_alb_target_group.playground]
   listener_arn = "${aws_alb_listener.playground.arn}"
   priority     = 100
+
   action {
     type             = "forward"
     target_group_arn = "${aws_alb_target_group.playground.id}"
   }
+
   condition {
-    field  = "host-header"
-    values = ["${local.plutus_domain_name}"]
+    host_header {
+      values = ["${local.plutus_domain_name}"]
+    }
   }
 }
 
@@ -143,6 +151,7 @@ resource "aws_alb_target_group_attachment" "playground_a" {
   target_id        = "${aws_instance.playground_a.id}"
   port             = "80"
 }
+
 resource "aws_alb_target_group_attachment" "playground_b" {
   target_group_arn = "${aws_alb_target_group.playground.arn}"
   target_id        = "${aws_instance.playground_b.id}"
@@ -153,6 +162,7 @@ resource "aws_route53_record" "playground_alb" {
   zone_id = "${var.plutus_public_zone}"
   name    = "${local.plutus_domain_name}"
   type    = "A"
+
   alias {
     name                   = "${aws_alb.plutus.dns_name}"
     zone_id                = "${aws_alb.plutus.zone_id}"
@@ -166,10 +176,12 @@ resource "aws_alb_target_group" "marlowe" {
   port     = "80"
   protocol = "HTTP"
   vpc_id   = "${aws_vpc.plutus.id}"
-  health_check = {
+
+  health_check {
     path = "/api/health"
   }
-  stickiness = {
+
+  stickiness {
     type = "lb_cookie"
   }
 }
@@ -178,13 +190,16 @@ resource "aws_alb_listener_rule" "marlowe" {
   depends_on   = ["aws_alb_target_group.marlowe"]
   listener_arn = "${aws_alb_listener.playground.arn}"
   priority     = 122
+
   action {
     type             = "forward"
     target_group_arn = "${aws_alb_target_group.marlowe.id}"
   }
+
   condition {
-    field  = "host-header"
-    values = ["${local.marlowe_domain_name}"]
+    host_header {
+      values = ["${local.marlowe_domain_name}"]
+    }
   }
 }
 
@@ -193,6 +208,7 @@ resource "aws_alb_target_group_attachment" "marlowe_a" {
   target_id        = "${aws_instance.marlowe_a.id}"
   port             = "80"
 }
+
 resource "aws_alb_target_group_attachment" "marlowe_b" {
   target_group_arn = "${aws_alb_target_group.marlowe.arn}"
   target_id        = "${aws_instance.marlowe_b.id}"
@@ -205,10 +221,12 @@ resource "aws_alb_target_group" "marlowe_a" {
   port     = "80"
   protocol = "HTTP"
   vpc_id   = "${aws_vpc.plutus.id}"
-  health_check = {
+
+  health_check {
     path = "/api/health"
   }
-  stickiness = {
+
+  stickiness {
     type = "lb_cookie"
   }
 }
@@ -217,17 +235,22 @@ resource "aws_alb_listener_rule" "marlowe_a" {
   depends_on   = ["aws_alb_target_group.marlowe_a"]
   listener_arn = "${aws_alb_listener.playground.arn}"
   priority     = 111
+
   action {
     type             = "forward"
     target_group_arn = "${aws_alb_target_group.marlowe_a.id}"
   }
+
   condition {
-    field  = "host-header"
-    values = ["${local.marlowe_domain_name}"]
+    host_header {
+      values = ["${local.marlowe_domain_name}"]
+    }
   }
+
   condition {
-    field  = "path-pattern"
-    values = ["/machine-a/*"]
+    path_pattern {
+      values = ["/machine-a/*"]
+    }
   }
 }
 
@@ -243,10 +266,12 @@ resource "aws_alb_target_group" "marlowe_b" {
   port     = "80"
   protocol = "HTTP"
   vpc_id   = "${aws_vpc.plutus.id}"
-  health_check = {
+
+  health_check {
     path = "/api/health"
   }
-  stickiness = {
+
+  stickiness {
     type = "lb_cookie"
   }
 }
@@ -255,17 +280,22 @@ resource "aws_alb_listener_rule" "marlowe_b" {
   depends_on   = ["aws_alb_target_group.marlowe_b"]
   listener_arn = "${aws_alb_listener.playground.arn}"
   priority     = 112
+
   action {
     type             = "forward"
     target_group_arn = "${aws_alb_target_group.marlowe_b.id}"
   }
+
   condition {
-    field  = "host-header"
-    values = ["${local.marlowe_domain_name}"]
+    host_header {
+      values = ["${local.marlowe_domain_name}"]
+    }
   }
+
   condition {
-    field  = "path-pattern"
-    values = ["/machine-b/*"]
+    path_pattern {
+      values = ["/machine-b/*"]
+    }
   }
 }
 
@@ -281,10 +311,12 @@ resource "aws_alb_target_group" "webghc" {
   port     = "80"
   protocol = "HTTP"
   vpc_id   = "${aws_vpc.plutus.id}"
-  health_check = {
+
+  health_check {
     path = "/health"
   }
-  stickiness = {
+
+  stickiness {
     type = "lb_cookie"
   }
 }
@@ -293,13 +325,16 @@ resource "aws_alb_listener_rule" "webghc" {
   depends_on   = ["aws_alb_target_group.webghc"]
   listener_arn = "${aws_alb_listener.playground.arn}"
   priority     = 113
+
   action {
     type             = "forward"
     target_group_arn = "${aws_alb_target_group.webghc.id}"
   }
+
   condition {
-    field  = "path-pattern"
-    values = ["/runghc"]
+    path_pattern {
+      values = ["/runghc"]
+    }
   }
 }
 
@@ -315,12 +350,12 @@ resource "aws_alb_target_group_attachment" "webghc_b" {
   port             = "80"
 }
 
-
 ## Route 53 for Marlowe
 resource "aws_route53_record" "marlowe_alb" {
   zone_id = "${var.marlowe_public_zone}"
   name    = "${local.marlowe_domain_name}"
   type    = "A"
+
   alias {
     name                   = "${aws_alb.plutus.dns_name}"
     zone_id                = "${aws_alb.plutus.zone_id}"
@@ -334,10 +369,12 @@ resource "aws_alb_target_group" "monitoring" {
   port     = "80"
   protocol = "HTTP"
   vpc_id   = "${aws_vpc.plutus.id}"
-  health_check = {
+
+  health_check {
     path = "/metrics"
   }
-  stickiness = {
+
+  stickiness {
     type = "lb_cookie"
   }
 }
@@ -346,13 +383,16 @@ resource "aws_alb_listener_rule" "monitoring" {
   depends_on   = ["aws_alb_target_group.monitoring"]
   listener_arn = "${aws_alb_listener.playground.arn}"
   priority     = 103
+
   action {
     type             = "forward"
     target_group_arn = "${aws_alb_target_group.monitoring.id}"
   }
+
   condition {
-    field  = "host-header"
-    values = ["${local.monitoring_domain_name}"]
+    host_header {
+      values = ["${local.monitoring_domain_name}"]
+    }
   }
 }
 
@@ -366,6 +406,7 @@ resource "aws_route53_record" "monitoring_alb" {
   zone_id = "${var.monitoring_public_zone}"
   name    = "${local.monitoring_domain_name}"
   type    = "A"
+
   alias {
     name                   = "${aws_alb.plutus.dns_name}"
     zone_id                = "${aws_alb.plutus.zone_id}"

--- a/deployment/terraform/machines.tf
+++ b/deployment/terraform/machines.tf
@@ -2,7 +2,7 @@ data "template_file" "playground_ssh_keys" {
   template = "$${ssh_key}"
   count    = "${length(var.playground_ssh_keys["${var.env}"])}"
 
-  vars {
+  vars = {
     ssh_key = "${var.ssh_keys["${element(var.playground_ssh_keys["${var.env}"], count.index)}"]}"
   }
 }

--- a/deployment/terraform/machines.tf
+++ b/deployment/terraform/machines.tf
@@ -81,10 +81,10 @@ locals {
 
 resource "local_file" "bastion_machines" {
   content  = "${jsonencode(local.bastionMachines)}"
-  filename = "${var.nixops_root}/bastion_machines.json"
+  filename = "${pathexpand(var.nixops_root)}/bastion_machines.json"
 }
 
 resource "local_file" "machines" {
   content  = "${jsonencode(local.machines)}"
-  filename = "${var.nixops_root}/machines.json"
+  filename = "${pathexpand(var.nixops_root)}/machines.json"
 }

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.11.0"
+  required_version = "~> 0.12.20"
 
   backend "s3" {
     bucket = "plutus-playground-tf"
@@ -11,6 +11,6 @@ terraform {
 
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "~> 2.0.0"
+  version = "~> 3.0"
   profile = "plutus-playground"
 }

--- a/deployment/terraform/marlowe-symbolic-lambda.tf
+++ b/deployment/terraform/marlowe-symbolic-lambda.tf
@@ -15,7 +15,7 @@ resource "aws_security_group" "marlowe_symbolic_lambda" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["${var.private_subnet_cidrs}"]
+    cidr_blocks = var.private_subnet_cidrs
   }
 
   tags = {
@@ -60,7 +60,7 @@ resource "aws_lambda_function" "marlowe_symbolic" {
   # The lambda zip needs to be built and placed on your local filesystem
   # TODO: This is only a temporary requirement and will be moved to the CD server soon
   filename = "${var.lambda_filename}"
-  source_code_hash = "${base64sha256(file(var.lambda_filename))}"
+  source_code_hash = filebase64sha256(var.lambda_filename)
   
   memory_size = 3008
   timeout = 120
@@ -71,121 +71,5 @@ resource "aws_lambda_function" "marlowe_symbolic" {
       SBV_Z3 = "z3"
       PATH = "/usr/local/bin:/usr/bin/:/bin:/opt/bin:."
     }
-  }
-}
-
-
-## API Gateway
-
-resource "aws_api_gateway_rest_api" "marlowe_symbolic_lambda" {
-  name        = "marlowe_symbolic_lambda_${var.env}"
-  description = "API Gateway for the Marlowe Symbolic Lambda"
-  endpoint_configuration {
-    types = ["REGIONAL"]
-  }
-}
-
-resource "aws_api_gateway_resource" "marlowe_symbolic_proxy" {
-  rest_api_id = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.id}"
-  parent_id   = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.root_resource_id}"
-  path_part   = "marlowe-analysis"
-}
-
-resource "aws_api_gateway_method" "marlowe_symbolic_proxy" {
-  rest_api_id   = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.id}"
-  resource_id   = "${aws_api_gateway_resource.marlowe_symbolic_proxy.id}"
-  http_method   = "POST"
-  authorization = "NONE"
-  api_key_required = false
-}
-
-resource "aws_api_gateway_integration" "marlowe_symbolic_lambda" {
-  rest_api_id = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.id}"
-  resource_id = "${aws_api_gateway_method.marlowe_symbolic_proxy.resource_id}"
-  http_method = "${aws_api_gateway_method.marlowe_symbolic_proxy.http_method}"
-
-  integration_http_method = "POST"
-  type                    = "AWS"
-  uri                     = "${aws_lambda_function.marlowe_symbolic.invoke_arn}"
-
-  request_parameters = {
-  }
-}
-
-resource "aws_api_gateway_method_response" "marlowe_symbolic_lambda" {
-  rest_api_id = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.id}"
-  resource_id = "${aws_api_gateway_resource.marlowe_symbolic_proxy.id}"
-  http_method = "${aws_api_gateway_method.marlowe_symbolic_proxy.http_method}"
-  status_code = "200"
-}
-
-resource "aws_api_gateway_integration_response" "marlowe_symbolic_lambda" {
-  rest_api_id = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.id}"
-  resource_id = "${aws_api_gateway_resource.marlowe_symbolic_proxy.id}"
-  http_method = "${aws_api_gateway_method.marlowe_symbolic_proxy.http_method}"
-  status_code = "${aws_api_gateway_method_response.marlowe_symbolic_lambda.status_code}"
-}
-
-resource "aws_api_gateway_deployment" "marlowe_symbolic_lambda" {
-  depends_on = [
-    "aws_api_gateway_integration.marlowe_symbolic_lambda",
-  ]
-
-  rest_api_id = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.id}"
-  stage_name  = "${var.env}"
-}
-
-resource "aws_lambda_permission" "marlowe_symbolic_lambda_api_gw" {
-  statement_id  = "AllowAPIGatewayInvoke"
-  action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.marlowe_symbolic.function_name}"
-  principal     = "apigateway.amazonaws.com"
-
-  # The "/*/*" portion grants access from any method on any resource
-  # within the API Gateway REST API.
-  source_arn = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.execution_arn}/*/*"
-}
-
-resource "aws_api_gateway_usage_plan" "marlowe_symbolic_lambda" {
-  name = "marlowe_symbolic_lambda_${var.env}"
-
-  api_stages {
-    api_id = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.id}"
-    stage  = "${aws_api_gateway_deployment.marlowe_symbolic_lambda.stage_name}"
-  }
-
-  quota_settings {
-    limit  = 86400
-    offset = 0
-    period = "DAY"
-  }
-}
-
-resource "aws_api_gateway_domain_name" "marlowe_symbolic_lambda" {
-  # AWS certificate wildcards can only have one level so we cannot use lambda.alpha.marlowe.iohk.io
-  # we must use lambda-alpha.marlowe.iohk.io instead
-  domain_name = "lambda-${local.marlowe_domain_name}"
-
-  regional_certificate_arn   = "${data.aws_acm_certificate.marlowe_private.arn}"
-  endpoint_configuration {
-    types = ["REGIONAL"]
-  }
-}
-
-resource "aws_api_gateway_base_path_mapping" "marlowe_symbolic_lambda" {
-  # The path, if not specified, is `/` by default
-  api_id      = "${aws_api_gateway_rest_api.marlowe_symbolic_lambda.id}"
-  stage_name  = "${aws_api_gateway_deployment.marlowe_symbolic_lambda.stage_name}"
-  domain_name = "${aws_api_gateway_domain_name.marlowe_symbolic_lambda.domain_name}"
-}
-
-resource "aws_route53_record" "lambda" {
-  name    = "lambda-${local.marlowe_domain_name}"
-  type    = "A"
-  zone_id = "${var.marlowe_public_zone}"
-  alias {
-    name                   = "${aws_api_gateway_domain_name.marlowe_symbolic_lambda.regional_domain_name}"
-    zone_id                = "${aws_api_gateway_domain_name.marlowe_symbolic_lambda.regional_zone_id}"
-    evaluate_target_health = true
   }
 }

--- a/deployment/terraform/marlowe-symbolic-lambda.tf
+++ b/deployment/terraform/marlowe-symbolic-lambda.tf
@@ -59,8 +59,8 @@ resource "aws_lambda_function" "marlowe_symbolic" {
 
   # The lambda zip needs to be built and placed on your local filesystem
   # TODO: This is only a temporary requirement and will be moved to the CD server soon
-  filename = "${var.lambda_filename}"
-  source_code_hash = filebase64sha256(var.lambda_filename)
+  filename = "${var.symbolic_lambda_file}"
+  source_code_hash = filebase64sha256(var.symbolic_lambda_file)
   
   memory_size = 3008
   timeout = 120

--- a/deployment/terraform/marlowe.tf
+++ b/deployment/terraform/marlowe.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "marlowe" {
     from_port   = 22
     to_port     = 22
     protocol    = "TCP"
-    cidr_blocks = ["${var.public_subnet_cidrs}", "${var.private_subnet_cidrs}"]
+    cidr_blocks = concat(var.public_subnet_cidrs, var.private_subnet_cidrs)
   }
 
   ## inbound (world): http
@@ -16,28 +16,28 @@ resource "aws_security_group" "marlowe" {
     from_port   = 80
     to_port     = 80
     protocol    = "TCP"
-    cidr_blocks = ["${var.public_subnet_cidrs}", "${var.private_subnet_cidrs}"]
+    cidr_blocks = concat(var.public_subnet_cidrs, var.private_subnet_cidrs)
   }
 
   ingress {
     from_port   = 9100
     to_port     = 9100
     protocol    = "TCP"
-    cidr_blocks = ["${var.private_subnet_cidrs}"]
+    cidr_blocks = var.private_subnet_cidrs
   }
 
   ingress {
     from_port   = 9091
     to_port     = 9091
     protocol    = "TCP"
-    cidr_blocks = ["${var.private_subnet_cidrs}"]
+    cidr_blocks = var.private_subnet_cidrs
   }
 
   ingress {
     from_port   = 9113
     to_port     = 9113
     protocol    = "TCP"
-    cidr_blocks = ["${var.private_subnet_cidrs}"]
+    cidr_blocks = var.private_subnet_cidrs
   }
 
   ## outgoing: all
@@ -58,7 +58,7 @@ resource "aws_security_group" "marlowe" {
 data "template_file" "marlowe_user_data" {
   template = "${file("${path.module}/templates/default_configuration.nix")}"
 
-  vars {
+  vars = {
     root_ssh_keys      = "${join(" ", formatlist("\"%s\"", data.template_file.nixops_ssh_keys.*.rendered))}"
   }
 }
@@ -74,11 +74,11 @@ resource "aws_instance" "marlowe_a" {
     "${aws_security_group.marlowe.id}",
   ]
 
-  root_block_device = {
+  root_block_device {
     volume_size = "20"
   }
 
-  tags {
+  tags = {
     Name        = "${var.project}_${var.env}_marlowe_a"
     Project     = "${var.project}"
     Environment = "${var.env}"
@@ -104,11 +104,11 @@ resource "aws_instance" "marlowe_b" {
     "${aws_security_group.marlowe.id}",
   ]
 
-  root_block_device = {
+  root_block_device {
     volume_size = "20"
   }
 
-  tags {
+  tags = {
     Name        = "${var.project}_${var.env}_marlowe_b"
     Project     = "${var.project}"
     Environment = "${var.env}"

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -247,5 +247,5 @@ locals {
 
 resource "local_file" "network" {
   content  = "${jsonencode(local.network)}"
-  filename = "${var.nixops_root}/network.json"
+  filename = "${pathexpand(var.nixops_root)}/network.json"
 }

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -132,7 +132,7 @@ data "template_file" "bastion_ssh_keys" {
   template = "$${ssh_key}"
   count    = "${length(var.bastion_ssh_keys["${var.env}"])}"
 
-  vars {
+  vars = {
     ssh_key = "${var.ssh_keys["${element(var.bastion_ssh_keys["${var.env}"], count.index)}"]}"
   }
 }
@@ -160,7 +160,7 @@ resource "aws_instance" "bastion" {
 
   subnet_id = "${aws_subnet.public.*.id[count.index]}"
 
-  root_block_device = {
+  root_block_device {
     volume_size = 20
   }
 
@@ -196,7 +196,7 @@ resource "aws_security_group" "bastion" {
     from_port   = 5601
     to_port     = 5601
     protocol    = "TCP"
-    cidr_blocks = ["${var.zerotier_subnet_cidrs}"]
+    cidr_blocks = var.zerotier_subnet_cidrs
   }
 
   ## inbound riemann websocket
@@ -204,7 +204,7 @@ resource "aws_security_group" "bastion" {
     from_port   = 5556
     to_port     = 5556
     protocol    = "TCP"
-    cidr_blocks = ["${var.zerotier_subnet_cidrs}"]
+    cidr_blocks = var.zerotier_subnet_cidrs
   }
 
   ## inbound riemann dash
@@ -212,7 +212,7 @@ resource "aws_security_group" "bastion" {
     from_port   = 4567
     to_port     = 4567
     protocol    = "TCP"
-    cidr_blocks = ["${var.zerotier_subnet_cidrs}"]
+    cidr_blocks = var.zerotier_subnet_cidrs
   }
 
   ## inbound zerotier
@@ -220,7 +220,7 @@ resource "aws_security_group" "bastion" {
     from_port   = 0
     to_port     = 0
     protocol    = "UDP"
-    cidr_blocks = ["${var.zerotier_subnet_cidrs}"]
+    cidr_blocks = var.zerotier_subnet_cidrs
   }
 
   ## zerotier must use some custom protocol, TCP + UDP doesn't work
@@ -236,7 +236,7 @@ resource "aws_security_group" "bastion" {
     from_port   = 22
     to_port     = 22
     protocol    = "TCP"
-    cidr_blocks = ["${var.private_subnet_cidrs}"]
+    cidr_blocks = var.private_subnet_cidrs
   }
 
   # Allow internet access to install things, we could maybe lock this down to nixpkgs somehow
@@ -264,7 +264,7 @@ resource "aws_security_group" "bastion" {
 }
 
 resource "aws_route53_zone" "plutus_private_zone" {
-  vpc = {
+  vpc {
     vpc_id = "${aws_vpc.plutus.id}"
   }
   name   = "internal.${var.env}.${var.plutus_tld}"

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -55,7 +55,7 @@ resource "aws_route" "zerotier" {
 # Elastic IPs
 resource "aws_eip" "nat" {
   vpc        = true
-  depends_on = ["aws_internet_gateway.plutus"]
+  depends_on = [aws_internet_gateway.plutus]
   count      = "${length(var.azs)}"
 
   tags = {
@@ -70,7 +70,7 @@ resource "aws_nat_gateway" "plutus" {
   count         = "${length(var.azs)}"
   allocation_id = "${aws_eip.nat.*.id[count.index]}"
   subnet_id     = "${aws_subnet.public.*.id[count.index]}"
-  depends_on    = ["aws_internet_gateway.plutus"]
+  depends_on    = [aws_internet_gateway.plutus]
 
   tags = {
     Name        = "${var.project}_${var.env}_${var.azs[count.index]}"

--- a/deployment/terraform/nixops.tf
+++ b/deployment/terraform/nixops.tf
@@ -19,14 +19,14 @@ resource "aws_security_group" "nixops" {
     from_port   = 22
     to_port     = 22
     protocol    = "TCP"
-    cidr_blocks = ["${var.public_subnet_cidrs}"]
+    cidr_blocks = var.public_subnet_cidrs
   }
 
   ingress {
     from_port   = "${local.nixops_nginx_port}"
     to_port     = "${local.nixops_nginx_port}"
     protocol    = "TCP"
-    cidr_blocks = ["${var.public_subnet_cidrs}", "${var.private_subnet_cidrs}"]
+    cidr_blocks = concat(var.public_subnet_cidrs, var.private_subnet_cidrs)
   }
 
   ## outgoing: all
@@ -48,7 +48,7 @@ data "template_file" "nixops_ssh_keys" {
   template = "$${ssh_key}"
   count    = "${length(var.nixops_ssh_keys["${var.env}"])}"
 
-  vars {
+  vars = {
     ssh_key = "${var.ssh_keys["${element(var.nixops_ssh_keys["${var.env}"], count.index)}"]}"
   }
 }
@@ -71,7 +71,7 @@ resource "aws_instance" "nixops" {
     "${aws_security_group.nixops.id}",
   ]
 
-  root_block_device = {
+  root_block_device {
     volume_size = 100
   }
 

--- a/deployment/terraform/plutus.tf
+++ b/deployment/terraform/plutus.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "playground" {
     from_port   = 22
     to_port     = 22
     protocol    = "TCP"
-    cidr_blocks = ["${var.public_subnet_cidrs}", "${var.private_subnet_cidrs}"]
+    cidr_blocks = concat(var.public_subnet_cidrs, var.private_subnet_cidrs)
   }
 
   ## inbound (world): http
@@ -15,35 +15,35 @@ resource "aws_security_group" "playground" {
     from_port   = 9100
     to_port     = 9100
     protocol    = "TCP"
-    cidr_blocks = ["${var.private_subnet_cidrs}"]
+    cidr_blocks = var.private_subnet_cidrs
   }
 
   ingress {
     from_port   = 9091
     to_port     = 9091
     protocol    = "TCP"
-    cidr_blocks = ["${var.private_subnet_cidrs}"]
+    cidr_blocks = var.private_subnet_cidrs
   }
 
   ingress {
     from_port   = 9113
     to_port     = 9113
     protocol    = "TCP"
-    cidr_blocks = ["${var.private_subnet_cidrs}"]
+    cidr_blocks = var.private_subnet_cidrs
   }
 
   ingress {
     from_port   = 80
     to_port     = 80
     protocol    = "TCP"
-    cidr_blocks = ["${var.public_subnet_cidrs}", "${var.private_subnet_cidrs}"]
+    cidr_blocks = concat(var.public_subnet_cidrs, var.private_subnet_cidrs)
   }
 
   ingress {
     from_port   = 8080
     to_port     = 8080
     protocol    = "TCP"
-    cidr_blocks = ["${var.private_subnet_cidrs}"]
+    cidr_blocks = var.private_subnet_cidrs
   }
 
   ## outgoing: all
@@ -64,7 +64,7 @@ resource "aws_security_group" "playground" {
 data "template_file" "playground_user_data" {
   template = "${file("${path.module}/templates/default_configuration.nix")}"
 
-  vars {
+  vars = {
     root_ssh_keys      = "${join(" ", formatlist("\"%s\"", data.template_file.nixops_ssh_keys.*.rendered))}"
   }
 }
@@ -81,11 +81,11 @@ resource "aws_instance" "playground_a" {
     "${aws_security_group.playground.id}",
   ]
 
-  root_block_device = {
+  root_block_device {
     volume_size = "40"
   }
 
-  tags {
+  tags = {
     Name        = "${var.project}_${var.env}_playground_a"
     Project     = "${var.project}"
     Environment = "${var.env}"
@@ -112,11 +112,11 @@ resource "aws_instance" "playground_b" {
     "${aws_security_group.playground.id}",
   ]
 
-  root_block_device = {
+  root_block_device {
     volume_size = "40"
   }
 
-  tags {
+  tags = {
     Name        = "${var.project}_${var.env}_playground_b"
     Project     = "${var.project}"
     Environment = "${var.env}"

--- a/deployment/terraform/ssh_config.tf
+++ b/deployment/terraform/ssh_config.tf
@@ -1,7 +1,7 @@
 data "template_file" "ssh_config_section_nixops" {
   template = "${file("${path.module}/templates/ssh-config")}"
 
-  vars {
+  vars = {
     full_hostname    = "nixops.${aws_route53_zone.plutus_private_zone.name}"
     short_hostname   = "nixops.${var.project}"
     ip               = "${aws_instance.nixops.private_ip}"
@@ -13,7 +13,7 @@ data "template_file" "ssh_config_section_nixops" {
 data "template_file" "ssh_config_section_playground_a" {
   template = "${file("${path.module}/templates/ssh-config")}"
 
-  vars {
+  vars = {
     full_hostname    = "playground-a.${aws_route53_zone.plutus_private_zone.name}"
     short_hostname   = "playground-a.${var.project}"
     ip               = "${aws_instance.playground_a.private_ip}"
@@ -25,7 +25,7 @@ data "template_file" "ssh_config_section_playground_a" {
 data "template_file" "ssh_config_section_playground_b" {
   template = "${file("${path.module}/templates/ssh-config")}"
 
-  vars {
+  vars = {
     full_hostname    = "playground-b.${aws_route53_zone.plutus_private_zone.name}"
     short_hostname   = "playground-b.${var.project}"
     ip               = "${aws_instance.playground_b.private_ip}"
@@ -37,7 +37,7 @@ data "template_file" "ssh_config_section_playground_b" {
 data "template_file" "ssh_config_section_marlowe_a" {
   template = "${file("${path.module}/templates/ssh-config")}"
 
-  vars {
+  vars = {
     full_hostname    = "marlowe-a.${aws_route53_zone.plutus_private_zone.name}"
     short_hostname   = "marlowe-a.${var.project}"
     ip               = "${aws_instance.marlowe_a.private_ip}"
@@ -49,7 +49,7 @@ data "template_file" "ssh_config_section_marlowe_a" {
 data "template_file" "ssh_config_section_marlowe_b" {
   template = "${file("${path.module}/templates/ssh-config")}"
 
-  vars {
+  vars = {
     full_hostname    = "marlowe-b.${aws_route53_zone.plutus_private_zone.name}"
     short_hostname   = "marlowe-b.${var.project}"
     ip               = "${aws_instance.marlowe_b.private_ip}"
@@ -61,7 +61,7 @@ data "template_file" "ssh_config_section_marlowe_b" {
 data "template_file" "ssh_config_section_webghc_a" {
   template = "${file("${path.module}/templates/ssh-config")}"
 
-  vars {
+  vars = {
     full_hostname    = "webghc-a.${aws_route53_zone.plutus_private_zone.name}"
     short_hostname   = "webghc-a.${var.project}"
     ip               = "${aws_instance.webghc_a.private_ip}"
@@ -73,7 +73,7 @@ data "template_file" "ssh_config_section_webghc_a" {
 data "template_file" "ssh_config_section_webghc_b" {
   template = "${file("${path.module}/templates/ssh-config")}"
 
-  vars {
+  vars = {
     full_hostname    = "webghc-b.${aws_route53_zone.plutus_private_zone.name}"
     short_hostname   = "webghc-b.${var.project}"
     ip               = "${aws_instance.webghc_b.private_ip}"
@@ -85,7 +85,7 @@ data "template_file" "ssh_config_section_webghc_b" {
 data "template_file" "ssh_config" {
   template = "\n$${nixops_node}\n$${playground_a}\n$${playground_b}\n$${marlowe_a}\n$${marlowe_b}\n$${webghc_a}\n$${webghc_b}"
 
-  vars {
+  vars = {
     nixops_node      = "${data.template_file.ssh_config_section_nixops.rendered}"
     playground_a     = "${data.template_file.ssh_config_section_playground_a.rendered}"
     playground_b     = "${data.template_file.ssh_config_section_playground_b.rendered}"

--- a/deployment/terraform/ssh_config.tf
+++ b/deployment/terraform/ssh_config.tf
@@ -98,5 +98,5 @@ data "template_file" "ssh_config" {
 
 resource "local_file" "ssh_config" {
   content  = "${data.template_file.ssh_config.rendered}"
-  filename = "${var.ssh_config_root}/config.d/${var.project}.conf"
+  filename = "${pathexpand(var.ssh_config_root)}/config.d/${var.project}.conf"
 }

--- a/deployment/terraform/static.tf
+++ b/deployment/terraform/static.tf
@@ -53,6 +53,56 @@ resource "aws_iam_role" "s3_proxy_role" {
 EOF
 }
 
+# Root path
+resource "aws_api_gateway_method" "marlowe_root_get_method" {
+  rest_api_id      = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id      = aws_api_gateway_rest_api.marlowe_symbolic_lambda.root_resource_id
+  http_method      = "GET"
+  authorization    = "NONE"
+  api_key_required = false
+}
+
+resource "aws_api_gateway_integration" "marlowe_root_get_method" {
+  rest_api_id      = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id      = aws_api_gateway_rest_api.marlowe_symbolic_lambda.root_resource_id
+  http_method      = aws_api_gateway_method.marlowe_root_get_method.http_method
+
+  type                    = "AWS"
+  integration_http_method = "GET"
+  credentials             = "${aws_iam_role.s3_proxy_role.arn}"
+  uri                     = "arn:aws:apigateway:${var.aws_region}:s3:path/marlowe-playground-website/${var.env}/index.html"
+}
+
+resource "aws_api_gateway_method_response" "marlowe_root_get_method" {
+  rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id      = aws_api_gateway_rest_api.marlowe_symbolic_lambda.root_resource_id
+  http_method = aws_api_gateway_method.marlowe_root_get_method.http_method
+  status_code = "200"
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
+    "method.response.header.Access-Control-Allow-Origin"  = true
+    "method.response.header.Content-Type" = true
+  }
+
+  depends_on = [aws_api_gateway_method.marlowe_root_get_method]
+}
+
+resource "aws_api_gateway_integration_response" "marlowe_root_get_method" {
+  rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.root_resource_id
+  http_method = aws_api_gateway_method.marlowe_root_get_method.http_method
+
+  status_code = aws_api_gateway_method_response.marlowe_root_get_method.status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Origin" = "'*'"
+    "method.response.header.Content-Type" = "integration.response.header.Content-Type"
+  }
+}
+
+# Other static files
 resource "aws_api_gateway_resource" "website_item_resource" {
   rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
   parent_id   = aws_api_gateway_rest_api.marlowe_symbolic_lambda.root_resource_id
@@ -79,7 +129,7 @@ resource "aws_api_gateway_integration" "marlowe_item_get_method" {
   type                    = "AWS"
   integration_http_method = "GET"
   credentials             = "${aws_iam_role.s3_proxy_role.arn}"
-  uri                     = "arn:aws:apigateway:${var.aws_region}:s3:path/marlowe-playground-website/{item}"
+  uri                     = "arn:aws:apigateway:${var.aws_region}:s3:path/marlowe-playground-website/${var.env}/{item}"
 
   request_parameters = {
     "integration.request.path.item"   = "method.request.path.item"
@@ -114,12 +164,3 @@ resource "aws_api_gateway_integration_response" "marlowe_item_get_method" {
     "method.response.header.Content-Type" = "integration.response.header.Content-Type"
   }
 }
-
-
-
-
-
-
-
-
-

--- a/deployment/terraform/static.tf
+++ b/deployment/terraform/static.tf
@@ -3,7 +3,6 @@
 resource "aws_s3_bucket" "marlowe_playground" {
   bucket = "marlowe-playground-website"
   acl    = "public-read"
-  # policy = file("policy.json")
 
   website {
     index_document = "index.html"
@@ -54,15 +53,6 @@ resource "aws_iam_role" "s3_proxy_role" {
 EOF
 }
 
-# resource "aws_s3_bucket_object" "marlowe_playground" {
-#   for_each = fileset(local.marlowe_client, "*")
-#   bucket = "marlowe-playground-website"
-#   key = each.value
-#   source = "${local.marlowe_client}/${each.value}"
-#   etag   = filemd5("${local.marlowe_client}/${each.value}")
-#   depends_on   = [aws_s3_bucket.marlowe_playground]
-# }
-
 resource "aws_api_gateway_resource" "website_item_resource" {
   rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
   parent_id   = aws_api_gateway_rest_api.marlowe_symbolic_lambda.root_resource_id
@@ -102,10 +92,6 @@ resource "aws_api_gateway_method_response" "marlowe_item_get_method" {
   http_method = aws_api_gateway_method.marlowe_item_get_method.http_method
   status_code = "200"
 
-  response_models = {
-    # "application/json" = "Empty"
-  }
-
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = true
     "method.response.header.Access-Control-Allow-Methods" = true
@@ -122,10 +108,6 @@ resource "aws_api_gateway_integration_response" "marlowe_item_get_method" {
   http_method = aws_api_gateway_method.marlowe_item_get_method.http_method
 
   status_code = aws_api_gateway_method_response.marlowe_item_get_method.status_code
-
-  response_templates = {
-    # "application/json" = ""
-  }
 
   response_parameters = {
     "method.response.header.Access-Control-Allow-Origin" = "'*'"

--- a/deployment/terraform/static.tf
+++ b/deployment/terraform/static.tf
@@ -1,0 +1,143 @@
+# Static website
+
+resource "aws_s3_bucket" "marlowe_playground" {
+  bucket = "marlowe-playground-website"
+  acl    = "public-read"
+  # policy = file("policy.json")
+
+  website {
+    index_document = "index.html"
+    error_document = "error.html"
+  }
+}
+
+resource "aws_s3_bucket_policy" "marlowe_playground_website" {
+  bucket = aws_s3_bucket.marlowe_playground.id
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "PublicReadGetObject",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::marlowe-playground-website/*"
+            ]
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role" "s3_proxy_role" {
+  name               = "marlowe_website_s3_${var.env}"
+  path               = "/"  
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "apigateway.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+# resource "aws_s3_bucket_object" "marlowe_playground" {
+#   for_each = fileset(local.marlowe_client, "*")
+#   bucket = "marlowe-playground-website"
+#   key = each.value
+#   source = "${local.marlowe_client}/${each.value}"
+#   etag   = filemd5("${local.marlowe_client}/${each.value}")
+#   depends_on   = [aws_s3_bucket.marlowe_playground]
+# }
+
+resource "aws_api_gateway_resource" "website_item_resource" {
+  rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  parent_id   = aws_api_gateway_rest_api.marlowe_symbolic_lambda.root_resource_id
+  path_part   = "{item}"
+}
+
+resource "aws_api_gateway_method" "marlowe_item_get_method" {
+  rest_api_id      = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id      = aws_api_gateway_resource.website_item_resource.id
+  http_method      = "GET"
+  authorization    = "NONE"
+  api_key_required = false
+
+  request_parameters = {
+    "method.request.path.item"   = true
+  }
+}
+
+resource "aws_api_gateway_integration" "marlowe_item_get_method" {
+  rest_api_id      = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id      = aws_api_gateway_resource.website_item_resource.id
+  http_method = aws_api_gateway_method.marlowe_item_get_method.http_method
+
+  type                    = "AWS"
+  integration_http_method = "GET"
+  credentials             = "${aws_iam_role.s3_proxy_role.arn}"
+  uri                     = "arn:aws:apigateway:${var.aws_region}:s3:path/marlowe-playground-website/{item}"
+
+  request_parameters = {
+    "integration.request.path.item"   = "method.request.path.item"
+  }
+}
+
+resource "aws_api_gateway_method_response" "marlowe_item_get_method" {
+  rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id = aws_api_gateway_resource.website_item_resource.id
+  http_method = aws_api_gateway_method.marlowe_item_get_method.http_method
+  status_code = "200"
+
+  response_models = {
+    # "application/json" = "Empty"
+  }
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
+    "method.response.header.Access-Control-Allow-Origin"  = true
+    "method.response.header.Content-Type" = true
+  }
+
+  depends_on = [aws_api_gateway_method.marlowe_item_get_method]
+}
+
+resource "aws_api_gateway_integration_response" "marlowe_item_get_method" {
+  rest_api_id = aws_api_gateway_rest_api.marlowe_symbolic_lambda.id
+  resource_id = aws_api_gateway_resource.website_item_resource.id
+  http_method = aws_api_gateway_method.marlowe_item_get_method.http_method
+
+  status_code = aws_api_gateway_method_response.marlowe_item_get_method.status_code
+
+  response_templates = {
+    # "application/json" = ""
+  }
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Origin" = "'*'"
+    "method.response.header.Content-Type" = "integration.response.header.Content-Type"
+  }
+}
+
+
+
+
+
+
+
+
+

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -64,7 +64,7 @@ variable "nixops_instance_type" {
   default = "t2.large"
 }
 variable "bastion_ssh_keys" {
-  default {
+  default = {
     alpha = ["david", "pablo"]
     patrick = ["david", "kris"]
     david   = ["david"]
@@ -77,7 +77,7 @@ variable "bastion_ssh_keys" {
 }
 
 variable "nixops_ssh_keys" {
-  default {
+  default = {
     alpha = ["david", "pablo"]
     patrick = ["david", "kris"]
     david   = ["david"]
@@ -90,7 +90,7 @@ variable "nixops_ssh_keys" {
 }
 
 variable "playground_ssh_keys" {
-  default {
+  default = {
     alpha = ["david", "pablo"]
     patrick = ["david", "kris"]
     david   = ["david"]
@@ -144,7 +144,7 @@ variable "aws_amis" {
   }
 }
 
-variable "20_03_amis" {
+variable "amis_20_03" {
   default = {
     "ap-east-1" = "ami-0d18fdd309cdefa86"
     "ap-northeast-1" = "ami-093d9cc49c191eb6c"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -8,9 +8,13 @@ variable "project" {
 
 variable "env" {}
 
-variable "nixops_root" {}
+variable "nixops_root" {
+  default = "../nixops"
+}
 
-variable "ssh_config_root" {}
+variable "ssh_config_root" {
+  default = "~/.ssh"
+}
 
 variable "plutus_tld" {
   default = "plutus.iohkdev.io"
@@ -170,11 +174,5 @@ variable "azs" {
   default = ["a", "b"]
 }
 
-variable "zerotier_network_id" {}
-
-variable "zerotier_subnet_cidrs" {
-  default = []
-}
-
-variable "lambda_filename" {
+variable "symbolic_lambda_file" {
 }

--- a/marlowe-playground-client/src/Simulation.purs
+++ b/marlowe-playground-client/src/Simulation.purs
@@ -242,6 +242,7 @@ handleAction settings AnalyseContract = do
       response <- checkContractForWarnings (encodeJSON contract) (encodeJSON currState)
       assign _analysisState (WarningAnalysis response)
   where
+  -- FIXME: now we need to get the client to post to lambda-env.marlowe.iohkdev.io
   checkContractForWarnings contract state = runAjax $ (flip runReaderT) settings (Server.postAnalyse (API.CheckForWarnings (encodeJSON false) contract state))
 
 handleAction settings AnalyseReachabilityContract = do

--- a/marlowe-playground-client/static/error.html
+++ b/marlowe-playground-client/static/error.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Marlowe Playground</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+<body>
+    <h1>There's a problem with the playground, please try to refresh in a few minutes </h1>
+</body>
+</html>

--- a/shell.nix
+++ b/shell.nix
@@ -27,7 +27,7 @@ in haskell.packages.shellFor {
     agdaWithStdlib
 
     # Deployment tools
-    pkgs.terraform_0_11
+    pkgs.terraform_0_12
     pkgs.awscli
     pkgs.aws_shell
 


### PR DESCRIPTION
This PR is part of the ongoing process of upgrading the infrastructure. In this PR we:

* upgrade terraform
* wrap up terraform deployment in scripts that are built with nix
* copy marlowe playground static files to S3
* serve the lambda and static files over api gateway

Currently none of the S3 stuff is used but it can be accessed, e.g. https://lambda-david.marlowe.iohkdev.io/#/simulation. Next we need to proxy the marlowe-playground-server and web-ghc through the api gateway so that everything can be accessed through API gateway. Once this is done we can change the frontend client to use the API gateway directly instead of the ALB.