### PR TITLE
PAB: Shell scripts for a demo environment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -274,7 +274,11 @@ in rec {
     inherit marlowe-playground plutus-playground marlowe-symbolic-lambda marlowe-playground-lambda plutus-playground-lambda; 
   };
 
-  inherit (haskell.packages.plutus-scb.components.exes) plutus-game plutus-currency;
+  inherit (haskell.packages.plutus-scb.components.exes)
+    plutus-game
+    plutus-currency
+    plutus-atomic-swap
+    plutus-pay-to-wallet;
 
   plutus-scb = pkgs.recurseIntoAttrs (rec {
     server-invoker = set-git-rev haskell.packages.plutus-scb.components.exes.plutus-scb;
@@ -300,6 +304,8 @@ in rec {
         name = (pkgs.lib.importJSON packageJSON).name;
         checkPhase = ''node -e 'require("./output/Test.Main").main()' '';
       };
+      demo-scripts = (dbPath: pkgs.callPackage ./pab-demo-scripts.nix { inherit pkgs dbPath plutus-scb; scb-exes = haskell.packages.plutus-scb.components.exes; });
+            
   });
 
   docker = rec {

--- a/pab-demo-scripts.nix
+++ b/pab-demo-scripts.nix
@@ -1,0 +1,139 @@
+########################################################################
+# pab-demo-scripts.nix -- Build two shell scripts that start
+# up a PAB demo environment.
+#
+# * 'start-all-servers.sh' starts the mock node and an instance of the
+#   PAB
+# * 'start-second-scb.sh' starts another instance of the PAB, connecting
+#   to the same mock node. The two instances don't share any services,
+#   so they communicate only through the blockchain.
+#
+# The scripts install a number of sample contracts, so the PAB is
+# ready to use right away.
+#
+#
+########################################################################
+
+{ pkgs
+, plutus-scb
+, scb-exes # The haskell.nix "exes" component with the sample contracts
+, dbPath # Temporary location where the SQLite databases can be placed. This has to be outside the nix store.
+}:
+    let 
+      inherit (scb-exes)
+          plutus-game
+          plutus-currency
+          plutus-atomic-swap
+          plutus-pay-to-wallet;
+      dbFile = name: "${dbPath}/${name}.db";
+      mkconf = conf: pkgs.writeTextFile {
+        name = "${conf.configname}.yaml";
+        text = ''
+        dbConfig:
+            dbConfigFile: ${dbFile conf.configname}
+            dbConfigPoolSize: 20
+
+        scbWebserverConfig:
+          baseUrl: http://localhost:${conf.webserver-port}
+          staticDir: ${plutus-scb.client}
+
+        walletServerConfig:
+          baseUrl: http://localhost:${conf.walletserver-port}
+          wallet: 
+            getWallet: ${conf.wallet}
+
+        nodeServerConfig:
+          mscBaseUrl: http://localhost:${conf.nodeserver-port}
+          mscSocketPath: ./node-server.sock
+          mscSlotLength: 5
+          mscRandomTxInterval: 20000000
+          mscBlockReaper:
+            brcInterval: 6000000
+            brcBlocksToKeep: 100000
+          mscInitialTxWallets:
+            - getWallet: 1
+            - getWallet: 2
+            - getWallet: 3
+
+        chainIndexConfig:
+          ciBaseUrl: http://localhost:${conf.chain-index-port}
+
+        requestProcessingConfig:
+          requestProcessingInterval: 1
+
+        signingProcessConfig:
+          spBaseUrl: http://localhost:${conf.signing-process-port}
+          spWallet: 
+            getWallet: ${conf.wallet}
+        
+        metadataServerConfig:
+          mdBaseUrl: http://localhost:${conf.metadata-server-port}
+
+        '';
+      };
+      node-port = "8082"; # mock node, needs to be the same for all PABs
+      scb = "${scb-exes.plutus-scb}/bin/plutus-scb";
+
+      primary = {
+        configname = "demo-primary";
+        webserver-port = "8080";
+        walletserver-port = "8081";
+        nodeserver-port = "${node-port}";
+        chain-index-port = "8083";
+        signing-process-port = "8084";
+        metadata-server-port = "8085";
+        wallet = "1";
+      };
+
+      secondary = { 
+        configname = "demo-secondary";
+        webserver-port = "8086";
+        walletserver-port = "8087";
+        nodeserver-port = "${node-port}"; 
+        chain-index-port = "8088";
+        signing-process-port = "8089";
+        metadata-server-port = "8090";
+        wallet = "2";
+        };
+
+      config-primary = mkconf primary;
+      config-secondary = mkconf secondary;
+
+      start-all-servers = pkgs.writeTextFile {
+          name = "start-all-servers.sh";
+          text = ''
+          rm -f ${dbFile primary.configname}
+          ${scb} --config=${config-primary} migrate
+          ${scb} --config=${config-primary} contracts install --path ${plutus-currency}/bin/plutus-currency
+          ${scb} --config=${config-primary} contracts install --path ${plutus-atomic-swap}/bin/plutus-atomic-swap
+          ${scb} --config=${config-primary} contracts install --path ${plutus-game}/bin/plutus-game
+          ${scb} --config=${config-primary} contracts install --path ${plutus-pay-to-wallet}/bin/plutus-pay-to-wallet
+          ${scb} --config=${config-primary} all-servers
+          '';
+          executable = true;
+        };
+
+      start-second-scb = pkgs.writeTextFile {
+          name = "start-second-scb.sh";
+          text = ''
+          rm -f ${dbFile secondary.configname}
+          ${scb} --config=${config-secondary} migrate
+          ${scb} --config=${config-secondary} contracts install --path ${plutus-currency}/bin/plutus-currency
+          ${scb} --config=${config-secondary} contracts install --path ${plutus-atomic-swap}/bin/plutus-atomic-swap
+          ${scb} --config=${config-secondary} contracts install --path ${plutus-game}/bin/plutus-game
+          ${scb} --config=${config-secondary} contracts install --path ${plutus-pay-to-wallet}/bin/plutus-pay-to-wallet
+          ${scb} --config=${config-secondary} client-services 
+          '';
+          executable = true;
+        };
+
+  in pkgs.stdenv.mkDerivation {
+    name = "plutus-scb-demo";
+    phases = "installPhase";
+    installPhase = ''
+      mkdir -p $out
+      cd $out
+      ln --symbolic ${start-all-servers} start-all-servers.sh
+      ln --symbolic ${start-second-scb} start-second-scb.sh
+    '';
+  }

--- a/plutus-scb/app/Main.hs
+++ b/plutus-scb/app/Main.hs
@@ -160,6 +160,7 @@ commandParser =
     mconcat
         [ migrationParser
         , allServersParser
+        , clientServicesParser
         , mockWalletParser
         , scbWebserverParser
         , psGeneratorCommandParser
@@ -257,6 +258,21 @@ allServersParser =
                   , ProcessAllContractOutboxes
                   ]))
         (fullDesc <> progDesc "Run all the mock servers needed.")
+
+clientServicesParser :: Mod CommandFields Command
+clientServicesParser =
+    command "client-services" $
+    info
+        (pure
+             (ForkCommands
+                  [ ChainIndex
+                  , Metadata
+                  , MockWallet
+                  , SCBWebserver
+                  , SigningProcess
+                  , ProcessAllContractOutboxes
+                  ]))
+        (fullDesc <> progDesc "Run the client services (all services except the mock node).")
 
 signingProcessParser :: Mod CommandFields Command
 signingProcessParser =


### PR DESCRIPTION
* `start-all-servers.sh` runs the PAB with all servers incl. mock node
* `start-second-scb.sh` runs a second instance of the PAB that connects
  to the same mock node as the first one (so they see the same blockchain)
* Both instances have a couple of demo contracts pre-installed.

Fixes SCP-871