### PR TITLE
Fix pubKeyHash in off-chain code

### DIFF
--- a/marlowe/test/contract.json
+++ b/marlowe/test/contract.json
@@ -18,10 +18,10 @@
             "add": 100
           },
           "into_account": {
-            "pk_hash": "4ecde0775d081e45f06141416cbc3afed4c44a08c93ea31281e25c8fa03548b9"
+            "pk_hash": "39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"
           },
           "party": {
-            "pk_hash": "4ecde0775d081e45f06141416cbc3afed4c44a08c93ea31281e25c8fa03548b9"
+            "pk_hash": "39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"
           }
         },
         "then": {
@@ -48,7 +48,7 @@
               "currency_symbol": ""
             },
             "from_account": {
-              "pk_hash": "4ecde0775d081e45f06141416cbc3afed4c44a08c93ea31281e25c8fa03548b9"
+              "pk_hash": "39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"
             },
             "then": "close"
           },
@@ -60,7 +60,7 @@
           "for_choice": {
             "choice_name": "choice",
             "choice_owner": {
-              "pk_hash": "4ecde0775d081e45f06141416cbc3afed4c44a08c93ea31281e25c8fa03548b9"
+              "pk_hash": "39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"
             }
           },
           "choose_between": [
@@ -80,7 +80,7 @@
               "chose_something_for": {
                 "choice_name": "choice",
                 "choice_owner": {
-                  "pk_hash": "4ecde0775d081e45f06141416cbc3afed4c44a08c93ea31281e25c8fa03548b9"
+                  "pk_hash": "39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"
                 }
               }
             },
@@ -89,7 +89,7 @@
                 "value_of_choice": {
                   "choice_name": "choice",
                   "choice_owner": {
-                    "pk_hash": "4ecde0775d081e45f06141416cbc3afed4c44a08c93ea31281e25c8fa03548b9"
+                    "pk_hash": "39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"
                   }
                 }
               },
@@ -107,12 +107,12 @@
                 "currency_symbol": "6161"
               },
               "in_account": {
-                "pk_hash": "4ecde0775d081e45f06141416cbc3afed4c44a08c93ea31281e25c8fa03548b9"
+                "pk_hash": "39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"
               }
             },
             "to": {
               "account": {
-                "pk_hash": "4ecde0775d081e45f06141416cbc3afed4c44a08c93ea31281e25c8fa03548b9"
+                "pk_hash": "39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"
               }
             },
             "token": {
@@ -120,7 +120,7 @@
               "currency_symbol": "6161"
             },
             "from_account": {
-              "pk_hash": "4ecde0775d081e45f06141416cbc3afed4c44a08c93ea31281e25c8fa03548b9"
+              "pk_hash": "39f713d0a644253f04529421b9f51b9b08979d08295959c4f3990ee617f5139f"
             },
             "then": "close"
           },

--- a/nix/stack.materialized/plutus-ledger.nix
+++ b/nix/stack.materialized/plutus-ledger.nix
@@ -115,6 +115,8 @@
             (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."plutus-core" or (errorHandler.buildDepError "plutus-core"))
+            (hsPkgs."plutus-tx-plugin" or (errorHandler.buildDepError "plutus-tx-plugin"))
             ];
           buildable = true;
           hsSourceDirs = [ "test" ];

--- a/plutus-ledger/plutus-ledger.cabal
+++ b/plutus-ledger/plutus-ledger.cabal
@@ -131,4 +131,6 @@ test-suite plutus-ledger-test
         plutus-tx -any,
         lens -any,
         bytestring -any,
-        aeson -any
+        aeson -any,
+        plutus-core -any,
+        plutus-tx-plugin -any

--- a/plutus-ledger/src/Ledger/Validation.hs
+++ b/plutus-ledger/src/Ledger/Validation.hs
@@ -35,6 +35,7 @@ module Ledger.Validation
     , getContinuingOutputs
     -- ** Hashes (see note [Hashes in validator scripts])
     , scriptCurrencySymbol
+    , pubKeyHash
     -- * Validator functions
     -- ** Signatures
     , txSignedBy
@@ -62,7 +63,7 @@ import           Language.PlutusTx.Prelude
 import           Ledger.Ada                 (Ada)
 import qualified Ledger.Ada                 as Ada
 import           Ledger.Address             (Address (..), scriptHashAddress)
-import           Ledger.Crypto              (PubKey (..), PubKeyHash (..), Signature (..))
+import           Ledger.Crypto              (PubKey (..), PubKeyHash (..), Signature (..), pubKeyHash)
 import           Ledger.Scripts
 import           Ledger.Slot                (SlotRange)
 import           Ledger.Tx                  (TxOut (..), TxOutRef (..), TxOutType (..))

