### PR TITLE
plutus-ledger: use de-bruijn indices for Scripts

### DIFF
--- a/nix/stack.materialized/plutus-core.nix
+++ b/nix/stack.materialized/plutus-core.nix
@@ -167,6 +167,7 @@
           "Language/UntypedPlutusCore/Core/Instance/Pretty/Readable"
           "Language/UntypedPlutusCore/Core/Instance/CBOR"
           "Language/UntypedPlutusCore/Core/Type"
+          "Language/UntypedPlutusCore/Core/Plated"
           "Language/UntypedPlutusCore/Size"
           "Language/UntypedPlutusCore/Subst"
           "Data/Aeson/THReader"

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -200,6 +200,7 @@ library
         Language.UntypedPlutusCore.Core.Instance.Pretty.Readable
         Language.UntypedPlutusCore.Core.Instance.CBOR
         Language.UntypedPlutusCore.Core.Type
+        Language.UntypedPlutusCore.Core.Plated
         Language.UntypedPlutusCore.Size
         Language.UntypedPlutusCore.Subst
 

--- a/plutus-core/src/Language/PlutusCore/CBOR.hs
+++ b/plutus-core/src/Language/PlutusCore/CBOR.hs
@@ -273,8 +273,8 @@ instance Serialise Special
 deriving newtype instance Serialise Index
 
 instance Serialise DeBruijn where
-    encode (DeBruijn txt i) = encode txt <> encode i
-    decode = DeBruijn <$> decode <*> decode
+    encode (DeBruijn i) = encode i
+    decode = DeBruijn <$> decode
 
 instance Serialise TyDeBruijn where
     encode (TyDeBruijn n) = encode n

--- a/plutus-core/src/Language/PlutusCore/Core/Type.hs
+++ b/plutus-core/src/Language/PlutusCore/Core/Type.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}

--- a/plutus-core/test/Spec.hs
+++ b/plutus-core/test/Spec.hs
@@ -127,7 +127,7 @@ propDeBruijn gen = property . generalizeT $ do
     let
         forward = deBruijnTerm
         backward
-            :: Except FreeVariableError (Term TyDeBruijn DeBruijn DefaultUni a)
+            :: Except FreeVariableError (Term NamedTyDeBruijn NamedDeBruijn DefaultUni a)
             -> Except FreeVariableError (Term TyName Name DefaultUni a)
         backward e = e >>= (\t -> runQuoteT $ unDeBruijnTerm t)
     Hedgehog.tripping body forward backward

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore.hs
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore.hs
@@ -5,6 +5,7 @@ module Language.UntypedPlutusCore
 
 import           Language.UntypedPlutusCore.Core               as Export
 import           Language.UntypedPlutusCore.Size               as Export
+import           Language.UntypedPlutusCore.Subst              as Export
 -- Also has some functions
 import           Language.UntypedPlutusCore.Core.Instance.CBOR as Export
 

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core.hs
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core.hs
@@ -3,4 +3,5 @@ module Language.UntypedPlutusCore.Core
     ) where
 
 import           Language.UntypedPlutusCore.Core.Instance ()
+import           Language.UntypedPlutusCore.Core.Plated   as Export
 import           Language.UntypedPlutusCore.Core.Type     as Export

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core/Instance/CBOR.hs
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core/Instance/CBOR.hs
@@ -9,7 +9,6 @@ module Language.UntypedPlutusCore.Core.Instance.CBOR where
 import           Language.UntypedPlutusCore.Core.Type
 
 import           Language.PlutusCore.CBOR
-import           Language.PlutusCore.Name
 import           Language.PlutusCore.Universe
 
 import           Codec.Serialise
@@ -99,16 +98,16 @@ we provide a wrapper class with an instance which performs the
 coercions for us.  This is used in `Ledger.Scripts.Script` to
 derive a suitable instance of `Serialise` for scripts. -}
 
-newtype OmitUnitAnnotations uni  = OmitUnitAnnotations { restoreUnitAnnotations :: Program Name uni () }
-    deriving Serialise via Program Name uni InvisibleUnit
+newtype OmitUnitAnnotations name uni  = OmitUnitAnnotations { restoreUnitAnnotations :: Program name uni () }
+    deriving Serialise via Program name uni InvisibleUnit
 
 {-| Convenience functions for serialisation/deserialisation without units -}
-serialiseOmittingUnits :: (Closed uni, uni `Everywhere` Serialise) => Program Name uni () -> BSL.ByteString
+serialiseOmittingUnits :: (Closed uni, Serialise name, uni `Everywhere` Serialise) => Program name uni () -> BSL.ByteString
 serialiseOmittingUnits = serialise . OmitUnitAnnotations
 
-deserialiseRestoringUnits :: (Closed uni, uni `Everywhere` Serialise) => BSL.ByteString -> Program Name uni ()
+deserialiseRestoringUnits :: (Closed uni, Serialise name, uni `Everywhere` Serialise) => BSL.ByteString -> Program name uni ()
 deserialiseRestoringUnits = restoreUnitAnnotations <$> deserialise
 
