### PR TITLE
plutus-core: add a UPLC parser

### DIFF
--- a/nix/stack.materialized/plutus-core.nix
+++ b/nix/stack.materialized/plutus-core.nix
@@ -124,6 +124,7 @@
           "Language/PlutusCore/Lexer/Type"
           "Language/PlutusCore/Eq"
           "Language/PlutusCore/Mark"
+          "Language/PlutusCore/Parser/Internal"
           "Language/PlutusCore/Pretty/Classic"
           "Language/PlutusCore/Pretty/Default"
           "Language/PlutusCore/Pretty/Plc"
@@ -245,6 +246,7 @@
           "Language/UntypedPlutusCore"
           "Language/UntypedPlutusCore/DeBruijn"
           "Language/UntypedPlutusCore/Evaluation/Machine/Cek"
+          "Language/UntypedPlutusCore/Parser"
           "PlutusPrelude"
           "Common"
           "Data/ByteString/Hash"
@@ -419,6 +421,7 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
             (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))

--- a/plutus-core/bench/Bench.hs
+++ b/plutus-core/bench/Bench.hs
@@ -7,10 +7,13 @@ import           Language.PlutusCore.Constant.Dynamic
 import           Language.PlutusCore.Evaluation.Machine.Cek                 (unsafeEvaluateCek)
 import           Language.PlutusCore.Evaluation.Machine.Ck                  (unsafeEvaluateCk)
 import           Language.PlutusCore.Evaluation.Machine.ExBudgetingDefaults
+import           Language.PlutusCore.Parser
 import           Language.PlutusCore.Pretty
 
 import           Codec.Serialise
 import           Control.Monad
+import           Control.Monad.Except
+import           Control.Monad.State
 import           Criterion.Main
 import           Crypto
 import qualified Data.ByteString                                            as BS
@@ -23,6 +26,9 @@ msg = ""
 
 traceBuiltins :: QuoteT (Either (Error DefaultUni ())) (DynamicBuiltinNameTypes DefaultUni)
 traceBuiltins = getStringBuiltinTypes ()
+
+parse :: BSL.ByteString -> Either (ParseError AlexPosn) (Program TyName Name DefaultUni AlexPosn)
+parse str = runQuote $ runExceptT $ flip evalStateT emptyIdentifierState $ parseProgram str
 
 main :: IO ()
 main =

--- a/plutus-core/plutus-core.cabal
+++ b/plutus-core/plutus-core.cabal
@@ -120,6 +120,7 @@ library
         Language.UntypedPlutusCore
         Language.UntypedPlutusCore.DeBruijn
         Language.UntypedPlutusCore.Evaluation.Machine.Cek
+        Language.UntypedPlutusCore.Parser
 
         PlutusPrelude
         Common
@@ -154,6 +155,7 @@ library
         Language.PlutusCore.Lexer.Type
         Language.PlutusCore.Eq
         Language.PlutusCore.Mark
+        Language.PlutusCore.Parser.Internal
         Language.PlutusCore.Pretty.Classic
         Language.PlutusCore.Pretty.ConfigName
         Language.PlutusCore.Pretty.Default
@@ -371,6 +373,7 @@ benchmark plutus-core-bench
     build-depends:
         base -any,
         bytestring -any,
+        mtl -any,
         containers -any,
         criterion -any,
         plutus-core -any,

