### PR TITLE
ledger: Fix a bug in the forwarding MPS

### DIFF
--- a/plutus-ledger/src/Ledger/Typed/Scripts.hs
+++ b/plutus-ledger/src/Ledger/Typed/Scripts.hs
@@ -62,7 +62,7 @@ validator ::
 validator vc wrapper =
     let val = mkValidatorScript $ wrapper `applyCode` vc
         hsh = validatorHash val
-        mps = mkMonetaryPolicy hsh
+        mps = forwardingMPS hsh
     in Validator
         { instanceScript  = val
         , instanceHash    = hsh
@@ -86,7 +86,7 @@ validatorScript = instanceScript
 fromValidator :: Validator -> ScriptInstance Any
 fromValidator vl =
     let vh = validatorHash vl
-        mps = mkMonetaryPolicy vh
+        mps = forwardingMPS vh
     in
     Validator
         { instanceScript  = vl


### PR DESCRIPTION
The forwarding policy should look at the transaction's *inputs*, not at its outputs, because the input scripts are the ones that get run when the tx is being validated.