### PR TITLE
Fixing a bug with the Data.String.Extra.abbreviate tests.

### DIFF
--- a/plutus-playground-client/test/Data/String/ExtraTests.purs
+++ b/plutus-playground-client/test/Data/String/ExtraTests.purs
@@ -6,7 +6,7 @@ import Prelude
 import Data.String as String
 import Data.String.Extra (abbreviate, leftPadTo, repeat, toHex)
 import Test.QuickCheck (arbitrary, (<=?), (===))
-import Test.QuickCheck.Gen (Gen, suchThat)
+import Test.QuickCheck.Gen (Gen, chooseInt)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (equal)
 import Test.Unit.QuickCheck (quickCheck)
@@ -32,8 +32,8 @@ abbreviateTests = do
       quickCheck
         $ do
             str <- arbitrary :: Gen String
-            n <- arbitrary `suchThat` (\n -> n >= 0)
-            pure $ abbreviate n (abbreviate n str) === str
+            n <- chooseInt 0 (String.length str * 2)
+            pure $ abbreviate n (abbreviate n str) === abbreviate n str
 
 toHexTests :: TestSuite
 toHexTests = do


### PR DESCRIPTION
Turns out it was the test at fault, in two ways. It was supposed to
compare applying the function once, and applying it twice, and expect
the same result. In reality, was comparing double-abbreviation with no
abbrevation at all, but choosing such a large maximum string length
that it didn't matter, most of the time. :laugh: :sob:


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Key commits have useful messages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] Reviewer requested
- If you updated any cabal files or added Haskell packages:
    - [ ] `$(nix-build default.nix -A dev.scripts.updateMaterialized)` to update the materialized Nix files
   - [ ] Update `hie-*.yaml` files if needed
- If you changed any Haskell files:
   - [ ] `$(nix-shell shell.nix --run fix-stylish-haskell)` to fix any formatting issues
- If you changed any Purescript files:
   - [X] `$(nix-shell shell.nix --run fix-purty)` to fix any formatting issues

Pre-merge checklist:
- [ ] Someone approved it
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
- [ ] History is moderately tidy; or going to squash-merge