### PR TITLE
SCP-1145: Fix a bug in process contract outboxes

### DIFF
--- a/plutus-scb/test/Plutus/SCB/CoreSpec.hs
+++ b/plutus-scb/test/Plutus/SCB/CoreSpec.hs
@@ -176,7 +176,6 @@ guessingGameTest =
                   Contracts.Game.GuessParams
                       {Contracts.Game.guessWord = "password"}
               syncAll
-              syncAll
               void Chain.processBlock
               assertTxCounts
                 "A correct guess creates a third transaction."


### PR DESCRIPTION
* `processContractOutboxes` kept servicing the same requests for each
  contract instance, instead of updating them. That way it would never
  make any progress.
* As a result we can get rid of one call to `syncAll` in the tests
* I also ran it in interactive mode, and noticed a speedup in the
  currency contract.