--- a/plutus-ledger/test/Spec.hs
+++ b/plutus-ledger/test/Spec.hs
@@ -1,43 +1,50 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 module Main(main) where
 
 import           Control.Lens
-import           Control.Monad              (void)
-import           Control.Monad.Trans.Except (runExcept)
-import qualified Data.Aeson                 as JSON
-import qualified Data.Aeson.Extras          as JSON
-import qualified Data.Aeson.Internal        as Aeson
-import qualified Data.ByteString            as BSS
-import qualified Data.ByteString.Lazy       as BSL
-import           Data.Either                (isLeft, isRight)
-import           Data.Foldable              (fold, foldl', traverse_)
-import           Data.List                  (sort)
-import qualified Data.Map                   as Map
-import           Data.Monoid                (Sum (..))
-import qualified Data.Set                   as Set
-import           Data.String                (IsString (fromString))
-import           Hedgehog                   (Property, forAll, property)
+import           Control.Monad                (void)
+import           Control.Monad.Trans.Except   (runExcept)
+import qualified Data.Aeson                   as JSON
+import qualified Data.Aeson.Extras            as JSON
+import qualified Data.Aeson.Internal          as Aeson
+import qualified Data.ByteString              as BSS
+import qualified Data.ByteString.Lazy         as BSL
+import           Data.Either                  (isLeft, isRight)
+import           Data.Foldable                (fold, foldl', traverse_)
+import           Data.List                    (sort)
+import qualified Data.Map                     as Map
+import           Data.Monoid                  (Sum (..))
+import qualified Data.Set                     as Set
+import           Data.String                  (IsString (fromString))
+import           Hedgehog                     (Property, forAll, property)
 import qualified Hedgehog
-import qualified Hedgehog.Gen               as Gen
-import qualified Hedgehog.Range             as Range
-import qualified Language.PlutusTx.AssocMap as AssocMap
-import qualified Language.PlutusTx.Builtins as Builtins
-import qualified Language.PlutusTx.Prelude  as PlutusTx
+import qualified Hedgehog.Gen                 as Gen
+import qualified Hedgehog.Range               as Range
+import qualified Language.PlutusCore.Universe as PLC
+import           Language.PlutusTx            (CompiledCode, applyCode, liftCode)
+import qualified Language.PlutusTx            as PlutusTx
+import qualified Language.PlutusTx.AssocMap   as AssocMap
+import qualified Language.PlutusTx.Builtins   as Builtins
+import qualified Language.PlutusTx.Prelude    as PlutusTx
 import           Ledger
-import qualified Ledger.Ada                 as Ada
-import qualified Ledger.Generators          as Gen
-import qualified Ledger.Index               as Index
-import qualified Ledger.Interval            as Interval
-import           Ledger.Value               (CurrencySymbol, Value (Value))
-import qualified Ledger.Value               as Value
+import qualified Ledger.Ada                   as Ada
+import qualified Ledger.Crypto                as Crypto
+import qualified Ledger.Generators            as Gen
+import qualified Ledger.Index                 as Index
+import qualified Ledger.Interval              as Interval
+import qualified Ledger.Scripts               as Scripts
+import qualified Ledger.Validation            as Validation
+import           Ledger.Value                 (CurrencySymbol, Value (Value))
+import qualified Ledger.Value                 as Value
 import           LedgerBytes
 import           Test.Tasty
-import           Test.Tasty.Hedgehog        (testProperty)
-import           Test.Tasty.HUnit           (testCase)
-import qualified Test.Tasty.HUnit           as HUnit
+import           Test.Tasty.Hedgehog          (testProperty)
+import           Test.Tasty.HUnit             (testCase)
+import qualified Test.Tasty.HUnit             as HUnit
 
 main :: IO ()
 main = defaultMain tests
@@ -60,7 +67,8 @@ tests = testGroup "all tests" [
     testGroup "Etc." [
         testProperty "splitVal" splitVal,
         testProperty "encodeByteString" encodeByteStringTest,
-        testProperty "encodeSerialise" encodeSerialiseTest
+        testProperty "encodeSerialise" encodeSerialiseTest,
+        testProperty "pubkey hash" pubkeyHashOnChainAndOffChain
         ],
     testGroup "LedgerBytes" [
         testProperty "show-fromHex" ledgerBytesShowFromHexProp,
@@ -192,3 +200,15 @@ byteStringJson jsonString value =
         HUnit.assertEqual "Simple Decode" (Right value) (JSON.eitherDecode jsonString)
     , testCase "encoding" $ HUnit.assertEqual "Simple Encode" jsonString (JSON.encode value)
     ]
+
+-- | Check that the on-chain version and the off-chain version of 'pubKeyHash'
+--   match.
+pubkeyHashOnChainAndOffChain :: Property
+pubkeyHashOnChainAndOffChain = property $ do
+    pk <- forAll $ PubKey . LedgerBytes <$> Gen.genSizedByteString 32 -- this won't generate a valid public key but that doesn't matter for the purposes of pubKeyHash
+    let offChainHash = Crypto.pubKeyHash pk
+        onchainProg :: CompiledCode PLC.DefaultUni (PubKey -> PubKeyHash -> ())
+        onchainProg = $$(PlutusTx.compile [|| \pk expected -> if (expected PlutusTx.== Validation.pubKeyHash pk) then PlutusTx.trace "correct" () else PlutusTx.traceError "not correct" ||])
+        script = Scripts.fromCompiledCode $ onchainProg `applyCode` (liftCode pk) `applyCode` (liftCode offChainHash)
+        result = runExcept $ evaluateScript script
+    Hedgehog.assert (result == Right ["correct"])

--- a/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Crowdfunding.hs
+++ b/plutus-use-cases/src/Language/PlutusTx/Coordination/Contracts/Crowdfunding.hs
@@ -59,7 +59,7 @@ import qualified Language.Plutus.Contract.Trace    as Trace
 import qualified Language.Plutus.Contract.Typed.Tx as Typed
 import qualified Language.PlutusTx                 as PlutusTx
 import           Language.PlutusTx.Prelude         hiding (Applicative (..), Semigroup(..), return, (<$>), (>>), (>>=))
-import           Ledger                            (PubKeyHash, pubKeyHash, Slot, Validator, txId)
+import           Ledger                            (PubKeyHash, Slot, Validator, txId)
 import qualified Ledger                            as Ledger
 import qualified Ledger.Ada                        as Ada
 import qualified Ledger.Constraints                as Constraints

--- a/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
+++ b/plutus-use-cases/test/Spec/crowdfundingTestOutput.txt
@@ -21,25 +21,25 @@ Events by wallet:
     - Iteration: 3
     Requests:
         4: {utxo-at:
-            ScriptAddress: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f}
+            ScriptAddress: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c}
       Response:
         ( 4
         , {utxo-at:
-           Utxo at ScriptAddress: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f =
-             b7fe813de2ef41d639abae64ab4e4b3a8717a339c20095891c80f7fd4bcb09ae!1: PayToScript: 4027db8b6fa1406b9af7a40cc636d7a0524b96690fb11ca690a27c903bd3d9ba Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-             ccce46a66de4daa3ffab3ded947cf1618d8ad7c710dafda1b26484eff1f934b1!1: PayToScript: 4154c4f434653f72e126e72829bcda1d19ddc76bb4f7ed7695e38edf8a17d381 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
-             e37d4cbe64e4d85512988e45f96a8266bacbd0b63c320abdbc424aca57f5b949!1: PayToScript: 1c26902e0eedb408b592e476fffb0815678ef869c7a2c2a17c81f089d0033a94 Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}} )
+           Utxo at ScriptAddress: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c =
+             1d6908a4cd2bcb02cb9475b3df8088ecb9908ab5ff89c3606f6d8f03a797d83a!1: PayToScript: 74e19fb9728f0d4a9f076ea93b6b74030e23cea48e164ca647801ab3927d9c7f Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}
+             b4e7bd51058aa2b6cc16fc42cd29da14a5745b773e6e71d708bde2d31bab0075!1: PayToScript: f7b7b251c9a7d29b8f19f8ee1669520684b77d0c0094dac41eb55ed09cd9b237 Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}}
+             d8d229d2385ab7d77471150ab6e186ad11e54d1887a58486e11034ab9158a6f1!1: PayToScript: 38d7d68a5896977749a1714ac7b0a4fa4136d6bd6f4a1bf452f526101b5d2033 Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}}} )
     - Iteration: 4
     Requests:
         5: {tx:
             Tx:
-              Tx 5fb9f19e7393983ca9726b08327ca8458b74d6cf1ca49bf692c82783a734a068:
+              Tx d8e0f8413dfd400d0081d08a123431c89bc2b74e9ac287de530a73b212c65108:
                 {inputs:
-                   - b7fe813de2ef41d639abae64ab4e4b3a8717a339c20095891c80f7fd4bcb09ae!1
+                   - 1d6908a4cd2bcb02cb9475b3df8088ecb9908ab5ff89c3606f6d8f03a797d83a!1
                      Redeemer: <>
-                   - ccce46a66de4daa3ffab3ded947cf1618d8ad7c710dafda1b26484eff1f934b1!1
+                   - b4e7bd51058aa2b6cc16fc42cd29da14a5745b773e6e71d708bde2d31bab0075!1
                      Redeemer: <>
-                   - e37d4cbe64e4d85512988e45f96a8266bacbd0b63c320abdbc424aca57f5b949!1
+                   - d8d229d2385ab7d77471150ab6e186ad11e54d1887a58486e11034ab9158a6f1!1
                      Redeemer: <>
                 outputs:
                 forge: Value {getValue = Map {unMap = []}}
@@ -52,7 +52,7 @@ Events by wallet:
       Response:
         ( 5
         , {tx:
-           WriteTxSuccess: 2992dad53bb5503526a378ba9d9ae497a3f3e5bcb141190351f4a2dd053f6cc0} )
+           WriteTxSuccess: ffb9fe176d8074776871fad5282fd5dec636c989b409e2e25b159618268b6f2a} )
   Events for W2:
     - Iteration: 1
     Requests:
