### PR TITLE
Fix typo

### DIFF
--- a/hie-stack.yaml
+++ b/hie-stack.yaml
@@ -216,7 +216,7 @@ cradle:
 
   - path: ./plutus-benchmark/bench
     config:
-      cradle
+      cradle:
         stack:
           component: "plutus-benchmark:large-plc-cek"
 


### PR DESCRIPTION
Just adding a missing `:`.  I don't think this needs review.