### PR TITLE
Filter unknown file types from the nix build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ plutus-scb/plutus-scb.yaml
 *.db-shm
 *.db-wal
 hie.yaml
+node-server.sock


### PR DESCRIPTION
If you have a socket-type file in the source repo, the nix build will
choke on it with an error like:

```
error: file '.../node-server.sock' has an unsupported type
```

Webpack creates temporary socket files, so if you're doing frontend work
this is a huge pain.