### PR TITLE
SCP-1188 - Remove need for bigInt constructor and get TS to compile in JS tab

### DIFF
--- a/marlowe-playground-client/spago-packages.nix
+++ b/marlowe-playground-client/spago-packages.nix
@@ -17,6 +17,18 @@ let
         installPhase = "ln -s $src $out";
       };
 
+    "aff-promise" = pkgs.stdenv.mkDerivation {
+        name = "aff-promise";
+        version = "v2.1.0";
+        src = pkgs.fetchgit {
+          url = "https://github.com/nwolverson/purescript-aff-promise.git";
+          rev = "033d6b90252e0390b0de7845e21de919bc4c3a0e";
+          sha256 = "0khm53lvxgvc7fbsvcr2h2wlhcgay8vq45755f0w8vpk1441dvww";
+        };
+        phases = "installPhase";
+        installPhase = "ln -s $src $out";
+      };
+
     "affjax" = pkgs.stdenv.mkDerivation {
         name = "affjax";
         version = "v10.0.0";

--- a/marlowe-playground-client/spago.dhall
+++ b/marlowe-playground-client/spago.dhall
@@ -4,7 +4,8 @@ You can edit this file as you like.
 -}
 { name = "marlowe-playground-client"
 , dependencies =
-  [ "avar"
+  [ "aff-promise"
+  , "avar"
   , "concurrent-queues"
   , "console"
   , "coroutines"

--- a/marlowe-playground-client/src/Examples/JS/Contracts.purs
+++ b/marlowe-playground-client/src/Examples/JS/Contracts.purs
@@ -3,80 +3,80 @@ module Examples.JS.Contracts where
 escrow :: String
 escrow =
   """/* Parties */
-const alice = role("alice");
-const bob = role("bob");
-const carol = role("carol");
+const alice : Party = role("alice");
+const bob : Party = role("bob");
+const carol : Party = role("carol");
 
 /* Accounts */
-const alicesAccount = accountId(new bigInt(0), alice);
+const alicesAccount : AccountId = accountId(0, alice);
 
 /* Value under escrow */
-const price = constant(new bigInt(450));
+const price : SomeNumber = new bignumber.BigNumber(450);
 
 /* helper function to build Actions */
 
-const choiceName = "choice";
+const choiceName : string = "choice";
 
-const choiceIdBy = function (party) {
+const choiceIdBy = function (party : Party) : ChoiceId {
                        return choiceId(choiceName, party);
                    }
 
-const choiceBy = function(party, bounds) {
+const choiceBy = function(party : Party, bounds : [Bound]) : Action {
                       return choice(choiceIdBy(party), bounds);
                   };
 
 
-const choiceValueBy = function(party) {
+const choiceValueBy = function(party : Party) : Value {
                           return choiceValue(choiceIdBy(party));
                       };
 
 /* Names for choices */
 
-const pay    = [bound(new bigInt(0), new bigInt(0))];
-const refund = [bound(new bigInt(1), new bigInt(1))];
-const both   = [bound(new bigInt(0), new bigInt(1))];
+const pay : [Bound]    = [bound(0, 0)];
+const refund : [Bound] = [bound(1, 1)];
+const both : [Bound]   = [bound(0, 1)];
 
 /* Name choices according to person making choice and choice made */
 
-const alicePay    = choiceBy(alice, pay);
-const aliceRefund = choiceBy(alice, refund);
-const aliceChoice = choiceBy(alice, both);
+const alicePay : Action    = choiceBy(alice, pay);
+const aliceRefund : Action = choiceBy(alice, refund);
+const aliceChoice : Action = choiceBy(alice, both);
 
-const bobPay    = choiceBy(bob, pay);
-const bobRefund = choiceBy(bob, refund);
-const bobChoice = choiceBy(bob, both);
+const bobPay : Action    = choiceBy(bob, pay);
+const bobRefund : Action = choiceBy(bob, refund);
+const bobChoice : Action = choiceBy(bob, both);
 
-const carolPay    = choiceBy(carol, pay);
-const carolRefund = choiceBy(carol, refund);
-const carolChoice = choiceBy(carol, both);
+const carolPay : Action    = choiceBy(carol, pay);
+const carolRefund : Action = choiceBy(carol, refund);
+const carolChoice : Action = choiceBy(carol, both);
 
 /* the values chosen in choices */
 
-const aliceChosen = choiceValueBy(alice);
-const bobChosen = choiceValueBy(bob);
+const aliceChosen : Value = choiceValueBy(alice);
+const bobChosen : Value = choiceValueBy(bob);
 
 /* The contract to follow when Alice and Bob disagree, or if
    Carol has to intervene after a single choice from Alice or Bob. */
 
-const arbitrate = whenM([caseM(carolRefund, closeM),
-                         caseM(carolPay, payM(alicesAccount, bob, ada, price, closeM))],
-                        new bigInt(100), closeM);
+const arbitrate : Contract = whenM([caseM(carolRefund, closeM),
+                                    caseM(carolPay, payM(alicesAccount, bob, ada, price, closeM))],
+                                   100, closeM);
 
 /* The contract to follow when Alice and Bob have made the same choice. */
 
-const agreement = ifM(valueEQ(aliceChosen, constant(new bigInt(0))),
-                      payM(alicesAccount, bob, ada, price, closeM),
-                      closeM);
+const agreement : Contract = ifM(valueEQ(aliceChosen, 0),
+                                 payM(alicesAccount, bob, ada, price, closeM),
+                                 closeM);
 
 /* Inner part of contract */
 
-const inner = whenM([caseM(aliceChoice,
-                whenM([caseM(bobChoice,
-                             ifM(valueEQ(aliceChosen, bobChosen),
-                               agreement,
-                               arbitrate))],
-                      new bigInt(60), arbitrate))],
-                new bigInt(40), closeM);
+const inner : Contract = whenM([caseM(aliceChoice,
+                           whenM([caseM(bobChoice,
+                                        ifM(valueEQ(aliceChosen, bobChosen),
+                                          agreement,
+                                          arbitrate))],
+                                 60, arbitrate))],
+                           40, closeM);
 
 /* What does the vanilla contract look like?
   - if Alice and Bob choose
@@ -85,82 +85,82 @@ const inner = whenM([caseM(aliceChoice,
   - Carol also decides if timeout after one choice has been made;
   - refund if no choices are made. */
 
-const contract = whenM([caseM(deposit(alicesAccount, alice, ada, price), inner)],
-                       new bigInt(10),
-                       closeM)
+const contract : Contract = whenM([caseM(deposit(alicesAccount, alice, ada, price), inner)],
+                                  10,
+                                  closeM)
 
 contract
 """
 
 zeroCouponBond :: String
 zeroCouponBond =
-  """const investor = role("investor");
-const issuer = role("issuer");
+  """const investor : Party = role("investor");
+const issuer : Party = role("issuer");
 
-const investorAcc = accountId(new bigInt(0), investor);
+const investorAcc : AccountId = accountId(0, investor);
 
 whenM([caseM(
-        deposit(investorAcc, investor, ada, constant(new bigInt(850))),
-        payM(investorAcc, issuer, ada, constant(new bigInt(850)),
-             whenM([ caseM(deposit(investorAcc, issuer, ada, constant(new bigInt(1000))),
-                           payM(investorAcc, investor, ada, constant(new bigInt(1000)), closeM))
+        deposit(investorAcc, investor, ada, 850),
+        payM(investorAcc, issuer, ada, 850,
+             whenM([ caseM(deposit(investorAcc, issuer, ada, 1000),
+                           payM(investorAcc, investor, ada, 1000, closeM))
                    ],
-                   new bigInt(20),
+                   20,
                    closeM)
             ))],
-      new bigInt(10),
+      10,
       closeM);
 """
 
 couponBondGuaranteed :: String
 couponBondGuaranteed =
-  """const issuer = role("issuer");
-const guarantor = role("guarantor");
-const investor = role("investor");
-const investorAcc = accountId(new bigInt(0), investor);
+  """const issuer : Party = role("issuer");
+const guarantor : Party = role("guarantor");
+const investor : Party = role("investor");
+const investorAcc : AccountId = accountId(0, investor);
 
-whenM([caseM(deposit(investorAcc, guarantor, ada, constant(new bigInt(1030))),
-        (whenM([caseM(deposit(investorAcc, investor, ada, constant(new bigInt(1000))),
-                payM(investorAcc, issuer, ada, constant(new bigInt(1000)),
-                    (whenM([caseM(deposit( investorAcc, issuer, ada, constant(new bigInt(10))),
-                            payM(investorAcc, investor, ada, constant(new bigInt(10)),
-                                payM(investorAcc, guarantor, ada, constant(new bigInt(10)),
-                                    (whenM([caseM(deposit(investorAcc, issuer, ada, constant(new bigInt(10))),
-                                            payM(investorAcc, investor, ada, constant(new bigInt(10)),
-                                                payM(investorAcc, guarantor, ada, constant(new bigInt(10)),
-                                                    (whenM([caseM(deposit(investorAcc, issuer, ada, constant(new bigInt(1010))),
-                                                            payM(investorAcc, investor, ada, constant(new bigInt(1010)),
-                                                                payM(investorAcc, guarantor, ada, constant(new bigInt(1010)), closeM)
-                                                            ))], new bigInt(20), closeM)
+whenM([caseM(deposit(investorAcc, guarantor, ada, 1030),
+        (whenM([caseM(deposit(investorAcc, investor, ada, 1000),
+                payM(investorAcc, issuer, ada, 1000,
+                    (whenM([caseM(deposit( investorAcc, issuer, ada, 10),
+                            payM(investorAcc, investor, ada, 10,
+                                payM(investorAcc, guarantor, ada, 10,
+                                    (whenM([caseM(deposit(investorAcc, issuer, ada, 10),
+                                            payM(investorAcc, investor, ada, 10,
+                                                payM(investorAcc, guarantor, ada, 10,
+                                                    (whenM([caseM(deposit(investorAcc, issuer, ada, 1010),
+                                                            payM(investorAcc, investor, ada, 1010,
+                                                                payM(investorAcc, guarantor, ada, 1010, closeM)
+                                                            ))], 20, closeM)
                                                     )
                                                 )
-                                            ))], new bigInt(15), closeM)
+                                            ))], 15, closeM)
                                     )
                                 )
-                            ))], new bigInt(10), closeM)
+                            ))], 10, closeM)
                     )
-                ))], new bigInt(5), closeM)
-        ))], new bigInt(5), closeM)
+                ))], 5, closeM)
+        ))], 5, closeM)
 """
 
 swap :: String
 swap =
-  """const party1 = role("party1");
-const party2 = role("party2");
-const gracePeriod = new bigInt(5);
-const date1 = new bigInt(20);
-const acc1 = accountId(new bigInt(1), party1);
-const acc2 = accountId(new bigInt(2), party2);
+  """const party1 : Party = role("party1");
+const party2 : Party = role("party2");
+const gracePeriod : SomeNumber = new bignumber.BigNumber(5);
+const date1 : SomeNumber = new bignumber.BigNumber(20);
+const acc1 : AccountId = accountId(1, party1);
+const acc2 : AccountId = accountId(2, party2);
 
-const contract = whenM([ caseM(deposit(acc1, party1, ada, constant(new bigInt(500))),
-                           /* when 1st party committed, wait for 2nd */
-                           whenM([caseM(deposit(acc2, party2, ada, constant(new bigInt(300))),
-                                       payM(acc1, party2, ada, constant(new bigInt(500)),
-                                           payM(acc2, party1, ada, constant(new bigInt(300)), closeM)))
-                               ], date1,
-                           /* if a party dosn't commit, simply Close to the owner */
-                           closeM))
-                       ], date1.minus(gracePeriod), closeM);
+const contract : Contract = whenM([ caseM(deposit(acc1, party1, ada, 500),
+                                      /* when 1st party committed, wait for 2nd */
+                                      whenM([caseM(deposit(acc2, party2, ada, 300),
+                                                  payM(acc1, party2, ada, 500,
+                                                      payM(acc2, party1, ada, 300, closeM)))
+                                          ], date1,
+                                      /* if a party dosn't commit, simply Close to the owner */
+                                      closeM))
+                                  ], date1.minus(gracePeriod), closeM);
 
 contract
 """

--- a/marlowe-playground-client/src/Halogen/Monaco.purs
+++ b/marlowe-playground-client/src/Halogen/Monaco.purs
@@ -67,6 +67,7 @@ type State
 data Query a
   = SetText String a
   | GetText (String -> a)
+  | GetModel (Monaco.ITextModel -> a)
   | SetPosition IPosition a
   | Resize a
   | SetTheme String a
@@ -185,6 +186,11 @@ handleQuery (GetText f) = do
     let
       s = Monaco.getValue model
     pure $ f s
+
+handleQuery (GetModel f) = do
+  withEditor \editor -> do
+    m <- liftEffect $ Monaco.getModel editor
+    pure $ f m
 
 handleQuery (SetPosition position next) = do
   withEditor \editor -> do

--- a/marlowe-playground-client/src/Language/Javascript/Interpreter.js
+++ b/marlowe-playground-client/src/Language/Javascript/Interpreter.js
@@ -2,19 +2,30 @@
 'use strict';
 const safeEval = require('notevil')
 
-exports.eval_ = async function (left, right, javascript) {
+exports.eval_ = function (left, right, model) {
   // include any libraries etc we want by providing a context. be careful!
   // here we can pass in our library for constructing contracts
+  var monaco = global.monaco;
   var context = require('src/Language/Javascript/MarloweJS.ts');
   context['bignumber'] = require('bignumber');
-  try {
-    var slices = javascript.split(/^.*\/\* === Code above this comment will be removed at compile time === \*\/$/gm);
-    var takeSlice = 0;
-    if (slices.length > 1) { takeSlice = 1 };
-    var justCode = slices.slice(takeSlice).join('');
-    let res = safeEval(justCode, context);
-    return right(JSON.stringify(res));
-  } catch (error) {
-    return (left(error.toString()));
-  }
+  return monaco.languages.typescript.getTypeScriptWorker()
+          .then(function(worker) {
+              return (worker(model.uri)
+                  .then(function(proxy) {
+                      return proxy.getEmitOutput(model.uri.toString())
+                                    .then((r) => {
+                        var javascript = r.outputFiles[0].text;
+                        try {
+                          var slices = javascript.split(/^.*\/\* === Code above this comment will be removed at compile time === \*\/$/gm);
+                          var takeSlice = 0;
+                          if (slices.length > 1) { takeSlice = 1 };
+                          var justCode = slices.slice(takeSlice).join('');
+                          let res = safeEval(justCode, context);
+                          return right(JSON.stringify(res));
+                        } catch (error) {
+                          return left(error.toString());
+                        }
+                    });
+                }));
+          })
 }

--- a/marlowe-playground-client/src/Language/Javascript/Interpreter.js
+++ b/marlowe-playground-client/src/Language/Javascript/Interpreter.js
@@ -2,13 +2,16 @@
 'use strict';
 const safeEval = require('notevil')
 
-exports.eval_ = function (left, right, javascript) {
+exports.eval_ = async function (left, right, javascript) {
   // include any libraries etc we want by providing a context. be careful!
   // here we can pass in our library for constructing contracts
   var context = require('src/Language/Javascript/MarloweJS.ts');
   context['bignumber'] = require('bignumber');
   try {
-    var justCode = javascript.split(/^.*\/\* === Code above this comment will be removed at compile time === \*\/$/gm).slice(1).join('');
+    var slices = javascript.split(/^.*\/\* === Code above this comment will be removed at compile time === \*\/$/gm);
+    var takeSlice = 0;
+    if (slices.length > 1) { takeSlice = 1 };
+    var justCode = slices.slice(takeSlice).join('');
     let res = safeEval(justCode, context);
     return right(JSON.stringify(res));
   } catch (error) {

--- a/marlowe-playground-client/src/Language/Javascript/Interpreter.js
+++ b/marlowe-playground-client/src/Language/Javascript/Interpreter.js
@@ -7,7 +7,7 @@ exports.eval_ = function (left, right, model) {
   // here we can pass in our library for constructing contracts
   var monaco = global.monaco;
   var context = require('src/Language/Javascript/MarloweJS.ts');
-  context['bignumber'] = require('bignumber');
+  context['bignumber'] = require('bignumber.js');
   return monaco.languages.typescript.getTypeScriptWorker()
           .then(function(worker) {
               return (worker(model.uri)

--- a/marlowe-playground-client/src/Language/Javascript/Interpreter.purs
+++ b/marlowe-playground-client/src/Language/Javascript/Interpreter.purs
@@ -1,9 +1,12 @@
 module Language.Javascript.Interpreter where
 
 import Prelude
+
 import Control.Monad.Except (runExcept)
+import Control.Promise (Promise, toAffE)
 import Data.Either (Either(..))
-import Data.Function.Uncurried (Fn3, runFn3)
+import Effect.Aff (Aff)
+import Effect.Uncurried (EffectFn3, runEffectFn3)
 import Foreign.Generic (decodeJSON)
 import Marlowe.Semantics (Contract)
 
@@ -25,11 +28,12 @@ newtype InterpreterResult a
   , result :: a
   }
 
-foreign import eval_ :: forall a b. Fn3 (String -> Either a b) (String -> Either a b) String (Either a b)
+foreign import eval_ :: forall a b. EffectFn3 (String -> Either a b) (String -> Either a b) String (Promise (Either a b))
 
-eval :: String -> Either CompilationError (InterpreterResult Contract)
-eval js = case runFn3 eval_ Left Right js of
-  Left err -> Left (RawError err)
-  Right result -> case runExcept (decodeJSON result) of
-    Left err -> Left (RawError (show err))
-    Right contract -> Right (InterpreterResult { warnings: [], result: contract })
+eval :: String -> Aff (Either CompilationError (InterpreterResult Contract))
+eval js = do res <- toAffE (runEffectFn3 eval_ Left Right js)
+             pure (case res of
+                     Left err -> Left (RawError err)
+                     Right result -> case runExcept (decodeJSON result) of
+                       Left err -> Left (RawError (show err))
+                       Right contract -> Right (InterpreterResult { warnings: [], result: contract }))

--- a/marlowe-playground-client/src/Language/Javascript/Interpreter.purs
+++ b/marlowe-playground-client/src/Language/Javascript/Interpreter.purs
@@ -1,7 +1,6 @@
 module Language.Javascript.Interpreter where
 
 import Prelude
-
 import Control.Monad.Except (runExcept)
 import Control.Promise (Promise, toAffE)
 import Data.Either (Either(..))
@@ -9,6 +8,7 @@ import Effect.Aff (Aff)
 import Effect.Uncurried (EffectFn3, runEffectFn3)
 import Foreign.Generic (decodeJSON)
 import Marlowe.Semantics (Contract)
+import Monaco (ITextModel)
 
 data CompilationError
   = RawError String
@@ -28,12 +28,15 @@ newtype InterpreterResult a
   , result :: a
   }
 
-foreign import eval_ :: forall a b. EffectFn3 (String -> Either a b) (String -> Either a b) String (Promise (Either a b))
+foreign import eval_ :: forall a b. EffectFn3 (String -> Either a b) (String -> Either a b) ITextModel (Promise (Either a b))
 
-eval :: String -> Aff (Either CompilationError (InterpreterResult Contract))
-eval js = do res <- toAffE (runEffectFn3 eval_ Left Right js)
-             pure (case res of
-                     Left err -> Left (RawError err)
-                     Right result -> case runExcept (decodeJSON result) of
-                       Left err -> Left (RawError (show err))
-                       Right contract -> Right (InterpreterResult { warnings: [], result: contract }))
+eval :: ITextModel -> Aff (Either CompilationError (InterpreterResult Contract))
+eval model = do
+  res <- toAffE (runEffectFn3 eval_ Left Right model)
+  pure
+    ( case res of
+        Left err -> Left (RawError err)
+        Right result -> case runExcept (decodeJSON result) of
+          Left err -> Left (RawError (show err))
+          Right contract -> Right (InterpreterResult { warnings: [], result: contract })
+    )

--- a/marlowe-playground-client/src/Language/Javascript/MarloweJS.ts
+++ b/marlowe-playground-client/src/Language/Javascript/MarloweJS.ts
@@ -1,7 +1,19 @@
-import bignumber = require("bignumber")
+import bignumber = require("bignumber.js")
 
 type Party = { "pk_hash" : string }
            | { "role_token" : string };
+
+type SomeNumber = bignumber.BigNumber | number | string;
+
+function coerceNumber(n : SomeNumber) : bignumber.BigNumber {
+    if (typeof(n) == 'string') {
+        return new bignumber.BigNumber(n);
+    } else if (typeof(n) == 'number') {
+        return new bignumber.BigNumber(n);
+    } else {
+        return n;
+    }
+}
 
 export const pk =
     function (pubKey : string) : Party {
@@ -22,8 +34,8 @@ type AccountId = { "account_number" : string,
                    "account_owner" : Party };
 
 export const accountId =
-    function (accountNumber : bignumber.BigNumber, accountOwner : Party) : AccountId {
-        return { "account_number": accountNumber.toString(),
+    function (accountNumber : SomeNumber, accountOwner : Party) : AccountId {
+        return { "account_number": coerceNumber(accountNumber).toString(),
                  "account_owner": accountOwner };
     };
 
@@ -81,6 +93,18 @@ type Value = { "amount_of_token": Token,
              , "then": Value
              , "else": Value };
 
+type EValue = SomeNumber | Value;
+
+function coerceValue(val : EValue) : Value {
+    if (typeof(val) == "number") {
+        return constant(new bignumber.BigNumber(val));
+    } else if (bignumber.BigNumber.isBigNumber(val)) {
+        return constant(val);
+    } else {
+        return val;
+    }
+}
+
 export const availableMoney =
     function (token : Token, accountId : AccountId) : Value {
         return { "amount_of_token": token,
@@ -88,41 +112,42 @@ export const availableMoney =
     };
 
 export const constant =
-    function (number : bignumber.BigNumber) : Value {
-        return number.toString();
+    function (number : SomeNumber) : Value {
+        return coerceNumber(number).toString();
     };
 
 export const negValue =
-    function (value : Value) : Value {
-        return { "negate": value };
+    function (value : EValue) : Value {
+        return { "negate": coerceValue(value) };
     };
 
 export const addValue =
-    function (lhs : Value, rhs : Value) : Value {
-        return { "add": lhs,
-                 "and": rhs };
+    function (lhs : EValue, rhs : EValue) : Value {
+        return { "add": coerceValue(lhs),
+                 "and": coerceValue(rhs) };
     };
 
 export const subValue =
-    function (lhs : Value, rhs : Value) : Value {
-        return { "value": lhs,
-                 "minus": rhs };
+    function (lhs : EValue, rhs : EValue) : Value {
+        return { "value": coerceValue(lhs),
+                 "minus": coerceValue(rhs) };
     };
 
 export const mulValue =
-    function (lhs : Value, rhs : Value) : Value {
-        return { "multiply": lhs,
-                 "times": rhs };
+    function (lhs : EValue, rhs : EValue) : Value {
+        return { "multiply": coerceValue(lhs),
+                 "times": coerceValue(rhs) };
     };
 
 export const scale =
-    function (num : bignumber.BigNumber, den : bignumber.BigNumber, val : Value) : Value {
-        if (den.leq(bignumber.zero)) {
+    function (num : SomeNumber, den : SomeNumber, val : EValue) : Value {
+        var cden = coerceNumber(den);
+        if (cden <= (new bignumber.BigNumber(0))) {
             throw(new Error("Denominator in scale must be strictly positve"));
         } else {
-            return { "multiply": val,
-                    "times": num.toString(),
-                    "divide_by": den.toString() };
+            return { "multiply": coerceValue(val),
+                    "times": coerceNumber(num).toString(),
+                    "divide_by": cden.toString() };
         }
     };
 
@@ -141,10 +166,10 @@ export const useValue =
     };
 
 export const cond =
-    function (obs : Observation, contThen : Value, contElse : Value) : Value {
+    function (obs : Observation, contThen : EValue, contElse : EValue) : Value {
         return { "if": obs,
-                 "then": contThen,
-                 "else": contElse }
+                 "then": coerceValue(contThen),
+                 "else": coerceValue(contElse) }
     };
 
 type Observation = { "both": Observation,
@@ -188,33 +213,33 @@ export const choseSomething =
     };
 
 export const valueGE =
-    function (lhs : Value, rhs : Value) : Observation {
-        return { "value": lhs,
-                 "ge_than": rhs };
+    function (lhs : EValue, rhs : EValue) : Observation {
+        return { "value": coerceValue(lhs),
+                 "ge_than": coerceValue(rhs) };
     };
 
 export const valueGT =
-    function (lhs : Value, rhs : Value) : Observation {
-        return { "value": lhs,
-                 "gt": rhs };
+    function (lhs : EValue, rhs : EValue) : Observation {
+        return { "value": coerceValue(lhs),
+                 "gt": coerceValue(rhs) };
     };
 
 export const valueLT =
-    function (lhs : Value, rhs : Value) : Observation {
-        return { "value": lhs,
-                 "lt": rhs };
+    function (lhs : EValue, rhs : EValue) : Observation {
+        return { "value": coerceValue(lhs),
+                 "lt": coerceValue(rhs) };
     };
 
 export const valueLE =
-    function (lhs : Value, rhs : Value) : Observation {
-        return { "value": lhs,
-                 "le_than": rhs };
+    function (lhs : EValue, rhs : EValue) : Observation {
+        return { "value": coerceValue(lhs),
+                 "le_than": coerceValue(rhs) };
     };
 
 export const valueEQ =
-    function (lhs : Value, rhs : Value) : Observation {
-        return { "value": lhs,
-                 "equal_to": rhs };
+    function (lhs : EValue, rhs : EValue) : Observation {
+        return { "value": coerceValue(lhs),
+                 "equal_to": coerceValue(rhs) };
     };
 
 export const trueObs : Observation = true;
@@ -225,9 +250,9 @@ type Bound = { "from": String,
                "to": String };
 
 export const bound =
-    function (boundMin : bignumber.BigNumber, boundMax : bignumber.BigNumber) : Bound {
-        return { "from": boundMin.toString(),
-                 "to": boundMax.toString() };
+    function (boundMin : SomeNumber, boundMax : SomeNumber) : Bound {
+        return { "from": coerceNumber(boundMin).toString(),
+                 "to": coerceNumber(boundMax).toString() };
     };
 
 type Action = { "party": Party,
@@ -239,9 +264,9 @@ type Action = { "party": Party,
             | { "notify_if": Observation };
 
 export const deposit =
-    function (accId : AccountId, party : Party, token : Token, value : Value) : Action {
+    function (accId : AccountId, party : Party, token : Token, value : EValue) : Action {
         return { "party": party,
-                 "deposits": value,
+                 "deposits": coerceValue(value),
                  "of_token": token,
                  "into_account": accId };
     };
@@ -291,8 +316,8 @@ export const closeM : Contract = "close";
 
 export const payM =
     function (accId : AccountId, payee : Payee, token : Token,
-              value : Value, continuation : Contract) : Contract {
-        return { "pay": value,
+              value : EValue, continuation : Contract) : Contract {
+        return { "pay": coerceValue(value),
                  "token": token,
                  "from_account": accId,
                  "to": payee,
@@ -307,9 +332,9 @@ export const ifM =
     };
 
 export const whenM =
-    function (cases : Case[], timeout : bignumber.BigNumber, timeoutCont : Contract) : Contract {
+    function (cases : Case[], timeout : SomeNumber, timeoutCont : Contract) : Contract {
         return { "when": cases,
-                 "timeout": timeout.toString(),
+                 "timeout": coerceNumber(timeout).toString(),
                  "timeout_continuation": timeoutCont };
     };
 

--- a/marlowe-playground-client/src/MainFrame.purs
+++ b/marlowe-playground-client/src/MainFrame.purs
@@ -41,7 +41,6 @@ import JSEditor as JSEditor
 import Language.Haskell.Interpreter (_InterpreterResult)
 import Language.Haskell.Monaco as HM
 import Language.Javascript.Interpreter as JSI
-import Language.Javascript.Interpreter as JSInterpreter
 import LocalStorage as LocalStorage
 import Marlowe (SPParams_)
 import Marlowe as Server
@@ -244,7 +243,8 @@ handleAction _ CompileJSProgram = do
         $ affEventSource
             ( \emitter -> do
                 delay (Milliseconds 10.0) -- Small pause to allow UI to redraw
-                emit emitter (CompiledJSProgram (JSInterpreter.eval contents))
+                res <- JSI.eval contents
+                emit emitter (CompiledJSProgram res)
                 pure mempty
             )
       pure unit

--- a/marlowe-playground-client/src/Monaco.js
+++ b/marlowe-playground-client/src/Monaco.js
@@ -56,7 +56,7 @@ exports.onDidChangeContent_ = function (editor, handler) {
 
 exports.addExtraLibsJS_ = function (monaco) {
   monaco.languages.typescript.typescriptDefaults.addExtraLib(
-    require('!!raw-loader!../node_modules/bignumber.js/bignumber.d.ts').default, 'inmemory://model/bignumber.d.ts'
+    require('!!raw-loader!../node_modules/bignumber.js/bignumber.d.ts').default, 'inmemory://model/bignumber.js.d.ts'
   );
   monaco.languages.typescript.typescriptDefaults.addExtraLib(
     require('!!raw-loader!src/Language/Javascript/MarloweJS.ts').default, "inmemory://model/marlowe-js.d.ts"

--- a/marlowe-playground-client/src/StaticData.purs
+++ b/marlowe-playground-client/src/StaticData.purs
@@ -35,12 +35,14 @@ demoFiles =
 
 addHeader :: Contents -> Contents
 addHeader c =
-  """import { BigNumber as bigInt } from 'bignumber';
+  """import * as bignumber from 'bignumber.js';
 import { role, accountId, choiceId, token, ada, valueId, availableMoney, constant, 
          negValue, addValue, subValue, mulValue, scale, choiceValue, slotIntervalStart, 
          slotIntervalEnd, useValue, cond, andObs, orObs, notObs, choseSomething, valueGE, 
          valueGT, valueLT, valueLE, valueEQ, trueObs, falseObs, bound, deposit, choice, 
-         notify, caseM, closeM, payM, ifM, whenM, letM, assertM } from 'marlowe-js';
+         notify, caseM, closeM, payM, ifM, whenM, letM, assertM, Party, SomeNumber,
+         AccountId, ChoiceId, Token, ValueId, Value, EValue, Observation, Bound, Action,
+         Payee, Case, Contract } from 'marlowe-js';
 
 /* === Code above this comment will be removed at compile time === */
 


### PR DESCRIPTION
- Modify JS evaluation process so that it uses Monaco editor's `TS -> JS` transpilation.
- Overload API to support `(string | number | bignumber.BigNumber)`, which I have called `SomeNumber`, and removes the need to use the `BigNumber` constructor for small numbers (or if using a string).
- Overload API to support `SomeNumber | Value` which I have called `EValue`, and removes the need to use the `constant` constructor.
- Add API types to JS import.
- Add type annotations to JS examples (now TS examples), to illustrate how to take advantage of TypeScript.
- Fix evaluation process so that it doesn't crash in the absence of the `/*  === Code above this comment  ...` comment.
- Fix some issues with transition from BigInt to BigNumber.