-deserialiseRestoringUnitsOrFail :: (Closed uni, uni `Everywhere` Serialise) =>
-                        BSL.ByteString -> Either DeserialiseFailure (Program Name uni ())
+deserialiseRestoringUnitsOrFail :: (Closed uni, Serialise name, uni `Everywhere` Serialise) =>
+                        BSL.ByteString -> Either DeserialiseFailure (Program name uni ())
 deserialiseRestoringUnitsOrFail bs = restoreUnitAnnotations <$> deserialiseOrFail bs

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core/Plated.hs
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core/Plated.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Language.UntypedPlutusCore.Core.Plated
+    ( termBinds
+    , termVars
+    , termUniques
+    , termSubterms
+    , termSubtermsDeep
+    , termUniquesDeep
+    ) where
+
+import           Language.PlutusCore.Core             (HasUniques)
+import           Language.PlutusCore.Name
+import           Language.UntypedPlutusCore.Core.Type
+
+import           Control.Lens
+
+-- | Get all the direct child 'name a's of the given 'Term' from 'LamAbs'es.
+termBinds :: Traversal' (Term name uni ann) name
+termBinds f = \case
+    LamAbs ann n t -> f n <&> \n' -> LamAbs ann n' t
+    x -> pure x
+
+-- | Get all the direct child 'name a's of the given 'Term' from 'Var's.
+termVars :: Traversal' (Term name uni ann) name
+termVars f = \case
+    Var ann n -> Var ann <$> f n
+    x -> pure x
+
+-- | Get all the direct child 'Unique's of the given 'Term'.
+termUniques :: HasUniques (Term name uni ann) => Traversal' (Term name uni ann) Unique
+termUniques f = \case
+    LamAbs ann n t -> theUnique f n <&> \n' -> LamAbs ann n' t
+    Var ann n -> theUnique f n <&> Var ann
+    x -> pure x
+
+{-# INLINE termSubterms #-}
+-- | Get all the direct child 'Term's of the given 'Term'.
+termSubterms :: Traversal' (Term name uni ann) (Term name uni ann)
+termSubterms f = \case
+    LamAbs ann n t -> LamAbs ann n <$> f t
+    Apply ann t1 t2 -> Apply ann <$> f t1 <*> f t2
+    Delay ann t -> Delay ann <$> f t
+    Force ann t -> Force ann <$> f t
+    e@Error {} -> pure e
+    v@Var {} -> pure v
+    c@Constant {} -> pure c
+    b@Builtin {} -> pure b
+
+-- | Get all the transitive child 'Term's of the given 'Term'.
+termSubtermsDeep :: Fold (Term name uni ann) (Term name uni ann)
+termSubtermsDeep = cosmosOf termSubterms
+
+-- | Get all the transitive child 'Unique's of the given 'Term'.
+termUniquesDeep :: HasUniques (Term name uni ann) => Fold (Term name uni ann) Unique
+termUniquesDeep = termSubtermsDeep . termUniques

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core/Type.hs
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core/Type.hs
@@ -23,6 +23,7 @@ import qualified Language.PlutusCore.Constant                       as TPLC
 import qualified Language.PlutusCore.Core                           as TPLC
 import           Language.PlutusCore.Evaluation.Machine.ExBudgeting
 import           Language.PlutusCore.Evaluation.Machine.ExMemory
+import qualified Language.PlutusCore.Name                           as TPLC
 import           Language.PlutusCore.Universe
 
 -- | The type of Untyped Plutus Core terms. Mirrors the type of Typed Plutus Core terms except
@@ -63,6 +64,11 @@ instance TPLC.AsConstant (Term name uni ann) where
 
 instance TPLC.FromConstant (Term name uni ()) where
     fromConstant = Constant ()
+
+type instance TPLC.HasUniques (Term name uni ann)
+    = TPLC.HasUnique name TPLC.TermUnique
+type instance TPLC.HasUniques (Program name uni ann) = TPLC.HasUniques
+    (Term name uni ann)
 
 instance ToExMemory (Term name uni ()) where
     toExMemory _ = 0

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/DeBruijn.hs
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/DeBruijn.hs
@@ -7,12 +7,13 @@
 module Language.UntypedPlutusCore.DeBruijn
     ( Index (..)
     , DeBruijn (..)
-    , TyDeBruijn (..)
+    , NamedDeBruijn (..)
     , FreeVariableError (..)
     , deBruijnTerm
     , deBruijnProgram
     , unDeBruijnTerm
     , unDeBruijnProgram
+    , unNameDeBruijn
     ) where
 
 import           Language.PlutusCore.DeBruijn.Internal
@@ -33,19 +34,19 @@ This module is just a boring port of the typed version.
 -- | Convert a 'Term' with 'TyName's and 'Name's into a 'Term' with 'TyDeBruijn's and 'DeBruijn's.
 deBruijnTerm
     :: MonadError FreeVariableError m
-    => Term Name uni ann -> m (Term DeBruijn uni ann)
+    => Term Name uni ann -> m (Term NamedDeBruijn uni ann)
 deBruijnTerm = flip runReaderT (Levels 0 BM.empty) . deBruijnTermM
 
 -- | Convert a 'Program' with 'TyName's and 'Name's into a 'Program' with 'TyDeBruijn's and 'DeBruijn's.
 deBruijnProgram
     :: MonadError FreeVariableError m
-    => Program Name uni ann -> m (Program DeBruijn uni ann)
+    => Program Name uni ann -> m (Program NamedDeBruijn uni ann)
 deBruijnProgram (Program ann ver term) = Program ann ver <$> deBruijnTerm term
 
 deBruijnTermM
     :: (MonadReader Levels m, MonadError FreeVariableError m)
     => Term Name uni ann
-    -> m (Term DeBruijn uni ann)
+    -> m (Term NamedDeBruijn uni ann)
 deBruijnTermM = \case
     -- variable case
     Var ann n -> Var ann <$> nameToDeBruijn n
@@ -65,18 +66,18 @@ deBruijnTermM = \case
 -- | Convert a 'Term' with 'TyDeBruijn's and 'DeBruijn's into a 'Term' with 'TyName's and 'Name's.
 unDeBruijnTerm
     :: (MonadQuote m, MonadError FreeVariableError m)
-    => Term DeBruijn uni ann -> m (Term Name uni ann)
+    => Term NamedDeBruijn uni ann -> m (Term Name uni ann)
 unDeBruijnTerm = flip runReaderT (Levels 0 BM.empty) . unDeBruijnTermM
 
 -- | Convert a 'Program' with 'TyDeBruijn's and 'DeBruijn's into a 'Program' with 'TyName's and 'Name's.
 unDeBruijnProgram
     :: (MonadQuote m, MonadError FreeVariableError m)
-    => Program DeBruijn uni ann -> m (Program Name uni ann)
+    => Program NamedDeBruijn uni ann -> m (Program Name uni ann)
 unDeBruijnProgram (Program ann ver term) = Program ann ver <$> unDeBruijnTerm term
 
 unDeBruijnTermM
     :: (MonadReader Levels m, MonadQuote m, MonadError FreeVariableError m)
-    => Term DeBruijn uni ann
+    => Term NamedDeBruijn uni ann
     -> m (Term Name uni ann)
 unDeBruijnTermM = \case
     -- variable case

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Subst.hs
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Subst.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Language.UntypedPlutusCore.Subst
-    ( termSubstFreeNamesA
+    ( substVarA
+    , substVar
+    , termSubstNamesM
+    , termSubstNames
+    , termSubstFreeNamesA
     , termSubstFreeNames
+    , termMapNames
     ) where
 
 import           PlutusPrelude
@@ -14,6 +21,37 @@ import           Data.Set                        as Set
 
 purely :: ((a -> Identity b) -> c -> Identity d) -> (a -> b) -> c -> d
 purely = coerce
+
+-- | Applicatively replace a variable using the given function.
+substVarA
+    :: Applicative f
+    => (name -> f (Maybe (Term name uni ann)))
+    -> Term name uni ann
+    -> f (Term name uni ann)
+substVarA nameF t@(Var _ name) = fromMaybe t <$> nameF name
+substVarA _     t              = pure t
+
+-- | Replace a variable using the given function.
+substVar
+    :: (name -> Maybe (Term name uni ann))
+    -> Term name uni ann
+    -> Term name uni ann
+substVar = purely substVarA
+
+-- | Naively monadically substitute names using the given function (i.e. do not substitute binders).
+termSubstNamesM
+    :: Monad m
+    => (name -> m (Maybe (Term name uni ann)))
+    -> Term name uni ann
+    -> m (Term name uni ann)
+termSubstNamesM = transformMOf termSubterms . substVarA
+
+-- | Naively substitute names using the given function (i.e. do not substitute binders).
+termSubstNames
+    :: (name -> Maybe (Term name uni ann))
+    -> Term name uni ann
+    -> Term name uni ann
+termSubstNames = purely termSubstNamesM
 
 -- | Applicatively substitute *free* names using the given function.
 termSubstFreeNamesA
@@ -41,3 +79,25 @@ termSubstFreeNames
     -> Term name uni ann
     -> Term name uni ann
 termSubstFreeNames = purely termSubstFreeNamesA
+
+-- | Completely replace the names with a new name type.
+termMapNames
+    :: forall name name' uni ann
+    . (name -> name')
+    -> Term name uni ann
+    -> Term name' uni ann
+termMapNames f = go
+    where
+        -- This is all a bit clunky because of the type-changing, I'm not sure of a nicer way to do it
+        go :: Term name uni ann -> Term name' uni ann
+        go = \case
+            LamAbs ann name body -> LamAbs ann (f name) (go body)
+            Var ann name -> Var ann (f name)
+
+            Apply ann t1 t2 -> Apply ann (go t1) (go t2)
+            Delay ann t -> Delay ann (go t)
+            Force ann t -> Force ann (go t)
+
+            Constant ann c -> Constant ann c
+            Builtin ann b -> Builtin ann b
+            Error ann -> Error ann

--- a/plutus-metatheory/src/Main.lagda
+++ b/plutus-metatheory/src/Main.lagda
@@ -1,7 +1,7 @@
 \begin{code}
 module Main where
 open import Agda.Builtin.IO
-import IO.Primitive as IO using (return;_>>=_) 
+import IO.Primitive as IO using (return;_>>=_)
 open import Agda.Builtin.Unit
 open import Agda.Builtin.String
 open import Function
@@ -135,11 +135,11 @@ postulate
 {-# COMPILE GHC deBruijnifyTy = either (\_ -> Nothing) Just . runExcept . deBruijnTy #-}
 {-# FOREIGN GHC import Language.PlutusCore #-}
 {-# COMPILE GHC ProgramN = type Language.PlutusCore.Program TyName Name DefaultUni Language.PlutusCore.Lexer.AlexPosn #-}
-{-# COMPILE GHC Program = type Language.PlutusCore.Program TyDeBruijn DeBruijn DefaultUni Language.PlutusCore.Lexer.AlexPosn #-}
+{-# COMPILE GHC Program = type Language.PlutusCore.Program NamedTyDeBruijn NamedDeBruijn DefaultUni Language.PlutusCore.Lexer.AlexPosn #-}
 {-# COMPILE GHC TermN = type Language.PlutusCore.Term TyName Name DefaultUni Language.PlutusCore.Lexer.AlexPosn #-}
-{-# COMPILE GHC Term = type Language.PlutusCore.Term TyDeBruijn DeBruijn DefaultUni Language.PlutusCore.Lexer.AlexPosn #-}
+{-# COMPILE GHC Term = type Language.PlutusCore.Term NamedTyDeBruijn NamedDeBruijn DefaultUni Language.PlutusCore.Lexer.AlexPosn #-}
 {-# COMPILE GHC TypeN = type Language.PlutusCore.Type TyName DefaultUni Language.PlutusCore.Lexer.AlexPosn #-}
-{-# COMPILE GHC Type = type Language.PlutusCore.Type TyDeBruijn DefaultUni Language.PlutusCore.Lexer.AlexPosn #-}
+{-# COMPILE GHC Type = type Language.PlutusCore.Type NamedTyDeBruijn DefaultUni Language.PlutusCore.Lexer.AlexPosn #-}
 {-# COMPILE GHC showTerm = T.pack . show #-}
 
 postulate

--- a/plutus-metatheory/src/Raw.hs
+++ b/plutus-metatheory/src/Raw.hs
@@ -51,21 +51,21 @@ data RTerm = RVar Integer
 unIndex :: Index -> Integer
 unIndex (Index n) = naturalToInteger n
 
-convP :: Program TyDeBruijn DeBruijn DefaultUni a -> RTerm
+convP :: Program NamedTyDeBruijn NamedDeBruijn DefaultUni a -> RTerm
 convP (Program _ _ t) = conv t
 
 convK :: Kind a -> RKind
 convK (Type _)            = RKiStar
 convK (KindArrow _ _K _J) = RKiFun (convK _K) (convK _J)
 
-convT :: Type TyDeBruijn DefaultUni a -> RType
-convT (TyVar _ (TyDeBruijn x)) = RTyVar (unIndex (dbnIndex x))
-convT (TyFun _ _A _B)          = RTyFun (convT _A) (convT _B)
-convT (TyForall _ _ _K _A)     = RTyPi (convK _K) (convT _A)
-convT (TyLam _ _ _K _A)        = RTyLambda (convK _K) (convT _A)
-convT (TyApp _ _A _B)          = RTyApp (convT _A) (convT _B)
-convT (TyBuiltin _ b)          = RTyCon b
-convT (TyIFix _ a b)           = RTyMu (convT a) (convT b)
+convT :: Type NamedTyDeBruijn DefaultUni a -> RType
+convT (TyVar _ (NamedTyDeBruijn x)) = RTyVar (unIndex (ndbnIndex x))
+convT (TyFun _ _A _B)               = RTyFun (convT _A) (convT _B)
+convT (TyForall _ _ _K _A)          = RTyPi (convK _K) (convT _A)
+convT (TyLam _ _ _K _A)             = RTyLambda (convK _K) (convT _A)
+convT (TyApp _ _A _B)               = RTyApp (convT _A) (convT _B)
+convT (TyBuiltin _ b)               = RTyCon b
+convT (TyIFix _ a b)                = RTyMu (convT a) (convT b)
 
 convC :: Some (ValueOf DefaultUni) -> RConstant
 convC (Some (ValueOf DefaultUniInteger    i)) = RConInt i
@@ -75,8 +75,8 @@ convC (Some (ValueOf DefaultUniChar       c)) = RConChar c
 convC (Some (ValueOf DefaultUniUnit       u)) = RConUnit
 convC (Some (ValueOf DefaultUniBool       b)) = RConBool b
 
-conv :: Term TyDeBruijn DeBruijn DefaultUni a -> RTerm
-conv (Var _ x)                         = RVar (unIndex (dbnIndex x))
+conv :: Term NamedTyDeBruijn NamedDeBruijn DefaultUni a -> RTerm
+conv (Var _ x)                         = RVar (unIndex (ndbnIndex x))
 conv (TyAbs _ _ _K t)                  = RTLambda (convK _K) (conv t)
 conv (TyInst _ t _A)                   = RTApp (conv t) (convT _A)
 conv (LamAbs _ _ _A t)                 = RLambda (convT _A) (conv t)
@@ -92,21 +92,21 @@ unconvK :: RKind -> Kind ()
 unconvK RKiStar        = Type ()
 unconvK (RKiFun _K _J) = KindArrow () (unconvK _K) (unconvK _J)
 
-varTm :: Int -> DeBruijn
-varTm i = DeBruijn (T.pack [tmnames !! i]) (Index (naturalFromInteger 0))
+varTm :: Int -> NamedDeBruijn
+varTm i = NamedDeBruijn (T.pack [tmnames !! i]) (Index (naturalFromInteger 0))
 
-varTy :: Int -> DeBruijn
-varTy i = DeBruijn (T.pack [tynames !! i]) (Index (naturalFromInteger 0))
+varTy :: Int -> NamedDeBruijn
+varTy i = NamedDeBruijn (T.pack [tynames !! i]) (Index (naturalFromInteger 0))
 
 -- this should take a level and render levels as names
-unconvT :: Int -> RType -> Type TyDeBruijn DefaultUni ()
+unconvT :: Int -> RType -> Type NamedTyDeBruijn DefaultUni ()
 unconvT i (RTyVar x)        =
   --TyVar () (TyDeBruijn (DeBruijn (T.pack (show (i,x))) (Index (naturalFromInteger x))))
-  TyVar () (TyDeBruijn (DeBruijn (T.pack [tynames !! (i - fromIntegral x)]) (Index (naturalFromInteger x))))
+  TyVar () (NamedTyDeBruijn (NamedDeBruijn (T.pack [tynames !! (i - fromIntegral x)]) (Index (naturalFromInteger x))))
 unconvT i (RTyFun t u)      = TyFun () (unconvT i t) (unconvT i u)
 unconvT i (RTyPi k t)       =
-  TyForall () (TyDeBruijn (varTy (i+1))) (unconvK k) (unconvT (i+1) t)
-unconvT i (RTyLambda k t) = TyLam () (TyDeBruijn (varTy (i+1))) (unconvK k) (unconvT (i+1) t)
+  TyForall () (NamedTyDeBruijn (varTy (i+1))) (unconvK k) (unconvT (i+1) t)
+unconvT i (RTyLambda k t) = TyLam () (NamedTyDeBruijn (varTy (i+1))) (unconvK k) (unconvT (i+1) t)
 unconvT i (RTyApp t u)      = TyApp () (unconvT i t) (unconvT i u)
 unconvT i (RTyCon c)        = TyBuiltin () c
 unconvT i (RTyMu t u)       = TyIFix () (unconvT i t) (unconvT i u)
@@ -124,10 +124,10 @@ tmnames = ['a' .. 'z']
 tynames = ['A' .. 'Z']
 
 
-unconv :: Int -> Int -> RTerm -> Term TyDeBruijn DeBruijn DefaultUni ()
+unconv :: Int -> Int -> RTerm -> Term NamedTyDeBruijn NamedDeBruijn DefaultUni ()
 unconv tyi tmi (RVar x)          =
-  Var () (DeBruijn (T.pack [tmnames !! (tmi - fromIntegral x)]) (Index (naturalFromInteger x)))
-unconv tyi tmi (RTLambda k tm)   = TyAbs () (TyDeBruijn (varTy (tyi+1))) (unconvK k) (unconv (tyi+1) tmi tm)
+  Var () (NamedDeBruijn (T.pack [tmnames !! (tmi - fromIntegral x)]) (Index (naturalFromInteger x)))
+unconv tyi tmi (RTLambda k tm)   = TyAbs () (NamedTyDeBruijn (varTy (tyi+1))) (unconvK k) (unconv (tyi+1) tmi tm)
 unconv tyi tmi (RTApp t ty)      = TyInst () (unconv tyi tmi t) (unconvT tyi ty)
 unconv tyi tmi (RLambda ty tm)   = LamAbs () (varTm (tmi+1)) (unconvT tyi ty) (unconv tyi (tmi+1) tm)
 unconv tyi tmi (RApp t u)        = Apply () (unconv tyi tmi t) (unconv tyi tmi u)
@@ -154,4 +154,3 @@ data Error = TypeError
            | ParseError
            | ScopeError
            | GasError
-

--- a/plutus-playground-server/usecases/Crowdfunding.hs
+++ b/plutus-playground-server/usecases/Crowdfunding.hs
@@ -133,7 +133,7 @@ validCollection campaign txinfo =
 
 -- | The validator script is of type 'CrowdfundingValidator', and is
 -- additionally parameterized by a 'Campaign' definition. This argument is
--- provided by the Plutus client, using 'Ledger.applyScript'.
+-- provided by the Plutus client, using 'PlutusTx.applyCode'.
 -- As a result, the 'Campaign' definition is part of the script address,
 -- and different campaigns have different addresses.
 mkValidator :: Campaign -> PubKeyHash -> CampaignAction -> ValidatorCtx -> Bool

--- a/plutus-tx-plugin/src/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Plugin.hs
@@ -285,7 +285,7 @@ compileCoreExpr (opts, famEnvs) locStr codeTy origE = do
                 pure $ GHC.mkRuntimeErrorApp GHC.rUNTIME_ERROR_ID (GHC.mkTyConApp tc args) shown
             -- this will actually terminate compilation
             else failCompilation shown
-        Right (pirP, _, uplcP) -> do
+        Right (pirP, uplcP) -> do
             bsLitPir <- makeByteStringLiteral $ BSL.toStrict $ serialise pirP
             bsLitPlc <- makeByteStringLiteral $ BSL.toStrict $ serialise uplcP
 
@@ -301,7 +301,7 @@ runCompiler
     :: forall uni m . (uni ~ PLC.DefaultUni, MonadReader (CompileContext uni) m, MonadState CompileState m, MonadQuote m, MonadError (CompileError uni) m, MonadIO m)
     => PluginOptions
     -> GHC.CoreExpr
-    -> m (PIRProgram uni, PLCProgram uni, UPLCProgram uni)
+    -> m (PIRProgram uni, UPLCProgram uni)
 runCompiler opts expr = do
     -- trick here to take out the concrete plc.error
     tcConfigConcrete <-
@@ -336,4 +336,4 @@ runCompiler opts expr = do
         liftEither $ first (view (re PIR._PLCError) . fmap PIR.Original) tcConcrete
 
     let uplcP = UPLC.eraseProgram plcP
-    pure (pirP, plcP, uplcP)
+    pure (pirP, uplcP)

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Crowdfunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Crowdfunding.hs
@@ -166,7 +166,7 @@ validCollection campaign txinfo =
 {-# INLINABLE mkValidator #-}
 -- | The validator script is of type 'CrowdfundingValidator', and is
 -- additionally parameterized by a 'Campaign' definition. This argument is
--- provided by the Plutus client, using 'Ledger.applyScript'.
+-- provided by the Plutus client, using 'PlutusTx.applyCode'.
 -- As a result, the 'Campaign' definition is part of the script address,
 -- and different campaigns have different addresses. The Campaign{..} syntax
 -- means that all fields of the 'Campaign' value are in scope

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -21,25 +21,25 @@ Events by wallet:
     - Iteration: 3
     Requests:
         4: {utxo-at:
-            ScriptAddress: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b}
+            ScriptAddress: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f}
       Response:
         ( 4
         , {utxo-at:
-           Utxo at ScriptAddress: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b =
-             0b20b7d5bf4512968943e7898434e702ba36cfe44a0c80e125fcdbde3a4f4fbb!1: PayToScript: 8c59e0540881f0f43935378d9e1c5c151b08b7f62c793ba558fb999401a01632 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-             53d05b3a0c9b6577f88719d75e8466b6d54b03c804d85949850bd372425e04f5!1: PayToScript: ef3f3ec8292df1c7a004a6d8cdbb94350781b4b3409cdbb0dbaba7b91ef2cdb3 Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}
-             e8429ee6ad83a77b455f9080513f706d3845cfdb605d9eb28156359f773e9005!1: PayToScript: a1014bfb71fbe7c7d3a12e00f6d1b8c2905a50d94a46d7e7dd6c9099dac70856 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}} )
+           Utxo at ScriptAddress: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f =
+             569709facb23e4afd3c653fd18632ab44a27d43f6a589f74f4ed533b935c4c01!1: PayToScript: a1014bfb71fbe7c7d3a12e00f6d1b8c2905a50d94a46d7e7dd6c9099dac70856 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+             8b935df104f76276f9a86fe60d92f88e3ce664bc4732a24dda9b854e81a180bf!1: PayToScript: ef3f3ec8292df1c7a004a6d8cdbb94350781b4b3409cdbb0dbaba7b91ef2cdb3 Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}
+             9255f7cc47c6d8b7f6f93e05e829ff016a0d4a1068741a45245e935f6a8b2fc3!1: PayToScript: 8c59e0540881f0f43935378d9e1c5c151b08b7f62c793ba558fb999401a01632 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}} )
     - Iteration: 4
     Requests:
         5: {tx:
             Tx:
-              Tx eeb53b69b991c9cda5eb4eee97523e74631260e6e8f545435ccdb5d60f0a3619:
+              Tx 2f3f698a15530a13deb996903ebebf4929bbb46457c7339c4f57959109f707f5:
                 {inputs:
-                   - 0b20b7d5bf4512968943e7898434e702ba36cfe44a0c80e125fcdbde3a4f4fbb!1
+                   - 569709facb23e4afd3c653fd18632ab44a27d43f6a589f74f4ed533b935c4c01!1
                      Redeemer: <>
-                   - 53d05b3a0c9b6577f88719d75e8466b6d54b03c804d85949850bd372425e04f5!1
+                   - 8b935df104f76276f9a86fe60d92f88e3ce664bc4732a24dda9b854e81a180bf!1
                      Redeemer: <>
-                   - e8429ee6ad83a77b455f9080513f706d3845cfdb605d9eb28156359f773e9005!1
+                   - 9255f7cc47c6d8b7f6f93e05e829ff016a0d4a1068741a45245e935f6a8b2fc3!1
                      Redeemer: <>
                 outputs:
                 forge: Value {getValue = Map {unMap = []}}
@@ -52,7 +52,7 @@ Events by wallet:
       Response:
         ( 5
         , {tx:
-           WriteTxSuccess: ab911d52513587c1e5b49dfee32732bad393ce6396ab73654207a4b181f4fc4a} )
+           WriteTxSuccess: bcb6ba3db33679793e80c2b4231724d4056c66398d59e2fcb4b2ed22c006c013} )
   Events for W2:
     - Iteration: 1
     Requests:
@@ -78,11 +78,11 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx af8f429166ae36f4df5cea55ffa0fb28c59c8b09f211b7ad5753e571d53b054b:
+              Tx 2a70c95afa4e1a0d5581a6dcd70d89dbeb2549c7eb1057e4a7e84cf7bc8524ed:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-                    ScriptAddress: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+                    ScriptAddress: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
@@ -94,7 +94,7 @@ Events by wallet:
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: e8429ee6ad83a77b455f9080513f706d3845cfdb605d9eb28156359f773e9005} )
+           WriteTxSuccess: 569709facb23e4afd3c653fd18632ab44a27d43f6a589f74f4ed533b935c4c01} )
   Events for W3:
     - Iteration: 1
     Requests:
@@ -120,11 +120,11 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx dc37efb0ba0bfb4147d3999c47e02cfb8a2be0ab51baa594ec1f54a12112f5f8:
+              Tx 1f619276cf5520a036c040ec24fe4e9917b81613152fcfe4aed15d21e6402a3d:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-                    ScriptAddress: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+                    ScriptAddress: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
@@ -136,7 +136,7 @@ Events by wallet:
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: 0b20b7d5bf4512968943e7898434e702ba36cfe44a0c80e125fcdbde3a4f4fbb} )
+           WriteTxSuccess: 9255f7cc47c6d8b7f6f93e05e829ff016a0d4a1068741a45245e935f6a8b2fc3} )
   Events for W4:
     - Iteration: 1
     Requests:
@@ -162,11 +162,11 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx dbc12bbc0448dbfb0a52ff93463a4a712a12eb87043dcd35cc16be2971954036:
+              Tx 29553a6dd936e1e6e15bab1b4e1df977a21831470cd3c1d3f31c5ed3cfa69af4:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} addressed to
-                    ScriptAddress: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+                    ScriptAddress: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
@@ -178,7 +178,7 @@ Events by wallet:
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: 53d05b3a0c9b6577f88719d75e8466b6d54b03c804d85949850bd372425e04f5} )
+           WriteTxSuccess: 8b935df104f76276f9a86fe60d92f88e3ce664bc4732a24dda9b854e81a180bf} )
 Contract result by wallet:
     Wallet: W1
       Done

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       e8429ee6ad83a77b455f9080513f706d3845cfdb605d9eb28156359f773e9005
+TxId:       569709facb23e4afd3c653fd18632ab44a27d43f6a589f74f4ed533b935c4c01
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5840c765f29357e0906f5e68c14ad0a7a828d09b...
+              Signature: 5840f391853028eacca7a2e21a9a8943a7985624...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
   Value:
     Ada:      Lovelace:  10
 
