### PR TITLE
Remove git from shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -23,7 +23,6 @@ haskell.packages.shellFor {
   nativeBuildInputs = [
     # From nixpkgs
     pkgs.ghcid
-    pkgs.git
     pkgs.cacert
     pkgs.niv
     pkgs.nodejs


### PR DESCRIPTION
Work around https://github.com/cachix/pre-commit-hooks.nix/issues/76.

I think everyone has git anyway, and I don't think we're likely to have
issues due to different versions, so it's not a big deal if we don't
provide it in the shell.