### PR TITLE
Pir tc escaping through a reader "mode"

### DIFF
--- a/plutus-core/plutus-ir-test/type-errors/nonSelfRecursive.golden
+++ b/plutus-core/plutus-ir-test/type-errors/nonSelfRecursive.golden
@@ -1,2 +1,2 @@
-Error during typechecking:
+Error during PIR typechecking:
 Free type variable at  nonSelfRecursive:8:62 :  List

--- a/plutus-core/plutus-ir-test/type-errors/wrongDataConstrReturnType.golden
+++ b/plutus-core/plutus-ir-test/type-errors/wrongDataConstrReturnType.golden
@@ -1,3 +1,3 @@
-Error during typechecking:
+Error during PIR typechecking:
 The result-type of a dataconstructor is malformed at location wrongDataConstrReturnType:4:6
 The expected result-type is: [Maybe a]

--- a/plutus-core/plutus-ir/Language/PlutusIR/Compiler.hs
+++ b/plutus-core/plutus-ir/Language/PlutusIR/Compiler.hs
@@ -19,11 +19,12 @@ module Language.PlutusIR.Compiler (
     ccEnclosing,
     ccBuiltinMeanings,
     ccTypeCheckConfig,
+    PirTCConfig(..),
+    AllowEscape(..),
     defaultCompilationCtx) where
 
 import           Language.PlutusIR
 
-import qualified Language.PlutusCore.TypeCheck.Internal      as PLC
 import qualified Language.PlutusIR.Compiler.Let              as Let
 import           Language.PlutusIR.Compiler.Lower
 import           Language.PlutusIR.Compiler.Provenance
@@ -63,7 +64,7 @@ floatTerm = runIfOpts letFloat
 typeCheckTerm :: Compiling m e uni b => Term TyName Name uni (Provenance b) -> m ()
 typeCheckTerm t = do
     tcconfig <- asks _ccTypeCheckConfig
-    void $ PLC.runTypeCheckM tcconfig $ inferTypeM t
+    void . runTypeCheckM tcconfig $ inferTypeM t
 
 -- | The 1st half of the PIR compiler pipeline up to floating/merging the lets.
 -- We stop momentarily here to give a chance to the tx-plugin