@@ -170,16 +170,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       0b20b7d5bf4512968943e7898434e702ba36cfe44a0c80e125fcdbde3a4f4fbb
+TxId:       9255f7cc47c6d8b7f6f93e05e829ff016a0d4a1068741a45245e935f6a8b2fc3
 Fee:        -
 Forge:      -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 58401aa4cd31e7163725c1377424c38f3b03e4ce...
+              Signature: 584099adb5c9db058d103038dcec6b102dc6fbb9...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
   Value:
     Ada:      Lovelace:  10
 
@@ -244,16 +244,16 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
   Value:
     Ada:      Lovelace:  20
 
 ==== Slot #3, Tx #0 ====
-TxId:       53d05b3a0c9b6577f88719d75e8466b6d54b03c804d85949850bd372425e04f5
+TxId:       8b935df104f76276f9a86fe60d92f88e3ce664bc4732a24dda9b854e81a180bf
 Fee:        -
 Forge:      -
 Signatures  PubKey: f81fb54a825fced95eb033afcd64314075abfb0a...
-              Signature: 58405ca4531573cfb9ee9f1a42db94e6dfdba767...
+              Signature: 584043793c9ff3b48fbbb8264d26387c11423816...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
@@ -272,7 +272,7 @@ Outputs:
     Ada:      Lovelace:  9999
   
   ---- Output 1 ----
