### PR TITLE
SCP-1171 - Fix Haskell to Marlowe conversion of PK hashes

### DIFF
--- a/marlowe/src/Language/Marlowe/Pretty.hs
+++ b/marlowe/src/Language/Marlowe/Pretty.hs
@@ -113,7 +113,7 @@ instance Pretty Slot where
     prettyFragment (Slot n) = prettyFragment n
 
 instance Pretty PubKeyHash where
-    prettyFragment (PubKeyHash bs) = prettyFragment bs
+    prettyFragment (PubKeyHash bs) = text ("\"" ++ show (PubKeyHash bs) ++ "\"")
 
 instance Pretty BS.ByteString where
     prettyFragment = text . show
@@ -121,5 +121,7 @@ instance Pretty BS.ByteString where
 instance Pretty Ada where
     prettyFragment x = prettyFragment (getLovelace x)
 
-deriving instance Pretty CurrencySymbol
+instance Pretty CurrencySymbol where
+    prettyFragment (CurrencySymbol bs) = text ("\"" ++ show (CurrencySymbol bs) ++ "\"")
+
 deriving instance Pretty TokenName


### PR DESCRIPTION
Contracts with non-empty PK identifiers are interpreted as base16 strings, instead of passed directly to simulator.
This fixes the pretty printer to return the base16 representation instead.