### PR TITLE
SCP-1245 - Cannot reduce contract when it doesn't start with When

### DIFF
--- a/marlowe-playground-client/src/Simulation/BottomPanel.purs
+++ b/marlowe-playground-client/src/Simulation/BottomPanel.purs
@@ -8,12 +8,12 @@ import Data.Either (Either(..), either)
 import Data.Eq (eq, (==))
 import Data.Foldable (foldMap)
 import Data.HeytingAlgebra (not, (||))
-import Data.Lens (_Just, previewOn, to, (^.))
+import Data.Lens (_Just, has, only, previewOn, to, (^.))
 import Data.Lens.NonEmptyList (_Head)
 import Data.List (List, toUnfoldable)
 import Data.List as List
 import Data.Map as Map
-import Data.Maybe (Maybe(..), isJust, isNothing, maybe)
+import Data.Maybe (Maybe(..), isJust, isNothing)
 import Data.Newtype (unwrap)
 import Data.String (take)
 import Data.String.Extra (unlines)
@@ -29,7 +29,7 @@ import Marlowe.Symbolic.Types.Response as R
 import Network.RemoteData (RemoteData(..), isLoading)
 import Prelude (bind, const, mempty, pure, show, zero, ($), (&&), (<$>), (<<<), (<>))
 import Servant.PureScript.Ajax (AjaxError(..), ErrorDescription(..))
-import Simulation.State (MarloweEvent(..), _contract, _editorErrors, _editorWarnings, _executionState, _log, _slot, _state, _transactionError, _transactionWarnings)
+import Simulation.State (MarloweEvent(..), _SimulationRunning, _SimulationNotStarted, _contract, _editorErrors, _editorWarnings, _executionState, _initialSlot, _log, _slot, _state, _transactionError, _transactionWarnings)
 import Simulation.Types (Action(..), AnalysisState(..), BottomPanelView(..), ReachabilityAnalysisData(..), State, _analysisState, _bottomPanelView, _marloweState, _showBottomPanel, _showErrorDetail, isContractValid)
 import Text.Parsing.StringParser.Basic (lines)
 
@@ -96,9 +96,9 @@ bottomPanel state =
 
   errors = state ^. (_marloweState <<< _Head <<< _editorErrors)
 
-  hasRuntimeWarnings = maybe false (\x -> x ^. (_transactionWarnings <<< to Array.null <<< to not)) (state ^. (_marloweState <<< _Head <<< _executionState))
+  hasRuntimeWarnings = has (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _transactionWarnings <<< to Array.null <<< only false) state
 
-  hasRuntimeError = maybe false (\x -> x ^. (_transactionError <<< to isJust)) (state ^. (_marloweState <<< _Head <<< _executionState))
+  hasRuntimeError = has (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _transactionError <<< to isJust <<< only true) state
 
   showingBottomPanel = state ^. _showBottomPanel
 
@@ -148,7 +148,7 @@ panelContents state CurrentStateView =
     in
       if t == zero then "Closed" else show t
 
-  warnings = state ^. (_marloweState <<< _Head <<< _executionState <<< _Just <<< _transactionWarnings)
+  warnings = state ^. (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _transactionWarnings)
 
   warningsRow =
     if Array.null warnings then
@@ -156,7 +156,7 @@ panelContents state CurrentStateView =
     else
       (headerRow "Warnings" ("type" /\ "details" /\ mempty /\ mempty /\ mempty)) <> foldMap displayWarning' warnings
 
-  error = previewOn state (_marloweState <<< _Head <<< _executionState <<< _Just <<< _transactionError <<< _Just)
+  error = previewOn state (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _transactionError <<< _Just)
 
   errorRow =
     if isNothing error then
@@ -164,9 +164,11 @@ panelContents state CurrentStateView =
     else
       (headerRow "Errors" ("details" /\ mempty /\ mempty /\ mempty /\ mempty)) <> displayError error
 
