### PR TITLE
Fix order of elements in TransactionPartialPay JSON decoding

### DIFF
--- a/marlowe-playground-client/src/Marlowe/Semantics.purs
+++ b/marlowe-playground-client/src/Marlowe/Semantics.purs
@@ -1133,8 +1133,8 @@ instance decodeTransactionWarning :: Decode TransactionWarning where
             ( TransactionPartialPay <$> decodeProp "account" a
                 <*> decodeProp "to_payee" a
                 <*> decodeProp "of_token" a
-                <*> decodeProp "asked_to_pay" a
                 <*> decodeProp "but_only_paid" a
+                <*> decodeProp "asked_to_pay" a
             )
           else
             ( TransactionNonPositivePay <$> decodeProp "account" a

--- a/marlowe/src/Language/Marlowe/Semantics.hs
+++ b/marlowe/src/Language/Marlowe/Semantics.hs
@@ -1307,8 +1307,8 @@ instance FromJSON TransactionWarning where
               Just butOnlyPaid -> TransactionPartialPay <$> (v .: "account")
                                                         <*> (v .: "to_payee")
                                                         <*> (v .: "of_token")
-                                                        <*> (v .: "asked_to_pay")
-                                                        <*> getInteger butOnlyPaid)
+                                                        <*> getInteger butOnlyPaid
+                                                        <*> (v .: "asked_to_pay"))
     <|> (TransactionShadowing <$> (v .: "value_id")
                               <*> (v .: "had_value")
                               <*> (v .: "is_now_assigned"))


### PR DESCRIPTION
Decoding the result of static analysis got values out of order for the `TransactionPartialPay` warning