-  Destination:  Script: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
   Value:
     Ada:      Lovelace:  1
 
@@ -318,43 +318,43 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9999
   
-  Script: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
   Value:
     Ada:      Lovelace:  21
 
 ==== Slot #20, Tx #0 ====
-TxId:       ab911d52513587c1e5b49dfee32732bad393ce6396ab73654207a4b181f4fc4a
+TxId:       bcb6ba3db33679793e80c2b4231724d4056c66398d59e2fcb4b2ed22c006c013
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840aed85cc361b9956034765c049f198ffd71fa...
+              Signature: 584062d372862854e7388b900ee51674b5bc64e5...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     0b20b7d5bf4512968943e7898434e702ba36cfe44a0c80e125fcdbde3a4f4fbb
+    Tx:     569709facb23e4afd3c653fd18632ab44a27d43f6a589f74f4ed533b935c4c01
     Output #1
-    Script: 0100000303026466697831182903030305010267...
+    Script: 0100000303020003030305010200020002000303...
   
   ---- Input 1 ----
-  Destination:  Script: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
   Value:
     Ada:      Lovelace:  1
   Source:
-    Tx:     53d05b3a0c9b6577f88719d75e8466b6d54b03c804d85949850bd372425e04f5
+    Tx:     8b935df104f76276f9a86fe60d92f88e3ce664bc4732a24dda9b854e81a180bf
     Output #1