@@ -78,23 +78,23 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx 9ecf80dcbee5aa647a0f0ddd1cedf8a1f3c97e209625430867e1f417962afd7d:
+              Tx 892ce90946a0971403cf3bbc387bba048aa9e27e1266ed109e90a4d51bd47db6:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-                    ScriptAddress: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+                    ScriptAddress: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
                 signatures:
                 validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}
                 data:
-                  "\"}\203\145\221q@\152\187\146\US#v7\216H\vH^\176(\DLE\181\161\204\NUL\SO\237\245\251 \222"}
+                  "\218\192s\224\DC2;\222\165\157\217\179\189\169\207`7\246:\202\130b}z\188\213\196\172)\221t\NUL>"}
             Requires signatures:}
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: b7fe813de2ef41d639abae64ab4e4b3a8717a339c20095891c80f7fd4bcb09ae} )
+           WriteTxSuccess: d8d229d2385ab7d77471150ab6e186ad11e54d1887a58486e11034ab9158a6f1} )
   Events for W3:
     - Iteration: 1
     Requests:
@@ -120,23 +120,23 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx 69273142f3e8192c3f77285072efd23e7261ac819c7d0e3659a22b380a914dfc:
+              Tx f6c87603719a56e2e4683a55a95afa50f617211b64d1f2759eba46d836ab2c92:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,10)]})]}} addressed to
-                    ScriptAddress: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+                    ScriptAddress: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
                 signatures:
                 validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}
                 data:
-                  "\178\178X\177\250\131MX\253\176S\SYN\202^\192\183S\230+U\b\219\225D\166\DC3\165\181\EMx\253 "}
+                  "\237\209\195sr\247R\201z\236\b\130E/\172\172\ETB\164\253\175F\230\FS\ETX?J\246x\164\a\155\205"}
             Requires signatures:}
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: ccce46a66de4daa3ffab3ded947cf1618d8ad7c710dafda1b26484eff1f934b1} )
+           WriteTxSuccess: 1d6908a4cd2bcb02cb9475b3df8088ecb9908ab5ff89c3606f6d8f03a797d83a} )
   Events for W4:
     - Iteration: 1
     Requests:
@@ -162,23 +162,23 @@ Events by wallet:
     Requests:
         3: {tx:
             Tx:
-              Tx c3f89dd395b9b6087d032842ad97b8658898cc054149066e179718fca0ef8c95:
+              Tx 61a5ab2da11751b2317ce24bd5f12ea5cdf073a22d48f49caf49f8fd9024bbf9:
                 {inputs:
                 outputs:
                   - Value {getValue = Map {unMap = [(,Map {unMap = [(,1)]})]}} addressed to
-                    ScriptAddress: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+                    ScriptAddress: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
                 forge: Value {getValue = Map {unMap = []}}
                 fee: Value {getValue = Map {unMap = []}}
                 mps:
                 signatures:
                 validity range: Interval {ivFrom = LowerBound (Finite (Slot {getSlot = 1})) True, ivTo = UpperBound (Finite (Slot {getSlot = 20})) True}
                 data:
-                  "\215\r\US\189.\165\&2\176x\EOT\163[\246<\SOH\146\144\168\151\&1\STX\NUL\247\219\184\241\ETX\143\198\196\198\152"}
+                  "u\210d\223\143Krhd8x<\133$g=*Z\233\172\SIw\STX!7\165\145\154\&7d]W"}
             Requires signatures:}
       Response:
         ( 3
         , {tx:
-           WriteTxSuccess: e37d4cbe64e4d85512988e45f96a8266bacbd0b63c320abdbc424aca57f5b949} )
+           WriteTxSuccess: b4e7bd51058aa2b6cc16fc42cd29da14a5745b773e6e71d708bde2d31bab0075} )
 Contract result by wallet:
     Wallet: W1
       Done

--- a/plutus-use-cases/test/Spec/renderCrowdfunding.txt
+++ b/plutus-use-cases/test/Spec/renderCrowdfunding.txt
@@ -1,5 +1,5 @@
 ==== Slot #0, Tx #0 ====
