### PR TITLE
Update PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,12 +13,8 @@ Pre-submit checklist:
     - [ ] Useful pull request description
     - [ ] Reviewer requested
 - If you updated any cabal files or added Haskell packages:
-    - [ ] `$(nix-build default.nix -A dev.scripts.updateMaterialized)` to update the materialized Nix files
+   - [ ] `$(nix-build default.nix -A dev.scripts.updateMaterialized)` to update the materialized Nix files
    - [ ] Update `hie-*.yaml` files if needed
-- If you changed any Haskell files:
-   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
-- If you changed any Purescript files:
-   - [ ] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues
 
 Pre-merge checklist:
 - [ ] Someone approved it


### PR DESCRIPTION
Remove checkboxes for stylish-haskell and purty since both are being taken care off through the git pre-commit hooks (and later through CI).

@michaelpj does this make sense to you? I think if something is fully automatically taken care of then there is no need for an added manual step of clicking a checkbox in the GitHub UI?

-----

Pre-submit checklist:
- Branch
    - [x] Commit sequence broadly makes sense
    - [x] Key commits have useful messages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [x] Reviewer requested

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