-    Script: 0100000303026466697831182903030305010267...
+    Script: 0100000303020003030305010200020002000303...
   
   ---- Input 2 ----
-  Destination:  Script: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     e8429ee6ad83a77b455f9080513f706d3845cfdb605d9eb28156359f773e9005
+    Tx:     9255f7cc47c6d8b7f6f93e05e829ff016a0d4a1068741a45245e935f6a8b2fc3
     Output #1
-    Script: 0100000303026466697831182903030305010267...
+    Script: 0100000303020003030305010200020002000303...
 
 
 Outputs:
@@ -405,6 +405,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  9999
   
-  Script: 5ffcc2ffa524eaf990bf8a46b738ccd8008a083be40aebc2b694e796141b991b
+  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       5fe3619636ed9d021aa97ddad8b514380b14f1aba9d5a0de5b5e74f1e0d4b10e
+TxId:       9d08870d29e4fde8f4d61d1388996e193c52c6bf043a126dd580969495df4033
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 584054acb8cf02bd59f53480ec5f776640539876...
+              Signature: 5840f413c5869fd4719cd2ba42da661ae46aae47...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: fec788f28d901e2aaefb8bb55bef113323047083ba3df652674fa5844a7f317f
+  Destination:  Script: c5925b540defe5b4db30d245e69c52f91369d4e4b35c838a1f1cb9c04bacb49a
   Value:
     Ada:      Lovelace:  10
 
