### PR TITLE
Expose pkgsLocal again

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -73,7 +73,7 @@ However, to avoid doing too much work all the time, we have checked the generate
 IMPORTANT: These files needs to be regenerated if you change any dependencies in cabal files or change the Stackage resolver.
 But the CI will tell you if you've failed to do so.
 
-You can regenerate the files by running `$(nix-build default.nix -A dev.scripts.updateMaterialized)`.
+You can regenerate the files by running `$(nix-build default.nix -A pkgsLocal.updateMaterialized)`.
 
 === How to add a new Haskell package
 
@@ -84,7 +84,7 @@ You need to do a few things when adding a new package, in the following order:
 . Add the package to link:cabal.project[`cabal.project`].
 . Update the xref:update-generated[package set].
 . Update the `xref:update-hie[hie-*.yaml` files].
-. Check that you can run `nix build -f default.nix haskell.projectPackages.<package name>` successfully.
+. Check that you can run `nix build -f default.nix pkgsLocal.haskell.projectPackages.<package name>` successfully.
 
 [[update-haskell-pins]]
 === How to update our pinned Haskell dependencies

--- a/default.nix
+++ b/default.nix
@@ -35,6 +35,7 @@ let
   latex = pkgs.callPackage ./nix/lib/latex.nix { };
 in
 rec {
+  inherit pkgs pkgsLocal;
 
   tests = import ./nix/tests/default.nix {
     inherit pkgs iohkNix haskell;


### PR DESCRIPTION
Quick patch to make sure everything is at least accessible from `default.nix` until we work out where we want to put things.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A dev.scripts.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