-TxId:       90093f72c1ac03b128f17b8ef9f45c7304f5fba4ef0ea06548c186320dfd9d5a
+TxId:       a75e51992a2909cb5242f70121087318d438f71c8b3c2bbcdf83a717b5937f1d
 Fee:        -
 Forge:      Ada:      Lovelace:  100000
 Signatures  -
@@ -9,402 +9,402 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
+  Destination:  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 1 ----
-  Destination:  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 2 ----
-  Destination:  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  Destination:  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 3 ----
-  Destination:  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  Destination:  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 4 ----
-  Destination:  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
+  Destination:  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 5 ----
-  Destination:  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
+  Destination:  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 6 ----
-  Destination:  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
+  Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 7 ----
-  Destination:  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  Destination:  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 8 ----
-  Destination:  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  Destination:  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 9 ----
-  Destination:  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
+  Destination:  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
   Value:
     Ada:      Lovelace:  10000
 
 
 Balances Carried Forward:
-  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
+  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
+  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
+  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
+  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
+  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       b7fe813de2ef41d639abae64ab4e4b3a8717a339c20095891c80f7fd4bcb09ae
+TxId:       d8d229d2385ab7d77471150ab6e186ad11e54d1887a58486e11034ab9158a6f1
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 58408b0b9032d9fe25b13baf216646e148e7b05a...
+              Signature: 58409424de555f6c8ad8e1361372e78522251393...
 Inputs:
   ---- Input 0 ----
-  Destination:  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  Destination:  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  10000
   Source:
-    Tx:     90093f72c1ac03b128f17b8ef9f45c7304f5fba4ef0ea06548c186320dfd9d5a
+    Tx:     a75e51992a2909cb5242f70121087318d438f71c8b3c2bbcdf83a717b5937f1d
     Output #8
     
 
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  Destination:  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+  Destination:  Script: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
   Value:
     Ada:      Lovelace:  10
 
 
 Balances Carried Forward:
-  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  9990
   
-  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
+  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+  Script: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
   Value:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       ccce46a66de4daa3ffab3ded947cf1618d8ad7c710dafda1b26484eff1f934b1
+TxId:       1d6908a4cd2bcb02cb9475b3df8088ecb9908ab5ff89c3606f6d8f03a797d83a
 Fee:        -
 Forge:      -
 Signatures  PubKey: 98a5e3a36e67aaba89888bf093de1ad963e77401...
-              Signature: 584058f5339976be12ea7576ed583089552f87f6...
+              Signature: 58405777900997a56e8cc3b924f8236104d51a03...
 Inputs:
   ---- Input 0 ----
-  Destination:  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  Destination:  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  10000
   Source:
-    Tx:     90093f72c1ac03b128f17b8ef9f45c7304f5fba4ef0ea06548c186320dfd9d5a
+    Tx:     a75e51992a2909cb5242f70121087318d438f71c8b3c2bbcdf83a717b5937f1d
     Output #3
     
 
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  Destination:  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  9990
   
   ---- Output 1 ----
-  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+  Destination:  Script: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
   Value:
     Ada:      Lovelace:  10
 
 
 Balances Carried Forward:
-  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  9990
   
-  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  9990
   
-  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+  Script: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
   Value:
     Ada:      Lovelace:  20
 
 ==== Slot #3, Tx #0 ====
-TxId:       e37d4cbe64e4d85512988e45f96a8266bacbd0b63c320abdbc424aca57f5b949
+TxId:       b4e7bd51058aa2b6cc16fc42cd29da14a5745b773e6e71d708bde2d31bab0075
 Fee:        -
 Forge:      -
 Signatures  PubKey: f81fb54a825fced95eb033afcd64314075abfb0a...
-              Signature: 58400f78eb874ed6d78d7588072e81aef401fdc6...
+              Signature: 5840915a1120a5cdbfdb61f62dcd582dbcf3cdb2...
 Inputs:
   ---- Input 0 ----
-  Destination:  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  Destination:  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  10000
   Source:
-    Tx:     90093f72c1ac03b128f17b8ef9f45c7304f5fba4ef0ea06548c186320dfd9d5a
+    Tx:     a75e51992a2909cb5242f70121087318d438f71c8b3c2bbcdf83a717b5937f1d
     Output #7
     
 
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  Destination:  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  9999
   
   ---- Output 1 ----
-  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+  Destination:  Script: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
   Value:
     Ada:      Lovelace:  1
 
 
 Balances Carried Forward:
-  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
-  Value:
-    Ada:      Lovelace:  9990
-  
-  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
+  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
-  Value:
-    Ada:      Lovelace:  9990
-  
-  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  9999
   