-  maybeExecutionState = state ^. (_marloweState <<< _Head <<< _executionState)
-
-  slotText = maybe (Left "Simulation has not started yet") (\x -> Right $ show (x ^. _slot)) maybeExecutionState
+  slotText = case previewOn state (_marloweState <<< _Head <<< _executionState <<< _SimulationNotStarted <<< _initialSlot) of
+    Just initialSlot -> Right $ show initialSlot
+    Nothing -> case previewOn state (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _slot) of
+      Just slot -> Right $ show slot
+      Nothing -> Left "Slot number not defined"
 
   displayError Nothing = []
 
@@ -177,7 +179,7 @@ panelContents state CurrentStateView =
 
   accountsData =
     let
-      (accounts :: Array (Tuple (Tuple Party Token) BigInteger)) = state ^. (_marloweState <<< _Head <<< _executionState <<< _Just <<< _state <<< _accounts <<< to Map.toUnfoldable)
+      (accounts :: Array (Tuple (Tuple Party Token) BigInteger)) = state ^. (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _state <<< _accounts <<< to Map.toUnfoldable)
 
       asTuple (Tuple (Tuple accountOwner (Token currSym tokName)) value) = show accountOwner /\ show currSym /\ show tokName /\ show value /\ mempty
     in
@@ -185,7 +187,7 @@ panelContents state CurrentStateView =
 
   choicesData =
     let
-      (choices :: Array (Tuple ChoiceId BigInteger)) = state ^. (_marloweState <<< _Head <<< _executionState <<< _Just <<< _state <<< _choices <<< to Map.toUnfoldable)
+      (choices :: Array (Tuple ChoiceId BigInteger)) = state ^. (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _state <<< _choices <<< to Map.toUnfoldable)
 
       asTuple (Tuple (ChoiceId choiceName choiceOwner) value) = show choiceName /\ show choiceOwner /\ show value /\ mempty /\ mempty
     in
@@ -193,7 +195,7 @@ panelContents state CurrentStateView =
 
   bindingsData =
     let
-      (bindings :: Array (Tuple ValueId BigInteger)) = state ^. (_marloweState <<< _Head <<< _executionState <<< _Just <<< _state <<< _boundValues <<< to Map.toUnfoldable)
+      (bindings :: Array (Tuple ValueId BigInteger)) = state ^. (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _state <<< _boundValues <<< to Map.toUnfoldable)
 
       asTuple (Tuple (ValueId valueId) value) = show valueId /\ show value /\ mempty /\ mempty /\ mempty
     in
@@ -398,7 +400,7 @@ panelContents state MarloweLogView =
     ]
     content
   where
