### PR TITLE
Fix nix-shell CPU affinity

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -53,4 +53,11 @@ in haskell.packages.shellFor {
   ]);
   # we have a local passwords store that we use for deployments etc.
   PASSWORD_STORE_DIR = toString ./. + "/secrets";
+
+  shellHook = ''
+    # Work around https://github.com/NixOS/nix/issues/3345, which makes
+    # tests etc. run single-threaded in a nix-shell.
+    # Sets the affinity to cores 0-1000 for $$ (current PID in bash)
+    taskset -pc 0-1000 $$ 
+  '';
 }


### PR DESCRIPTION
A long time ago, Nikos pointed out to me that running the tests inside
`nix-shell` was much slower than outside it. I don't notice since I'm
using `lorri`, but this is quite annoying. I never figured out what the
issue was, it didn't seem to be environments or anything.

Someone else recently noticed something similar, and managed to  track it down
to a Nix bug where it sets the processor affinity wrong
(https://github.com/NixOS/nix/issues/3345). I didn't even know about
processor affinity! (Don't mutate global state while forking processes,
kids.)

The fix is a `shellHook` to put it back to something sensible, which
indeed gives us the behaviour we expect.
