### PR TITLE
Fixing a dependncy problem with the OSX Marlowe build.

### DIFF
--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -83,7 +83,7 @@ pkgs.recurseIntoAttrs (rec {
       #!${pkgs.runtimeShell}
       set -eou pipefail
 
-      export PATH=${pkgs.gccStdenv.lib.makeBinPath [
+      export PATH=${pkgs.gccStdenv.lib.makeBinPath ([
         pkgs.coreutils
         pkgs.git
         pkgs.python
@@ -100,7 +100,7 @@ pkgs.recurseIntoAttrs (rec {
         easyPS.psc-package
         easyPS.spago
         easyPS.spago2nix
-      ]}
+      ] ++ (if pkgs.stdenv.isDarwin then [ pkgs.clang ] else [ ]))}
 
       if [ ! -f package.json ]
       then


### PR DESCRIPTION
On OSX, clang++ is required, but may not be available. It is now.