-  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
+  Value:
+    Ada:      Lovelace:  9990
+  
+  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
+  Value:
+    Ada:      Lovelace:  9990
+  
+  Script: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
   Value:
     Ada:      Lovelace:  21
 
 ==== Slot #20, Tx #0 ====
-TxId:       2992dad53bb5503526a378ba9d9ae497a3f3e5bcb141190351f4a2dd053f6cc0
+TxId:       ffb9fe176d8074776871fad5282fd5dec636c989b409e2e25b159618268b6f2a
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840b8187423488f9f81147bd26f010347542bea...
+              Signature: 584089a71674d30956b53825beb60c1ed54c514f...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+  Destination:  Script: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     b7fe813de2ef41d639abae64ab4e4b3a8717a339c20095891c80f7fd4bcb09ae
+    Tx:     1d6908a4cd2bcb02cb9475b3df8088ecb9908ab5ff89c3606f6d8f03a797d83a
     Output #1
     Script: 0100000303020003030305010200020002000303...
   
   ---- Input 1 ----
-  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+  Destination:  Script: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
   Value:
-    Ada:      Lovelace:  10
+    Ada:      Lovelace:  1
   Source:
-    Tx:     ccce46a66de4daa3ffab3ded947cf1618d8ad7c710dafda1b26484eff1f934b1
+    Tx:     b4e7bd51058aa2b6cc16fc42cd29da14a5745b773e6e71d708bde2d31bab0075
     Output #1
     Script: 0100000303020003030305010200020002000303...
   
   ---- Input 2 ----
-  Destination:  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+  Destination:  Script: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
   Value:
-    Ada:      Lovelace:  1
+    Ada:      Lovelace:  10
   Source:
-    Tx:     e37d4cbe64e4d85512988e45f96a8266bacbd0b63c320abdbc424aca57f5b949
+    Tx:     d8d229d2385ab7d77471150ab6e186ad11e54d1887a58486e11034ab9158a6f1
     Output #1
     Script: 0100000303020003030305010200020002000303...
 
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  21
 
 
 Balances Carried Forward:
-  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
-  Value:
-    Ada:      Lovelace:  9990
-  
-  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  10021
   
-  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
-  Value:
-    Ada:      Lovelace:  9990
-  
-  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  9999
   
-  Script: d0b2549a3cff9ef9e2b93b273a84ff7cb08a06eebe536f9ca3279825dde20e4f
+  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
+  Value:
+    Ada:      Lovelace:  9990
+  
+  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
+  Value:
+    Ada:      Lovelace:  9990
+  
+  Script: 8ed044b440c5480d1df26be535a3ee1979c5bac08e021457bf18a9f97debd15c
   Value:
     Ada:      Lovelace:  0

--- a/plutus-use-cases/test/Spec/renderGuess.txt
+++ b/plutus-use-cases/test/Spec/renderGuess.txt
@@ -1,5 +1,5 @@
 ==== Slot #0, Tx #0 ====
-TxId:       90093f72c1ac03b128f17b8ef9f45c7304f5fba4ef0ea06548c186320dfd9d5a
+TxId:       a75e51992a2909cb5242f70121087318d438f71c8b3c2bbcdf83a717b5937f1d
 Fee:        -
 Forge:      Ada:      Lovelace:  100000
 Signatures  -
@@ -9,117 +9,117 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
+  Destination:  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 1 ----
-  Destination:  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 2 ----
-  Destination:  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  Destination:  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 3 ----
-  Destination:  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  Destination:  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 4 ----
-  Destination:  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
+  Destination:  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 5 ----
-  Destination:  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
+  Destination:  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 6 ----
-  Destination:  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
+  Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 7 ----
-  Destination:  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  Destination:  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 8 ----
-  Destination:  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  Destination:  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 9 ----
-  Destination:  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
+  Destination:  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
   Value:
     Ada:      Lovelace:  10000
 
 
 Balances Carried Forward:
-  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
+  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
+  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
+  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
+  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
+  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       0e28d14c3f10c45d9089e18deaac0450d5be88898594d7a9a3a811f8562c7719
+TxId:       ae3edc80f2a3be1e54b8e14afa097068e0797126e754301c56ade7cc4623df61
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 58407cf9b436944bba50d39bdc15a7bdb7974781...
+              Signature: 58403887709f44b414fe7af1fbd0df78dfcd3d8f...
 Inputs:
   ---- Input 0 ----
-  Destination:  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  10000
   Source:
-    Tx:     90093f72c1ac03b128f17b8ef9f45c7304f5fba4ef0ea06548c186320dfd9d5a
+    Tx:     a75e51992a2909cb5242f70121087318d438f71c8b3c2bbcdf83a717b5937f1d
     Output #1
     
 
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  9990
   
@@ -130,43 +130,43 @@ Outputs:
 
 
 Balances Carried Forward:
-  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  9990
   
-  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
+  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
+  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
+  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
+  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  10000
   
@@ -175,67 +175,67 @@ Balances Carried Forward:
     Ada:      Lovelace:  10
 
 ==== Slot #2, Tx #0 ====
-TxId:       81140600334d4232e4486208ec2781ee67d6c9fbdc091d3226f01832ea6c7d5d
+TxId:       33491adcc44c75b84b656ca80b8493542529607b265450610991bd7ef5f3ca36
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 584001ca44e1557887e3e9008c06b6f28641cc8b...
+              Signature: 584073c8af6a2ea3b7ec0aea7b20ebe37512da79...
 Inputs:
   ---- Input 0 ----
   Destination:  Script: c5925b540defe5b4db30d245e69c52f91369d4e4b35c838a1f1cb9c04bacb49a
   Value:
     Ada:      Lovelace:  10
   Source:
-    Tx:     0e28d14c3f10c45d9089e18deaac0450d5be88898594d7a9a3a811f8562c7719
+    Tx:     ae3edc80f2a3be1e54b8e14afa097068e0797126e754301c56ade7cc4623df61
     Output #1
     Script: 0100000303020003030501020002000303050102...
 
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  Destination:  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  10
 
 
 Balances Carried Forward:
-  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
-  Value:
-    Ada:      Lovelace:  10010
-  
-  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  9990
   
-  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
+  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
+  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
+  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
+  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
+  Value:
+    Ada:      Lovelace:  10010
+  
+  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  10000
   

--- a/plutus-use-cases/test/Spec/renderVesting.txt
+++ b/plutus-use-cases/test/Spec/renderVesting.txt
@@ -1,5 +1,5 @@
 ==== Slot #0, Tx #0 ====
-TxId:       90093f72c1ac03b128f17b8ef9f45c7304f5fba4ef0ea06548c186320dfd9d5a
+TxId:       a75e51992a2909cb5242f70121087318d438f71c8b3c2bbcdf83a717b5937f1d
 Fee:        -
 Forge:      Ada:      Lovelace:  100000
 Signatures  -
@@ -9,241 +9,241 @@ Inputs:
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
+  Destination:  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 1 ----
-  Destination:  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 2 ----
-  Destination:  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  Destination:  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 3 ----
-  Destination:  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  Destination:  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 4 ----
-  Destination:  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
+  Destination:  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 5 ----
-  Destination:  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
+  Destination:  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 6 ----
-  Destination:  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
+  Destination:  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 7 ----
-  Destination:  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  Destination:  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 8 ----
-  Destination:  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  Destination:  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  10000
   
   ---- Output 9 ----
-  Destination:  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
+  Destination:  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
   Value:
     Ada:      Lovelace:  10000
 
 
 Balances Carried Forward:
-  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
+  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
+  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
+  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
+  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
+  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  10000
 
 ==== Slot #1, Tx #0 ====
-TxId:       be73bfa581ac7daf26cba8c83d69b5d6cd171cd161d4bd1e29eb662ba07c8fac
+TxId:       0e9fa37afc2b28185350ac52326ffb81b529598d989d7eaaa601beaaeaa72e9d
 Fee:        -
 Forge:      -
 Signatures  PubKey: fc51cd8e6218a1a38da47ed00230f0580816ed13...
-              Signature: 5840e274f1735a7efa448a65758657b8816f72cc...
+              Signature: 5840b04a970dee5662372aeae5a1d19bb74d1b0f...
 Inputs:
   ---- Input 0 ----
-  Destination:  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  Destination:  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  10000
   Source:
-    Tx:     90093f72c1ac03b128f17b8ef9f45c7304f5fba4ef0ea06548c186320dfd9d5a
+    Tx:     a75e51992a2909cb5242f70121087318d438f71c8b3c2bbcdf83a717b5937f1d
     Output #8
     
 
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  Destination:  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  9940
   
   ---- Output 1 ----
-  Destination:  Script: 837a7b277972291274d3443c3cee9cb0aa06a5961bc4cfede476b01b16d76959
+  Destination:  Script: e738d55b25320cfd45936a0320941dfa674c79d984ed42f53cfc4080a9bee362
   Value:
     Ada:      Lovelace:  60
 
 
 Balances Carried Forward:
-  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
+  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
   Value:
     Ada:      Lovelace:  9940
   
-  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
+  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  Script: 837a7b277972291274d3443c3cee9cb0aa06a5961bc4cfede476b01b16d76959
+  Script: e738d55b25320cfd45936a0320941dfa674c79d984ed42f53cfc4080a9bee362
   Value:
     Ada:      Lovelace:  60
 
 ==== Slot #12, Tx #0 ====