--- a/plutus-core/src/Language/PlutusCore.hs
+++ b/plutus-core/src/Language/PlutusCore.hs
@@ -5,14 +5,10 @@
 module Language.PlutusCore
     (
       -- * Parser
-      parse
-    , parseST
-    , parseTermST
-    , parseTypeST
-    , parseScoped
-    , parseProgram
+    parseProgram
     , parseTerm
     , parseType
+    , parseScoped
     -- * Universe
     , Some (..)
     , TypeIn (..)

--- a/plutus-core/src/Language/PlutusCore/Lexer.x
+++ b/plutus-core/src/Language/PlutusCore/Lexer.x
@@ -145,6 +145,8 @@ tokens :-
     <kwd> iwrap          { mkKeyword KwIWrap       `andBegin` 0 }
     <kwd> unwrap         { mkKeyword KwUnwrap      `andBegin` 0 }
     <kwd> error          { mkKeyword KwError       `andBegin` 0 }
+    <kwd> force          { mkKeyword KwForce       `andBegin` 0 }
+    <kwd> delay          { mkKeyword KwDelay       `andBegin` 0 }
     <kwd> builtin        { mkKeyword KwBuiltin     `andBegin` builtin }
     -- ^ Switch the lexer into a mode where it's looking for a builtin id.
     -- These are converted into Builtin names (possibly dynamic) in the parser.

--- a/plutus-core/src/Language/PlutusCore/Lexer/Type.hs
+++ b/plutus-core/src/Language/PlutusCore/Lexer/Type.hs
@@ -20,20 +20,25 @@ import           Control.Monad.State
 import qualified Data.Map                 as M
 import qualified Data.Text                as T
 
--- | A keyword in Plutus Core.
+-- | A keyword in Plutus Core. Some of these are only for UPLC or TPLC, but it's simplest to share
+-- the lexer, so we have a joint enumeration of them.
 data Keyword
-    = KwAbs
-    | KwLam
-    | KwIFix
+    = KwLam
+    | KwProgram
+    | KwCon
+    | KwBuiltin
+    | KwError
+    -- UPLC only
+    | KwAbs
     | KwFun
     | KwAll
     | KwType
-    | KwProgram
-    | KwCon
+    | KwIFix
     | KwIWrap
-    | KwBuiltin
     | KwUnwrap
-    | KwError
+    -- UPLC only
+    | KwForce
+    | KwDelay
     deriving (Show, Eq, Enum, Bounded, Generic, NFData)
 
 -- | A special character. This type is only used internally between the lexer
@@ -85,6 +90,8 @@ instance Pretty Keyword where
     pretty KwBuiltin = "builtin"
     pretty KwUnwrap  = "unwrap"
     pretty KwError   = "error"
+    pretty KwForce   = "force"
+    pretty KwDelay   = "delay"
 
 instance Pretty (Token ann) where
     pretty (TkName _ n _)            = pretty n

--- a/plutus-core/src/Language/PlutusCore/Parser/Internal.hs
+++ b/plutus-core/src/Language/PlutusCore/Parser/Internal.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE TypeOperators     #-}
+
+module Language.PlutusCore.Parser.Internal where
+
+import           Language.PlutusCore.Core
+import           Language.PlutusCore.Error
+import           Language.PlutusCore.Lexer
+import           Language.PlutusCore.Lexer.Type
+import           Language.PlutusCore.Name
+import           Language.PlutusCore.Parsable
+import           Language.PlutusCore.Universe
+
+import           Control.Monad.Except
+
+import           Data.Proxy
+import qualified Data.Text                      as T
+
+--- The Parse monad ---
+
+type Parse = ExceptT (ParseError AlexPosn) Alex
+
+parseError :: Token AlexPosn -> Parse b
+parseError = throwError . Unexpected
+
+--- Static built-in functions ---
+
+getStaticBuiltinName :: T.Text -> Maybe StaticBuiltinName
+getStaticBuiltinName = \case
+    "addInteger"               -> Just AddInteger
+    "subtractInteger"          -> Just SubtractInteger
+    "multiplyInteger"          -> Just MultiplyInteger
+    "divideInteger"            -> Just DivideInteger
+    "quotientInteger"          -> Just QuotientInteger
+    "modInteger"               -> Just ModInteger
+    "remainderInteger"         -> Just RemainderInteger
+    "lessThanInteger"          -> Just LessThanInteger
+    "lessThanEqualsInteger"    -> Just LessThanEqInteger
+    "greaterThanInteger"       -> Just GreaterThanInteger
+    "greaterThanEqualsInteger" -> Just GreaterThanEqInteger
+    "equalsInteger"            -> Just EqInteger
+    "concatenate"              -> Just Concatenate
+    "takeByteString"           -> Just TakeByteString
+    "dropByteString"           -> Just DropByteString
+    "equalsByteString"         -> Just EqByteString
+    "lessThanByteString"       -> Just LtByteString
+    "greaterThanByteString"    -> Just GtByteString
+    "sha2_256"                 -> Just SHA2
+    "sha3_256"                 -> Just SHA3
+    "verifySignature"          -> Just VerifySignature
+    "ifThenElse"               -> Just IfThenElse
+    _                          -> Nothing
+
+
+--- Parsing built-in types and constants ---
+
+-- | Tags of types in the default universe.
+encodeTyName :: T.Text -> Maybe [Int]
+encodeTyName = \case
+    "bool"       -> Just $ encodeUni DefaultUniBool
+    "bytestring" -> Just $ encodeUni DefaultUniByteString
+    "char"       -> Just $ encodeUni DefaultUniChar
+    "integer"    -> Just $ encodeUni DefaultUniInteger
+    "string"     -> Just $ encodeUni DefaultUniString
+    "unit"       -> Just $ encodeUni DefaultUniUnit
+    _ -> Nothing
+
+-- | Given a type name, return a type in the (default) universe.
+-- This can fail in two ways: there's no type with that name, or decodeUni fails because
+-- it's been given an unknown tag.  In both cases we report an unknown built-in type.
+decodeTyName :: Closed uni => AlexPosn -> T.Text -> Parse (Some (TypeIn uni))
+decodeTyName tyloc tyname =
+    case encodeTyName tyname >>= decodeUni of
+        Nothing -> throwError $ UnknownBuiltinType tyloc tyname
+        Just ty -> pure ty
+
+-- | Convert a textual type name into a Type.
+mkBuiltinType :: Closed uni => AlexPosn -> T.Text -> Parse (Type TyName uni AlexPosn)
+mkBuiltinType tyloc tyname = TyBuiltin tyloc <$> decodeTyName tyloc tyname
+
+-- | Produce (the contents of) a constant term from a type name and a literal constant.
+-- We return a pair of the position and the value rather than the actual term, since we want
+-- to share this between UPLC and TPLC.
+mkBuiltinConstant
+  :: (Closed uni, uni `Everywhere` Parsable)
+  => AlexPosn -> T.Text -> AlexPosn -> T.Text -> Parse (AlexPosn, Some (ValueOf uni))
+mkBuiltinConstant tyloc tyname litloc lit  = do
+    Some (TypeIn uni1) <- decodeTyName tyloc tyname
+    case bring (Proxy @Parsable) uni1 (parseConstant lit) of
+        Nothing -> throwError $ InvalidBuiltinConstant litloc lit tyname
+        Just w  -> pure (litloc, Some (ValueOf uni1 w))
+
+-- | Produce (the contents of) a builtin function term from a type name and a literal constant.
+-- We return a pair of the position and the value rather than the actual term, since we want
+-- to share this between UPLC and TPLC.
+mkBuiltinFunction :: a -> T.Text -> (a, BuiltinName)
+mkBuiltinFunction loc ident =
+    case getStaticBuiltinName ident of
+        Just b  -> (loc, StaticBuiltinName b)
+        Nothing -> (loc, (DynBuiltinName (DynamicBuiltinName ident)))

--- a/plutus-core/test/Spec.hs
+++ b/plutus-core/test/Spec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE TypeOperators     #-}
 
 module Main
@@ -103,7 +104,7 @@ propParser :: Property
 propParser = property $ do
     prog <- TextualProgram <$> forAllPretty (runAstGen genProgram)
     let reprint = BSL.fromStrict . encodeUtf8 . displayPlcDef . unTextualProgram
-    Hedgehog.tripping prog reprint (fmap (TextualProgram . void) . parse)
+    Hedgehog.tripping prog reprint (\p -> fmap (TextualProgram . void) $ runQuote $ runExceptT $ parseProgram @(Error DefaultUni AlexPosn) p)
 
 propRename :: Property
 propRename = property $ do

--- a/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core/Type.hs
+++ b/plutus-core/untyped-plutus-core/Language/UntypedPlutusCore/Core/Type.hs
@@ -10,6 +10,7 @@ module Language.UntypedPlutusCore.Core.Type
     , TPLC.StaticBuiltinName (..)
     , TPLC.DynamicBuiltinName (..)
     , TPLC.BuiltinName (..)
+    , TPLC.Version (..)
     , Term (..)
     , Program (..)
     , termAnn

--- a/plutus-metatheory/src/Main.lagda
+++ b/plutus-metatheory/src/Main.lagda
@@ -127,9 +127,9 @@ postulate
 {-# COMPILE GHC convTy = convT #-}
 {-# COMPILE GHC unconvTy = \ ty -> AlexPn 0 0 0 <$ (unconvT (-1) ty) #-}
 {-# FOREIGN GHC import Data.Bifunctor #-}
-{-# COMPILE GHC parse = first (const ParseError) . parse  #-}
-{-# COMPILE GHC parseTm = either (\_ -> Nothing) Just . parseTm  #-}
-{-# COMPILE GHC parseTy = either (\_ -> Nothing) Just . parseTy  #-}
+{-# COMPILE GHC parse = first (\(_::ParseError AlexPosn) -> ParseError) . runQuote . runExceptT . parseProgram #-}
+{-# COMPILE GHC parseTm = either (\(_::ParseError AlexPosn) -> Nothing) Just . runQuote . runExceptT . parseTerm #-}
+{-# COMPILE GHC parseTy = either (\(_::ParseError AlexPosn) -> Nothing) Just . runQuote . runExceptT . parseType #-}
 {-# COMPILE GHC deBruijnify = first (const ScopeError) . runExcept . deBruijnProgram #-}
 {-# COMPILE GHC deBruijnifyTm = either (\_ -> Nothing) Just . runExcept . deBruijnTerm #-}
 {-# COMPILE GHC deBruijnifyTy = either (\_ -> Nothing) Just . runExcept . deBruijnTy #-}


### PR DESCRIPTION
- Augment the TPLC lexer and share it: doesn't seem worth having another
lexer.
- Add a UPLC parser that's mostly a copy of the TPLC parser.
- Pull out some helper stuff from the TPLC parser to reduce the
duplication a bit.
- Kill some pointless extra functions we had lying around.