### PR TITLE
SCP-1251 - Unify choices in Marlowe Playground simulation

### DIFF
--- a/marlowe-playground-client/src/Simulation.purs
+++ b/marlowe-playground-client/src/Simulation.purs
@@ -299,7 +299,7 @@ setOraclePrice settings = do
       case Map.lookup (Role "kraken") actions of
         Just acts -> do
           case Array.head (Map.toUnfoldable acts) of
-            Just (Tuple (ChoiceInputId choiceId@(ChoiceId pair _) bounds) _) -> do
+            Just (Tuple (ChoiceInputId choiceId@(ChoiceId pair _)) _) -> do
               price <- getPrice settings "kraken" pair
               handleAction settings (SetChoice choiceId price)
             _ -> pure unit


### PR DESCRIPTION
- Unify choices with the same `ChoiceId` in the same option in the input composer
- Simplify choice bound lists by sorting and minimising the number of intervals

Deployed in: https://pablo.marlowe.iohkdev.io/