-TxId:       666bfb316450b015980c6d2f68c4a16aa5bc90acafa54f4f00e1baf5c74f481e
+TxId:       368b2167dd981b28286f28cdf84847cd53e313158c4b55d1dafd01279e8fa43c
 Fee:        -
 Forge:      -
 Signatures  PubKey: 3d4017c3e843895a92b70aa74d1b7ebc9c982ccf...
-              Signature: 5840a333d9e01ce7c919659ff6f9f041a9b677e9...
+              Signature: 584047c082a4a17c0861cbb76c9b666c1634568b...
 Inputs:
   ---- Input 0 ----
-  Destination:  Script: 837a7b277972291274d3443c3cee9cb0aa06a5961bc4cfede476b01b16d76959
+  Destination:  Script: e738d55b25320cfd45936a0320941dfa674c79d984ed42f53cfc4080a9bee362
   Value:
     Ada:      Lovelace:  60
   Source:
-    Tx:     be73bfa581ac7daf26cba8c83d69b5d6cd171cd161d4bd1e29eb662ba07c8fac
+    Tx:     0e9fa37afc2b28185350ac52326ffb81b529598d989d7eaaa601beaaeaa72e9d
     Output #1
     Script: 0100000303020003030305010200020002000302...
 
 
 Outputs:
   ---- Output 0 ----
-  Destination:  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  Destination:  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  10
   
   ---- Output 1 ----
-  Destination:  Script: 837a7b277972291274d3443c3cee9cb0aa06a5961bc4cfede476b01b16d76959
+  Destination:  Script: e738d55b25320cfd45936a0320941dfa674c79d984ed42f53cfc4080a9bee362
   Value:
     Ada:      Lovelace:  50
 
 
 Balances Carried Forward:
-  PubKeyHash: 0845247280057a432dc316ed39e563841a4d0387... (Wallet 6)
+  PubKeyHash: 21fe31dfa154a261626bf854046fd2271b7bed4b... (Wallet 10)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 227dcb91dd714098bb921f237637d8480b485eb0... (Wallet 2)
-  Value:
-    Ada:      Lovelace:  9940
-  
-  PubKeyHash: 3cb7747f8712dd435a82aacbf32e146aa6123f4f... (Wallet 10)
-  Value:
-    Ada:      Lovelace:  10000
-  
-  PubKeyHash: 4ecde0775d081e45f06141416cbc3afed4c44a08... (Wallet 1)
+  PubKeyHash: 39f713d0a644253f04529421b9f51b9b08979d08... (Wallet 1)
   Value:
     Ada:      Lovelace:  10010
   
-  PubKeyHash: 68d8462e8f3410bc05699e33a56735de21b08687... (Wallet 5)
+  PubKeyHash: 75d264df8f4b72686438783c8524673d2a5ae9ac... (Wallet 4)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: 894c463566537d31643b288323b945f42d8204cf... (Wallet 9)
+  PubKeyHash: a681d6553fa906569b6293876e0a4bd30800fc41... (Wallet 8)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: b2b258b1fa834d58fdb05316ca5ec0b753e62b55... (Wallet 3)
+  PubKeyHash: b2ecdd08b94ba9639dd8d287f48a0e00f76f8ac6... (Wallet 7)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: ccb1a9ed65d2b38f71045930b50e8fb7b2259772... (Wallet 7)
+  PubKeyHash: bb3177fb6ea918a70fd7c2f180d5a49951e80a5a... (Wallet 6)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d0a391a67ec66dbb75a4fccb9d741e07c3df0d56... (Wallet 8)
+  PubKeyHash: cce78f1f01cbbc3c0fb6f0b8e45d9fad929f30d0... (Wallet 5)
   Value:
     Ada:      Lovelace:  10000
   
-  PubKeyHash: d70d1fbd2ea532b07804a35bf63c019290a89731... (Wallet 4)
+  PubKeyHash: d62e939c16a54d86493149d7d4291b0f766773d3... (Wallet 9)
   Value:
     Ada:      Lovelace:  10000
   
-  Script: 837a7b277972291274d3443c3cee9cb0aa06a5961bc4cfede476b01b16d76959
+  PubKeyHash: dac073e0123bdea59dd9b3bda9cf6037f63aca82... (Wallet 2)
+  Value:
+    Ada:      Lovelace:  9940
+  
+  PubKeyHash: edd1c37372f752c97aec0882452facac17a4fdaf... (Wallet 3)
+  Value:
+    Ada:      Lovelace:  10000
+  
+  Script: e738d55b25320cfd45936a0320941dfa674c79d984ed42f53cfc4080a9bee362
   Value:
     Ada:      Lovelace:  50


### PR DESCRIPTION
* The sha2_256 functions works in principle, but the off-chain version of `pubKeyHash` used the wrong bytestring.
* `Ledger.Validation` now also exports `pubKeyHash`