### PR TITLE
Batch queries against the live metadata server.

### DIFF
--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -13,6 +13,24 @@ pkgs.recurseIntoAttrs (rec {
     spago = easyPS.spago;
   };
 
+  metadataQueryPayload1 = {
+    subjects = [
+      "44b57ee30cdb55829d0a5d4f046baef078f1e97a7f21b62d75f8e96ea139c35f"
+      "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c274d1888c0"
+    ];
+  };
+
+  metadataQueryPayload2 = {
+    subjects = [
+      "44b57ee30cdb55829d0a5d4f046baef078f1e97a7f21b62d75f8e96ea139c35f"
+      "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c274d1888c0"
+    ];
+    properties = [
+      "name"
+      "description"
+    ];
+  };
+
   scripts = pkgs.recurseIntoAttrs {
     updateMaterialized = haskell.project.stack-nix.passthru.updateMaterialized;
 
@@ -114,6 +132,14 @@ pkgs.recurseIntoAttrs (rec {
       do
         ${pkgs.curl}/bin/curl -o $DATA_DIR/property_$PROPERTY.json $SERVER/metadata/$SUBJECT/properties/$PROPERTY
       done
+
+      ${pkgs.curl}/bin/curl -X POST -o $DATA_DIR/query_response1.json $SERVER/metadata/query \
+        -H 'Content-Type: application/json' \
+        -d '${builtins.toJSON metadataQueryPayload1}'
+
+      ${pkgs.curl}/bin/curl -X POST -o $DATA_DIR/query_response2.json $SERVER/metadata/query \
+        -H 'Content-Type: application/json' \
+        -d '${builtins.toJSON metadataQueryPayload2}'
     '';
   };
 })

--- a/plutus-scb/src/Cardano/Metadata/API.hs
+++ b/plutus-scb/src/Cardano/Metadata/API.hs
@@ -6,10 +6,11 @@ module Cardano.Metadata.API
     ( API
     ) where
 
-import           Cardano.Metadata.Types (JSONEncoding, Property, PropertyKey, Query, Subject, SubjectProperties)
+import           Cardano.Metadata.Types (JSONEncoding, Property, PropertyKey, Query, QueryResult, Subject,
+                                         SubjectProperties)
 import           Servant.API            ((:<|>), (:>), Capture, Get, JSON, Post, ReqBody)
 
 type API (encoding :: JSONEncoding)
      = "metadata" :> (Capture "subject" Subject :> ("properties" :> Get '[ JSON] (SubjectProperties encoding)
                                                     :<|> "property" :> Capture "property" PropertyKey :> Get '[ JSON] (Property encoding))
-                      :<|> "query" :> ReqBody '[ JSON] Query :> Post '[ JSON] [SubjectProperties encoding])
+                      :<|> "query" :> ReqBody '[ JSON] Query :> Post '[ JSON] (QueryResult encoding))

--- a/plutus-scb/src/Cardano/Metadata/Client.hs
+++ b/plutus-scb/src/Cardano/Metadata/Client.hs
@@ -16,7 +16,8 @@ module Cardano.Metadata.Client
 import           Cardano.Metadata.API      (API)
 import           Cardano.Metadata.Types    (JSONEncoding (AesonEncoding),
                                             MetadataEffect (BatchQuery, GetProperties, GetProperty),
-                                            MetadataError (MetadataClientError, SubjectNotFound, SubjectPropertyNotFound))
+                                            MetadataError (MetadataClientError, SubjectNotFound, SubjectPropertyNotFound),
+                                            QueryResult (QueryResult))
 import           Control.Monad.Freer       (Eff, LastMember, Member, type (~>), interpret, sendM)
 import           Control.Monad.Freer.Error (Error, throwError)
 import           Control.Monad.IO.Class    (MonadIO, liftIO)
@@ -62,4 +63,4 @@ handleMetadataClient clientEnv =
                 runClient
                     (throwError (SubjectPropertyNotFound subject propertyKey))
                     (getProperty subject propertyKey)
-            BatchQuery query -> runClient (pure []) (batchQuery query)
+            BatchQuery query -> runClient (pure (QueryResult [])) (batchQuery query)

--- a/plutus-scb/src/Cardano/Metadata/Server.hs
+++ b/plutus-scb/src/Cardano/Metadata/Server.hs
@@ -142,6 +142,7 @@ handleMetadata =
         BatchQuery query@QuerySubjects {subjects, propertyNames} -> do
             logInfo $ Querying query
             pure .
+                QueryResult .
                 fmap (filterSubjectProperties propertyNames) .
                 fromMaybe [] . traverse fetchSubject $
                 Set.toList subjects
@@ -166,7 +167,7 @@ handler ::
        Member MetadataEffect effs
     => (Subject -> (Eff effs (SubjectProperties 'AesonEncoding)
                     :<|> (PropertyKey -> Eff effs (Property 'AesonEncoding))))
-       :<|> (Query -> Eff effs [SubjectProperties 'AesonEncoding])
+       :<|> (Query -> Eff effs (QueryResult 'AesonEncoding))
 handler =
     (\subject -> getProperties subject :<|> getProperty subject) :<|> batchQuery
 

--- a/plutus-scb/src/Cardano/Metadata/Types.hs
+++ b/plutus-scb/src/Cardano/Metadata/Types.hs
@@ -284,6 +284,19 @@ data Query =
 instance Pretty Query where
     pretty = viaShow
 
+newtype QueryResult (encoding :: k) =
+    QueryResult
+        { results :: [SubjectProperties encoding]
+        }
+    deriving (Show, Eq, Generic)
+
+deriving newtype instance FromJSON (QueryResult 'AesonEncoding)
+deriving newtype instance ToJSON (QueryResult 'AesonEncoding)
+
+instance FromJSON (QueryResult 'ExternalEncoding) where
+    parseJSON =
+        withObject "QueryResult" $ \o -> QueryResult <$> o .: "subjects"
+
 ------------------------------------------------------------
 data MetadataEffect r where
     GetProperties
@@ -292,7 +305,7 @@ data MetadataEffect r where
         :: Subject
         -> PropertyKey
         -> MetadataEffect (Property 'AesonEncoding)
-    BatchQuery :: Query -> MetadataEffect [SubjectProperties 'AesonEncoding]
+    BatchQuery :: Query -> MetadataEffect (QueryResult 'AesonEncoding)
 
 makeEffect ''MetadataEffect
 

--- a/plutus-scb/test/Cardano/Metadata/ServerSpec.hs
+++ b/plutus-scb/test/Cardano/Metadata/ServerSpec.hs
@@ -10,8 +10,8 @@ module Cardano.Metadata.ServerSpec
 import           Cardano.Metadata.Server   (annotatedSignature1, handleMetadata, script1)
 import           Cardano.Metadata.Types    (HashFunction (SHA256), MetadataEffect, MetadataError, MetadataLogMessage,
                                             Property (Name, Preimage), PropertyKey (PropertyKey), Query (QuerySubjects),
-                                            SubjectProperties (SubjectProperties), batchQuery, getProperties,
-                                            getProperty, propertyNames, subjects, toSubject)
+                                            QueryResult (QueryResult), SubjectProperties (SubjectProperties),
+                                            batchQuery, getProperties, getProperty, propertyNames, subjects, toSubject)
 import           Control.Monad.Freer       (Eff, runM)
 import           Control.Monad.Freer.Error (Error, runError)
 import           Control.Monad.Freer.Log   (LogMsg, handleLogTrace)
@@ -43,12 +43,13 @@ queryTests =
         , assertReturns
               "Query by Subjects"
               (Right
-                   [ SubjectProperties
-                         (toSubject script1)
-                         [ Preimage SHA256 script1
-                         , Name "Fred's Script" (annotatedSignature1 :| [])
-                         ]
-                   ])
+                   (QueryResult
+                        [ SubjectProperties
+                              (toSubject script1)
+                              [ Preimage SHA256 script1
+                              , Name "Fred's Script" (annotatedSignature1 :| [])
+                              ]
+                        ]))
               (batchQuery
                    (QuerySubjects
                         { subjects = Set.fromList [toSubject script1]
@@ -57,14 +58,16 @@ queryTests =
         , assertReturns
               "Query by Subjects/Properties"
               (Right
-                   [ SubjectProperties
-                         (toSubject script1)
-                         [Name "Fred's Script" (annotatedSignature1 :| [])]
-                   ])
+                   (QueryResult
+                        [ SubjectProperties
+                              (toSubject script1)
+                              [Name "Fred's Script" (annotatedSignature1 :| [])]
+                        ]))
               (batchQuery
                    (QuerySubjects
                         { subjects = Set.fromList [toSubject script1]
-                        , propertyNames = Just (Set.fromList [PropertyKey "name"])
+                        , propertyNames =
+                              Just (Set.fromList [PropertyKey "name"])
                         }))
         ]
 

--- a/plutus-scb/test/Cardano/Metadata/TypesSpec.hs
+++ b/plutus-scb/test/Cardano/Metadata/TypesSpec.hs
@@ -10,7 +10,7 @@ module Cardano.Metadata.TypesSpec
     ) where
 
 import           Cardano.Metadata.Types (AnnotatedSignature, HashFunction, JSONEncoding (ExternalEncoding), Property,
-                                         SubjectProperties)
+                                         QueryResult, SubjectProperties)
 import           Control.Monad          (void)
 import           Data.Aeson             (FromJSON, eitherDecode, encode)
 import qualified Data.ByteString.Lazy   as LBS
@@ -65,6 +65,16 @@ jsonTests =
                 assertDecodes
                     @(SubjectProperties 'ExternalEncoding)
                     "test/Cardano/Metadata/subject_response1.json"
+              , testCase "Batch query response 1" $
+                void $
+                assertDecodes
+                    @(QueryResult 'ExternalEncoding)
+                    "test/Cardano/Metadata/query_response1.json"
+              , testCase "Batch query response 1" $
+                void $
+                assertDecodes
+                    @(QueryResult 'ExternalEncoding)
+                    "test/Cardano/Metadata/query_response2.json"
               ]
         ]
 

--- a/plutus-scb/test/Cardano/Metadata/query_response1.json
+++ b/plutus-scb/test/Cardano/Metadata/query_response1.json
@@ -1,0 +1,73 @@
+{
+    "subjects": [
+        {
+            "subject": "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c274d1888c0",
+            "owner": {
+                "signature": "62e800b8c540b218396174f9c42fc253ab461961e20a4cc8ed4ba8b3fdff760cf8422e80d2504829a1d84458093880f02629524416f895b802cb9211f5145808",
+                "publicKey": "25912b3081c20782aaa576af51ef3b17d7370d9fdf6641fec28012678ac1d179"
+            },
+            "description": {
+                "value": "A sample description",
+                "anSignatures": [
+                    {
+                        "signature": "83ef5c04882e43e5f1c8e9bc386bd51cdda163f5cbd1996d1d066238de063d4b79b1648b48aec63dddff05649911ca116579842c8e9a08a3bc7ae1a0ec7ef000",
+                        "publicKey": "1446c9d327b0f07aa691014c08578867674f3a88b36f2017a58c37a8a7799058"
+                    },
+                    {
+                        "signature": "4e29a00feaeb24b25315f0eac28bbfc550dabfb847bf6a06cb8086120201f90c64fab778037d0ef009ab4669121a38fe9b8c0a6aec99c68366c5187c0889520a",
+                        "publicKey": "1910312a9a6998c7e4f585dc138f85a90f50a28397b8ea05eb23355fb8ea4fa0"
+                    },
+                    {
+                        "signature": "ce939acca5677bc6d436bd8f054ed8fb03d143e0a9792c1f58592c43f175e89bb72d4d7114c1474b86e0d8fbf7807f4506325b56fcc6b87b2cb7002872527106",
+                        "publicKey": "4c5bbbbe7caaa18372aa8edc1ef2d2a770d18a5c2d142b9d695619c3365dd297"
+                    },
+                    {
+                        "signature": "5a1d55048234d92057dfd1938f49935a33751ee604b7dbd02a315418ced6f0836a51107512b192eae6133403bb437c6850b1af1c62c3b17a372acce77adf9903",
+                        "publicKey": "57fa73123c3b39489c4d6c2ff3cab9952e56e556daab9f8f333bc5ca6984fa5e"
+                    },
+                    {
+                        "signature": "e13c9ba5b084dc126d34f3f1120fff75495b64a41a98a69071b5c5ed01bb9d273f51d570cf4fdaa42969fa2c775c12ec05c496cd8f61323d343970136781f60e",
+                        "publicKey": "8cc8963b65ddd0a49f7ce1acc2915d8baff505bbc4f8727a22bd1d28f8ad6632"
+                    }
+                ]
+            },
+            "name": {
+                "value": "SteveToken",
+                "anSignatures": [
+                    {
+                        "signature": "7ef6ed44ba9456737ef8d2e31596fdafb66d5775ac1a254086a553b666516e5895bb0c6b7ba8bef1f6b4d9bd9253b4449d1354de2f9e043ea4eb43fd42f87108",
+                        "publicKey": "0ee262f062528667964782777917cd7139e19e8eb2c591767629e4200070c661"
+                    },
+                    {
+                        "signature": "c95cf87b74d1e4d3b413c927c65de836f0905ba2cd176c7cbff83d8b886b30fe1560c542c1f77bb88280dff55c2d267c9840fe36560fb13ba4a78b6429e51500",
+                        "publicKey": "7c3bfe2a11290a9b6ea054b4d0932678f88130511cfbfe3f634ee77d71edebe7"
+                    },
+                    {
+                        "signature": "f88692b13212bac8121151a99a4de4d5244e5f63566babd2b8ac20950ede74073af0570772b3ce3d11b72e972079199f02306e947cd5fcca688a9d4664eddb04",
+                        "publicKey": "8899d0777f399fffd44f72c85a8aa51605123a7ebf20bba42650780a0c81096a"
+                    },
+                    {
+                        "signature": "c2b30fa5f2c09323d81e5050af681c023089d832d0b85d05f60f4278fba3011ab03e6bd9bd2b8649080a368ecfe51573cd232efe8f1e7ca69ff8334ced7b6801",
+                        "publicKey": "d40688a3eeda1f229c64efc56dd53b363ff981f71a7462f78c8cc444117a03db"
+                    }
+                ]
+            },
+            "preImage": {
+                "hex": "f026b38d5bfdd8d8d838df4c4cc5d6aa4e",
+                "hashFn": "blake2b-256"
+            }
+        },
+        {
+            "subject": "44b57ee30cdb55829d0a5d4f046baef078f1e97a7f21b62d75f8e96ea139c35f",
+            "name": {
+                "value": "Wallet #6",
+                "anSignatures": [
+                    {
+                        "signature": "2e27065e365d38bef19b7bec139206f99b00effc8a2ad05bd22259aa939dd5083f25da91c4cb764eb1bfbce243ec32cce112be9762e1da7a38e975ebb0cc0b08",
+                        "publicKey": "44b57ee30cdb55829d0a5d4f046baef078f1e97a7f21b62d75f8e96ea139c35f"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/plutus-scb/test/Cardano/Metadata/query_response2.json
+++ b/plutus-scb/test/Cardano/Metadata/query_response2.json
@@ -1,0 +1,65 @@
+{
+    "subjects": [
+        {
+            "description": {
+                "value": "A sample description",
+                "anSignatures": [
+                    {
+                        "signature": "83ef5c04882e43e5f1c8e9bc386bd51cdda163f5cbd1996d1d066238de063d4b79b1648b48aec63dddff05649911ca116579842c8e9a08a3bc7ae1a0ec7ef000",
+                        "publicKey": "1446c9d327b0f07aa691014c08578867674f3a88b36f2017a58c37a8a7799058"
+                    },
+                    {
+                        "signature": "4e29a00feaeb24b25315f0eac28bbfc550dabfb847bf6a06cb8086120201f90c64fab778037d0ef009ab4669121a38fe9b8c0a6aec99c68366c5187c0889520a",
+                        "publicKey": "1910312a9a6998c7e4f585dc138f85a90f50a28397b8ea05eb23355fb8ea4fa0"
+                    },
+                    {
+                        "signature": "ce939acca5677bc6d436bd8f054ed8fb03d143e0a9792c1f58592c43f175e89bb72d4d7114c1474b86e0d8fbf7807f4506325b56fcc6b87b2cb7002872527106",
+                        "publicKey": "4c5bbbbe7caaa18372aa8edc1ef2d2a770d18a5c2d142b9d695619c3365dd297"
+                    },
+                    {
+                        "signature": "5a1d55048234d92057dfd1938f49935a33751ee604b7dbd02a315418ced6f0836a51107512b192eae6133403bb437c6850b1af1c62c3b17a372acce77adf9903",
+                        "publicKey": "57fa73123c3b39489c4d6c2ff3cab9952e56e556daab9f8f333bc5ca6984fa5e"
+                    },
+                    {
+                        "signature": "e13c9ba5b084dc126d34f3f1120fff75495b64a41a98a69071b5c5ed01bb9d273f51d570cf4fdaa42969fa2c775c12ec05c496cd8f61323d343970136781f60e",
+                        "publicKey": "8cc8963b65ddd0a49f7ce1acc2915d8baff505bbc4f8727a22bd1d28f8ad6632"
+                    }
+                ]
+            },
+            "subject": "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c274d1888c0",
+            "name": {
+                "value": "SteveToken",
+                "anSignatures": [
+                    {
+                        "signature": "7ef6ed44ba9456737ef8d2e31596fdafb66d5775ac1a254086a553b666516e5895bb0c6b7ba8bef1f6b4d9bd9253b4449d1354de2f9e043ea4eb43fd42f87108",
+                        "publicKey": "0ee262f062528667964782777917cd7139e19e8eb2c591767629e4200070c661"
+                    },
+                    {
+                        "signature": "c95cf87b74d1e4d3b413c927c65de836f0905ba2cd176c7cbff83d8b886b30fe1560c542c1f77bb88280dff55c2d267c9840fe36560fb13ba4a78b6429e51500",
+                        "publicKey": "7c3bfe2a11290a9b6ea054b4d0932678f88130511cfbfe3f634ee77d71edebe7"
+                    },
+                    {
+                        "signature": "f88692b13212bac8121151a99a4de4d5244e5f63566babd2b8ac20950ede74073af0570772b3ce3d11b72e972079199f02306e947cd5fcca688a9d4664eddb04",
+                        "publicKey": "8899d0777f399fffd44f72c85a8aa51605123a7ebf20bba42650780a0c81096a"
+                    },
+                    {
+                        "signature": "c2b30fa5f2c09323d81e5050af681c023089d832d0b85d05f60f4278fba3011ab03e6bd9bd2b8649080a368ecfe51573cd232efe8f1e7ca69ff8334ced7b6801",
+                        "publicKey": "d40688a3eeda1f229c64efc56dd53b363ff981f71a7462f78c8cc444117a03db"
+                    }
+                ]
+            }
+        },
+        {
+            "subject": "44b57ee30cdb55829d0a5d4f046baef078f1e97a7f21b62d75f8e96ea139c35f",
+            "name": {
+                "value": "Wallet #6",
+                "anSignatures": [
+                    {
+                        "signature": "2e27065e365d38bef19b7bec139206f99b00effc8a2ad05bd22259aa939dd5083f25da91c4cb764eb1bfbce243ec32cce112be9762e1da7a38e975ebb0cc0b08",
+                        "publicKey": "44b57ee30cdb55829d0a5d4f046baef078f1e97a7f21b62d75f8e96ea139c35f"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This final metadata change essentially just wraps the existing batch
query in a result object (`QueryResult`) to comply to the JSON spec,
which says the top-level type _must_ be an object.