-  inputLines = state ^. (_marloweState <<< _Head <<< _executionState <<< _Just <<< _log <<< to (concatMap logToLines))
+  inputLines = state ^. (_marloweState <<< _Head <<< _executionState <<< _SimulationRunning <<< _log <<< to (concatMap logToLines))
 
   content =
     [ div [ classes [ ClassName "error-headers", ClassName "error-row" ] ]

--- a/marlowe-playground-client/src/Simulation/State.purs
+++ b/marlowe-playground-client/src/Simulation/State.purs
@@ -1,12 +1,13 @@
 module Simulation.State where
 
+import Control.Bind
 import Control.Monad.State (class MonadState)
 import Data.Array (fromFoldable, mapMaybe, uncons)
 import Data.BigInteger (BigInteger)
 import Data.Either (Either(..))
 import Data.FoldableWithIndex (foldlWithIndex)
 import Data.Generic.Rep (class Generic)
-import Data.Lens (Getter', Lens', Traversal', _Just, has, lens, modifying, over, preview, set, to, view, (^.))
+import Data.Lens (Getter', Lens', Prism', Traversal', has, lens, modifying, over, preview, previewOn, prism, set, to, use, view, (^.))
 import Data.Lens.At (at)
 import Data.Lens.Index (ix)
 import Data.Lens.Iso.Newtype (_Newtype)
@@ -31,7 +32,7 @@ import Marlowe.Parser (parseContract)
 import Marlowe.Semantics (AccountId, Action(..), Assets, Bound, ChoiceId(..), ChosenNum, Contract(..), Environment(..), Input, IntervalResult(..), Observation, Party(..), Payment, Slot, SlotInterval(..), State, Token, TransactionError, TransactionInput(..), TransactionOutput(..), TransactionWarning, _minSlot, aesonCompatibleOptions, boundFrom, computeTransaction, emptyState, evalValue, extractRequiredActionsWithTxs, fixInterval, moneyInContract, timeouts)
 import Marlowe.Semantics as S
 import Monaco (IMarker)
-import Prelude (class Eq, class Monoid, class Ord, class Semigroup, Unit, add, append, map, mempty, min, one, zero, (#), ($), (<<<), (==))
+import Prelude (class Eq, class Monoid, class Ord, class Semigroup, Unit, add, append, identity, map, mempty, min, one, zero, (#), ($), (<<<), (==))
 
 data ActionInputId
   = DepositInputId AccountId Party Token BigInteger
@@ -140,7 +141,7 @@ _moveToAction = lens get' set'
     in
       set (_Newtype <<< at otherActionsParty) m p
 
-type ExecutionState
+type ExecutionStateRecord
   = { possibleActions :: Parties
     , pendingInputs :: Array Input
     , transactionError :: Maybe TransactionError
@@ -182,20 +183,55 @@ _payments = _log <<< to (mapMaybe f)
 
   f (OutputEvent _ payment) = Just payment
 
+type InitialConditionsRecord
+  = { initialSlot :: Slot }
+
+_initialSlot :: forall s a. Lens' { initialSlot :: a | s } a
+_initialSlot = prop (SProxy :: SProxy "initialSlot")
+
+data ExecutionState
+  = SimulationRunning ExecutionStateRecord
+  | SimulationNotStarted InitialConditionsRecord
+
+-- | Prism for the `ExecutionState` constructor of `SimulationRunning`.
+_SimulationRunning :: Prism' ExecutionState ExecutionStateRecord
+_SimulationRunning =
+  prism SimulationRunning
+    $ ( \x -> case x of
+          SimulationRunning record -> Right record
+          anotherCase -> Left anotherCase
+      )
+
+-- | Prism for the `ExecutionState` constructor of `SimulationNotStarted`.
+_SimulationNotStarted :: Prism' ExecutionState InitialConditionsRecord
+_SimulationNotStarted =
+  prism SimulationNotStarted
+    $ ( \x -> case x of
+          SimulationNotStarted record -> Right record
+          anotherCase -> Left anotherCase
+      )
+
 emptyExecutionStateWithSlot :: Slot -> ExecutionState
 emptyExecutionStateWithSlot sn =
-  { possibleActions: mempty
-  , pendingInputs: mempty
-  , transactionError: Nothing
-  , transactionWarnings: []
-  , log: []
-  , state: emptyState sn
-  , slot: sn
-  , moneyInContract: mempty
-  }
+  SimulationRunning
+    { possibleActions: mempty
+    , pendingInputs: mempty
+    , transactionError: Nothing
+    , transactionWarnings: []
+    , log: []
+    , state: emptyState sn
+    , slot: sn
+    , moneyInContract: mempty
+    }
+
+simulationNotStartedWithSlot :: Slot -> ExecutionState
+simulationNotStartedWithSlot slot = SimulationNotStarted { initialSlot: slot }
+
+simulationNotStarted :: ExecutionState
+simulationNotStarted = simulationNotStartedWithSlot zero
 
 type MarloweState
-  = { executionState :: Maybe ExecutionState
+  = { executionState :: ExecutionState
     , contract :: Maybe Contract
     , editorErrors :: Array IMarker
     , editorWarnings :: Array IMarker
@@ -227,7 +263,7 @@ emptyMarloweState =
   , editorErrors: mempty
   , editorWarnings: mempty
   , holes: mempty
-  , executionState: Nothing
+  , executionState: simulationNotStarted
   }
 
 emptyMarloweStateWithSlot :: Slot -> MarloweState
@@ -236,8 +272,17 @@ emptyMarloweStateWithSlot sn =
   , editorErrors: mempty
   , editorWarnings: mempty
   , holes: mempty
-  , executionState: Just $ emptyExecutionStateWithSlot sn
+  , executionState: emptyExecutionStateWithSlot sn
   }
+
+getAsMuchStateAP :: forall m t0. Bind m => MonadState { marloweState :: NonEmptyList MarloweState | t0 } m => m State
+getAsMuchStateAP = do
+  executionState <- use (_currentMarloweState <<< _executionState)
+  pure
+    ( case executionState of
+        SimulationRunning runRecord -> runRecord.state
+        SimulationNotStarted notRunRecord -> emptyState notRunRecord.initialSlot
+    )
 
 -- We have a special person for notifications
 otherActionsParty :: Party
@@ -260,10 +305,10 @@ updateContractInStateP text state = case parseContract text of
           (set _holes holes) state
   Left error -> (set _holes mempty) state
   where
-  marloweState = maybe (emptyState zero) (\s -> s.state) state.executionState
+  marloweState = maybe (emptyState zero) identity (previewOn state (_executionState <<< _SimulationRunning <<< _state))
 
 updatePossibleActions :: MarloweState -> MarloweState
-updatePossibleActions oldState@{ executionState: Just executionState } =
+updatePossibleActions oldState@{ executionState: SimulationRunning executionState } =
   let
     contract = fromMaybe Close (oldState ^. _contract)
 
@@ -287,7 +332,7 @@ updatePossibleActions oldState@{ executionState: Just executionState } =
       executionState # over _possibleActions (updateActions actionInputs)
         # set (_possibleActions <<< _moveToAction) moveTo
   in
-    oldState # set _executionState (Just newExecutionState)
+    oldState # set _executionState (SimulationRunning newExecutionState)
   where
   removeUseless :: Action -> Maybe Action
   removeUseless action@(Notify observation) = if evalObservation oldState observation then Just action else Nothing
@@ -330,7 +375,7 @@ updatePossibleActions oldState@{ executionState: Just executionState } =
 updatePossibleActions oldState = oldState
 
 updateStateP :: MarloweState -> MarloweState
-updateStateP oldState@{ executionState: Just executionState } = actState
+updateStateP oldState@{ executionState: SimulationRunning executionState } = actState
   where
   txInput@(TransactionInput txIn) = stateToTxInput executionState
 
@@ -348,7 +393,7 @@ updateStateP oldState@{ executionState: Just executionState } = actState
           )
             executionState
       in
-        ( set _executionState (Just newExecutionState)
+        ( set _executionState (SimulationRunning newExecutionState)
             <<< set _contract (Just txOutContract)
         )
           oldState
@@ -364,11 +409,11 @@ updateStateP oldState@{ executionState: Just executionState } = actState
           )
             executionState
       in
-        set _executionState (Just newExecutionState) oldState
+        set _executionState (SimulationRunning newExecutionState) oldState
 
 updateStateP oldState = oldState
 
-stateToTxInput :: ExecutionState -> TransactionInput
+stateToTxInput :: ExecutionStateRecord -> TransactionInput
 stateToTxInput executionState =
   let
     slot = executionState ^. _slot
@@ -402,27 +447,27 @@ applyInput ::
   MonadState { marloweState :: NonEmptyList MarloweState | s } m =>
   (Array Input -> Array Input) ->
   m Unit
-applyInput inputs = modifying _marloweState (extendWith (updatePossibleActions <<< updateStateP <<< (over (_executionState <<< _Just <<< _pendingInputs) inputs)))
+applyInput inputs = modifying _marloweState (extendWith (updatePossibleActions <<< updateStateP <<< (over (_executionState <<< _SimulationRunning <<< _pendingInputs) inputs)))
 
 moveToSignificantSlot ::
   forall s m.
   MonadState { marloweState :: NonEmptyList MarloweState | s } m =>
   Slot ->
   m Unit
-moveToSignificantSlot slot = modifying _marloweState (extendWith (updatePossibleActions <<< updateStateP <<< (set (_executionState <<< _Just <<< _slot) slot)))
+moveToSignificantSlot slot = modifying _marloweState (extendWith (updatePossibleActions <<< updateStateP <<< (set (_executionState <<< _SimulationRunning <<< _slot) slot)))
 
 moveToSlot ::
   forall s m.
   MonadState { marloweState :: NonEmptyList MarloweState | s } m =>
   Slot ->
   m Unit
-moveToSlot slot = modifying _marloweState (extendWith (updatePossibleActions <<< (set (_executionState <<< _Just <<< _slot) slot)))
+moveToSlot slot = modifying _marloweState (extendWith (updatePossibleActions <<< (set (_executionState <<< _SimulationRunning <<< _slot) slot)))
 
 hasHistory :: forall s. { marloweState :: NonEmptyList MarloweState | s } -> Boolean
 hasHistory state = has (_marloweState <<< _Tail) state
 
 evalObservation :: MarloweState -> Observation -> Boolean
-evalObservation state@{ executionState: Just executionState } observation =
+evalObservation state@{ executionState: SimulationRunning executionState } observation =
   let
     txInput = stateToTxInput executionState
   in

--- a/marlowe-playground-client/src/Simulation/Types.purs
+++ b/marlowe-playground-client/src/Simulation/Types.purs
@@ -159,6 +159,7 @@ data Action
   | LoadScript String
   | SetEditorText String
   -- marlowe actions
+  | SetInitialSlot Slot
   | StartSimulation
   | MoveSlot Slot
   | SetSlot Slot
@@ -197,6 +198,7 @@ instance isEventAction :: IsEvent Action where
   toEvent (SelectEditorKeyBindings _) = Just $ defaultEvent "SelectEditorKeyBindings"
   toEvent (LoadScript script) = Just $ (defaultEvent "LoadScript") { label = Just script }
   toEvent (SetEditorText _) = Just $ defaultEvent "SetEditorText"
+  toEvent (SetInitialSlot _) = Just $ defaultEvent "SetInitialSlot"
   toEvent StartSimulation = Just $ defaultEvent "StartSimulation"
   toEvent (MoveSlot _) = Just $ defaultEvent "MoveSlot"
   toEvent (SetSlot _) = Just $ defaultEvent "SetSlot"

--- a/marlowe-playground-client/src/Wallet.purs
+++ b/marlowe-playground-client/src/Wallet.purs
@@ -52,7 +52,7 @@ import Marlowe.Parser (parseContract)
 import Marlowe.Semantics (AccountId, Assets(..), Bound(..), ChoiceId(..), ChosenNum, Input(..), Party, Payee(..), Payment(..), PubKey, Slot, Token(..), TransactionWarning(..), ValueId(..), _accounts, _boundValues, _choices, inBounds, timeouts)
 import Marlowe.Semantics as S
 import Prelude (class Eq, class Ord, class Show, Unit, add, bind, const, discard, eq, flip, map, mempty, not, one, otherwise, pure, show, unit, when, zero, ($), (&&), (+), (-), (<$>), (<<<), (<>), (=<<), (==), (>=), (||), (>))
-import Simulation.State (ActionInput(..), ActionInputId, MarloweState, _contract, _currentMarloweState, _executionState, _marloweState, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError, _transactionWarnings, emptyMarloweStateWithSlot, mapPartiesActionInput, updateContractInStateP, updatePossibleActions, updateStateP)
+import Simulation.State (ActionInput(..), ActionInputId, MarloweState, _SimulationRunning, _contract, _currentMarloweState, _executionState, _marloweState, _payments, _pendingInputs, _possibleActions, _slot, _state, _transactionError, _transactionWarnings, emptyMarloweStateWithSlot, mapPartiesActionInput, updateContractInStateP, updatePossibleActions, updateStateP)
 import Text.Extra (stripParens)
 import Text.Pretty (pretty)
 import Web.DOM.Document as D
@@ -300,9 +300,9 @@ mkComponent =
 
 applyTransactions :: forall m. MonadState State m => m Unit
 applyTransactions = do
-  initialPayments <- fromMaybe mempty <$> peruse (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _payments)
+  initialPayments <- fromMaybe mempty <$> peruse (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _payments)
   modifying _loadedMarloweState (extendWith (updatePossibleActions <<< updateStateP))
-  updatedPayments <- fromMaybe mempty <$> peruse (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _payments)
+  updatedPayments <- fromMaybe mempty <$> peruse (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _payments)
   let
     newPayments = drop (Array.length initialPayments) updatedPayments
   mContract <- use _walletLoadedContract
@@ -426,7 +426,7 @@ handleAction ResetAll = do
 handleAction NextSlot = do
   modifying _slot (add one)
   modifying (_contracts <<< traversed <<< _marloweState)
-    (extendWith (updatePossibleActions <<< over (_executionState <<< _Just <<< _slot) (add one)))
+    (extendWith (updatePossibleActions <<< over (_executionState <<< _SimulationRunning <<< _slot) (add one)))
 
 handleAction ApplyTransaction = do
   assign _addInputError Nothing
@@ -460,7 +460,7 @@ handleAction (AddInput input@(IDeposit _ _ token amount) bounds) = do
     Just walletAmount ->
       if walletAmount >= amount then do
         assign (_openWallet <<< _Just <<< _assets <<< ix token) (walletAmount - amount)
-        updateMarloweState (over (_executionState <<< _Just <<< _pendingInputs) ((flip snoc) input))
+        updateMarloweState (over (_executionState <<< _SimulationRunning <<< _pendingInputs) ((flip snoc) input))
       else
         assign _addInputError $ Just "Insufficient funds to add this input"
 
@@ -471,20 +471,20 @@ handleAction (AddInput input bounds) = do
       (IChoice _ chosenNum) -> inBounds chosenNum bounds
       _ -> true
   if validChoice then
-    updateMarloweState (over (_executionState <<< _Just <<< _pendingInputs) ((flip snoc) input))
+    updateMarloweState (over (_executionState <<< _SimulationRunning <<< _pendingInputs) ((flip snoc) input))
   else
     assign _addInputError $ Just "Invalid Choice"
 
 handleAction (RemoveInput input@(IDeposit _ _ token amount)) = do
   assign _addInputError Nothing
   modifying (_openWallet <<< _Just <<< _assets <<< ix token) (\v -> v + amount)
-  updateMarloweState (over (_executionState <<< _Just <<< _pendingInputs) (delete input))
+  updateMarloweState (over (_executionState <<< _SimulationRunning <<< _pendingInputs) (delete input))
 
 handleAction (RemoveInput input) = do
   assign _addInputError Nothing
-  updateMarloweState (over (_executionState <<< _Just <<< _pendingInputs) (delete input))
+  updateMarloweState (over (_executionState <<< _SimulationRunning <<< _pendingInputs) (delete input))
 
-handleAction (SetChoice choiceId chosenNum) = updateMarloweState (over (_executionState <<< _Just <<< _possibleActions) (mapPartiesActionInput (updateChoice choiceId)))
+handleAction (SetChoice choiceId chosenNum) = updateMarloweState (over (_executionState <<< _SimulationRunning <<< _possibleActions) (mapPartiesActionInput (updateChoice choiceId)))
   where
   updateChoice :: ChoiceId -> ActionInput -> ActionInput
   updateChoice wantedChoiceId input@(ChoiceInput currentChoiceId bounds _)
@@ -687,14 +687,14 @@ renderActions state =
       )
   ]
   where
-  pendingInputs = fromMaybe mempty (state ^? (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _pendingInputs))
+  pendingInputs = fromMaybe mempty (state ^? (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _pendingInputs))
 
   possibleActions =
     fromMaybe mempty
       $ state
       ^? ( _currentLoadedMarloweState
             <<< _executionState
-            <<< _Just
+            <<< _SimulationRunning
             <<< _possibleActions
             <<< to unwrap
             <<< to (Map.filterKeys walletKeys)
@@ -713,7 +713,7 @@ renderActions state =
     in
       Set.member party walletParties
 
-  hasTransactions = has (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _pendingInputs <<< to Array.null <<< to not) state
+  hasTransactions = has (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _pendingInputs <<< to Array.null <<< to not) state
 
   renderAction :: (Tuple ActionInputId ActionInput) -> HTML p Action
   renderAction (Tuple actionInputId actionInput) = inputItem true "" actionInput
@@ -835,7 +835,7 @@ renderCurrentState state =
     in
       if t == zero then "Closed" else show t
 
-  warnings = state ^. (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _transactionWarnings)
+  warnings = state ^. (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _transactionWarnings)
 
   warningsRow =
     if Array.null warnings then
@@ -843,7 +843,7 @@ renderCurrentState state =
     else
       (headerRow "Warnings" ("type" /\ "details" /\ mempty)) <> foldMap displayWarning' warnings
 
-  errorRow = case state ^? (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _transactionError) of
+  errorRow = case state ^? (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _transactionError) of
     Nothing -> []
     Just error ->
       if isNothing error then
@@ -860,7 +860,7 @@ renderCurrentState state =
 
   accountsData =
     let
-      (accounts :: Array _) = state ^. (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _state <<< _accounts <<< to Map.toUnfoldable)
+      (accounts :: Array _) = state ^. (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _state <<< _accounts <<< to Map.toUnfoldable)
 
       asTuple (Tuple (Tuple accountOwner token) value) = stripParens (show accountOwner) /\ (show value <> " " <> shortTokenString token) /\ mempty
     in
@@ -872,7 +872,7 @@ renderCurrentState state =
 
   choicesData =
     let
-      (choices :: Array _) = state ^. (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _state <<< _choices <<< to Map.toUnfoldable)
+      (choices :: Array _) = state ^. (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _state <<< _choices <<< to Map.toUnfoldable)
 
       asTuple (Tuple (ChoiceId choiceName choiceOwner) value) = show choiceName /\ stripParens (show choiceOwner) /\ show value
     in
@@ -880,7 +880,7 @@ renderCurrentState state =
 
   paymentsData =
     let
-      payments = state ^. (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _payments)
+      payments = state ^. (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _payments)
 
       asTuple :: Payment -> Array (String /\ String /\ String)
       asTuple (Payment party (Assets mon)) =
@@ -899,7 +899,7 @@ renderCurrentState state =
 
   bindingsData =
     let
-      (bindings :: Array _) = state ^. (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _state <<< _boundValues <<< to Map.toUnfoldable)
+      (bindings :: Array _) = state ^. (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _state <<< _boundValues <<< to Map.toUnfoldable)
 
       asTuple (Tuple (ValueId valueId) value) = show valueId /\ show value /\ mempty
     in
@@ -1198,9 +1198,9 @@ transactionComposer state =
     else
       [ transaction state ]
   where
-  currentBlock = state ^? (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _slot)
+  currentBlock = state ^? (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _slot)
 
-  pendingInputs = fromMaybe mempty (state ^? (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _pendingInputs))
+  pendingInputs = fromMaybe mempty (state ^? (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _pendingInputs))
 
 transaction ::
   forall p.
@@ -1210,7 +1210,7 @@ transaction state =
   li [ classes [ ClassName "participant-a", noMargins ] ]
     [ ul
         []
-        (map (transactionRow state) (state ^. (_currentLoadedMarloweState <<< _executionState <<< _Just <<< _pendingInputs)))
+        (map (transactionRow state) (state ^. (_currentLoadedMarloweState <<< _executionState <<< _SimulationRunning <<< _pendingInputs)))
     ]
 
 transactionRow ::

--- a/marlowe-playground-client/static/css/panels.scss
+++ b/marlowe-playground-client/static/css/panels.scss
@@ -170,6 +170,14 @@
   width: 150px;
 }
 
+.initial-slot-input {
+  margin: 1rem 0rem;
+}
+
+.initial-slot-input > span {
+  margin-right: 1rem;
+}
+
 .transaction-composer ul li ul {
   display: flex;
 }


### PR DESCRIPTION
Deployed to https://pablo.marlowe.iohkdev.io/

Use start button to reduce initial contract when it doesn't start with a When.

It was impossible to just reduce the contract for a particular slot if it doesn't start with When or Close. We would need an option that allows you to reduce the contract without issuing any actions (empty transaction).

It can be exposed by trying to falsify the assertion in the following contract, which seemed impossible to do in the simulator before this fix:
```
Let
  "value"
  SlotIntervalStart
  (When
    [Case
      (Deposit
        (Role "role")
        (Role "role")
        (Token "" "")
        (AddValue
          (UseValue "value")
          SlotIntervalStart
        )
      )
      (Assert
        (ValueEQ
          (AvailableMoney
            (Role "role")
            (Token "" "")
          )
          (Scale
            (2%1)
            (UseValue "value")
          )
        )
        Close
      )]
    10 Close
  )
```