@@ -170,25 +170,25 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: fec788f28d901e2aaefb8bb55bef113323047083ba3df652674fa5844a7f317f
+  Script: c5925b540defe5b4db30d245e69c52f91369d4e4b35c838a1f1cb9c04bacb49a
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       599c0b047e79a07706ea39fef73a1d0df7ad1f2e6d984cc59949fc6e890982d9
+TxId:       e4bd1e6bd77a6b5816cc6b0f4e2af330e94cbf7c1d441f672315a6cd078229d8
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 584078c9ce0bff79dac99e5d41f600bb9902b852...
+              Signature: 58401d9d875bb7f7bc1e7a4170bd135742c5a5e9...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: fec788f28d901e2aaefb8bb55bef113323047083ba3df652674fa5844a7f317f
+  Destination:  Script: c5925b540defe5b4db30d245e69c52f91369d4e4b35c838a1f1cb9c04bacb49a
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     5fe3619636ed9d021aa97ddad8b514380b14f1aba9d5a0de5b5e74f1e0d4b10e
+    Tx:     9d08870d29e4fde8f4d61d1388996e193c52c6bf043a126dd580969495df4033
     Output #1
-    Script: 0100000303026466697831182903030501026455...
+    Script: 0100000303020003030501020002000303050102...
 
 
 Outputs:
@@ -239,6 +239,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: fec788f28d901e2aaefb8bb55bef113323047083ba3df652674fa5844a7f317f
+  Script: c5925b540defe5b4db30d245e69c52f91369d4e4b35c838a1f1cb9c04bacb49a
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -101,11 +101,11 @@ Balances Carried Forward:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       945e615a708e13ba3c9541aff36aaed048e9fcf5766e6870f08f397ffa7a35e3
+TxId:       8c63f1f26ce44520250dbacfc4def3b22c40feb6b81cc0e127d3b098d2e416e7
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 584059a3217ccd61ed75b162d23f819d496b8b46...
+              Signature: 58408260bcc1d76ee33e0defd380b884a1ba51f5...
 Inputs:
   ---- Input 0 ----
   Destination:  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
@@ -124,7 +124,7 @@ Outputs:
     Ada:      Lovelace:  9940
   
   ---- Output 1 ----
-  Destination:  Script: 365178713b1f3779509907efb19f79598aa0ca0c838adb725966f2469c5fdb0d
+  Destination:  Script: 837a7b277972291274d3443c3cee9cb0aa06a5961bc4cfede476b01b16d76959
   Value:
     Ada:      Lovelace:  60
 
@@ -170,25 +170,25 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 365178713b1f3779509907efb19f79598aa0ca0c838adb725966f2469c5fdb0d
+  Script: 837a7b277972291274d3443c3cee9cb0aa06a5961bc4cfede476b01b16d76959
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #12, Tx #0 ====
-TxId:       1bc5f381e8c3a4bfc556c30572ec3f07d7c3e938d02f718a3d8b792ba62068dd
+TxId:       eda5281530b105345c58fd787c9f31adc0e08cbd25b7bc0ab0bc5c75caa5b708
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840bcf21d6450f86a1c70b82aa9edef6c801f05...
+              Signature: 58408949e10886d7c50fe490608c1667c1a241c9...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 365178713b1f3779509907efb19f79598aa0ca0c838adb725966f2469c5fdb0d
+  Destination:  Script: 837a7b277972291274d3443c3cee9cb0aa06a5961bc4cfede476b01b16d76959
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     945e615a708e13ba3c9541aff36aaed048e9fcf5766e6870f08f397ffa7a35e3
+    Tx:     8c63f1f26ce44520250dbacfc4def3b22c40feb6b81cc0e127d3b098d2e416e7
     Output #1
