### PR TITLE
nofib-hs was benchmarking compilation times, not execution times

### DIFF
--- a/nix/stack.materialized/plutus-benchmark.nix
+++ b/nix/stack.materialized/plutus-benchmark.nix
@@ -1,152 +1,154 @@
 { system
-  , compiler
-  , flags
-  , pkgs
-  , hsPkgs
-  , pkgconfPkgs
-  , errorHandler
-  , config
-  , ... }:
-  {
-    flags = {};
-    package = {
-      specVersion = "2.2";
-      identifier = { name = "plutus-benchmark"; version = "0.1.0.0"; };
-      license = "Apache-2.0";
-      copyright = "";
-      maintainer = "radu.ometita@iohk.io";
-      author = "Radu Ometita";
-      homepage = "https://github.com/iohk/plutus#readme";
-      url = "";
-      synopsis = "";
-      description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
-      buildType = "Simple";
-      isLocal = true;
-      detailLevel = "FullDetails";
-      licenseFiles = [ "LICENSE" "NOTICE" ];
-      dataDir = "";
-      dataFiles = [
-        "validation/data/crowdfunding/*.plc"
-        "validation/data/future/*.plc"
-        "validation/data/multisigSM/*.plc"
-        "validation/data/vesting/*.plc"
-        "validation/data/marlowe/trustfund/*.plc"
-        "validation/data/marlowe/zerocoupon/*.plc"
-        "templates/*.tpl"
-        ];
-      extraSrcFiles = [];
-      extraTmpFiles = [];
-      extraDocFiles = [];
-      };
-    components = {
-      "library" = {
+, compiler
+, flags
+, pkgs
+, hsPkgs
+, pkgconfPkgs
+, errorHandler
+, config
+, ...
+}:
+{
+  flags = { };
+  package = {
+    specVersion = "2.2";
+    identifier = { name = "plutus-benchmark"; version = "0.1.0.0"; };
+    license = "Apache-2.0";
+    copyright = "";
+    maintainer = "radu.ometita@iohk.io";
+    author = "Radu Ometita";
+    homepage = "https://github.com/iohk/plutus#readme";
+    url = "";
+    synopsis = "";
+    description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
+    buildType = "Simple";
+    isLocal = true;
+    detailLevel = "FullDetails";
+    licenseFiles = [ "LICENSE" "NOTICE" ];
+    dataDir = "";
+    dataFiles = [
+      "validation/data/crowdfunding/*.plc"
+      "validation/data/future/*.plc"
+      "validation/data/multisigSM/*.plc"
+      "validation/data/vesting/*.plc"
+      "validation/data/marlowe/trustfund/*.plc"
+      "validation/data/marlowe/zerocoupon/*.plc"
+      "templates/*.tpl"
+    ];
+    extraSrcFiles = [ ];
+    extraTmpFiles = [ ];
+    extraDocFiles = [ ];
+  };
+  components = {
+    "library" = {
+      depends = [
+        (hsPkgs."base" or (errorHandler.buildDepError "base"))
+        (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+        (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+        (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+        (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+      ];
+      buildable = true;
+      modules = [
+        "Plutus/Benchmark/Clausify"
+        "Plutus/Benchmark/Queens"
+        "Plutus/Benchmark/Knights"
+        "Plutus/Benchmark/Knights/ChessSetList"
+        "Plutus/Benchmark/Knights/KnightHeuristic"
+        "Plutus/Benchmark/Knights/Queue"
+        "Plutus/Benchmark/Knights/Sort"
+        "Plutus/Benchmark/Knights/Utils"
+        "Plutus/Benchmark/LastPiece"
+        "Plutus/Benchmark/Prime"
+      ];
+      hsSourceDirs = [ "nofib/src" ];
+    };
+    exes = {
+      "nofib-exe" = {
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
           (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
           (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-          ];
+          (hsPkgs."ansi-wl-pprint" or (errorHandler.buildDepError "ansi-wl-pprint"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
+          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+        ];
         buildable = true;
-        modules = [
-          "Plutus/Benchmark/Clausify"
-          "Plutus/Benchmark/Queens"
-          "Plutus/Benchmark/Knights"
-          "Plutus/Benchmark/Knights/ChessSetList"
-          "Plutus/Benchmark/Knights/KnightHeuristic"
-          "Plutus/Benchmark/Knights/Queue"
-          "Plutus/Benchmark/Knights/Sort"
-          "Plutus/Benchmark/Knights/Utils"
-          "Plutus/Benchmark/LastPiece"
-          "Plutus/Benchmark/Prime"
-          ];
-        hsSourceDirs = [ "nofib/src" ];
-        };
-      exes = {
-        "nofib-exe" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
-            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
-            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-            (hsPkgs."ansi-wl-pprint" or (errorHandler.buildDepError "ansi-wl-pprint"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
-            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "nofib/exe" ];
-          mainPath = [ "Main.hs" ];
-          };
-        };
-      tests = {
-        "plutus-benchmark-nofib-tests" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
-            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
-            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
-            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
-            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
-            ];
-          buildable = true;
-          hsSourceDirs = [ "nofib/test" ];
-          mainPath = [ "Spec.hs" ];
-          };
-        };
-      benchmarks = {
-        "nofib" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
-            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
-            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            ];
-          buildable = true;
-          modules = [ "Common" "Paths_plutus_benchmark" ];
-          hsSourceDirs = [ "nofib/bench" ];
-          };
-        "nofib-hs" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
-            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
-            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            ];
-          buildable = true;
-          modules = [ "Common" "Paths_plutus_benchmark" ];
-          hsSourceDirs = [ "nofib/bench" ];
-          };
-        "validation" = {
-          depends = [
-            (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
-            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-            (hsPkgs."text" or (errorHandler.buildDepError "text"))
-            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
-            ];
-          buildable = true;
-          modules = [ "Paths_plutus_benchmark" ];
-          hsSourceDirs = [ "validation" ];
-          };
-        };
+        hsSourceDirs = [ "nofib/exe" ];
+        mainPath = [ "Main.hs" ];
       };
-    } // rec {
-    src = (pkgs.lib).mkDefault ./plutus-benchmark;
-    }
+    };
+    tests = {
+      "plutus-benchmark-nofib-tests" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
+          (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+          (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+          (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+          (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+          (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+        ];
+        buildable = true;
+        hsSourceDirs = [ "nofib/test" ];
+        mainPath = [ "Spec.hs" ];
+      };
+    };
+    benchmarks = {
+      "nofib" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
+          (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+          (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+          (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+        ];
+        buildable = true;
+        modules = [ "Common" "Paths_plutus_benchmark" ];
+        hsSourceDirs = [ "nofib/bench" ];
+      };
+      "nofib-hs" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
+          (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+          (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+          (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+        ];
+        buildable = true;
+        modules = [ "Common" "Paths_plutus_benchmark" ];
+        hsSourceDirs = [ "nofib/bench" ];
+      };
+      "validation" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+        ];
+        buildable = true;
+        modules = [ "Paths_plutus_benchmark" ];
+        hsSourceDirs = [ "validation" ];
+      };
+    };
+  };
+} // rec {
+  src = (pkgs.lib).mkDefault ./plutus-benchmark;
+}

--- a/nix/stack.materialized/plutus-benchmark.nix
+++ b/nix/stack.materialized/plutus-benchmark.nix
@@ -1,154 +1,153 @@
 { system
-, compiler
-, flags
-, pkgs
-, hsPkgs
-, pkgconfPkgs
-, errorHandler
-, config
-, ...
-}:
-{
-  flags = { };
-  package = {
-    specVersion = "2.2";
-    identifier = { name = "plutus-benchmark"; version = "0.1.0.0"; };
-    license = "Apache-2.0";
-    copyright = "";
-    maintainer = "radu.ometita@iohk.io";
-    author = "Radu Ometita";
-    homepage = "https://github.com/iohk/plutus#readme";
-    url = "";
-    synopsis = "";
-    description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
-    buildType = "Simple";
-    isLocal = true;
-    detailLevel = "FullDetails";
-    licenseFiles = [ "LICENSE" "NOTICE" ];
-    dataDir = "";
-    dataFiles = [
-      "validation/data/crowdfunding/*.plc"
-      "validation/data/future/*.plc"
-      "validation/data/multisigSM/*.plc"
-      "validation/data/vesting/*.plc"
-      "validation/data/marlowe/trustfund/*.plc"
-      "validation/data/marlowe/zerocoupon/*.plc"
-      "templates/*.tpl"
-    ];
-    extraSrcFiles = [ ];
-    extraTmpFiles = [ ];
-    extraDocFiles = [ ];
-  };
-  components = {
-    "library" = {
-      depends = [
-        (hsPkgs."base" or (errorHandler.buildDepError "base"))
-        (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-        (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
-        (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-        (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-      ];
-      buildable = true;
-      modules = [
-        "Plutus/Benchmark/Clausify"
-        "Plutus/Benchmark/Queens"
-        "Plutus/Benchmark/Knights"
-        "Plutus/Benchmark/Knights/ChessSetList"
-        "Plutus/Benchmark/Knights/KnightHeuristic"
-        "Plutus/Benchmark/Knights/Queue"
-        "Plutus/Benchmark/Knights/Sort"
-        "Plutus/Benchmark/Knights/Utils"
-        "Plutus/Benchmark/LastPiece"
-        "Plutus/Benchmark/Prime"
-      ];
-      hsSourceDirs = [ "nofib/src" ];
-    };
-    exes = {
-      "nofib-exe" = {
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.2";
+      identifier = { name = "plutus-benchmark"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "";
+      maintainer = "radu.ometita@iohk.io";
+      author = "Radu Ometita";
+      homepage = "https://github.com/iohk/plutus#readme";
+      url = "";
+      synopsis = "";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/plutus#readme>";
+      buildType = "Simple";
+      isLocal = true;
+      detailLevel = "FullDetails";
+      licenseFiles = [ "LICENSE" "NOTICE" ];
+      dataDir = "";
+      dataFiles = [
+        "validation/data/crowdfunding/*.plc"
+        "validation/data/future/*.plc"
+        "validation/data/multisigSM/*.plc"
+        "validation/data/vesting/*.plc"
+        "validation/data/marlowe/trustfund/*.plc"
+        "validation/data/marlowe/zerocoupon/*.plc"
+        "templates/*.tpl"
+        ];
+      extraSrcFiles = [];
+      extraTmpFiles = [];
+      extraDocFiles = [];
+      };
+    components = {
+      "library" = {
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
-          (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
           (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
           (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
           (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-          (hsPkgs."ansi-wl-pprint" or (errorHandler.buildDepError "ansi-wl-pprint"))
-          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
-          (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
-          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
-        ];
+          (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          ];
         buildable = true;
-        hsSourceDirs = [ "nofib/exe" ];
-        mainPath = [ "Main.hs" ];
+        modules = [
+          "Plutus/Benchmark/Clausify"
+          "Plutus/Benchmark/Queens"
+          "Plutus/Benchmark/Knights"
+          "Plutus/Benchmark/Knights/ChessSetList"
+          "Plutus/Benchmark/Knights/KnightHeuristic"
+          "Plutus/Benchmark/Knights/Queue"
+          "Plutus/Benchmark/Knights/Sort"
+          "Plutus/Benchmark/Knights/Utils"
+          "Plutus/Benchmark/LastPiece"
+          "Plutus/Benchmark/Prime"
+          ];
+        hsSourceDirs = [ "nofib/src" ];
+        };
+      exes = {
+        "nofib-exe" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."ansi-wl-pprint" or (errorHandler.buildDepError "ansi-wl-pprint"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "nofib/exe" ];
+          mainPath = [ "Main.hs" ];
+          };
+        };
+      tests = {
+        "plutus-benchmark-nofib-tests" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
+            ];
+          buildable = true;
+          hsSourceDirs = [ "nofib/test" ];
+          mainPath = [ "Spec.hs" ];
+          };
+        };
+      benchmarks = {
+        "nofib" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            ];
+          buildable = true;
+          modules = [ "Common" "Paths_plutus_benchmark" ];
+          hsSourceDirs = [ "nofib/bench" ];
+          };
+        "nofib-hs" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
+            (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
+            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            ];
+          buildable = true;
+          modules = [ "Common" "Paths_plutus_benchmark" ];
+          hsSourceDirs = [ "nofib/bench" ];
+          };
+        "validation" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            ];
+          buildable = true;
+          modules = [ "Paths_plutus_benchmark" ];
+          hsSourceDirs = [ "validation" ];
+          };
+        };
       };
-    };
-    tests = {
-      "plutus-benchmark-nofib-tests" = {
-        depends = [
-          (hsPkgs."base" or (errorHandler.buildDepError "base"))
-          (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
-          (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-          (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
-          (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-          (hsPkgs."tasty" or (errorHandler.buildDepError "tasty"))
-          (hsPkgs."tasty-hunit" or (errorHandler.buildDepError "tasty-hunit"))
-          (hsPkgs."tasty-quickcheck" or (errorHandler.buildDepError "tasty-quickcheck"))
-        ];
-        buildable = true;
-        hsSourceDirs = [ "nofib/test" ];
-        mainPath = [ "Spec.hs" ];
-      };
-    };
-    benchmarks = {
-      "nofib" = {
-        depends = [
-          (hsPkgs."base" or (errorHandler.buildDepError "base"))
-          (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
-          (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-          (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
-          (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-          (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
-          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-        ];
-        buildable = true;
-        modules = [ "Common" "Paths_plutus_benchmark" ];
-        hsSourceDirs = [ "nofib/bench" ];
-      };
-      "nofib-hs" = {
-        depends = [
-          (hsPkgs."base" or (errorHandler.buildDepError "base"))
-          (hsPkgs."plutus-benchmark" or (errorHandler.buildDepError "plutus-benchmark"))
-          (hsPkgs."plutus-tx" or (errorHandler.buildDepError "plutus-tx"))
-          (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
-          (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-          (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
-          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-        ];
-        buildable = true;
-        modules = [ "Common" "Paths_plutus_benchmark" ];
-        hsSourceDirs = [ "nofib/bench" ];
-      };
-      "validation" = {
-        depends = [
-          (hsPkgs."base" or (errorHandler.buildDepError "base"))
-          (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
-          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
-          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
-          (hsPkgs."criterion" or (errorHandler.buildDepError "criterion"))
-          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
-          (hsPkgs."text" or (errorHandler.buildDepError "text"))
-          (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
-        ];
-        buildable = true;
-        modules = [ "Paths_plutus_benchmark" ];
-        hsSourceDirs = [ "validation" ];
-      };
-    };
-  };
-} // rec {
-  src = (pkgs.lib).mkDefault ./plutus-benchmark;
-}
+    } // rec {
+    src = (pkgs.lib).mkDefault ./plutus-benchmark;
+    }

--- a/plutus-benchmark/README.md
+++ b/plutus-benchmark/README.md
@@ -15,7 +15,7 @@ This directory contains two sets of benchmarks:
 
    * The corresponding cabal commands are
        * `cabal v2-bench plutus-benchmark:nofib`
-       * `cabal v2-bench plutus-benchmark:nofib --benchmark-options "clausify/formula2 -L300"``
+       * `cabal v2-bench plutus-benchmark:nofib --benchmark-options "clausify/formula2 -L300"`
 
    * By default, the benchmarks are run for a minimum of **60 seconds each** in order to get a
      statistically reasonable number of executions.  You can change this with Criterion's `-L` option.

--- a/plutus-benchmark/nofib/bench/BenchHaskell.hs
+++ b/plutus-benchmark/nofib/bench/BenchHaskell.hs
@@ -13,16 +13,16 @@ import qualified Plutus.Benchmark.Prime    as Prime
 import qualified Plutus.Benchmark.Queens   as Queens
 
 benchClausify :: Clausify.StaticFormula -> Benchmarkable
-benchClausify f = nf Clausify.mkClausifyTerm f
+benchClausify f = nf Clausify.runClausify f
 
 benchKnights :: Integer -> Integer -> Benchmarkable
-benchKnights depth sz = nf (Knights.mkKnightsTerm depth) sz
+benchKnights depth sz = nf (Knights.runKnights depth) sz
 
 benchPrime :: Prime.PrimeID -> Benchmarkable
-benchPrime pid = nf Prime.mkPrimalityBenchTerm pid
+benchPrime pid = nf Prime.runFixedPrimalityTest pid
 
 benchQueens :: Integer -> Queens.Algorithm -> Benchmarkable
-benchQueens sz alg = nf (Queens.mkQueensTerm sz) alg
+benchQueens sz alg = nf (Queens.runQueens sz) alg
 
 main :: IO ()
 main = do

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Knights/ChessSetList.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Knights/ChessSetList.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Plutus.Benchmark.Knights.ChessSetList
@@ -15,6 +17,9 @@ module Plutus.Benchmark.Knights.ChessSetList
       isSquareFree
     ) where
 
+import           Control.DeepSeq                (NFData)
+import           GHC.Generics
+
 import           Plutus.Benchmark.Knights.Sort
 import           Plutus.Benchmark.Knights.Utils
 
@@ -28,7 +33,7 @@ data ChessSet = Board
                 Integer      -- % Current move number
                 (Maybe Tile) -- % Initial square: see Note [deleteFirst] below
                 [Tile]       -- % All squares visited (in reverse: the last element is the initial square).
-
+                deriving (Generic, NFData)
 instance Tx.Eq ChessSet where
     _ == _ = True
 

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Prime.hs
@@ -2,6 +2,8 @@
   Most of the literate Haskell stuff has been removed and everything's
   been put into one file for simplicity. %-}
 
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -fno-warn-identities              #-}
@@ -11,7 +13,9 @@
 
 module Plutus.Benchmark.Prime where
 
+import           Control.DeepSeq              (NFData)
 import           Data.Char                    (isSpace)
+import           GHC.Generics
 import qualified Prelude                      (Eq (..), String)
 
 import           Language.PlutusCore          (Name (..))
@@ -259,7 +263,7 @@ numTests :: Integer
 numTests = 100
 
 data Result = Composite | Prime
-    deriving (Show, Prelude.Eq)
+    deriving (Show, Prelude.Eq, Generic, NFData)
 -- Prelude.Eq needed for comparing Haskell results in tests.
 
 -- % The @processList@ function takes a list of input numbers

--- a/plutus-benchmark/nofib/src/Plutus/Benchmark/Queens.hs
+++ b/plutus-benchmark/nofib/src/Plutus/Benchmark/Queens.hs
@@ -1,5 +1,7 @@
 {-% nofib/spectral/constraints converted to Plutus.
     Renamed to avoid conflict with existing package. %-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing      #-}
@@ -13,8 +15,10 @@ module Plutus.Benchmark.Queens where
 	See Proceedings of WAAAPL '99
 -}
 
+import           Control.DeepSeq              (NFData)
 import           Control.Monad                (forM_)
 import           Data.Char                    (isSpace)
+import           GHC.Generics
 import qualified Prelude
 import           System.Environment
 
@@ -227,7 +231,8 @@ sortBy cmp = mergeAll . sequences
 type Var = Integer
 type Value = Integer
 
-data Assign = Var := Value deriving (Show, Prelude.Eq, Prelude.Ord)
+data Assign = Var := Value
+    deriving (Show, Prelude.Eq, Prelude.Ord, Generic, NFData)
 instance TxPrelude.Eq Assign
     where (a := b) == (a' := b') = a==a' && b==b'
 instance TxPrelude.Ord Assign

--- a/plutus-benchmark/plutus-benchmark.cabal
+++ b/plutus-benchmark/plutus-benchmark.cabal
@@ -61,6 +61,7 @@ library
     , plutus-tx -any
     , plutus-tx-plugin -any
     , plutus-core -any
+    , deepseq -any
   default-extensions:
     DataKinds
     NamedFieldPuns


### PR DESCRIPTION
The `nofib-hs` benchmarks were in fact benchmarking the plutus-tx compilation times of the nofib examples, not the execution times.  I think this should fix it.  

Maybe we should keep the compliation time benchmarks, since it'd be cheap to do so.