### PR TITLE
SCB: Minor change the metadata batch query structure.

### DIFF
--- a/plutus-scb/src/Cardano/Metadata/Server.hs
+++ b/plutus-scb/src/Cardano/Metadata/Server.hs
@@ -139,10 +139,10 @@ handleMetadata =
                 Nothing ->
                     throwError $ SubjectPropertyNotFound subject propertyKey
                 Just result -> pure result
-        BatchQuery query@QuerySubjects {subjects, properties} -> do
+        BatchQuery query@QuerySubjects {subjects, propertyNames} -> do
             logInfo $ Querying query
             pure .
-                fmap (filterSubjectProperties properties) .
+                fmap (filterSubjectProperties propertyNames) .
                 fromMaybe [] . traverse fetchSubject $
                 Set.toList subjects
 

--- a/plutus-scb/src/Cardano/Metadata/Types.hs
+++ b/plutus-scb/src/Cardano/Metadata/Types.hs
@@ -275,8 +275,8 @@ toPropertyKey (Other name _ _)  = PropertyKey name
 
 data Query =
     QuerySubjects
-        { subjects   :: Set Subject
-        , properties :: Maybe (Set PropertyKey)
+        { subjects      :: Set Subject
+        , propertyNames :: Maybe (Set PropertyKey)
         }
     deriving (Show, Eq, Generic)
     deriving anyclass (ToJSON, FromJSON)

--- a/plutus-scb/src/Plutus/SCB/Webserver/Handler.hs
+++ b/plutus-scb/src/Plutus/SCB/Webserver/Handler.hs
@@ -96,7 +96,7 @@ getChainReport = do
         batchQuery
             (Metadata.QuerySubjects
                  { Metadata.subjects = Set.fromList subjects
-                 , Metadata.properties = Nothing
+                 , Metadata.propertyNames = Nothing
                  })
     annotatedBlockchain <- Rollup.doAnnotateBlockchain chainOverviewBlockchain
     pure

--- a/plutus-scb/test/Cardano/Metadata/ServerSpec.hs
+++ b/plutus-scb/test/Cardano/Metadata/ServerSpec.hs
@@ -11,7 +11,7 @@ import           Cardano.Metadata.Server   (annotatedSignature1, handleMetadata,
 import           Cardano.Metadata.Types    (HashFunction (SHA256), MetadataEffect, MetadataError, MetadataLogMessage,
                                             Property (Name, Preimage), PropertyKey (PropertyKey), Query (QuerySubjects),
                                             SubjectProperties (SubjectProperties), batchQuery, getProperties,
-                                            getProperty, properties, subjects, toSubject)
+                                            getProperty, propertyNames, subjects, toSubject)
 import           Control.Monad.Freer       (Eff, runM)
 import           Control.Monad.Freer.Error (Error, runError)
 import           Control.Monad.Freer.Log   (LogMsg, handleLogTrace)
@@ -52,7 +52,7 @@ queryTests =
               (batchQuery
                    (QuerySubjects
                         { subjects = Set.fromList [toSubject script1]
-                        , properties = Nothing
+                        , propertyNames = Nothing
                         }))
         , assertReturns
               "Query by Subjects/Properties"
@@ -64,7 +64,7 @@ queryTests =
               (batchQuery
                    (QuerySubjects
                         { subjects = Set.fromList [toSubject script1]
-                        , properties = Just (Set.fromList [PropertyKey "name"])
+                        , propertyNames = Just (Set.fromList [PropertyKey "name"])
                         }))
         ]
 


### PR DESCRIPTION
Writing up the spec made me realise we should be using `propertyNames`
instead of `properties` as the field name.