-    Script: 0100000303026466697831182903030305010264...
+    Script: 0100000303020003030305010200020002000302...
 
 
 Outputs:
@@ -198,7 +198,7 @@ Outputs:
     Ada:      Lovelace:  10
   
   ---- Output 1 ----
-  Destination:  Script: 365178713b1f3779509907efb19f79598aa0ca0c838adb725966f2469c5fdb0d
+  Destination:  Script: 837a7b277972291274d3443c3cee9cb0aa06a5961bc4cfede476b01b16d76959
   Value:
     Ada:      Lovelace:  50
 
@@ -244,6 +244,6 @@ Balances Carried Forward:
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 365178713b1f3779509907efb19f79598aa0ca0c838adb725966f2469c5fdb0d
+  Script: 837a7b277972291274d3443c3cee9cb0aa06a5961bc4cfede476b01b16d76959
   Value:
     Ada:      Lovelace:  50


### PR DESCRIPTION
Fixes SCP-616

This corresponds to using de-bruijn indices on-chain, since `Script`s
are our representation of "a PLC program in a transaction".

Note, this currently has an `error` in it. I'm trying to decide whether it's evil or whether it should be turned into a proper `throw` of some kind of "impossible" exception. It can only happen if the script does not typecheck, which shouldn't be possible at this stage.