### PR TITLE
Enable shellcheck pre-commit hook

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -12,10 +12,12 @@ let
     tools = {
       stylish-haskell = dev.packages.stylish-haskell;
       nixpkgs-fmt = pkgs.nixpkgs-fmt;
+      shellcheck = pkgs.shellcheck;
     };
     hooks = {
       stylish-haskell.enable = true;
       nixpkgs-fmt.enable = true;
+      shellcheck.enable = true;
     };
   };
 in


### PR DESCRIPTION
This enables the shellcheck pre-commit check of pre-commit-hooks.nix
The hook will be enabled on the first invocation of `shellHook` which
occurs either when entering a `nix-shell` or via `.envrc` in case
your integration is configured to evaluate shell hooks.