### PR TITLE
Fix ci.nix to avoid importing everything 3 times

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -18,18 +18,20 @@ let
 in
 dimension "System" (systems genericPkgs) (systemName: system:
   let
-    packageSet = import ./default.nix { inherit system rev; checkMaterialization = true; };
-    packages = import ./nix { inherit system rev; checkMaterialization = true; };
+    packages = import ./default.nix { inherit system rev; checkMaterialization = true; };
     pkgs = packages.pkgs;
     pkgsLocal = packages.pkgsLocal;
+    pkgsMusl = packages.pkgsMusl;
     lib = pkgs.lib;
     platformFilter = platformFilterGeneric pkgs system;
   in
   filterAttrsOnlyRecursive (_: v: platformFilter v) {
-    inherit (packageSet) docs papers tests plutus-playground marlowe-playground plutus-scb marlowe-symbolic-lambda;
+    inherit (packages) docs papers tests plutus-playground marlowe-playground plutus-scb marlowe-symbolic-lambda;
     inherit (pkgsLocal.haskell.project) roots;
+
     # build the shell expression to be sure it works on all platforms
-    shell = import ./shell.nix { };
+    shell = import ./shell.nix { inherit packages; };
+
     haskell =
       let
         # These functions pull out from the Haskell package set either all the components of a particular type, or

--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ let
   latex = pkgs.callPackage ./nix/lib/latex.nix { };
 in
 rec {
-  inherit pkgs pkgsLocal;
+  inherit pkgs pkgsLocal pkgsMusl;
 
   tests = import ./nix/tests/default.nix {
     inherit pkgs iohkNix haskell;


### PR DESCRIPTION
This changes the the attribute set that the `dimension` function
receives such that everything doesn't get instantiated multiple times.

The fact that this is happening could actually been noticed through the
trace messages that are being printed during instantiation.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] Reviewer requested
Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge
