### PR TITLE
Fix pre-commit-check

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -18,10 +18,9 @@ let
       stylish-haskell.enable = true;
       nixpkgs-fmt = {
         enable = true;
-        # While nixpkgs-fmt does exclude patterns specified in `.ignore` this
-        # does not appear to work inside the hook. For now we have to thus
-        # maintain excludes here *and* in `./.ignore` and *keep them in sync*.
-        excludes = [ ".*nix/stack.materialized/.*" ".*nix/sources.nix$" ];
+        # Get the hook to respect ignore patterns
+        # See https://github.com/cachix/pre-commit-hooks.nix/pull/77
+        raw.files = "(\\.nix$)|(\\.ignore$)";
       };
       shellcheck.enable = true;
     };
@@ -31,6 +30,8 @@ haskell.packages.shellFor {
   nativeBuildInputs = [
     # From nixpkgs
     pkgs.ghcid
+    # pre-commit-check needs git here
+    pkgs.git
     pkgs.cacert
     pkgs.niv
     pkgs.nodejs


### PR DESCRIPTION
Adding `.ignore` to the `files` config section of `pre-commit-check`
leads to the hook respecting the exclude patterns in `ignore` again so
those patterns do not have to be synced manually between `excludes` and
`.ignore`.

This commit also adds `git` back to the shell environment because
without it the hook doesn't find git and doesn't update the pre-commit
config on changes - you can see output warning about that when
`shellHook` is executed. (Haven't had time yet to understand why, but i want
this to work reliably for everyone and having git in the `buildInputs` isn't that big an
impact anyway).