### PR TITLE
Configure nixpkgs pre-commit hook excludes

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,13 @@ let
     };
     hooks = {
       stylish-haskell.enable = true;
-      nixpkgs-fmt.enable = true;
+      nixpkgs-fmt = {
+        enable = true;
+        # While nixpkgs-fmt does exclude patterns specified in `.ignore` this
+        # does not appear to work inside the hook. For now we have to thus
+        # maintain excludes here *and* in `./.ignore` and *keep them in sync*.
+        excludes = [ ".*nix/stack.materialized/.*" ".*nix/sources.nix$" ];
+      };
       shellcheck.enable = true;
     };
   };


### PR DESCRIPTION
Unfortunately the pre-commit invocations appear to ignore the exludes
specified in .ignore so this has to be fixed with the `excludes`
option of the hook config.