### PR TITLE
SCP-818: add a very simple inliner to plutus-ir

### DIFF
--- a/nix/stack.materialized/default.nix
+++ b/nix/stack.materialized/default.nix
@@ -29,6 +29,8 @@
         "servant-options" = (((hackage.servant-options)."0.1.0.0").revisions).default;
         "sbv" = (((hackage.sbv)."8.6").revisions).default;
         "inline-r" = (((hackage.inline-r)."0.10.3").revisions).default;
+        "witherable" = (((hackage.witherable)."0.3.5").revisions).default;
+        "witherable-class" = (((hackage.witherable-class)."0").revisions).default;
         "Stream" = (((hackage.Stream)."0.4.7.2").revisions)."ed78165aa34c4e23dc53c9072f8715d414a585037f2145ea0eb2b38300354c53";
         "lazysmallcheck" = (((hackage.lazysmallcheck)."0.6").revisions)."dac7a1e4877681f1260309e863e896674dd6efc1159897b7945893e693f2a6bc";
         "time-out" = (((hackage.time-out)."0.2").revisions)."b9a6b4dee64f030ecb2a25dca0faff39b3cb3b5fefbb8af3cdec4142bfd291f2";

--- a/nix/stack.materialized/plutus-core.nix
+++ b/nix/stack.materialized/plutus-core.nix
@@ -91,6 +91,7 @@
           (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
           (hsPkgs."data-default-class" or (errorHandler.buildDepError "data-default-class"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+          (hsPkgs."witherable" or (errorHandler.buildDepError "witherable"))
           (hsPkgs."Stream" or (errorHandler.buildDepError "Stream"))
           ];
         build-tools = [
@@ -235,6 +236,7 @@
           "Language/PlutusIR/Transform/Rename"
           "Language/PlutusIR/Transform/NonStrict"
           "Language/PlutusIR/Transform/LetFloat"
+          "Language/PlutusIR/Transform/Inline"
           "Language/PlutusIR/TypeCheck"
           "Language/UntypedPlutusCore"
           "Language/UntypedPlutusCore/Evaluation/Machine/Cek"

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -114,6 +114,7 @@ library
         Language.PlutusIR.Transform.Rename
         Language.PlutusIR.Transform.NonStrict
         Language.PlutusIR.Transform.LetFloat
+        Language.PlutusIR.Transform.Inline
         Language.PlutusIR.TypeCheck
 
         Language.UntypedPlutusCore
@@ -252,6 +253,7 @@ library
         data-default -any,
         data-default-class -any,
         transformers -any,
+        witherable -any,
         Stream -any
 
 executable plutus-core-generate-evaluation-test

--- a/plutus-core/plutus-ir-test/TransformSpec.hs
+++ b/plutus-core/plutus-ir-test/TransformSpec.hs
@@ -12,10 +12,12 @@ import qualified Language.PlutusCore                         as PLC
 import qualified Language.PlutusCore.Constant.Dynamic        as PLC
 
 import           Language.PlutusIR.Parser
+import qualified Language.PlutusIR.Transform.Inline          as Inline
 import qualified Language.PlutusIR.Transform.LetFloat        as LetFloat
 import qualified Language.PlutusIR.Transform.NonStrict       as NonStrict
 import           Language.PlutusIR.Transform.Rename          ()
 import qualified Language.PlutusIR.Transform.ThunkRecursions as ThunkRec
+
 import           Text.Megaparsec.Pos
 
 transform :: TestNested
@@ -23,6 +25,7 @@ transform = testNested "transform" [
     thunkRecursions
     , nonStrict
     , letFloat
+    , inline
     ]
 
 thunkRecursions :: TestNested
@@ -39,7 +42,6 @@ nonStrict = testNested "nonStrict"
     ]
 
 letFloat :: TestNested
-
 letFloat =
     let means = PLC.getStringBuiltinMeanings @(PLC.Term PLC.TyName PLC.Name PLC.DefaultUni ())
     in testNested "letFloat"
@@ -78,3 +80,16 @@ instance Semigroup SourcePos where
 
 instance Monoid SourcePos where
   mempty = initialPos ""
+
+inline :: TestNested
+inline =
+    let means = PLC.getStringBuiltinMeanings @(PLC.Term PLC.TyName PLC.Name PLC.DefaultUni ())
+    in testNested "inline"
+    $ map (goldenPir (Inline.inline means . runQuote . PLC.rename) term)
+    [ "var"
+    , "builtin"
+    , "constant"
+    , "transitive"
+    -- We don't do beta reduction, but we could
+    , "lamapp"
+    ]

--- a/plutus-core/plutus-ir-test/lets/letDep.golden
+++ b/plutus-core/plutus-ir-test/lets/letDep.golden
@@ -1,6 +1,3 @@
 (program 1.0.0
-  [
-    (lam i_i0 (con integer) [ (lam j_i0 (con integer) j_i1) i_i1 ])
-    (con integer 3)
-  ]
+  (con integer 3)
 )

--- a/plutus-core/plutus-ir-test/transform/inline/builtin
+++ b/plutus-core/plutus-ir-test/transform/inline/builtin
@@ -1,0 +1,5 @@
+(let
+  (nonrec)
+  (termbind (strict) (vardecl add (fun (con integer) (fun (con integer) (con integer)))) (builtin addInteger))
+  add
+)

--- a/plutus-core/plutus-ir-test/transform/inline/builtin.golden
+++ b/plutus-core/plutus-ir-test/transform/inline/builtin.golden
@@ -1,0 +1,1 @@
+(builtin addInteger)

--- a/plutus-core/plutus-ir-test/transform/inline/constant
+++ b/plutus-core/plutus-ir-test/transform/inline/constant
@@ -1,0 +1,5 @@
+(let
+  (nonrec)
+  (termbind (strict) (vardecl x (con integer)) (con integer 1))
+  x
+)

--- a/plutus-core/plutus-ir-test/transform/inline/constant.golden
+++ b/plutus-core/plutus-ir-test/transform/inline/constant.golden
@@ -1,0 +1,1 @@
+(con integer 1)

--- a/plutus-core/plutus-ir-test/transform/inline/lamapp
+++ b/plutus-core/plutus-ir-test/transform/inline/lamapp
@@ -1,0 +1,1 @@
+[ (lam y (con integer) y) (con integer 1) ]

--- a/plutus-core/plutus-ir-test/transform/inline/lamapp.golden
+++ b/plutus-core/plutus-ir-test/transform/inline/lamapp.golden
@@ -1,0 +1,1 @@
+[ (lam y (con integer) y) (con integer 1) ]

--- a/plutus-core/plutus-ir-test/transform/inline/transitive
+++ b/plutus-core/plutus-ir-test/transform/inline/transitive
@@ -1,0 +1,9 @@
+(let
+  (nonrec)
+  (termbind (strict) (vardecl x1 (con integer)) (con integer 1))
+  (termbind (strict) (vardecl x2 (con integer)) x1)
+  (termbind (strict) (vardecl x3 (con integer)) x2)
+  (termbind (strict) (vardecl x4 (con integer)) x3)
+  (termbind (strict) (vardecl x5 (con integer)) x4)
+  x5
+)

--- a/plutus-core/plutus-ir-test/transform/inline/transitive.golden
+++ b/plutus-core/plutus-ir-test/transform/inline/transitive.golden
@@ -1,0 +1,1 @@
+(con integer 1)

--- a/plutus-core/plutus-ir-test/transform/inline/var
+++ b/plutus-core/plutus-ir-test/transform/inline/var
@@ -1,0 +1,7 @@
+(lam y (con integer)
+(let
+  (nonrec)
+  (termbind (strict) (vardecl x (con integer)) y)
+  x
+)
+)

--- a/plutus-core/plutus-ir-test/transform/inline/var.golden
+++ b/plutus-core/plutus-ir-test/transform/inline/var.golden
@@ -1,0 +1,1 @@
+(lam y (con integer) y)

--- a/plutus-core/plutus-ir/Language/PlutusIR/MkPir.hs
+++ b/plutus-core/plutus-ir/Language/PlutusIR/MkPir.hs
@@ -26,5 +26,5 @@ mkLet
     -> Term tyname name uni a
     -> Term tyname name uni a
 mkLet x r bs t =  case NE.nonEmpty bs of
-  Nothing  -> t;
+  Nothing  -> t
   Just bs' -> Let x r bs' t

--- a/plutus-core/plutus-ir/Language/PlutusIR/Optimizer/DeadCode.hs
+++ b/plutus-core/plutus-ir/Language/PlutusIR/Optimizer/DeadCode.hs
@@ -47,7 +47,7 @@ calculateLiveness
 calculateLiveness means t =
     let
         depGraph :: G.Graph Deps.Node
-        depGraph = Deps.runTermDeps means t
+        depGraph = fst $ Deps.runTermDeps means t
     in Set.fromList $ T.reachable Deps.Root depGraph
 
 live :: (MonadReader Liveness m, PLC.HasUnique n unique) => n -> m Bool

--- a/plutus-core/plutus-ir/Language/PlutusIR/Transform/Inline.hs
+++ b/plutus-core/plutus-ir/Language/PlutusIR/Transform/Inline.hs
@@ -1,0 +1,248 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs            #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE TypeFamilies     #-}
+{-# LANGUAGE TypeOperators    #-}
+{-# LANGUAGE ConstraintKinds  #-}
+{-|
+A simple inlining pass.
+
+The point of this pass is mainly to tidy up the code, not to particularly optimize performance.
+In particular, we want to get rid of "trivial" let bindings which the Plutus Tx compiler sometimes creates.
+-}
+module Language.PlutusIR.Transform.Inline where
+
+import           Language.PlutusIR
+import           Language.PlutusIR.MkPir
+import           Language.PlutusIR.Purity
+import qualified Language.PlutusIR.Analysis.Dependencies as Deps
+
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Constant.Typed
+import qualified Language.PlutusCore as PLC
+
+import           Control.Lens                           hiding (Strict)
+import           Control.Monad.Reader
+import           Control.Monad.State
+
+import qualified Algebra.Graph as G
+import           Data.Foldable
+import qualified Data.Map as Map
+import           Data.Witherable
+
+{- Note [Inlining approach and 'Secrets of the GHC Inliner']
+The approach we take is more-or-less exactly taken from 'Secrets of the GHC Inliner'.
+
+Overall, the cause of differences is that we are largely trying to just clean up some
+basic issues, not do serious optimization. In many cases we've already run the GHC simplifier
+on our input!
+
+We differ from the paper a few ways, mostly leaving things out:
+
+Functionality
+------------
+
+PreInlineUncoditional: we don't do it, since we don't bother using usage information.
+We *could* do it, but it doesn't seem worth it. We also don't need to worry about
+inlining nested let-bindings, since we don't inline any.
+
+CallSiteInline: not worth it.
+
+Inlining recursive bindings: not worth it, complicated.
+
+Context-based inlining: we don't do CallSiteInline, so no point.
+
+Beta reduction: not worth it, but would be easy. We could do the inlining of the argument
+here and also detect dead immediately-applied-lambdas in the dead code pass.
+
+Implementation
+--------------
+
+In-scope set: we don't bother keeping it, since we only ever substitute in things that
+don't have bound variables. This is largely because we don't do PreInlineUnconditional, which
+would inline big things that were only used once, including lambdas etc.
+
+Suspended substitutions for values: we don't do it, since you only need it for
+PreInlineUnconditional
+
+Optimization after substituting in DoneExprs: we can't make different inlining decisions
+contextually, so there's no point doing this.
+-}
+
+
+-- 'SubstRng' in the paper, no 'Susp' case
+-- See Note [Inlining approach and 'Secrets of the GHC Inliner']
+newtype InlineTerm tyname name uni a = Done (Term tyname name uni a)
+
+newtype TermEnv tyname name uni a = TermEnv { unTermEnv :: UniqueMap TermUnique (InlineTerm tyname name uni a) }
+    deriving newtype (Semigroup, Monoid)
+
+newtype Subst tyname name uni a = Subst { sTermEnv :: TermEnv tyname name uni a }
+    deriving newtype (Semigroup, Monoid)
+
+type ExternalConstraints tyname name uni a term =
+    ( HasUnique name TermUnique
+    , HasUnique tyname TypeUnique
+    , HasConstantIn uni term
+    , PLC.GShow uni
+    , PLC.GEq uni
+    , PLC.DefaultUni PLC.<: uni)
+
+type Inlining tyname name uni a term m =
+    ( MonadState (Subst tyname name uni a) m
+    , MonadReader (Deps.StrictnessMap, DynamicBuiltinNameMeanings term) m
+    , ExternalConstraints tyname name uni a term)
+
+lookupSubst
+    :: (HasUnique name TermUnique)
+    => name
+    -> Subst tyname name uni a
+    -> Maybe (InlineTerm tyname name uni a)
+lookupSubst n (Subst (TermEnv env)) = lookupName n env
+
+extendSubst
+    :: (HasUnique name TermUnique)
+    => name
+    -> InlineTerm tyname name uni a
+    -> Subst tyname name uni a
+    -> Subst tyname name uni a
+extendSubst n clos (Subst (TermEnv env)) = Subst $ TermEnv $ insertByName n clos env
+
+{- Note [Inlining and global uniqueness]
+Inlining relies on global uniqueness (we store things in a unique map), and *does* currently
+preserve it because we don't currently inline anything with binders.
+
+If we do start inlining things with binders in them, we should probably try and preserve it by
+doing something like 'The rapier' section from the paper. We could also just bite the bullet
+and rename everything when we substitute in, which GHC considers too expensive but we might accept.
+-}
+
+-- | Inline simple bindings. Relies on global uniqueness, and preserves it.
+-- See Note [Inlining and global uniqueness]
+inline
+    :: ExternalConstraints tyname name uni a term
+    => DynamicBuiltinNameMeanings term
+    -> Term tyname name uni a
+    -> Term tyname name uni a
+inline means t =
+    let
+        -- We actually just want the variable strictness information here!
+        deps :: (G.Graph Deps.Node, Map.Map PLC.Unique Strictness)
+        deps = Deps.runTermDeps means t
+    in flip runReader (snd deps, means) $ flip evalStateT mempty $ processTerm t
+
+{- Note [Removing inlined bindings]
+We *do* remove bindings that we inline (since we only do unconditional inlining). We *could*
+leave this to the dead code pass, but we m
+Crucially, we have to do the same reasoning wrt strict bindings and purity (see Note [Inlining and purity]):
+we can only inline *pure* strict bindings, which is effectively the same as what we do in the dead
+code pass.
+
+Annoyingly, this requires us to redo the analysis that we do for the dead binding pass.
+TODO: merge them or figure out a way to share more work, especially since there's similar logic.
+This might mean reinventing GHC's OccAnal...
+-}
+
+processTerm
+    :: Inlining tyname name uni a term m
+    => Term tyname name uni a
+    -> m (Term tyname name uni a)
+processTerm = \case
+    v@(Var _ n) -> do
+        subst <- get
+        pure $ case lookupSubst n subst of
+            -- Not substituted for, leave it as it is
+            Nothing -> v
+            -- Already processed term, just put it in, don't do any further optimization here.
+            -- See Note [Inlining approach and 'Secrets of the GHC Inliner']
+            Just (Done t) -> t
+    Let a NonRec bs t -> do
+        -- Process bindings, eliminating those which will be inlined unconditionally,
+        -- and accumulating the new substitutions
+        -- See Note [Removing inlined bindings]
+        -- Note that we don't *remove* the bindings or scope the state, so the state will carry over
+        -- into "sibling" terms. This is fine because we have global uniqueness
+        -- (see Note [Inlining and global uniqueness]), if somewhat wasteful.
+        bs' <- wither processSingleBinding (toList bs)
+        t' <- processTerm t
+        -- Use 'mkLet': we're using lists of bindings rather than NonEmpty since we might actually
+        -- have got rid of all of them!
+        pure $ mkLet a NonRec bs' t'
+    -- This includes recursive let terms, we don't even consider inlining them at the moment
+    t -> forMOf termSubterms t processTerm
+
+{- Note [Inlining various kinds of binding]
+We can inline term and type bindings, we can't do anything with datatype bindings.
+
+We don't actually inline type bindings at the moment, mostly because I think it
+won't get us much as they aren't created very often.
+-}
+
+processSingleBinding
+    :: Inlining tyname name uni a term m
+    => Binding tyname name uni a
+    -> m (Maybe (Binding tyname name uni a))
+processSingleBinding = \case
+    -- See Note [Inlining various kinds of binding]
+    TermBind a s v@(VarDecl _ n _) rhs -> do
+        maybeRhs' <- maybeAddSubst s n rhs
+        pure $ TermBind a s v <$> maybeRhs'
+    -- Not a strict binding, just process all the subterms
+    b -> Just <$> forMOf bindingSubterms b processTerm
+
+maybeAddSubst
+    :: Inlining tyname name uni a term m
+    => Strictness
+    -> name
+    -> Term tyname name uni a
+    -> m (Maybe (Term tyname name uni a))
+maybeAddSubst s n rhs = do
+    -- Only do PostInlineUnconditional
+    -- See Note [Inlining approach and 'Secrets of the GHC Inliner']
+    rhs' <- processTerm rhs
+    doInline <- postInlineUnconditional s rhs'
+    if doInline then do
+        modify (\subst -> extendSubst n (Done rhs') subst)
+        pure Nothing
+    else pure $ Just rhs'
+
+{- Note [Inlining criteria]
+What gets inlined? We don't really care about performance here, so we're really just
+angling to simplify the code without making things worse.
+
+The obvious candidates are tiny things like builtins, variables, or constants.
+We could also consider inlining variables with arbitrary RHSs that are used only
+once, but we don't do that currently.
+-}
+
+{- Note [Inlining and purity]
+When can we inline something that might have effects? We must remember that we often also
+remove a binding that we inline.
+
+For strict bindings, the answer is that we can't: we will delay the effects to the use site,
+so they may happen multiple times (or none). So we can only inline bindings whose RHS is pure.
+
+For non-strict bindings, the effects already happened at the use site, so it's fine to inline it
+unconditionally.
+-}
+
+-- | Should we inline? Should only inline things that won't duplicate work or code.
+-- See Note [Inlining approach and 'Secrets of the GHC Inliner']
+postInlineUnconditional :: Inlining tyname name uni a term m => Strictness -> Term tyname name uni a -> m Bool
+postInlineUnconditional s t = do
+    (strictnessMap, means) <- ask
+    let -- See Note [Inlining criteria]
+        termIsTrivial = trivialTerm t
+        -- See Note [Inlining and purity]
+        strictnessFun = \n' -> Map.findWithDefault NonStrict (n' ^. theUnique) strictnessMap
+        termIsPure = case s of { Strict -> isPure means strictnessFun t; NonStrict -> True; }
+    pure $ termIsTrivial && termIsPure
+
+-- | Is this a an utterly trivial term which might as well be inlined?
+trivialTerm :: Term tyname name uni a -> Bool
+trivialTerm = \case
+    Builtin{} -> True
+    Var{} -> True
+    -- TODO: Should this depend on the size of the constant?
+    Constant{} -> True
+    _ -> False

--- a/plutus-core/plutus-ir/Language/PlutusIR/Transform/LetFloat.hs
+++ b/plutus-core/plutus-ir/Language/PlutusIR/Transform/LetFloat.hs
@@ -412,7 +412,7 @@ p2Term means pir fd =
              AM.gmap (\case Variable u -> Just u;
                             -- we remove Root because we do not care about it
                             Root -> Nothing)
-             $ runTermDeps means pir
+             $ fst $ runTermDeps means pir
 
   -- | the dependency graph as before, but with datatype-bind nodes merged/reduced under the "principal" node, See Note [Principal].
   reducedDepGraph :: AM.AdjacencyMap PLC.Unique

--- a/plutus-core/plutus-ir/Language/PlutusIR/Transform/Substitute.hs
+++ b/plutus-core/plutus-ir/Language/PlutusIR/Transform/Substitute.hs
@@ -17,15 +17,17 @@ import           Language.PlutusCore.Subst (substTyVar, typeSubstTyNames)
 
 import           Control.Lens
 
+import           Data.Maybe
+
 -- Needs to be different from the PLC version since we have different Terms
 -- | Replace a variable using the given function.
-substVar :: (name -> Maybe (Term tyname name uni a)) -> Term tyname name uni a -> Term tyname name uni a
-substVar nameF (Var _ (nameF -> Just t)) = t
-substVar _ t                             = t
+substVar :: (name -> Maybe (Term tyname name uni a)) -> Term tyname name uni a -> Maybe (Term tyname name uni a)
+substVar nameF (Var _ n) = nameF n
+substVar _     _         = Nothing
 
 -- | Naively substitute names using the given functions (i.e. do not substitute binders).
 termSubstNames :: (name -> Maybe (Term tyname name uni a)) -> Term tyname name uni a -> Term tyname name uni a
-termSubstNames nameF = transformOf termSubterms (substVar nameF)
+termSubstNames nameF = transformOf termSubterms (\x -> fromMaybe x (substVar nameF x))
 
 -- | Naively substitute type names using the given functions (i.e. do not substitute binders).
 termSubstTyNames :: (tyname -> Maybe (Type tyname uni a)) -> Term tyname name uni a -> Term tyname name uni a

--- a/plutus-tx-plugin/test/Plugin/Basic/ifOpt.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Basic/ifOpt.plc.golden
@@ -1,13 +1,6 @@
 (program
   (let
     (nonrec)
-    (termbind
-      (strict)
-      (vardecl
-        divideInteger (fun (con integer) (fun (con integer) (con integer)))
-      )
-      (builtin divideInteger)
-    )
     (datatypebind
       (datatype
         (tyvardecl Bool (type))
@@ -40,7 +33,10 @@
       (strict)
       (vardecl wild Bool)
       [
-        [ equalsInteger [ [ divideInteger (con integer 1) ] (con integer 0) ] ]
+        [
+          equalsInteger
+          [ [ (builtin divideInteger) (con integer 1) ] (con integer 0) ]
+        ]
         (con integer 0)
       ]
     )

--- a/plutus-tx-plugin/test/Plugin/Data/monomorphic/atPattern.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Data/monomorphic/atPattern.plc.golden
@@ -9,43 +9,30 @@
         (vardecl Tuple2 (fun a (fun b [[Tuple2 a] b])))
       )
     )
-    (termbind
-      (strict)
-      (vardecl addInteger (fun (con integer) (fun (con integer) (con integer))))
-      (builtin addInteger)
-    )
     (lam
       t
       [[Tuple2 (con integer)] (con integer)]
-      (let
-        (nonrec)
-        (termbind
-          (nonstrict) (vardecl wild [[Tuple2 (con integer)] (con integer)]) t
-        )
-        [
-          {
-            [ { { Tuple2_match (con integer) } (con integer) } t ] (con integer)
-          }
+      [
+        { [ { { Tuple2_match (con integer) } (con integer) } t ] (con integer) }
+        (lam
+          ds
+          (con integer)
           (lam
             ds
             (con integer)
-            (lam
-              ds
-              (con integer)
+            [
+              [ (builtin addInteger) ds ]
               [
-                [ addInteger ds ]
-                [
-                  {
-                    [ { { Tuple2_match (con integer) } (con integer) } wild ]
-                    (con integer)
-                  }
-                  (lam a (con integer) (lam b (con integer) a))
-                ]
+                {
+                  [ { { Tuple2_match (con integer) } (con integer) } t ]
+                  (con integer)
+                }
+                (lam a (con integer) (lam b (con integer) a))
               ]
-            )
+            ]
           )
-        ]
-      )
+        )
+      ]
     )
   )
 )

--- a/plutus-tx-plugin/test/Plugin/Data/monomorphic/strictPattern.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Data/monomorphic/strictPattern.plc.golden
@@ -12,27 +12,7 @@
     (termbind
       (strict)
       (vardecl WStrictPattern (all a (type) (fun a (fun a [StrictPattern a]))))
-      (abs
-        a
-        (type)
-        (lam
-          dt
-          a
-          (lam
-            dt
-            a
-            (let
-              (nonrec)
-              (termbind (strict) (vardecl dt a) dt)
-              (let
-                (nonrec)
-                (termbind (strict) (vardecl dt a) dt)
-                [ [ { StrictPattern a } dt ] dt ]
-              )
-            )
-          )
-        )
-      )
+      (abs a (type) (lam dt a (lam dt a [ [ { StrictPattern a } dt ] dt ])))
     )
     [ [ { WStrictPattern (con integer) } (con integer 1) ] (con integer 2) ]
   )

--- a/plutus-tx-plugin/test/Plugin/Errors/literalCaseOther.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Errors/literalCaseOther.plc.golden
@@ -65,144 +65,111 @@
                                                                   (fun [List_i5 (con char)] AType_i16)
                                                                   [
                                                                     (lam
-                                                                      fIsStringAType_i0
-                                                                      (fun (all a_i0 (type) (fun a_i1 a_i1)) [(lam a_i0 (type) (fun [List_i7 (con char)] a_i1)) AType_i17])
-                                                                      [
-                                                                        (lam
-                                                                          fromString_i0
-                                                                          (all a_i0 (type) (fun [(lam a_i0 (type) (fun [List_i9 (con char)] a_i1)) a_i1] (fun [List_i8 (con char)] a_i1)))
-                                                                          (lam
-                                                                            x_i0
-                                                                            AType_i19
+                                                                      fromString_i0
+                                                                      (all a_i0 (type) (fun [(lam a_i0 (type) (fun [List_i8 (con char)] a_i1)) a_i1] (fun [List_i7 (con char)] a_i1)))
+                                                                      (lam
+                                                                        x_i0
+                                                                        AType_i18
+                                                                        [
+                                                                          [
                                                                             [
-                                                                              [
+                                                                              {
                                                                                 [
-                                                                                  {
+                                                                                  Bool_match_i9
+                                                                                  [
                                                                                     [
-                                                                                      Bool_match_i10
+                                                                                      c_i8
+                                                                                      x_i1
+                                                                                    ]
+                                                                                    [
+                                                                                      [
+                                                                                        {
+                                                                                          fromString_i2
+                                                                                          AType_i18
+                                                                                        }
+                                                                                        cfromString_i3
+                                                                                      ]
                                                                                       [
                                                                                         [
-                                                                                          c_i9
-                                                                                          x_i1
+                                                                                          {
+                                                                                            Cons_i5
+                                                                                            (con char)
+                                                                                          }
+                                                                                          (con
+                                                                                            char
+                                                                                              'a'
+                                                                                          )
                                                                                         ]
                                                                                         [
                                                                                           [
                                                                                             {
-                                                                                              fromString_i2
-                                                                                              AType_i19
+                                                                                              Cons_i5
+                                                                                              (con char)
                                                                                             }
-                                                                                            [
-                                                                                              fIsStringAType_i3
-                                                                                              (abs
-                                                                                                a_i0
-                                                                                                (type)
-                                                                                                (lam
-                                                                                                  x_i0
-                                                                                                  a_i2
-                                                                                                  x_i1
-                                                                                                )
-                                                                                              )
-                                                                                            ]
+                                                                                            (con
+                                                                                              char
+                                                                                                'b'
+                                                                                            )
                                                                                           ]
                                                                                           [
                                                                                             [
                                                                                               {
-                                                                                                Cons_i6
+                                                                                                Cons_i5
                                                                                                 (con char)
                                                                                               }
                                                                                               (con
                                                                                                 char
-                                                                                                  'a'
+                                                                                                  'c'
                                                                                               )
                                                                                             ]
-                                                                                            [
-                                                                                              [
-                                                                                                {
-                                                                                                  Cons_i6
-                                                                                                  (con char)
-                                                                                                }
-                                                                                                (con
-                                                                                                  char
-                                                                                                    'b'
-                                                                                                )
-                                                                                              ]
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    Cons_i6
-                                                                                                    (con char)
-                                                                                                  }
-                                                                                                  (con
-                                                                                                    char
-                                                                                                      'c'
-                                                                                                  )
-                                                                                                ]
-                                                                                                {
-                                                                                                  Nil_i7
-                                                                                                  (con char)
-                                                                                                }
-                                                                                              ]
-                                                                                            ]
+                                                                                            {
+                                                                                              Nil_i6
+                                                                                              (con char)
+                                                                                            }
                                                                                           ]
                                                                                         ]
                                                                                       ]
                                                                                     ]
-                                                                                    (fun Unit_i16 AType_i19)
-                                                                                  }
-                                                                                  (lam
-                                                                                    thunk_i0
-                                                                                    Unit_i17
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          fromString_i3
-                                                                                          AType_i20
-                                                                                        }
-                                                                                        [
-                                                                                          fIsStringAType_i4
-                                                                                          (abs
-                                                                                            a_i0
-                                                                                            (type)
-                                                                                            (lam
-                                                                                              x_i0
-                                                                                              a_i2
-                                                                                              x_i1
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                      ]
-                                                                                      {
-                                                                                        Nil_i8
-                                                                                        (con char)
-                                                                                      }
-                                                                                    ]
-                                                                                  )
+                                                                                  ]
                                                                                 ]
-                                                                                (lam
-                                                                                  thunk_i0
-                                                                                  Unit_i17
-                                                                                  x_i2
-                                                                                )
-                                                                              ]
-                                                                              Unit_i15
+                                                                                (fun Unit_i15 AType_i18)
+                                                                              }
+                                                                              (lam
+                                                                                thunk_i0
+                                                                                Unit_i16
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      fromString_i3
+                                                                                      AType_i19
+                                                                                    }
+                                                                                    cfromString_i4
+                                                                                  ]
+                                                                                  {
+                                                                                    Nil_i7
+                                                                                    (con char)
+                                                                                  }
+                                                                                ]
+                                                                              )
                                                                             ]
-                                                                          )
-                                                                        )
-                                                                        (abs
-                                                                          a_i0
-                                                                          (type)
-                                                                          (lam
-                                                                            v_i0
-                                                                            [(lam a_i0 (type) (fun [List_i9 (con char)] a_i1)) a_i2]
-                                                                            v_i1
-                                                                          )
-                                                                        )
-                                                                      ]
+                                                                            (lam
+                                                                              thunk_i0
+                                                                              Unit_i16
+                                                                              x_i2
+                                                                            )
+                                                                          ]
+                                                                          Unit_i14
+                                                                        ]
+                                                                      )
                                                                     )
-                                                                    (lam
-                                                                      arg_i0
-                                                                      (all a_i0 (type) (fun a_i1 a_i1))
-                                                                      cfromString_i2
+                                                                    (abs
+                                                                      a_i0
+                                                                      (type)
+                                                                      (lam
+                                                                        v_i0
+                                                                        [(lam a_i0 (type) (fun [List_i8 (con char)] a_i1)) a_i2]
+                                                                        v_i1
+                                                                      )
                                                                     )
                                                                   ]
                                                                 )

--- a/plutus-tx-plugin/test/Plugin/Functions/recursive/even.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/recursive/even.plc.golden
@@ -1,13 +1,6 @@
 (program
   (let
     (nonrec)
-    (termbind
-      (strict)
-      (vardecl
-        subtractInteger (fun (con integer) (fun (con integer) (con integer)))
-      )
-      (builtin subtractInteger)
-    )
     (datatypebind
       (datatype
         (tyvardecl Bool (type))
@@ -64,7 +57,7 @@
                   (termbind
                     (nonstrict)
                     (vardecl n (con integer))
-                    [ [ subtractInteger n ] (con integer 1) ]
+                    [ [ (builtin subtractInteger) n ] (con integer 1) ]
                   )
                   [
                     [
@@ -78,7 +71,10 @@
                       (lam
                         thunk
                         Unit
-                        [ even [ [ subtractInteger n ] (con integer 1) ] ]
+                        [
+                          even
+                          [ [ (builtin subtractInteger) n ] (con integer 1) ]
+                        ]
                       )
                     ]
                     Unit

--- a/plutus-tx-plugin/test/Plugin/Functions/recursive/even3.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/recursive/even3.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_107
+  out_Bool_106
   (type)
   (lam
-    case_True_108 out_Bool_107 (lam case_False_109 out_Bool_107 case_False_109)
+    case_True_107 out_Bool_106 (lam case_False_108 out_Bool_106 case_False_108)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/Functions/recursive/even4.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/recursive/even4.plc.golden
@@ -1,7 +1,7 @@
 (abs
-  out_Bool_104
+  out_Bool_103
   (type)
   (lam
-    case_True_105 out_Bool_104 (lam case_False_106 out_Bool_104 case_True_105)
+    case_True_104 out_Bool_103 (lam case_False_105 out_Bool_103 case_True_104)
   )
 )

--- a/plutus-tx-plugin/test/Plugin/Functions/recursive/fib.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/recursive/fib.plc.golden
@@ -1,11 +1,6 @@
 (program
   (let
     (nonrec)
-    (termbind
-      (strict)
-      (vardecl addInteger (fun (con integer) (fun (con integer) (con integer))))
-      (builtin addInteger)
-    )
     (datatypebind
       (datatype
         (tyvardecl Bool (type))
@@ -33,13 +28,6 @@
           ]
         )
       )
-    )
-    (termbind
-      (strict)
-      (vardecl
-        subtractInteger (fun (con integer) (fun (con integer) (con integer)))
-      )
-      (builtin subtractInteger)
     )
     (datatypebind
       (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
@@ -78,10 +66,16 @@
                       Unit
                       [
                         [
-                          addInteger
-                          [ fib [ [ subtractInteger n ] (con integer 1) ] ]
+                          (builtin addInteger)
+                          [
+                            fib
+                            [ [ (builtin subtractInteger) n ] (con integer 1) ]
+                          ]
                         ]
-                        [ fib [ [ subtractInteger n ] (con integer 2) ] ]
+                        [
+                          fib
+                          [ [ (builtin subtractInteger) n ] (con integer 2) ]
+                        ]
                       ]
                     )
                   ]

--- a/plutus-tx-plugin/test/Plugin/Functions/recursive/sum.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/recursive/sum.plc.golden
@@ -10,37 +10,31 @@
       )
     )
     (let
-      (nonrec)
+      (rec)
       (termbind
         (strict)
-        (vardecl
-          addInteger (fun (con integer) (fun (con integer) (con integer)))
-        )
-        (builtin addInteger)
-      )
-      (let
-        (rec)
-        (termbind
-          (strict)
-          (vardecl sum (fun [List (con integer)] (con integer)))
-          (lam
-            ds
-            [List (con integer)]
+        (vardecl sum (fun [List (con integer)] (con integer)))
+        (lam
+          ds
+          [List (con integer)]
+          [
             [
-              [
-                { [ { Nil_match (con integer) } ds ] (con integer) }
-                (con integer 0)
-              ]
-              (lam
-                x
-                (con integer)
-                (lam xs [List (con integer)] [ [ addInteger x ] [ sum xs ] ])
-              )
+              { [ { Nil_match (con integer) } ds ] (con integer) }
+              (con integer 0)
             ]
-          )
+            (lam
+              x
+              (con integer)
+              (lam
+                xs
+                [List (con integer)]
+                [ [ (builtin addInteger) x ] [ sum xs ] ]
+              )
+            )
+          ]
         )
-        sum
       )
+      sum
     )
   )
 )

--- a/plutus-tx-plugin/test/Plugin/Functions/unfoldings/applicationFunction.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/unfoldings/applicationFunction.plc.golden
@@ -3,18 +3,13 @@
     (nonrec)
     (termbind
       (strict)
-      (vardecl addInteger (fun (con integer) (fun (con integer) (con integer))))
-      (builtin addInteger)
-    )
-    (termbind
-      (strict)
       (vardecl myDollar (all a (type) (all b (type) (fun (fun a b) (fun a b)))))
       (abs a (type) (abs b (type) (lam f (fun a b) (lam a a [ f a ]))))
     )
     [
       [
         { { myDollar (con integer) } (con integer) }
-        (lam x (con integer) [ [ addInteger (con integer 1) ] x ])
+        (lam x (con integer) [ [ (builtin addInteger) (con integer 1) ] x ])
       ]
       (con integer 1)
     ]

--- a/plutus-tx-plugin/test/Plugin/Functions/unfoldings/mutualRecursionUnfoldings.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/unfoldings/mutualRecursionUnfoldings.plc.golden
@@ -32,13 +32,6 @@
         )
       )
     )
-    (termbind
-      (strict)
-      (vardecl
-        subtractInteger (fun (con integer) (fun (con integer) (con integer)))
-      )
-      (builtin subtractInteger)
-    )
     (let
       (rec)
       (termbind
@@ -59,7 +52,9 @@
               (lam
                 thunk
                 Unit
-                [ oddDirect [ [ subtractInteger n ] (con integer 1) ] ]
+                [
+                  oddDirect [ [ (builtin subtractInteger) n ] (con integer 1) ]
+                ]
               )
             ]
             Unit
@@ -84,7 +79,9 @@
               (lam
                 thunk
                 Unit
-                [ evenDirect [ [ subtractInteger n ] (con integer 1) ] ]
+                [
+                  evenDirect [ [ (builtin subtractInteger) n ] (con integer 1) ]
+                ]
               )
             ]
             Unit

--- a/plutus-tx-plugin/test/Plugin/Functions/unfoldings/polyMap.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Functions/unfoldings/polyMap.plc.golden
@@ -1,112 +1,103 @@
 (program
   (let
-    (nonrec)
-    (termbind
-      (strict)
-      (vardecl addInteger (fun (con integer) (fun (con integer) (con integer))))
-      (builtin addInteger)
+    (rec)
+    (datatypebind
+      (datatype
+        (tyvardecl List (fun (type) (type)))
+        (tyvardecl a (type))
+        Nil_match
+        (vardecl Nil [List a]) (vardecl Cons (fun a (fun [List a] [List a])))
+      )
     )
     (let
-      (rec)
-      (datatypebind
-        (datatype
-          (tyvardecl List (fun (type) (type)))
-          (tyvardecl a (type))
-          Nil_match
-          (vardecl Nil [List a]) (vardecl Cons (fun a (fun [List a] [List a])))
+      (nonrec)
+      (termbind
+        (strict)
+        (vardecl
+          build
+          (all a (type) (fun (all b (type) (fun (fun a (fun b b)) (fun b b))) [List a]))
+        )
+        (abs
+          a
+          (type)
+          (lam
+            g
+            (all b (type) (fun (fun a (fun b b)) (fun b b)))
+            [ [ { g [List a] } { Cons a } ] { Nil a } ]
+          )
         )
       )
+      (datatypebind
+        (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
+      )
       (let
-        (nonrec)
+        (rec)
         (termbind
-          (strict)
+          (nonstrict)
           (vardecl
-            build
-            (all a (type) (fun (all b (type) (fun (fun a (fun b b)) (fun b b))) [List a]))
+            mapDirect
+            (all a (type) (all b (type) (fun (fun a b) (fun [List a] [List b]))))
           )
           (abs
             a
             (type)
-            (lam
-              g
-              (all b (type) (fun (fun a (fun b b)) (fun b b)))
-              [ [ { g [List a] } { Cons a } ] { Nil a } ]
+            (abs
+              b
+              (type)
+              (lam
+                f
+                (fun a b)
+                (lam
+                  l
+                  [List a]
+                  [
+                    [
+                      [
+                        { [ { Nil_match a } l ] (fun Unit [List b]) }
+                        (lam thunk Unit { Nil b })
+                      ]
+                      (lam
+                        x
+                        a
+                        (lam
+                          xs
+                          [List a]
+                          (lam
+                            thunk
+                            Unit
+                            [
+                              [ { Cons b } [ f x ] ]
+                              [ [ { { mapDirect a } b } f ] xs ]
+                            ]
+                          )
+                        )
+                      )
+                    ]
+                    Unit
+                  ]
+                )
+              )
             )
           )
         )
-        (datatypebind
-          (datatype (tyvardecl Unit (type))  Unit_match (vardecl Unit Unit))
-        )
-        (let
-          (rec)
-          (termbind
-            (nonstrict)
-            (vardecl
-              mapDirect
-              (all a (type) (all b (type) (fun (fun a b) (fun [List a] [List b]))))
-            )
+        [
+          [
+            { { mapDirect (con integer) } (con integer) }
+            [ (builtin addInteger) (con integer 1) ]
+          ]
+          [
+            { build (con integer) }
             (abs
               a
               (type)
-              (abs
-                b
-                (type)
-                (lam
-                  f
-                  (fun a b)
-                  (lam
-                    l
-                    [List a]
-                    [
-                      [
-                        [
-                          { [ { Nil_match a } l ] (fun Unit [List b]) }
-                          (lam thunk Unit { Nil b })
-                        ]
-                        (lam
-                          x
-                          a
-                          (lam
-                            xs
-                            [List a]
-                            (lam
-                              thunk
-                              Unit
-                              [
-                                [ { Cons b } [ f x ] ]
-                                [ [ { { mapDirect a } b } f ] xs ]
-                              ]
-                            )
-                          )
-                        )
-                      ]
-                      Unit
-                    ]
-                  )
-                )
+              (lam
+                c
+                (fun (con integer) (fun a a))
+                (lam n a [ [ c (con integer 0) ] [ [ c (con integer 1) ] n ] ])
               )
             )
-          )
-          [
-            [
-              { { mapDirect (con integer) } (con integer) }
-              [ addInteger (con integer 1) ]
-            ]
-            [
-              { build (con integer) }
-              (abs
-                a
-                (type)
-                (lam
-                  c
-                  (fun (con integer) (fun a a))
-                  (lam n a [ [ c (con integer 0) ] [ [ c (con integer 1) ] n ] ]
-                  )
-                )
-              )
-            ]
           ]
-        )
+        ]
       )
     )
   )

--- a/plutus-tx-plugin/test/Plugin/Laziness/lazyDepUnit.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Laziness/lazyDepUnit.plc.golden
@@ -2,9 +2,6 @@
   (let
     (nonrec)
     (termbind
-      (strict) (vardecl emptyByteString (con bytestring)) (con bytestring #)
-    )
-    (termbind
       (strict)
       (vardecl monoId (fun (con bytestring) (con bytestring)))
       (lam x (con bytestring) x)
@@ -12,7 +9,7 @@
     (termbind
       (nonstrict)
       (vardecl aByteString (con bytestring))
-      [ monoId emptyByteString ]
+      [ monoId (con bytestring #) ]
     )
     aByteString
   )

--- a/plutus-tx-plugin/test/Plugin/Primitives/intDiv.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/intDiv.plc.golden
@@ -1,13 +1,7 @@
 (program
-  (let
-    (nonrec)
-    (termbind
-      (strict)
-      (vardecl
-        divideInteger (fun (con integer) (fun (con integer) (con integer)))
-      )
-      (builtin divideInteger)
-    )
-    (lam ds (con integer) (lam ds (con integer) [ [ divideInteger ds ] ds ]))
+  (lam
+    ds
+    (con integer)
+    (lam ds (con integer) [ [ (builtin divideInteger) ds ] ds ])
   )
 )

--- a/plutus-tx-plugin/test/Plugin/Primitives/intPlus.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Primitives/intPlus.plc.golden
@@ -1,11 +1,5 @@
 (program
-  (let
-    (nonrec)
-    (termbind
-      (strict)
-      (vardecl addInteger (fun (con integer) (fun (con integer) (con integer))))
-      (builtin addInteger)
-    )
-    (lam ds (con integer) (lam ds (con integer) [ [ addInteger ds ] ds ]))
+  (lam
+    ds (con integer) (lam ds (con integer) [ [ (builtin addInteger) ds ] ds ])
   )
 )

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/defaultMethods.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/defaultMethods.plc.golden
@@ -50,13 +50,8 @@
     )
     (termbind
       (strict)
-      (vardecl addInteger (fun (con integer) (fun (con integer) (con integer))))
-      (builtin addInteger)
-    )
-    (termbind
-      (strict)
       (vardecl fDefaultMethodsInteger_cmethod (fun (con integer) (con integer)))
-      (lam a (con integer) [ [ addInteger a ] (con integer 1) ])
+      (lam a (con integer) [ [ (builtin addInteger) a ] (con integer 1) ])
     )
     (termbind
       (nonstrict)

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/sizedBasic.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/sizedBasic.plc.golden
@@ -7,13 +7,6 @@
       (lam x (con integer) x)
     )
     (termbind
-      (nonstrict)
-      (vardecl
-        fSizedInteger [(lam a (type) (fun a (con integer))) (con integer)]
-      )
-      csize
-    )
-    (termbind
       (strict)
       (vardecl
         size
@@ -21,6 +14,6 @@
       )
       (abs a (type) (lam v [(lam a (type) (fun a (con integer))) a] v))
     )
-    (lam ds (con integer) [ [ { size (con integer) } fSizedInteger ] ds ])
+    (lam ds (con integer) [ [ { size (con integer) } csize ] ds ])
   )
 )

--- a/plutus-tx-plugin/test/Plugin/Typeclasses/sizedPair.plc.golden
+++ b/plutus-tx-plugin/test/Plugin/Typeclasses/sizedPair.plc.golden
@@ -11,11 +11,6 @@
     )
     (termbind
       (strict)
-      (vardecl addInteger (fun (con integer) (fun (con integer) (con integer))))
-      (builtin addInteger)
-    )
-    (termbind
-      (strict)
       (vardecl
         csize
         (all a (type) (all b (type) (fun [(lam a (type) (fun a (con integer))) a] (fun [(lam a (type) (fun a (con integer))) b] (fun [[Tuple2 a] b] (con integer))))))
@@ -38,7 +33,11 @@
                 [
                   { [ { { Tuple2_match a } b } ds ] (con integer) }
                   (lam
-                    a a (lam b b [ [ addInteger [ dSized a ] ] [ dSized b ] ])
+                    a
+                    a
+                    (lam
+                      b b [ [ (builtin addInteger) [ dSized a ] ] [ dSized b ] ]
+                    )
                   )
                 ]
               )
@@ -48,14 +47,6 @@
       )
     )
     (termbind
-      (nonstrict)
-      (vardecl
-        fSizedTuple2
-        (all a (type) (all b (type) (fun [(lam a (type) (fun a (con integer))) a] (fun [(lam a (type) (fun a (con integer))) b] [(lam a (type) (fun a (con integer))) [[Tuple2 a] b]]))))
-      )
-      csize
-    )
-    (termbind
       (strict)
       (vardecl csize (fun (con integer) (con integer)))
       (lam x (con integer) x)
@@ -63,20 +54,10 @@
     (termbind
       (nonstrict)
       (vardecl
-        fSizedInteger [(lam a (type) (fun a (con integer))) (con integer)]
-      )
-      csize
-    )
-    (termbind
-      (nonstrict)
-      (vardecl
         dSized
         [(lam a (type) (fun a (con integer))) [[Tuple2 (con integer)] (con integer)]]
       )
-      [
-        [ { { fSizedTuple2 (con integer) } (con integer) } fSizedInteger ]
-        fSizedInteger
-      ]
+      [ [ { { csize (con integer) } (con integer) } csize ] csize ]
     )
     (termbind
       (strict)

--- a/plutus-tx-plugin/test/TH/power.plc.golden
+++ b/plutus-tx-plugin/test/TH/power.plc.golden
@@ -1,28 +1,20 @@
 (program
-  (let
-    (nonrec)
-    (termbind
-      (strict)
-      (vardecl
-        multiplyInteger (fun (con integer) (fun (con integer) (con integer)))
+  (lam
+    ds
+    (con integer)
+    (let
+      (nonrec)
+      (termbind
+        (nonstrict)
+        (vardecl y (con integer))
+        [ [ (builtin multiplyInteger) ds ] (con integer 1) ]
       )
-      (builtin multiplyInteger)
-    )
-    (lam
-      ds
-      (con integer)
-      (let
-        (nonrec)
-        (termbind
-          (nonstrict)
-          (vardecl y (con integer))
-          [ [ multiplyInteger ds ] (con integer 1) ]
-        )
-        (termbind
-          (nonstrict) (vardecl y (con integer)) [ [ multiplyInteger y ] y ]
-        )
-        [ [ multiplyInteger y ] y ]
+      (termbind
+        (nonstrict)
+        (vardecl y (con integer))
+        [ [ (builtin multiplyInteger) y ] y ]
       )
+      [ [ (builtin multiplyInteger) y ] y ]
     )
   )
 )

--- a/plutus-use-cases/test/Spec/crowdfunding.pir
+++ b/plutus-use-cases/test/Spec/crowdfunding.pir
@@ -192,13 +192,6 @@
                 )
               )
             )
-            (termbind
-              (strict)
-              (vardecl
-                addInteger (fun (con integer) (fun (con integer) (con integer)))
-              )
-              (builtin addInteger)
-            )
             (let
               (rec)
               (termbind
@@ -385,137 +378,126 @@
                                               (lam
                                                 xs
                                                 [List [[Tuple2 k] r]]
-                                                (let
-                                                  (nonrec)
-                                                  (termbind
-                                                    (nonstrict)
-                                                    (vardecl wild [[Tuple2 k] r]
-                                                    )
-                                                    e
-                                                  )
-                                                  [
-                                                    {
-                                                      [
-                                                        { { Tuple2_match k } r }
-                                                        e
-                                                      ]
-                                                      [List [[Tuple2 k] r]]
-                                                    }
+                                                [
+                                                  {
+                                                    [
+                                                      { { Tuple2_match k } r } e
+                                                    ]
+                                                    [List [[Tuple2 k] r]]
+                                                  }
+                                                  (lam
+                                                    c
+                                                    k
                                                     (lam
-                                                      c
-                                                      k
-                                                      (lam
-                                                        ds
-                                                        r
+                                                      ds
+                                                      r
+                                                      [
                                                         [
                                                           [
-                                                            [
-                                                              {
+                                                            {
+                                                              [
+                                                                Bool_match
                                                                 [
-                                                                  Bool_match
                                                                   [
                                                                     [
-                                                                      [
+                                                                      {
                                                                         {
-                                                                          {
-                                                                            foldr
-                                                                            [[Tuple2 k] v]
-                                                                          }
-                                                                          Bool
-                                                                        }
-                                                                        (lam
-                                                                          a
+                                                                          foldr
                                                                           [[Tuple2 k] v]
-                                                                          (lam
-                                                                            acc
-                                                                            Bool
+                                                                        }
+                                                                        Bool
+                                                                      }
+                                                                      (lam
+                                                                        a
+                                                                        [[Tuple2 k] v]
+                                                                        (lam
+                                                                          acc
+                                                                          Bool
+                                                                          [
                                                                             [
                                                                               [
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      Bool_match
-                                                                                      acc
-                                                                                    ]
-                                                                                    (fun Unit Bool)
-                                                                                  }
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    True
-                                                                                  )
-                                                                                ]
+                                                                                {
+                                                                                  [
+                                                                                    Bool_match
+                                                                                    acc
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
                                                                                 (lam
                                                                                   thunk
                                                                                   Unit
-                                                                                  [
-                                                                                    {
-                                                                                      [
-                                                                                        {
-                                                                                          {
-                                                                                            Tuple2_match
-                                                                                            k
-                                                                                          }
-                                                                                          v
-                                                                                        }
-                                                                                        a
-                                                                                      ]
-                                                                                      Bool
-                                                                                    }
-                                                                                    (lam
-                                                                                      c
-                                                                                      k
-                                                                                      (lam
-                                                                                        ds
-                                                                                        v
-                                                                                        [
-                                                                                          [
-                                                                                            dEq
-                                                                                            c
-                                                                                          ]
-                                                                                          c
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
+                                                                                  True
                                                                                 )
                                                                               ]
-                                                                              Unit
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                [
+                                                                                  {
+                                                                                    [
+                                                                                      {
+                                                                                        {
+                                                                                          Tuple2_match
+                                                                                          k
+                                                                                        }
+                                                                                        v
+                                                                                      }
+                                                                                      a
+                                                                                    ]
+                                                                                    Bool
+                                                                                  }
+                                                                                  (lam
+                                                                                    c
+                                                                                    k
+                                                                                    (lam
+                                                                                      ds
+                                                                                      v
+                                                                                      [
+                                                                                        [
+                                                                                          dEq
+                                                                                          c
+                                                                                        ]
+                                                                                        c
+                                                                                      ]
+                                                                                    )
+                                                                                  )
+                                                                                ]
+                                                                              )
                                                                             ]
-                                                                          )
+                                                                            Unit
+                                                                          ]
                                                                         )
-                                                                      ]
-                                                                      False
+                                                                      )
                                                                     ]
-                                                                    ds
+                                                                    False
                                                                   ]
+                                                                  ds
                                                                 ]
-                                                                (fun Unit [List [[Tuple2 k] r]])
-                                                              }
-                                                              (lam thunk Unit xs
-                                                              )
-                                                            ]
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              [
-                                                                [
-                                                                  {
-                                                                    Cons
-                                                                    [[Tuple2 k] r]
-                                                                  }
-                                                                  wild
-                                                                ]
-                                                                xs
                                                               ]
-                                                            )
+                                                              (fun Unit [List [[Tuple2 k] r]])
+                                                            }
+                                                            (lam thunk Unit xs)
                                                           ]
-                                                          Unit
+                                                          (lam
+                                                            thunk
+                                                            Unit
+                                                            [
+                                                              [
+                                                                {
+                                                                  Cons
+                                                                  [[Tuple2 k] r]
+                                                                }
+                                                                e
+                                                              ]
+                                                              xs
+                                                            ]
+                                                          )
                                                         ]
-                                                      )
+                                                        Unit
+                                                      ]
                                                     )
-                                                  ]
-                                                )
+                                                  )
+                                                ]
                                               )
                                             )
                                           ]
@@ -1393,7 +1375,7 @@
                       fMonoidValue_c
                       (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]))
                     )
-                    [ unionWith addInteger ]
+                    [ unionWith (builtin addInteger) ]
                   )
                   (termbind
                     (strict)
@@ -2226,20 +2208,7 @@
                                                                   (fun Unit Bool)
                                                                 }
                                                                 (lam
-                                                                  thunk
-                                                                  Unit
-                                                                  (let
-                                                                    (nonrec)
-                                                                    (termbind
-                                                                      (strict)
-                                                                      (vardecl
-                                                                        wild
-                                                                        Bool
-                                                                      )
-                                                                      in
-                                                                    )
-                                                                    j
-                                                                  )
+                                                                  thunk Unit j
                                                                 )
                                                               ]
                                                               (lam
@@ -2346,20 +2315,7 @@
                                                           ]
                                                           (fun Unit Bool)
                                                         }
-                                                        (lam
-                                                          thunk
-                                                          Unit
-                                                          (let
-                                                            (nonrec)
-                                                            (termbind
-                                                              (strict)
-                                                              (vardecl wild Bool
-                                                              )
-                                                              ww
-                                                            )
-                                                            j
-                                                          )
-                                                        )
+                                                        (lam thunk Unit j)
                                                       ]
                                                       (lam
                                                         thunk
@@ -2636,86 +2592,64 @@
                                                         (lam
                                                           thunk
                                                           Unit
-                                                          (let
-                                                            (nonrec)
-                                                            (termbind
-                                                              (strict)
-                                                              (vardecl wild Bool
-                                                              )
-                                                              ww
-                                                            )
-                                                            [
-                                                              {
-                                                                [
-                                                                  {
-                                                                    UpperBound_match
-                                                                    (con integer)
-                                                                  }
-                                                                  ww
-                                                                ]
-                                                                Bool
-                                                              }
+                                                          [
+                                                            {
+                                                              [
+                                                                {
+                                                                  UpperBound_match
+                                                                  (con integer)
+                                                                }
+                                                                ww
+                                                              ]
+                                                              Bool
+                                                            }
+                                                            (lam
+                                                              v
+                                                              [Extended (con integer)]
                                                               (lam
-                                                                v
-                                                                [Extended (con integer)]
-                                                                (lam
-                                                                  in
-                                                                  Bool
+                                                                in
+                                                                Bool
+                                                                [
                                                                   [
                                                                     [
                                                                       [
-                                                                        [
-                                                                          {
-                                                                            [
-                                                                              {
-                                                                                Extended_match
-                                                                                (con integer)
-                                                                              }
-                                                                              v
-                                                                            ]
-                                                                            (fun Unit Bool)
-                                                                          }
-                                                                          (lam
-                                                                            default_arg0
-                                                                            (con integer)
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              j
-                                                                            )
-                                                                          )
-                                                                        ]
+                                                                        {
+                                                                          [
+                                                                            {
+                                                                              Extended_match
+                                                                              (con integer)
+                                                                            }
+                                                                            v
+                                                                          ]
+                                                                          (fun Unit Bool)
+                                                                        }
                                                                         (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          j
+                                                                          default_arg0
+                                                                          (con integer)
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            j
+                                                                          )
                                                                         )
                                                                       ]
                                                                       (lam
                                                                         thunk
                                                                         Unit
-                                                                        (let
-                                                                          (nonrec
-                                                                          )
-                                                                          (termbind
-                                                                            (strict
-                                                                            )
-                                                                            (vardecl
-                                                                              wild
-                                                                              Bool
-                                                                            )
-                                                                            in
-                                                                          )
-                                                                          j
-                                                                        )
+                                                                        j
                                                                       )
                                                                     ]
-                                                                    Unit
+                                                                    (lam
+                                                                      thunk
+                                                                      Unit
+                                                                      j
+                                                                    )
                                                                   ]
-                                                                )
+                                                                  Unit
+                                                                ]
                                                               )
-                                                            ]
-                                                          )
+                                                            )
+                                                          ]
                                                         )
                                                       ]
                                                       (lam
@@ -2790,20 +2724,7 @@
                                                                           (lam
                                                                             thunk
                                                                             Unit
-                                                                            (let
-                                                                              (nonrec
-                                                                              )
-                                                                              (termbind
-                                                                                (strict
-                                                                                )
-                                                                                (vardecl
-                                                                                  wild
-                                                                                  Bool
-                                                                                )
-                                                                                in
-                                                                              )
-                                                                              j
-                                                                            )
+                                                                            j
                                                                           )
                                                                         ]
                                                                         Unit
@@ -2870,19 +2791,7 @@
                                                         ]
                                                         (lam thunk Unit j)
                                                       ]
-                                                      (lam
-                                                        thunk
-                                                        Unit
-                                                        (let
-                                                          (nonrec)
-                                                          (termbind
-                                                            (strict)
-                                                            (vardecl wild Bool)
-                                                            in
-                                                          )
-                                                          j
-                                                        )
-                                                      )
+                                                      (lam thunk Unit j)
                                                     ]
                                                     Unit
                                                   ]

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -21,25 +21,25 @@ Events by wallet:
     - Iteration: 3
     Requests:
         4: {utxo-at:
-            ScriptAddress: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c}
+            ScriptAddress: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a}
       Response:
         ( 4
         , {utxo-at:
-           Utxo at ScriptAddress: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c =
-             41a75e6d15503a0e28cdd13f06d801e86812d93eb67a5c2cda8514a16644171b!1: PayToScript: 49cd69a6941f191e3d14ce83834e0f2ce175318995b40380854e3201171c0baa Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-             bfd3168dc3cace5f95ac0ad0052334a641a475155e74e23c5a37327e0e6b2aa2!1: PayToScript: 4c592448cff8d2b2ee40a509e1d5224260ef29f5b22cd920616e39cad65f466c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}
-             ca63281ddcc92149602f29042b7a00ee117365352dd41ec790a0d304889f97e6!1: PayToScript: b8324180800f57f26dee2ad65990e0a762a5dab9424d32e49855abd495f7196b Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}} )
+           Utxo at ScriptAddress: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a =
+             3e94c00e20f8044e3c527896b04a0d11f81b4faf2896b13ac8fca8cec9c7f253!1: PayToScript: 4c592448cff8d2b2ee40a509e1d5224260ef29f5b22cd920616e39cad65f466c Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}
+             770f7791e1c3a43bbefde6d0b1aaf7576ce8c4318c306bfbed0c707309138a38!1: PayToScript: 49cd69a6941f191e3d14ce83834e0f2ce175318995b40380854e3201171c0baa Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+             e11fa679b699d7ef9f41f82e827516fe93710f6f2cb2b5d32d3e06eba0a561dd!1: PayToScript: b8324180800f57f26dee2ad65990e0a762a5dab9424d32e49855abd495f7196b Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}} )
     - Iteration: 4
     Requests:
         5: {tx:
             Tx:
-              Tx fc8a6bb88a2fce62b1aee9e5dcea933e56a360310c3e5a6e477fa9fbd5bd5994:
+              Tx 79b9e175538e2dc88902fc3e956c7c4fb897460f36a7b4b99231b6196f299b86:
                 {inputs:
-                   - 41a75e6d15503a0e28cdd13f06d801e86812d93eb67a5c2cda8514a16644171b!1
+                   - 3e94c00e20f8044e3c527896b04a0d11f81b4faf2896b13ac8fca8cec9c7f253!1
                      Redeemer: <>
-                   - bfd3168dc3cace5f95ac0ad0052334a641a475155e74e23c5a37327e0e6b2aa2!1
+                   - 770f7791e1c3a43bbefde6d0b1aaf7576ce8c4318c306bfbed0c707309138a38!1
                      Redeemer: <>
-                   - ca63281ddcc92149602f29042b7a00ee117365352dd41ec790a0d304889f97e6!1
+                   - e11fa679b699d7ef9f41f82e827516fe93710f6f2cb2b5d32d3e06eba0a561dd!1
                      Redeemer: <>
                 outputs:
                 forge: Value {getValue = Map {unMap = []}}
@@ -52,7 +52,7 @@ Events by wallet:
       Response:
         ( 5
         , {tx:
-           WriteTxSuccess: b8b9c6f3f8637d167484e362b47ebd3a2eca0b8ace1f9e62bcb82325d5a8867d} )
+           WriteTxSuccess: 398751383afe598ba9f0f3691896126eb37a15c7f93ab33951e13f2bc8a3460c} )
   Events for W2:
     - Iteration: 1
     Requests:
@@ -78,11 +78,11 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx 8d209e3ba6f92d9159c26f334034694d87818e991e23885344420ed7205c42f8:
+              Tx b1a282980eba9457c92d7e0aeec840ff518427c4cd38fb992b1f5f7efca788b6:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-                    ScriptAddress: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+                    ScriptAddress: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
@@ -94,7 +94,7 @@ Events by wallet:
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: ca63281ddcc92149602f29042b7a00ee117365352dd41ec790a0d304889f97e6} )
+           WriteTxSuccess: e11fa679b699d7ef9f41f82e827516fe93710f6f2cb2b5d32d3e06eba0a561dd} )
   Events for W3:
     - Iteration: 1
     Requests:
@@ -120,11 +120,11 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx 6a4c4ba705ec26c0f3daee49bbf44c7fa14452a4875fb270aaca809e28a68ab8:
+              Tx 1f89c203f2df84b7121c3b4cc3c9940ede8df8916771ff96a082d927e36ff98b:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-                    ScriptAddress: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+                    ScriptAddress: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
@@ -136,7 +136,7 @@ Events by wallet:
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: 41a75e6d15503a0e28cdd13f06d801e86812d93eb67a5c2cda8514a16644171b} )
+           WriteTxSuccess: 770f7791e1c3a43bbefde6d0b1aaf7576ce8c4318c306bfbed0c707309138a38} )
   Events for W4:
     - Iteration: 1
     Requests:
@@ -162,11 +162,11 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx 950d6a72c34042928f872d9fb55bb6b042304c9e6b82577f08f78ed4fcdb849a:
+              Tx 5116952593de5a1591952eccb5a7f388d7338306e0d65cf0b0d0bd381a433fd2:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} addressed to
-                    ScriptAddress: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+                    ScriptAddress: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
@@ -178,7 +178,7 @@ Events by wallet:
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: bfd3168dc3cace5f95ac0ad0052334a641a475155e74e23c5a37327e0e6b2aa2} )
+           WriteTxSuccess: 3e94c00e20f8044e3c527896b04a0d11f81b4faf2896b13ac8fca8cec9c7f253} )
 Contract result by wallet:
     Wallet: W1
       Done

--- a/plutus-use-cases/test/Spec/future.pir
+++ b/plutus-use-cases/test/Spec/future.pir
@@ -305,19 +305,6 @@
             )
             (termbind
               (strict)
-              (vardecl fAdditiveGroupValue (con integer))
-              (con integer -1)
-            )
-            (termbind
-              (strict)
-              (vardecl
-                multiplyInteger
-                (fun (con integer) (fun (con integer) (con integer)))
-              )
-              (builtin multiplyInteger)
-            )
-            (termbind
-              (strict)
               (vardecl
                 fAdditiveGroupValue_cscale
                 (fun (con integer) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]))
@@ -468,7 +455,9 @@
                                                                     ]
                                                                     [
                                                                       [
-                                                                        multiplyInteger
+                                                                        (builtin
+                                                                          multiplyInteger
+                                                                        )
                                                                         i
                                                                       ]
                                                                       i
@@ -523,13 +512,6 @@
                   )
                 )
               )
-            )
-            (termbind
-              (strict)
-              (vardecl
-                addInteger (fun (con integer) (fun (con integer) (con integer)))
-              )
-              (builtin addInteger)
             )
             (termbind
               (strict)
@@ -740,137 +722,126 @@
                                               (lam
                                                 xs
                                                 [List [[Tuple2 k] r]]
-                                                (let
-                                                  (nonrec)
-                                                  (termbind
-                                                    (nonstrict)
-                                                    (vardecl wild [[Tuple2 k] r]
-                                                    )
-                                                    e
-                                                  )
-                                                  [
-                                                    {
-                                                      [
-                                                        { { Tuple2_match k } r }
-                                                        e
-                                                      ]
-                                                      [List [[Tuple2 k] r]]
-                                                    }
+                                                [
+                                                  {
+                                                    [
+                                                      { { Tuple2_match k } r } e
+                                                    ]
+                                                    [List [[Tuple2 k] r]]
+                                                  }
+                                                  (lam
+                                                    c
+                                                    k
                                                     (lam
-                                                      c
-                                                      k
-                                                      (lam
-                                                        ds
-                                                        r
+                                                      ds
+                                                      r
+                                                      [
                                                         [
                                                           [
-                                                            [
-                                                              {
+                                                            {
+                                                              [
+                                                                Bool_match
                                                                 [
-                                                                  Bool_match
                                                                   [
                                                                     [
-                                                                      [
+                                                                      {
                                                                         {
-                                                                          {
-                                                                            foldr
-                                                                            [[Tuple2 k] v]
-                                                                          }
-                                                                          Bool
-                                                                        }
-                                                                        (lam
-                                                                          a
+                                                                          foldr
                                                                           [[Tuple2 k] v]
-                                                                          (lam
-                                                                            acc
-                                                                            Bool
+                                                                        }
+                                                                        Bool
+                                                                      }
+                                                                      (lam
+                                                                        a
+                                                                        [[Tuple2 k] v]
+                                                                        (lam
+                                                                          acc
+                                                                          Bool
+                                                                          [
                                                                             [
                                                                               [
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      Bool_match
-                                                                                      acc
-                                                                                    ]
-                                                                                    (fun Unit Bool)
-                                                                                  }
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    True
-                                                                                  )
-                                                                                ]
+                                                                                {
+                                                                                  [
+                                                                                    Bool_match
+                                                                                    acc
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
                                                                                 (lam
                                                                                   thunk
                                                                                   Unit
-                                                                                  [
-                                                                                    {
-                                                                                      [
-                                                                                        {
-                                                                                          {
-                                                                                            Tuple2_match
-                                                                                            k
-                                                                                          }
-                                                                                          v
-                                                                                        }
-                                                                                        a
-                                                                                      ]
-                                                                                      Bool
-                                                                                    }
-                                                                                    (lam
-                                                                                      c
-                                                                                      k
-                                                                                      (lam
-                                                                                        ds
-                                                                                        v
-                                                                                        [
-                                                                                          [
-                                                                                            dEq
-                                                                                            c
-                                                                                          ]
-                                                                                          c
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
+                                                                                  True
                                                                                 )
                                                                               ]
-                                                                              Unit
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                [
+                                                                                  {
+                                                                                    [
+                                                                                      {
+                                                                                        {
+                                                                                          Tuple2_match
+                                                                                          k
+                                                                                        }
+                                                                                        v
+                                                                                      }
+                                                                                      a
+                                                                                    ]
+                                                                                    Bool
+                                                                                  }
+                                                                                  (lam
+                                                                                    c
+                                                                                    k
+                                                                                    (lam
+                                                                                      ds
+                                                                                      v
+                                                                                      [
+                                                                                        [
+                                                                                          dEq
+                                                                                          c
+                                                                                        ]
+                                                                                        c
+                                                                                      ]
+                                                                                    )
+                                                                                  )
+                                                                                ]
+                                                                              )
                                                                             ]
-                                                                          )
+                                                                            Unit
+                                                                          ]
                                                                         )
-                                                                      ]
-                                                                      False
+                                                                      )
                                                                     ]
-                                                                    ds
+                                                                    False
                                                                   ]
+                                                                  ds
                                                                 ]
-                                                                (fun Unit [List [[Tuple2 k] r]])
-                                                              }
-                                                              (lam thunk Unit xs
-                                                              )
-                                                            ]
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              [
-                                                                [
-                                                                  {
-                                                                    Cons
-                                                                    [[Tuple2 k] r]
-                                                                  }
-                                                                  wild
-                                                                ]
-                                                                xs
                                                               ]
-                                                            )
+                                                              (fun Unit [List [[Tuple2 k] r]])
+                                                            }
+                                                            (lam thunk Unit xs)
                                                           ]
-                                                          Unit
+                                                          (lam
+                                                            thunk
+                                                            Unit
+                                                            [
+                                                              [
+                                                                {
+                                                                  Cons
+                                                                  [[Tuple2 k] r]
+                                                                }
+                                                                e
+                                                              ]
+                                                              xs
+                                                            ]
+                                                          )
                                                         ]
-                                                      )
+                                                        Unit
+                                                      ]
                                                     )
-                                                  ]
-                                                )
+                                                  )
+                                                ]
                                               )
                                             )
                                           ]
@@ -1730,11 +1701,8 @@
                         ds
                         [(lam a (type) a) [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
                         [
-                          [ [ unionWith addInteger ] ds ]
-                          [
-                            [ fAdditiveGroupValue_cscale fAdditiveGroupValue ]
-                            ds
-                          ]
+                          [ [ unionWith (builtin addInteger) ] ds ]
+                          [ [ fAdditiveGroupValue_cscale (con integer -1) ] ds ]
                         ]
                       )
                     )
@@ -2089,12 +2057,9 @@
                     )
                   )
                   (termbind
-                    (strict) (vardecl unitDatum (con integer)) (con integer 0)
-                  )
-                  (termbind
                     (nonstrict)
                     (vardecl unitDatum Data)
-                    [ [ Constr unitDatum ] { Nil Data } ]
+                    [ [ Constr (con integer 0) ] { Nil Data } ]
                   )
                   (termbind
                     (strict)
@@ -2192,7 +2157,7 @@
                       (lam
                         ds
                         [(lam a (type) a) [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                        [ [ [ unionWith addInteger ] ds ] ds ]
+                        [ [ [ unionWith (builtin addInteger) ] ds ] ds ]
                       )
                     )
                   )
@@ -2204,17 +2169,6 @@
                       (vardecl
                         Margins
                         (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] Margins))
-                      )
-                    )
-                  )
-                  (datatypebind
-                    (datatype
-                      (tyvardecl Future (type))
-                      
-                      Future_match
-                      (vardecl
-                        Future
-                        (fun (con integer) (fun (con integer) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun (con bytestring) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] Future))))))
                       )
                     )
                   )
@@ -2239,11 +2193,6 @@
                         ]
                       )
                     )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl fIsDataFutureAction (con integer))
-                    (con integer 0)
                   )
                   (termbind
                     (strict)
@@ -3538,7 +3487,10 @@
                                                                                     equalsInteger
                                                                                     i
                                                                                   ]
-                                                                                  fIsDataFutureAction
+                                                                                  (con
+                                                                                    integer
+                                                                                      0
+                                                                                  )
                                                                                 ]
                                                                               ]
                                                                               (fun Unit [Maybe [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]])
@@ -3918,11 +3870,6 @@
                       )
                       (termbind
                         (strict)
-                        (vardecl scheckHashConstraints (con string))
-                        (con string "DecodingError")
-                      )
-                      (termbind
-                        (strict)
                         (vardecl trace (fun (con string) Unit))
                         (lam
                           arg
@@ -3933,7 +3880,7 @@
                       (termbind
                         (nonstrict)
                         (vardecl scheckHashConstraints Unit)
-                        [ trace scheckHashConstraints ]
+                        [ trace (con string "DecodingError") ]
                       )
                       (termbind
                         (strict)
@@ -4277,7 +4224,13 @@
                                             [
                                               [ Margins ds ]
                                               [
-                                                [ [ unionWith addInteger ] ds ]
+                                                [
+                                                  [
+                                                    unionWith
+                                                    (builtin addInteger)
+                                                  ]
+                                                  ds
+                                                ]
                                                 value
                                               ]
                                             ]
@@ -4301,7 +4254,13 @@
                                             [
                                               Margins
                                               [
-                                                [ [ unionWith addInteger ] ds ]
+                                                [
+                                                  [
+                                                    unionWith
+                                                    (builtin addInteger)
+                                                  ]
+                                                  ds
+                                                ]
                                                 value
                                               ]
                                             ]
@@ -4389,6 +4348,17 @@
                           ]
                         )
                       )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl Future (type))
+                          
+                          Future_match
+                          (vardecl
+                            Future
+                            (fun (con integer) (fun (con integer) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun (con bytestring) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] Future))))))
+                          )
+                        )
+                      )
                       (termbind
                         (strict)
                         (vardecl
@@ -4425,7 +4395,10 @@
                                           ds
                                           [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                           [
-                                            [ [ unionWith addInteger ] ds ]
+                                            [
+                                              [ unionWith (builtin addInteger) ]
+                                              ds
+                                            ]
                                             [
                                               [ fAdditiveGroupValue_cscale ds ]
                                               [
@@ -5141,705 +5114,145 @@
                               (lam
                                 i
                                 FutureAction
-                                (let
-                                  (nonrec)
-                                  (termbind
-                                    (nonstrict) (vardecl wild Future) future
-                                  )
-                                  [
-                                    {
-                                      [ Future_match future ]
-                                      [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
-                                    }
+                                [
+                                  {
+                                    [ Future_match future ]
+                                    [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
+                                  }
+                                  (lam
+                                    ds
+                                    (con integer)
                                     (lam
                                       ds
                                       (con integer)
                                       (lam
                                         ds
-                                        (con integer)
+                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                         (lam
                                           ds
                                           [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                           (lam
                                             ds
-                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                            (con bytestring)
                                             (lam
                                               ds
-                                              (con bytestring)
-                                              (lam
-                                                ds
-                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                [
-                                                  {
-                                                    [
-                                                      {
-                                                        State_match FutureState
-                                                      }
-                                                      ds
-                                                    ]
-                                                    [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
-                                                  }
+                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                              [
+                                                {
+                                                  [
+                                                    { State_match FutureState }
+                                                    ds
+                                                  ]
+                                                  [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
+                                                }
+                                                (lam
+                                                  ds
+                                                  FutureState
                                                   (lam
                                                     ds
-                                                    FutureState
-                                                    (lam
-                                                      ds
-                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                    [
                                                       [
                                                         [
-                                                          [
-                                                            {
-                                                              [
-                                                                FutureState_match
-                                                                ds
-                                                              ]
-                                                              (fun Unit [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]])
-                                                            }
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              {
-                                                                Nothing
-                                                                [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
-                                                              }
-                                                            )
-                                                          ]
+                                                          {
+                                                            [
+                                                              FutureState_match
+                                                              ds
+                                                            ]
+                                                            (fun Unit [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]])
+                                                          }
                                                           (lam
-                                                            accounts
-                                                            Margins
-                                                            (lam
-                                                              thunk
-                                                              Unit
+                                                            thunk
+                                                            Unit
+                                                            {
+                                                              Nothing
+                                                              [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
+                                                            }
+                                                          )
+                                                        ]
+                                                        (lam
+                                                          accounts
+                                                          Margins
+                                                          (lam
+                                                            thunk
+                                                            Unit
+                                                            [
                                                               [
                                                                 [
-                                                                  [
-                                                                    {
-                                                                      [
-                                                                        FutureAction_match
-                                                                        i
-                                                                      ]
-                                                                      [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
-                                                                    }
+                                                                  {
+                                                                    [
+                                                                      FutureAction_match
+                                                                      i
+                                                                    ]
+                                                                    [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
+                                                                  }
+                                                                  (lam
+                                                                    role
+                                                                    Role
                                                                     (lam
-                                                                      role
-                                                                      Role
-                                                                      (lam
-                                                                        topUp
-                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                      topUp
+                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                      [
+                                                                        {
+                                                                          Just
+                                                                          [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
+                                                                        }
                                                                         [
-                                                                          {
-                                                                            Just
-                                                                            [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
-                                                                          }
+                                                                          [
+                                                                            {
+                                                                              {
+                                                                                Tuple2
+                                                                                [[TxConstraints Void] Void]
+                                                                              }
+                                                                              [State FutureState]
+                                                                            }
+                                                                            {
+                                                                              {
+                                                                                fMonoidTxConstraints_cmempty
+                                                                                Void
+                                                                              }
+                                                                              Void
+                                                                            }
+                                                                          ]
                                                                           [
                                                                             [
                                                                               {
-                                                                                {
-                                                                                  Tuple2
-                                                                                  [[TxConstraints Void] Void]
-                                                                                }
-                                                                                [State FutureState]
+                                                                                State
+                                                                                FutureState
                                                                               }
-                                                                              {
-                                                                                {
-                                                                                  fMonoidTxConstraints_cmempty
-                                                                                  Void
-                                                                                }
-                                                                                Void
-                                                                              }
-                                                                            ]
-                                                                            [
                                                                               [
-                                                                                {
-                                                                                  State
-                                                                                  FutureState
-                                                                                }
+                                                                                Running
                                                                                 [
-                                                                                  Running
                                                                                   [
                                                                                     [
-                                                                                      [
-                                                                                        adjustMargin
-                                                                                        role
-                                                                                      ]
-                                                                                      topUp
+                                                                                      adjustMargin
+                                                                                      role
                                                                                     ]
-                                                                                    accounts
+                                                                                    topUp
                                                                                   ]
-                                                                                ]
-                                                                              ]
-                                                                              [
-                                                                                [
-                                                                                  [
-                                                                                    unionWith
-                                                                                    addInteger
-                                                                                  ]
-                                                                                  topUp
-                                                                                ]
-                                                                                [
-                                                                                  totalMargin
                                                                                   accounts
                                                                                 ]
                                                                               ]
                                                                             ]
-                                                                          ]
-                                                                        ]
-                                                                      )
-                                                                    )
-                                                                  ]
-                                                                  (lam
-                                                                    ov
-                                                                    [SignedMessage [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]]
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          [
-                                                                            {
-                                                                              {
-                                                                                Either_match
-                                                                                SignedMessageCheckError
-                                                                              }
-                                                                              [[Tuple2 [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]] [[TxConstraints Void] Void]]
-                                                                            }
                                                                             [
                                                                               [
-                                                                                {
-                                                                                  {
-                                                                                    sverifySignedMessageConstraints
-                                                                                    Void
-                                                                                  }
-                                                                                  Void
-                                                                                }
-                                                                                ds
-                                                                              ]
-                                                                              ov
-                                                                            ]
-                                                                          ]
-                                                                          [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
-                                                                        }
-                                                                        (lam
-                                                                          x
-                                                                          SignedMessageCheckError
-                                                                          {
-                                                                            Nothing
-                                                                            [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
-                                                                          }
-                                                                        )
-                                                                      ]
-                                                                      (lam
-                                                                        y
-                                                                        [[Tuple2 [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]] [[TxConstraints Void] Void]]
-                                                                        [
-                                                                          {
-                                                                            [
-                                                                              {
-                                                                                {
-                                                                                  Tuple2_match
-                                                                                  [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                                                                                }
-                                                                                [[TxConstraints Void] Void]
-                                                                              }
-                                                                              y
-                                                                            ]
-                                                                            [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
-                                                                          }
-                                                                          (lam
-                                                                            ds
-                                                                            [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                                                                            (lam
-                                                                              oracleConstraints
-                                                                              [[TxConstraints Void] Void]
-                                                                              [
-                                                                                {
-                                                                                  [
-                                                                                    {
-                                                                                      Observation_match
-                                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                    }
-                                                                                    ds
-                                                                                  ]
-                                                                                  [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
-                                                                                }
-                                                                                (lam
-                                                                                  ds
-                                                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                  (lam
-                                                                                    ds
-                                                                                    (con integer)
-                                                                                    [
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              Bool_match
-                                                                                              [
-                                                                                                [
-                                                                                                  equalsInteger
-                                                                                                  ds
-                                                                                                ]
-                                                                                                ds
-                                                                                              ]
-                                                                                            ]
-                                                                                            (fun Unit [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]])
-                                                                                          }
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            (let
-                                                                                              (nonrec
-                                                                                              )
-                                                                                              (termbind
-                                                                                                (nonstrict
-                                                                                                )
-                                                                                                (vardecl
-                                                                                                  r
-                                                                                                  [[TxConstraints Void] Void]
-                                                                                                )
-                                                                                                [
-                                                                                                  [
-                                                                                                    payoutsTx
-                                                                                                    [
-                                                                                                      {
-                                                                                                        [
-                                                                                                          Margins_match
-                                                                                                          accounts
-                                                                                                        ]
-                                                                                                        Payouts
-                                                                                                      }
-                                                                                                      (lam
-                                                                                                        ds
-                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                        (lam
-                                                                                                          ds
-                                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                          (let
-                                                                                                            (nonrec
-                                                                                                            )
-                                                                                                            (termbind
-                                                                                                              (nonstrict
-                                                                                                              )
-                                                                                                              (vardecl
-                                                                                                                delta
-                                                                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                              )
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  fAdditiveGroupValue_cscale
-                                                                                                                  ds
-                                                                                                                ]
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    fAdditiveGroupValue
-                                                                                                                    ds
-                                                                                                                  ]
-                                                                                                                  ds
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                            )
-                                                                                                            [
-                                                                                                              [
-                                                                                                                Payouts
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    fAdditiveGroupValue
-                                                                                                                    ds
-                                                                                                                  ]
-                                                                                                                  delta
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  fAdditiveMonoidValue
-                                                                                                                  ds
-                                                                                                                ]
-                                                                                                                delta
-                                                                                                              ]
-                                                                                                            ]
-                                                                                                          )
-                                                                                                        )
-                                                                                                      )
-                                                                                                    ]
-                                                                                                  ]
-                                                                                                  owners
-                                                                                                ]
-                                                                                              )
-                                                                                              [
-                                                                                                {
-                                                                                                  Just
-                                                                                                  [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
-                                                                                                }
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      {
-                                                                                                        Tuple2
-                                                                                                        [[TxConstraints Void] Void]
-                                                                                                      }
-                                                                                                      [State FutureState]
-                                                                                                    }
-                                                                                                    [
-                                                                                                      [
-                                                                                                        [
-                                                                                                          {
-                                                                                                            {
-                                                                                                              TxConstraints
-                                                                                                              Void
-                                                                                                            }
-                                                                                                            Void
-                                                                                                          }
-                                                                                                          [
-                                                                                                            [
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  {
-                                                                                                                    foldr
-                                                                                                                    TxConstraint
-                                                                                                                  }
-                                                                                                                  [List TxConstraint]
-                                                                                                                }
-                                                                                                                {
-                                                                                                                  Cons
-                                                                                                                  TxConstraint
-                                                                                                                }
-                                                                                                              ]
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      {
-                                                                                                                        TxConstraints_match
-                                                                                                                        Void
-                                                                                                                      }
-                                                                                                                      Void
-                                                                                                                    }
-                                                                                                                    r
-                                                                                                                  ]
-                                                                                                                  [List TxConstraint]
-                                                                                                                }
-                                                                                                                (lam
-                                                                                                                  ds
-                                                                                                                  [List TxConstraint]
-                                                                                                                  (lam
-                                                                                                                    ds
-                                                                                                                    [List [InputConstraint Void]]
-                                                                                                                    (lam
-                                                                                                                      ds
-                                                                                                                      [List [OutputConstraint Void]]
-                                                                                                                      ds
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                )
-                                                                                                              ]
-                                                                                                            ]
-                                                                                                            [
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  {
-                                                                                                                    {
-                                                                                                                      foldr
-                                                                                                                      TxConstraint
-                                                                                                                    }
-                                                                                                                    [List TxConstraint]
-                                                                                                                  }
-                                                                                                                  {
-                                                                                                                    Cons
-                                                                                                                    TxConstraint
-                                                                                                                  }
-                                                                                                                ]
-                                                                                                                [
-                                                                                                                  {
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        {
-                                                                                                                          TxConstraints_match
-                                                                                                                          Void
-                                                                                                                        }
-                                                                                                                        Void
-                                                                                                                      }
-                                                                                                                      oracleConstraints
-                                                                                                                    ]
-                                                                                                                    [List TxConstraint]
-                                                                                                                  }
-                                                                                                                  (lam
-                                                                                                                    ds
-                                                                                                                    [List TxConstraint]
-                                                                                                                    (lam
-                                                                                                                      ds
-                                                                                                                      [List [InputConstraint Void]]
-                                                                                                                      (lam
-                                                                                                                        ds
-                                                                                                                        [List [OutputConstraint Void]]
-                                                                                                                        ds
-                                                                                                                      )
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  build
-                                                                                                                  TxConstraint
-                                                                                                                }
-                                                                                                                (abs
-                                                                                                                  a
-                                                                                                                  (type)
-                                                                                                                  (lam
-                                                                                                                    c
-                                                                                                                    (fun TxConstraint (fun a a))
-                                                                                                                    (lam
-                                                                                                                      n
-                                                                                                                      a
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          c
-                                                                                                                          [
-                                                                                                                            MustValidateIn
-                                                                                                                            [
-                                                                                                                              {
-                                                                                                                                from
-                                                                                                                                (con integer)
-                                                                                                                              }
-                                                                                                                              ds
-                                                                                                                            ]
-                                                                                                                          ]
-                                                                                                                        ]
-                                                                                                                        n
-                                                                                                                      ]
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                )
-                                                                                                              ]
-                                                                                                            ]
-                                                                                                          ]
-                                                                                                        ]
-                                                                                                        [
-                                                                                                          [
-                                                                                                            [
-                                                                                                              {
-                                                                                                                {
-                                                                                                                  foldr
-                                                                                                                  [InputConstraint Void]
-                                                                                                                }
-                                                                                                                [List [InputConstraint Void]]
-                                                                                                              }
-                                                                                                              {
-                                                                                                                Cons
-                                                                                                                [InputConstraint Void]
-                                                                                                              }
-                                                                                                            ]
-                                                                                                            [
-                                                                                                              {
-                                                                                                                [
-                                                                                                                  {
-                                                                                                                    {
-                                                                                                                      TxConstraints_match
-                                                                                                                      Void
-                                                                                                                    }
-                                                                                                                    Void
-                                                                                                                  }
-                                                                                                                  r
-                                                                                                                ]
-                                                                                                                [List [InputConstraint Void]]
-                                                                                                              }
-                                                                                                              (lam
-                                                                                                                ds
-                                                                                                                [List TxConstraint]
-                                                                                                                (lam
-                                                                                                                  ds
-                                                                                                                  [List [InputConstraint Void]]
-                                                                                                                  (lam
-                                                                                                                    ds
-                                                                                                                    [List [OutputConstraint Void]]
-                                                                                                                    ds
-                                                                                                                  )
-                                                                                                                )
-                                                                                                              )
-                                                                                                            ]
-                                                                                                          ]
-                                                                                                          [
-                                                                                                            [
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  {
-                                                                                                                    foldr
-                                                                                                                    [InputConstraint Void]
-                                                                                                                  }
-                                                                                                                  [List [InputConstraint Void]]
-                                                                                                                }
-                                                                                                                {
-                                                                                                                  Cons
-                                                                                                                  [InputConstraint Void]
-                                                                                                                }
-                                                                                                              ]
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      {
-                                                                                                                        TxConstraints_match
-                                                                                                                        Void
-                                                                                                                      }
-                                                                                                                      Void
-                                                                                                                    }
-                                                                                                                    oracleConstraints
-                                                                                                                  ]
-                                                                                                                  [List [InputConstraint Void]]
-                                                                                                                }
-                                                                                                                (lam
-                                                                                                                  ds
-                                                                                                                  [List TxConstraint]
-                                                                                                                  (lam
-                                                                                                                    ds
-                                                                                                                    [List [InputConstraint Void]]
-                                                                                                                    (lam
-                                                                                                                      ds
-                                                                                                                      [List [OutputConstraint Void]]
-                                                                                                                      ds
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                )
-                                                                                                              ]
-                                                                                                            ]
-                                                                                                            {
-                                                                                                              Nil
-                                                                                                              [InputConstraint Void]
-                                                                                                            }
-                                                                                                          ]
-                                                                                                        ]
-                                                                                                      ]
-                                                                                                      [
-                                                                                                        [
-                                                                                                          [
-                                                                                                            {
-                                                                                                              {
-                                                                                                                foldr
-                                                                                                                [OutputConstraint Void]
-                                                                                                              }
-                                                                                                              [List [OutputConstraint Void]]
-                                                                                                            }
-                                                                                                            {
-                                                                                                              Cons
-                                                                                                              [OutputConstraint Void]
-                                                                                                            }
-                                                                                                          ]
-                                                                                                          [
-                                                                                                            {
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  {
-                                                                                                                    TxConstraints_match
-                                                                                                                    Void
-                                                                                                                  }
-                                                                                                                  Void
-                                                                                                                }
-                                                                                                                r
-                                                                                                              ]
-                                                                                                              [List [OutputConstraint Void]]
-                                                                                                            }
-                                                                                                            (lam
-                                                                                                              ds
-                                                                                                              [List TxConstraint]
-                                                                                                              (lam
-                                                                                                                ds
-                                                                                                                [List [InputConstraint Void]]
-                                                                                                                (lam
-                                                                                                                  ds
-                                                                                                                  [List [OutputConstraint Void]]
-                                                                                                                  ds
-                                                                                                                )
-                                                                                                              )
-                                                                                                            )
-                                                                                                          ]
-                                                                                                        ]
-                                                                                                        [
-                                                                                                          [
-                                                                                                            [
-                                                                                                              {
-                                                                                                                {
-                                                                                                                  foldr
-                                                                                                                  [OutputConstraint Void]
-                                                                                                                }
-                                                                                                                [List [OutputConstraint Void]]
-                                                                                                              }
-                                                                                                              {
-                                                                                                                Cons
-                                                                                                                [OutputConstraint Void]
-                                                                                                              }
-                                                                                                            ]
-                                                                                                            [
-                                                                                                              {
-                                                                                                                [
-                                                                                                                  {
-                                                                                                                    {
-                                                                                                                      TxConstraints_match
-                                                                                                                      Void
-                                                                                                                    }
-                                                                                                                    Void
-                                                                                                                  }
-                                                                                                                  oracleConstraints
-                                                                                                                ]
-                                                                                                                [List [OutputConstraint Void]]
-                                                                                                              }
-                                                                                                              (lam
-                                                                                                                ds
-                                                                                                                [List TxConstraint]
-                                                                                                                (lam
-                                                                                                                  ds
-                                                                                                                  [List [InputConstraint Void]]
-                                                                                                                  (lam
-                                                                                                                    ds
-                                                                                                                    [List [OutputConstraint Void]]
-                                                                                                                    ds
-                                                                                                                  )
-                                                                                                                )
-                                                                                                              )
-                                                                                                            ]
-                                                                                                          ]
-                                                                                                          {
-                                                                                                            Nil
-                                                                                                            [OutputConstraint Void]
-                                                                                                          }
-                                                                                                        ]
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                  ]
-                                                                                                  [
-                                                                                                    [
-                                                                                                      {
-                                                                                                        State
-                                                                                                        FutureState
-                                                                                                      }
-                                                                                                      Finished
-                                                                                                    ]
-                                                                                                    {
-                                                                                                      Nil
-                                                                                                      [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                    }
-                                                                                                  ]
-                                                                                                ]
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          {
-                                                                                            Nothing
-                                                                                            [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
-                                                                                          }
-                                                                                        )
-                                                                                      ]
-                                                                                      Unit
-                                                                                    ]
+                                                                                [
+                                                                                  unionWith
+                                                                                  (builtin
+                                                                                    addInteger
                                                                                   )
-                                                                                )
+                                                                                ]
+                                                                                topUp
                                                                               ]
-                                                                            )
-                                                                          )
+                                                                              [
+                                                                                totalMargin
+                                                                                accounts
+                                                                              ]
+                                                                            ]
+                                                                          ]
                                                                         ]
-                                                                      )
-                                                                    ]
+                                                                      ]
+                                                                    )
                                                                   )
                                                                 ]
                                                                 (lam
@@ -5926,17 +5339,11 @@
                                                                                       [
                                                                                         {
                                                                                           [
-                                                                                            {
-                                                                                              Maybe_match
-                                                                                              Role
-                                                                                            }
+                                                                                            Bool_match
                                                                                             [
                                                                                               [
-                                                                                                [
-                                                                                                  violatingRole
-                                                                                                  wild
-                                                                                                ]
-                                                                                                accounts
+                                                                                                equalsInteger
+                                                                                                ds
                                                                                               ]
                                                                                               ds
                                                                                             ]
@@ -5944,132 +5351,624 @@
                                                                                           (fun Unit [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]])
                                                                                         }
                                                                                         (lam
-                                                                                          vRole
-                                                                                          Role
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          (let
+                                                                                            (nonrec
+                                                                                            )
+                                                                                            (termbind
+                                                                                              (nonstrict
+                                                                                              )
+                                                                                              (vardecl
+                                                                                                r
+                                                                                                [[TxConstraints Void] Void]
+                                                                                              )
+                                                                                              [
+                                                                                                [
+                                                                                                  payoutsTx
+                                                                                                  [
+                                                                                                    {
+                                                                                                      [
+                                                                                                        Margins_match
+                                                                                                        accounts
+                                                                                                      ]
+                                                                                                      Payouts
+                                                                                                    }
+                                                                                                    (lam
+                                                                                                      ds
+                                                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                      (lam
+                                                                                                        ds
+                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                        (let
+                                                                                                          (nonrec
+                                                                                                          )
+                                                                                                          (termbind
+                                                                                                            (nonstrict
+                                                                                                            )
+                                                                                                            (vardecl
+                                                                                                              delta
+                                                                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                            )
+                                                                                                            [
+                                                                                                              [
+                                                                                                                fAdditiveGroupValue_cscale
+                                                                                                                ds
+                                                                                                              ]
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  fAdditiveGroupValue
+                                                                                                                  ds
+                                                                                                                ]
+                                                                                                                ds
+                                                                                                              ]
+                                                                                                            ]
+                                                                                                          )
+                                                                                                          [
+                                                                                                            [
+                                                                                                              Payouts
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  fAdditiveGroupValue
+                                                                                                                  ds
+                                                                                                                ]
+                                                                                                                delta
+                                                                                                              ]
+                                                                                                            ]
+                                                                                                            [
+                                                                                                              [
+                                                                                                                fAdditiveMonoidValue
+                                                                                                                ds
+                                                                                                              ]
+                                                                                                              delta
+                                                                                                            ]
+                                                                                                          ]
+                                                                                                        )
+                                                                                                      )
+                                                                                                    )
+                                                                                                  ]
+                                                                                                ]
+                                                                                                owners
+                                                                                              ]
+                                                                                            )
                                                                                             [
+                                                                                              {
+                                                                                                Just
+                                                                                                [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
+                                                                                              }
                                                                                               [
                                                                                                 [
                                                                                                   {
-                                                                                                    [
-                                                                                                      Bool_match
-                                                                                                      [
-                                                                                                        [
-                                                                                                          greaterThanInteger
-                                                                                                          ds
-                                                                                                        ]
-                                                                                                        ds
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                    (fun Unit [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]])
+                                                                                                    {
+                                                                                                      Tuple2
+                                                                                                      [[TxConstraints Void] Void]
+                                                                                                    }
+                                                                                                    [State FutureState]
                                                                                                   }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
+                                                                                                  [
                                                                                                     [
-                                                                                                      {
-                                                                                                        Just
-                                                                                                        [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
-                                                                                                      }
                                                                                                       [
-                                                                                                        [
+                                                                                                        {
                                                                                                           {
-                                                                                                            {
-                                                                                                              Tuple2
-                                                                                                              [[TxConstraints Void] Void]
-                                                                                                            }
-                                                                                                            [State FutureState]
+                                                                                                            TxConstraints
+                                                                                                            Void
                                                                                                           }
+                                                                                                          Void
+                                                                                                        }
+                                                                                                        [
                                                                                                           [
                                                                                                             [
                                                                                                               {
                                                                                                                 {
-                                                                                                                  fMonoidTxConstraints_c
+                                                                                                                  foldr
+                                                                                                                  TxConstraint
+                                                                                                                }
+                                                                                                                [List TxConstraint]
+                                                                                                              }
+                                                                                                              {
+                                                                                                                Cons
+                                                                                                                TxConstraint
+                                                                                                              }
+                                                                                                            ]
+                                                                                                            [
+                                                                                                              {
+                                                                                                                [
+                                                                                                                  {
+                                                                                                                    {
+                                                                                                                      TxConstraints_match
+                                                                                                                      Void
+                                                                                                                    }
+                                                                                                                    Void
+                                                                                                                  }
+                                                                                                                  r
+                                                                                                                ]
+                                                                                                                [List TxConstraint]
+                                                                                                              }
+                                                                                                              (lam
+                                                                                                                ds
+                                                                                                                [List TxConstraint]
+                                                                                                                (lam
+                                                                                                                  ds
+                                                                                                                  [List [InputConstraint Void]]
+                                                                                                                  (lam
+                                                                                                                    ds
+                                                                                                                    [List [OutputConstraint Void]]
+                                                                                                                    ds
+                                                                                                                  )
+                                                                                                                )
+                                                                                                              )
+                                                                                                            ]
+                                                                                                          ]
+                                                                                                          [
+                                                                                                            [
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  {
+                                                                                                                    foldr
+                                                                                                                    TxConstraint
+                                                                                                                  }
+                                                                                                                  [List TxConstraint]
+                                                                                                                }
+                                                                                                                {
+                                                                                                                  Cons
+                                                                                                                  TxConstraint
+                                                                                                                }
+                                                                                                              ]
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  [
+                                                                                                                    {
+                                                                                                                      {
+                                                                                                                        TxConstraints_match
+                                                                                                                        Void
+                                                                                                                      }
+                                                                                                                      Void
+                                                                                                                    }
+                                                                                                                    oracleConstraints
+                                                                                                                  ]
+                                                                                                                  [List TxConstraint]
+                                                                                                                }
+                                                                                                                (lam
+                                                                                                                  ds
+                                                                                                                  [List TxConstraint]
+                                                                                                                  (lam
+                                                                                                                    ds
+                                                                                                                    [List [InputConstraint Void]]
+                                                                                                                    (lam
+                                                                                                                      ds
+                                                                                                                      [List [OutputConstraint Void]]
+                                                                                                                      ds
+                                                                                                                    )
+                                                                                                                  )
+                                                                                                                )
+                                                                                                              ]
+                                                                                                            ]
+                                                                                                            [
+                                                                                                              {
+                                                                                                                build
+                                                                                                                TxConstraint
+                                                                                                              }
+                                                                                                              (abs
+                                                                                                                a
+                                                                                                                (type)
+                                                                                                                (lam
+                                                                                                                  c
+                                                                                                                  (fun TxConstraint (fun a a))
+                                                                                                                  (lam
+                                                                                                                    n
+                                                                                                                    a
+                                                                                                                    [
+                                                                                                                      [
+                                                                                                                        c
+                                                                                                                        [
+                                                                                                                          MustValidateIn
+                                                                                                                          [
+                                                                                                                            {
+                                                                                                                              from
+                                                                                                                              (con integer)
+                                                                                                                            }
+                                                                                                                            ds
+                                                                                                                          ]
+                                                                                                                        ]
+                                                                                                                      ]
+                                                                                                                      n
+                                                                                                                    ]
+                                                                                                                  )
+                                                                                                                )
+                                                                                                              )
+                                                                                                            ]
+                                                                                                          ]
+                                                                                                        ]
+                                                                                                      ]
+                                                                                                      [
+                                                                                                        [
+                                                                                                          [
+                                                                                                            {
+                                                                                                              {
+                                                                                                                foldr
+                                                                                                                [InputConstraint Void]
+                                                                                                              }
+                                                                                                              [List [InputConstraint Void]]
+                                                                                                            }
+                                                                                                            {
+                                                                                                              Cons
+                                                                                                              [InputConstraint Void]
+                                                                                                            }
+                                                                                                          ]
+                                                                                                          [
+                                                                                                            {
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  {
+                                                                                                                    TxConstraints_match
+                                                                                                                    Void
+                                                                                                                  }
+                                                                                                                  Void
+                                                                                                                }
+                                                                                                                r
+                                                                                                              ]
+                                                                                                              [List [InputConstraint Void]]
+                                                                                                            }
+                                                                                                            (lam
+                                                                                                              ds
+                                                                                                              [List TxConstraint]
+                                                                                                              (lam
+                                                                                                                ds
+                                                                                                                [List [InputConstraint Void]]
+                                                                                                                (lam
+                                                                                                                  ds
+                                                                                                                  [List [OutputConstraint Void]]
+                                                                                                                  ds
+                                                                                                                )
+                                                                                                              )
+                                                                                                            )
+                                                                                                          ]
+                                                                                                        ]
+                                                                                                        [
+                                                                                                          [
+                                                                                                            [
+                                                                                                              {
+                                                                                                                {
+                                                                                                                  foldr
+                                                                                                                  [InputConstraint Void]
+                                                                                                                }
+                                                                                                                [List [InputConstraint Void]]
+                                                                                                              }
+                                                                                                              {
+                                                                                                                Cons
+                                                                                                                [InputConstraint Void]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                            [
+                                                                                                              {
+                                                                                                                [
+                                                                                                                  {
+                                                                                                                    {
+                                                                                                                      TxConstraints_match
+                                                                                                                      Void
+                                                                                                                    }
+                                                                                                                    Void
+                                                                                                                  }
+                                                                                                                  oracleConstraints
+                                                                                                                ]
+                                                                                                                [List [InputConstraint Void]]
+                                                                                                              }
+                                                                                                              (lam
+                                                                                                                ds
+                                                                                                                [List TxConstraint]
+                                                                                                                (lam
+                                                                                                                  ds
+                                                                                                                  [List [InputConstraint Void]]
+                                                                                                                  (lam
+                                                                                                                    ds
+                                                                                                                    [List [OutputConstraint Void]]
+                                                                                                                    ds
+                                                                                                                  )
+                                                                                                                )
+                                                                                                              )
+                                                                                                            ]
+                                                                                                          ]
+                                                                                                          {
+                                                                                                            Nil
+                                                                                                            [InputConstraint Void]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      ]
+                                                                                                    ]
+                                                                                                    [
+                                                                                                      [
+                                                                                                        [
+                                                                                                          {
+                                                                                                            {
+                                                                                                              foldr
+                                                                                                              [OutputConstraint Void]
+                                                                                                            }
+                                                                                                            [List [OutputConstraint Void]]
+                                                                                                          }
+                                                                                                          {
+                                                                                                            Cons
+                                                                                                            [OutputConstraint Void]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                        [
+                                                                                                          {
+                                                                                                            [
+                                                                                                              {
+                                                                                                                {
+                                                                                                                  TxConstraints_match
                                                                                                                   Void
                                                                                                                 }
                                                                                                                 Void
                                                                                                               }
+                                                                                                              r
+                                                                                                            ]
+                                                                                                            [List [OutputConstraint Void]]
+                                                                                                          }
+                                                                                                          (lam
+                                                                                                            ds
+                                                                                                            [List TxConstraint]
+                                                                                                            (lam
+                                                                                                              ds
+                                                                                                              [List [InputConstraint Void]]
+                                                                                                              (lam
+                                                                                                                ds
+                                                                                                                [List [OutputConstraint Void]]
+                                                                                                                ds
+                                                                                                              )
+                                                                                                            )
+                                                                                                          )
+                                                                                                        ]
+                                                                                                      ]
+                                                                                                      [
+                                                                                                        [
+                                                                                                          [
+                                                                                                            {
+                                                                                                              {
+                                                                                                                foldr
+                                                                                                                [OutputConstraint Void]
+                                                                                                              }
+                                                                                                              [List [OutputConstraint Void]]
+                                                                                                            }
+                                                                                                            {
+                                                                                                              Cons
+                                                                                                              [OutputConstraint Void]
+                                                                                                            }
+                                                                                                          ]
+                                                                                                          [
+                                                                                                            {
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  {
+                                                                                                                    TxConstraints_match
+                                                                                                                    Void
+                                                                                                                  }
+                                                                                                                  Void
+                                                                                                                }
+                                                                                                                oracleConstraints
+                                                                                                              ]
+                                                                                                              [List [OutputConstraint Void]]
+                                                                                                            }
+                                                                                                            (lam
+                                                                                                              ds
+                                                                                                              [List TxConstraint]
+                                                                                                              (lam
+                                                                                                                ds
+                                                                                                                [List [InputConstraint Void]]
+                                                                                                                (lam
+                                                                                                                  ds
+                                                                                                                  [List [OutputConstraint Void]]
+                                                                                                                  ds
+                                                                                                                )
+                                                                                                              )
+                                                                                                            )
+                                                                                                          ]
+                                                                                                        ]
+                                                                                                        {
+                                                                                                          Nil
+                                                                                                          [OutputConstraint Void]
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    ]
+                                                                                                  ]
+                                                                                                ]
+                                                                                                [
+                                                                                                  [
+                                                                                                    {
+                                                                                                      State
+                                                                                                      FutureState
+                                                                                                    }
+                                                                                                    Finished
+                                                                                                  ]
+                                                                                                  {
+                                                                                                    Nil
+                                                                                                    [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                  }
+                                                                                                ]
+                                                                                              ]
+                                                                                            ]
+                                                                                          )
+                                                                                        )
+                                                                                      ]
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        {
+                                                                                          Nothing
+                                                                                          [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
+                                                                                        }
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
+                                                                                  ]
+                                                                                )
+                                                                              )
+                                                                            ]
+                                                                          )
+                                                                        )
+                                                                      ]
+                                                                    )
+                                                                  ]
+                                                                )
+                                                              ]
+                                                              (lam
+                                                                ov
+                                                                [SignedMessage [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]]
+                                                                [
+                                                                  [
+                                                                    {
+                                                                      [
+                                                                        {
+                                                                          {
+                                                                            Either_match
+                                                                            SignedMessageCheckError
+                                                                          }
+                                                                          [[Tuple2 [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]] [[TxConstraints Void] Void]]
+                                                                        }
+                                                                        [
+                                                                          [
+                                                                            {
+                                                                              {
+                                                                                sverifySignedMessageConstraints
+                                                                                Void
+                                                                              }
+                                                                              Void
+                                                                            }
+                                                                            ds
+                                                                          ]
+                                                                          ov
+                                                                        ]
+                                                                      ]
+                                                                      [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
+                                                                    }
+                                                                    (lam
+                                                                      x
+                                                                      SignedMessageCheckError
+                                                                      {
+                                                                        Nothing
+                                                                        [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
+                                                                      }
+                                                                    )
+                                                                  ]
+                                                                  (lam
+                                                                    y
+                                                                    [[Tuple2 [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]] [[TxConstraints Void] Void]]
+                                                                    [
+                                                                      {
+                                                                        [
+                                                                          {
+                                                                            {
+                                                                              Tuple2_match
+                                                                              [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                                                            }
+                                                                            [[TxConstraints Void] Void]
+                                                                          }
+                                                                          y
+                                                                        ]
+                                                                        [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
+                                                                      }
+                                                                      (lam
+                                                                        ds
+                                                                        [Observation [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                                                        (lam
+                                                                          oracleConstraints
+                                                                          [[TxConstraints Void] Void]
+                                                                          [
+                                                                            {
+                                                                              [
+                                                                                {
+                                                                                  Observation_match
+                                                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                }
+                                                                                ds
+                                                                              ]
+                                                                              [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]]
+                                                                            }
+                                                                            (lam
+                                                                              ds
+                                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                              (lam
+                                                                                ds
+                                                                                (con integer)
+                                                                                [
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        [
+                                                                                          {
+                                                                                            Maybe_match
+                                                                                            Role
+                                                                                          }
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                violatingRole
+                                                                                                future
+                                                                                              ]
+                                                                                              accounts
+                                                                                            ]
+                                                                                            ds
+                                                                                          ]
+                                                                                        ]
+                                                                                        (fun Unit [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]])
+                                                                                      }
+                                                                                      (lam
+                                                                                        vRole
+                                                                                        Role
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                {
+                                                                                                  [
+                                                                                                    Bool_match
+                                                                                                    [
+                                                                                                      [
+                                                                                                        greaterThanInteger
+                                                                                                        ds
+                                                                                                      ]
+                                                                                                      ds
+                                                                                                    ]
+                                                                                                  ]
+                                                                                                  (fun Unit [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]])
+                                                                                                }
+                                                                                                (lam
+                                                                                                  thunk
+                                                                                                  Unit
+                                                                                                  [
+                                                                                                    {
+                                                                                                      Just
+                                                                                                      [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
+                                                                                                    }
+                                                                                                    [
+                                                                                                      [
+                                                                                                        {
+                                                                                                          {
+                                                                                                            Tuple2
+                                                                                                            [[TxConstraints Void] Void]
+                                                                                                          }
+                                                                                                          [State FutureState]
+                                                                                                        }
+                                                                                                        [
+                                                                                                          [
+                                                                                                            {
+                                                                                                              {
+                                                                                                                fMonoidTxConstraints_c
+                                                                                                                Void
+                                                                                                              }
+                                                                                                              Void
+                                                                                                            }
+                                                                                                            [
                                                                                                               [
                                                                                                                 [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      [
-                                                                                                                        Role_match
-                                                                                                                        vRole
-                                                                                                                      ]
-                                                                                                                      (fun Unit [[TxConstraints Void] Void])
-                                                                                                                    }
-                                                                                                                    (lam
-                                                                                                                      thunk
-                                                                                                                      Unit
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          [
-                                                                                                                            {
-                                                                                                                              {
-                                                                                                                                mustPayToOtherScript
-                                                                                                                                Void
-                                                                                                                              }
-                                                                                                                              Void
-                                                                                                                            }
-                                                                                                                            [
-                                                                                                                              {
-                                                                                                                                [
-                                                                                                                                  FutureAccounts_match
-                                                                                                                                  owners
-                                                                                                                                ]
-                                                                                                                                (con bytestring)
-                                                                                                                              }
-                                                                                                                              (lam
-                                                                                                                                ds
-                                                                                                                                [[Tuple2 (con bytestring)] (con bytestring)]
-                                                                                                                                (lam
-                                                                                                                                  ds
-                                                                                                                                  (con bytestring)
-                                                                                                                                  (lam
-                                                                                                                                    ds
-                                                                                                                                    [[Tuple2 (con bytestring)] (con bytestring)]
-                                                                                                                                    (lam
-                                                                                                                                      ds
-                                                                                                                                      (con bytestring)
-                                                                                                                                      ds
-                                                                                                                                    )
-                                                                                                                                  )
-                                                                                                                                )
-                                                                                                                              )
-                                                                                                                            ]
-                                                                                                                          ]
-                                                                                                                          unitDatum
-                                                                                                                        ]
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            [
-                                                                                                                              Margins_match
-                                                                                                                              accounts
-                                                                                                                            ]
-                                                                                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                          }
-                                                                                                                          (lam
-                                                                                                                            ds
-                                                                                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                            (lam
-                                                                                                                              ds
-                                                                                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                              [
-                                                                                                                                [
-                                                                                                                                  fAdditiveMonoidValue
-                                                                                                                                  ds
-                                                                                                                                ]
-                                                                                                                                ds
-                                                                                                                              ]
-                                                                                                                            )
-                                                                                                                          )
-                                                                                                                        ]
-                                                                                                                      ]
-                                                                                                                    )
-                                                                                                                  ]
+                                                                                                                  {
+                                                                                                                    [
+                                                                                                                      Role_match
+                                                                                                                      vRole
+                                                                                                                    ]
+                                                                                                                    (fun Unit [[TxConstraints Void] Void])
+                                                                                                                  }
                                                                                                                   (lam
                                                                                                                     thunk
                                                                                                                     Unit
@@ -6139,80 +6038,148 @@
                                                                                                                     ]
                                                                                                                   )
                                                                                                                 ]
-                                                                                                                Unit
+                                                                                                                (lam
+                                                                                                                  thunk
+                                                                                                                  Unit
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      [
+                                                                                                                        {
+                                                                                                                          {
+                                                                                                                            mustPayToOtherScript
+                                                                                                                            Void
+                                                                                                                          }
+                                                                                                                          Void
+                                                                                                                        }
+                                                                                                                        [
+                                                                                                                          {
+                                                                                                                            [
+                                                                                                                              FutureAccounts_match
+                                                                                                                              owners
+                                                                                                                            ]
+                                                                                                                            (con bytestring)
+                                                                                                                          }
+                                                                                                                          (lam
+                                                                                                                            ds
+                                                                                                                            [[Tuple2 (con bytestring)] (con bytestring)]
+                                                                                                                            (lam
+                                                                                                                              ds
+                                                                                                                              (con bytestring)
+                                                                                                                              (lam
+                                                                                                                                ds
+                                                                                                                                [[Tuple2 (con bytestring)] (con bytestring)]
+                                                                                                                                (lam
+                                                                                                                                  ds
+                                                                                                                                  (con bytestring)
+                                                                                                                                  ds
+                                                                                                                                )
+                                                                                                                              )
+                                                                                                                            )
+                                                                                                                          )
+                                                                                                                        ]
+                                                                                                                      ]
+                                                                                                                      unitDatum
+                                                                                                                    ]
+                                                                                                                    [
+                                                                                                                      {
+                                                                                                                        [
+                                                                                                                          Margins_match
+                                                                                                                          accounts
+                                                                                                                        ]
+                                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                      }
+                                                                                                                      (lam
+                                                                                                                        ds
+                                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                        (lam
+                                                                                                                          ds
+                                                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                          [
+                                                                                                                            [
+                                                                                                                              fAdditiveMonoidValue
+                                                                                                                              ds
+                                                                                                                            ]
+                                                                                                                            ds
+                                                                                                                          ]
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                )
                                                                                                               ]
+                                                                                                              Unit
                                                                                                             ]
-                                                                                                            oracleConstraints
                                                                                                           ]
-                                                                                                        ]
-                                                                                                        [
-                                                                                                          [
-                                                                                                            {
-                                                                                                              State
-                                                                                                              FutureState
-                                                                                                            }
-                                                                                                            Finished
-                                                                                                          ]
-                                                                                                          {
-                                                                                                            Nil
-                                                                                                            [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                          }
+                                                                                                          oracleConstraints
                                                                                                         ]
                                                                                                       ]
+                                                                                                      [
+                                                                                                        [
+                                                                                                          {
+                                                                                                            State
+                                                                                                            FutureState
+                                                                                                          }
+                                                                                                          Finished
+                                                                                                        ]
+                                                                                                        {
+                                                                                                          Nil
+                                                                                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                        }
+                                                                                                      ]
                                                                                                     ]
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  {
-                                                                                                    Nothing
-                                                                                                    [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
-                                                                                                  }
+                                                                                                  ]
                                                                                                 )
                                                                                               ]
-                                                                                              Unit
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                {
+                                                                                                  Nothing
+                                                                                                  [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
+                                                                                                }
+                                                                                              )
                                                                                             ]
-                                                                                          )
+                                                                                            Unit
+                                                                                          ]
                                                                                         )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        {
-                                                                                          Nothing
-                                                                                          [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
-                                                                                        }
                                                                                       )
                                                                                     ]
-                                                                                    Unit
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      {
+                                                                                        Nothing
+                                                                                        [[Tuple2 [[TxConstraints Void] Void]] [State FutureState]]
+                                                                                      }
+                                                                                    )
                                                                                   ]
-                                                                                )
+                                                                                  Unit
+                                                                                ]
                                                                               )
-                                                                            ]
-                                                                          )
+                                                                            )
+                                                                          ]
                                                                         )
-                                                                      ]
-                                                                    )
-                                                                  ]
-                                                                )
-                                                              ]
-                                                            )
+                                                                      )
+                                                                    ]
+                                                                  )
+                                                                ]
+                                                              )
+                                                            ]
                                                           )
-                                                        ]
-                                                        Unit
+                                                        )
                                                       ]
-                                                    )
+                                                      Unit
+                                                    ]
                                                   )
-                                                ]
-                                              )
+                                                )
+                                              ]
                                             )
                                           )
                                         )
                                       )
                                     )
-                                  ]
-                                )
+                                  )
+                                ]
                               )
                             )
                           )

--- a/plutus-use-cases/test/Spec/game.pir
+++ b/plutus-use-cases/test/Spec/game.pir
@@ -191,11 +191,6 @@
           )
           (termbind
             (strict)
-            (vardecl sha2_ (fun (con bytestring) (con bytestring)))
-            (builtin sha2_256)
-          )
-          (termbind
-            (strict)
             (vardecl
               validateGuess
               (fun (con bytestring) (fun (con bytestring) (fun ValidatorCtx Bool)))
@@ -206,7 +201,11 @@
               (lam
                 ds
                 (con bytestring)
-                (lam ds ValidatorCtx [ [ equalsByteString ds ] [ sha2_ ds ] ])
+                (lam
+                  ds
+                  ValidatorCtx
+                  [ [ equalsByteString ds ] [ (builtin sha2_256) ds ] ]
+                )
               )
             )
           )

--- a/plutus-use-cases/test/Spec/gameStateMachine.pir
+++ b/plutus-use-cases/test/Spec/gameStateMachine.pir
@@ -1746,19 +1746,6 @@
                   )
                   (termbind
                     (strict)
-                    (vardecl fAdditiveGroupValue (con integer))
-                    (con integer -1)
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      multiplyInteger
-                      (fun (con integer) (fun (con integer) (con integer)))
-                    )
-                    (builtin multiplyInteger)
-                  )
-                  (termbind
-                    (strict)
                     (vardecl
                       fAdditiveGroupValue_cscale
                       (fun (con integer) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]))
@@ -1911,7 +1898,9 @@
                                                                           ]
                                                                           [
                                                                             [
-                                                                              multiplyInteger
+                                                                              (builtin
+                                                                                multiplyInteger
+                                                                              )
                                                                               i
                                                                             ]
                                                                             i
@@ -1969,14 +1958,6 @@
                         )
                       )
                     )
-                  )
-                  (termbind
-                    (strict)
-                    (vardecl
-                      addInteger
-                      (fun (con integer) (fun (con integer) (con integer)))
-                    )
-                    (builtin addInteger)
                   )
                   (let
                     (rec)
@@ -2181,146 +2162,134 @@
                                                     (lam
                                                       xs
                                                       [List [[Tuple2 k] r]]
-                                                      (let
-                                                        (nonrec)
-                                                        (termbind
-                                                          (nonstrict)
-                                                          (vardecl
-                                                            wild [[Tuple2 k] r]
-                                                          )
-                                                          e
-                                                        )
-                                                        [
-                                                          {
-                                                            [
-                                                              {
-                                                                {
-                                                                  Tuple2_match k
-                                                                }
-                                                                r
-                                                              }
-                                                              e
-                                                            ]
-                                                            [List [[Tuple2 k] r]]
-                                                          }
-                                                          (lam
-                                                            c
-                                                            k
-                                                            (lam
-                                                              ds
+                                                      [
+                                                        {
+                                                          [
+                                                            {
+                                                              { Tuple2_match k }
                                                               r
+                                                            }
+                                                            e
+                                                          ]
+                                                          [List [[Tuple2 k] r]]
+                                                        }
+                                                        (lam
+                                                          c
+                                                          k
+                                                          (lam
+                                                            ds
+                                                            r
+                                                            [
                                                               [
                                                                 [
-                                                                  [
-                                                                    {
+                                                                  {
+                                                                    [
+                                                                      Bool_match
                                                                       [
-                                                                        Bool_match
                                                                         [
                                                                           [
-                                                                            [
+                                                                            {
                                                                               {
-                                                                                {
-                                                                                  foldr
-                                                                                  [[Tuple2 k] v]
-                                                                                }
-                                                                                Bool
-                                                                              }
-                                                                              (lam
-                                                                                a
+                                                                                foldr
                                                                                 [[Tuple2 k] v]
-                                                                                (lam
-                                                                                  acc
-                                                                                  Bool
+                                                                              }
+                                                                              Bool
+                                                                            }
+                                                                            (lam
+                                                                              a
+                                                                              [[Tuple2 k] v]
+                                                                              (lam
+                                                                                acc
+                                                                                Bool
+                                                                                [
                                                                                   [
                                                                                     [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            Bool_match
-                                                                                            acc
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          True
-                                                                                        )
-                                                                                      ]
+                                                                                      {
+                                                                                        [
+                                                                                          Bool_match
+                                                                                          acc
+                                                                                        ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
                                                                                       (lam
                                                                                         thunk
                                                                                         Unit
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              {
-                                                                                                {
-                                                                                                  Tuple2_match
-                                                                                                  k
-                                                                                                }
-                                                                                                v
-                                                                                              }
-                                                                                              a
-                                                                                            ]
-                                                                                            Bool
-                                                                                          }
-                                                                                          (lam
-                                                                                            c
-                                                                                            k
-                                                                                            (lam
-                                                                                              ds
-                                                                                              v
-                                                                                              [
-                                                                                                [
-                                                                                                  dEq
-                                                                                                  c
-                                                                                                ]
-                                                                                                c
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                        ]
+                                                                                        True
                                                                                       )
                                                                                     ]
-                                                                                    Unit
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      [
+                                                                                        {
+                                                                                          [
+                                                                                            {
+                                                                                              {
+                                                                                                Tuple2_match
+                                                                                                k
+                                                                                              }
+                                                                                              v
+                                                                                            }
+                                                                                            a
+                                                                                          ]
+                                                                                          Bool
+                                                                                        }
+                                                                                        (lam
+                                                                                          c
+                                                                                          k
+                                                                                          (lam
+                                                                                            ds
+                                                                                            v
+                                                                                            [
+                                                                                              [
+                                                                                                dEq
+                                                                                                c
+                                                                                              ]
+                                                                                              c
+                                                                                            ]
+                                                                                          )
+                                                                                        )
+                                                                                      ]
+                                                                                    )
                                                                                   ]
-                                                                                )
+                                                                                  Unit
+                                                                                ]
                                                                               )
-                                                                            ]
-                                                                            False
+                                                                            )
                                                                           ]
-                                                                          ds
+                                                                          False
                                                                         ]
+                                                                        ds
                                                                       ]
-                                                                      (fun Unit [List [[Tuple2 k] r]])
-                                                                    }
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      xs
-                                                                    )
-                                                                  ]
+                                                                    ]
+                                                                    (fun Unit [List [[Tuple2 k] r]])
+                                                                  }
                                                                   (lam
                                                                     thunk
                                                                     Unit
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          Cons
-                                                                          [[Tuple2 k] r]
-                                                                        }
-                                                                        wild
-                                                                      ]
-                                                                      xs
-                                                                    ]
+                                                                    xs
                                                                   )
                                                                 ]
-                                                                Unit
+                                                                (lam
+                                                                  thunk
+                                                                  Unit
+                                                                  [
+                                                                    [
+                                                                      {
+                                                                        Cons
+                                                                        [[Tuple2 k] r]
+                                                                      }
+                                                                      e
+                                                                    ]
+                                                                    xs
+                                                                  ]
+                                                                )
                                                               ]
-                                                            )
+                                                              Unit
+                                                            ]
                                                           )
-                                                        ]
-                                                      )
+                                                        )
+                                                      ]
                                                     )
                                                   )
                                                 ]
@@ -3191,11 +3160,10 @@
                               ds
                               [(lam a (type) a) [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
                               [
-                                [ [ unionWith addInteger ] ds ]
+                                [ [ unionWith (builtin addInteger) ] ds ]
                                 [
                                   [
-                                    fAdditiveGroupValue_cscale
-                                    fAdditiveGroupValue
+                                    fAdditiveGroupValue_cscale (con integer -1)
                                   ]
                                   ds
                                 ]
@@ -3214,11 +3182,6 @@
                               (fun (con bytestring) (fun (con bytestring) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] GameInput)))
                             )
                           )
-                        )
-                        (termbind
-                          (strict)
-                          (vardecl contract (con integer))
-                          (con integer 1)
                         )
                         (termbind
                           (strict)
@@ -3260,7 +3223,7 @@
                                             }
                                             tn
                                           ]
-                                          contract
+                                          (con integer 1)
                                         ]
                                       ]
                                       {
@@ -3277,12 +3240,6 @@
                               ]
                             )
                           )
-                        )
-                        (termbind
-                          (strict)
-                          (vardecl sha2_ (fun (con bytestring) (con bytestring))
-                          )
-                          (builtin sha2_256)
                         )
                         (termbind
                           (strict)
@@ -3500,7 +3457,9 @@
                                                                       currentSecret
                                                                     ]
                                                                     [
-                                                                      sha2_
+                                                                      (builtin
+                                                                        sha2_256
+                                                                      )
                                                                       theGuess
                                                                     ]
                                                                   ]
@@ -3830,80 +3789,68 @@
                                                                 (lam
                                                                   thunk
                                                                   Unit
-                                                                  (let
-                                                                    (nonrec)
-                                                                    (termbind
-                                                                      (nonstrict
-                                                                      )
-                                                                      (vardecl
-                                                                        wild
-                                                                        [[Tuple2 (con bytestring)] Data]
-                                                                      )
-                                                                      x
-                                                                    )
-                                                                    [
-                                                                      {
-                                                                        [
+                                                                  [
+                                                                    {
+                                                                      [
+                                                                        {
                                                                           {
-                                                                            {
-                                                                              Tuple2_match
-                                                                              (con bytestring)
-                                                                            }
-                                                                            Data
+                                                                            Tuple2_match
+                                                                            (con bytestring)
                                                                           }
-                                                                          x
-                                                                        ]
-                                                                        [Maybe [[Tuple2 (con bytestring)] Data]]
-                                                                      }
+                                                                          Data
+                                                                        }
+                                                                        x
+                                                                      ]
+                                                                      [Maybe [[Tuple2 (con bytestring)] Data]]
+                                                                    }
+                                                                    (lam
+                                                                      ds
+                                                                      (con bytestring)
                                                                       (lam
                                                                         ds
-                                                                        (con bytestring)
-                                                                        (lam
-                                                                          ds
-                                                                          Data
+                                                                        Data
+                                                                        [
                                                                           [
                                                                             [
-                                                                              [
-                                                                                {
+                                                                              {
+                                                                                [
+                                                                                  Bool_match
                                                                                   [
-                                                                                    Bool_match
                                                                                     [
-                                                                                      [
-                                                                                        fEqData_c
-                                                                                        ds
-                                                                                      ]
+                                                                                      fEqData_c
                                                                                       ds
                                                                                     ]
+                                                                                    ds
                                                                                   ]
-                                                                                  (fun Unit [Maybe [[Tuple2 (con bytestring)] Data]])
-                                                                                }
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
-                                                                                    {
-                                                                                      Just
-                                                                                      [[Tuple2 (con bytestring)] Data]
-                                                                                    }
-                                                                                    wild
-                                                                                  ]
-                                                                                )
-                                                                              ]
+                                                                                ]
+                                                                                (fun Unit [Maybe [[Tuple2 (con bytestring)] Data]])
+                                                                              }
                                                                               (lam
                                                                                 thunk
                                                                                 Unit
                                                                                 [
-                                                                                  go
-                                                                                  xs
+                                                                                  {
+                                                                                    Just
+                                                                                    [[Tuple2 (con bytestring)] Data]
+                                                                                  }
+                                                                                  x
                                                                                 ]
                                                                               )
                                                                             ]
-                                                                            Unit
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              [
+                                                                                go
+                                                                                xs
+                                                                              ]
+                                                                            )
                                                                           ]
-                                                                        )
+                                                                          Unit
+                                                                        ]
                                                                       )
-                                                                    ]
-                                                                  )
+                                                                    )
+                                                                  ]
                                                                 )
                                                               )
                                                             )
@@ -3989,11 +3936,6 @@
                         )
                         (termbind
                           (strict)
-                          (vardecl scheckOwnOutputConstraint (con string))
-                          (con string "Output constraint")
-                        )
-                        (termbind
-                          (strict)
                           (vardecl trace (fun (con string) Unit))
                           (lam
                             arg
@@ -4004,20 +3946,12 @@
                         (termbind
                           (nonstrict)
                           (vardecl scheckOwnOutputConstraint Unit)
-                          [ trace scheckOwnOutputConstraint ]
+                          [ trace (con string "Output constraint") ]
                         )
                         (termbind
                           (strict)
                           (vardecl error (all a (type) (fun Unit a)))
                           (abs e (type) (lam thunk Unit (error e)))
-                        )
-                        (termbind
-                          (strict)
-                          (vardecl
-                            subtractInteger
-                            (fun (con integer) (fun (con integer) (con integer)))
-                          )
-                          (builtin subtractInteger)
                         )
                         (let
                           (rec)
@@ -4072,7 +4006,11 @@
                                                   [
                                                     [ { bad_name a } xs ]
                                                     [
-                                                      [ subtractInteger ds ]
+                                                      [
+                                                        (builtin subtractInteger
+                                                        )
+                                                        ds
+                                                      ]
                                                       (con integer 1)
                                                     ]
                                                   ]
@@ -4225,126 +4163,113 @@
                                                                                             (lam
                                                                                               xs
                                                                                               [List TxOut]
-                                                                                              (let
-                                                                                                (nonrec
-                                                                                                )
-                                                                                                (termbind
-                                                                                                  (nonstrict
-                                                                                                  )
-                                                                                                  (vardecl
-                                                                                                    wild
-                                                                                                    TxOut
-                                                                                                  )
-                                                                                                  e
-                                                                                                )
-                                                                                                [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      TxOut_match
-                                                                                                      e
-                                                                                                    ]
-                                                                                                    [List TxOut]
-                                                                                                  }
+                                                                                              [
+                                                                                                {
+                                                                                                  [
+                                                                                                    TxOut_match
+                                                                                                    e
+                                                                                                  ]
+                                                                                                  [List TxOut]
+                                                                                                }
+                                                                                                (lam
+                                                                                                  ds
+                                                                                                  Address
                                                                                                   (lam
                                                                                                     ds
-                                                                                                    Address
+                                                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                                                     (lam
                                                                                                       ds
-                                                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                      (lam
-                                                                                                        ds
-                                                                                                        TxOutType
+                                                                                                      TxOutType
+                                                                                                      [
                                                                                                         [
                                                                                                           [
-                                                                                                            [
-                                                                                                              {
-                                                                                                                [
-                                                                                                                  TxOutType_match
-                                                                                                                  ds
-                                                                                                                ]
-                                                                                                                (fun Unit [List TxOut])
-                                                                                                              }
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                xs
-                                                                                                              )
-                                                                                                            ]
+                                                                                                            {
+                                                                                                              [
+                                                                                                                TxOutType_match
+                                                                                                                ds
+                                                                                                              ]
+                                                                                                              (fun Unit [List TxOut])
+                                                                                                            }
                                                                                                             (lam
-                                                                                                              ds
-                                                                                                              (con bytestring)
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
+                                                                                                              thunk
+                                                                                                              Unit
+                                                                                                              xs
+                                                                                                            )
+                                                                                                          ]
+                                                                                                          (lam
+                                                                                                            ds
+                                                                                                            (con bytestring)
+                                                                                                            (lam
+                                                                                                              thunk
+                                                                                                              Unit
+                                                                                                              [
                                                                                                                 [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      [
-                                                                                                                        Address_match
-                                                                                                                        ds
-                                                                                                                      ]
-                                                                                                                      [List TxOut]
-                                                                                                                    }
-                                                                                                                    (lam
-                                                                                                                      pkh
-                                                                                                                      (con bytestring)
-                                                                                                                      xs
-                                                                                                                    )
-                                                                                                                  ]
+                                                                                                                  {
+                                                                                                                    [
+                                                                                                                      Address_match
+                                                                                                                      ds
+                                                                                                                    ]
+                                                                                                                    [List TxOut]
+                                                                                                                  }
                                                                                                                   (lam
-                                                                                                                    vh
+                                                                                                                    pkh
                                                                                                                     (con bytestring)
+                                                                                                                    xs
+                                                                                                                  )
+                                                                                                                ]
+                                                                                                                (lam
+                                                                                                                  vh
+                                                                                                                  (con bytestring)
+                                                                                                                  [
                                                                                                                     [
                                                                                                                       [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            [
-                                                                                                                              Bool_match
-                                                                                                                              [
-                                                                                                                                [
-                                                                                                                                  equalsByteString
-                                                                                                                                  vh
-                                                                                                                                ]
-                                                                                                                                inpHsh
-                                                                                                                              ]
-                                                                                                                            ]
-                                                                                                                            (fun Unit [List TxOut])
-                                                                                                                          }
-                                                                                                                          (lam
-                                                                                                                            thunk
-                                                                                                                            Unit
+                                                                                                                        {
+                                                                                                                          [
+                                                                                                                            Bool_match
                                                                                                                             [
                                                                                                                               [
-                                                                                                                                {
-                                                                                                                                  Cons
-                                                                                                                                  TxOut
-                                                                                                                                }
-                                                                                                                                wild
+                                                                                                                                equalsByteString
+                                                                                                                                vh
                                                                                                                               ]
-                                                                                                                              xs
+                                                                                                                              inpHsh
                                                                                                                             ]
-                                                                                                                          )
-                                                                                                                        ]
+                                                                                                                          ]
+                                                                                                                          (fun Unit [List TxOut])
+                                                                                                                        }
                                                                                                                         (lam
                                                                                                                           thunk
                                                                                                                           Unit
-                                                                                                                          xs
+                                                                                                                          [
+                                                                                                                            [
+                                                                                                                              {
+                                                                                                                                Cons
+                                                                                                                                TxOut
+                                                                                                                              }
+                                                                                                                              e
+                                                                                                                            ]
+                                                                                                                            xs
+                                                                                                                          ]
                                                                                                                         )
                                                                                                                       ]
-                                                                                                                      Unit
+                                                                                                                      (lam
+                                                                                                                        thunk
+                                                                                                                        Unit
+                                                                                                                        xs
+                                                                                                                      )
                                                                                                                     ]
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                              )
+                                                                                                                    Unit
+                                                                                                                  ]
+                                                                                                                )
+                                                                                                              ]
                                                                                                             )
-                                                                                                          ]
-                                                                                                          Unit
+                                                                                                          )
                                                                                                         ]
-                                                                                                      )
+                                                                                                        Unit
+                                                                                                      ]
                                                                                                     )
                                                                                                   )
-                                                                                                ]
-                                                                                              )
+                                                                                                )
+                                                                                              ]
                                                                                             )
                                                                                           )
                                                                                         ]
@@ -4980,17 +4905,18 @@
                               )
                             )
                             (termbind
-                              (strict)
-                              (vardecl scheckValidatorCtx (con string))
-                              (con string "checkValidatorCtx failed")
-                            )
-                            (termbind
                               (nonstrict)
                               (vardecl scheckValidatorCtx_j Bool)
                               [
                                 [
                                   {
-                                    [ Unit_match [ trace scheckValidatorCtx ] ]
+                                    [
+                                      Unit_match
+                                      [
+                                        trace
+                                        (con string "checkValidatorCtx failed")
+                                      ]
+                                    ]
                                     (fun Unit Bool)
                                   }
                                   (lam thunk Unit False)
@@ -5802,81 +5728,68 @@
                                                                         (lam
                                                                           thunk
                                                                           Unit
-                                                                          (let
-                                                                            (nonrec
-                                                                            )
-                                                                            (termbind
-                                                                              (nonstrict
-                                                                              )
-                                                                              (vardecl
-                                                                                wild
-                                                                                [[Tuple2 (con bytestring)] Data]
-                                                                              )
-                                                                              x
-                                                                            )
-                                                                            [
-                                                                              {
-                                                                                [
+                                                                          [
+                                                                            {
+                                                                              [
+                                                                                {
                                                                                   {
-                                                                                    {
-                                                                                      Tuple2_match
-                                                                                      (con bytestring)
-                                                                                    }
-                                                                                    Data
+                                                                                    Tuple2_match
+                                                                                    (con bytestring)
                                                                                   }
-                                                                                  x
-                                                                                ]
-                                                                                [Maybe [[Tuple2 (con bytestring)] Data]]
-                                                                              }
-                                                                              (lam
-                                                                                dsh
-                                                                                (con bytestring)
-                                                                                (lam
-                                                                                  ds
                                                                                   Data
+                                                                                }
+                                                                                x
+                                                                              ]
+                                                                              [Maybe [[Tuple2 (con bytestring)] Data]]
+                                                                            }
+                                                                            (lam
+                                                                              dsh
+                                                                              (con bytestring)
+                                                                              (lam
+                                                                                ds
+                                                                                Data
+                                                                                [
                                                                                   [
                                                                                     [
-                                                                                      [
-                                                                                        {
+                                                                                      {
+                                                                                        [
+                                                                                          Bool_match
                                                                                           [
-                                                                                            Bool_match
                                                                                             [
-                                                                                              [
-                                                                                                equalsByteString
-                                                                                                dsh
-                                                                                              ]
+                                                                                              equalsByteString
                                                                                               dsh
                                                                                             ]
+                                                                                            dsh
                                                                                           ]
-                                                                                          (fun Unit [Maybe [[Tuple2 (con bytestring)] Data]])
-                                                                                        }
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          [
-                                                                                            {
-                                                                                              Just
-                                                                                              [[Tuple2 (con bytestring)] Data]
-                                                                                            }
-                                                                                            wild
-                                                                                          ]
-                                                                                        )
-                                                                                      ]
+                                                                                        ]
+                                                                                        (fun Unit [Maybe [[Tuple2 (con bytestring)] Data]])
+                                                                                      }
                                                                                       (lam
                                                                                         thunk
                                                                                         Unit
                                                                                         [
-                                                                                          go
-                                                                                          xs
+                                                                                          {
+                                                                                            Just
+                                                                                            [[Tuple2 (con bytestring)] Data]
+                                                                                          }
+                                                                                          x
                                                                                         ]
                                                                                       )
                                                                                     ]
-                                                                                    Unit
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      [
+                                                                                        go
+                                                                                        xs
+                                                                                      ]
+                                                                                    )
                                                                                   ]
-                                                                                )
+                                                                                  Unit
+                                                                                ]
                                                                               )
-                                                                            ]
-                                                                          )
+                                                                            )
+                                                                          ]
                                                                         )
                                                                       )
                                                                     )
@@ -6027,79 +5940,66 @@
                                                                             (lam
                                                                               xs
                                                                               [List TxInInfo]
-                                                                              (let
-                                                                                (nonrec
-                                                                                )
-                                                                                (termbind
-                                                                                  (nonstrict
-                                                                                  )
-                                                                                  (vardecl
-                                                                                    wild
-                                                                                    TxInInfo
-                                                                                  )
-                                                                                  e
-                                                                                )
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      TxInInfo_match
-                                                                                      e
-                                                                                    ]
-                                                                                    [List TxInInfo]
-                                                                                  }
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    TxInInfo_match
+                                                                                    e
+                                                                                  ]
+                                                                                  [List TxInInfo]
+                                                                                }
+                                                                                (lam
+                                                                                  ds
+                                                                                  TxOutRef
                                                                                   (lam
                                                                                     ds
-                                                                                    TxOutRef
+                                                                                    [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
                                                                                     (lam
                                                                                       ds
-                                                                                      [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
-                                                                                      (lam
-                                                                                        ds
-                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                      [
                                                                                         [
                                                                                           [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  Bool_match
-                                                                                                  [
-                                                                                                    [
-                                                                                                      fEqTxOutRef_c
-                                                                                                      ds
-                                                                                                    ]
-                                                                                                    outRef
-                                                                                                  ]
-                                                                                                ]
-                                                                                                (fun Unit [List TxInInfo])
-                                                                                              }
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
+                                                                                            {
+                                                                                              [
+                                                                                                Bool_match
                                                                                                 [
                                                                                                   [
-                                                                                                    {
-                                                                                                      Cons
-                                                                                                      TxInInfo
-                                                                                                    }
-                                                                                                    wild
+                                                                                                    fEqTxOutRef_c
+                                                                                                    ds
                                                                                                   ]
-                                                                                                  xs
+                                                                                                  outRef
                                                                                                 ]
-                                                                                              )
-                                                                                            ]
+                                                                                              ]
+                                                                                              (fun Unit [List TxInInfo])
+                                                                                            }
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              xs
+                                                                                              [
+                                                                                                [
+                                                                                                  {
+                                                                                                    Cons
+                                                                                                    TxInInfo
+                                                                                                  }
+                                                                                                  e
+                                                                                                ]
+                                                                                                xs
+                                                                                              ]
                                                                                             )
                                                                                           ]
-                                                                                          Unit
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            xs
+                                                                                          )
                                                                                         ]
-                                                                                      )
+                                                                                        Unit
+                                                                                      ]
                                                                                     )
                                                                                   )
-                                                                                ]
-                                                                              )
+                                                                                )
+                                                                              ]
                                                                             )
                                                                           )
                                                                         ]
@@ -6247,1232 +6147,1082 @@
                                                     (lam
                                                       in
                                                       Bool
-                                                      (let
-                                                        (nonrec)
-                                                        (termbind
-                                                          (nonstrict)
-                                                          (vardecl
-                                                            wild [Extended a]
-                                                          )
-                                                          v
-                                                        )
+                                                      [
                                                         [
                                                           [
                                                             [
-                                                              [
-                                                                {
-                                                                  [
-                                                                    {
-                                                                      Extended_match
-                                                                      a
-                                                                    }
-                                                                    v
-                                                                  ]
-                                                                  (fun Unit Bool)
-                                                                }
-                                                                (lam
-                                                                  default_arg0
-                                                                  a
-                                                                  (lam
-                                                                    thunk
-                                                                    Unit
-                                                                    (let
-                                                                      (nonrec)
-                                                                      (termbind
-                                                                        (nonstrict
-                                                                        )
-                                                                        (vardecl
-                                                                          wild
-                                                                          [Extended a]
-                                                                        )
-                                                                        v
-                                                                      )
-                                                                      [
-                                                                        [
-                                                                          [
-                                                                            [
-                                                                              {
-                                                                                [
-                                                                                  {
-                                                                                    Extended_match
-                                                                                    a
-                                                                                  }
-                                                                                  v
-                                                                                ]
-                                                                                (fun Unit Bool)
-                                                                              }
-                                                                              (lam
-                                                                                default_arg0
-                                                                                a
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              {
-                                                                                                Extended_match
-                                                                                                a
-                                                                                              }
-                                                                                              wild
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            ipv
-                                                                                            a
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    [
-                                                                                                      {
-                                                                                                        [
-                                                                                                          {
-                                                                                                            Extended_match
-                                                                                                            a
-                                                                                                          }
-                                                                                                          wild
-                                                                                                        ]
-                                                                                                        (fun Unit Bool)
-                                                                                                      }
-                                                                                                      (lam
-                                                                                                        ipv
-                                                                                                        a
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          [
-                                                                                                            [
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  {
-                                                                                                                    [
-                                                                                                                      Ordering_match
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          [
-                                                                                                                            {
-                                                                                                                              compare
-                                                                                                                              a
-                                                                                                                            }
-                                                                                                                            dOrd
-                                                                                                                          ]
-                                                                                                                          ipv
-                                                                                                                        ]
-                                                                                                                        ipv
-                                                                                                                      ]
-                                                                                                                    ]
-                                                                                                                    (fun Unit Bool)
-                                                                                                                  }
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            [
-                                                                                                                              Bool_match
-                                                                                                                              in
-                                                                                                                            ]
-                                                                                                                            (fun Unit Bool)
-                                                                                                                          }
-                                                                                                                          (lam
-                                                                                                                            thunk
-                                                                                                                            Unit
-                                                                                                                            in
-                                                                                                                          )
-                                                                                                                        ]
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          (let
-                                                                                                                            (nonrec
-                                                                                                                            )
-                                                                                                                            (termbind
-                                                                                                                              (strict
-                                                                                                                              )
-                                                                                                                              (vardecl
-                                                                                                                                wild
-                                                                                                                                Bool
-                                                                                                                              )
-                                                                                                                              in
-                                                                                                                            )
-                                                                                                                            True
-                                                                                                                          )
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      Unit
-                                                                                                                    ]
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                                (lam
-                                                                                                                  thunk
-                                                                                                                  Unit
-                                                                                                                  False
-                                                                                                                )
-                                                                                                              ]
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                True
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            Unit
-                                                                                                          ]
-                                                                                                        )
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      {
-                                                                                                        (abs
-                                                                                                          e
-                                                                                                          (type)
-                                                                                                          (error
-                                                                                                            e
-                                                                                                          )
-                                                                                                        )
-                                                                                                        Bool
-                                                                                                      }
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    True
-                                                                                                  )
-                                                                                                ]
-                                                                                                Unit
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          {
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
-                                                                                              )
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              [
-                                                                                                {
-                                                                                                  [
-                                                                                                    {
-                                                                                                      Extended_match
-                                                                                                      a
-                                                                                                    }
-                                                                                                    wild
-                                                                                                  ]
-                                                                                                  (fun Unit Bool)
-                                                                                                }
-                                                                                                (lam
-                                                                                                  ipv
-                                                                                                  a
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    False
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                {
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
-                                                                                                  )
-                                                                                                  Bool
-                                                                                                }
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        Bool_match
-                                                                                                        in
-                                                                                                      ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      in
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    (let
-                                                                                                      (nonrec
-                                                                                                      )
-                                                                                                      (termbind
-                                                                                                        (strict
-                                                                                                        )
-                                                                                                        (vardecl
-                                                                                                          wild
-                                                                                                          Bool
-                                                                                                        )
-                                                                                                        in
-                                                                                                      )
-                                                                                                      True
-                                                                                                    )
-                                                                                                  )
-                                                                                                ]
-                                                                                                Unit
-                                                                                              ]
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            ]
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              False
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  [
-                                                                                    {
-                                                                                      [
-                                                                                        {
-                                                                                          Extended_match
-                                                                                          a
-                                                                                        }
-                                                                                        wild
-                                                                                      ]
-                                                                                      (fun Unit Bool)
-                                                                                    }
-                                                                                    (lam
-                                                                                      ipv
-                                                                                      a
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              [
-                                                                                                {
-                                                                                                  [
-                                                                                                    {
-                                                                                                      Extended_match
-                                                                                                      a
-                                                                                                    }
-                                                                                                    wild
-                                                                                                  ]
-                                                                                                  (fun Unit Bool)
-                                                                                                }
-                                                                                                (lam
-                                                                                                  ipv
-                                                                                                  a
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    [
-                                                                                                      [
-                                                                                                        [
-                                                                                                          [
-                                                                                                            {
-                                                                                                              [
-                                                                                                                Ordering_match
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        compare
-                                                                                                                        a
-                                                                                                                      }
-                                                                                                                      dOrd
-                                                                                                                    ]
-                                                                                                                    ipv
-                                                                                                                  ]
-                                                                                                                  ipv
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                              (fun Unit Bool)
-                                                                                                            }
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      [
-                                                                                                                        Bool_match
-                                                                                                                        in
-                                                                                                                      ]
-                                                                                                                      (fun Unit Bool)
-                                                                                                                    }
-                                                                                                                    (lam
-                                                                                                                      thunk
-                                                                                                                      Unit
-                                                                                                                      in
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    (let
-                                                                                                                      (nonrec
-                                                                                                                      )
-                                                                                                                      (termbind
-                                                                                                                        (strict
-                                                                                                                        )
-                                                                                                                        (vardecl
-                                                                                                                          wild
-                                                                                                                          Bool
-                                                                                                                        )
-                                                                                                                        in
-                                                                                                                      )
-                                                                                                                      True
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                                Unit
-                                                                                                              ]
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          (lam
-                                                                                                            thunk
-                                                                                                            Unit
-                                                                                                            False
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          True
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      Unit
-                                                                                                    ]
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                {
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
-                                                                                                  )
-                                                                                                  Bool
-                                                                                                }
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              True
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    {
-                                                                                      (abs
-                                                                                        e
-                                                                                        (type)
-                                                                                        (error
-                                                                                          e
-                                                                                        )
-                                                                                      )
-                                                                                      Bool
-                                                                                    }
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              {
-                                                                                                Extended_match
-                                                                                                a
-                                                                                              }
-                                                                                              wild
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            ipv
-                                                                                            a
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              False
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          {
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
-                                                                                              )
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  Bool_match
-                                                                                                  in
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                in
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              (let
-                                                                                                (nonrec
-                                                                                                )
-                                                                                                (termbind
-                                                                                                  (strict
-                                                                                                  )
-                                                                                                  (vardecl
-                                                                                                    wild
-                                                                                                    Bool
-                                                                                                  )
-                                                                                                  in
-                                                                                                )
-                                                                                                True
-                                                                                              )
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              ]
-                                                                              Unit
-                                                                            ]
-                                                                          )
-                                                                        ]
-                                                                        Unit
-                                                                      ]
-                                                                    )
-                                                                  )
-                                                                )
-                                                              ]
-                                                              (lam
-                                                                thunk
-                                                                Unit
+                                                              {
                                                                 [
-                                                                  [
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          [
-                                                                            {
-                                                                              Extended_match
-                                                                              a
-                                                                            }
-                                                                            v
-                                                                          ]
-                                                                          (fun Unit Bool)
-                                                                        }
-                                                                        (lam
-                                                                          default_arg0
-                                                                          a
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            True
-                                                                          )
-                                                                        )
-                                                                      ]
-                                                                      (lam
-                                                                        thunk
-                                                                        Unit
-                                                                        [
-                                                                          [
-                                                                            [
-                                                                              {
-                                                                                [
-                                                                                  Bool_match
-                                                                                  in
-                                                                                ]
-                                                                                (fun Unit Bool)
-                                                                              }
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                in
-                                                                              )
-                                                                            ]
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              (let
-                                                                                (nonrec
-                                                                                )
-                                                                                (termbind
-                                                                                  (strict
-                                                                                  )
-                                                                                  (vardecl
-                                                                                    wild
-                                                                                    Bool
-                                                                                  )
-                                                                                  in
-                                                                                )
-                                                                                True
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                          Unit
-                                                                        ]
-                                                                      )
-                                                                    ]
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      True
-                                                                    )
-                                                                  ]
-                                                                  Unit
-                                                                ]
-                                                              )
-                                                            ]
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              (let
-                                                                (nonrec)
-                                                                (termbind
-                                                                  (nonstrict)
-                                                                  (vardecl
-                                                                    wild
-                                                                    [Extended a]
-                                                                  )
+                                                                  {
+                                                                    Extended_match
+                                                                    a
+                                                                  }
                                                                   v
-                                                                )
-                                                                [
+                                                                ]
+                                                                (fun Unit Bool)
+                                                              }
+                                                              (lam
+                                                                default_arg0
+                                                                a
+                                                                (lam
+                                                                  thunk
+                                                                  Unit
                                                                   [
                                                                     [
                                                                       [
-                                                                        {
-                                                                          [
-                                                                            {
-                                                                              Extended_match
-                                                                              a
-                                                                            }
-                                                                            v
-                                                                          ]
-                                                                          (fun Unit Bool)
-                                                                        }
-                                                                        (lam
-                                                                          default_arg0
-                                                                          a
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
+                                                                        [
+                                                                          {
                                                                             [
+                                                                              {
+                                                                                Extended_match
+                                                                                a
+                                                                              }
+                                                                              v
+                                                                            ]
+                                                                            (fun Unit Bool)
+                                                                          }
+                                                                          (lam
+                                                                            default_arg0
+                                                                            a
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
                                                                               [
                                                                                 [
                                                                                   [
-                                                                                    {
-                                                                                      [
-                                                                                        {
-                                                                                          Extended_match
-                                                                                          a
-                                                                                        }
-                                                                                        wild
-                                                                                      ]
-                                                                                      (fun Unit Bool)
-                                                                                    }
-                                                                                    (lam
-                                                                                      ipv
-                                                                                      a
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              [
-                                                                                                {
-                                                                                                  [
-                                                                                                    {
-                                                                                                      Extended_match
-                                                                                                      a
-                                                                                                    }
-                                                                                                    wild
-                                                                                                  ]
-                                                                                                  (fun Unit Bool)
-                                                                                                }
-                                                                                                (lam
-                                                                                                  ipv
-                                                                                                  a
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    [
-                                                                                                      [
-                                                                                                        [
-                                                                                                          [
-                                                                                                            {
-                                                                                                              [
-                                                                                                                Ordering_match
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        compare
-                                                                                                                        a
-                                                                                                                      }
-                                                                                                                      dOrd
-                                                                                                                    ]
-                                                                                                                    ipv
-                                                                                                                  ]
-                                                                                                                  ipv
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                              (fun Unit Bool)
-                                                                                                            }
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      [
-                                                                                                                        Bool_match
-                                                                                                                        in
-                                                                                                                      ]
-                                                                                                                      (fun Unit Bool)
-                                                                                                                    }
-                                                                                                                    (lam
-                                                                                                                      thunk
-                                                                                                                      Unit
-                                                                                                                      in
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    (let
-                                                                                                                      (nonrec
-                                                                                                                      )
-                                                                                                                      (termbind
-                                                                                                                        (strict
-                                                                                                                        )
-                                                                                                                        (vardecl
-                                                                                                                          wild
-                                                                                                                          Bool
-                                                                                                                        )
-                                                                                                                        in
-                                                                                                                      )
-                                                                                                                      True
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                                Unit
-                                                                                                              ]
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          (lam
-                                                                                                            thunk
-                                                                                                            Unit
-                                                                                                            False
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          True
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      Unit
-                                                                                                    ]
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                {
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
-                                                                                                  )
-                                                                                                  Bool
-                                                                                                }
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              True
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    {
-                                                                                      (abs
-                                                                                        e
-                                                                                        (type)
-                                                                                        (error
-                                                                                          e
-                                                                                        )
-                                                                                      )
-                                                                                      Bool
-                                                                                    }
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
                                                                                     [
-                                                                                      [
+                                                                                      {
                                                                                         [
                                                                                           {
-                                                                                            [
-                                                                                              {
-                                                                                                Extended_match
-                                                                                                a
-                                                                                              }
-                                                                                              wild
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            ipv
+                                                                                            Extended_match
                                                                                             a
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              False
-                                                                                            )
-                                                                                          )
+                                                                                          }
+                                                                                          v
                                                                                         ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
+                                                                                      (lam
+                                                                                        ipv
+                                                                                        a
                                                                                         (lam
                                                                                           thunk
                                                                                           Unit
-                                                                                          {
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
-                                                                                              )
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        [
                                                                                           [
                                                                                             [
-                                                                                              {
-                                                                                                [
-                                                                                                  Bool_match
-                                                                                                  in
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                in
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              (let
-                                                                                                (nonrec
-                                                                                                )
-                                                                                                (termbind
-                                                                                                  (strict
-                                                                                                  )
-                                                                                                  (vardecl
-                                                                                                    wild
-                                                                                                    Bool
-                                                                                                  )
-                                                                                                  in
-                                                                                                )
-                                                                                                True
-                                                                                              )
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              ]
-                                                                              Unit
-                                                                            ]
-                                                                          )
-                                                                        )
-                                                                      ]
-                                                                      (lam
-                                                                        thunk
-                                                                        Unit
-                                                                        False
-                                                                      )
-                                                                    ]
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      [
-                                                                        [
-                                                                          [
-                                                                            [
-                                                                              {
-                                                                                [
-                                                                                  {
-                                                                                    Extended_match
-                                                                                    a
-                                                                                  }
-                                                                                  wild
-                                                                                ]
-                                                                                (fun Unit Bool)
-                                                                              }
-                                                                              (lam
-                                                                                ipv
-                                                                                a
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              {
-                                                                                                Extended_match
-                                                                                                a
-                                                                                              }
-                                                                                              wild
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            ipv
-                                                                                            a
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
                                                                                               [
                                                                                                 [
-                                                                                                  [
+                                                                                                  {
                                                                                                     [
                                                                                                       {
-                                                                                                        [
-                                                                                                          Ordering_match
-                                                                                                          [
-                                                                                                            [
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  compare
-                                                                                                                  a
-                                                                                                                }
-                                                                                                                dOrd
-                                                                                                              ]
-                                                                                                              ipv
-                                                                                                            ]
-                                                                                                            ipv
-                                                                                                          ]
-                                                                                                        ]
-                                                                                                        (fun Unit Bool)
+                                                                                                        Extended_match
+                                                                                                        a
                                                                                                       }
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
+                                                                                                      v
+                                                                                                    ]
+                                                                                                    (fun Unit Bool)
+                                                                                                  }
+                                                                                                  (lam
+                                                                                                    ipv
+                                                                                                    a
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      [
                                                                                                         [
                                                                                                           [
                                                                                                             [
                                                                                                               {
                                                                                                                 [
-                                                                                                                  Bool_match
-                                                                                                                  in
+                                                                                                                  Ordering_match
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      [
+                                                                                                                        {
+                                                                                                                          compare
+                                                                                                                          a
+                                                                                                                        }
+                                                                                                                        dOrd
+                                                                                                                      ]
+                                                                                                                      ipv
+                                                                                                                    ]
+                                                                                                                    ipv
+                                                                                                                  ]
                                                                                                                 ]
                                                                                                                 (fun Unit Bool)
                                                                                                               }
                                                                                                               (lam
                                                                                                                 thunk
                                                                                                                 Unit
-                                                                                                                in
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      {
+                                                                                                                        [
+                                                                                                                          Bool_match
+                                                                                                                          in
+                                                                                                                        ]
+                                                                                                                        (fun Unit Bool)
+                                                                                                                      }
+                                                                                                                      (lam
+                                                                                                                        thunk
+                                                                                                                        Unit
+                                                                                                                        in
+                                                                                                                      )
+                                                                                                                    ]
+                                                                                                                    (lam
+                                                                                                                      thunk
+                                                                                                                      Unit
+                                                                                                                      True
+                                                                                                                    )
+                                                                                                                  ]
+                                                                                                                  Unit
+                                                                                                                ]
                                                                                                               )
                                                                                                             ]
                                                                                                             (lam
                                                                                                               thunk
                                                                                                               Unit
-                                                                                                              (let
-                                                                                                                (nonrec
-                                                                                                                )
-                                                                                                                (termbind
-                                                                                                                  (strict
-                                                                                                                  )
-                                                                                                                  (vardecl
-                                                                                                                    wild
-                                                                                                                    Bool
-                                                                                                                  )
-                                                                                                                  in
-                                                                                                                )
-                                                                                                                True
-                                                                                                              )
+                                                                                                              False
                                                                                                             )
                                                                                                           ]
-                                                                                                          Unit
+                                                                                                          (lam
+                                                                                                            thunk
+                                                                                                            Unit
+                                                                                                            True
+                                                                                                          )
                                                                                                         ]
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      False
+                                                                                                        Unit
+                                                                                                      ]
                                                                                                     )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    True
                                                                                                   )
                                                                                                 ]
-                                                                                                Unit
+                                                                                                (lam
+                                                                                                  thunk
+                                                                                                  Unit
+                                                                                                  {
+                                                                                                    (abs
+                                                                                                      e
+                                                                                                      (type)
+                                                                                                      (error
+                                                                                                        e
+                                                                                                      )
+                                                                                                    )
+                                                                                                    Bool
+                                                                                                  }
+                                                                                                )
                                                                                               ]
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          {
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                True
                                                                                               )
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
+                                                                                            ]
+                                                                                            Unit
+                                                                                          ]
                                                                                         )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        True
                                                                                       )
                                                                                     ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            ]
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              {
-                                                                                (abs
-                                                                                  e
-                                                                                  (type)
-                                                                                  (error
-                                                                                    e
-                                                                                  )
-                                                                                )
-                                                                                Bool
-                                                                              }
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  [
-                                                                                    {
-                                                                                      [
-                                                                                        {
-                                                                                          Extended_match
-                                                                                          a
-                                                                                        }
-                                                                                        wild
-                                                                                      ]
-                                                                                      (fun Unit Bool)
-                                                                                    }
                                                                                     (lam
-                                                                                      ipv
-                                                                                      a
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        False
-                                                                                      )
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      {
+                                                                                        (abs
+                                                                                          e
+                                                                                          (type)
+                                                                                          (error
+                                                                                            e
+                                                                                          )
+                                                                                        )
+                                                                                        Bool
+                                                                                      }
                                                                                     )
                                                                                   ]
                                                                                   (lam
                                                                                     thunk
                                                                                     Unit
-                                                                                    {
-                                                                                      (abs
-                                                                                        e
-                                                                                        (type)
-                                                                                        (error
-                                                                                          e
-                                                                                        )
-                                                                                      )
-                                                                                      Bool
-                                                                                    }
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
                                                                                     [
                                                                                       [
-                                                                                        {
+                                                                                        [
                                                                                           [
-                                                                                            Bool_match
-                                                                                            in
+                                                                                            {
+                                                                                              [
+                                                                                                {
+                                                                                                  Extended_match
+                                                                                                  a
+                                                                                                }
+                                                                                                v
+                                                                                              ]
+                                                                                              (fun Unit Bool)
+                                                                                            }
+                                                                                            (lam
+                                                                                              ipv
+                                                                                              a
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                False
+                                                                                              )
+                                                                                            )
                                                                                           ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            {
+                                                                                              (abs
+                                                                                                e
+                                                                                                (type)
+                                                                                                (error
+                                                                                                  e
+                                                                                                )
+                                                                                              )
+                                                                                              Bool
+                                                                                            }
+                                                                                          )
+                                                                                        ]
                                                                                         (lam
                                                                                           thunk
                                                                                           Unit
-                                                                                          in
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                {
+                                                                                                  [
+                                                                                                    Bool_match
+                                                                                                    in
+                                                                                                  ]
+                                                                                                  (fun Unit Bool)
+                                                                                                }
+                                                                                                (lam
+                                                                                                  thunk
+                                                                                                  Unit
+                                                                                                  in
+                                                                                                )
+                                                                                              ]
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                True
+                                                                                              )
+                                                                                            ]
+                                                                                            Unit
+                                                                                          ]
                                                                                         )
                                                                                       ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        (let
-                                                                                          (nonrec
-                                                                                          )
-                                                                                          (termbind
-                                                                                            (strict
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
+                                                                          )
+                                                                        ]
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          False
+                                                                        )
+                                                                      ]
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        [
+                                                                          [
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    {
+                                                                                      Extended_match
+                                                                                      a
+                                                                                    }
+                                                                                    v
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
+                                                                                (lam
+                                                                                  ipv
+                                                                                  a
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          [
+                                                                                            {
+                                                                                              [
+                                                                                                {
+                                                                                                  Extended_match
+                                                                                                  a
+                                                                                                }
+                                                                                                v
+                                                                                              ]
+                                                                                              (fun Unit Bool)
+                                                                                            }
+                                                                                            (lam
+                                                                                              ipv
+                                                                                              a
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                [
+                                                                                                  [
+                                                                                                    [
+                                                                                                      [
+                                                                                                        {
+                                                                                                          [
+                                                                                                            Ordering_match
+                                                                                                            [
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  {
+                                                                                                                    compare
+                                                                                                                    a
+                                                                                                                  }
+                                                                                                                  dOrd
+                                                                                                                ]
+                                                                                                                ipv
+                                                                                                              ]
+                                                                                                              ipv
+                                                                                                            ]
+                                                                                                          ]
+                                                                                                          (fun Unit Bool)
+                                                                                                        }
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          [
+                                                                                                            [
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  [
+                                                                                                                    Bool_match
+                                                                                                                    in
+                                                                                                                  ]
+                                                                                                                  (fun Unit Bool)
+                                                                                                                }
+                                                                                                                (lam
+                                                                                                                  thunk
+                                                                                                                  Unit
+                                                                                                                  in
+                                                                                                                )
+                                                                                                              ]
+                                                                                                              (lam
+                                                                                                                thunk
+                                                                                                                Unit
+                                                                                                                True
+                                                                                                              )
+                                                                                                            ]
+                                                                                                            Unit
+                                                                                                          ]
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      (lam
+                                                                                                        thunk
+                                                                                                        Unit
+                                                                                                        False
+                                                                                                      )
+                                                                                                    ]
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      True
+                                                                                                    )
+                                                                                                  ]
+                                                                                                  Unit
+                                                                                                ]
+                                                                                              )
                                                                                             )
-                                                                                            (vardecl
-                                                                                              wild
+                                                                                          ]
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            {
+                                                                                              (abs
+                                                                                                e
+                                                                                                (type)
+                                                                                                (error
+                                                                                                  e
+                                                                                                )
+                                                                                              )
                                                                                               Bool
-                                                                                            )
-                                                                                            in
+                                                                                            }
                                                                                           )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
                                                                                           True
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                {
+                                                                                  (abs
+                                                                                    e
+                                                                                    (type)
+                                                                                    (error
+                                                                                      e
+                                                                                    )
+                                                                                  )
+                                                                                  Bool
+                                                                                }
+                                                                              )
+                                                                            ]
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        [
+                                                                                          {
+                                                                                            Extended_match
+                                                                                            a
+                                                                                          }
+                                                                                          v
+                                                                                        ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
+                                                                                      (lam
+                                                                                        ipv
+                                                                                        a
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          False
                                                                                         )
                                                                                       )
                                                                                     ]
-                                                                                    Unit
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      {
+                                                                                        (abs
+                                                                                          e
+                                                                                          (type)
+                                                                                          (error
+                                                                                            e
+                                                                                          )
+                                                                                        )
+                                                                                        Bool
+                                                                                      }
+                                                                                    )
                                                                                   ]
-                                                                                )
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              Bool_match
+                                                                                              in
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            in
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          True
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
+                                                                                ]
+                                                                                Unit
                                                                               ]
+                                                                            )
+                                                                          ]
+                                                                          Unit
+                                                                        ]
+                                                                      )
+                                                                    ]
+                                                                    Unit
+                                                                  ]
+                                                                )
+                                                              )
+                                                            ]
+                                                            (lam
+                                                              thunk
+                                                              Unit
+                                                              [
+                                                                [
+                                                                  [
+                                                                    [
+                                                                      {
+                                                                        [
+                                                                          {
+                                                                            Extended_match
+                                                                            a
+                                                                          }
+                                                                          v
+                                                                        ]
+                                                                        (fun Unit Bool)
+                                                                      }
+                                                                      (lam
+                                                                        default_arg0
+                                                                        a
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          True
+                                                                        )
+                                                                      )
+                                                                    ]
+                                                                    (lam
+                                                                      thunk
+                                                                      Unit
+                                                                      [
+                                                                        [
+                                                                          [
+                                                                            {
+                                                                              [
+                                                                                Bool_match
+                                                                                in
+                                                                              ]
+                                                                              (fun Unit Bool)
+                                                                            }
+                                                                            (lam
+                                                                              thunk
                                                                               Unit
-                                                                            ]
+                                                                              in
+                                                                            )
+                                                                          ]
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            True
                                                                           )
                                                                         ]
                                                                         Unit
                                                                       ]
                                                                     )
                                                                   ]
-                                                                  Unit
+                                                                  (lam
+                                                                    thunk
+                                                                    Unit
+                                                                    True
+                                                                  )
                                                                 ]
-                                                              )
+                                                                Unit
+                                                              ]
                                                             )
                                                           ]
-                                                          Unit
+                                                          (lam
+                                                            thunk
+                                                            Unit
+                                                            [
+                                                              [
+                                                                [
+                                                                  [
+                                                                    {
+                                                                      [
+                                                                        {
+                                                                          Extended_match
+                                                                          a
+                                                                        }
+                                                                        v
+                                                                      ]
+                                                                      (fun Unit Bool)
+                                                                    }
+                                                                    (lam
+                                                                      default_arg0
+                                                                      a
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        [
+                                                                          [
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    {
+                                                                                      Extended_match
+                                                                                      a
+                                                                                    }
+                                                                                    v
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
+                                                                                (lam
+                                                                                  ipv
+                                                                                  a
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          [
+                                                                                            {
+                                                                                              [
+                                                                                                {
+                                                                                                  Extended_match
+                                                                                                  a
+                                                                                                }
+                                                                                                v
+                                                                                              ]
+                                                                                              (fun Unit Bool)
+                                                                                            }
+                                                                                            (lam
+                                                                                              ipv
+                                                                                              a
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                [
+                                                                                                  [
+                                                                                                    [
+                                                                                                      [
+                                                                                                        {
+                                                                                                          [
+                                                                                                            Ordering_match
+                                                                                                            [
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  {
+                                                                                                                    compare
+                                                                                                                    a
+                                                                                                                  }
+                                                                                                                  dOrd
+                                                                                                                ]
+                                                                                                                ipv
+                                                                                                              ]
+                                                                                                              ipv
+                                                                                                            ]
+                                                                                                          ]
+                                                                                                          (fun Unit Bool)
+                                                                                                        }
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          [
+                                                                                                            [
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  [
+                                                                                                                    Bool_match
+                                                                                                                    in
+                                                                                                                  ]
+                                                                                                                  (fun Unit Bool)
+                                                                                                                }
+                                                                                                                (lam
+                                                                                                                  thunk
+                                                                                                                  Unit
+                                                                                                                  in
+                                                                                                                )
+                                                                                                              ]
+                                                                                                              (lam
+                                                                                                                thunk
+                                                                                                                Unit
+                                                                                                                True
+                                                                                                              )
+                                                                                                            ]
+                                                                                                            Unit
+                                                                                                          ]
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      (lam
+                                                                                                        thunk
+                                                                                                        Unit
+                                                                                                        False
+                                                                                                      )
+                                                                                                    ]
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      True
+                                                                                                    )
+                                                                                                  ]
+                                                                                                  Unit
+                                                                                                ]
+                                                                                              )
+                                                                                            )
+                                                                                          ]
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            {
+                                                                                              (abs
+                                                                                                e
+                                                                                                (type)
+                                                                                                (error
+                                                                                                  e
+                                                                                                )
+                                                                                              )
+                                                                                              Bool
+                                                                                            }
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          True
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                {
+                                                                                  (abs
+                                                                                    e
+                                                                                    (type)
+                                                                                    (error
+                                                                                      e
+                                                                                    )
+                                                                                  )
+                                                                                  Bool
+                                                                                }
+                                                                              )
+                                                                            ]
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        [
+                                                                                          {
+                                                                                            Extended_match
+                                                                                            a
+                                                                                          }
+                                                                                          v
+                                                                                        ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
+                                                                                      (lam
+                                                                                        ipv
+                                                                                        a
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          False
+                                                                                        )
+                                                                                      )
+                                                                                    ]
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      {
+                                                                                        (abs
+                                                                                          e
+                                                                                          (type)
+                                                                                          (error
+                                                                                            e
+                                                                                          )
+                                                                                        )
+                                                                                        Bool
+                                                                                      }
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              Bool_match
+                                                                                              in
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            in
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          True
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
+                                                                          ]
+                                                                          Unit
+                                                                        ]
+                                                                      )
+                                                                    )
+                                                                  ]
+                                                                  (lam
+                                                                    thunk
+                                                                    Unit
+                                                                    False
+                                                                  )
+                                                                ]
+                                                                (lam
+                                                                  thunk
+                                                                  Unit
+                                                                  [
+                                                                    [
+                                                                      [
+                                                                        [
+                                                                          {
+                                                                            [
+                                                                              {
+                                                                                Extended_match
+                                                                                a
+                                                                              }
+                                                                              v
+                                                                            ]
+                                                                            (fun Unit Bool)
+                                                                          }
+                                                                          (lam
+                                                                            ipv
+                                                                            a
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        [
+                                                                                          {
+                                                                                            Extended_match
+                                                                                            a
+                                                                                          }
+                                                                                          v
+                                                                                        ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
+                                                                                      (lam
+                                                                                        ipv
+                                                                                        a
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                [
+                                                                                                  {
+                                                                                                    [
+                                                                                                      Ordering_match
+                                                                                                      [
+                                                                                                        [
+                                                                                                          [
+                                                                                                            {
+                                                                                                              compare
+                                                                                                              a
+                                                                                                            }
+                                                                                                            dOrd
+                                                                                                          ]
+                                                                                                          ipv
+                                                                                                        ]
+                                                                                                        ipv
+                                                                                                      ]
+                                                                                                    ]
+                                                                                                    (fun Unit Bool)
+                                                                                                  }
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    [
+                                                                                                      [
+                                                                                                        [
+                                                                                                          {
+                                                                                                            [
+                                                                                                              Bool_match
+                                                                                                              in
+                                                                                                            ]
+                                                                                                            (fun Unit Bool)
+                                                                                                          }
+                                                                                                          (lam
+                                                                                                            thunk
+                                                                                                            Unit
+                                                                                                            in
+                                                                                                          )
+                                                                                                        ]
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          True
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      Unit
+                                                                                                    ]
+                                                                                                  )
+                                                                                                ]
+                                                                                                (lam
+                                                                                                  thunk
+                                                                                                  Unit
+                                                                                                  False
+                                                                                                )
+                                                                                              ]
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                True
+                                                                                              )
+                                                                                            ]
+                                                                                            Unit
+                                                                                          ]
+                                                                                        )
+                                                                                      )
+                                                                                    ]
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      {
+                                                                                        (abs
+                                                                                          e
+                                                                                          (type)
+                                                                                          (error
+                                                                                            e
+                                                                                          )
+                                                                                        )
+                                                                                        Bool
+                                                                                      }
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    True
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
+                                                                          )
+                                                                        ]
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          {
+                                                                            (abs
+                                                                              e
+                                                                              (type)
+                                                                              (error
+                                                                                e
+                                                                              )
+                                                                            )
+                                                                            Bool
+                                                                          }
+                                                                        )
+                                                                      ]
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        [
+                                                                          [
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    {
+                                                                                      Extended_match
+                                                                                      a
+                                                                                    }
+                                                                                    v
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
+                                                                                (lam
+                                                                                  ipv
+                                                                                  a
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    False
+                                                                                  )
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                {
+                                                                                  (abs
+                                                                                    e
+                                                                                    (type)
+                                                                                    (error
+                                                                                      e
+                                                                                    )
+                                                                                  )
+                                                                                  Bool
+                                                                                }
+                                                                              )
+                                                                            ]
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        Bool_match
+                                                                                        in
+                                                                                      ]
+                                                                                      (fun Unit Bool)
+                                                                                    }
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      in
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    True
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
+                                                                          ]
+                                                                          Unit
+                                                                        ]
+                                                                      )
+                                                                    ]
+                                                                    Unit
+                                                                  ]
+                                                                )
+                                                              ]
+                                                              Unit
+                                                            ]
+                                                          )
                                                         ]
-                                                      )
+                                                        Unit
+                                                      ]
                                                     )
                                                   )
                                                 ]
@@ -7523,1232 +7273,1082 @@
                                                     (lam
                                                       in
                                                       Bool
-                                                      (let
-                                                        (nonrec)
-                                                        (termbind
-                                                          (nonstrict)
-                                                          (vardecl
-                                                            wild [Extended a]
-                                                          )
-                                                          v
-                                                        )
+                                                      [
                                                         [
                                                           [
                                                             [
-                                                              [
-                                                                {
-                                                                  [
-                                                                    {
-                                                                      Extended_match
-                                                                      a
-                                                                    }
-                                                                    v
-                                                                  ]
-                                                                  (fun Unit Bool)
-                                                                }
-                                                                (lam
-                                                                  default_arg0
-                                                                  a
-                                                                  (lam
-                                                                    thunk
-                                                                    Unit
-                                                                    (let
-                                                                      (nonrec)
-                                                                      (termbind
-                                                                        (nonstrict
-                                                                        )
-                                                                        (vardecl
-                                                                          wild
-                                                                          [Extended a]
-                                                                        )
-                                                                        v
-                                                                      )
-                                                                      [
-                                                                        [
-                                                                          [
-                                                                            [
-                                                                              {
-                                                                                [
-                                                                                  {
-                                                                                    Extended_match
-                                                                                    a
-                                                                                  }
-                                                                                  v
-                                                                                ]
-                                                                                (fun Unit Bool)
-                                                                              }
-                                                                              (lam
-                                                                                default_arg0
-                                                                                a
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              {
-                                                                                                Extended_match
-                                                                                                a
-                                                                                              }
-                                                                                              wild
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            ipv
-                                                                                            a
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    [
-                                                                                                      {
-                                                                                                        [
-                                                                                                          {
-                                                                                                            Extended_match
-                                                                                                            a
-                                                                                                          }
-                                                                                                          wild
-                                                                                                        ]
-                                                                                                        (fun Unit Bool)
-                                                                                                      }
-                                                                                                      (lam
-                                                                                                        ipv
-                                                                                                        a
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          [
-                                                                                                            [
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  {
-                                                                                                                    [
-                                                                                                                      Ordering_match
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          [
-                                                                                                                            {
-                                                                                                                              compare
-                                                                                                                              a
-                                                                                                                            }
-                                                                                                                            dOrd
-                                                                                                                          ]
-                                                                                                                          ipv
-                                                                                                                        ]
-                                                                                                                        ipv
-                                                                                                                      ]
-                                                                                                                    ]
-                                                                                                                    (fun Unit Bool)
-                                                                                                                  }
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            [
-                                                                                                                              Bool_match
-                                                                                                                              in
-                                                                                                                            ]
-                                                                                                                            (fun Unit Bool)
-                                                                                                                          }
-                                                                                                                          (lam
-                                                                                                                            thunk
-                                                                                                                            Unit
-                                                                                                                            in
-                                                                                                                          )
-                                                                                                                        ]
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          (let
-                                                                                                                            (nonrec
-                                                                                                                            )
-                                                                                                                            (termbind
-                                                                                                                              (strict
-                                                                                                                              )
-                                                                                                                              (vardecl
-                                                                                                                                wild
-                                                                                                                                Bool
-                                                                                                                              )
-                                                                                                                              in
-                                                                                                                            )
-                                                                                                                            True
-                                                                                                                          )
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      Unit
-                                                                                                                    ]
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                                (lam
-                                                                                                                  thunk
-                                                                                                                  Unit
-                                                                                                                  False
-                                                                                                                )
-                                                                                                              ]
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                True
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            Unit
-                                                                                                          ]
-                                                                                                        )
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      {
-                                                                                                        (abs
-                                                                                                          e
-                                                                                                          (type)
-                                                                                                          (error
-                                                                                                            e
-                                                                                                          )
-                                                                                                        )
-                                                                                                        Bool
-                                                                                                      }
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    True
-                                                                                                  )
-                                                                                                ]
-                                                                                                Unit
-                                                                                              ]
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          {
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
-                                                                                              )
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              [
-                                                                                                {
-                                                                                                  [
-                                                                                                    {
-                                                                                                      Extended_match
-                                                                                                      a
-                                                                                                    }
-                                                                                                    wild
-                                                                                                  ]
-                                                                                                  (fun Unit Bool)
-                                                                                                }
-                                                                                                (lam
-                                                                                                  ipv
-                                                                                                  a
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    False
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                {
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
-                                                                                                  )
-                                                                                                  Bool
-                                                                                                }
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        Bool_match
-                                                                                                        in
-                                                                                                      ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      in
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    (let
-                                                                                                      (nonrec
-                                                                                                      )
-                                                                                                      (termbind
-                                                                                                        (strict
-                                                                                                        )
-                                                                                                        (vardecl
-                                                                                                          wild
-                                                                                                          Bool
-                                                                                                        )
-                                                                                                        in
-                                                                                                      )
-                                                                                                      True
-                                                                                                    )
-                                                                                                  )
-                                                                                                ]
-                                                                                                Unit
-                                                                                              ]
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            ]
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              False
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  [
-                                                                                    {
-                                                                                      [
-                                                                                        {
-                                                                                          Extended_match
-                                                                                          a
-                                                                                        }
-                                                                                        wild
-                                                                                      ]
-                                                                                      (fun Unit Bool)
-                                                                                    }
-                                                                                    (lam
-                                                                                      ipv
-                                                                                      a
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              [
-                                                                                                {
-                                                                                                  [
-                                                                                                    {
-                                                                                                      Extended_match
-                                                                                                      a
-                                                                                                    }
-                                                                                                    wild
-                                                                                                  ]
-                                                                                                  (fun Unit Bool)
-                                                                                                }
-                                                                                                (lam
-                                                                                                  ipv
-                                                                                                  a
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    [
-                                                                                                      [
-                                                                                                        [
-                                                                                                          [
-                                                                                                            {
-                                                                                                              [
-                                                                                                                Ordering_match
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        compare
-                                                                                                                        a
-                                                                                                                      }
-                                                                                                                      dOrd
-                                                                                                                    ]
-                                                                                                                    ipv
-                                                                                                                  ]
-                                                                                                                  ipv
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                              (fun Unit Bool)
-                                                                                                            }
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      [
-                                                                                                                        Bool_match
-                                                                                                                        in
-                                                                                                                      ]
-                                                                                                                      (fun Unit Bool)
-                                                                                                                    }
-                                                                                                                    (lam
-                                                                                                                      thunk
-                                                                                                                      Unit
-                                                                                                                      in
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    (let
-                                                                                                                      (nonrec
-                                                                                                                      )
-                                                                                                                      (termbind
-                                                                                                                        (strict
-                                                                                                                        )
-                                                                                                                        (vardecl
-                                                                                                                          wild
-                                                                                                                          Bool
-                                                                                                                        )
-                                                                                                                        in
-                                                                                                                      )
-                                                                                                                      True
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                                Unit
-                                                                                                              ]
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          (lam
-                                                                                                            thunk
-                                                                                                            Unit
-                                                                                                            False
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          True
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      Unit
-                                                                                                    ]
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                {
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
-                                                                                                  )
-                                                                                                  Bool
-                                                                                                }
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              True
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    {
-                                                                                      (abs
-                                                                                        e
-                                                                                        (type)
-                                                                                        (error
-                                                                                          e
-                                                                                        )
-                                                                                      )
-                                                                                      Bool
-                                                                                    }
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              {
-                                                                                                Extended_match
-                                                                                                a
-                                                                                              }
-                                                                                              wild
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            ipv
-                                                                                            a
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              False
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          {
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
-                                                                                              )
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  Bool_match
-                                                                                                  in
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                in
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              (let
-                                                                                                (nonrec
-                                                                                                )
-                                                                                                (termbind
-                                                                                                  (strict
-                                                                                                  )
-                                                                                                  (vardecl
-                                                                                                    wild
-                                                                                                    Bool
-                                                                                                  )
-                                                                                                  in
-                                                                                                )
-                                                                                                True
-                                                                                              )
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              ]
-                                                                              Unit
-                                                                            ]
-                                                                          )
-                                                                        ]
-                                                                        Unit
-                                                                      ]
-                                                                    )
-                                                                  )
-                                                                )
-                                                              ]
-                                                              (lam
-                                                                thunk
-                                                                Unit
+                                                              {
                                                                 [
-                                                                  [
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          [
-                                                                            {
-                                                                              Extended_match
-                                                                              a
-                                                                            }
-                                                                            v
-                                                                          ]
-                                                                          (fun Unit Bool)
-                                                                        }
-                                                                        (lam
-                                                                          default_arg0
-                                                                          a
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            True
-                                                                          )
-                                                                        )
-                                                                      ]
-                                                                      (lam
-                                                                        thunk
-                                                                        Unit
-                                                                        [
-                                                                          [
-                                                                            [
-                                                                              {
-                                                                                [
-                                                                                  Bool_match
-                                                                                  in
-                                                                                ]
-                                                                                (fun Unit Bool)
-                                                                              }
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                in
-                                                                              )
-                                                                            ]
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              (let
-                                                                                (nonrec
-                                                                                )
-                                                                                (termbind
-                                                                                  (strict
-                                                                                  )
-                                                                                  (vardecl
-                                                                                    wild
-                                                                                    Bool
-                                                                                  )
-                                                                                  in
-                                                                                )
-                                                                                True
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                          Unit
-                                                                        ]
-                                                                      )
-                                                                    ]
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      True
-                                                                    )
-                                                                  ]
-                                                                  Unit
-                                                                ]
-                                                              )
-                                                            ]
-                                                            (lam
-                                                              thunk
-                                                              Unit
-                                                              (let
-                                                                (nonrec)
-                                                                (termbind
-                                                                  (nonstrict)
-                                                                  (vardecl
-                                                                    wild
-                                                                    [Extended a]
-                                                                  )
+                                                                  {
+                                                                    Extended_match
+                                                                    a
+                                                                  }
                                                                   v
-                                                                )
-                                                                [
+                                                                ]
+                                                                (fun Unit Bool)
+                                                              }
+                                                              (lam
+                                                                default_arg0
+                                                                a
+                                                                (lam
+                                                                  thunk
+                                                                  Unit
                                                                   [
                                                                     [
                                                                       [
-                                                                        {
-                                                                          [
-                                                                            {
-                                                                              Extended_match
-                                                                              a
-                                                                            }
-                                                                            v
-                                                                          ]
-                                                                          (fun Unit Bool)
-                                                                        }
-                                                                        (lam
-                                                                          default_arg0
-                                                                          a
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
+                                                                        [
+                                                                          {
                                                                             [
+                                                                              {
+                                                                                Extended_match
+                                                                                a
+                                                                              }
+                                                                              v
+                                                                            ]
+                                                                            (fun Unit Bool)
+                                                                          }
+                                                                          (lam
+                                                                            default_arg0
+                                                                            a
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
                                                                               [
                                                                                 [
                                                                                   [
-                                                                                    {
-                                                                                      [
-                                                                                        {
-                                                                                          Extended_match
-                                                                                          a
-                                                                                        }
-                                                                                        wild
-                                                                                      ]
-                                                                                      (fun Unit Bool)
-                                                                                    }
-                                                                                    (lam
-                                                                                      ipv
-                                                                                      a
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              [
-                                                                                                {
-                                                                                                  [
-                                                                                                    {
-                                                                                                      Extended_match
-                                                                                                      a
-                                                                                                    }
-                                                                                                    wild
-                                                                                                  ]
-                                                                                                  (fun Unit Bool)
-                                                                                                }
-                                                                                                (lam
-                                                                                                  ipv
-                                                                                                  a
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    [
-                                                                                                      [
-                                                                                                        [
-                                                                                                          [
-                                                                                                            {
-                                                                                                              [
-                                                                                                                Ordering_match
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        compare
-                                                                                                                        a
-                                                                                                                      }
-                                                                                                                      dOrd
-                                                                                                                    ]
-                                                                                                                    ipv
-                                                                                                                  ]
-                                                                                                                  ipv
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                              (fun Unit Bool)
-                                                                                                            }
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      [
-                                                                                                                        Bool_match
-                                                                                                                        in
-                                                                                                                      ]
-                                                                                                                      (fun Unit Bool)
-                                                                                                                    }
-                                                                                                                    (lam
-                                                                                                                      thunk
-                                                                                                                      Unit
-                                                                                                                      in
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    (let
-                                                                                                                      (nonrec
-                                                                                                                      )
-                                                                                                                      (termbind
-                                                                                                                        (strict
-                                                                                                                        )
-                                                                                                                        (vardecl
-                                                                                                                          wild
-                                                                                                                          Bool
-                                                                                                                        )
-                                                                                                                        in
-                                                                                                                      )
-                                                                                                                      True
-                                                                                                                    )
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                                Unit
-                                                                                                              ]
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          (lam
-                                                                                                            thunk
-                                                                                                            Unit
-                                                                                                            False
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          True
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      Unit
-                                                                                                    ]
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                {
-                                                                                                  (abs
-                                                                                                    e
-                                                                                                    (type)
-                                                                                                    (error
-                                                                                                      e
-                                                                                                    )
-                                                                                                  )
-                                                                                                  Bool
-                                                                                                }
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              True
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    {
-                                                                                      (abs
-                                                                                        e
-                                                                                        (type)
-                                                                                        (error
-                                                                                          e
-                                                                                        )
-                                                                                      )
-                                                                                      Bool
-                                                                                    }
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
                                                                                     [
-                                                                                      [
+                                                                                      {
                                                                                         [
                                                                                           {
-                                                                                            [
-                                                                                              {
-                                                                                                Extended_match
-                                                                                                a
-                                                                                              }
-                                                                                              wild
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            ipv
+                                                                                            Extended_match
                                                                                             a
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              False
-                                                                                            )
-                                                                                          )
+                                                                                          }
+                                                                                          v
                                                                                         ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
+                                                                                      (lam
+                                                                                        ipv
+                                                                                        a
                                                                                         (lam
                                                                                           thunk
                                                                                           Unit
-                                                                                          {
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
-                                                                                              )
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        [
                                                                                           [
                                                                                             [
-                                                                                              {
-                                                                                                [
-                                                                                                  Bool_match
-                                                                                                  in
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                thunk
-                                                                                                Unit
-                                                                                                in
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              (let
-                                                                                                (nonrec
-                                                                                                )
-                                                                                                (termbind
-                                                                                                  (strict
-                                                                                                  )
-                                                                                                  (vardecl
-                                                                                                    wild
-                                                                                                    Bool
-                                                                                                  )
-                                                                                                  in
-                                                                                                )
-                                                                                                True
-                                                                                              )
-                                                                                            )
-                                                                                          ]
-                                                                                          Unit
-                                                                                        ]
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              ]
-                                                                              Unit
-                                                                            ]
-                                                                          )
-                                                                        )
-                                                                      ]
-                                                                      (lam
-                                                                        thunk
-                                                                        Unit
-                                                                        False
-                                                                      )
-                                                                    ]
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      [
-                                                                        [
-                                                                          [
-                                                                            [
-                                                                              {
-                                                                                [
-                                                                                  {
-                                                                                    Extended_match
-                                                                                    a
-                                                                                  }
-                                                                                  wild
-                                                                                ]
-                                                                                (fun Unit Bool)
-                                                                              }
-                                                                              (lam
-                                                                                ipv
-                                                                                a
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              {
-                                                                                                Extended_match
-                                                                                                a
-                                                                                              }
-                                                                                              wild
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            ipv
-                                                                                            a
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
                                                                                               [
                                                                                                 [
-                                                                                                  [
+                                                                                                  {
                                                                                                     [
                                                                                                       {
-                                                                                                        [
-                                                                                                          Ordering_match
-                                                                                                          [
-                                                                                                            [
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  compare
-                                                                                                                  a
-                                                                                                                }
-                                                                                                                dOrd
-                                                                                                              ]
-                                                                                                              ipv
-                                                                                                            ]
-                                                                                                            ipv
-                                                                                                          ]
-                                                                                                        ]
-                                                                                                        (fun Unit Bool)
+                                                                                                        Extended_match
+                                                                                                        a
                                                                                                       }
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
+                                                                                                      v
+                                                                                                    ]
+                                                                                                    (fun Unit Bool)
+                                                                                                  }
+                                                                                                  (lam
+                                                                                                    ipv
+                                                                                                    a
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      [
                                                                                                         [
                                                                                                           [
                                                                                                             [
                                                                                                               {
                                                                                                                 [
-                                                                                                                  Bool_match
-                                                                                                                  in
+                                                                                                                  Ordering_match
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      [
+                                                                                                                        {
+                                                                                                                          compare
+                                                                                                                          a
+                                                                                                                        }
+                                                                                                                        dOrd
+                                                                                                                      ]
+                                                                                                                      ipv
+                                                                                                                    ]
+                                                                                                                    ipv
+                                                                                                                  ]
                                                                                                                 ]
                                                                                                                 (fun Unit Bool)
                                                                                                               }
                                                                                                               (lam
                                                                                                                 thunk
                                                                                                                 Unit
-                                                                                                                in
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      {
+                                                                                                                        [
+                                                                                                                          Bool_match
+                                                                                                                          in
+                                                                                                                        ]
+                                                                                                                        (fun Unit Bool)
+                                                                                                                      }
+                                                                                                                      (lam
+                                                                                                                        thunk
+                                                                                                                        Unit
+                                                                                                                        in
+                                                                                                                      )
+                                                                                                                    ]
+                                                                                                                    (lam
+                                                                                                                      thunk
+                                                                                                                      Unit
+                                                                                                                      True
+                                                                                                                    )
+                                                                                                                  ]
+                                                                                                                  Unit
+                                                                                                                ]
                                                                                                               )
                                                                                                             ]
                                                                                                             (lam
                                                                                                               thunk
                                                                                                               Unit
-                                                                                                              (let
-                                                                                                                (nonrec
-                                                                                                                )
-                                                                                                                (termbind
-                                                                                                                  (strict
-                                                                                                                  )
-                                                                                                                  (vardecl
-                                                                                                                    wild
-                                                                                                                    Bool
-                                                                                                                  )
-                                                                                                                  in
-                                                                                                                )
-                                                                                                                True
-                                                                                                              )
+                                                                                                              False
                                                                                                             )
                                                                                                           ]
-                                                                                                          Unit
+                                                                                                          (lam
+                                                                                                            thunk
+                                                                                                            Unit
+                                                                                                            True
+                                                                                                          )
                                                                                                         ]
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      False
+                                                                                                        Unit
+                                                                                                      ]
                                                                                                     )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    True
                                                                                                   )
                                                                                                 ]
-                                                                                                Unit
+                                                                                                (lam
+                                                                                                  thunk
+                                                                                                  Unit
+                                                                                                  {
+                                                                                                    (abs
+                                                                                                      e
+                                                                                                      (type)
+                                                                                                      (error
+                                                                                                        e
+                                                                                                      )
+                                                                                                    )
+                                                                                                    Bool
+                                                                                                  }
+                                                                                                )
                                                                                               ]
-                                                                                            )
-                                                                                          )
-                                                                                        ]
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          {
-                                                                                            (abs
-                                                                                              e
-                                                                                              (type)
-                                                                                              (error
-                                                                                                e
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                True
                                                                                               )
-                                                                                            )
-                                                                                            Bool
-                                                                                          }
+                                                                                            ]
+                                                                                            Unit
+                                                                                          ]
                                                                                         )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        True
                                                                                       )
                                                                                     ]
-                                                                                    Unit
-                                                                                  ]
-                                                                                )
-                                                                              )
-                                                                            ]
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              {
-                                                                                (abs
-                                                                                  e
-                                                                                  (type)
-                                                                                  (error
-                                                                                    e
-                                                                                  )
-                                                                                )
-                                                                                Bool
-                                                                              }
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  [
-                                                                                    {
-                                                                                      [
-                                                                                        {
-                                                                                          Extended_match
-                                                                                          a
-                                                                                        }
-                                                                                        wild
-                                                                                      ]
-                                                                                      (fun Unit Bool)
-                                                                                    }
                                                                                     (lam
-                                                                                      ipv
-                                                                                      a
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        False
-                                                                                      )
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      {
+                                                                                        (abs
+                                                                                          e
+                                                                                          (type)
+                                                                                          (error
+                                                                                            e
+                                                                                          )
+                                                                                        )
+                                                                                        Bool
+                                                                                      }
                                                                                     )
                                                                                   ]
                                                                                   (lam
                                                                                     thunk
                                                                                     Unit
-                                                                                    {
-                                                                                      (abs
-                                                                                        e
-                                                                                        (type)
-                                                                                        (error
-                                                                                          e
-                                                                                        )
-                                                                                      )
-                                                                                      Bool
-                                                                                    }
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  [
                                                                                     [
                                                                                       [
-                                                                                        {
+                                                                                        [
                                                                                           [
-                                                                                            Bool_match
-                                                                                            in
+                                                                                            {
+                                                                                              [
+                                                                                                {
+                                                                                                  Extended_match
+                                                                                                  a
+                                                                                                }
+                                                                                                v
+                                                                                              ]
+                                                                                              (fun Unit Bool)
+                                                                                            }
+                                                                                            (lam
+                                                                                              ipv
+                                                                                              a
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                False
+                                                                                              )
+                                                                                            )
                                                                                           ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            {
+                                                                                              (abs
+                                                                                                e
+                                                                                                (type)
+                                                                                                (error
+                                                                                                  e
+                                                                                                )
+                                                                                              )
+                                                                                              Bool
+                                                                                            }
+                                                                                          )
+                                                                                        ]
                                                                                         (lam
                                                                                           thunk
                                                                                           Unit
-                                                                                          in
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                {
+                                                                                                  [
+                                                                                                    Bool_match
+                                                                                                    in
+                                                                                                  ]
+                                                                                                  (fun Unit Bool)
+                                                                                                }
+                                                                                                (lam
+                                                                                                  thunk
+                                                                                                  Unit
+                                                                                                  in
+                                                                                                )
+                                                                                              ]
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                True
+                                                                                              )
+                                                                                            ]
+                                                                                            Unit
+                                                                                          ]
                                                                                         )
                                                                                       ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        (let
-                                                                                          (nonrec
-                                                                                          )
-                                                                                          (termbind
-                                                                                            (strict
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
+                                                                          )
+                                                                        ]
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          False
+                                                                        )
+                                                                      ]
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        [
+                                                                          [
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    {
+                                                                                      Extended_match
+                                                                                      a
+                                                                                    }
+                                                                                    v
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
+                                                                                (lam
+                                                                                  ipv
+                                                                                  a
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          [
+                                                                                            {
+                                                                                              [
+                                                                                                {
+                                                                                                  Extended_match
+                                                                                                  a
+                                                                                                }
+                                                                                                v
+                                                                                              ]
+                                                                                              (fun Unit Bool)
+                                                                                            }
+                                                                                            (lam
+                                                                                              ipv
+                                                                                              a
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                [
+                                                                                                  [
+                                                                                                    [
+                                                                                                      [
+                                                                                                        {
+                                                                                                          [
+                                                                                                            Ordering_match
+                                                                                                            [
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  {
+                                                                                                                    compare
+                                                                                                                    a
+                                                                                                                  }
+                                                                                                                  dOrd
+                                                                                                                ]
+                                                                                                                ipv
+                                                                                                              ]
+                                                                                                              ipv
+                                                                                                            ]
+                                                                                                          ]
+                                                                                                          (fun Unit Bool)
+                                                                                                        }
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          [
+                                                                                                            [
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  [
+                                                                                                                    Bool_match
+                                                                                                                    in
+                                                                                                                  ]
+                                                                                                                  (fun Unit Bool)
+                                                                                                                }
+                                                                                                                (lam
+                                                                                                                  thunk
+                                                                                                                  Unit
+                                                                                                                  in
+                                                                                                                )
+                                                                                                              ]
+                                                                                                              (lam
+                                                                                                                thunk
+                                                                                                                Unit
+                                                                                                                True
+                                                                                                              )
+                                                                                                            ]
+                                                                                                            Unit
+                                                                                                          ]
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      (lam
+                                                                                                        thunk
+                                                                                                        Unit
+                                                                                                        False
+                                                                                                      )
+                                                                                                    ]
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      True
+                                                                                                    )
+                                                                                                  ]
+                                                                                                  Unit
+                                                                                                ]
+                                                                                              )
                                                                                             )
-                                                                                            (vardecl
-                                                                                              wild
+                                                                                          ]
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            {
+                                                                                              (abs
+                                                                                                e
+                                                                                                (type)
+                                                                                                (error
+                                                                                                  e
+                                                                                                )
+                                                                                              )
                                                                                               Bool
-                                                                                            )
-                                                                                            in
+                                                                                            }
                                                                                           )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
                                                                                           True
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                {
+                                                                                  (abs
+                                                                                    e
+                                                                                    (type)
+                                                                                    (error
+                                                                                      e
+                                                                                    )
+                                                                                  )
+                                                                                  Bool
+                                                                                }
+                                                                              )
+                                                                            ]
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        [
+                                                                                          {
+                                                                                            Extended_match
+                                                                                            a
+                                                                                          }
+                                                                                          v
+                                                                                        ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
+                                                                                      (lam
+                                                                                        ipv
+                                                                                        a
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          False
                                                                                         )
                                                                                       )
                                                                                     ]
-                                                                                    Unit
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      {
+                                                                                        (abs
+                                                                                          e
+                                                                                          (type)
+                                                                                          (error
+                                                                                            e
+                                                                                          )
+                                                                                        )
+                                                                                        Bool
+                                                                                      }
+                                                                                    )
                                                                                   ]
-                                                                                )
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              Bool_match
+                                                                                              in
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            in
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          True
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
+                                                                                ]
+                                                                                Unit
                                                                               ]
+                                                                            )
+                                                                          ]
+                                                                          Unit
+                                                                        ]
+                                                                      )
+                                                                    ]
+                                                                    Unit
+                                                                  ]
+                                                                )
+                                                              )
+                                                            ]
+                                                            (lam
+                                                              thunk
+                                                              Unit
+                                                              [
+                                                                [
+                                                                  [
+                                                                    [
+                                                                      {
+                                                                        [
+                                                                          {
+                                                                            Extended_match
+                                                                            a
+                                                                          }
+                                                                          v
+                                                                        ]
+                                                                        (fun Unit Bool)
+                                                                      }
+                                                                      (lam
+                                                                        default_arg0
+                                                                        a
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          True
+                                                                        )
+                                                                      )
+                                                                    ]
+                                                                    (lam
+                                                                      thunk
+                                                                      Unit
+                                                                      [
+                                                                        [
+                                                                          [
+                                                                            {
+                                                                              [
+                                                                                Bool_match
+                                                                                in
+                                                                              ]
+                                                                              (fun Unit Bool)
+                                                                            }
+                                                                            (lam
+                                                                              thunk
                                                                               Unit
-                                                                            ]
+                                                                              in
+                                                                            )
+                                                                          ]
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            True
                                                                           )
                                                                         ]
                                                                         Unit
                                                                       ]
                                                                     )
                                                                   ]
-                                                                  Unit
+                                                                  (lam
+                                                                    thunk
+                                                                    Unit
+                                                                    True
+                                                                  )
                                                                 ]
-                                                              )
+                                                                Unit
+                                                              ]
                                                             )
                                                           ]
-                                                          Unit
+                                                          (lam
+                                                            thunk
+                                                            Unit
+                                                            [
+                                                              [
+                                                                [
+                                                                  [
+                                                                    {
+                                                                      [
+                                                                        {
+                                                                          Extended_match
+                                                                          a
+                                                                        }
+                                                                        v
+                                                                      ]
+                                                                      (fun Unit Bool)
+                                                                    }
+                                                                    (lam
+                                                                      default_arg0
+                                                                      a
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        [
+                                                                          [
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    {
+                                                                                      Extended_match
+                                                                                      a
+                                                                                    }
+                                                                                    v
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
+                                                                                (lam
+                                                                                  ipv
+                                                                                  a
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          [
+                                                                                            {
+                                                                                              [
+                                                                                                {
+                                                                                                  Extended_match
+                                                                                                  a
+                                                                                                }
+                                                                                                v
+                                                                                              ]
+                                                                                              (fun Unit Bool)
+                                                                                            }
+                                                                                            (lam
+                                                                                              ipv
+                                                                                              a
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                [
+                                                                                                  [
+                                                                                                    [
+                                                                                                      [
+                                                                                                        {
+                                                                                                          [
+                                                                                                            Ordering_match
+                                                                                                            [
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  {
+                                                                                                                    compare
+                                                                                                                    a
+                                                                                                                  }
+                                                                                                                  dOrd
+                                                                                                                ]
+                                                                                                                ipv
+                                                                                                              ]
+                                                                                                              ipv
+                                                                                                            ]
+                                                                                                          ]
+                                                                                                          (fun Unit Bool)
+                                                                                                        }
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          [
+                                                                                                            [
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  [
+                                                                                                                    Bool_match
+                                                                                                                    in
+                                                                                                                  ]
+                                                                                                                  (fun Unit Bool)
+                                                                                                                }
+                                                                                                                (lam
+                                                                                                                  thunk
+                                                                                                                  Unit
+                                                                                                                  in
+                                                                                                                )
+                                                                                                              ]
+                                                                                                              (lam
+                                                                                                                thunk
+                                                                                                                Unit
+                                                                                                                True
+                                                                                                              )
+                                                                                                            ]
+                                                                                                            Unit
+                                                                                                          ]
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      (lam
+                                                                                                        thunk
+                                                                                                        Unit
+                                                                                                        False
+                                                                                                      )
+                                                                                                    ]
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      True
+                                                                                                    )
+                                                                                                  ]
+                                                                                                  Unit
+                                                                                                ]
+                                                                                              )
+                                                                                            )
+                                                                                          ]
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            {
+                                                                                              (abs
+                                                                                                e
+                                                                                                (type)
+                                                                                                (error
+                                                                                                  e
+                                                                                                )
+                                                                                              )
+                                                                                              Bool
+                                                                                            }
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          True
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                {
+                                                                                  (abs
+                                                                                    e
+                                                                                    (type)
+                                                                                    (error
+                                                                                      e
+                                                                                    )
+                                                                                  )
+                                                                                  Bool
+                                                                                }
+                                                                              )
+                                                                            ]
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        [
+                                                                                          {
+                                                                                            Extended_match
+                                                                                            a
+                                                                                          }
+                                                                                          v
+                                                                                        ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
+                                                                                      (lam
+                                                                                        ipv
+                                                                                        a
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          False
+                                                                                        )
+                                                                                      )
+                                                                                    ]
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      {
+                                                                                        (abs
+                                                                                          e
+                                                                                          (type)
+                                                                                          (error
+                                                                                            e
+                                                                                          )
+                                                                                        )
+                                                                                        Bool
+                                                                                      }
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              Bool_match
+                                                                                              in
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            thunk
+                                                                                            Unit
+                                                                                            in
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          True
+                                                                                        )
+                                                                                      ]
+                                                                                      Unit
+                                                                                    ]
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
+                                                                          ]
+                                                                          Unit
+                                                                        ]
+                                                                      )
+                                                                    )
+                                                                  ]
+                                                                  (lam
+                                                                    thunk
+                                                                    Unit
+                                                                    False
+                                                                  )
+                                                                ]
+                                                                (lam
+                                                                  thunk
+                                                                  Unit
+                                                                  [
+                                                                    [
+                                                                      [
+                                                                        [
+                                                                          {
+                                                                            [
+                                                                              {
+                                                                                Extended_match
+                                                                                a
+                                                                              }
+                                                                              v
+                                                                            ]
+                                                                            (fun Unit Bool)
+                                                                          }
+                                                                          (lam
+                                                                            ipv
+                                                                            a
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        [
+                                                                                          {
+                                                                                            Extended_match
+                                                                                            a
+                                                                                          }
+                                                                                          v
+                                                                                        ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
+                                                                                      (lam
+                                                                                        ipv
+                                                                                        a
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                [
+                                                                                                  {
+                                                                                                    [
+                                                                                                      Ordering_match
+                                                                                                      [
+                                                                                                        [
+                                                                                                          [
+                                                                                                            {
+                                                                                                              compare
+                                                                                                              a
+                                                                                                            }
+                                                                                                            dOrd
+                                                                                                          ]
+                                                                                                          ipv
+                                                                                                        ]
+                                                                                                        ipv
+                                                                                                      ]
+                                                                                                    ]
+                                                                                                    (fun Unit Bool)
+                                                                                                  }
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    [
+                                                                                                      [
+                                                                                                        [
+                                                                                                          {
+                                                                                                            [
+                                                                                                              Bool_match
+                                                                                                              in
+                                                                                                            ]
+                                                                                                            (fun Unit Bool)
+                                                                                                          }
+                                                                                                          (lam
+                                                                                                            thunk
+                                                                                                            Unit
+                                                                                                            in
+                                                                                                          )
+                                                                                                        ]
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          True
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      Unit
+                                                                                                    ]
+                                                                                                  )
+                                                                                                ]
+                                                                                                (lam
+                                                                                                  thunk
+                                                                                                  Unit
+                                                                                                  False
+                                                                                                )
+                                                                                              ]
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                True
+                                                                                              )
+                                                                                            ]
+                                                                                            Unit
+                                                                                          ]
+                                                                                        )
+                                                                                      )
+                                                                                    ]
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      {
+                                                                                        (abs
+                                                                                          e
+                                                                                          (type)
+                                                                                          (error
+                                                                                            e
+                                                                                          )
+                                                                                        )
+                                                                                        Bool
+                                                                                      }
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    True
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
+                                                                          )
+                                                                        ]
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          {
+                                                                            (abs
+                                                                              e
+                                                                              (type)
+                                                                              (error
+                                                                                e
+                                                                              )
+                                                                            )
+                                                                            Bool
+                                                                          }
+                                                                        )
+                                                                      ]
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        [
+                                                                          [
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    {
+                                                                                      Extended_match
+                                                                                      a
+                                                                                    }
+                                                                                    v
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
+                                                                                (lam
+                                                                                  ipv
+                                                                                  a
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    False
+                                                                                  )
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                {
+                                                                                  (abs
+                                                                                    e
+                                                                                    (type)
+                                                                                    (error
+                                                                                      e
+                                                                                    )
+                                                                                  )
+                                                                                  Bool
+                                                                                }
+                                                                              )
+                                                                            ]
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        Bool_match
+                                                                                        in
+                                                                                      ]
+                                                                                      (fun Unit Bool)
+                                                                                    }
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      in
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    True
+                                                                                  )
+                                                                                ]
+                                                                                Unit
+                                                                              ]
+                                                                            )
+                                                                          ]
+                                                                          Unit
+                                                                        ]
+                                                                      )
+                                                                    ]
+                                                                    Unit
+                                                                  ]
+                                                                )
+                                                              ]
+                                                              Unit
+                                                            ]
+                                                          )
                                                         ]
-                                                      )
+                                                        Unit
+                                                      ]
                                                     )
                                                   )
                                                 ]
@@ -9166,7 +8766,7 @@
                                     fMonoidValue_c
                                     (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]))
                                   )
-                                  [ unionWith addInteger ]
+                                  [ unionWith (builtin addInteger) ]
                                 )
                                 (termbind
                                   (strict)
@@ -11095,285 +10695,276 @@
                                             (lam
                                               ds
                                               [OutputConstraint o]
-                                              (let
-                                                (nonrec)
-                                                (termbind
-                                                  (nonstrict)
-                                                  (vardecl wild ValidatorCtx)
-                                                  ctx
-                                                )
-                                                [
-                                                  {
-                                                    [ ValidatorCtx_match ctx ]
-                                                    Bool
-                                                  }
+                                              [
+                                                {
+                                                  [ ValidatorCtx_match ctx ]
+                                                  Bool
+                                                }
+                                                (lam
+                                                  ds
+                                                  TxInfo
                                                   (lam
                                                     ds
-                                                    TxInfo
-                                                    (lam
-                                                      ds
-                                                      (con integer)
-                                                      [
-                                                        {
-                                                          [
-                                                            {
-                                                              OutputConstraint_match
-                                                              o
-                                                            }
-                                                            ds
-                                                          ]
-                                                          Bool
-                                                        }
+                                                    (con integer)
+                                                    [
+                                                      {
+                                                        [
+                                                          {
+                                                            OutputConstraint_match
+                                                            o
+                                                          }
+                                                          ds
+                                                        ]
+                                                        Bool
+                                                      }
+                                                      (lam
+                                                        ds
+                                                        o
                                                         (lam
                                                           ds
-                                                          o
-                                                          (lam
-                                                            ds
-                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                            (let
-                                                              (nonrec)
-                                                              (termbind
-                                                                (nonstrict)
-                                                                (vardecl
-                                                                  hsh
-                                                                  [Maybe (con bytestring)]
-                                                                )
-                                                                [
-                                                                  [
-                                                                    findDatumHash
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          toData
-                                                                          o
-                                                                        }
-                                                                        dIsData
-                                                                      ]
-                                                                      ds
-                                                                    ]
-                                                                  ]
-                                                                  ds
-                                                                ]
+                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                          (let
+                                                            (nonrec)
+                                                            (termbind
+                                                              (nonstrict)
+                                                              (vardecl
+                                                                hsh
+                                                                [Maybe (con bytestring)]
                                                               )
                                                               [
                                                                 [
+                                                                  findDatumHash
                                                                   [
-                                                                    {
+                                                                    [
+                                                                      {
+                                                                        toData o
+                                                                      }
+                                                                      dIsData
+                                                                    ]
+                                                                    ds
+                                                                  ]
+                                                                ]
+                                                                ds
+                                                              ]
+                                                            )
+                                                            [
+                                                              [
+                                                                [
+                                                                  {
+                                                                    [
+                                                                      Bool_match
                                                                       [
-                                                                        Bool_match
                                                                         [
                                                                           [
-                                                                            [
+                                                                            {
                                                                               {
-                                                                                {
-                                                                                  foldr
-                                                                                  TxOut
-                                                                                }
-                                                                                Bool
-                                                                              }
-                                                                              (lam
-                                                                                a
+                                                                                foldr
                                                                                 TxOut
-                                                                                (lam
-                                                                                  acc
-                                                                                  Bool
+                                                                              }
+                                                                              Bool
+                                                                            }
+                                                                            (lam
+                                                                              a
+                                                                              TxOut
+                                                                              (lam
+                                                                                acc
+                                                                                Bool
+                                                                                [
                                                                                   [
                                                                                     [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            Bool_match
-                                                                                            acc
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          True
-                                                                                        )
-                                                                                      ]
+                                                                                      {
+                                                                                        [
+                                                                                          Bool_match
+                                                                                          acc
+                                                                                        ]
+                                                                                        (fun Unit Bool)
+                                                                                      }
                                                                                       (lam
                                                                                         thunk
                                                                                         Unit
-                                                                                        [
-                                                                                          {
-                                                                                            [
-                                                                                              TxOut_match
-                                                                                              a
-                                                                                            ]
-                                                                                            Bool
-                                                                                          }
+                                                                                        True
+                                                                                      )
+                                                                                    ]
+                                                                                    (lam
+                                                                                      thunk
+                                                                                      Unit
+                                                                                      [
+                                                                                        {
+                                                                                          [
+                                                                                            TxOut_match
+                                                                                            a
+                                                                                          ]
+                                                                                          Bool
+                                                                                        }
+                                                                                        (lam
+                                                                                          ds
+                                                                                          Address
                                                                                           (lam
                                                                                             ds
-                                                                                            Address
+                                                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                                             (lam
                                                                                               ds
-                                                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                              (lam
-                                                                                                ds
-                                                                                                TxOutType
+                                                                                              TxOutType
+                                                                                              [
                                                                                                 [
                                                                                                   [
-                                                                                                    [
-                                                                                                      {
-                                                                                                        [
-                                                                                                          TxOutType_match
-                                                                                                          ds
-                                                                                                        ]
-                                                                                                        (fun Unit Bool)
-                                                                                                      }
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        False
-                                                                                                      )
-                                                                                                    ]
+                                                                                                    {
+                                                                                                      [
+                                                                                                        TxOutType_match
+                                                                                                        ds
+                                                                                                      ]
+                                                                                                      (fun Unit Bool)
+                                                                                                    }
                                                                                                     (lam
-                                                                                                      svh
-                                                                                                      (con bytestring)
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      False
+                                                                                                    )
+                                                                                                  ]
+                                                                                                  (lam
+                                                                                                    svh
+                                                                                                    (con bytestring)
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      [
                                                                                                         [
                                                                                                           [
-                                                                                                            [
-                                                                                                              {
+                                                                                                            {
+                                                                                                              [
+                                                                                                                Bool_match
                                                                                                                 [
-                                                                                                                  Bool_match
                                                                                                                   [
                                                                                                                     [
-                                                                                                                      [
-                                                                                                                        checkBinRel
-                                                                                                                        equalsInteger
-                                                                                                                      ]
-                                                                                                                      ds
+                                                                                                                      checkBinRel
+                                                                                                                      equalsInteger
                                                                                                                     ]
                                                                                                                     ds
                                                                                                                   ]
+                                                                                                                  ds
                                                                                                                 ]
-                                                                                                                (fun Unit Bool)
-                                                                                                              }
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            Maybe_match
-                                                                                                                            (con bytestring)
-                                                                                                                          }
-                                                                                                                          hsh
-                                                                                                                        ]
-                                                                                                                        (fun Unit Bool)
-                                                                                                                      }
-                                                                                                                      (lam
-                                                                                                                        a
-                                                                                                                        (con bytestring)
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          [
-                                                                                                                            [
-                                                                                                                              equalsByteString
-                                                                                                                              a
-                                                                                                                            ]
-                                                                                                                            svh
-                                                                                                                          ]
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    (lam
-                                                                                                                      thunk
-                                                                                                                      Unit
-                                                                                                                      False
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  Unit
-                                                                                                                ]
-                                                                                                              )
-                                                                                                            ]
+                                                                                                              ]
+                                                                                                              (fun Unit Bool)
+                                                                                                            }
                                                                                                             (lam
                                                                                                               thunk
                                                                                                               Unit
-                                                                                                              False
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    {
+                                                                                                                      [
+                                                                                                                        {
+                                                                                                                          Maybe_match
+                                                                                                                          (con bytestring)
+                                                                                                                        }
+                                                                                                                        hsh
+                                                                                                                      ]
+                                                                                                                      (fun Unit Bool)
+                                                                                                                    }
+                                                                                                                    (lam
+                                                                                                                      a
+                                                                                                                      (con bytestring)
+                                                                                                                      (lam
+                                                                                                                        thunk
+                                                                                                                        Unit
+                                                                                                                        [
+                                                                                                                          [
+                                                                                                                            equalsByteString
+                                                                                                                            a
+                                                                                                                          ]
+                                                                                                                          svh
+                                                                                                                        ]
+                                                                                                                      )
+                                                                                                                    )
+                                                                                                                  ]
+                                                                                                                  (lam
+                                                                                                                    thunk
+                                                                                                                    Unit
+                                                                                                                    False
+                                                                                                                  )
+                                                                                                                ]
+                                                                                                                Unit
+                                                                                                              ]
                                                                                                             )
                                                                                                           ]
-                                                                                                          Unit
+                                                                                                          (lam
+                                                                                                            thunk
+                                                                                                            Unit
+                                                                                                            False
+                                                                                                          )
                                                                                                         ]
-                                                                                                      )
+                                                                                                        Unit
+                                                                                                      ]
                                                                                                     )
-                                                                                                  ]
-                                                                                                  Unit
+                                                                                                  )
                                                                                                 ]
-                                                                                              )
+                                                                                                Unit
+                                                                                              ]
                                                                                             )
                                                                                           )
-                                                                                        ]
-                                                                                      )
-                                                                                    ]
-                                                                                    Unit
+                                                                                        )
+                                                                                      ]
+                                                                                    )
                                                                                   ]
-                                                                                )
+                                                                                  Unit
+                                                                                ]
                                                                               )
-                                                                            ]
-                                                                            False
+                                                                            )
                                                                           ]
-                                                                          [
-                                                                            getContinuingOutputs
-                                                                            wild
-                                                                          ]
+                                                                          False
+                                                                        ]
+                                                                        [
+                                                                          getContinuingOutputs
+                                                                          ctx
                                                                         ]
                                                                       ]
-                                                                      (fun Unit Bool)
-                                                                    }
-                                                                    (lam
-                                                                      thunk
-                                                                      Unit
-                                                                      True
-                                                                    )
-                                                                  ]
+                                                                    ]
+                                                                    (fun Unit Bool)
+                                                                  }
                                                                   (lam
                                                                     thunk
                                                                     Unit
-                                                                    [
-                                                                      [
-                                                                        {
-                                                                          [
-                                                                            Unit_match
-                                                                            [
-                                                                              trace
-                                                                              (con
-                                                                                string
-                                                                                  "Output constraint"
-                                                                              )
-                                                                            ]
-                                                                          ]
-                                                                          (fun Unit Bool)
-                                                                        }
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          False
-                                                                        )
-                                                                      ]
-                                                                      Unit
-                                                                    ]
+                                                                    True
                                                                   )
                                                                 ]
-                                                                Unit
+                                                                (lam
+                                                                  thunk
+                                                                  Unit
+                                                                  [
+                                                                    [
+                                                                      {
+                                                                        [
+                                                                          Unit_match
+                                                                          [
+                                                                            trace
+                                                                            (con
+                                                                              string
+                                                                                "Output constraint"
+                                                                            )
+                                                                          ]
+                                                                        ]
+                                                                        (fun Unit Bool)
+                                                                      }
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        False
+                                                                      )
+                                                                    ]
+                                                                    Unit
+                                                                  ]
+                                                                )
                                                               ]
-                                                            )
+                                                              Unit
+                                                            ]
                                                           )
                                                         )
-                                                      ]
-                                                    )
+                                                      )
+                                                    ]
                                                   )
-                                                ]
-                                              )
+                                                )
+                                              ]
                                             )
                                           )
                                         )

--- a/plutus-use-cases/test/Spec/multisig.pir
+++ b/plutus-use-cases/test/Spec/multisig.pir
@@ -136,13 +136,6 @@
             )
           )
         )
-        (termbind
-          (strict)
-          (vardecl
-            addInteger (fun (con integer) (fun (con integer) (con integer)))
-          )
-          (builtin addInteger)
-        )
         (let
           (rec)
           (termbind
@@ -211,7 +204,9 @@
                       ds
                       a
                       (lam
-                        acc (con integer) [ [ addInteger acc ] (con integer 1) ]
+                        acc
+                        (con integer)
+                        [ [ (builtin addInteger) acc ] (con integer 1) ]
                       )
                     )
                   ]

--- a/plutus-use-cases/test/Spec/multisigStateMachine.pir
+++ b/plutus-use-cases/test/Spec/multisigStateMachine.pir
@@ -3238,80 +3238,68 @@
                                                                   (lam
                                                                     thunk
                                                                     Unit
-                                                                    (let
-                                                                      (nonrec)
-                                                                      (termbind
-                                                                        (nonstrict
-                                                                        )
-                                                                        (vardecl
-                                                                          wild
-                                                                          [[Tuple2 (con bytestring)] Data]
-                                                                        )
-                                                                        x
-                                                                      )
-                                                                      [
-                                                                        {
-                                                                          [
+                                                                    [
+                                                                      {
+                                                                        [
+                                                                          {
                                                                             {
-                                                                              {
-                                                                                Tuple2_match
-                                                                                (con bytestring)
-                                                                              }
-                                                                              Data
+                                                                              Tuple2_match
+                                                                              (con bytestring)
                                                                             }
-                                                                            x
-                                                                          ]
-                                                                          [Maybe [[Tuple2 (con bytestring)] Data]]
-                                                                        }
+                                                                            Data
+                                                                          }
+                                                                          x
+                                                                        ]
+                                                                        [Maybe [[Tuple2 (con bytestring)] Data]]
+                                                                      }
+                                                                      (lam
+                                                                        ds
+                                                                        (con bytestring)
                                                                         (lam
                                                                           ds
-                                                                          (con bytestring)
-                                                                          (lam
-                                                                            ds
-                                                                            Data
+                                                                          Data
+                                                                          [
                                                                             [
                                                                               [
-                                                                                [
-                                                                                  {
+                                                                                {
+                                                                                  [
+                                                                                    Bool_match
                                                                                     [
-                                                                                      Bool_match
                                                                                       [
-                                                                                        [
-                                                                                          fEqData_c
-                                                                                          ds
-                                                                                        ]
+                                                                                        fEqData_c
                                                                                         ds
                                                                                       ]
+                                                                                      ds
                                                                                     ]
-                                                                                    (fun Unit [Maybe [[Tuple2 (con bytestring)] Data]])
-                                                                                  }
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    [
-                                                                                      {
-                                                                                        Just
-                                                                                        [[Tuple2 (con bytestring)] Data]
-                                                                                      }
-                                                                                      wild
-                                                                                    ]
-                                                                                  )
-                                                                                ]
+                                                                                  ]
+                                                                                  (fun Unit [Maybe [[Tuple2 (con bytestring)] Data]])
+                                                                                }
                                                                                 (lam
                                                                                   thunk
                                                                                   Unit
                                                                                   [
-                                                                                    go
-                                                                                    xs
+                                                                                    {
+                                                                                      Just
+                                                                                      [[Tuple2 (con bytestring)] Data]
+                                                                                    }
+                                                                                    x
                                                                                   ]
                                                                                 )
                                                                               ]
-                                                                              Unit
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                [
+                                                                                  go
+                                                                                  xs
+                                                                                ]
+                                                                              )
                                                                             ]
-                                                                          )
+                                                                            Unit
+                                                                          ]
                                                                         )
-                                                                      ]
-                                                                    )
+                                                                      )
+                                                                    ]
                                                                   )
                                                                 )
                                                               )
@@ -3402,11 +3390,6 @@
                           )
                           (termbind
                             (strict)
-                            (vardecl scheckOwnOutputConstraint (con string))
-                            (con string "Output constraint")
-                          )
-                          (termbind
-                            (strict)
                             (vardecl trace (fun (con string) Unit))
                             (lam
                               arg
@@ -3419,20 +3402,12 @@
                           (termbind
                             (nonstrict)
                             (vardecl scheckOwnOutputConstraint Unit)
-                            [ trace scheckOwnOutputConstraint ]
+                            [ trace (con string "Output constraint") ]
                           )
                           (termbind
                             (strict)
                             (vardecl error (all a (type) (fun Unit a)))
                             (abs e (type) (lam thunk Unit (error e)))
-                          )
-                          (termbind
-                            (strict)
-                            (vardecl
-                              subtractInteger
-                              (fun (con integer) (fun (con integer) (con integer)))
-                            )
-                            (builtin subtractInteger)
                           )
                           (let
                             (rec)
@@ -3489,7 +3464,12 @@
                                                     [
                                                       [ { bad_name a } xs ]
                                                       [
-                                                        [ subtractInteger ds ]
+                                                        [
+                                                          (builtin
+                                                            subtractInteger
+                                                          )
+                                                          ds
+                                                        ]
                                                         (con integer 1)
                                                       ]
                                                     ]
@@ -3709,126 +3689,113 @@
                                                                                                 (lam
                                                                                                   xs
                                                                                                   [List TxOut]
-                                                                                                  (let
-                                                                                                    (nonrec
-                                                                                                    )
-                                                                                                    (termbind
-                                                                                                      (nonstrict
-                                                                                                      )
-                                                                                                      (vardecl
-                                                                                                        wild
-                                                                                                        TxOut
-                                                                                                      )
-                                                                                                      e
-                                                                                                    )
-                                                                                                    [
-                                                                                                      {
-                                                                                                        [
-                                                                                                          TxOut_match
-                                                                                                          e
-                                                                                                        ]
-                                                                                                        [List TxOut]
-                                                                                                      }
+                                                                                                  [
+                                                                                                    {
+                                                                                                      [
+                                                                                                        TxOut_match
+                                                                                                        e
+                                                                                                      ]
+                                                                                                      [List TxOut]
+                                                                                                    }
+                                                                                                    (lam
+                                                                                                      ds
+                                                                                                      Address
                                                                                                       (lam
                                                                                                         ds
-                                                                                                        Address
+                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                                                         (lam
                                                                                                           ds
-                                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                          (lam
-                                                                                                            ds
-                                                                                                            TxOutType
+                                                                                                          TxOutType
+                                                                                                          [
                                                                                                             [
                                                                                                               [
-                                                                                                                [
-                                                                                                                  {
-                                                                                                                    [
-                                                                                                                      TxOutType_match
-                                                                                                                      ds
-                                                                                                                    ]
-                                                                                                                    (fun Unit [List TxOut])
-                                                                                                                  }
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    xs
-                                                                                                                  )
-                                                                                                                ]
+                                                                                                                {
+                                                                                                                  [
+                                                                                                                    TxOutType_match
+                                                                                                                    ds
+                                                                                                                  ]
+                                                                                                                  (fun Unit [List TxOut])
+                                                                                                                }
                                                                                                                 (lam
-                                                                                                                  ds
-                                                                                                                  (con bytestring)
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
+                                                                                                                  thunk
+                                                                                                                  Unit
+                                                                                                                  xs
+                                                                                                                )
+                                                                                                              ]
+                                                                                                              (lam
+                                                                                                                ds
+                                                                                                                (con bytestring)
+                                                                                                                (lam
+                                                                                                                  thunk
+                                                                                                                  Unit
+                                                                                                                  [
                                                                                                                     [
-                                                                                                                      [
-                                                                                                                        {
-                                                                                                                          [
-                                                                                                                            Address_match
-                                                                                                                            ds
-                                                                                                                          ]
-                                                                                                                          [List TxOut]
-                                                                                                                        }
-                                                                                                                        (lam
-                                                                                                                          pkh
-                                                                                                                          (con bytestring)
-                                                                                                                          xs
-                                                                                                                        )
-                                                                                                                      ]
+                                                                                                                      {
+                                                                                                                        [
+                                                                                                                          Address_match
+                                                                                                                          ds
+                                                                                                                        ]
+                                                                                                                        [List TxOut]
+                                                                                                                      }
                                                                                                                       (lam
-                                                                                                                        vh
+                                                                                                                        pkh
                                                                                                                         (con bytestring)
+                                                                                                                        xs
+                                                                                                                      )
+                                                                                                                    ]
+                                                                                                                    (lam
+                                                                                                                      vh
+                                                                                                                      (con bytestring)
+                                                                                                                      [
                                                                                                                         [
                                                                                                                           [
-                                                                                                                            [
-                                                                                                                              {
-                                                                                                                                [
-                                                                                                                                  Bool_match
-                                                                                                                                  [
-                                                                                                                                    [
-                                                                                                                                      equalsByteString
-                                                                                                                                      vh
-                                                                                                                                    ]
-                                                                                                                                    inpHsh
-                                                                                                                                  ]
-                                                                                                                                ]
-                                                                                                                                (fun Unit [List TxOut])
-                                                                                                                              }
-                                                                                                                              (lam
-                                                                                                                                thunk
-                                                                                                                                Unit
+                                                                                                                            {
+                                                                                                                              [
+                                                                                                                                Bool_match
                                                                                                                                 [
                                                                                                                                   [
-                                                                                                                                    {
-                                                                                                                                      Cons
-                                                                                                                                      TxOut
-                                                                                                                                    }
-                                                                                                                                    wild
+                                                                                                                                    equalsByteString
+                                                                                                                                    vh
                                                                                                                                   ]
-                                                                                                                                  xs
+                                                                                                                                  inpHsh
                                                                                                                                 ]
-                                                                                                                              )
-                                                                                                                            ]
+                                                                                                                              ]
+                                                                                                                              (fun Unit [List TxOut])
+                                                                                                                            }
                                                                                                                             (lam
                                                                                                                               thunk
                                                                                                                               Unit
-                                                                                                                              xs
+                                                                                                                              [
+                                                                                                                                [
+                                                                                                                                  {
+                                                                                                                                    Cons
+                                                                                                                                    TxOut
+                                                                                                                                  }
+                                                                                                                                  e
+                                                                                                                                ]
+                                                                                                                                xs
+                                                                                                                              ]
                                                                                                                             )
                                                                                                                           ]
-                                                                                                                          Unit
+                                                                                                                          (lam
+                                                                                                                            thunk
+                                                                                                                            Unit
+                                                                                                                            xs
+                                                                                                                          )
                                                                                                                         ]
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                  )
+                                                                                                                        Unit
+                                                                                                                      ]
+                                                                                                                    )
+                                                                                                                  ]
                                                                                                                 )
-                                                                                                              ]
-                                                                                                              Unit
+                                                                                                              )
                                                                                                             ]
-                                                                                                          )
+                                                                                                            Unit
+                                                                                                          ]
                                                                                                         )
                                                                                                       )
-                                                                                                    ]
-                                                                                                  )
+                                                                                                    )
+                                                                                                  ]
                                                                                                 )
                                                                                               )
                                                                                             ]
@@ -3985,148 +3952,137 @@
                                                             (lam
                                                               xs
                                                               [List [[Tuple2 k] r]]
-                                                              (let
-                                                                (nonrec)
-                                                                (termbind
-                                                                  (nonstrict)
-                                                                  (vardecl
-                                                                    wild
-                                                                    [[Tuple2 k] r]
-                                                                  )
-                                                                  e
-                                                                )
-                                                                [
-                                                                  {
-                                                                    [
+                                                              [
+                                                                {
+                                                                  [
+                                                                    {
                                                                       {
-                                                                        {
-                                                                          Tuple2_match
-                                                                          k
-                                                                        }
-                                                                        r
+                                                                        Tuple2_match
+                                                                        k
                                                                       }
-                                                                      e
-                                                                    ]
-                                                                    [List [[Tuple2 k] r]]
-                                                                  }
-                                                                  (lam
-                                                                    c
-                                                                    k
-                                                                    (lam
-                                                                      ds
                                                                       r
+                                                                    }
+                                                                    e
+                                                                  ]
+                                                                  [List [[Tuple2 k] r]]
+                                                                }
+                                                                (lam
+                                                                  c
+                                                                  k
+                                                                  (lam
+                                                                    ds
+                                                                    r
+                                                                    [
                                                                       [
                                                                         [
-                                                                          [
-                                                                            {
+                                                                          {
+                                                                            [
+                                                                              Bool_match
                                                                               [
-                                                                                Bool_match
                                                                                 [
                                                                                   [
-                                                                                    [
+                                                                                    {
                                                                                       {
-                                                                                        {
-                                                                                          foldr
-                                                                                          [[Tuple2 k] v]
-                                                                                        }
-                                                                                        Bool
-                                                                                      }
-                                                                                      (lam
-                                                                                        a
+                                                                                        foldr
                                                                                         [[Tuple2 k] v]
-                                                                                        (lam
-                                                                                          acc
-                                                                                          Bool
+                                                                                      }
+                                                                                      Bool
+                                                                                    }
+                                                                                    (lam
+                                                                                      a
+                                                                                      [[Tuple2 k] v]
+                                                                                      (lam
+                                                                                        acc
+                                                                                        Bool
+                                                                                        [
                                                                                           [
                                                                                             [
-                                                                                              [
-                                                                                                {
-                                                                                                  [
-                                                                                                    Bool_match
-                                                                                                    acc
-                                                                                                  ]
-                                                                                                  (fun Unit Bool)
-                                                                                                }
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  True
-                                                                                                )
-                                                                                              ]
+                                                                                              {
+                                                                                                [
+                                                                                                  Bool_match
+                                                                                                  acc
+                                                                                                ]
+                                                                                                (fun Unit Bool)
+                                                                                              }
                                                                                               (lam
                                                                                                 thunk
                                                                                                 Unit
-                                                                                                [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      {
-                                                                                                        {
-                                                                                                          Tuple2_match
-                                                                                                          k
-                                                                                                        }
-                                                                                                        v
-                                                                                                      }
-                                                                                                      a
-                                                                                                    ]
-                                                                                                    Bool
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    c
-                                                                                                    k
-                                                                                                    (lam
-                                                                                                      ds
-                                                                                                      v
-                                                                                                      [
-                                                                                                        [
-                                                                                                          dEq
-                                                                                                          c
-                                                                                                        ]
-                                                                                                        c
-                                                                                                      ]
-                                                                                                    )
-                                                                                                  )
-                                                                                                ]
+                                                                                                True
                                                                                               )
                                                                                             ]
-                                                                                            Unit
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              [
+                                                                                                {
+                                                                                                  [
+                                                                                                    {
+                                                                                                      {
+                                                                                                        Tuple2_match
+                                                                                                        k
+                                                                                                      }
+                                                                                                      v
+                                                                                                    }
+                                                                                                    a
+                                                                                                  ]
+                                                                                                  Bool
+                                                                                                }
+                                                                                                (lam
+                                                                                                  c
+                                                                                                  k
+                                                                                                  (lam
+                                                                                                    ds
+                                                                                                    v
+                                                                                                    [
+                                                                                                      [
+                                                                                                        dEq
+                                                                                                        c
+                                                                                                      ]
+                                                                                                      c
+                                                                                                    ]
+                                                                                                  )
+                                                                                                )
+                                                                                              ]
+                                                                                            )
                                                                                           ]
-                                                                                        )
+                                                                                          Unit
+                                                                                        ]
                                                                                       )
-                                                                                    ]
-                                                                                    False
+                                                                                    )
                                                                                   ]
-                                                                                  ds
+                                                                                  False
                                                                                 ]
+                                                                                ds
                                                                               ]
-                                                                              (fun Unit [List [[Tuple2 k] r]])
-                                                                            }
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              xs
-                                                                            )
-                                                                          ]
+                                                                            ]
+                                                                            (fun Unit [List [[Tuple2 k] r]])
+                                                                          }
                                                                           (lam
                                                                             thunk
                                                                             Unit
-                                                                            [
-                                                                              [
-                                                                                {
-                                                                                  Cons
-                                                                                  [[Tuple2 k] r]
-                                                                                }
-                                                                                wild
-                                                                              ]
-                                                                              xs
-                                                                            ]
+                                                                            xs
                                                                           )
                                                                         ]
-                                                                        Unit
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          [
+                                                                            [
+                                                                              {
+                                                                                Cons
+                                                                                [[Tuple2 k] r]
+                                                                              }
+                                                                              e
+                                                                            ]
+                                                                            xs
+                                                                          ]
+                                                                        )
                                                                       ]
-                                                                    )
+                                                                      Unit
+                                                                    ]
                                                                   )
-                                                                ]
-                                                              )
+                                                                )
+                                                              ]
                                                             )
                                                           )
                                                         ]
@@ -5332,11 +5288,6 @@
                                   )
                                 )
                                 (termbind
-                                  (strict)
-                                  (vardecl scheckValidatorCtx (con string))
-                                  (con string "checkValidatorCtx failed")
-                                )
-                                (termbind
                                   (nonstrict)
                                   (vardecl scheckValidatorCtx_j Bool)
                                   [
@@ -5344,7 +5295,12 @@
                                       {
                                         [
                                           Unit_match
-                                          [ trace scheckValidatorCtx ]
+                                          [
+                                            trace
+                                            (con
+                                              string "checkValidatorCtx failed"
+                                            )
+                                          ]
                                         ]
                                         (fun Unit Bool)
                                       }
@@ -6213,81 +6169,68 @@
                                                                             (lam
                                                                               thunk
                                                                               Unit
-                                                                              (let
-                                                                                (nonrec
-                                                                                )
-                                                                                (termbind
-                                                                                  (nonstrict
-                                                                                  )
-                                                                                  (vardecl
-                                                                                    wild
-                                                                                    [[Tuple2 (con bytestring)] Data]
-                                                                                  )
-                                                                                  x
-                                                                                )
-                                                                                [
-                                                                                  {
-                                                                                    [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    {
                                                                                       {
-                                                                                        {
-                                                                                          Tuple2_match
-                                                                                          (con bytestring)
-                                                                                        }
-                                                                                        Data
+                                                                                        Tuple2_match
+                                                                                        (con bytestring)
                                                                                       }
-                                                                                      x
-                                                                                    ]
-                                                                                    [Maybe [[Tuple2 (con bytestring)] Data]]
-                                                                                  }
-                                                                                  (lam
-                                                                                    dsh
-                                                                                    (con bytestring)
-                                                                                    (lam
-                                                                                      ds
                                                                                       Data
+                                                                                    }
+                                                                                    x
+                                                                                  ]
+                                                                                  [Maybe [[Tuple2 (con bytestring)] Data]]
+                                                                                }
+                                                                                (lam
+                                                                                  dsh
+                                                                                  (con bytestring)
+                                                                                  (lam
+                                                                                    ds
+                                                                                    Data
+                                                                                    [
                                                                                       [
                                                                                         [
-                                                                                          [
-                                                                                            {
+                                                                                          {
+                                                                                            [
+                                                                                              Bool_match
                                                                                               [
-                                                                                                Bool_match
                                                                                                 [
-                                                                                                  [
-                                                                                                    equalsByteString
-                                                                                                    dsh
-                                                                                                  ]
+                                                                                                  equalsByteString
                                                                                                   dsh
                                                                                                 ]
+                                                                                                dsh
                                                                                               ]
-                                                                                              (fun Unit [Maybe [[Tuple2 (con bytestring)] Data]])
-                                                                                            }
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              [
-                                                                                                {
-                                                                                                  Just
-                                                                                                  [[Tuple2 (con bytestring)] Data]
-                                                                                                }
-                                                                                                wild
-                                                                                              ]
-                                                                                            )
-                                                                                          ]
+                                                                                            ]
+                                                                                            (fun Unit [Maybe [[Tuple2 (con bytestring)] Data]])
+                                                                                          }
                                                                                           (lam
                                                                                             thunk
                                                                                             Unit
                                                                                             [
-                                                                                              go
-                                                                                              xs
+                                                                                              {
+                                                                                                Just
+                                                                                                [[Tuple2 (con bytestring)] Data]
+                                                                                              }
+                                                                                              x
                                                                                             ]
                                                                                           )
                                                                                         ]
-                                                                                        Unit
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          [
+                                                                                            go
+                                                                                            xs
+                                                                                          ]
+                                                                                        )
                                                                                       ]
-                                                                                    )
+                                                                                      Unit
+                                                                                    ]
                                                                                   )
-                                                                                ]
-                                                                              )
+                                                                                )
+                                                                              ]
                                                                             )
                                                                           )
                                                                         )
@@ -6445,79 +6388,66 @@
                                                                                 (lam
                                                                                   xs
                                                                                   [List TxInInfo]
-                                                                                  (let
-                                                                                    (nonrec
-                                                                                    )
-                                                                                    (termbind
-                                                                                      (nonstrict
-                                                                                      )
-                                                                                      (vardecl
-                                                                                        wild
-                                                                                        TxInInfo
-                                                                                      )
-                                                                                      e
-                                                                                    )
-                                                                                    [
-                                                                                      {
-                                                                                        [
-                                                                                          TxInInfo_match
-                                                                                          e
-                                                                                        ]
-                                                                                        [List TxInInfo]
-                                                                                      }
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        TxInInfo_match
+                                                                                        e
+                                                                                      ]
+                                                                                      [List TxInInfo]
+                                                                                    }
+                                                                                    (lam
+                                                                                      ds
+                                                                                      TxOutRef
                                                                                       (lam
                                                                                         ds
-                                                                                        TxOutRef
+                                                                                        [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
                                                                                         (lam
                                                                                           ds
-                                                                                          [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
-                                                                                          (lam
-                                                                                            ds
-                                                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                          [
                                                                                             [
                                                                                               [
-                                                                                                [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      Bool_match
-                                                                                                      [
-                                                                                                        [
-                                                                                                          fEqTxOutRef_c
-                                                                                                          ds
-                                                                                                        ]
-                                                                                                        outRef
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                    (fun Unit [List TxInInfo])
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
+                                                                                                {
+                                                                                                  [
+                                                                                                    Bool_match
                                                                                                     [
                                                                                                       [
-                                                                                                        {
-                                                                                                          Cons
-                                                                                                          TxInInfo
-                                                                                                        }
-                                                                                                        wild
+                                                                                                        fEqTxOutRef_c
+                                                                                                        ds
                                                                                                       ]
-                                                                                                      xs
+                                                                                                      outRef
                                                                                                     ]
-                                                                                                  )
-                                                                                                ]
+                                                                                                  ]
+                                                                                                  (fun Unit [List TxInInfo])
+                                                                                                }
                                                                                                 (lam
                                                                                                   thunk
                                                                                                   Unit
-                                                                                                  xs
+                                                                                                  [
+                                                                                                    [
+                                                                                                      {
+                                                                                                        Cons
+                                                                                                        TxInInfo
+                                                                                                      }
+                                                                                                      e
+                                                                                                    ]
+                                                                                                    xs
+                                                                                                  ]
                                                                                                 )
                                                                                               ]
-                                                                                              Unit
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                xs
+                                                                                              )
                                                                                             ]
-                                                                                          )
+                                                                                            Unit
+                                                                                          ]
                                                                                         )
                                                                                       )
-                                                                                    ]
-                                                                                  )
+                                                                                    )
+                                                                                  ]
                                                                                 )
                                                                               )
                                                                             ]
@@ -6672,1235 +6602,1082 @@
                                                         (lam
                                                           in
                                                           Bool
-                                                          (let
-                                                            (nonrec)
-                                                            (termbind
-                                                              (nonstrict)
-                                                              (vardecl
-                                                                wild
-                                                                [Extended a]
-                                                              )
-                                                              v
-                                                            )
+                                                          [
                                                             [
                                                               [
                                                                 [
-                                                                  [
-                                                                    {
-                                                                      [
-                                                                        {
-                                                                          Extended_match
-                                                                          a
-                                                                        }
-                                                                        v
-                                                                      ]
-                                                                      (fun Unit Bool)
-                                                                    }
-                                                                    (lam
-                                                                      default_arg0
-                                                                      a
-                                                                      (lam
-                                                                        thunk
-                                                                        Unit
-                                                                        (let
-                                                                          (nonrec
-                                                                          )
-                                                                          (termbind
-                                                                            (nonstrict
-                                                                            )
-                                                                            (vardecl
-                                                                              wild
-                                                                              [Extended a]
-                                                                            )
-                                                                            v
-                                                                          )
-                                                                          [
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      {
-                                                                                        Extended_match
-                                                                                        a
-                                                                                      }
-                                                                                      v
-                                                                                    ]
-                                                                                    (fun Unit Bool)
-                                                                                  }
-                                                                                  (lam
-                                                                                    default_arg0
-                                                                                    a
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  {
-                                                                                                    Extended_match
-                                                                                                    a
-                                                                                                  }
-                                                                                                  wild
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                ipv
-                                                                                                a
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  [
-                                                                                                    [
-                                                                                                      [
-                                                                                                        [
-                                                                                                          {
-                                                                                                            [
-                                                                                                              {
-                                                                                                                Extended_match
-                                                                                                                a
-                                                                                                              }
-                                                                                                              wild
-                                                                                                            ]
-                                                                                                            (fun Unit Bool)
-                                                                                                          }
-                                                                                                          (lam
-                                                                                                            ipv
-                                                                                                            a
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        [
-                                                                                                                          Ordering_match
-                                                                                                                          [
-                                                                                                                            [
-                                                                                                                              [
-                                                                                                                                {
-                                                                                                                                  compare
-                                                                                                                                  a
-                                                                                                                                }
-                                                                                                                                dOrd
-                                                                                                                              ]
-                                                                                                                              ipv
-                                                                                                                            ]
-                                                                                                                            ipv
-                                                                                                                          ]
-                                                                                                                        ]
-                                                                                                                        (fun Unit Bool)
-                                                                                                                      }
-                                                                                                                      (lam
-                                                                                                                        thunk
-                                                                                                                        Unit
-                                                                                                                        [
-                                                                                                                          [
-                                                                                                                            [
-                                                                                                                              {
-                                                                                                                                [
-                                                                                                                                  Bool_match
-                                                                                                                                  in
-                                                                                                                                ]
-                                                                                                                                (fun Unit Bool)
-                                                                                                                              }
-                                                                                                                              (lam
-                                                                                                                                thunk
-                                                                                                                                Unit
-                                                                                                                                in
-                                                                                                                              )
-                                                                                                                            ]
-                                                                                                                            (lam
-                                                                                                                              thunk
-                                                                                                                              Unit
-                                                                                                                              (let
-                                                                                                                                (nonrec
-                                                                                                                                )
-                                                                                                                                (termbind
-                                                                                                                                  (strict
-                                                                                                                                  )
-                                                                                                                                  (vardecl
-                                                                                                                                    wild
-                                                                                                                                    Bool
-                                                                                                                                  )
-                                                                                                                                  in
-                                                                                                                                )
-                                                                                                                                True
-                                                                                                                              )
-                                                                                                                            )
-                                                                                                                          ]
-                                                                                                                          Unit
-                                                                                                                        ]
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    (lam
-                                                                                                                      thunk
-                                                                                                                      Unit
-                                                                                                                      False
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    True
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                                Unit
-                                                                                                              ]
-                                                                                                            )
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          {
-                                                                                                            (abs
-                                                                                                              e
-                                                                                                              (type)
-                                                                                                              (error
-                                                                                                                e
-                                                                                                              )
-                                                                                                            )
-                                                                                                            Bool
-                                                                                                          }
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        True
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    Unit
-                                                                                                  ]
-                                                                                                )
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              {
-                                                                                                (abs
-                                                                                                  e
-                                                                                                  (type)
-                                                                                                  (error
-                                                                                                    e
-                                                                                                  )
-                                                                                                )
-                                                                                                Bool
-                                                                                              }
-                                                                                            )
-                                                                                          ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        {
-                                                                                                          Extended_match
-                                                                                                          a
-                                                                                                        }
-                                                                                                        wild
-                                                                                                      ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      ipv
-                                                                                                      a
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        False
-                                                                                                      )
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    {
-                                                                                                      (abs
-                                                                                                        e
-                                                                                                        (type)
-                                                                                                        (error
-                                                                                                          e
-                                                                                                        )
-                                                                                                      )
-                                                                                                      Bool
-                                                                                                    }
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  [
-                                                                                                    [
-                                                                                                      [
-                                                                                                        {
-                                                                                                          [
-                                                                                                            Bool_match
-                                                                                                            in
-                                                                                                          ]
-                                                                                                          (fun Unit Bool)
-                                                                                                        }
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          in
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        (let
-                                                                                                          (nonrec
-                                                                                                          )
-                                                                                                          (termbind
-                                                                                                            (strict
-                                                                                                            )
-                                                                                                            (vardecl
-                                                                                                              wild
-                                                                                                              Bool
-                                                                                                            )
-                                                                                                            in
-                                                                                                          )
-                                                                                                          True
-                                                                                                        )
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    Unit
-                                                                                                  ]
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        ]
-                                                                                        Unit
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  False
-                                                                                )
-                                                                              ]
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                [
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            {
-                                                                                              Extended_match
-                                                                                              a
-                                                                                            }
-                                                                                            wild
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          ipv
-                                                                                          a
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        {
-                                                                                                          Extended_match
-                                                                                                          a
-                                                                                                        }
-                                                                                                        wild
-                                                                                                      ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      ipv
-                                                                                                      a
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        [
-                                                                                                          [
-                                                                                                            [
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  [
-                                                                                                                    Ordering_match
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            compare
-                                                                                                                            a
-                                                                                                                          }
-                                                                                                                          dOrd
-                                                                                                                        ]
-                                                                                                                        ipv
-                                                                                                                      ]
-                                                                                                                      ipv
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  (fun Unit Bool)
-                                                                                                                }
-                                                                                                                (lam
-                                                                                                                  thunk
-                                                                                                                  Unit
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        {
-                                                                                                                          [
-                                                                                                                            Bool_match
-                                                                                                                            in
-                                                                                                                          ]
-                                                                                                                          (fun Unit Bool)
-                                                                                                                        }
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          in
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      (lam
-                                                                                                                        thunk
-                                                                                                                        Unit
-                                                                                                                        (let
-                                                                                                                          (nonrec
-                                                                                                                          )
-                                                                                                                          (termbind
-                                                                                                                            (strict
-                                                                                                                            )
-                                                                                                                            (vardecl
-                                                                                                                              wild
-                                                                                                                              Bool
-                                                                                                                            )
-                                                                                                                            in
-                                                                                                                          )
-                                                                                                                          True
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    Unit
-                                                                                                                  ]
-                                                                                                                )
-                                                                                                              ]
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                False
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              True
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          Unit
-                                                                                                        ]
-                                                                                                      )
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    {
-                                                                                                      (abs
-                                                                                                        e
-                                                                                                        (type)
-                                                                                                        (error
-                                                                                                          e
-                                                                                                        )
-                                                                                                      )
-                                                                                                      Bool
-                                                                                                    }
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  True
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        {
-                                                                                          (abs
-                                                                                            e
-                                                                                            (type)
-                                                                                            (error
-                                                                                              e
-                                                                                            )
-                                                                                          )
-                                                                                          Bool
-                                                                                        }
-                                                                                      )
-                                                                                    ]
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  {
-                                                                                                    Extended_match
-                                                                                                    a
-                                                                                                  }
-                                                                                                  wild
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                ipv
-                                                                                                a
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  False
-                                                                                                )
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              {
-                                                                                                (abs
-                                                                                                  e
-                                                                                                  (type)
-                                                                                                  (error
-                                                                                                    e
-                                                                                                  )
-                                                                                                )
-                                                                                                Bool
-                                                                                              }
-                                                                                            )
-                                                                                          ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      Bool_match
-                                                                                                      in
-                                                                                                    ]
-                                                                                                    (fun Unit Bool)
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    in
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  (let
-                                                                                                    (nonrec
-                                                                                                    )
-                                                                                                    (termbind
-                                                                                                      (strict
-                                                                                                      )
-                                                                                                      (vardecl
-                                                                                                        wild
-                                                                                                        Bool
-                                                                                                      )
-                                                                                                      in
-                                                                                                    )
-                                                                                                    True
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        ]
-                                                                                        Unit
-                                                                                      ]
-                                                                                    )
-                                                                                  ]
-                                                                                  Unit
-                                                                                ]
-                                                                              )
-                                                                            ]
-                                                                            Unit
-                                                                          ]
-                                                                        )
-                                                                      )
-                                                                    )
-                                                                  ]
-                                                                  (lam
-                                                                    thunk
-                                                                    Unit
+                                                                  {
                                                                     [
-                                                                      [
-                                                                        [
-                                                                          [
-                                                                            {
-                                                                              [
-                                                                                {
-                                                                                  Extended_match
-                                                                                  a
-                                                                                }
-                                                                                v
-                                                                              ]
-                                                                              (fun Unit Bool)
-                                                                            }
-                                                                            (lam
-                                                                              default_arg0
-                                                                              a
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                True
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      Bool_match
-                                                                                      in
-                                                                                    ]
-                                                                                    (fun Unit Bool)
-                                                                                  }
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    in
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  (let
-                                                                                    (nonrec
-                                                                                    )
-                                                                                    (termbind
-                                                                                      (strict
-                                                                                      )
-                                                                                      (vardecl
-                                                                                        wild
-                                                                                        Bool
-                                                                                      )
-                                                                                      in
-                                                                                    )
-                                                                                    True
-                                                                                  )
-                                                                                )
-                                                                              ]
-                                                                              Unit
-                                                                            ]
-                                                                          )
-                                                                        ]
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          True
-                                                                        )
-                                                                      ]
-                                                                      Unit
-                                                                    ]
-                                                                  )
-                                                                ]
-                                                                (lam
-                                                                  thunk
-                                                                  Unit
-                                                                  (let
-                                                                    (nonrec)
-                                                                    (termbind
-                                                                      (nonstrict
-                                                                      )
-                                                                      (vardecl
-                                                                        wild
-                                                                        [Extended a]
-                                                                      )
+                                                                      {
+                                                                        Extended_match
+                                                                        a
+                                                                      }
                                                                       v
-                                                                    )
-                                                                    [
+                                                                    ]
+                                                                    (fun Unit Bool)
+                                                                  }
+                                                                  (lam
+                                                                    default_arg0
+                                                                    a
+                                                                    (lam
+                                                                      thunk
+                                                                      Unit
                                                                       [
                                                                         [
                                                                           [
-                                                                            {
-                                                                              [
-                                                                                {
-                                                                                  Extended_match
-                                                                                  a
-                                                                                }
-                                                                                v
-                                                                              ]
-                                                                              (fun Unit Bool)
-                                                                            }
-                                                                            (lam
-                                                                              default_arg0
-                                                                              a
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
+                                                                            [
+                                                                              {
                                                                                 [
+                                                                                  {
+                                                                                    Extended_match
+                                                                                    a
+                                                                                  }
+                                                                                  v
+                                                                                ]
+                                                                                (fun Unit Bool)
+                                                                              }
+                                                                              (lam
+                                                                                default_arg0
+                                                                                a
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
                                                                                   [
                                                                                     [
                                                                                       [
-                                                                                        {
-                                                                                          [
-                                                                                            {
-                                                                                              Extended_match
-                                                                                              a
-                                                                                            }
-                                                                                            wild
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          ipv
-                                                                                          a
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        {
-                                                                                                          Extended_match
-                                                                                                          a
-                                                                                                        }
-                                                                                                        wild
-                                                                                                      ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      ipv
-                                                                                                      a
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        [
-                                                                                                          [
-                                                                                                            [
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  [
-                                                                                                                    Ordering_match
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            compare
-                                                                                                                            a
-                                                                                                                          }
-                                                                                                                          dOrd
-                                                                                                                        ]
-                                                                                                                        ipv
-                                                                                                                      ]
-                                                                                                                      ipv
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  (fun Unit Bool)
-                                                                                                                }
-                                                                                                                (lam
-                                                                                                                  thunk
-                                                                                                                  Unit
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        {
-                                                                                                                          [
-                                                                                                                            Bool_match
-                                                                                                                            in
-                                                                                                                          ]
-                                                                                                                          (fun Unit Bool)
-                                                                                                                        }
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          in
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      (lam
-                                                                                                                        thunk
-                                                                                                                        Unit
-                                                                                                                        (let
-                                                                                                                          (nonrec
-                                                                                                                          )
-                                                                                                                          (termbind
-                                                                                                                            (strict
-                                                                                                                            )
-                                                                                                                            (vardecl
-                                                                                                                              wild
-                                                                                                                              Bool
-                                                                                                                            )
-                                                                                                                            in
-                                                                                                                          )
-                                                                                                                          True
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    Unit
-                                                                                                                  ]
-                                                                                                                )
-                                                                                                              ]
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                False
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              True
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          Unit
-                                                                                                        ]
-                                                                                                      )
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    {
-                                                                                                      (abs
-                                                                                                        e
-                                                                                                        (type)
-                                                                                                        (error
-                                                                                                          e
-                                                                                                        )
-                                                                                                      )
-                                                                                                      Bool
-                                                                                                    }
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  True
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        {
-                                                                                          (abs
-                                                                                            e
-                                                                                            (type)
-                                                                                            (error
-                                                                                              e
-                                                                                            )
-                                                                                          )
-                                                                                          Bool
-                                                                                        }
-                                                                                      )
-                                                                                    ]
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
                                                                                         [
-                                                                                          [
+                                                                                          {
                                                                                             [
                                                                                               {
-                                                                                                [
-                                                                                                  {
-                                                                                                    Extended_match
-                                                                                                    a
-                                                                                                  }
-                                                                                                  wild
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                ipv
+                                                                                                Extended_match
                                                                                                 a
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  False
-                                                                                                )
-                                                                                              )
+                                                                                              }
+                                                                                              v
                                                                                             ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            ipv
+                                                                                            a
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              {
-                                                                                                (abs
-                                                                                                  e
-                                                                                                  (type)
-                                                                                                  (error
-                                                                                                    e
-                                                                                                  )
-                                                                                                )
-                                                                                                Bool
-                                                                                              }
-                                                                                            )
-                                                                                          ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
                                                                                               [
                                                                                                 [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      Bool_match
-                                                                                                      in
-                                                                                                    ]
-                                                                                                    (fun Unit Bool)
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    in
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  (let
-                                                                                                    (nonrec
-                                                                                                    )
-                                                                                                    (termbind
-                                                                                                      (strict
-                                                                                                      )
-                                                                                                      (vardecl
-                                                                                                        wild
-                                                                                                        Bool
-                                                                                                      )
-                                                                                                      in
-                                                                                                    )
-                                                                                                    True
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        ]
-                                                                                        Unit
-                                                                                      ]
-                                                                                    )
-                                                                                  ]
-                                                                                  Unit
-                                                                                ]
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            False
-                                                                          )
-                                                                        ]
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          [
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      {
-                                                                                        Extended_match
-                                                                                        a
-                                                                                      }
-                                                                                      wild
-                                                                                    ]
-                                                                                    (fun Unit Bool)
-                                                                                  }
-                                                                                  (lam
-                                                                                    ipv
-                                                                                    a
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  {
-                                                                                                    Extended_match
-                                                                                                    a
-                                                                                                  }
-                                                                                                  wild
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                ipv
-                                                                                                a
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
                                                                                                   [
                                                                                                     [
-                                                                                                      [
+                                                                                                      {
                                                                                                         [
                                                                                                           {
-                                                                                                            [
-                                                                                                              Ordering_match
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      compare
-                                                                                                                      a
-                                                                                                                    }
-                                                                                                                    dOrd
-                                                                                                                  ]
-                                                                                                                  ipv
-                                                                                                                ]
-                                                                                                                ipv
-                                                                                                              ]
-                                                                                                            ]
-                                                                                                            (fun Unit Bool)
+                                                                                                            Extended_match
+                                                                                                            a
                                                                                                           }
-                                                                                                          (lam
-                                                                                                            thunk
-                                                                                                            Unit
+                                                                                                          v
+                                                                                                        ]
+                                                                                                        (fun Unit Bool)
+                                                                                                      }
+                                                                                                      (lam
+                                                                                                        ipv
+                                                                                                        a
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          [
                                                                                                             [
                                                                                                               [
                                                                                                                 [
                                                                                                                   {
                                                                                                                     [
-                                                                                                                      Bool_match
-                                                                                                                      in
+                                                                                                                      Ordering_match
+                                                                                                                      [
+                                                                                                                        [
+                                                                                                                          [
+                                                                                                                            {
+                                                                                                                              compare
+                                                                                                                              a
+                                                                                                                            }
+                                                                                                                            dOrd
+                                                                                                                          ]
+                                                                                                                          ipv
+                                                                                                                        ]
+                                                                                                                        ipv
+                                                                                                                      ]
                                                                                                                     ]
                                                                                                                     (fun Unit Bool)
                                                                                                                   }
                                                                                                                   (lam
                                                                                                                     thunk
                                                                                                                     Unit
-                                                                                                                    in
+                                                                                                                    [
+                                                                                                                      [
+                                                                                                                        [
+                                                                                                                          {
+                                                                                                                            [
+                                                                                                                              Bool_match
+                                                                                                                              in
+                                                                                                                            ]
+                                                                                                                            (fun Unit Bool)
+                                                                                                                          }
+                                                                                                                          (lam
+                                                                                                                            thunk
+                                                                                                                            Unit
+                                                                                                                            in
+                                                                                                                          )
+                                                                                                                        ]
+                                                                                                                        (lam
+                                                                                                                          thunk
+                                                                                                                          Unit
+                                                                                                                          True
+                                                                                                                        )
+                                                                                                                      ]
+                                                                                                                      Unit
+                                                                                                                    ]
                                                                                                                   )
                                                                                                                 ]
                                                                                                                 (lam
                                                                                                                   thunk
                                                                                                                   Unit
-                                                                                                                  (let
-                                                                                                                    (nonrec
-                                                                                                                    )
-                                                                                                                    (termbind
-                                                                                                                      (strict
-                                                                                                                      )
-                                                                                                                      (vardecl
-                                                                                                                        wild
-                                                                                                                        Bool
-                                                                                                                      )
-                                                                                                                      in
-                                                                                                                    )
-                                                                                                                    True
-                                                                                                                  )
+                                                                                                                  False
                                                                                                                 )
                                                                                                               ]
-                                                                                                              Unit
+                                                                                                              (lam
+                                                                                                                thunk
+                                                                                                                Unit
+                                                                                                                True
+                                                                                                              )
                                                                                                             ]
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          False
+                                                                                                            Unit
+                                                                                                          ]
                                                                                                         )
-                                                                                                      ]
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        True
                                                                                                       )
                                                                                                     ]
-                                                                                                    Unit
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      {
+                                                                                                        (abs
+                                                                                                          e
+                                                                                                          (type)
+                                                                                                          (error
+                                                                                                            e
+                                                                                                          )
+                                                                                                        )
+                                                                                                        Bool
+                                                                                                      }
+                                                                                                    )
                                                                                                   ]
-                                                                                                )
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              {
-                                                                                                (abs
-                                                                                                  e
-                                                                                                  (type)
-                                                                                                  (error
-                                                                                                    e
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    True
                                                                                                   )
-                                                                                                )
-                                                                                                Bool
-                                                                                              }
+                                                                                                ]
+                                                                                                Unit
+                                                                                              ]
                                                                                             )
-                                                                                          ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            True
                                                                                           )
                                                                                         ]
-                                                                                        Unit
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  {
-                                                                                    (abs
-                                                                                      e
-                                                                                      (type)
-                                                                                      (error
-                                                                                        e
-                                                                                      )
-                                                                                    )
-                                                                                    Bool
-                                                                                  }
-                                                                                )
-                                                                              ]
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                [
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            {
-                                                                                              Extended_match
-                                                                                              a
-                                                                                            }
-                                                                                            wild
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
                                                                                         (lam
-                                                                                          ipv
-                                                                                          a
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            False
-                                                                                          )
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          {
+                                                                                            (abs
+                                                                                              e
+                                                                                              (type)
+                                                                                              (error
+                                                                                                e
+                                                                                              )
+                                                                                            )
+                                                                                            Bool
+                                                                                          }
                                                                                         )
                                                                                       ]
                                                                                       (lam
                                                                                         thunk
                                                                                         Unit
-                                                                                        {
-                                                                                          (abs
-                                                                                            e
-                                                                                            (type)
-                                                                                            (error
-                                                                                              e
-                                                                                            )
-                                                                                          )
-                                                                                          Bool
-                                                                                        }
-                                                                                      )
-                                                                                    ]
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
                                                                                         [
                                                                                           [
-                                                                                            {
+                                                                                            [
                                                                                               [
-                                                                                                Bool_match
-                                                                                                in
+                                                                                                {
+                                                                                                  [
+                                                                                                    {
+                                                                                                      Extended_match
+                                                                                                      a
+                                                                                                    }
+                                                                                                    v
+                                                                                                  ]
+                                                                                                  (fun Unit Bool)
+                                                                                                }
+                                                                                                (lam
+                                                                                                  ipv
+                                                                                                  a
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    False
+                                                                                                  )
+                                                                                                )
                                                                                               ]
-                                                                                              (fun Unit Bool)
-                                                                                            }
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                {
+                                                                                                  (abs
+                                                                                                    e
+                                                                                                    (type)
+                                                                                                    (error
+                                                                                                      e
+                                                                                                    )
+                                                                                                  )
+                                                                                                  Bool
+                                                                                                }
+                                                                                              )
+                                                                                            ]
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              in
+                                                                                              [
+                                                                                                [
+                                                                                                  [
+                                                                                                    {
+                                                                                                      [
+                                                                                                        Bool_match
+                                                                                                        in
+                                                                                                      ]
+                                                                                                      (fun Unit Bool)
+                                                                                                    }
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      in
+                                                                                                    )
+                                                                                                  ]
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    True
+                                                                                                  )
+                                                                                                ]
+                                                                                                Unit
+                                                                                              ]
                                                                                             )
                                                                                           ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            (let
-                                                                                              (nonrec
-                                                                                              )
-                                                                                              (termbind
-                                                                                                (strict
+                                                                                          Unit
+                                                                                        ]
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
+                                                                                  ]
+                                                                                )
+                                                                              )
+                                                                            ]
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              False
+                                                                            )
+                                                                          ]
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            [
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        {
+                                                                                          Extended_match
+                                                                                          a
+                                                                                        }
+                                                                                        v
+                                                                                      ]
+                                                                                      (fun Unit Bool)
+                                                                                    }
+                                                                                    (lam
+                                                                                      ipv
+                                                                                      a
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        [
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                {
+                                                                                                  [
+                                                                                                    {
+                                                                                                      Extended_match
+                                                                                                      a
+                                                                                                    }
+                                                                                                    v
+                                                                                                  ]
+                                                                                                  (fun Unit Bool)
+                                                                                                }
+                                                                                                (lam
+                                                                                                  ipv
+                                                                                                  a
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    [
+                                                                                                      [
+                                                                                                        [
+                                                                                                          [
+                                                                                                            {
+                                                                                                              [
+                                                                                                                Ordering_match
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      {
+                                                                                                                        compare
+                                                                                                                        a
+                                                                                                                      }
+                                                                                                                      dOrd
+                                                                                                                    ]
+                                                                                                                    ipv
+                                                                                                                  ]
+                                                                                                                  ipv
+                                                                                                                ]
+                                                                                                              ]
+                                                                                                              (fun Unit Bool)
+                                                                                                            }
+                                                                                                            (lam
+                                                                                                              thunk
+                                                                                                              Unit
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    {
+                                                                                                                      [
+                                                                                                                        Bool_match
+                                                                                                                        in
+                                                                                                                      ]
+                                                                                                                      (fun Unit Bool)
+                                                                                                                    }
+                                                                                                                    (lam
+                                                                                                                      thunk
+                                                                                                                      Unit
+                                                                                                                      in
+                                                                                                                    )
+                                                                                                                  ]
+                                                                                                                  (lam
+                                                                                                                    thunk
+                                                                                                                    Unit
+                                                                                                                    True
+                                                                                                                  )
+                                                                                                                ]
+                                                                                                                Unit
+                                                                                                              ]
+                                                                                                            )
+                                                                                                          ]
+                                                                                                          (lam
+                                                                                                            thunk
+                                                                                                            Unit
+                                                                                                            False
+                                                                                                          )
+                                                                                                        ]
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          True
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      Unit
+                                                                                                    ]
+                                                                                                  )
                                                                                                 )
-                                                                                                (vardecl
-                                                                                                  wild
+                                                                                              ]
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                {
+                                                                                                  (abs
+                                                                                                    e
+                                                                                                    (type)
+                                                                                                    (error
+                                                                                                      e
+                                                                                                    )
+                                                                                                  )
                                                                                                   Bool
-                                                                                                )
-                                                                                                in
+                                                                                                }
                                                                                               )
+                                                                                            ]
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
                                                                                               True
+                                                                                            )
+                                                                                          ]
+                                                                                          Unit
+                                                                                        ]
+                                                                                      )
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    {
+                                                                                      (abs
+                                                                                        e
+                                                                                        (type)
+                                                                                        (error
+                                                                                          e
+                                                                                        )
+                                                                                      )
+                                                                                      Bool
+                                                                                    }
+                                                                                  )
+                                                                                ]
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  [
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              {
+                                                                                                Extended_match
+                                                                                                a
+                                                                                              }
+                                                                                              v
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            ipv
+                                                                                            a
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              False
                                                                                             )
                                                                                           )
                                                                                         ]
-                                                                                        Unit
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          {
+                                                                                            (abs
+                                                                                              e
+                                                                                              (type)
+                                                                                              (error
+                                                                                                e
+                                                                                              )
+                                                                                            )
+                                                                                            Bool
+                                                                                          }
+                                                                                        )
                                                                                       ]
-                                                                                    )
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        [
+                                                                                          [
+                                                                                            [
+                                                                                              {
+                                                                                                [
+                                                                                                  Bool_match
+                                                                                                  in
+                                                                                                ]
+                                                                                                (fun Unit Bool)
+                                                                                              }
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                in
+                                                                                              )
+                                                                                            ]
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              True
+                                                                                            )
+                                                                                          ]
+                                                                                          Unit
+                                                                                        ]
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
                                                                                   ]
+                                                                                )
+                                                                              ]
+                                                                              Unit
+                                                                            ]
+                                                                          )
+                                                                        ]
+                                                                        Unit
+                                                                      ]
+                                                                    )
+                                                                  )
+                                                                ]
+                                                                (lam
+                                                                  thunk
+                                                                  Unit
+                                                                  [
+                                                                    [
+                                                                      [
+                                                                        [
+                                                                          {
+                                                                            [
+                                                                              {
+                                                                                Extended_match
+                                                                                a
+                                                                              }
+                                                                              v
+                                                                            ]
+                                                                            (fun Unit Bool)
+                                                                          }
+                                                                          (lam
+                                                                            default_arg0
+                                                                            a
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              True
+                                                                            )
+                                                                          )
+                                                                        ]
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          [
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    Bool_match
+                                                                                    in
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
+                                                                                (lam
+                                                                                  thunk
                                                                                   Unit
-                                                                                ]
+                                                                                  in
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                True
                                                                               )
                                                                             ]
                                                                             Unit
                                                                           ]
                                                                         )
                                                                       ]
-                                                                      Unit
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        True
+                                                                      )
                                                                     ]
-                                                                  )
+                                                                    Unit
+                                                                  ]
                                                                 )
                                                               ]
-                                                              Unit
+                                                              (lam
+                                                                thunk
+                                                                Unit
+                                                                [
+                                                                  [
+                                                                    [
+                                                                      [
+                                                                        {
+                                                                          [
+                                                                            {
+                                                                              Extended_match
+                                                                              a
+                                                                            }
+                                                                            v
+                                                                          ]
+                                                                          (fun Unit Bool)
+                                                                        }
+                                                                        (lam
+                                                                          default_arg0
+                                                                          a
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            [
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        {
+                                                                                          Extended_match
+                                                                                          a
+                                                                                        }
+                                                                                        v
+                                                                                      ]
+                                                                                      (fun Unit Bool)
+                                                                                    }
+                                                                                    (lam
+                                                                                      ipv
+                                                                                      a
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        [
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                {
+                                                                                                  [
+                                                                                                    {
+                                                                                                      Extended_match
+                                                                                                      a
+                                                                                                    }
+                                                                                                    v
+                                                                                                  ]
+                                                                                                  (fun Unit Bool)
+                                                                                                }
+                                                                                                (lam
+                                                                                                  ipv
+                                                                                                  a
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    [
+                                                                                                      [
+                                                                                                        [
+                                                                                                          [
+                                                                                                            {
+                                                                                                              [
+                                                                                                                Ordering_match
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      {
+                                                                                                                        compare
+                                                                                                                        a
+                                                                                                                      }
+                                                                                                                      dOrd
+                                                                                                                    ]
+                                                                                                                    ipv
+                                                                                                                  ]
+                                                                                                                  ipv
+                                                                                                                ]
+                                                                                                              ]
+                                                                                                              (fun Unit Bool)
+                                                                                                            }
+                                                                                                            (lam
+                                                                                                              thunk
+                                                                                                              Unit
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    {
+                                                                                                                      [
+                                                                                                                        Bool_match
+                                                                                                                        in
+                                                                                                                      ]
+                                                                                                                      (fun Unit Bool)
+                                                                                                                    }
+                                                                                                                    (lam
+                                                                                                                      thunk
+                                                                                                                      Unit
+                                                                                                                      in
+                                                                                                                    )
+                                                                                                                  ]
+                                                                                                                  (lam
+                                                                                                                    thunk
+                                                                                                                    Unit
+                                                                                                                    True
+                                                                                                                  )
+                                                                                                                ]
+                                                                                                                Unit
+                                                                                                              ]
+                                                                                                            )
+                                                                                                          ]
+                                                                                                          (lam
+                                                                                                            thunk
+                                                                                                            Unit
+                                                                                                            False
+                                                                                                          )
+                                                                                                        ]
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          True
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      Unit
+                                                                                                    ]
+                                                                                                  )
+                                                                                                )
+                                                                                              ]
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                {
+                                                                                                  (abs
+                                                                                                    e
+                                                                                                    (type)
+                                                                                                    (error
+                                                                                                      e
+                                                                                                    )
+                                                                                                  )
+                                                                                                  Bool
+                                                                                                }
+                                                                                              )
+                                                                                            ]
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              True
+                                                                                            )
+                                                                                          ]
+                                                                                          Unit
+                                                                                        ]
+                                                                                      )
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    {
+                                                                                      (abs
+                                                                                        e
+                                                                                        (type)
+                                                                                        (error
+                                                                                          e
+                                                                                        )
+                                                                                      )
+                                                                                      Bool
+                                                                                    }
+                                                                                  )
+                                                                                ]
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  [
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              {
+                                                                                                Extended_match
+                                                                                                a
+                                                                                              }
+                                                                                              v
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            ipv
+                                                                                            a
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              False
+                                                                                            )
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          {
+                                                                                            (abs
+                                                                                              e
+                                                                                              (type)
+                                                                                              (error
+                                                                                                e
+                                                                                              )
+                                                                                            )
+                                                                                            Bool
+                                                                                          }
+                                                                                        )
+                                                                                      ]
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        [
+                                                                                          [
+                                                                                            [
+                                                                                              {
+                                                                                                [
+                                                                                                  Bool_match
+                                                                                                  in
+                                                                                                ]
+                                                                                                (fun Unit Bool)
+                                                                                              }
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                in
+                                                                                              )
+                                                                                            ]
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              True
+                                                                                            )
+                                                                                          ]
+                                                                                          Unit
+                                                                                        ]
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
+                                                                                  ]
+                                                                                )
+                                                                              ]
+                                                                              Unit
+                                                                            ]
+                                                                          )
+                                                                        )
+                                                                      ]
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        False
+                                                                      )
+                                                                    ]
+                                                                    (lam
+                                                                      thunk
+                                                                      Unit
+                                                                      [
+                                                                        [
+                                                                          [
+                                                                            [
+                                                                              {
+                                                                                [
+                                                                                  {
+                                                                                    Extended_match
+                                                                                    a
+                                                                                  }
+                                                                                  v
+                                                                                ]
+                                                                                (fun Unit Bool)
+                                                                              }
+                                                                              (lam
+                                                                                ipv
+                                                                                a
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  [
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              {
+                                                                                                Extended_match
+                                                                                                a
+                                                                                              }
+                                                                                              v
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            ipv
+                                                                                            a
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              [
+                                                                                                [
+                                                                                                  [
+                                                                                                    [
+                                                                                                      {
+                                                                                                        [
+                                                                                                          Ordering_match
+                                                                                                          [
+                                                                                                            [
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  compare
+                                                                                                                  a
+                                                                                                                }
+                                                                                                                dOrd
+                                                                                                              ]
+                                                                                                              ipv
+                                                                                                            ]
+                                                                                                            ipv
+                                                                                                          ]
+                                                                                                        ]
+                                                                                                        (fun Unit Bool)
+                                                                                                      }
+                                                                                                      (lam
+                                                                                                        thunk
+                                                                                                        Unit
+                                                                                                        [
+                                                                                                          [
+                                                                                                            [
+                                                                                                              {
+                                                                                                                [
+                                                                                                                  Bool_match
+                                                                                                                  in
+                                                                                                                ]
+                                                                                                                (fun Unit Bool)
+                                                                                                              }
+                                                                                                              (lam
+                                                                                                                thunk
+                                                                                                                Unit
+                                                                                                                in
+                                                                                                              )
+                                                                                                            ]
+                                                                                                            (lam
+                                                                                                              thunk
+                                                                                                              Unit
+                                                                                                              True
+                                                                                                            )
+                                                                                                          ]
+                                                                                                          Unit
+                                                                                                        ]
+                                                                                                      )
+                                                                                                    ]
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      False
+                                                                                                    )
+                                                                                                  ]
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    True
+                                                                                                  )
+                                                                                                ]
+                                                                                                Unit
+                                                                                              ]
+                                                                                            )
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          {
+                                                                                            (abs
+                                                                                              e
+                                                                                              (type)
+                                                                                              (error
+                                                                                                e
+                                                                                              )
+                                                                                            )
+                                                                                            Bool
+                                                                                          }
+                                                                                        )
+                                                                                      ]
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        True
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
+                                                                                  ]
+                                                                                )
+                                                                              )
+                                                                            ]
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              {
+                                                                                (abs
+                                                                                  e
+                                                                                  (type)
+                                                                                  (error
+                                                                                    e
+                                                                                  )
+                                                                                )
+                                                                                Bool
+                                                                              }
+                                                                            )
+                                                                          ]
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            [
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        {
+                                                                                          Extended_match
+                                                                                          a
+                                                                                        }
+                                                                                        v
+                                                                                      ]
+                                                                                      (fun Unit Bool)
+                                                                                    }
+                                                                                    (lam
+                                                                                      ipv
+                                                                                      a
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        False
+                                                                                      )
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    {
+                                                                                      (abs
+                                                                                        e
+                                                                                        (type)
+                                                                                        (error
+                                                                                          e
+                                                                                        )
+                                                                                      )
+                                                                                      Bool
+                                                                                    }
+                                                                                  )
+                                                                                ]
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  [
+                                                                                    [
+                                                                                      [
+                                                                                        {
+                                                                                          [
+                                                                                            Bool_match
+                                                                                            in
+                                                                                          ]
+                                                                                          (fun Unit Bool)
+                                                                                        }
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          in
+                                                                                        )
+                                                                                      ]
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        True
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
+                                                                                  ]
+                                                                                )
+                                                                              ]
+                                                                              Unit
+                                                                            ]
+                                                                          )
+                                                                        ]
+                                                                        Unit
+                                                                      ]
+                                                                    )
+                                                                  ]
+                                                                  Unit
+                                                                ]
+                                                              )
                                                             ]
-                                                          )
+                                                            Unit
+                                                          ]
                                                         )
                                                       )
                                                     ]
@@ -7955,1235 +7732,1082 @@
                                                         (lam
                                                           in
                                                           Bool
-                                                          (let
-                                                            (nonrec)
-                                                            (termbind
-                                                              (nonstrict)
-                                                              (vardecl
-                                                                wild
-                                                                [Extended a]
-                                                              )
-                                                              v
-                                                            )
+                                                          [
                                                             [
                                                               [
                                                                 [
-                                                                  [
-                                                                    {
-                                                                      [
-                                                                        {
-                                                                          Extended_match
-                                                                          a
-                                                                        }
-                                                                        v
-                                                                      ]
-                                                                      (fun Unit Bool)
-                                                                    }
-                                                                    (lam
-                                                                      default_arg0
-                                                                      a
-                                                                      (lam
-                                                                        thunk
-                                                                        Unit
-                                                                        (let
-                                                                          (nonrec
-                                                                          )
-                                                                          (termbind
-                                                                            (nonstrict
-                                                                            )
-                                                                            (vardecl
-                                                                              wild
-                                                                              [Extended a]
-                                                                            )
-                                                                            v
-                                                                          )
-                                                                          [
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      {
-                                                                                        Extended_match
-                                                                                        a
-                                                                                      }
-                                                                                      v
-                                                                                    ]
-                                                                                    (fun Unit Bool)
-                                                                                  }
-                                                                                  (lam
-                                                                                    default_arg0
-                                                                                    a
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  {
-                                                                                                    Extended_match
-                                                                                                    a
-                                                                                                  }
-                                                                                                  wild
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                ipv
-                                                                                                a
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  [
-                                                                                                    [
-                                                                                                      [
-                                                                                                        [
-                                                                                                          {
-                                                                                                            [
-                                                                                                              {
-                                                                                                                Extended_match
-                                                                                                                a
-                                                                                                              }
-                                                                                                              wild
-                                                                                                            ]
-                                                                                                            (fun Unit Bool)
-                                                                                                          }
-                                                                                                          (lam
-                                                                                                            ipv
-                                                                                                            a
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      {
-                                                                                                                        [
-                                                                                                                          Ordering_match
-                                                                                                                          [
-                                                                                                                            [
-                                                                                                                              [
-                                                                                                                                {
-                                                                                                                                  compare
-                                                                                                                                  a
-                                                                                                                                }
-                                                                                                                                dOrd
-                                                                                                                              ]
-                                                                                                                              ipv
-                                                                                                                            ]
-                                                                                                                            ipv
-                                                                                                                          ]
-                                                                                                                        ]
-                                                                                                                        (fun Unit Bool)
-                                                                                                                      }
-                                                                                                                      (lam
-                                                                                                                        thunk
-                                                                                                                        Unit
-                                                                                                                        [
-                                                                                                                          [
-                                                                                                                            [
-                                                                                                                              {
-                                                                                                                                [
-                                                                                                                                  Bool_match
-                                                                                                                                  in
-                                                                                                                                ]
-                                                                                                                                (fun Unit Bool)
-                                                                                                                              }
-                                                                                                                              (lam
-                                                                                                                                thunk
-                                                                                                                                Unit
-                                                                                                                                in
-                                                                                                                              )
-                                                                                                                            ]
-                                                                                                                            (lam
-                                                                                                                              thunk
-                                                                                                                              Unit
-                                                                                                                              (let
-                                                                                                                                (nonrec
-                                                                                                                                )
-                                                                                                                                (termbind
-                                                                                                                                  (strict
-                                                                                                                                  )
-                                                                                                                                  (vardecl
-                                                                                                                                    wild
-                                                                                                                                    Bool
-                                                                                                                                  )
-                                                                                                                                  in
-                                                                                                                                )
-                                                                                                                                True
-                                                                                                                              )
-                                                                                                                            )
-                                                                                                                          ]
-                                                                                                                          Unit
-                                                                                                                        ]
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    (lam
-                                                                                                                      thunk
-                                                                                                                      Unit
-                                                                                                                      False
-                                                                                                                    )
-                                                                                                                  ]
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    True
-                                                                                                                  )
-                                                                                                                ]
-                                                                                                                Unit
-                                                                                                              ]
-                                                                                                            )
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          {
-                                                                                                            (abs
-                                                                                                              e
-                                                                                                              (type)
-                                                                                                              (error
-                                                                                                                e
-                                                                                                              )
-                                                                                                            )
-                                                                                                            Bool
-                                                                                                          }
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        True
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    Unit
-                                                                                                  ]
-                                                                                                )
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              {
-                                                                                                (abs
-                                                                                                  e
-                                                                                                  (type)
-                                                                                                  (error
-                                                                                                    e
-                                                                                                  )
-                                                                                                )
-                                                                                                Bool
-                                                                                              }
-                                                                                            )
-                                                                                          ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        {
-                                                                                                          Extended_match
-                                                                                                          a
-                                                                                                        }
-                                                                                                        wild
-                                                                                                      ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      ipv
-                                                                                                      a
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        False
-                                                                                                      )
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    {
-                                                                                                      (abs
-                                                                                                        e
-                                                                                                        (type)
-                                                                                                        (error
-                                                                                                          e
-                                                                                                        )
-                                                                                                      )
-                                                                                                      Bool
-                                                                                                    }
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  [
-                                                                                                    [
-                                                                                                      [
-                                                                                                        {
-                                                                                                          [
-                                                                                                            Bool_match
-                                                                                                            in
-                                                                                                          ]
-                                                                                                          (fun Unit Bool)
-                                                                                                        }
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          in
-                                                                                                        )
-                                                                                                      ]
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        (let
-                                                                                                          (nonrec
-                                                                                                          )
-                                                                                                          (termbind
-                                                                                                            (strict
-                                                                                                            )
-                                                                                                            (vardecl
-                                                                                                              wild
-                                                                                                              Bool
-                                                                                                            )
-                                                                                                            in
-                                                                                                          )
-                                                                                                          True
-                                                                                                        )
-                                                                                                      )
-                                                                                                    ]
-                                                                                                    Unit
-                                                                                                  ]
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        ]
-                                                                                        Unit
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  False
-                                                                                )
-                                                                              ]
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                [
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            {
-                                                                                              Extended_match
-                                                                                              a
-                                                                                            }
-                                                                                            wild
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          ipv
-                                                                                          a
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        {
-                                                                                                          Extended_match
-                                                                                                          a
-                                                                                                        }
-                                                                                                        wild
-                                                                                                      ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      ipv
-                                                                                                      a
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        [
-                                                                                                          [
-                                                                                                            [
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  [
-                                                                                                                    Ordering_match
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            compare
-                                                                                                                            a
-                                                                                                                          }
-                                                                                                                          dOrd
-                                                                                                                        ]
-                                                                                                                        ipv
-                                                                                                                      ]
-                                                                                                                      ipv
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  (fun Unit Bool)
-                                                                                                                }
-                                                                                                                (lam
-                                                                                                                  thunk
-                                                                                                                  Unit
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        {
-                                                                                                                          [
-                                                                                                                            Bool_match
-                                                                                                                            in
-                                                                                                                          ]
-                                                                                                                          (fun Unit Bool)
-                                                                                                                        }
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          in
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      (lam
-                                                                                                                        thunk
-                                                                                                                        Unit
-                                                                                                                        (let
-                                                                                                                          (nonrec
-                                                                                                                          )
-                                                                                                                          (termbind
-                                                                                                                            (strict
-                                                                                                                            )
-                                                                                                                            (vardecl
-                                                                                                                              wild
-                                                                                                                              Bool
-                                                                                                                            )
-                                                                                                                            in
-                                                                                                                          )
-                                                                                                                          True
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    Unit
-                                                                                                                  ]
-                                                                                                                )
-                                                                                                              ]
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                False
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              True
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          Unit
-                                                                                                        ]
-                                                                                                      )
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    {
-                                                                                                      (abs
-                                                                                                        e
-                                                                                                        (type)
-                                                                                                        (error
-                                                                                                          e
-                                                                                                        )
-                                                                                                      )
-                                                                                                      Bool
-                                                                                                    }
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  True
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        {
-                                                                                          (abs
-                                                                                            e
-                                                                                            (type)
-                                                                                            (error
-                                                                                              e
-                                                                                            )
-                                                                                          )
-                                                                                          Bool
-                                                                                        }
-                                                                                      )
-                                                                                    ]
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  {
-                                                                                                    Extended_match
-                                                                                                    a
-                                                                                                  }
-                                                                                                  wild
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                ipv
-                                                                                                a
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  False
-                                                                                                )
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              {
-                                                                                                (abs
-                                                                                                  e
-                                                                                                  (type)
-                                                                                                  (error
-                                                                                                    e
-                                                                                                  )
-                                                                                                )
-                                                                                                Bool
-                                                                                              }
-                                                                                            )
-                                                                                          ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      Bool_match
-                                                                                                      in
-                                                                                                    ]
-                                                                                                    (fun Unit Bool)
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    in
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  (let
-                                                                                                    (nonrec
-                                                                                                    )
-                                                                                                    (termbind
-                                                                                                      (strict
-                                                                                                      )
-                                                                                                      (vardecl
-                                                                                                        wild
-                                                                                                        Bool
-                                                                                                      )
-                                                                                                      in
-                                                                                                    )
-                                                                                                    True
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        ]
-                                                                                        Unit
-                                                                                      ]
-                                                                                    )
-                                                                                  ]
-                                                                                  Unit
-                                                                                ]
-                                                                              )
-                                                                            ]
-                                                                            Unit
-                                                                          ]
-                                                                        )
-                                                                      )
-                                                                    )
-                                                                  ]
-                                                                  (lam
-                                                                    thunk
-                                                                    Unit
+                                                                  {
                                                                     [
-                                                                      [
-                                                                        [
-                                                                          [
-                                                                            {
-                                                                              [
-                                                                                {
-                                                                                  Extended_match
-                                                                                  a
-                                                                                }
-                                                                                v
-                                                                              ]
-                                                                              (fun Unit Bool)
-                                                                            }
-                                                                            (lam
-                                                                              default_arg0
-                                                                              a
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                True
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      Bool_match
-                                                                                      in
-                                                                                    ]
-                                                                                    (fun Unit Bool)
-                                                                                  }
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    in
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  (let
-                                                                                    (nonrec
-                                                                                    )
-                                                                                    (termbind
-                                                                                      (strict
-                                                                                      )
-                                                                                      (vardecl
-                                                                                        wild
-                                                                                        Bool
-                                                                                      )
-                                                                                      in
-                                                                                    )
-                                                                                    True
-                                                                                  )
-                                                                                )
-                                                                              ]
-                                                                              Unit
-                                                                            ]
-                                                                          )
-                                                                        ]
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          True
-                                                                        )
-                                                                      ]
-                                                                      Unit
-                                                                    ]
-                                                                  )
-                                                                ]
-                                                                (lam
-                                                                  thunk
-                                                                  Unit
-                                                                  (let
-                                                                    (nonrec)
-                                                                    (termbind
-                                                                      (nonstrict
-                                                                      )
-                                                                      (vardecl
-                                                                        wild
-                                                                        [Extended a]
-                                                                      )
+                                                                      {
+                                                                        Extended_match
+                                                                        a
+                                                                      }
                                                                       v
-                                                                    )
-                                                                    [
+                                                                    ]
+                                                                    (fun Unit Bool)
+                                                                  }
+                                                                  (lam
+                                                                    default_arg0
+                                                                    a
+                                                                    (lam
+                                                                      thunk
+                                                                      Unit
                                                                       [
                                                                         [
                                                                           [
-                                                                            {
-                                                                              [
-                                                                                {
-                                                                                  Extended_match
-                                                                                  a
-                                                                                }
-                                                                                v
-                                                                              ]
-                                                                              (fun Unit Bool)
-                                                                            }
-                                                                            (lam
-                                                                              default_arg0
-                                                                              a
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
+                                                                            [
+                                                                              {
                                                                                 [
+                                                                                  {
+                                                                                    Extended_match
+                                                                                    a
+                                                                                  }
+                                                                                  v
+                                                                                ]
+                                                                                (fun Unit Bool)
+                                                                              }
+                                                                              (lam
+                                                                                default_arg0
+                                                                                a
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
                                                                                   [
                                                                                     [
                                                                                       [
-                                                                                        {
-                                                                                          [
-                                                                                            {
-                                                                                              Extended_match
-                                                                                              a
-                                                                                            }
-                                                                                            wild
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
-                                                                                        (lam
-                                                                                          ipv
-                                                                                          a
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
-                                                                                              [
-                                                                                                [
-                                                                                                  [
-                                                                                                    {
-                                                                                                      [
-                                                                                                        {
-                                                                                                          Extended_match
-                                                                                                          a
-                                                                                                        }
-                                                                                                        wild
-                                                                                                      ]
-                                                                                                      (fun Unit Bool)
-                                                                                                    }
-                                                                                                    (lam
-                                                                                                      ipv
-                                                                                                      a
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        [
-                                                                                                          [
-                                                                                                            [
-                                                                                                              [
-                                                                                                                {
-                                                                                                                  [
-                                                                                                                    Ordering_match
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            compare
-                                                                                                                            a
-                                                                                                                          }
-                                                                                                                          dOrd
-                                                                                                                        ]
-                                                                                                                        ipv
-                                                                                                                      ]
-                                                                                                                      ipv
-                                                                                                                    ]
-                                                                                                                  ]
-                                                                                                                  (fun Unit Bool)
-                                                                                                                }
-                                                                                                                (lam
-                                                                                                                  thunk
-                                                                                                                  Unit
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        {
-                                                                                                                          [
-                                                                                                                            Bool_match
-                                                                                                                            in
-                                                                                                                          ]
-                                                                                                                          (fun Unit Bool)
-                                                                                                                        }
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          in
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      (lam
-                                                                                                                        thunk
-                                                                                                                        Unit
-                                                                                                                        (let
-                                                                                                                          (nonrec
-                                                                                                                          )
-                                                                                                                          (termbind
-                                                                                                                            (strict
-                                                                                                                            )
-                                                                                                                            (vardecl
-                                                                                                                              wild
-                                                                                                                              Bool
-                                                                                                                            )
-                                                                                                                            in
-                                                                                                                          )
-                                                                                                                          True
-                                                                                                                        )
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    Unit
-                                                                                                                  ]
-                                                                                                                )
-                                                                                                              ]
-                                                                                                              (lam
-                                                                                                                thunk
-                                                                                                                Unit
-                                                                                                                False
-                                                                                                              )
-                                                                                                            ]
-                                                                                                            (lam
-                                                                                                              thunk
-                                                                                                              Unit
-                                                                                                              True
-                                                                                                            )
-                                                                                                          ]
-                                                                                                          Unit
-                                                                                                        ]
-                                                                                                      )
-                                                                                                    )
-                                                                                                  ]
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    {
-                                                                                                      (abs
-                                                                                                        e
-                                                                                                        (type)
-                                                                                                        (error
-                                                                                                          e
-                                                                                                        )
-                                                                                                      )
-                                                                                                      Bool
-                                                                                                    }
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  True
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        {
-                                                                                          (abs
-                                                                                            e
-                                                                                            (type)
-                                                                                            (error
-                                                                                              e
-                                                                                            )
-                                                                                          )
-                                                                                          Bool
-                                                                                        }
-                                                                                      )
-                                                                                    ]
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
                                                                                         [
-                                                                                          [
+                                                                                          {
                                                                                             [
                                                                                               {
-                                                                                                [
-                                                                                                  {
-                                                                                                    Extended_match
-                                                                                                    a
-                                                                                                  }
-                                                                                                  wild
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                ipv
+                                                                                                Extended_match
                                                                                                 a
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  False
-                                                                                                )
-                                                                                              )
+                                                                                              }
+                                                                                              v
                                                                                             ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            ipv
+                                                                                            a
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              {
-                                                                                                (abs
-                                                                                                  e
-                                                                                                  (type)
-                                                                                                  (error
-                                                                                                    e
-                                                                                                  )
-                                                                                                )
-                                                                                                Bool
-                                                                                              }
-                                                                                            )
-                                                                                          ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
                                                                                               [
                                                                                                 [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      Bool_match
-                                                                                                      in
-                                                                                                    ]
-                                                                                                    (fun Unit Bool)
-                                                                                                  }
-                                                                                                  (lam
-                                                                                                    thunk
-                                                                                                    Unit
-                                                                                                    in
-                                                                                                  )
-                                                                                                ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  (let
-                                                                                                    (nonrec
-                                                                                                    )
-                                                                                                    (termbind
-                                                                                                      (strict
-                                                                                                      )
-                                                                                                      (vardecl
-                                                                                                        wild
-                                                                                                        Bool
-                                                                                                      )
-                                                                                                      in
-                                                                                                    )
-                                                                                                    True
-                                                                                                  )
-                                                                                                )
-                                                                                              ]
-                                                                                              Unit
-                                                                                            ]
-                                                                                          )
-                                                                                        ]
-                                                                                        Unit
-                                                                                      ]
-                                                                                    )
-                                                                                  ]
-                                                                                  Unit
-                                                                                ]
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            thunk
-                                                                            Unit
-                                                                            False
-                                                                          )
-                                                                        ]
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          [
-                                                                            [
-                                                                              [
-                                                                                [
-                                                                                  {
-                                                                                    [
-                                                                                      {
-                                                                                        Extended_match
-                                                                                        a
-                                                                                      }
-                                                                                      wild
-                                                                                    ]
-                                                                                    (fun Unit Bool)
-                                                                                  }
-                                                                                  (lam
-                                                                                    ipv
-                                                                                    a
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        [
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  {
-                                                                                                    Extended_match
-                                                                                                    a
-                                                                                                  }
-                                                                                                  wild
-                                                                                                ]
-                                                                                                (fun Unit Bool)
-                                                                                              }
-                                                                                              (lam
-                                                                                                ipv
-                                                                                                a
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
                                                                                                   [
                                                                                                     [
-                                                                                                      [
+                                                                                                      {
                                                                                                         [
                                                                                                           {
-                                                                                                            [
-                                                                                                              Ordering_match
-                                                                                                              [
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      compare
-                                                                                                                      a
-                                                                                                                    }
-                                                                                                                    dOrd
-                                                                                                                  ]
-                                                                                                                  ipv
-                                                                                                                ]
-                                                                                                                ipv
-                                                                                                              ]
-                                                                                                            ]
-                                                                                                            (fun Unit Bool)
+                                                                                                            Extended_match
+                                                                                                            a
                                                                                                           }
-                                                                                                          (lam
-                                                                                                            thunk
-                                                                                                            Unit
+                                                                                                          v
+                                                                                                        ]
+                                                                                                        (fun Unit Bool)
+                                                                                                      }
+                                                                                                      (lam
+                                                                                                        ipv
+                                                                                                        a
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          [
                                                                                                             [
                                                                                                               [
                                                                                                                 [
                                                                                                                   {
                                                                                                                     [
-                                                                                                                      Bool_match
-                                                                                                                      in
+                                                                                                                      Ordering_match
+                                                                                                                      [
+                                                                                                                        [
+                                                                                                                          [
+                                                                                                                            {
+                                                                                                                              compare
+                                                                                                                              a
+                                                                                                                            }
+                                                                                                                            dOrd
+                                                                                                                          ]
+                                                                                                                          ipv
+                                                                                                                        ]
+                                                                                                                        ipv
+                                                                                                                      ]
                                                                                                                     ]
                                                                                                                     (fun Unit Bool)
                                                                                                                   }
                                                                                                                   (lam
                                                                                                                     thunk
                                                                                                                     Unit
-                                                                                                                    in
+                                                                                                                    [
+                                                                                                                      [
+                                                                                                                        [
+                                                                                                                          {
+                                                                                                                            [
+                                                                                                                              Bool_match
+                                                                                                                              in
+                                                                                                                            ]
+                                                                                                                            (fun Unit Bool)
+                                                                                                                          }
+                                                                                                                          (lam
+                                                                                                                            thunk
+                                                                                                                            Unit
+                                                                                                                            in
+                                                                                                                          )
+                                                                                                                        ]
+                                                                                                                        (lam
+                                                                                                                          thunk
+                                                                                                                          Unit
+                                                                                                                          True
+                                                                                                                        )
+                                                                                                                      ]
+                                                                                                                      Unit
+                                                                                                                    ]
                                                                                                                   )
                                                                                                                 ]
                                                                                                                 (lam
                                                                                                                   thunk
                                                                                                                   Unit
-                                                                                                                  (let
-                                                                                                                    (nonrec
-                                                                                                                    )
-                                                                                                                    (termbind
-                                                                                                                      (strict
-                                                                                                                      )
-                                                                                                                      (vardecl
-                                                                                                                        wild
-                                                                                                                        Bool
-                                                                                                                      )
-                                                                                                                      in
-                                                                                                                    )
-                                                                                                                    True
-                                                                                                                  )
+                                                                                                                  False
                                                                                                                 )
                                                                                                               ]
-                                                                                                              Unit
+                                                                                                              (lam
+                                                                                                                thunk
+                                                                                                                Unit
+                                                                                                                True
+                                                                                                              )
                                                                                                             ]
-                                                                                                          )
-                                                                                                        ]
-                                                                                                        (lam
-                                                                                                          thunk
-                                                                                                          Unit
-                                                                                                          False
+                                                                                                            Unit
+                                                                                                          ]
                                                                                                         )
-                                                                                                      ]
-                                                                                                      (lam
-                                                                                                        thunk
-                                                                                                        Unit
-                                                                                                        True
                                                                                                       )
                                                                                                     ]
-                                                                                                    Unit
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      {
+                                                                                                        (abs
+                                                                                                          e
+                                                                                                          (type)
+                                                                                                          (error
+                                                                                                            e
+                                                                                                          )
+                                                                                                        )
+                                                                                                        Bool
+                                                                                                      }
+                                                                                                    )
                                                                                                   ]
-                                                                                                )
-                                                                                              )
-                                                                                            ]
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              {
-                                                                                                (abs
-                                                                                                  e
-                                                                                                  (type)
-                                                                                                  (error
-                                                                                                    e
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    True
                                                                                                   )
-                                                                                                )
-                                                                                                Bool
-                                                                                              }
+                                                                                                ]
+                                                                                                Unit
+                                                                                              ]
                                                                                             )
-                                                                                          ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            True
                                                                                           )
                                                                                         ]
-                                                                                        Unit
-                                                                                      ]
-                                                                                    )
-                                                                                  )
-                                                                                ]
-                                                                                (lam
-                                                                                  thunk
-                                                                                  Unit
-                                                                                  {
-                                                                                    (abs
-                                                                                      e
-                                                                                      (type)
-                                                                                      (error
-                                                                                        e
-                                                                                      )
-                                                                                    )
-                                                                                    Bool
-                                                                                  }
-                                                                                )
-                                                                              ]
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                [
-                                                                                  [
-                                                                                    [
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            {
-                                                                                              Extended_match
-                                                                                              a
-                                                                                            }
-                                                                                            wild
-                                                                                          ]
-                                                                                          (fun Unit Bool)
-                                                                                        }
                                                                                         (lam
-                                                                                          ipv
-                                                                                          a
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            False
-                                                                                          )
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          {
+                                                                                            (abs
+                                                                                              e
+                                                                                              (type)
+                                                                                              (error
+                                                                                                e
+                                                                                              )
+                                                                                            )
+                                                                                            Bool
+                                                                                          }
                                                                                         )
                                                                                       ]
                                                                                       (lam
                                                                                         thunk
                                                                                         Unit
-                                                                                        {
-                                                                                          (abs
-                                                                                            e
-                                                                                            (type)
-                                                                                            (error
-                                                                                              e
-                                                                                            )
-                                                                                          )
-                                                                                          Bool
-                                                                                        }
-                                                                                      )
-                                                                                    ]
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
                                                                                         [
                                                                                           [
-                                                                                            {
+                                                                                            [
                                                                                               [
-                                                                                                Bool_match
-                                                                                                in
+                                                                                                {
+                                                                                                  [
+                                                                                                    {
+                                                                                                      Extended_match
+                                                                                                      a
+                                                                                                    }
+                                                                                                    v
+                                                                                                  ]
+                                                                                                  (fun Unit Bool)
+                                                                                                }
+                                                                                                (lam
+                                                                                                  ipv
+                                                                                                  a
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    False
+                                                                                                  )
+                                                                                                )
                                                                                               ]
-                                                                                              (fun Unit Bool)
-                                                                                            }
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                {
+                                                                                                  (abs
+                                                                                                    e
+                                                                                                    (type)
+                                                                                                    (error
+                                                                                                      e
+                                                                                                    )
+                                                                                                  )
+                                                                                                  Bool
+                                                                                                }
+                                                                                              )
+                                                                                            ]
                                                                                             (lam
                                                                                               thunk
                                                                                               Unit
-                                                                                              in
+                                                                                              [
+                                                                                                [
+                                                                                                  [
+                                                                                                    {
+                                                                                                      [
+                                                                                                        Bool_match
+                                                                                                        in
+                                                                                                      ]
+                                                                                                      (fun Unit Bool)
+                                                                                                    }
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      in
+                                                                                                    )
+                                                                                                  ]
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    True
+                                                                                                  )
+                                                                                                ]
+                                                                                                Unit
+                                                                                              ]
                                                                                             )
                                                                                           ]
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            (let
-                                                                                              (nonrec
-                                                                                              )
-                                                                                              (termbind
-                                                                                                (strict
+                                                                                          Unit
+                                                                                        ]
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
+                                                                                  ]
+                                                                                )
+                                                                              )
+                                                                            ]
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              False
+                                                                            )
+                                                                          ]
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            [
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        {
+                                                                                          Extended_match
+                                                                                          a
+                                                                                        }
+                                                                                        v
+                                                                                      ]
+                                                                                      (fun Unit Bool)
+                                                                                    }
+                                                                                    (lam
+                                                                                      ipv
+                                                                                      a
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        [
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                {
+                                                                                                  [
+                                                                                                    {
+                                                                                                      Extended_match
+                                                                                                      a
+                                                                                                    }
+                                                                                                    v
+                                                                                                  ]
+                                                                                                  (fun Unit Bool)
+                                                                                                }
+                                                                                                (lam
+                                                                                                  ipv
+                                                                                                  a
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    [
+                                                                                                      [
+                                                                                                        [
+                                                                                                          [
+                                                                                                            {
+                                                                                                              [
+                                                                                                                Ordering_match
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      {
+                                                                                                                        compare
+                                                                                                                        a
+                                                                                                                      }
+                                                                                                                      dOrd
+                                                                                                                    ]
+                                                                                                                    ipv
+                                                                                                                  ]
+                                                                                                                  ipv
+                                                                                                                ]
+                                                                                                              ]
+                                                                                                              (fun Unit Bool)
+                                                                                                            }
+                                                                                                            (lam
+                                                                                                              thunk
+                                                                                                              Unit
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    {
+                                                                                                                      [
+                                                                                                                        Bool_match
+                                                                                                                        in
+                                                                                                                      ]
+                                                                                                                      (fun Unit Bool)
+                                                                                                                    }
+                                                                                                                    (lam
+                                                                                                                      thunk
+                                                                                                                      Unit
+                                                                                                                      in
+                                                                                                                    )
+                                                                                                                  ]
+                                                                                                                  (lam
+                                                                                                                    thunk
+                                                                                                                    Unit
+                                                                                                                    True
+                                                                                                                  )
+                                                                                                                ]
+                                                                                                                Unit
+                                                                                                              ]
+                                                                                                            )
+                                                                                                          ]
+                                                                                                          (lam
+                                                                                                            thunk
+                                                                                                            Unit
+                                                                                                            False
+                                                                                                          )
+                                                                                                        ]
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          True
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      Unit
+                                                                                                    ]
+                                                                                                  )
                                                                                                 )
-                                                                                                (vardecl
-                                                                                                  wild
+                                                                                              ]
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                {
+                                                                                                  (abs
+                                                                                                    e
+                                                                                                    (type)
+                                                                                                    (error
+                                                                                                      e
+                                                                                                    )
+                                                                                                  )
                                                                                                   Bool
-                                                                                                )
-                                                                                                in
+                                                                                                }
                                                                                               )
+                                                                                            ]
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
                                                                                               True
+                                                                                            )
+                                                                                          ]
+                                                                                          Unit
+                                                                                        ]
+                                                                                      )
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    {
+                                                                                      (abs
+                                                                                        e
+                                                                                        (type)
+                                                                                        (error
+                                                                                          e
+                                                                                        )
+                                                                                      )
+                                                                                      Bool
+                                                                                    }
+                                                                                  )
+                                                                                ]
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  [
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              {
+                                                                                                Extended_match
+                                                                                                a
+                                                                                              }
+                                                                                              v
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            ipv
+                                                                                            a
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              False
                                                                                             )
                                                                                           )
                                                                                         ]
-                                                                                        Unit
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          {
+                                                                                            (abs
+                                                                                              e
+                                                                                              (type)
+                                                                                              (error
+                                                                                                e
+                                                                                              )
+                                                                                            )
+                                                                                            Bool
+                                                                                          }
+                                                                                        )
                                                                                       ]
-                                                                                    )
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        [
+                                                                                          [
+                                                                                            [
+                                                                                              {
+                                                                                                [
+                                                                                                  Bool_match
+                                                                                                  in
+                                                                                                ]
+                                                                                                (fun Unit Bool)
+                                                                                              }
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                in
+                                                                                              )
+                                                                                            ]
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              True
+                                                                                            )
+                                                                                          ]
+                                                                                          Unit
+                                                                                        ]
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
                                                                                   ]
+                                                                                )
+                                                                              ]
+                                                                              Unit
+                                                                            ]
+                                                                          )
+                                                                        ]
+                                                                        Unit
+                                                                      ]
+                                                                    )
+                                                                  )
+                                                                ]
+                                                                (lam
+                                                                  thunk
+                                                                  Unit
+                                                                  [
+                                                                    [
+                                                                      [
+                                                                        [
+                                                                          {
+                                                                            [
+                                                                              {
+                                                                                Extended_match
+                                                                                a
+                                                                              }
+                                                                              v
+                                                                            ]
+                                                                            (fun Unit Bool)
+                                                                          }
+                                                                          (lam
+                                                                            default_arg0
+                                                                            a
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              True
+                                                                            )
+                                                                          )
+                                                                        ]
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          [
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  [
+                                                                                    Bool_match
+                                                                                    in
+                                                                                  ]
+                                                                                  (fun Unit Bool)
+                                                                                }
+                                                                                (lam
+                                                                                  thunk
                                                                                   Unit
-                                                                                ]
+                                                                                  in
+                                                                                )
+                                                                              ]
+                                                                              (lam
+                                                                                thunk
+                                                                                Unit
+                                                                                True
                                                                               )
                                                                             ]
                                                                             Unit
                                                                           ]
                                                                         )
                                                                       ]
-                                                                      Unit
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        True
+                                                                      )
                                                                     ]
-                                                                  )
+                                                                    Unit
+                                                                  ]
                                                                 )
                                                               ]
-                                                              Unit
+                                                              (lam
+                                                                thunk
+                                                                Unit
+                                                                [
+                                                                  [
+                                                                    [
+                                                                      [
+                                                                        {
+                                                                          [
+                                                                            {
+                                                                              Extended_match
+                                                                              a
+                                                                            }
+                                                                            v
+                                                                          ]
+                                                                          (fun Unit Bool)
+                                                                        }
+                                                                        (lam
+                                                                          default_arg0
+                                                                          a
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            [
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        {
+                                                                                          Extended_match
+                                                                                          a
+                                                                                        }
+                                                                                        v
+                                                                                      ]
+                                                                                      (fun Unit Bool)
+                                                                                    }
+                                                                                    (lam
+                                                                                      ipv
+                                                                                      a
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        [
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                {
+                                                                                                  [
+                                                                                                    {
+                                                                                                      Extended_match
+                                                                                                      a
+                                                                                                    }
+                                                                                                    v
+                                                                                                  ]
+                                                                                                  (fun Unit Bool)
+                                                                                                }
+                                                                                                (lam
+                                                                                                  ipv
+                                                                                                  a
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    [
+                                                                                                      [
+                                                                                                        [
+                                                                                                          [
+                                                                                                            {
+                                                                                                              [
+                                                                                                                Ordering_match
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      {
+                                                                                                                        compare
+                                                                                                                        a
+                                                                                                                      }
+                                                                                                                      dOrd
+                                                                                                                    ]
+                                                                                                                    ipv
+                                                                                                                  ]
+                                                                                                                  ipv
+                                                                                                                ]
+                                                                                                              ]
+                                                                                                              (fun Unit Bool)
+                                                                                                            }
+                                                                                                            (lam
+                                                                                                              thunk
+                                                                                                              Unit
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    {
+                                                                                                                      [
+                                                                                                                        Bool_match
+                                                                                                                        in
+                                                                                                                      ]
+                                                                                                                      (fun Unit Bool)
+                                                                                                                    }
+                                                                                                                    (lam
+                                                                                                                      thunk
+                                                                                                                      Unit
+                                                                                                                      in
+                                                                                                                    )
+                                                                                                                  ]
+                                                                                                                  (lam
+                                                                                                                    thunk
+                                                                                                                    Unit
+                                                                                                                    True
+                                                                                                                  )
+                                                                                                                ]
+                                                                                                                Unit
+                                                                                                              ]
+                                                                                                            )
+                                                                                                          ]
+                                                                                                          (lam
+                                                                                                            thunk
+                                                                                                            Unit
+                                                                                                            False
+                                                                                                          )
+                                                                                                        ]
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          True
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      Unit
+                                                                                                    ]
+                                                                                                  )
+                                                                                                )
+                                                                                              ]
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                {
+                                                                                                  (abs
+                                                                                                    e
+                                                                                                    (type)
+                                                                                                    (error
+                                                                                                      e
+                                                                                                    )
+                                                                                                  )
+                                                                                                  Bool
+                                                                                                }
+                                                                                              )
+                                                                                            ]
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              True
+                                                                                            )
+                                                                                          ]
+                                                                                          Unit
+                                                                                        ]
+                                                                                      )
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    {
+                                                                                      (abs
+                                                                                        e
+                                                                                        (type)
+                                                                                        (error
+                                                                                          e
+                                                                                        )
+                                                                                      )
+                                                                                      Bool
+                                                                                    }
+                                                                                  )
+                                                                                ]
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  [
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              {
+                                                                                                Extended_match
+                                                                                                a
+                                                                                              }
+                                                                                              v
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            ipv
+                                                                                            a
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              False
+                                                                                            )
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          {
+                                                                                            (abs
+                                                                                              e
+                                                                                              (type)
+                                                                                              (error
+                                                                                                e
+                                                                                              )
+                                                                                            )
+                                                                                            Bool
+                                                                                          }
+                                                                                        )
+                                                                                      ]
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        [
+                                                                                          [
+                                                                                            [
+                                                                                              {
+                                                                                                [
+                                                                                                  Bool_match
+                                                                                                  in
+                                                                                                ]
+                                                                                                (fun Unit Bool)
+                                                                                              }
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                in
+                                                                                              )
+                                                                                            ]
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              True
+                                                                                            )
+                                                                                          ]
+                                                                                          Unit
+                                                                                        ]
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
+                                                                                  ]
+                                                                                )
+                                                                              ]
+                                                                              Unit
+                                                                            ]
+                                                                          )
+                                                                        )
+                                                                      ]
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        False
+                                                                      )
+                                                                    ]
+                                                                    (lam
+                                                                      thunk
+                                                                      Unit
+                                                                      [
+                                                                        [
+                                                                          [
+                                                                            [
+                                                                              {
+                                                                                [
+                                                                                  {
+                                                                                    Extended_match
+                                                                                    a
+                                                                                  }
+                                                                                  v
+                                                                                ]
+                                                                                (fun Unit Bool)
+                                                                              }
+                                                                              (lam
+                                                                                ipv
+                                                                                a
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  [
+                                                                                    [
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            [
+                                                                                              {
+                                                                                                Extended_match
+                                                                                                a
+                                                                                              }
+                                                                                              v
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
+                                                                                          (lam
+                                                                                            ipv
+                                                                                            a
+                                                                                            (lam
+                                                                                              thunk
+                                                                                              Unit
+                                                                                              [
+                                                                                                [
+                                                                                                  [
+                                                                                                    [
+                                                                                                      {
+                                                                                                        [
+                                                                                                          Ordering_match
+                                                                                                          [
+                                                                                                            [
+                                                                                                              [
+                                                                                                                {
+                                                                                                                  compare
+                                                                                                                  a
+                                                                                                                }
+                                                                                                                dOrd
+                                                                                                              ]
+                                                                                                              ipv
+                                                                                                            ]
+                                                                                                            ipv
+                                                                                                          ]
+                                                                                                        ]
+                                                                                                        (fun Unit Bool)
+                                                                                                      }
+                                                                                                      (lam
+                                                                                                        thunk
+                                                                                                        Unit
+                                                                                                        [
+                                                                                                          [
+                                                                                                            [
+                                                                                                              {
+                                                                                                                [
+                                                                                                                  Bool_match
+                                                                                                                  in
+                                                                                                                ]
+                                                                                                                (fun Unit Bool)
+                                                                                                              }
+                                                                                                              (lam
+                                                                                                                thunk
+                                                                                                                Unit
+                                                                                                                in
+                                                                                                              )
+                                                                                                            ]
+                                                                                                            (lam
+                                                                                                              thunk
+                                                                                                              Unit
+                                                                                                              True
+                                                                                                            )
+                                                                                                          ]
+                                                                                                          Unit
+                                                                                                        ]
+                                                                                                      )
+                                                                                                    ]
+                                                                                                    (lam
+                                                                                                      thunk
+                                                                                                      Unit
+                                                                                                      False
+                                                                                                    )
+                                                                                                  ]
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    True
+                                                                                                  )
+                                                                                                ]
+                                                                                                Unit
+                                                                                              ]
+                                                                                            )
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          {
+                                                                                            (abs
+                                                                                              e
+                                                                                              (type)
+                                                                                              (error
+                                                                                                e
+                                                                                              )
+                                                                                            )
+                                                                                            Bool
+                                                                                          }
+                                                                                        )
+                                                                                      ]
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        True
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
+                                                                                  ]
+                                                                                )
+                                                                              )
+                                                                            ]
+                                                                            (lam
+                                                                              thunk
+                                                                              Unit
+                                                                              {
+                                                                                (abs
+                                                                                  e
+                                                                                  (type)
+                                                                                  (error
+                                                                                    e
+                                                                                  )
+                                                                                )
+                                                                                Bool
+                                                                              }
+                                                                            )
+                                                                          ]
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            [
+                                                                              [
+                                                                                [
+                                                                                  [
+                                                                                    {
+                                                                                      [
+                                                                                        {
+                                                                                          Extended_match
+                                                                                          a
+                                                                                        }
+                                                                                        v
+                                                                                      ]
+                                                                                      (fun Unit Bool)
+                                                                                    }
+                                                                                    (lam
+                                                                                      ipv
+                                                                                      a
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        False
+                                                                                      )
+                                                                                    )
+                                                                                  ]
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    {
+                                                                                      (abs
+                                                                                        e
+                                                                                        (type)
+                                                                                        (error
+                                                                                          e
+                                                                                        )
+                                                                                      )
+                                                                                      Bool
+                                                                                    }
+                                                                                  )
+                                                                                ]
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  [
+                                                                                    [
+                                                                                      [
+                                                                                        {
+                                                                                          [
+                                                                                            Bool_match
+                                                                                            in
+                                                                                          ]
+                                                                                          (fun Unit Bool)
+                                                                                        }
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          in
+                                                                                        )
+                                                                                      ]
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        True
+                                                                                      )
+                                                                                    ]
+                                                                                    Unit
+                                                                                  ]
+                                                                                )
+                                                                              ]
+                                                                              Unit
+                                                                            ]
+                                                                          )
+                                                                        ]
+                                                                        Unit
+                                                                      ]
+                                                                    )
+                                                                  ]
+                                                                  Unit
+                                                                ]
+                                                              )
                                                             ]
-                                                          )
+                                                            Unit
+                                                          ]
                                                         )
                                                       )
                                                     ]
@@ -9652,14 +9276,6 @@
                                     (termbind
                                       (strict)
                                       (vardecl
-                                        addInteger
-                                        (fun (con integer) (fun (con integer) (con integer)))
-                                      )
-                                      (builtin addInteger)
-                                    )
-                                    (termbind
-                                      (strict)
-                                      (vardecl
                                         unionWith
                                         (fun (fun (con integer) (fun (con integer) (con integer))) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])))
                                       )
@@ -9941,7 +9557,7 @@
                                         fMonoidValue_c
                                         (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]))
                                       )
-                                      [ unionWith addInteger ]
+                                      [ unionWith (builtin addInteger) ]
                                     )
                                     (termbind
                                       (strict)
@@ -11864,288 +11480,277 @@
                                                 (lam
                                                   ds
                                                   [OutputConstraint o]
-                                                  (let
-                                                    (nonrec)
-                                                    (termbind
-                                                      (nonstrict)
-                                                      (vardecl wild ValidatorCtx
-                                                      )
-                                                      ctx
-                                                    )
-                                                    [
-                                                      {
-                                                        [
-                                                          ValidatorCtx_match ctx
-                                                        ]
-                                                        Bool
-                                                      }
+                                                  [
+                                                    {
+                                                      [ ValidatorCtx_match ctx ]
+                                                      Bool
+                                                    }
+                                                    (lam
+                                                      ds
+                                                      TxInfo
                                                       (lam
                                                         ds
-                                                        TxInfo
-                                                        (lam
-                                                          ds
-                                                          (con integer)
-                                                          [
-                                                            {
-                                                              [
-                                                                {
-                                                                  OutputConstraint_match
-                                                                  o
-                                                                }
-                                                                ds
-                                                              ]
-                                                              Bool
-                                                            }
+                                                        (con integer)
+                                                        [
+                                                          {
+                                                            [
+                                                              {
+                                                                OutputConstraint_match
+                                                                o
+                                                              }
+                                                              ds
+                                                            ]
+                                                            Bool
+                                                          }
+                                                          (lam
+                                                            ds
+                                                            o
                                                             (lam
                                                               ds
-                                                              o
-                                                              (lam
-                                                                ds
-                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                (let
-                                                                  (nonrec)
-                                                                  (termbind
-                                                                    (nonstrict)
-                                                                    (vardecl
-                                                                      hsh
-                                                                      [Maybe (con bytestring)]
-                                                                    )
-                                                                    [
-                                                                      [
-                                                                        findDatumHash
-                                                                        [
-                                                                          [
-                                                                            {
-                                                                              toData
-                                                                              o
-                                                                            }
-                                                                            dIsData
-                                                                          ]
-                                                                          ds
-                                                                        ]
-                                                                      ]
-                                                                      ds
-                                                                    ]
+                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                              (let
+                                                                (nonrec)
+                                                                (termbind
+                                                                  (nonstrict)
+                                                                  (vardecl
+                                                                    hsh
+                                                                    [Maybe (con bytestring)]
                                                                   )
                                                                   [
                                                                     [
+                                                                      findDatumHash
                                                                       [
-                                                                        {
+                                                                        [
+                                                                          {
+                                                                            toData
+                                                                            o
+                                                                          }
+                                                                          dIsData
+                                                                        ]
+                                                                        ds
+                                                                      ]
+                                                                    ]
+                                                                    ds
+                                                                  ]
+                                                                )
+                                                                [
+                                                                  [
+                                                                    [
+                                                                      {
+                                                                        [
+                                                                          Bool_match
                                                                           [
-                                                                            Bool_match
                                                                             [
                                                                               [
-                                                                                [
+                                                                                {
                                                                                   {
-                                                                                    {
-                                                                                      foldr
-                                                                                      TxOut
-                                                                                    }
-                                                                                    Bool
-                                                                                  }
-                                                                                  (lam
-                                                                                    a
+                                                                                    foldr
                                                                                     TxOut
-                                                                                    (lam
-                                                                                      acc
-                                                                                      Bool
+                                                                                  }
+                                                                                  Bool
+                                                                                }
+                                                                                (lam
+                                                                                  a
+                                                                                  TxOut
+                                                                                  (lam
+                                                                                    acc
+                                                                                    Bool
+                                                                                    [
                                                                                       [
                                                                                         [
-                                                                                          [
-                                                                                            {
-                                                                                              [
-                                                                                                Bool_match
-                                                                                                acc
-                                                                                              ]
-                                                                                              (fun Unit Bool)
-                                                                                            }
-                                                                                            (lam
-                                                                                              thunk
-                                                                                              Unit
-                                                                                              True
-                                                                                            )
-                                                                                          ]
+                                                                                          {
+                                                                                            [
+                                                                                              Bool_match
+                                                                                              acc
+                                                                                            ]
+                                                                                            (fun Unit Bool)
+                                                                                          }
                                                                                           (lam
                                                                                             thunk
                                                                                             Unit
-                                                                                            [
-                                                                                              {
-                                                                                                [
-                                                                                                  TxOut_match
-                                                                                                  a
-                                                                                                ]
-                                                                                                Bool
-                                                                                              }
+                                                                                            True
+                                                                                          )
+                                                                                        ]
+                                                                                        (lam
+                                                                                          thunk
+                                                                                          Unit
+                                                                                          [
+                                                                                            {
+                                                                                              [
+                                                                                                TxOut_match
+                                                                                                a
+                                                                                              ]
+                                                                                              Bool
+                                                                                            }
+                                                                                            (lam
+                                                                                              ds
+                                                                                              Address
                                                                                               (lam
                                                                                                 ds
-                                                                                                Address
+                                                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                                                 (lam
                                                                                                   ds
-                                                                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                  (lam
-                                                                                                    ds
-                                                                                                    TxOutType
+                                                                                                  TxOutType
+                                                                                                  [
                                                                                                     [
                                                                                                       [
-                                                                                                        [
-                                                                                                          {
-                                                                                                            [
-                                                                                                              TxOutType_match
-                                                                                                              ds
-                                                                                                            ]
-                                                                                                            (fun Unit Bool)
-                                                                                                          }
-                                                                                                          (lam
-                                                                                                            thunk
-                                                                                                            Unit
-                                                                                                            False
-                                                                                                          )
-                                                                                                        ]
+                                                                                                        {
+                                                                                                          [
+                                                                                                            TxOutType_match
+                                                                                                            ds
+                                                                                                          ]
+                                                                                                          (fun Unit Bool)
+                                                                                                        }
                                                                                                         (lam
-                                                                                                          svh
-                                                                                                          (con bytestring)
-                                                                                                          (lam
-                                                                                                            thunk
-                                                                                                            Unit
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          False
+                                                                                                        )
+                                                                                                      ]
+                                                                                                      (lam
+                                                                                                        svh
+                                                                                                        (con bytestring)
+                                                                                                        (lam
+                                                                                                          thunk
+                                                                                                          Unit
+                                                                                                          [
                                                                                                             [
                                                                                                               [
-                                                                                                                [
-                                                                                                                  {
+                                                                                                                {
+                                                                                                                  [
+                                                                                                                    Bool_match
                                                                                                                     [
-                                                                                                                      Bool_match
                                                                                                                       [
                                                                                                                         [
-                                                                                                                          [
-                                                                                                                            checkBinRel
-                                                                                                                            equalsInteger
-                                                                                                                          ]
-                                                                                                                          ds
+                                                                                                                          checkBinRel
+                                                                                                                          equalsInteger
                                                                                                                         ]
                                                                                                                         ds
                                                                                                                       ]
+                                                                                                                      ds
                                                                                                                     ]
-                                                                                                                    (fun Unit Bool)
-                                                                                                                  }
-                                                                                                                  (lam
-                                                                                                                    thunk
-                                                                                                                    Unit
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            [
-                                                                                                                              {
-                                                                                                                                Maybe_match
-                                                                                                                                (con bytestring)
-                                                                                                                              }
-                                                                                                                              hsh
-                                                                                                                            ]
-                                                                                                                            (fun Unit Bool)
-                                                                                                                          }
-                                                                                                                          (lam
-                                                                                                                            a
-                                                                                                                            (con bytestring)
-                                                                                                                            (lam
-                                                                                                                              thunk
-                                                                                                                              Unit
-                                                                                                                              [
-                                                                                                                                [
-                                                                                                                                  equalsByteString
-                                                                                                                                  a
-                                                                                                                                ]
-                                                                                                                                svh
-                                                                                                                              ]
-                                                                                                                            )
-                                                                                                                          )
-                                                                                                                        ]
-                                                                                                                        (lam
-                                                                                                                          thunk
-                                                                                                                          Unit
-                                                                                                                          False
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      Unit
-                                                                                                                    ]
-                                                                                                                  )
-                                                                                                                ]
+                                                                                                                  ]
+                                                                                                                  (fun Unit Bool)
+                                                                                                                }
                                                                                                                 (lam
                                                                                                                   thunk
                                                                                                                   Unit
-                                                                                                                  False
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      [
+                                                                                                                        {
+                                                                                                                          [
+                                                                                                                            {
+                                                                                                                              Maybe_match
+                                                                                                                              (con bytestring)
+                                                                                                                            }
+                                                                                                                            hsh
+                                                                                                                          ]
+                                                                                                                          (fun Unit Bool)
+                                                                                                                        }
+                                                                                                                        (lam
+                                                                                                                          a
+                                                                                                                          (con bytestring)
+                                                                                                                          (lam
+                                                                                                                            thunk
+                                                                                                                            Unit
+                                                                                                                            [
+                                                                                                                              [
+                                                                                                                                equalsByteString
+                                                                                                                                a
+                                                                                                                              ]
+                                                                                                                              svh
+                                                                                                                            ]
+                                                                                                                          )
+                                                                                                                        )
+                                                                                                                      ]
+                                                                                                                      (lam
+                                                                                                                        thunk
+                                                                                                                        Unit
+                                                                                                                        False
+                                                                                                                      )
+                                                                                                                    ]
+                                                                                                                    Unit
+                                                                                                                  ]
                                                                                                                 )
                                                                                                               ]
-                                                                                                              Unit
+                                                                                                              (lam
+                                                                                                                thunk
+                                                                                                                Unit
+                                                                                                                False
+                                                                                                              )
                                                                                                             ]
-                                                                                                          )
+                                                                                                            Unit
+                                                                                                          ]
                                                                                                         )
-                                                                                                      ]
-                                                                                                      Unit
+                                                                                                      )
                                                                                                     ]
-                                                                                                  )
+                                                                                                    Unit
+                                                                                                  ]
                                                                                                 )
                                                                                               )
-                                                                                            ]
-                                                                                          )
-                                                                                        ]
-                                                                                        Unit
+                                                                                            )
+                                                                                          ]
+                                                                                        )
                                                                                       ]
-                                                                                    )
+                                                                                      Unit
+                                                                                    ]
                                                                                   )
-                                                                                ]
-                                                                                False
+                                                                                )
                                                                               ]
-                                                                              [
-                                                                                getContinuingOutputs
-                                                                                wild
-                                                                              ]
+                                                                              False
+                                                                            ]
+                                                                            [
+                                                                              getContinuingOutputs
+                                                                              ctx
                                                                             ]
                                                                           ]
-                                                                          (fun Unit Bool)
-                                                                        }
-                                                                        (lam
-                                                                          thunk
-                                                                          Unit
-                                                                          True
-                                                                        )
-                                                                      ]
+                                                                        ]
+                                                                        (fun Unit Bool)
+                                                                      }
                                                                       (lam
                                                                         thunk
                                                                         Unit
-                                                                        [
-                                                                          [
-                                                                            {
-                                                                              [
-                                                                                Unit_match
-                                                                                [
-                                                                                  trace
-                                                                                  (con
-                                                                                    string
-                                                                                      "Output constraint"
-                                                                                  )
-                                                                                ]
-                                                                              ]
-                                                                              (fun Unit Bool)
-                                                                            }
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              False
-                                                                            )
-                                                                          ]
-                                                                          Unit
-                                                                        ]
+                                                                        True
                                                                       )
                                                                     ]
-                                                                    Unit
+                                                                    (lam
+                                                                      thunk
+                                                                      Unit
+                                                                      [
+                                                                        [
+                                                                          {
+                                                                            [
+                                                                              Unit_match
+                                                                              [
+                                                                                trace
+                                                                                (con
+                                                                                  string
+                                                                                    "Output constraint"
+                                                                                )
+                                                                              ]
+                                                                            ]
+                                                                            (fun Unit Bool)
+                                                                          }
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            False
+                                                                          )
+                                                                        ]
+                                                                        Unit
+                                                                      ]
+                                                                    )
                                                                   ]
-                                                                )
+                                                                  Unit
+                                                                ]
                                                               )
                                                             )
-                                                          ]
-                                                        )
+                                                          )
+                                                        ]
                                                       )
-                                                    ]
-                                                  )
+                                                    )
+                                                  ]
                                                 )
                                               )
                                             )
@@ -13388,21 +12993,6 @@
                                         (termbind
                                           (strict)
                                           (vardecl
-                                            fAdditiveGroupValue (con integer)
-                                          )
-                                          (con integer -1)
-                                        )
-                                        (termbind
-                                          (strict)
-                                          (vardecl
-                                            multiplyInteger
-                                            (fun (con integer) (fun (con integer) (con integer)))
-                                          )
-                                          (builtin multiplyInteger)
-                                        )
-                                        (termbind
-                                          (strict)
-                                          (vardecl
                                             fAdditiveGroupValue_cscale
                                             (fun (con integer) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]))
                                           )
@@ -13555,7 +13145,9 @@
                                                                                                 ]
                                                                                                 [
                                                                                                   [
-                                                                                                    multiplyInteger
+                                                                                                    (builtin
+                                                                                                      multiplyInteger
+                                                                                                    )
                                                                                                     i
                                                                                                   ]
                                                                                                   i
@@ -13635,11 +13227,17 @@
                                               ds
                                               [(lam a (type) a) [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
                                               [
-                                                [ [ unionWith addInteger ] ds ]
+                                                [
+                                                  [
+                                                    unionWith
+                                                    (builtin addInteger)
+                                                  ]
+                                                  ds
+                                                ]
                                                 [
                                                   [
                                                     fAdditiveGroupValue_cscale
-                                                    fAdditiveGroupValue
+                                                    (con integer -1)
                                                   ]
                                                   ds
                                                 ]
@@ -13850,7 +13448,9 @@
                                                     acc
                                                     (con integer)
                                                     [
-                                                      [ addInteger acc ]
+                                                      [
+                                                        (builtin addInteger) acc
+                                                      ]
                                                       (con integer 1)
                                                     ]
                                                   )
@@ -14768,117 +14368,105 @@
                                                                   (lam
                                                                     thunk
                                                                     Unit
-                                                                    (let
-                                                                      (nonrec)
-                                                                      (termbind
-                                                                        (nonstrict
-                                                                        )
-                                                                        (vardecl
-                                                                          wild
-                                                                          Payment
-                                                                        )
-                                                                        pmt
-                                                                      )
-                                                                      [
-                                                                        {
-                                                                          [
-                                                                            Payment_match
-                                                                            pmt
-                                                                          ]
-                                                                          [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State MSState]]]
-                                                                        }
+                                                                    [
+                                                                      {
+                                                                        [
+                                                                          Payment_match
+                                                                          pmt
+                                                                        ]
+                                                                        [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State MSState]]]
+                                                                      }
+                                                                      (lam
+                                                                        amt
+                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                         (lam
-                                                                          amt
-                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                          ds
+                                                                          (con bytestring)
                                                                           (lam
                                                                             ds
-                                                                            (con bytestring)
-                                                                            (lam
-                                                                              ds
-                                                                              (con integer)
+                                                                            (con integer)
+                                                                            [
                                                                               [
                                                                                 [
-                                                                                  [
-                                                                                    {
+                                                                                  {
+                                                                                    [
+                                                                                      Bool_match
                                                                                       [
-                                                                                        Bool_match
                                                                                         [
                                                                                           [
+                                                                                            checkBinRel
+                                                                                            lessThanEqInteger
+                                                                                          ]
+                                                                                          amt
+                                                                                        ]
+                                                                                        ds
+                                                                                      ]
+                                                                                    ]
+                                                                                    (fun Unit [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State MSState]]])
+                                                                                  }
+                                                                                  (lam
+                                                                                    thunk
+                                                                                    Unit
+                                                                                    [
+                                                                                      {
+                                                                                        Just
+                                                                                        [[Tuple2 [[TxConstraints Void] Void]] [State MSState]]
+                                                                                      }
+                                                                                      [
+                                                                                        [
+                                                                                          {
+                                                                                            {
+                                                                                              Tuple2
+                                                                                              [[TxConstraints Void] Void]
+                                                                                            }
+                                                                                            [State MSState]
+                                                                                          }
+                                                                                          {
+                                                                                            {
+                                                                                              fMonoidTxConstraints_cmempty
+                                                                                              Void
+                                                                                            }
+                                                                                            Void
+                                                                                          }
+                                                                                        ]
+                                                                                        [
+                                                                                          [
+                                                                                            {
+                                                                                              State
+                                                                                              MSState
+                                                                                            }
                                                                                             [
-                                                                                              checkBinRel
-                                                                                              lessThanEqInteger
+                                                                                              [
+                                                                                                CollectingSignatures
+                                                                                                pmt
+                                                                                              ]
+                                                                                              {
+                                                                                                Nil
+                                                                                                (con bytestring)
+                                                                                              }
                                                                                             ]
-                                                                                            amt
                                                                                           ]
                                                                                           ds
                                                                                         ]
                                                                                       ]
-                                                                                      (fun Unit [Maybe [[Tuple2 [[TxConstraints Void] Void]] [State MSState]]])
-                                                                                    }
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        {
-                                                                                          Just
-                                                                                          [[Tuple2 [[TxConstraints Void] Void]] [State MSState]]
-                                                                                        }
-                                                                                        [
-                                                                                          [
-                                                                                            {
-                                                                                              {
-                                                                                                Tuple2
-                                                                                                [[TxConstraints Void] Void]
-                                                                                              }
-                                                                                              [State MSState]
-                                                                                            }
-                                                                                            {
-                                                                                              {
-                                                                                                fMonoidTxConstraints_cmempty
-                                                                                                Void
-                                                                                              }
-                                                                                              Void
-                                                                                            }
-                                                                                          ]
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                State
-                                                                                                MSState
-                                                                                              }
-                                                                                              [
-                                                                                                [
-                                                                                                  CollectingSignatures
-                                                                                                  wild
-                                                                                                ]
-                                                                                                {
-                                                                                                  Nil
-                                                                                                  (con bytestring)
-                                                                                                }
-                                                                                              ]
-                                                                                            ]
-                                                                                            ds
-                                                                                          ]
-                                                                                        ]
-                                                                                      ]
-                                                                                    )
-                                                                                  ]
-                                                                                  (lam
-                                                                                    thunk
-                                                                                    Unit
-                                                                                    {
-                                                                                      Nothing
-                                                                                      [[Tuple2 [[TxConstraints Void] Void]] [State MSState]]
-                                                                                    }
+                                                                                    ]
                                                                                   )
                                                                                 ]
-                                                                                Unit
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  {
+                                                                                    Nothing
+                                                                                    [[Tuple2 [[TxConstraints Void] Void]] [State MSState]]
+                                                                                  }
+                                                                                )
                                                                               ]
-                                                                            )
+                                                                              Unit
+                                                                            ]
                                                                           )
                                                                         )
-                                                                      ]
-                                                                    )
+                                                                      )
+                                                                    ]
                                                                   )
                                                                 )
                                                               ]

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       ca63281ddcc92149602f29042b7a00ee117365352dd41ec790a0d304889f97e6
+TxId:       e11fa679b699d7ef9f41f82e827516fe93710f6f2cb2b5d32d3e06eba0a561dd
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f5820a8a7d1dd8cfcf6cc170a4920c6791bc9bb...
+              Signature: 5f582000a8de50b13f36addcac36dd603bad3d47...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 03d200a81ee0feace8fb845e5ec950a6f9add837... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+  Destination:  Script: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
   Value:
     Ada:      Lovelace:  10
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+  Script: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       41a75e6d15503a0e28cdd13f06d801e86812d93eb67a5c2cda8514a16644171b
+TxId:       770f7791e1c3a43bbefde6d0b1aaf7576ce8c4318c306bfbed0c707309138a38
 Fee:        -
 Forge:      -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 5f5820358cefa0c60965b39a95a9e2e62709b0e0...
+              Signature: 5f58206cb3a27bf88c1755f836491725333d1f6f...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: feb345e86b9c2a7add2bfc695fa8aecd4ac5b0df... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+  Destination:  Script: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
   Value:
     Ada:      Lovelace:  10
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+  Script: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
   Value:
     Ada:      Lovelace:  20
 
 ==== Slot #3, Tx #0 ====
-TxId:       bfd3168dc3cace5f95ac0ad0052334a641a475155e74e23c5a37327e0e6b2aa2
+TxId:       3e94c00e20f8044e3c527896b04a0d11f81b4faf2896b13ac8fca8cec9c7f253
 Fee:        -
 Forge:      -
 Signatures  PubKey: f81fb54a825fced95eb033afcd64314075abfb0a...
-              Signature: 5f5820ab001256a384bc36459850a571a1de34d6...
+              Signature: 5f5820a574a2d69d36376e17a6fed2813a35ad65...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 5aebc31421e7af1bdb47326709c27f3fd9381b00... (Wallet 4)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  9999
   
   ---- Output 1 ----
-  Destination:  Script: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+  Destination:  Script: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
   Value:
     Ada:      Lovelace:  1
 
@@ -318,41 +318,41 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+  Script: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
   Value:
     Ada:      Lovelace:  21
 
 ==== Slot #20, Tx #0 ====
-TxId:       b8b9c6f3f8637d167484e362b47ebd3a2eca0b8ace1f9e62bcb82325d5a8867d
+TxId:       398751383afe598ba9f0f3691896126eb37a15c7f93ab33951e13f2bc8a3460c
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f58207be6f9c78de0b25475eb9b77ac5de22f49...
+              Signature: 5f5820dad3fd072cad8f9060f1932c8d873e9315...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+  Destination:  Script: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
   Value:
-    Ada:      Lovelace:  10
+    Ada:      Lovelace:  1
   Source:
-    Tx:     41a75e6d15503a0e28cdd13f06d801e86812d93eb67a5c2cda8514a16644171b
+    Tx:     3e94c00e20f8044e3c527896b04a0d11f81b4faf2896b13ac8fca8cec9c7f253
     Output #1
     Script: 01000003030264666978311829036161182a0003...
   
   ---- Input 1 ----
-  Destination:  Script: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+  Destination:  Script: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
   Value:
-    Ada:      Lovelace:  1
+    Ada:      Lovelace:  10
   Source:
-    Tx:     bfd3168dc3cace5f95ac0ad0052334a641a475155e74e23c5a37327e0e6b2aa2
+    Tx:     770f7791e1c3a43bbefde6d0b1aaf7576ce8c4318c306bfbed0c707309138a38
     Output #1
     Script: 01000003030264666978311829036161182a0003...
   
   ---- Input 2 ----
-  Destination:  Script: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+  Destination:  Script: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     ca63281ddcc92149602f29042b7a00ee117365352dd41ec790a0d304889f97e6
+    Tx:     e11fa679b699d7ef9f41f82e827516fe93710f6f2cb2b5d32d3e06eba0a561dd
     Output #1
     Script: 01000003030264666978311829036161182a0003...
 
@@ -405,6 +405,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9990
   
-  Script: 15b00591a2b41c38e2643299b773e706d895eb8d2938ddb62e482b1942a0c00c
+  Script: 885261789f4051ed59d639829eb281c9f05ab1e0cc7f856644c164c607970b7a
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       71d9d74f83fe0068eb2c328b0243b6176cb39ac4949a9b734bd4ed5667d55a9d
+TxId:       5a4e6b57f50add1ae3d12709a5a71f5a2573dd74ccaf2cc4c8540347bf0f5e15
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f5820891b51ecf2c9c34f9191cf42278c13879d...
+              Signature: 5f58209b77b37522ab89fe75fbb446d73be58923...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 2721f657e9ed91d2fc2a282f7ff5ed81ae48f48b... (Wallet 1)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 03125b3f3347794b9f98a7ea070f259057f60324ee08393e6154e6ab384a9017
+  Destination:  Script: 3d2b8d6755d80d64855f94c9e61d850895f19c5de83c7d479dfb3713c525eae4
   Value:
     Ada:      Lovelace:  10
 
@@ -170,23 +170,23 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 03125b3f3347794b9f98a7ea070f259057f60324ee08393e6154e6ab384a9017
+  Script: 3d2b8d6755d80d64855f94c9e61d850895f19c5de83c7d479dfb3713c525eae4
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       c6d6841cc484375b7665b707c7fcb17c0f00f0b5ad6efbfcd37c6cc05cb43628
+TxId:       a12b9ae41f9e3408aadc88632e46292c9b6e935a5559d4db8af6283d8f80eea0
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f582041e8f9cc277be5a936c930046c4c1de972...
+              Signature: 5f582066741712a1ccf444211e62b8b7bbd496dc...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 03125b3f3347794b9f98a7ea070f259057f60324ee08393e6154e6ab384a9017
+  Destination:  Script: 3d2b8d6755d80d64855f94c9e61d850895f19c5de83c7d479dfb3713c525eae4
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     71d9d74f83fe0068eb2c328b0243b6176cb39ac4949a9b734bd4ed5667d55a9d
+    Tx:     5a4e6b57f50add1ae3d12709a5a71f5a2573dd74ccaf2cc4c8540347bf0f5e15
     Output #1
     Script: 01000003030264666978311829036161182a0003...
 
@@ -239,6 +239,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 03125b3f3347794b9f98a7ea070f259057f60324ee08393e6154e6ab384a9017
+  Script: 3d2b8d6755d80d64855f94c9e61d850895f19c5de83c7d479dfb3713c525eae4
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       3073dfdf8b8f15ed78df1bef98bf8187677932dfa438659864a4358dec84a86a
+TxId:       cfd10aa5d1cfb532d92b9688d6d7cb507df9f83b6ad693acd88ed3bae2c27e73
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5f5820e268c9401147d146a2b01662a7b9487164...
+              Signature: 5f58208b340f2964288960d7fd0d419aef2cf787...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 03d200a81ee0feace8fb845e5ec950a6f9add837... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9940
   
   ---- Output 1 ----
-  Destination:  Script: 5a0fdebae24ff3966a60b59afd41b675c970aea4750661af0bd94a3b87dab855
+  Destination:  Script: e15772c2ba8e9ad84ed4a5a868c2c2677aadc47216ed0d7b8e6f9bad80c55b11
   Value:
     Ada:      Lovelace:  60
 
@@ -170,23 +170,23 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 5a0fdebae24ff3966a60b59afd41b675c970aea4750661af0bd94a3b87dab855
+  Script: e15772c2ba8e9ad84ed4a5a868c2c2677aadc47216ed0d7b8e6f9bad80c55b11
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #12, Tx #0 ====
-TxId:       61442ed898ecdbadb86b35fb79878c32cc630a95eb8a355101b475029662ba9e
+TxId:       b661d3ca2bc12ccd103600dec8b63b1de9b66c5e2fcac321022dcbefbcf081ee
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5f582072a36fc1f5fd9055138088066607220aaf...
+              Signature: 5f5820c506ce1289369c2d2b36359f91acc1d049...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 5a0fdebae24ff3966a60b59afd41b675c970aea4750661af0bd94a3b87dab855
+  Destination:  Script: e15772c2ba8e9ad84ed4a5a868c2c2677aadc47216ed0d7b8e6f9bad80c55b11
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     3073dfdf8b8f15ed78df1bef98bf8187677932dfa438659864a4358dec84a86a
+    Tx:     cfd10aa5d1cfb532d92b9688d6d7cb507df9f83b6ad693acd88ed3bae2c27e73
     Output #1
     Script: 01000003030264666978311829036161182a0003...
 
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  10
   
   ---- Output 1 ----
-  Destination:  Script: 5a0fdebae24ff3966a60b59afd41b675c970aea4750661af0bd94a3b87dab855
+  Destination:  Script: e15772c2ba8e9ad84ed4a5a868c2c2677aadc47216ed0d7b8e6f9bad80c55b11
   Value:
     Ada:      Lovelace:  50
 
@@ -244,6 +244,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 5a0fdebae24ff3966a60b59afd41b675c970aea4750661af0bd94a3b87dab855
+  Script: e15772c2ba8e9ad84ed4a5a868c2c2677aadc47216ed0d7b8e6f9bad80c55b11
   Value:
     Ada:      Lovelace:  50

--- a/plutus-use-cases/test/Spec/vesting.pir
+++ b/plutus-use-cases/test/Spec/vesting.pir
@@ -42,169 +42,119 @@
             (vardecl True Bool) (vardecl False Bool)
           )
         )
+        (termbind
+          (strict)
+          (vardecl error (all a (type) (fun Unit a)))
+          (abs e (type) (lam thunk Unit (error e)))
+        )
+        (termbind
+          (strict)
+          (vardecl equalsInteger (fun (con integer) (fun (con integer) Bool)))
+          (lam
+            arg
+            (con integer)
+            (lam
+              arg
+              (con integer)
+              [
+                (lam
+                  b
+                  (con bool)
+                  [ [ [ { (builtin ifThenElse) Bool } b ] True ] False ]
+                )
+                [ [ (builtin equalsInteger) arg ] arg ]
+              ]
+            )
+          )
+        )
         (let
           (rec)
-          (datatypebind
-            (datatype
-              (tyvardecl Data (type))
-              
-              Data_match
-              (vardecl B (fun (con bytestring) Data))
-              (vardecl Constr (fun (con integer) (fun [List Data] Data)))
-              (vardecl I (fun (con integer) Data))
-              (vardecl List (fun [List Data] Data))
-              (vardecl Map (fun [List [[Tuple2 Data] Data]] Data))
+          (termbind
+            (nonstrict)
+            (vardecl
+              bad_name (all a (type) (fun [List a] (fun (con integer) a)))
+            )
+            (abs
+              a
+              (type)
+              (lam
+                ds
+                [List a]
+                (lam
+                  ds
+                  (con integer)
+                  [
+                    [
+                      [
+                        { [ { Nil_match a } ds ] (fun Unit a) }
+                        (lam thunk Unit [ { error a } Unit ])
+                      ]
+                      (lam
+                        x
+                        a
+                        (lam
+                          xs
+                          [List a]
+                          (lam
+                            thunk
+                            Unit
+                            [
+                              [
+                                [
+                                  {
+                                    [
+                                      Bool_match
+                                      [ [ equalsInteger ds ] (con integer 0) ]
+                                    ]
+                                    (fun Unit a)
+                                  }
+                                  (lam thunk Unit x)
+                                ]
+                                (lam
+                                  thunk
+                                  Unit
+                                  [
+                                    [ { bad_name a } xs ]
+                                    [
+                                      [ (builtin subtractInteger) ds ]
+                                      (con integer 1)
+                                    ]
+                                  ]
+                                )
+                              ]
+                              Unit
+                            ]
+                          )
+                        )
+                      )
+                    ]
+                    Unit
+                  ]
+                )
+              )
             )
           )
           (let
             (nonrec)
-            (datatypebind
-              (datatype
-                (tyvardecl Extended (fun (type) (type)))
-                (tyvardecl a (type))
-                Extended_match
-                (vardecl Finite (fun a [Extended a]))
-                (vardecl NegInf [Extended a])
-                (vardecl PosInf [Extended a])
-              )
-            )
-            (datatypebind
-              (datatype
-                (tyvardecl LowerBound (fun (type) (type)))
-                (tyvardecl a (type))
-                LowerBound_match
-                (vardecl LowerBound (fun [Extended a] (fun Bool [LowerBound a]))
-                )
-              )
-            )
-            (datatypebind
-              (datatype
-                (tyvardecl UpperBound (fun (type) (type)))
-                (tyvardecl a (type))
-                UpperBound_match
-                (vardecl UpperBound (fun [Extended a] (fun Bool [UpperBound a]))
-                )
-              )
-            )
-            (datatypebind
-              (datatype
-                (tyvardecl Interval (fun (type) (type)))
-                (tyvardecl a (type))
-                Interval_match
-                (vardecl
-                  Interval
-                  (fun [LowerBound a] (fun [UpperBound a] [Interval a]))
-                )
-              )
-            )
-            (datatypebind
-              (datatype
-                (tyvardecl Tuple3 (fun (type) (fun (type) (fun (type) (type)))))
-                (tyvardecl a (type)) (tyvardecl b (type)) (tyvardecl c (type))
-                Tuple3_match
-                (vardecl Tuple3 (fun a (fun b (fun c [[[Tuple3 a] b] c]))))
-              )
-            )
-            (datatypebind
-              (datatype
-                (tyvardecl Maybe (fun (type) (type)))
-                (tyvardecl a (type))
-                Maybe_match
-                (vardecl Just (fun a [Maybe a])) (vardecl Nothing [Maybe a])
-              )
-            )
-            (datatypebind
-              (datatype
-                (tyvardecl TxOutRef (type))
-                
-                TxOutRef_match
-                (vardecl
-                  TxOutRef (fun (con bytestring) (fun (con integer) TxOutRef))
-                )
-              )
-            )
-            (datatypebind
-              (datatype
-                (tyvardecl TxInInfo (type))
-                
-                TxInInfo_match
-                (vardecl
-                  TxInInfo
-                  (fun TxOutRef (fun [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] TxInInfo)))
-                )
-              )
-            )
-            (datatypebind
-              (datatype
-                (tyvardecl Address (type))
-                
-                Address_match
-                (vardecl PubKeyAddress (fun (con bytestring) Address))
-                (vardecl ScriptAddress (fun (con bytestring) Address))
-              )
-            )
-            (datatypebind
-              (datatype
-                (tyvardecl TxOutType (type))
-                
-                TxOutType_match
-                (vardecl PayToPubKey TxOutType)
-                (vardecl PayToScript (fun (con bytestring) TxOutType))
-              )
-            )
-            (datatypebind
-              (datatype
-                (tyvardecl TxOut (type))
-                
-                TxOut_match
-                (vardecl
-                  TxOut
-                  (fun Address (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun TxOutType TxOut)))
-                )
-              )
-            )
-            (datatypebind
-              (datatype
-                (tyvardecl TxInfo (type))
-                
-                TxInfo_match
-                (vardecl
-                  TxInfo
-                  (fun [List TxInInfo] (fun [List TxOut] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [Interval (con integer)] (fun [List (con bytestring)] (fun [List (con bytestring)] (fun [List [[Tuple2 (con bytestring)] Data]] (fun (con bytestring) TxInfo)))))))))
-                )
-              )
-            )
             (termbind
               (strict)
               (vardecl
-                subtractInteger
-                (fun (con integer) (fun (con integer) (con integer)))
-              )
-              (builtin subtractInteger)
-            )
-            (termbind
-              (strict)
-              (vardecl error (all a (type) (fun Unit a)))
-              (abs e (type) (lam thunk Unit (error e)))
-            )
-            (termbind
-              (strict)
-              (vardecl
-                equalsInteger (fun (con integer) (fun (con integer) Bool))
+                equalsByteString
+                (fun (con bytestring) (fun (con bytestring) Bool))
               )
               (lam
                 arg
-                (con integer)
+                (con bytestring)
                 (lam
                   arg
-                  (con integer)
+                  (con bytestring)
                   [
                     (lam
                       b
                       (con bool)
                       [ [ [ { (builtin ifThenElse) Bool } b ] True ] False ]
                     )
-                    [ [ (builtin equalsInteger) arg ] arg ]
+                    [ [ (builtin equalsByteString) arg ] arg ]
                   ]
                 )
               )
@@ -214,127 +164,79 @@
               (termbind
                 (nonstrict)
                 (vardecl
-                  bad_name (all a (type) (fun [List a] (fun (con integer) a)))
+                  fFunctorNil_cfmap
+                  (all a (type) (all b (type) (fun (fun a b) (fun [List a] [List b]))))
                 )
                 (abs
                   a
                   (type)
-                  (lam
-                    ds
-                    [List a]
+                  (abs
+                    b
+                    (type)
                     (lam
-                      ds
-                      (con integer)
-                      [
+                      f
+                      (fun a b)
+                      (lam
+                        l
+                        [List a]
                         [
                           [
-                            { [ { Nil_match a } ds ] (fun Unit a) }
-                            (lam thunk Unit [ { error a } Unit ])
-                          ]
-                          (lam
-                            x
-                            a
+                            [
+                              { [ { Nil_match a } l ] (fun Unit [List b]) }
+                              (lam thunk Unit { Nil b })
+                            ]
                             (lam
-                              xs
-                              [List a]
+                              x
+                              a
                               (lam
-                                thunk
-                                Unit
-                                [
-                                  [
-                                    [
-                                      {
-                                        [
-                                          Bool_match
-                                          [
-                                            [ equalsInteger ds ] (con integer 0)
-                                          ]
-                                        ]
-                                        (fun Unit a)
-                                      }
-                                      (lam thunk Unit x)
-                                    ]
-                                    (lam
-                                      thunk
-                                      Unit
-                                      [
-                                        [ { bad_name a } xs ]
-                                        [
-                                          [ subtractInteger ds ] (con integer 1)
-                                        ]
-                                      ]
-                                    )
-                                  ]
+                                xs
+                                [List a]
+                                (lam
+                                  thunk
                                   Unit
-                                ]
+                                  [
+                                    [ { Cons b } [ f x ] ]
+                                    [ [ { { fFunctorNil_cfmap a } b } f ] xs ]
+                                  ]
+                                )
                               )
                             )
-                          )
+                          ]
+                          Unit
                         ]
-                        Unit
-                      ]
+                      )
                     )
                   )
                 )
               )
               (let
-                (nonrec)
+                (rec)
                 (termbind
-                  (strict)
+                  (nonstrict)
                   (vardecl
-                    addInteger
-                    (fun (con integer) (fun (con integer) (con integer)))
+                    foldr
+                    (all a (type) (all b (type) (fun (fun a (fun b b)) (fun b (fun [List a] b)))))
                   )
-                  (builtin addInteger)
-                )
-                (termbind
-                  (strict)
-                  (vardecl
-                    equalsByteString
-                    (fun (con bytestring) (fun (con bytestring) Bool))
-                  )
-                  (lam
-                    arg
-                    (con bytestring)
-                    (lam
-                      arg
-                      (con bytestring)
-                      [
-                        (lam
-                          b
-                          (con bool)
-                          [ [ [ { (builtin ifThenElse) Bool } b ] True ] False ]
-                        )
-                        [ [ (builtin equalsByteString) arg ] arg ]
-                      ]
-                    )
-                  )
-                )
-                (let
-                  (rec)
-                  (termbind
-                    (nonstrict)
-                    (vardecl
-                      fFunctorNil_cfmap
-                      (all a (type) (all b (type) (fun (fun a b) (fun [List a] [List b]))))
-                    )
+                  (abs
+                    a
+                    (type)
                     (abs
-                      a
+                      b
                       (type)
-                      (abs
-                        b
-                        (type)
+                      (lam
+                        f
+                        (fun a (fun b b))
                         (lam
-                          f
-                          (fun a b)
+                          acc
+                          b
                           (lam
                             l
                             [List a]
                             [
                               [
                                 [
-                                  { [ { Nil_match a } l ] (fun Unit [List b]) }
-                                  (lam thunk Unit { Nil b })
+                                  { [ { Nil_match a } l ] (fun Unit b) }
+                                  (lam thunk Unit acc)
                                 ]
                                 (lam
                                   x
@@ -346,10 +248,8 @@
                                       thunk
                                       Unit
                                       [
-                                        [ { Cons b } [ f x ] ]
-                                        [
-                                          [ { { fFunctorNil_cfmap a } b } f ] xs
-                                        ]
+                                        [ f x ]
+                                        [ [ [ { { foldr a } b } f ] acc ] xs ]
                                       ]
                                     )
                                   )
@@ -362,611 +262,140 @@
                       )
                     )
                   )
-                  (let
-                    (rec)
-                    (termbind
-                      (nonstrict)
-                      (vardecl
-                        foldr
-                        (all a (type) (all b (type) (fun (fun a (fun b b)) (fun b (fun [List a] b)))))
-                      )
+                )
+                (let
+                  (nonrec)
+                  (termbind
+                    (strict)
+                    (vardecl
+                      union
+                      (all k (type) (all v (type) (all r (type) (fun [(lam a (type) (fun a (fun a Bool))) k] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] r] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] [[These v] r]]))))))
+                    )
+                    (abs
+                      k
+                      (type)
                       (abs
-                        a
+                        v
                         (type)
                         (abs
-                          b
+                          r
                           (type)
                           (lam
-                            f
-                            (fun a (fun b b))
+                            dEq
+                            [(lam a (type) (fun a (fun a Bool))) k]
                             (lam
-                              acc
-                              b
+                              ds
+                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]
                               (lam
-                                l
-                                [List a]
+                                ds
+                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] r]
                                 [
                                   [
                                     [
-                                      { [ { Nil_match a } l ] (fun Unit b) }
-                                      (lam thunk Unit acc)
+                                      {
+                                        { foldr [[Tuple2 k] [[These v] r]] }
+                                        [List [[Tuple2 k] [[These v] r]]]
+                                      }
+                                      { Cons [[Tuple2 k] [[These v] r]] }
                                     ]
-                                    (lam
-                                      x
-                                      a
-                                      (lam
-                                        xs
-                                        [List a]
-                                        (lam
-                                          thunk
-                                          Unit
-                                          [
-                                            [ f x ]
-                                            [
-                                              [ [ { { foldr a } b } f ] acc ] xs
-                                            ]
-                                          ]
-                                        )
-                                      )
-                                    )
-                                  ]
-                                  Unit
-                                ]
-                              )
-                            )
-                          )
-                        )
-                      )
-                    )
-                    (let
-                      (nonrec)
-                      (termbind
-                        (strict)
-                        (vardecl
-                          union
-                          (all k (type) (all v (type) (all r (type) (fun [(lam a (type) (fun a (fun a Bool))) k] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] r] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] [[These v] r]]))))))
-                        )
-                        (abs
-                          k
-                          (type)
-                          (abs
-                            v
-                            (type)
-                            (abs
-                              r
-                              (type)
-                              (lam
-                                dEq
-                                [(lam a (type) (fun a (fun a Bool))) k]
-                                (lam
-                                  ds
-                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] v]
-                                  (lam
-                                    ds
-                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) k] r]
-                                    [
-                                      [
-                                        [
-                                          {
-                                            { foldr [[Tuple2 k] [[These v] r]] }
-                                            [List [[Tuple2 k] [[These v] r]]]
-                                          }
-                                          { Cons [[Tuple2 k] [[These v] r]] }
-                                        ]
-                                        [
-                                          [
-                                            {
-                                              {
-                                                fFunctorNil_cfmap [[Tuple2 k] r]
-                                              }
-                                              [[Tuple2 k] [[These v] r]]
-                                            }
-                                            (lam
-                                              ds
-                                              [[Tuple2 k] r]
-                                              [
-                                                {
-                                                  [
-                                                    { { Tuple2_match k } r } ds
-                                                  ]
-                                                  [[Tuple2 k] [[These v] r]]
-                                                }
-                                                (lam
-                                                  c
-                                                  k
-                                                  (lam
-                                                    b
-                                                    r
-                                                    [
-                                                      [
-                                                        {
-                                                          { Tuple2 k }
-                                                          [[These v] r]
-                                                        }
-                                                        c
-                                                      ]
-                                                      [ { { That v } r } b ]
-                                                    ]
-                                                  )
-                                                )
-                                              ]
-                                            )
-                                          ]
-                                          [
-                                            [
-                                              [
-                                                {
-                                                  { foldr [[Tuple2 k] r] }
-                                                  [List [[Tuple2 k] r]]
-                                                }
-                                                (lam
-                                                  e
-                                                  [[Tuple2 k] r]
-                                                  (lam
-                                                    xs
-                                                    [List [[Tuple2 k] r]]
-                                                    (let
-                                                      (nonrec)
-                                                      (termbind
-                                                        (nonstrict)
-                                                        (vardecl
-                                                          wild [[Tuple2 k] r]
-                                                        )
-                                                        e
-                                                      )
-                                                      [
-                                                        {
-                                                          [
-                                                            {
-                                                              { Tuple2_match k }
-                                                              r
-                                                            }
-                                                            e
-                                                          ]
-                                                          [List [[Tuple2 k] r]]
-                                                        }
-                                                        (lam
-                                                          c
-                                                          k
-                                                          (lam
-                                                            ds
-                                                            r
-                                                            [
-                                                              [
-                                                                [
-                                                                  {
-                                                                    [
-                                                                      Bool_match
-                                                                      [
-                                                                        [
-                                                                          [
-                                                                            {
-                                                                              {
-                                                                                foldr
-                                                                                [[Tuple2 k] v]
-                                                                              }
-                                                                              Bool
-                                                                            }
-                                                                            (lam
-                                                                              a
-                                                                              [[Tuple2 k] v]
-                                                                              (lam
-                                                                                acc
-                                                                                Bool
-                                                                                [
-                                                                                  [
-                                                                                    [
-                                                                                      {
-                                                                                        [
-                                                                                          Bool_match
-                                                                                          acc
-                                                                                        ]
-                                                                                        (fun Unit Bool)
-                                                                                      }
-                                                                                      (lam
-                                                                                        thunk
-                                                                                        Unit
-                                                                                        True
-                                                                                      )
-                                                                                    ]
-                                                                                    (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      [
-                                                                                        {
-                                                                                          [
-                                                                                            {
-                                                                                              {
-                                                                                                Tuple2_match
-                                                                                                k
-                                                                                              }
-                                                                                              v
-                                                                                            }
-                                                                                            a
-                                                                                          ]
-                                                                                          Bool
-                                                                                        }
-                                                                                        (lam
-                                                                                          c
-                                                                                          k
-                                                                                          (lam
-                                                                                            ds
-                                                                                            v
-                                                                                            [
-                                                                                              [
-                                                                                                dEq
-                                                                                                c
-                                                                                              ]
-                                                                                              c
-                                                                                            ]
-                                                                                          )
-                                                                                        )
-                                                                                      ]
-                                                                                    )
-                                                                                  ]
-                                                                                  Unit
-                                                                                ]
-                                                                              )
-                                                                            )
-                                                                          ]
-                                                                          False
-                                                                        ]
-                                                                        ds
-                                                                      ]
-                                                                    ]
-                                                                    (fun Unit [List [[Tuple2 k] r]])
-                                                                  }
-                                                                  (lam
-                                                                    thunk
-                                                                    Unit
-                                                                    xs
-                                                                  )
-                                                                ]
-                                                                (lam
-                                                                  thunk
-                                                                  Unit
-                                                                  [
-                                                                    [
-                                                                      {
-                                                                        Cons
-                                                                        [[Tuple2 k] r]
-                                                                      }
-                                                                      wild
-                                                                    ]
-                                                                    xs
-                                                                  ]
-                                                                )
-                                                              ]
-                                                              Unit
-                                                            ]
-                                                          )
-                                                        )
-                                                      ]
-                                                    )
-                                                  )
-                                                )
-                                              ]
-                                              { Nil [[Tuple2 k] r] }
-                                            ]
-                                            ds
-                                          ]
-                                        ]
-                                      ]
-                                      [
-                                        [
-                                          {
-                                            { fFunctorNil_cfmap [[Tuple2 k] v] }
-                                            [[Tuple2 k] [[These v] r]]
-                                          }
-                                          (lam
-                                            ds
-                                            [[Tuple2 k] v]
-                                            [
-                                              {
-                                                [ { { Tuple2_match k } v } ds ]
-                                                [[Tuple2 k] [[These v] r]]
-                                              }
-                                              (lam
-                                                c
-                                                k
-                                                (lam
-                                                  i
-                                                  v
-                                                  (let
-                                                    (rec)
-                                                    (termbind
-                                                      (strict)
-                                                      (vardecl
-                                                        go
-                                                        (fun [List [[Tuple2 k] r]] [[These v] r])
-                                                      )
-                                                      (lam
-                                                        ds
-                                                        [List [[Tuple2 k] r]]
-                                                        [
-                                                          [
-                                                            [
-                                                              {
-                                                                [
-                                                                  {
-                                                                    Nil_match
-                                                                    [[Tuple2 k] r]
-                                                                  }
-                                                                  ds
-                                                                ]
-                                                                (fun Unit [[These v] r])
-                                                              }
-                                                              (lam
-                                                                thunk
-                                                                Unit
-                                                                [
-                                                                  {
-                                                                    { This v } r
-                                                                  }
-                                                                  i
-                                                                ]
-                                                              )
-                                                            ]
-                                                            (lam
-                                                              ds
-                                                              [[Tuple2 k] r]
-                                                              (lam
-                                                                xs
-                                                                [List [[Tuple2 k] r]]
-                                                                (lam
-                                                                  thunk
-                                                                  Unit
-                                                                  [
-                                                                    {
-                                                                      [
-                                                                        {
-                                                                          {
-                                                                            Tuple2_match
-                                                                            k
-                                                                          }
-                                                                          r
-                                                                        }
-                                                                        ds
-                                                                      ]
-                                                                      [[These v] r]
-                                                                    }
-                                                                    (lam
-                                                                      c
-                                                                      k
-                                                                      (lam
-                                                                        i
-                                                                        r
-                                                                        [
-                                                                          [
-                                                                            [
-                                                                              {
-                                                                                [
-                                                                                  Bool_match
-                                                                                  [
-                                                                                    [
-                                                                                      dEq
-                                                                                      c
-                                                                                    ]
-                                                                                    c
-                                                                                  ]
-                                                                                ]
-                                                                                (fun Unit [[These v] r])
-                                                                              }
-                                                                              (lam
-                                                                                thunk
-                                                                                Unit
-                                                                                [
-                                                                                  [
-                                                                                    {
-                                                                                      {
-                                                                                        These
-                                                                                        v
-                                                                                      }
-                                                                                      r
-                                                                                    }
-                                                                                    i
-                                                                                  ]
-                                                                                  i
-                                                                                ]
-                                                                              )
-                                                                            ]
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              [
-                                                                                go
-                                                                                xs
-                                                                              ]
-                                                                            )
-                                                                          ]
-                                                                          Unit
-                                                                        ]
-                                                                      )
-                                                                    )
-                                                                  ]
-                                                                )
-                                                              )
-                                                            )
-                                                          ]
-                                                          Unit
-                                                        ]
-                                                      )
-                                                    )
-                                                    [
-                                                      [
-                                                        {
-                                                          { Tuple2 k }
-                                                          [[These v] r]
-                                                        }
-                                                        c
-                                                      ]
-                                                      [ go ds ]
-                                                    ]
-                                                  )
-                                                )
-                                              )
-                                            ]
-                                          )
-                                        ]
-                                        ds
-                                      ]
-                                    ]
-                                  )
-                                )
-                              )
-                            )
-                          )
-                        )
-                      )
-                      (termbind
-                        (strict)
-                        (vardecl
-                          unionVal
-                          (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]))
-                        )
-                        (lam
-                          ds
-                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                          (lam
-                            ds
-                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                            (let
-                              (rec)
-                              (termbind
-                                (strict)
-                                (vardecl
-                                  go
-                                  (fun [List [[Tuple2 (con bytestring)] [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]] [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]])
-                                )
-                                (lam
-                                  ds
-                                  [List [[Tuple2 (con bytestring)] [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]]
-                                  [
                                     [
                                       [
                                         {
-                                          [
-                                            {
-                                              Nil_match
-                                              [[Tuple2 (con bytestring)] [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                                            }
-                                            ds
-                                          ]
-                                          (fun Unit [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]])
+                                          { fFunctorNil_cfmap [[Tuple2 k] r] }
+                                          [[Tuple2 k] [[These v] r]]
                                         }
                                         (lam
-                                          thunk
-                                          Unit
-                                          {
-                                            Nil
-                                            [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                          }
+                                          ds
+                                          [[Tuple2 k] r]
+                                          [
+                                            {
+                                              [ { { Tuple2_match k } r } ds ]
+                                              [[Tuple2 k] [[These v] r]]
+                                            }
+                                            (lam
+                                              c
+                                              k
+                                              (lam
+                                                b
+                                                r
+                                                [
+                                                  [
+                                                    {
+                                                      { Tuple2 k } [[These v] r]
+                                                    }
+                                                    c
+                                                  ]
+                                                  [ { { That v } r } b ]
+                                                ]
+                                              )
+                                            )
+                                          ]
                                         )
                                       ]
-                                      (lam
-                                        ds
-                                        [[Tuple2 (con bytestring)] [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                                        (lam
-                                          xs
-                                          [List [[Tuple2 (con bytestring)] [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]]
-                                          (lam
-                                            thunk
-                                            Unit
-                                            [
-                                              {
+                                      [
+                                        [
+                                          [
+                                            {
+                                              { foldr [[Tuple2 k] r] }
+                                              [List [[Tuple2 k] r]]
+                                            }
+                                            (lam
+                                              e
+                                              [[Tuple2 k] r]
+                                              (lam
+                                                xs
+                                                [List [[Tuple2 k] r]]
                                                 [
                                                   {
-                                                    {
-                                                      Tuple2_match
-                                                      (con bytestring)
-                                                    }
-                                                    [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                  }
-                                                  ds
-                                                ]
-                                                [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
-                                              }
-                                              (lam
-                                                c
-                                                (con bytestring)
-                                                (lam
-                                                  i
-                                                  [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                  [
                                                     [
-                                                      {
-                                                        Cons
-                                                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                                      }
+                                                      { { Tuple2_match k } r } e
+                                                    ]
+                                                    [List [[Tuple2 k] r]]
+                                                  }
+                                                  (lam
+                                                    c
+                                                    k
+                                                    (lam
+                                                      ds
+                                                      r
                                                       [
                                                         [
-                                                          {
-                                                            {
-                                                              Tuple2
-                                                              (con bytestring)
-                                                            }
-                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                          }
-                                                          c
-                                                        ]
-                                                        [
                                                           [
-                                                            [
-                                                              {
+                                                            {
+                                                              [
+                                                                Bool_match
                                                                 [
-                                                                  {
-                                                                    {
-                                                                      These_match
-                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                                    }
-                                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                                  }
-                                                                  i
-                                                                ]
-                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                              }
-                                                              (lam
-                                                                b
-                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                                (let
-                                                                  (rec)
-                                                                  (termbind
-                                                                    (strict)
-                                                                    (vardecl
-                                                                      go
-                                                                      (fun [List [[Tuple2 (con bytestring)] (con integer)]] [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]])
-                                                                    )
-                                                                    (lam
-                                                                      ds
-                                                                      [List [[Tuple2 (con bytestring)] (con integer)]]
-                                                                      [
-                                                                        [
+                                                                  [
+                                                                    [
+                                                                      {
+                                                                        {
+                                                                          foldr
+                                                                          [[Tuple2 k] v]
+                                                                        }
+                                                                        Bool
+                                                                      }
+                                                                      (lam
+                                                                        a
+                                                                        [[Tuple2 k] v]
+                                                                        (lam
+                                                                          acc
+                                                                          Bool
                                                                           [
-                                                                            {
+                                                                            [
                                                                               [
                                                                                 {
-                                                                                  Nil_match
-                                                                                  [[Tuple2 (con bytestring)] (con integer)]
+                                                                                  [
+                                                                                    Bool_match
+                                                                                    acc
+                                                                                  ]
+                                                                                  (fun Unit Bool)
                                                                                 }
-                                                                                ds
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  True
+                                                                                )
                                                                               ]
-                                                                              (fun Unit [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]])
-                                                                            }
-                                                                            (lam
-                                                                              thunk
-                                                                              Unit
-                                                                              {
-                                                                                Nil
-                                                                                [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                              }
-                                                                            )
-                                                                          ]
-                                                                          (lam
-                                                                            ds
-                                                                            [[Tuple2 (con bytestring)] (con integer)]
-                                                                            (lam
-                                                                              xs
-                                                                              [List [[Tuple2 (con bytestring)] (con integer)]]
                                                                               (lam
                                                                                 thunk
                                                                                 Unit
@@ -976,99 +405,345 @@
                                                                                       {
                                                                                         {
                                                                                           Tuple2_match
-                                                                                          (con bytestring)
+                                                                                          k
                                                                                         }
-                                                                                        (con integer)
+                                                                                        v
                                                                                       }
-                                                                                      ds
+                                                                                      a
                                                                                     ]
-                                                                                    [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                                                    Bool
                                                                                   }
                                                                                   (lam
                                                                                     c
-                                                                                    (con bytestring)
+                                                                                    k
                                                                                     (lam
-                                                                                      i
-                                                                                      (con integer)
+                                                                                      ds
+                                                                                      v
                                                                                       [
                                                                                         [
-                                                                                          {
-                                                                                            Cons
-                                                                                            [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                                          }
-                                                                                          [
-                                                                                            [
-                                                                                              {
-                                                                                                {
-                                                                                                  Tuple2
-                                                                                                  (con bytestring)
-                                                                                                }
-                                                                                                [[These (con integer)] (con integer)]
-                                                                                              }
-                                                                                              c
-                                                                                            ]
-                                                                                            [
-                                                                                              {
-                                                                                                {
-                                                                                                  That
-                                                                                                  (con integer)
-                                                                                                }
-                                                                                                (con integer)
-                                                                                              }
-                                                                                              i
-                                                                                            ]
-                                                                                          ]
+                                                                                          dEq
+                                                                                          c
                                                                                         ]
-                                                                                        [
-                                                                                          go
-                                                                                          xs
-                                                                                        ]
+                                                                                        c
                                                                                       ]
                                                                                     )
                                                                                   )
                                                                                 ]
                                                                               )
-                                                                            )
-                                                                          )
-                                                                        ]
-                                                                        Unit
-                                                                      ]
-                                                                    )
-                                                                  )
-                                                                  [ go b ]
-                                                                )
-                                                              )
-                                                            ]
-                                                            (lam
-                                                              a
-                                                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                              (lam
-                                                                b
-                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                                [
-                                                                  [
-                                                                    [
-                                                                      {
-                                                                        {
-                                                                          {
-                                                                            union
-                                                                            (con bytestring)
-                                                                          }
-                                                                          (con integer)
-                                                                        }
-                                                                        (con integer)
-                                                                      }
-                                                                      equalsByteString
+                                                                            ]
+                                                                            Unit
+                                                                          ]
+                                                                        )
+                                                                      )
                                                                     ]
-                                                                    a
+                                                                    False
                                                                   ]
-                                                                  b
+                                                                  ds
                                                                 ]
-                                                              )
-                                                            )
+                                                              ]
+                                                              (fun Unit [List [[Tuple2 k] r]])
+                                                            }
+                                                            (lam thunk Unit xs)
                                                           ]
                                                           (lam
-                                                            a
+                                                            thunk
+                                                            Unit
+                                                            [
+                                                              [
+                                                                {
+                                                                  Cons
+                                                                  [[Tuple2 k] r]
+                                                                }
+                                                                e
+                                                              ]
+                                                              xs
+                                                            ]
+                                                          )
+                                                        ]
+                                                        Unit
+                                                      ]
+                                                    )
+                                                  )
+                                                ]
+                                              )
+                                            )
+                                          ]
+                                          { Nil [[Tuple2 k] r] }
+                                        ]
+                                        ds
+                                      ]
+                                    ]
+                                  ]
+                                  [
+                                    [
+                                      {
+                                        { fFunctorNil_cfmap [[Tuple2 k] v] }
+                                        [[Tuple2 k] [[These v] r]]
+                                      }
+                                      (lam
+                                        ds
+                                        [[Tuple2 k] v]
+                                        [
+                                          {
+                                            [ { { Tuple2_match k } v } ds ]
+                                            [[Tuple2 k] [[These v] r]]
+                                          }
+                                          (lam
+                                            c
+                                            k
+                                            (lam
+                                              i
+                                              v
+                                              (let
+                                                (rec)
+                                                (termbind
+                                                  (strict)
+                                                  (vardecl
+                                                    go
+                                                    (fun [List [[Tuple2 k] r]] [[These v] r])
+                                                  )
+                                                  (lam
+                                                    ds
+                                                    [List [[Tuple2 k] r]]
+                                                    [
+                                                      [
+                                                        [
+                                                          {
+                                                            [
+                                                              {
+                                                                Nil_match
+                                                                [[Tuple2 k] r]
+                                                              }
+                                                              ds
+                                                            ]
+                                                            (fun Unit [[These v] r])
+                                                          }
+                                                          (lam
+                                                            thunk
+                                                            Unit
+                                                            [
+                                                              { { This v } r } i
+                                                            ]
+                                                          )
+                                                        ]
+                                                        (lam
+                                                          ds
+                                                          [[Tuple2 k] r]
+                                                          (lam
+                                                            xs
+                                                            [List [[Tuple2 k] r]]
+                                                            (lam
+                                                              thunk
+                                                              Unit
+                                                              [
+                                                                {
+                                                                  [
+                                                                    {
+                                                                      {
+                                                                        Tuple2_match
+                                                                        k
+                                                                      }
+                                                                      r
+                                                                    }
+                                                                    ds
+                                                                  ]
+                                                                  [[These v] r]
+                                                                }
+                                                                (lam
+                                                                  c
+                                                                  k
+                                                                  (lam
+                                                                    i
+                                                                    r
+                                                                    [
+                                                                      [
+                                                                        [
+                                                                          {
+                                                                            [
+                                                                              Bool_match
+                                                                              [
+                                                                                [
+                                                                                  dEq
+                                                                                  c
+                                                                                ]
+                                                                                c
+                                                                              ]
+                                                                            ]
+                                                                            (fun Unit [[These v] r])
+                                                                          }
+                                                                          (lam
+                                                                            thunk
+                                                                            Unit
+                                                                            [
+                                                                              [
+                                                                                {
+                                                                                  {
+                                                                                    These
+                                                                                    v
+                                                                                  }
+                                                                                  r
+                                                                                }
+                                                                                i
+                                                                              ]
+                                                                              i
+                                                                            ]
+                                                                          )
+                                                                        ]
+                                                                        (lam
+                                                                          thunk
+                                                                          Unit
+                                                                          [
+                                                                            go
+                                                                            xs
+                                                                          ]
+                                                                        )
+                                                                      ]
+                                                                      Unit
+                                                                    ]
+                                                                  )
+                                                                )
+                                                              ]
+                                                            )
+                                                          )
+                                                        )
+                                                      ]
+                                                      Unit
+                                                    ]
+                                                  )
+                                                )
+                                                [
+                                                  [
+                                                    {
+                                                      { Tuple2 k } [[These v] r]
+                                                    }
+                                                    c
+                                                  ]
+                                                  [ go ds ]
+                                                ]
+                                              )
+                                            )
+                                          )
+                                        ]
+                                      )
+                                    ]
+                                    ds
+                                  ]
+                                ]
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                  (termbind
+                    (strict)
+                    (vardecl
+                      unionVal
+                      (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]))
+                    )
+                    (lam
+                      ds
+                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                      (lam
+                        ds
+                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                        (let
+                          (rec)
+                          (termbind
+                            (strict)
+                            (vardecl
+                              go
+                              (fun [List [[Tuple2 (con bytestring)] [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]] [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]])
+                            )
+                            (lam
+                              ds
+                              [List [[Tuple2 (con bytestring)] [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]]
+                              [
+                                [
+                                  [
+                                    {
+                                      [
+                                        {
+                                          Nil_match
+                                          [[Tuple2 (con bytestring)] [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                        }
+                                        ds
+                                      ]
+                                      (fun Unit [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]])
+                                    }
+                                    (lam
+                                      thunk
+                                      Unit
+                                      {
+                                        Nil
+                                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                      }
+                                    )
+                                  ]
+                                  (lam
+                                    ds
+                                    [[Tuple2 (con bytestring)] [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                    (lam
+                                      xs
+                                      [List [[Tuple2 (con bytestring)] [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]]
+                                      (lam
+                                        thunk
+                                        Unit
+                                        [
+                                          {
+                                            [
+                                              {
+                                                {
+                                                  Tuple2_match (con bytestring)
+                                                }
+                                                [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                              }
+                                              ds
+                                            ]
+                                            [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
+                                          }
+                                          (lam
+                                            c
+                                            (con bytestring)
+                                            (lam
+                                              i
+                                              [[These [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                              [
+                                                [
+                                                  {
+                                                    Cons
+                                                    [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                  }
+                                                  [
+                                                    [
+                                                      {
+                                                        {
+                                                          Tuple2
+                                                          (con bytestring)
+                                                        }
+                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
+                                                      }
+                                                      c
+                                                    ]
+                                                    [
+                                                      [
+                                                        [
+                                                          {
+                                                            [
+                                                              {
+                                                                {
+                                                                  These_match
+                                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                                                }
+                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                                              }
+                                                              i
+                                                            ]
+                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
+                                                          }
+                                                          (lam
+                                                            b
                                                             [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
                                                             (let
                                                               (rec)
@@ -1152,7 +827,7 @@
                                                                                         [
                                                                                           {
                                                                                             {
-                                                                                              This
+                                                                                              That
                                                                                               (con integer)
                                                                                             }
                                                                                             (con integer)
@@ -1177,331 +852,618 @@
                                                                   ]
                                                                 )
                                                               )
-                                                              [ go a ]
+                                                              [ go b ]
                                                             )
                                                           )
                                                         ]
+                                                        (lam
+                                                          a
+                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                                          (lam
+                                                            b
+                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                                            [
+                                                              [
+                                                                [
+                                                                  {
+                                                                    {
+                                                                      {
+                                                                        union
+                                                                        (con bytestring)
+                                                                      }
+                                                                      (con integer)
+                                                                    }
+                                                                    (con integer)
+                                                                  }
+                                                                  equalsByteString
+                                                                ]
+                                                                a
+                                                              ]
+                                                              b
+                                                            ]
+                                                          )
+                                                        )
                                                       ]
+                                                      (lam
+                                                        a
+                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                                        (let
+                                                          (rec)
+                                                          (termbind
+                                                            (strict)
+                                                            (vardecl
+                                                              go
+                                                              (fun [List [[Tuple2 (con bytestring)] (con integer)]] [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]])
+                                                            )
+                                                            (lam
+                                                              ds
+                                                              [List [[Tuple2 (con bytestring)] (con integer)]]
+                                                              [
+                                                                [
+                                                                  [
+                                                                    {
+                                                                      [
+                                                                        {
+                                                                          Nil_match
+                                                                          [[Tuple2 (con bytestring)] (con integer)]
+                                                                        }
+                                                                        ds
+                                                                      ]
+                                                                      (fun Unit [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]])
+                                                                    }
+                                                                    (lam
+                                                                      thunk
+                                                                      Unit
+                                                                      {
+                                                                        Nil
+                                                                        [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
+                                                                      }
+                                                                    )
+                                                                  ]
+                                                                  (lam
+                                                                    ds
+                                                                    [[Tuple2 (con bytestring)] (con integer)]
+                                                                    (lam
+                                                                      xs
+                                                                      [List [[Tuple2 (con bytestring)] (con integer)]]
+                                                                      (lam
+                                                                        thunk
+                                                                        Unit
+                                                                        [
+                                                                          {
+                                                                            [
+                                                                              {
+                                                                                {
+                                                                                  Tuple2_match
+                                                                                  (con bytestring)
+                                                                                }
+                                                                                (con integer)
+                                                                              }
+                                                                              ds
+                                                                            ]
+                                                                            [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                                          }
+                                                                          (lam
+                                                                            c
+                                                                            (con bytestring)
+                                                                            (lam
+                                                                              i
+                                                                              (con integer)
+                                                                              [
+                                                                                [
+                                                                                  {
+                                                                                    Cons
+                                                                                    [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
+                                                                                  }
+                                                                                  [
+                                                                                    [
+                                                                                      {
+                                                                                        {
+                                                                                          Tuple2
+                                                                                          (con bytestring)
+                                                                                        }
+                                                                                        [[These (con integer)] (con integer)]
+                                                                                      }
+                                                                                      c
+                                                                                    ]
+                                                                                    [
+                                                                                      {
+                                                                                        {
+                                                                                          This
+                                                                                          (con integer)
+                                                                                        }
+                                                                                        (con integer)
+                                                                                      }
+                                                                                      i
+                                                                                    ]
+                                                                                  ]
+                                                                                ]
+                                                                                [
+                                                                                  go
+                                                                                  xs
+                                                                                ]
+                                                                              ]
+                                                                            )
+                                                                          )
+                                                                        ]
+                                                                      )
+                                                                    )
+                                                                  )
+                                                                ]
+                                                                Unit
+                                                              ]
+                                                            )
+                                                          )
+                                                          [ go a ]
+                                                        )
+                                                      )
                                                     ]
-                                                    [ go xs ]
                                                   ]
-                                                )
-                                              )
-                                            ]
+                                                ]
+                                                [ go xs ]
+                                              ]
+                                            )
                                           )
-                                        )
+                                        ]
                                       )
-                                    ]
-                                    Unit
-                                  ]
-                                )
-                              )
+                                    )
+                                  )
+                                ]
+                                Unit
+                              ]
+                            )
+                          )
+                          [
+                            go
+                            [
                               [
+                                [
+                                  {
+                                    {
+                                      { union (con bytestring) }
+                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                    }
+                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                  }
+                                  equalsByteString
+                                ]
+                                ds
+                              ]
+                              ds
+                            ]
+                          ]
+                        )
+                      )
+                    )
+                  )
+                  (termbind
+                    (strict)
+                    (vardecl
+                      unionWith
+                      (fun (fun (con integer) (fun (con integer) (con integer))) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])))
+                    )
+                    (lam
+                      f
+                      (fun (con integer) (fun (con integer) (con integer)))
+                      (lam
+                        ls
+                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                        (lam
+                          rs
+                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                          (let
+                            (rec)
+                            (termbind
+                              (strict)
+                              (vardecl
                                 go
+                                (fun [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]] [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]])
+                              )
+                              (lam
+                                ds
+                                [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
                                 [
                                   [
                                     [
                                       {
-                                        {
-                                          { union (con bytestring) }
-                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                        }
-                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                      }
-                                      equalsByteString
-                                    ]
-                                    ds
-                                  ]
-                                  ds
-                                ]
-                              ]
-                            )
-                          )
-                        )
-                      )
-                      (termbind
-                        (strict)
-                        (vardecl
-                          unionWith
-                          (fun (fun (con integer) (fun (con integer) (con integer))) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])))
-                        )
-                        (lam
-                          f
-                          (fun (con integer) (fun (con integer) (con integer)))
-                          (lam
-                            ls
-                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                            (lam
-                              rs
-                              [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                              (let
-                                (rec)
-                                (termbind
-                                  (strict)
-                                  (vardecl
-                                    go
-                                    (fun [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]] [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]])
-                                  )
-                                  (lam
-                                    ds
-                                    [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
-                                    [
-                                      [
                                         [
                                           {
-                                            [
-                                              {
-                                                Nil_match
-                                                [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                              }
-                                              ds
-                                            ]
-                                            (fun Unit [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]])
+                                            Nil_match
+                                            [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
                                           }
-                                          (lam
-                                            thunk
-                                            Unit
-                                            {
-                                              Nil
-                                              [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                            }
-                                          )
-                                        ]
-                                        (lam
                                           ds
-                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
-                                          (lam
-                                            xs
-                                            [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
-                                            (lam
-                                              thunk
-                                              Unit
+                                        ]
+                                        (fun Unit [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]])
+                                      }
+                                      (lam
+                                        thunk
+                                        Unit
+                                        {
+                                          Nil
+                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                        }
+                                      )
+                                    ]
+                                    (lam
+                                      ds
+                                      [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]
+                                      (lam
+                                        xs
+                                        [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]]]
+                                        (lam
+                                          thunk
+                                          Unit
+                                          [
+                                            {
                                               [
                                                 {
-                                                  [
-                                                    {
-                                                      {
-                                                        Tuple2_match
-                                                        (con bytestring)
-                                                      }
-                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                    }
-                                                    ds
-                                                  ]
-                                                  [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                                  {
+                                                    Tuple2_match
+                                                    (con bytestring)
+                                                  }
+                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
                                                 }
-                                                (lam
-                                                  c
-                                                  (con bytestring)
-                                                  (lam
-                                                    i
-                                                    [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
-                                                    (let
-                                                      (rec)
-                                                      (termbind
-                                                        (strict)
-                                                        (vardecl
-                                                          go
-                                                          (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] [List [[Tuple2 (con bytestring)] (con integer)]])
-                                                        )
-                                                        (lam
-                                                          ds
-                                                          [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                ds
+                                              ]
+                                              [List [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                            }
+                                            (lam
+                                              c
+                                              (con bytestring)
+                                              (lam
+                                                i
+                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[These (con integer)] (con integer)]]
+                                                (let
+                                                  (rec)
+                                                  (termbind
+                                                    (strict)
+                                                    (vardecl
+                                                      go
+                                                      (fun [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]] [List [[Tuple2 (con bytestring)] (con integer)]])
+                                                    )
+                                                    (lam
+                                                      ds
+                                                      [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                      [
+                                                        [
                                                           [
-                                                            [
+                                                            {
                                                               [
                                                                 {
-                                                                  [
-                                                                    {
-                                                                      Nil_match
-                                                                      [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                    }
-                                                                    ds
-                                                                  ]
-                                                                  (fun Unit [List [[Tuple2 (con bytestring)] (con integer)]])
+                                                                  Nil_match
+                                                                  [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
                                                                 }
-                                                                (lam
-                                                                  thunk
-                                                                  Unit
-                                                                  {
-                                                                    Nil
-                                                                    [[Tuple2 (con bytestring)] (con integer)]
-                                                                  }
-                                                                )
-                                                              ]
-                                                              (lam
                                                                 ds
-                                                                [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
-                                                                (lam
-                                                                  xs
-                                                                  [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
-                                                                  (lam
-                                                                    thunk
-                                                                    Unit
+                                                              ]
+                                                              (fun Unit [List [[Tuple2 (con bytestring)] (con integer)]])
+                                                            }
+                                                            (lam
+                                                              thunk
+                                                              Unit
+                                                              {
+                                                                Nil
+                                                                [[Tuple2 (con bytestring)] (con integer)]
+                                                              }
+                                                            )
+                                                          ]
+                                                          (lam
+                                                            ds
+                                                            [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]
+                                                            (lam
+                                                              xs
+                                                              [List [[Tuple2 (con bytestring)] [[These (con integer)] (con integer)]]]
+                                                              (lam
+                                                                thunk
+                                                                Unit
+                                                                [
+                                                                  {
                                                                     [
                                                                       {
+                                                                        {
+                                                                          Tuple2_match
+                                                                          (con bytestring)
+                                                                        }
+                                                                        [[These (con integer)] (con integer)]
+                                                                      }
+                                                                      ds
+                                                                    ]
+                                                                    [List [[Tuple2 (con bytestring)] (con integer)]]
+                                                                  }
+                                                                  (lam
+                                                                    c
+                                                                    (con bytestring)
+                                                                    (lam
+                                                                      i
+                                                                      [[These (con integer)] (con integer)]
+                                                                      [
                                                                         [
                                                                           {
-                                                                            {
-                                                                              Tuple2_match
-                                                                              (con bytestring)
-                                                                            }
-                                                                            [[These (con integer)] (con integer)]
+                                                                            Cons
+                                                                            [[Tuple2 (con bytestring)] (con integer)]
                                                                           }
-                                                                          ds
-                                                                        ]
-                                                                        [List [[Tuple2 (con bytestring)] (con integer)]]
-                                                                      }
-                                                                      (lam
-                                                                        c
-                                                                        (con bytestring)
-                                                                        (lam
-                                                                          i
-                                                                          [[These (con integer)] (con integer)]
                                                                           [
                                                                             [
                                                                               {
-                                                                                Cons
-                                                                                [[Tuple2 (con bytestring)] (con integer)]
+                                                                                {
+                                                                                  Tuple2
+                                                                                  (con bytestring)
+                                                                                }
+                                                                                (con integer)
                                                                               }
+                                                                              c
+                                                                            ]
+                                                                            [
                                                                               [
                                                                                 [
                                                                                   {
-                                                                                    {
-                                                                                      Tuple2
-                                                                                      (con bytestring)
-                                                                                    }
-                                                                                    (con integer)
-                                                                                  }
-                                                                                  c
-                                                                                ]
-                                                                                [
-                                                                                  [
                                                                                     [
                                                                                       {
-                                                                                        [
-                                                                                          {
-                                                                                            {
-                                                                                              These_match
-                                                                                              (con integer)
-                                                                                            }
-                                                                                            (con integer)
-                                                                                          }
-                                                                                          i
-                                                                                        ]
+                                                                                        {
+                                                                                          These_match
+                                                                                          (con integer)
+                                                                                        }
                                                                                         (con integer)
                                                                                       }
-                                                                                      (lam
-                                                                                        b
-                                                                                        (con integer)
-                                                                                        [
-                                                                                          [
-                                                                                            f
-                                                                                            (con
-                                                                                              integer
-                                                                                                0
-                                                                                            )
-                                                                                          ]
-                                                                                          b
-                                                                                        ]
-                                                                                      )
+                                                                                      i
                                                                                     ]
-                                                                                    (lam
-                                                                                      a
-                                                                                      (con integer)
-                                                                                      (lam
-                                                                                        b
-                                                                                        (con integer)
-                                                                                        [
-                                                                                          [
-                                                                                            f
-                                                                                            a
-                                                                                          ]
-                                                                                          b
-                                                                                        ]
-                                                                                      )
-                                                                                    )
-                                                                                  ]
+                                                                                    (con integer)
+                                                                                  }
                                                                                   (lam
-                                                                                    a
+                                                                                    b
+                                                                                    (con integer)
+                                                                                    [
+                                                                                      [
+                                                                                        f
+                                                                                        (con
+                                                                                          integer
+                                                                                            0
+                                                                                        )
+                                                                                      ]
+                                                                                      b
+                                                                                    ]
+                                                                                  )
+                                                                                ]
+                                                                                (lam
+                                                                                  a
+                                                                                  (con integer)
+                                                                                  (lam
+                                                                                    b
                                                                                     (con integer)
                                                                                     [
                                                                                       [
                                                                                         f
                                                                                         a
                                                                                       ]
-                                                                                      (con
-                                                                                        integer
-                                                                                          0
-                                                                                      )
+                                                                                      b
                                                                                     ]
                                                                                   )
-                                                                                ]
+                                                                                )
                                                                               ]
-                                                                            ]
-                                                                            [
-                                                                              go
-                                                                              xs
+                                                                              (lam
+                                                                                a
+                                                                                (con integer)
+                                                                                [
+                                                                                  [
+                                                                                    f
+                                                                                    a
+                                                                                  ]
+                                                                                  (con
+                                                                                    integer
+                                                                                      0
+                                                                                  )
+                                                                                ]
+                                                                              )
                                                                             ]
                                                                           ]
-                                                                        )
-                                                                      )
-                                                                    ]
+                                                                        ]
+                                                                        [
+                                                                          go xs
+                                                                        ]
+                                                                      ]
+                                                                    )
                                                                   )
-                                                                )
+                                                                ]
                                                               )
-                                                            ]
-                                                            Unit
-                                                          ]
-                                                        )
-                                                      )
-                                                      [
-                                                        [
-                                                          {
-                                                            Cons
-                                                            [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                          }
-                                                          [
-                                                            [
-                                                              {
-                                                                {
-                                                                  Tuple2
-                                                                  (con bytestring)
-                                                                }
-                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
-                                                              }
-                                                              c
-                                                            ]
-                                                            [ go i ]
-                                                          ]
+                                                            )
+                                                          )
                                                         ]
-                                                        [ go xs ]
+                                                        Unit
                                                       ]
                                                     )
                                                   )
+                                                  [
+                                                    [
+                                                      {
+                                                        Cons
+                                                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                      }
+                                                      [
+                                                        [
+                                                          {
+                                                            {
+                                                              Tuple2
+                                                              (con bytestring)
+                                                            }
+                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]
+                                                          }
+                                                          c
+                                                        ]
+                                                        [ go i ]
+                                                      ]
+                                                    ]
+                                                    [ go xs ]
+                                                  ]
                                                 )
-                                              ]
+                                              )
                                             )
-                                          )
+                                          ]
                                         )
-                                      ]
-                                      Unit
-                                    ]
-                                  )
-                                )
-                                [ go [ [ unionVal ls ] rs ] ]
+                                      )
+                                    )
+                                  ]
+                                  Unit
+                                ]
                               )
                             )
+                            [ go [ [ unionVal ls ] rs ] ]
                           )
                         )
                       )
-                      (termbind
-                        (nonstrict)
+                    )
+                  )
+                  (termbind
+                    (nonstrict)
+                    (vardecl
+                      fMonoidValue_c
+                      (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]))
+                    )
+                    [ unionWith (builtin addInteger) ]
+                  )
+                  (let
+                    (rec)
+                    (datatypebind
+                      (datatype
+                        (tyvardecl Data (type))
+                        
+                        Data_match
+                        (vardecl B (fun (con bytestring) Data))
                         (vardecl
-                          fMonoidValue_c
-                          (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]))
+                          Constr (fun (con integer) (fun [List Data] Data))
                         )
-                        [ unionWith addInteger ]
+                        (vardecl I (fun (con integer) Data))
+                        (vardecl List (fun [List Data] Data))
+                        (vardecl Map (fun [List [[Tuple2 Data] Data]] Data))
+                      )
+                    )
+                    (let
+                      (nonrec)
+                      (datatypebind
+                        (datatype
+                          (tyvardecl Extended (fun (type) (type)))
+                          (tyvardecl a (type))
+                          Extended_match
+                          (vardecl Finite (fun a [Extended a]))
+                          (vardecl NegInf [Extended a])
+                          (vardecl PosInf [Extended a])
+                        )
+                      )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl LowerBound (fun (type) (type)))
+                          (tyvardecl a (type))
+                          LowerBound_match
+                          (vardecl
+                            LowerBound
+                            (fun [Extended a] (fun Bool [LowerBound a]))
+                          )
+                        )
+                      )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl UpperBound (fun (type) (type)))
+                          (tyvardecl a (type))
+                          UpperBound_match
+                          (vardecl
+                            UpperBound
+                            (fun [Extended a] (fun Bool [UpperBound a]))
+                          )
+                        )
+                      )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl Interval (fun (type) (type)))
+                          (tyvardecl a (type))
+                          Interval_match
+                          (vardecl
+                            Interval
+                            (fun [LowerBound a] (fun [UpperBound a] [Interval a]))
+                          )
+                        )
+                      )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl
+                            Tuple3 (fun (type) (fun (type) (fun (type) (type))))
+                          )
+                          (tyvardecl a (type))
+                          (tyvardecl b (type))
+                          (tyvardecl c (type))
+                          Tuple3_match
+                          (vardecl
+                            Tuple3 (fun a (fun b (fun c [[[Tuple3 a] b] c])))
+                          )
+                        )
+                      )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl Maybe (fun (type) (type)))
+                          (tyvardecl a (type))
+                          Maybe_match
+                          (vardecl Just (fun a [Maybe a]))
+                          (vardecl Nothing [Maybe a])
+                        )
+                      )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl TxOutRef (type))
+                          
+                          TxOutRef_match
+                          (vardecl
+                            TxOutRef
+                            (fun (con bytestring) (fun (con integer) TxOutRef))
+                          )
+                        )
+                      )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl TxInInfo (type))
+                          
+                          TxInInfo_match
+                          (vardecl
+                            TxInInfo
+                            (fun TxOutRef (fun [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] TxInInfo)))
+                          )
+                        )
+                      )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl Address (type))
+                          
+                          Address_match
+                          (vardecl PubKeyAddress (fun (con bytestring) Address))
+                          (vardecl ScriptAddress (fun (con bytestring) Address))
+                        )
+                      )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl TxOutType (type))
+                          
+                          TxOutType_match
+                          (vardecl PayToPubKey TxOutType)
+                          (vardecl PayToScript (fun (con bytestring) TxOutType))
+                        )
+                      )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl TxOut (type))
+                          
+                          TxOut_match
+                          (vardecl
+                            TxOut
+                            (fun Address (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun TxOutType TxOut)))
+                          )
+                        )
+                      )
+                      (datatypebind
+                        (datatype
+                          (tyvardecl TxInfo (type))
+                          
+                          TxInfo_match
+                          (vardecl
+                            TxInfo
+                            (fun [List TxInInfo] (fun [List TxOut] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] (fun [Interval (con integer)] (fun [List (con bytestring)] (fun [List (con bytestring)] (fun [List [[Tuple2 (con bytestring)] Data]] (fun (con bytestring) TxInfo)))))))))
+                          )
+                        )
                       )
                       (datatypebind
                         (datatype
@@ -2042,19 +2004,6 @@
                           (nonrec)
                           (termbind
                             (strict)
-                            (vardecl fAdditiveGroupValue (con integer))
-                            (con integer -1)
-                          )
-                          (termbind
-                            (strict)
-                            (vardecl
-                              multiplyInteger
-                              (fun (con integer) (fun (con integer) (con integer)))
-                            )
-                            (builtin multiplyInteger)
-                          )
-                          (termbind
-                            (strict)
                             (vardecl
                               fAdditiveGroupValue_cscale
                               (fun (con integer) (fun [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]))
@@ -2208,7 +2157,9 @@
                                                                                   ]
                                                                                   [
                                                                                     [
-                                                                                      multiplyInteger
+                                                                                      (builtin
+                                                                                        multiplyInteger
+                                                                                      )
                                                                                       i
                                                                                     ]
                                                                                     i
@@ -2316,11 +2267,11 @@
                                   w
                                   [Interval (con integer)]
                                   [
-                                    [ [ unionWith addInteger ] ww ]
+                                    [ [ unionWith (builtin addInteger) ] ww ]
                                     [
                                       [
                                         fAdditiveGroupValue_cscale
-                                        fAdditiveGroupValue
+                                        (con integer -1)
                                       ]
                                       [
                                         {
@@ -2389,89 +2340,64 @@
                                                                     (lam
                                                                       thunk
                                                                       Unit
-                                                                      (let
-                                                                        (nonrec)
-                                                                        (termbind
-                                                                          (strict
-                                                                          )
-                                                                          (vardecl
-                                                                            wild
-                                                                            Bool
-                                                                          )
-                                                                          in
-                                                                        )
-                                                                        [
-                                                                          {
-                                                                            [
-                                                                              {
-                                                                                UpperBound_match
-                                                                                (con integer)
-                                                                              }
-                                                                              h
-                                                                            ]
-                                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                          }
+                                                                      [
+                                                                        {
+                                                                          [
+                                                                            {
+                                                                              UpperBound_match
+                                                                              (con integer)
+                                                                            }
+                                                                            h
+                                                                          ]
+                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                        }
+                                                                        (lam
+                                                                          v
+                                                                          [Extended (con integer)]
                                                                           (lam
-                                                                            v
-                                                                            [Extended (con integer)]
-                                                                            (lam
-                                                                              in
-                                                                              Bool
+                                                                            in
+                                                                            Bool
+                                                                            [
                                                                               [
                                                                                 [
                                                                                   [
-                                                                                    [
-                                                                                      {
-                                                                                        [
-                                                                                          {
-                                                                                            Extended_match
-                                                                                            (con integer)
-                                                                                          }
-                                                                                          v
-                                                                                        ]
-                                                                                        (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
-                                                                                      }
-                                                                                      (lam
-                                                                                        default_arg0
-                                                                                        (con integer)
-                                                                                        (lam
-                                                                                          thunk
-                                                                                          Unit
-                                                                                          ww
-                                                                                        )
-                                                                                      )
-                                                                                    ]
+                                                                                    {
+                                                                                      [
+                                                                                        {
+                                                                                          Extended_match
+                                                                                          (con integer)
+                                                                                        }
+                                                                                        v
+                                                                                      ]
+                                                                                      (fun Unit [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]])
+                                                                                    }
                                                                                     (lam
-                                                                                      thunk
-                                                                                      Unit
-                                                                                      ww
+                                                                                      default_arg0
+                                                                                      (con integer)
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        ww
+                                                                                      )
                                                                                     )
                                                                                   ]
                                                                                   (lam
                                                                                     thunk
                                                                                     Unit
-                                                                                    (let
-                                                                                      (nonrec
-                                                                                      )
-                                                                                      (termbind
-                                                                                        (strict
-                                                                                        )
-                                                                                        (vardecl
-                                                                                          wild
-                                                                                          Bool
-                                                                                        )
-                                                                                        in
-                                                                                      )
-                                                                                      ww
-                                                                                    )
+                                                                                    ww
                                                                                   )
                                                                                 ]
-                                                                                Unit
+                                                                                (lam
+                                                                                  thunk
+                                                                                  Unit
+                                                                                  ww
+                                                                                )
                                                                               ]
-                                                                            )
+                                                                              Unit
+                                                                            ]
                                                                           )
-                                                                        ]
-                                                                      )
+                                                                        )
+                                                                      ]
                                                                     )
                                                                   ]
                                                                   (lam
@@ -2546,20 +2472,7 @@
                                                                                       (lam
                                                                                         thunk
                                                                                         Unit
-                                                                                        (let
-                                                                                          (nonrec
-                                                                                          )
-                                                                                          (termbind
-                                                                                            (strict
-                                                                                            )
-                                                                                            (vardecl
-                                                                                              wild
-                                                                                              Bool
-                                                                                            )
-                                                                                            in
-                                                                                          )
-                                                                                          ww
-                                                                                        )
+                                                                                        ww
                                                                                       )
                                                                                     ]
                                                                                     Unit
@@ -2649,18 +2562,7 @@
                                                                   (lam
                                                                     thunk
                                                                     Unit
-                                                                    (let
-                                                                      (nonrec)
-                                                                      (termbind
-                                                                        (strict)
-                                                                        (vardecl
-                                                                          wild
-                                                                          Bool
-                                                                        )
-                                                                        in
-                                                                      )
-                                                                      ww
-                                                                    )
+                                                                    ww
                                                                   )
                                                                 ]
                                                                 Unit
@@ -2997,245 +2899,230 @@
                                                             (lam
                                                               ds
                                                               (con integer)
-                                                              (let
-                                                                (nonrec)
-                                                                (termbind
-                                                                  (nonstrict)
-                                                                  (vardecl
-                                                                    wild TxInfo
-                                                                  )
+                                                              [
+                                                                {
+                                                                  [
+                                                                    TxInfo_match
+                                                                    ds
+                                                                  ]
+                                                                  Bool
+                                                                }
+                                                                (lam
                                                                   ds
-                                                                )
-                                                                [
-                                                                  {
-                                                                    [
-                                                                      TxInfo_match
-                                                                      ds
-                                                                    ]
-                                                                    Bool
-                                                                  }
+                                                                  [List TxInInfo]
                                                                   (lam
                                                                     ds
-                                                                    [List TxInInfo]
+                                                                    [List TxOut]
                                                                     (lam
                                                                       ds
-                                                                      [List TxOut]
+                                                                      [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                       (lam
                                                                         ds
                                                                         [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
                                                                         (lam
                                                                           ds
-                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                          [Interval (con integer)]
                                                                           (lam
                                                                             ds
-                                                                            [Interval (con integer)]
+                                                                            [List (con bytestring)]
                                                                             (lam
                                                                               ds
                                                                               [List (con bytestring)]
                                                                               (lam
                                                                                 ds
-                                                                                [List (con bytestring)]
+                                                                                [List [[Tuple2 (con bytestring)] Data]]
                                                                                 (lam
                                                                                   ds
-                                                                                  [List [[Tuple2 (con bytestring)] Data]]
-                                                                                  (lam
-                                                                                    ds
-                                                                                    (con bytestring)
+                                                                                  (con bytestring)
+                                                                                  [
                                                                                     [
                                                                                       [
-                                                                                        [
-                                                                                          {
+                                                                                        {
+                                                                                          [
+                                                                                            Bool_match
                                                                                             [
-                                                                                              Bool_match
                                                                                               [
                                                                                                 [
-                                                                                                  [
-                                                                                                    checkBinRel
-                                                                                                    greaterThanEqInteger
-                                                                                                  ]
-                                                                                                  [
-                                                                                                    [
-                                                                                                      [
-                                                                                                        {
-                                                                                                          {
-                                                                                                            foldr
-                                                                                                            [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                          }
-                                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                        }
-                                                                                                        fMonoidValue_c
-                                                                                                      ]
-                                                                                                      {
-                                                                                                        Nil
-                                                                                                        [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                      }
-                                                                                                    ]
-                                                                                                    [
-                                                                                                      [
-                                                                                                        {
-                                                                                                          {
-                                                                                                            map
-                                                                                                            [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
-                                                                                                          }
-                                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                        }
-                                                                                                        {
-                                                                                                          {
-                                                                                                            snd
-                                                                                                            (con bytestring)
-                                                                                                          }
-                                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                        }
-                                                                                                      ]
-                                                                                                      [
-                                                                                                        [
-                                                                                                          scriptOutputsAt
-                                                                                                          [
-                                                                                                            {
-                                                                                                              [
-                                                                                                                TxInInfo_match
-                                                                                                                [
-                                                                                                                  [
-                                                                                                                    {
-                                                                                                                      bad_name
-                                                                                                                      TxInInfo
-                                                                                                                    }
-                                                                                                                    ds
-                                                                                                                  ]
-                                                                                                                  ds
-                                                                                                                ]
-                                                                                                              ]
-                                                                                                              (con bytestring)
-                                                                                                            }
-                                                                                                            (lam
-                                                                                                              ds
-                                                                                                              TxOutRef
-                                                                                                              (lam
-                                                                                                                ds
-                                                                                                                [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
-                                                                                                                (lam
-                                                                                                                  ds
-                                                                                                                  [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
-                                                                                                                  [
-                                                                                                                    [
-                                                                                                                      [
-                                                                                                                        {
-                                                                                                                          [
-                                                                                                                            {
-                                                                                                                              Maybe_match
-                                                                                                                              [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
-                                                                                                                            }
-                                                                                                                            ds
-                                                                                                                          ]
-                                                                                                                          (fun Unit (con bytestring))
-                                                                                                                        }
-                                                                                                                        (lam
-                                                                                                                          witness
-                                                                                                                          [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
-                                                                                                                          (lam
-                                                                                                                            thunk
-                                                                                                                            Unit
-                                                                                                                            [
-                                                                                                                              {
-                                                                                                                                [
-                                                                                                                                  {
-                                                                                                                                    {
-                                                                                                                                      {
-                                                                                                                                        Tuple3_match
-                                                                                                                                        (con bytestring)
-                                                                                                                                      }
-                                                                                                                                      (con bytestring)
-                                                                                                                                    }
-                                                                                                                                    (con bytestring)
-                                                                                                                                  }
-                                                                                                                                  witness
-                                                                                                                                ]
-                                                                                                                                (con bytestring)
-                                                                                                                              }
-                                                                                                                              (lam
-                                                                                                                                vh
-                                                                                                                                (con bytestring)
-                                                                                                                                (lam
-                                                                                                                                  ds
-                                                                                                                                  (con bytestring)
-                                                                                                                                  (lam
-                                                                                                                                    ds
-                                                                                                                                    (con bytestring)
-                                                                                                                                    vh
-                                                                                                                                  )
-                                                                                                                                )
-                                                                                                                              )
-                                                                                                                            ]
-                                                                                                                          )
-                                                                                                                        )
-                                                                                                                      ]
-                                                                                                                      (lam
-                                                                                                                        thunk
-                                                                                                                        Unit
-                                                                                                                        [
-                                                                                                                          {
-                                                                                                                            [
-                                                                                                                              {
-                                                                                                                                {
-                                                                                                                                  {
-                                                                                                                                    Tuple3_match
-                                                                                                                                    (con bytestring)
-                                                                                                                                  }
-                                                                                                                                  (con bytestring)
-                                                                                                                                }
-                                                                                                                                (con bytestring)
-                                                                                                                              }
-                                                                                                                              [
-                                                                                                                                {
-                                                                                                                                  error
-                                                                                                                                  [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
-                                                                                                                                }
-                                                                                                                                Unit
-                                                                                                                              ]
-                                                                                                                            ]
-                                                                                                                            (con bytestring)
-                                                                                                                          }
-                                                                                                                          (lam
-                                                                                                                            vh
-                                                                                                                            (con bytestring)
-                                                                                                                            (lam
-                                                                                                                              ds
-                                                                                                                              (con bytestring)
-                                                                                                                              (lam
-                                                                                                                                ds
-                                                                                                                                (con bytestring)
-                                                                                                                                vh
-                                                                                                                              )
-                                                                                                                            )
-                                                                                                                          )
-                                                                                                                        ]
-                                                                                                                      )
-                                                                                                                    ]
-                                                                                                                    Unit
-                                                                                                                  ]
-                                                                                                                )
-                                                                                                              )
-                                                                                                            )
-                                                                                                          ]
-                                                                                                        ]
-                                                                                                        wild
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                  ]
+                                                                                                  checkBinRel
+                                                                                                  greaterThanEqInteger
                                                                                                 ]
                                                                                                 [
                                                                                                   [
                                                                                                     [
-                                                                                                      unionWith
-                                                                                                      addInteger
+                                                                                                      {
+                                                                                                        {
+                                                                                                          foldr
+                                                                                                          [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                        }
+                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                      }
+                                                                                                      fMonoidValue_c
+                                                                                                    ]
+                                                                                                    {
+                                                                                                      Nil
+                                                                                                      [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                    }
+                                                                                                  ]
+                                                                                                  [
+                                                                                                    [
+                                                                                                      {
+                                                                                                        {
+                                                                                                          map
+                                                                                                          [[Tuple2 (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]]
+                                                                                                        }
+                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                      }
+                                                                                                      {
+                                                                                                        {
+                                                                                                          snd
+                                                                                                          (con bytestring)
+                                                                                                        }
+                                                                                                        [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                      }
                                                                                                     ]
                                                                                                     [
                                                                                                       [
-                                                                                                        remainingFrom
-                                                                                                        ds
+                                                                                                        scriptOutputsAt
+                                                                                                        [
+                                                                                                          {
+                                                                                                            [
+                                                                                                              TxInInfo_match
+                                                                                                              [
+                                                                                                                [
+                                                                                                                  {
+                                                                                                                    bad_name
+                                                                                                                    TxInInfo
+                                                                                                                  }
+                                                                                                                  ds
+                                                                                                                ]
+                                                                                                                ds
+                                                                                                              ]
+                                                                                                            ]
+                                                                                                            (con bytestring)
+                                                                                                          }
+                                                                                                          (lam
+                                                                                                            ds
+                                                                                                            TxOutRef
+                                                                                                            (lam
+                                                                                                              ds
+                                                                                                              [Maybe [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]]
+                                                                                                              (lam
+                                                                                                                ds
+                                                                                                                [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] [[(lam k (type) (lam v (type) [List [[Tuple2 k] v]])) (con bytestring)] (con integer)]]
+                                                                                                                [
+                                                                                                                  [
+                                                                                                                    [
+                                                                                                                      {
+                                                                                                                        [
+                                                                                                                          {
+                                                                                                                            Maybe_match
+                                                                                                                            [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
+                                                                                                                          }
+                                                                                                                          ds
+                                                                                                                        ]
+                                                                                                                        (fun Unit (con bytestring))
+                                                                                                                      }
+                                                                                                                      (lam
+                                                                                                                        witness
+                                                                                                                        [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
+                                                                                                                        (lam
+                                                                                                                          thunk
+                                                                                                                          Unit
+                                                                                                                          [
+                                                                                                                            {
+                                                                                                                              [
+                                                                                                                                {
+                                                                                                                                  {
+                                                                                                                                    {
+                                                                                                                                      Tuple3_match
+                                                                                                                                      (con bytestring)
+                                                                                                                                    }
+                                                                                                                                    (con bytestring)
+                                                                                                                                  }
+                                                                                                                                  (con bytestring)
+                                                                                                                                }
+                                                                                                                                witness
+                                                                                                                              ]
+                                                                                                                              (con bytestring)
+                                                                                                                            }
+                                                                                                                            (lam
+                                                                                                                              vh
+                                                                                                                              (con bytestring)
+                                                                                                                              (lam
+                                                                                                                                ds
+                                                                                                                                (con bytestring)
+                                                                                                                                (lam
+                                                                                                                                  ds
+                                                                                                                                  (con bytestring)
+                                                                                                                                  vh
+                                                                                                                                )
+                                                                                                                              )
+                                                                                                                            )
+                                                                                                                          ]
+                                                                                                                        )
+                                                                                                                      )
+                                                                                                                    ]
+                                                                                                                    (lam
+                                                                                                                      thunk
+                                                                                                                      Unit
+                                                                                                                      [
+                                                                                                                        {
+                                                                                                                          [
+                                                                                                                            {
+                                                                                                                              {
+                                                                                                                                {
+                                                                                                                                  Tuple3_match
+                                                                                                                                  (con bytestring)
+                                                                                                                                }
+                                                                                                                                (con bytestring)
+                                                                                                                              }
+                                                                                                                              (con bytestring)
+                                                                                                                            }
+                                                                                                                            [
+                                                                                                                              {
+                                                                                                                                error
+                                                                                                                                [[[Tuple3 (con bytestring)] (con bytestring)] (con bytestring)]
+                                                                                                                              }
+                                                                                                                              Unit
+                                                                                                                            ]
+                                                                                                                          ]
+                                                                                                                          (con bytestring)
+                                                                                                                        }
+                                                                                                                        (lam
+                                                                                                                          vh
+                                                                                                                          (con bytestring)
+                                                                                                                          (lam
+                                                                                                                            ds
+                                                                                                                            (con bytestring)
+                                                                                                                            (lam
+                                                                                                                              ds
+                                                                                                                              (con bytestring)
+                                                                                                                              vh
+                                                                                                                            )
+                                                                                                                          )
+                                                                                                                        )
+                                                                                                                      ]
+                                                                                                                    )
+                                                                                                                  ]
+                                                                                                                  Unit
+                                                                                                                ]
+                                                                                                              )
+                                                                                                            )
+                                                                                                          )
+                                                                                                        ]
                                                                                                       ]
                                                                                                       ds
                                                                                                     ]
+                                                                                                  ]
+                                                                                                ]
+                                                                                              ]
+                                                                                              [
+                                                                                                [
+                                                                                                  [
+                                                                                                    unionWith
+                                                                                                    (builtin
+                                                                                                      addInteger
+                                                                                                    )
                                                                                                   ]
                                                                                                   [
                                                                                                     [
@@ -3245,67 +3132,74 @@
                                                                                                     ds
                                                                                                   ]
                                                                                                 ]
-                                                                                              ]
-                                                                                            ]
-                                                                                            (fun Unit Bool)
-                                                                                          }
-                                                                                          (lam
-                                                                                            thunk
-                                                                                            Unit
-                                                                                            [
-                                                                                              [
                                                                                                 [
-                                                                                                  {
-                                                                                                    [
-                                                                                                      {
-                                                                                                        Maybe_match
-                                                                                                        (con bytestring)
-                                                                                                      }
-                                                                                                      [
-                                                                                                        [
-                                                                                                          {
-                                                                                                            find
-                                                                                                            (con bytestring)
-                                                                                                          }
-                                                                                                          [
-                                                                                                            equalsByteString
-                                                                                                            ds
-                                                                                                          ]
-                                                                                                        ]
-                                                                                                        ds
-                                                                                                      ]
-                                                                                                    ]
-                                                                                                    (fun Unit Bool)
-                                                                                                  }
-                                                                                                  (lam
+                                                                                                  [
+                                                                                                    remainingFrom
                                                                                                     ds
-                                                                                                    (con bytestring)
-                                                                                                    (lam
-                                                                                                      thunk
-                                                                                                      Unit
-                                                                                                      True
-                                                                                                    )
-                                                                                                  )
+                                                                                                  ]
+                                                                                                  ds
                                                                                                 ]
-                                                                                                (lam
-                                                                                                  thunk
-                                                                                                  Unit
-                                                                                                  False
-                                                                                                )
                                                                                               ]
-                                                                                              Unit
                                                                                             ]
-                                                                                          )
-                                                                                        ]
+                                                                                          ]
+                                                                                          (fun Unit Bool)
+                                                                                        }
                                                                                         (lam
                                                                                           thunk
                                                                                           Unit
-                                                                                          False
+                                                                                          [
+                                                                                            [
+                                                                                              [
+                                                                                                {
+                                                                                                  [
+                                                                                                    {
+                                                                                                      Maybe_match
+                                                                                                      (con bytestring)
+                                                                                                    }
+                                                                                                    [
+                                                                                                      [
+                                                                                                        {
+                                                                                                          find
+                                                                                                          (con bytestring)
+                                                                                                        }
+                                                                                                        [
+                                                                                                          equalsByteString
+                                                                                                          ds
+                                                                                                        ]
+                                                                                                      ]
+                                                                                                      ds
+                                                                                                    ]
+                                                                                                  ]
+                                                                                                  (fun Unit Bool)
+                                                                                                }
+                                                                                                (lam
+                                                                                                  ds
+                                                                                                  (con bytestring)
+                                                                                                  (lam
+                                                                                                    thunk
+                                                                                                    Unit
+                                                                                                    True
+                                                                                                  )
+                                                                                                )
+                                                                                              ]
+                                                                                              (lam
+                                                                                                thunk
+                                                                                                Unit
+                                                                                                False
+                                                                                              )
+                                                                                            ]
+                                                                                            Unit
+                                                                                          ]
                                                                                         )
                                                                                       ]
-                                                                                      Unit
+                                                                                      (lam
+                                                                                        thunk
+                                                                                        Unit
+                                                                                        False
+                                                                                      )
                                                                                     ]
-                                                                                  )
+                                                                                    Unit
+                                                                                  ]
                                                                                 )
                                                                               )
                                                                             )
@@ -3314,8 +3208,8 @@
                                                                       )
                                                                     )
                                                                   )
-                                                                ]
-                                                              )
+                                                                )
+                                                              ]
                                                             )
                                                           )
                                                         ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -63,6 +63,8 @@ extra-deps:
 - random-strings-0.1.1.0@sha256:935a7a23dab45411960df77636a29b44ce42b89eeb15f2b1e809d771491fa677,2517
 - wl-pprint-1.2.1@sha256:aea676cff4a062d7d912149d270e33f5bb0c01b68a9db46ff13b438141ff4b7c
 - inline-r-0.10.3
+- witherable-0.3.5
+- witherable-class-0
 # Needs some patches, but upstream seems to be fairly dead (no activity in > 1 year)
 - git: https://github.com/shmish111/purescript-bridge.git
   commit: 28c37771ef30b0d751960c061ef95627f05d290e


### PR DESCRIPTION
(Comments from https://github.com/input-output-hk/plutus/pull/2197 and https://github.com/input-output-hk/plutus/pull/2286 addressed)

This finishes off the cleanup for the unnecessary builtin bindings that
the Plutus Tx compiler creates, by inlining them.

For now, we *only* inline very small simple terms. There are various
ways we could inline more, but we don't need it at the moment.

Fixes SCP-818.