--- a/plutus-core/plutus-ir/Language/PlutusIR/Error.hs
+++ b/plutus-core/plutus-ir/Language/PlutusIR/Error.hs
@@ -85,5 +85,5 @@ instance (PLC.GShow uni, PLC.Closed uni, uni `PLC.Everywhere` PLC.PrettyConst, P
         CompilationError x e -> "Error during compilation:" <+> PP.pretty e <> "(" <> PP.pretty x <> ")"
         UnsupportedError x e -> "Unsupported construct:" <+> PP.pretty e <+> "(" <> PP.pretty x <> ")"
         PLCError e -> PP.vsep [ "Error from the PLC compiler:", PLC.prettyBy config e ]
-        PLCTypeError e -> PP.vsep ["Error during typechecking:" , PLC.prettyBy config e ]
-        PIRTypeError e -> PP.vsep ["Error during typechecking:" , PLC.prettyBy config e ]
+        PLCTypeError e -> PP.vsep ["Error during PIR typechecking:" , PLC.prettyBy config e ]
+        PIRTypeError e -> PP.vsep ["Error during PIR typechecking:" , PLC.prettyBy config e ]

--- a/plutus-core/plutus-ir/Language/PlutusIR/TypeCheck/Internal.hs
+++ b/plutus-core/plutus-ir/Language/PlutusIR/TypeCheck/Internal.hs
@@ -5,33 +5,40 @@
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RankNTypes         #-}
-{-# LANGUAGE TupleSections      #-}
 {-# LANGUAGE TypeOperators      #-}
 module Language.PlutusIR.TypeCheck.Internal
     ( DynamicBuiltinNameTypes (..)
-    , TypeCheckConfig (..)
+    , PirTCConfig (..)
+    , defConfig
     , TypeCheckM
+    , AllowEscape (..)
     , tccDynamicBuiltinNameTypes
     , inferTypeM
     , checkTypeM
+    , runTypeCheckM
     ) where
 
 
 import           Control.Monad.Error.Lens
 import           Control.Monad.Except
+import           Control.Monad.Reader
 import           Data.Foldable
 import           Language.PlutusCore                    (typeAnn)
 import           Language.PlutusCore.Error              as PLC
+import           Language.PlutusCore.Quote
 import           Language.PlutusCore.Rename             as PLC
 import           Language.PlutusCore.Universe
 import           Language.PlutusIR
 import           Language.PlutusIR.Compiler.Datatype
 import           Language.PlutusIR.Compiler.Provenance
+import           Language.PlutusIR.Compiler.Types
 import           Language.PlutusIR.Error
+import           Language.PlutusIR.Transform.Rename     ()
 import           PlutusPrelude
 
 -- we mirror inferTypeM, checkTypeM of plc-tc and extend it for plutus-ir terms
-import           Language.PlutusCore.TypeCheck.Internal hiding (checkTypeM, inferTypeM)
+import qualified Language.PlutusCore.TypeCheck          as PLC
+import           Language.PlutusCore.TypeCheck.Internal hiding (checkTypeM, inferTypeM, runTypeCheckM)
 import qualified Language.PlutusIR.MkPir                as PIR
 
 {- Note [PLC Typechecker code reuse]
@@ -45,11 +52,8 @@ We then extend this ported `PIR.inferTypeM` with cases for inferring type of Let
 See Note [Notation] of Language.PlutusCore.TypeCheck.Internal for the notation of inference rules, which appear in the comments.
 -}
 
-{- Note [PIR vs paper FIR differences]
+{- Note [PIR vs Paper Syntax Difference]
 Link to the paper: <https://hydra.iohk.io/job/Cardano/plutus/linux.papers.unraveling-recursion/latest/download-by-type/doc-pdf/unraveling-recursion>
-
-Difference1:
-
 FIR's syntax requires that the data-constructor is annotated with a *list of its argument types* (domain),
 instead of requiring a single valid type T (usually in the form `dataconstr : arg1 -> arg2 ->... argn`)
 The codomain is also left out of the syntax and implied to be of the type `[TypeCons tyarg1 tyarg2 ... tyargn]`
@@ -64,29 +68,33 @@ the PIR user may have placed inside there a non-normalized type there. Currently
 assume the types of all data-constructors are prior normalized *before* type-checking, otherwise
 the PIR typechecking and PIR compilation will fail.
 See NOTE [Normalization of data-constructors' types] at Language.PlutusIR.Compiler.Datatype
-
-Difference2:
-
-In FIR paper's Fig.6, T-Let and T-LetRec rules dictate that: G !- inTerm :: *
-In the implemenetation, however, we do not have this check and instead rely
-in the proof-by-construction: "All terms that can be constructed have types that are *-kinded."
 -}
 
-{- NOTE [TODO: Unexpose Escaping Types]
- The let datatypebinds and/or typebinds introduce new types which may be exposed to the user
-from the "inferred type" of the PIRs' inTerm.
-e.g. `let data List a = Nil | Cons a (List a) in Nil :: List Integer` will infer the overall type `List Integer`,
-which exposes the List to the outside of the let.
+{- Note [PIR vs Paper Escaping Types Difference]
+Link to the paper: <https://hydra.iohk.io/job/Cardano/plutus/linux.papers.unraveling-recursion/latest/download-by-type/doc-pdf/unraveling-recursion>
+In FIR paper's Fig.6, T-Let and T-LetRec rules dictate that: Gamma !- inTerm :: * for two reasons:
+1. check (locally) that the kind of the in-term's inferred type is indeed *
+2. ensure that the inferred type does not escaping its scope (hence Gamma)
 
-Although such programs compile fine to PLC , are PLC typechecked and run correctly (e.g. the program at `./test/recursion/even3Eval`),
-their inferred types have to be constrained in terms of PIR typechecking.
+This is in general true for the PIR implementation as well, except in the special
+case when a Type is inferred for the top-level expression (`program`-level).
+In contrast to (2), we allow such a "top-level" type to escape its scope;
+the reasoning is that PIR programs with toplevel escaping types would behave correctly when they are translated down to PLC.
+Even in the case where we let the type variables escape, (1) must still hold:
+the kind of the escaping type should still be star. Unfortunately, in order to check that we'd have to use the variables
+which are no longer in scope. So we skip the rule (Gamma !- inTermTopLevel :: *) in case of top-level inferred types.
 
-The PIR typechecker has to be modified to not expose the types of such programs (still to be implemented).
-For more please see the more elaborate documentation about PIR typechecking at
-<https://github.com/effectfully/plutus-prototype/blob/master/language-plutus-core/docs/Typechecking%20PIR.md>
-and the discussion at <https://groups.google.com/a/iohk.io/forum/#!msg/plutus/6ycMTngVomc/VKeb00DuHwAJ>
+The implementation has a user-configurable flag to let the typechecker know if the current term under examination
+is at the program's "top-level" position, and thus allow its type to escape. The flag is automatically set to no-type-escape
+when typechecking inside a let termbind's rhs term.
 -}
 
+-- | The default 'TypeCheckConfig'.
+defConfig :: PirTCConfig uni
+defConfig = PirTCConfig PLC.defConfig YesEscape
+
+-- | a shorthand for our pir-specialized tc functions
+type PirTCEnv uni e a = TypeCheckM uni (PirTCConfig uni) e a
 
 -- ###########################
 -- ## Port of Type checking ##
@@ -97,7 +105,7 @@ and the discussion at <https://groups.google.com/a/iohk.io/forum/#!msg/plutus/6y
 -- | Check a 'Term' against a 'NormalizedType'.
 checkTypeM
     :: (GShow uni, GEq uni, DefaultUni <: uni, AsTypeErrorExt e uni ann, AsTypeError e (Term TyName Name uni ()) uni ann)
-    => ann -> Term TyName Name uni ann -> Normalized (Type TyName uni ()) -> TypeCheckM uni e ()
+    => ann -> Term TyName Name uni ann -> Normalized (Type TyName uni ()) -> PirTCEnv uni e ()
 -- [infer| G !- term : vTermTy]    vTermTy ~ vTy
 -- ---------------------------------------------
 -- [check| G !- term : vTy]
@@ -109,7 +117,7 @@ checkTypeM ann term vTy = do
 -- | Synthesize the type of a term, returning a normalized type.
 inferTypeM
     :: forall uni ann e. (GShow uni, GEq uni, DefaultUni <: uni, AsTypeError e (Term TyName Name uni ()) uni ann, AsTypeErrorExt e uni ann)
-    => Term TyName Name uni ann -> TypeCheckM uni e (Normalized (Type TyName uni ()))
+    => Term TyName Name uni ann -> PirTCEnv uni e (Normalized (Type TyName uni ()))
 -- c : vTy
 -- -------------------------
 -- [infer| G !- con c : vTy]
@@ -212,11 +220,14 @@ ty ~> vTy
 -------------------------------------------------
 [infer| G !- (let nonrec {b ; bs} in inT) : vTy]
 -}
-inferTypeM (Let _ r@NonRec bs inTerm) =
+inferTypeM (Let ann r@NonRec bs inTerm) = do
     -- Check each binding individually, then if ok, introduce its new type/vars to the (linearly) next let or inTerm
-    foldr checkBindingThenScope (inferTypeM inTerm) bs
+    ty <- foldr checkBindingThenScope (inferTypeM inTerm) bs
+    -- check the in-term's inferred type has kind * (except at toplevel)
+    checkStarInferred ann ty
+    pure ty
  where
-   checkBindingThenScope :: Binding TyName Name uni ann -> TypeCheckM uni e res -> TypeCheckM uni e res
+   checkBindingThenScope :: Binding TyName Name uni ann -> PirTCEnv uni e res -> PirTCEnv uni e res
    checkBindingThenScope b acc = do
        -- check that the kinds of the declared types are correct
        checkKindFromBinding b
@@ -236,8 +247,8 @@ forall b in bs. checkTypeFromBinding(G'', b)
 -------------------------------------------------
 [infer| G !- (let rec bs in inT) : vTy]
 -}
-inferTypeM (Let _ r@Rec bs inTerm) =
-    withTyVarsOfBindings bs $ do
+inferTypeM (Let ann r@Rec bs inTerm) = do
+    ty <- withTyVarsOfBindings bs $ do
        -- check that the kinds of the declared types *over all bindings* are correct
        -- Note that, compared to NonRec, we need the newtyvars in scope to do kindchecking
        for_ bs checkKindFromBinding
@@ -246,10 +257,13 @@ inferTypeM (Let _ r@Rec bs inTerm) =
               -- Note that, compared to NonRec, we need the newtyvars+newvars in scope to do typechecking
               for_ bs $ checkTypeFromBinding r
               inferTypeM inTerm
+    -- check the in-term's inferred type has kind * (except at toplevel)
+    checkStarInferred ann ty
+    pure ty
 
 {-| This checks that a newly-introduced type variable is correctly kinded.
 
-(b is ty::K = _) => [check| G !- ty :: K]
+(b is ty::K = rhs) => [check| G !- rhs :: K]
 (b is term (X::T) => [check| G !- T :: *])
 (b is data (X::K) tyarg1::K1 ... tyargN::KN  = _) => [check| G, X::K, tyarg1::K1...tyargN::KN !- [X tyarg1 ... tyargN] :: *]
 --------------------------------------------------------------------------------------
@@ -258,7 +272,7 @@ checkKindFromBinding(G,b)
 checkKindFromBinding :: forall e uni ann.
                    AsTypeError e (Term TyName Name uni ()) uni ann
                  => Binding TyName Name uni ann
-                 -> TypeCheckM uni e ()
+                 -> PirTCEnv uni e ()
 checkKindFromBinding = \case
     -- For a type binding, correct means that the the RHS is indeed kinded by the declared kind.
     TypeBind _ (TyVarDecl ann _ k) rhs ->
@@ -272,7 +286,7 @@ checkKindFromBinding = \case
         withTyVarDecls (tycon:tyargs) $ do
           -- the fully-applied type-constructor must be *-kinded
           checkKindM ann appliedTyCon $ Type ()
-          -- the types of all the data-constructors types must be *-kinded
+          -- the types of all the data-constructors must be *-kinded
           for_ (varDeclType <$> vdecls) $
                checkKindM ann `flip` Type ()
      where
@@ -287,17 +301,18 @@ checkKindFromBinding = \case
 checkTypeFromBinding(G,b)
 -}
 checkTypeFromBinding :: forall e uni a. (GShow uni, GEq uni, DefaultUni <: uni, AsTypeError e (Term TyName Name uni ()) uni a, AsTypeErrorExt e uni a)
-                 => Recursivity ->Binding TyName Name uni a  -> TypeCheckM uni e ()
+                 => Recursivity -> Binding TyName Name uni a  -> PirTCEnv uni e ()
 checkTypeFromBinding recurs = \case
     TypeBind{} -> pure () -- no types to check
     TermBind _ _ (VarDecl ann _ ty) rhs ->
-        checkTypeM ann rhs . fmap void =<< normalizeTypeM ty
+        -- See Note [PIR vs Paper Escaping Types Difference]
+        withNoEscapingTypes (checkTypeM ann rhs . fmap void =<< normalizeTypeM ty)
     DatatypeBind _ dt@(Datatype ann _ tyargs _ constrs) ->
         for_ (varDeclType <$> constrs) $
             \ ty -> checkConRes ty *> checkNonRecScope ty
       where
        appliedTyCon :: Type TyName uni a = mkDatatypeValueType ann dt
-       checkConRes :: Type TyName uni a -> TypeCheckM uni e ()
+       checkConRes :: Type TyName uni a -> PirTCEnv uni e ()
        checkConRes ty =
            -- We earlier checked that datacons' type is *-kinded (using checkKindBinding), but this is not enough:
            -- we must also check that its result type is EXACTLY `[[TypeCon tyarg1] ... tyargn]`
@@ -305,7 +320,7 @@ checkTypeFromBinding recurs = \case
                throwing _TypeErrorExt $ MalformedDataConstrResType ann appliedTyCon
 
        -- if nonrec binding, make sure that type-constructor is not part of the data-constructor's argument types.
-       checkNonRecScope :: Type TyName uni a -> TypeCheckM uni e ()
+       checkNonRecScope :: Type TyName uni a -> PirTCEnv uni e ()
        checkNonRecScope ty = case recurs of
            Rec -> pure ()
            NonRec ->
@@ -314,18 +329,42 @@ checkTypeFromBinding recurs = \case
                       -- OPTIMIZE: we use inferKind for scope-checking, but a simple ADT-traversal would suffice
                       for_ (funTyArgs ty) inferKindM
 
+-- | Check that the in-Term's inferred type of a Let has kind *.
+-- Skip this check at the top-level, to allow top-level types to escape; see Note [PIR vs Paper Escaping Types Difference].
+checkStarInferred :: AsTypeError e term uni ann
+                  => ann -> Normalized (Type TyName uni b) -> PirTCEnv uni e ()
+checkStarInferred ann t = do
+    allowEscape <- view $ tceTypeCheckConfig . pirConfigAllowEscape
+    case allowEscape of
+        NoEscape  -> checkKindM ann (ann <$ unNormalized t) $ Type ()
+        -- NOTE: we completely skip the check in case of toplevel because we would need an *final, extended Gamma environment*
+        -- to run the kind-check in, but we cannot easily get that since we are using a Reader for environments and not State
+        YesEscape -> pure ()
+
+
+-- | Changes the flag in nested-lets so to disallow returning a type outside of the type's scope
+withNoEscapingTypes :: PirTCEnv uni e a -> PirTCEnv uni e a
+withNoEscapingTypes = local $ set (tceTypeCheckConfig.pirConfigAllowEscape) NoEscape
+
+-- | Run a 'TypeCheckM' computation by supplying a 'TypeCheckConfig' to it.
+-- Differs from its PLC version in that is passes an extra env flag 'YesEscape'.
+runTypeCheckM :: (MonadError e m, MonadQuote m)
+              => PirTCConfig uni -> PirTCEnv uni e a -> m a
+runTypeCheckM config a =
+    liftEither =<< liftQuote (runExceptT $ runReaderT a env) where
+        env = TypeCheckEnv config mempty mempty
+
 -- Helpers
 ----------
-
 
 -- | For a single binding, generate the newly-introduce term-variables' types,
 -- normalize them, rename them and add them into scope.
 -- Newly-declared term variables are: variables of termbinds, constructors, destructor
 -- Note: Assumes that the input is globally-unique and preserves global-uniqueness
 -- Note to self: actually passing here recursivity is unnecessary, but we do it for sake of compiler/datatype.hs api
-withVarsOfBinding :: forall uni e a res.
+withVarsOfBinding :: forall uni c e a res.
                     Recursivity -> Binding TyName Name uni a
-                  -> TypeCheckM uni e res -> TypeCheckM uni e res
+                  -> TypeCheckM uni c e res -> TypeCheckM uni c e res
 withVarsOfBinding _ TypeBind{} k = k
 withVarsOfBinding _ (TermBind _ _ vdecl _) k = do
     vTy <- normalizeTypeM $ varDeclType vdecl
@@ -335,33 +374,32 @@ withVarsOfBinding r (DatatypeBind _ dt) k = do
     -- generate all the definitions
     (_tyconstrDef, constrDefs, destrDef) <- compileDatatypeDefs r (original dt)
     -- ignore the generated rhs terms of constructors/destructor
-    let structorDecls = fmap (PIR.defVar) $ destrDef:constrDefs
+    let structorDecls = PIR.defVar <$> destrDef:constrDefs
     -- normalize, then rename, then only introduce the vardecl to scope
     foldr normRenameScope k structorDecls
     where
       normRenameScope :: VarDecl TyName Name uni (Provenance a)
-                      -> TypeCheckM uni e res -> TypeCheckM uni e res
+                      -> TypeCheckM uni c e res -> TypeCheckM uni c e res
       normRenameScope v acc = do
           normRenamedTy <- rename =<< (normalizeTypeM $ varDeclType v)
           withVar (varDeclName v) (void <$> normRenamedTy) acc
 
 
 withVarsOfBindings :: Foldable t => Recursivity -> t (Binding TyName Name uni a)
-                   -> TypeCheckM uni e res -> TypeCheckM uni e res
+                   -> TypeCheckM uni c e res -> TypeCheckM uni c e res
 withVarsOfBindings r bs k = foldr (withVarsOfBinding r) k bs
 
-
 -- | Scope a typechecking computation with the given binding's newly-introducing type (if there is one)
-withTyVarsOfBinding :: Binding TyName name uni ann -> TypeCheckM uni e res -> TypeCheckM uni e res
+withTyVarsOfBinding :: Binding TyName name uni ann -> TypeCheckM uni c e res -> TypeCheckM uni c e res
 withTyVarsOfBinding = \case
        TypeBind _ tvdecl _ -> withTyVarDecls [tvdecl]
        DatatypeBind _ (Datatype _ tvdecl _ _ _) -> withTyVarDecls [tvdecl]
        TermBind{} -> id -- no type to introduce
 
 -- | Extend the typecheck reader environment with the kinds of the newly-introduced type variables of a binding.
-withTyVarsOfBindings :: Foldable f => f (Binding TyName name uni ann) -> TypeCheckM uni e res -> TypeCheckM uni e res
+withTyVarsOfBindings :: Foldable f => f (Binding TyName name uni ann) -> TypeCheckM uni c e res -> TypeCheckM uni c e res
 withTyVarsOfBindings = flip $ foldr withTyVarsOfBinding
 
 -- | Helper to add type variables into a computation's environment.
-withTyVarDecls :: [TyVarDecl TyName ann] -> TypeCheckM uni e a -> TypeCheckM uni e a
+withTyVarDecls :: [TyVarDecl TyName ann] -> TypeCheckM uni c e a -> TypeCheckM uni c e a
 withTyVarDecls = flip . foldr $ \(TyVarDecl _ n k) -> withTyVar n $ void k

--- a/plutus-core/src/Language/PlutusCore.hs
+++ b/plutus-core/src/Language/PlutusCore.hs
@@ -154,7 +154,7 @@ printType
     -> m T.Text
 printType bs = runQuoteT $ displayPlcDef <$> do
     scoped <- parseScoped bs
-    inferTypeOfProgram (TypeCheckConfig mempty) scoped
+    inferTypeOfProgram defConfig scoped
 
 -- | Parse and rewrite so that names are globally unique, not just unique within
 -- their scope.

--- a/plutus-tx-plugin/src/Language/PlutusTx/Plugin.hs
+++ b/plutus-tx-plugin/src/Language/PlutusTx/Plugin.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TemplateHaskell            #-}
@@ -312,8 +311,8 @@ runCompiler opts expr = do
 
     let ctx = PIR.defaultCompilationCtx
               & set (PIR.ccOpts . PIR.coOptimize) (poOptimize opts)
-              & set (PIR.ccBuiltinMeanings) PLC.getStringBuiltinMeanings
-              & set PIR.ccTypeCheckConfig stringBuiltinTCConfig
+              & set PIR.ccBuiltinMeanings PLC.getStringBuiltinMeanings
+              & set PIR.ccTypeCheckConfig (PIR.PirTCConfig stringBuiltinTCConfig PIR.YesEscape)
 
     pirT <- PIR.runDefT () $ compileExprWithDefs expr
 


### PR DESCRIPTION
This adresses the following:

1) Allows PIR programs to escape types at top-level only
2) By default, the escape types cannot be seen by the user; only that the PIR program is well-typed. Testing/debugging code can use Internal module
3) Added back the `G !- inTerm:: *` rule to run only inside nested lets (not top-level)

About the implementation:

- Used an extra Reader flag for `TypeCheckM` monad to be aware if the current input `Term` to be typechecked is at top-level vs nested position
- This flag is automatically set to top-level by the `runTypeCheckTerm` which runs the typechecker monad. So I assume that runTypecheckTerm and its callers (inferType,checkType,PIR.Compiler.compileTerm) are actually inputted **top-level PIR terms**, aka PIR programs. This flag is automatically set to nested (by `noEscapeType`).
- The top-level types are always exposed by the `Internal.runTypeCheckTerm` (for testing/debugging code). These exposed types are hidden to the library-user by using `TypeCheck.checkTypeOfProgram :: MonadError e m => m ()` which throws away the escaped type, and is only run for its effects (type errors).


