### PR TITLE
Generalising an unnecessarily specific type signature.

### DIFF
--- a/plutus-contract/src/Control/Monad/Freer/Log.hs
+++ b/plutus-contract/src/Control/Monad/Freer/Log.hs
@@ -224,7 +224,7 @@ handleLogIgnore = interpret $ \case
     LMessage _ -> pure ()
 
 -- | Write the log to stdout using 'Debug.Trace.trace'
-handleLogTrace :: Eff (LogMsg String ': effs) ~> Eff effs
+handleLogTrace :: Pretty a => Eff (LogMsg a ': effs) ~> Eff effs
 handleLogTrace = interpret $ \case
     LMessage msg -> Trace.trace (Render.renderString . layoutPretty defaultLayoutOptions . pretty $ msg) (pure ())
 


### PR DESCRIPTION
I would like to use `handleLogTrace`, but its type signature too
restrictive. It claims to be limited to strings, but it will actually
work with anything `Pretty`.